### PR TITLE
do not fail disable operation when if instances are not in discovery

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -119,12 +119,13 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
       } catch (e) {
         def errorMessage = "Could not ${verb} ASG '$description.asgName' in region $region! Failure Type: ${e.class.simpleName}; Message: ${e.message}"
         log.error(errorMessage, e)
-
-        task.updateStatus phaseName, errorMessage
+        if (!task.status.isFailed()) {
+          task.updateStatus phaseName, errorMessage
+        }
         failures = true
       }
     }
-    if (failures) {
+    if (failures && !task.status.isFailed()) {
       task.fail()
     }
     null

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/discovery/DiscoverySupport.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/discovery/DiscoverySupport.groovy
@@ -104,7 +104,12 @@ class DiscoverySupport {
           if (resp.status != 200) {
             throw new RetryableException("Non HTTP 200 response from discovery for instance ${instanceId}, will retry (attempt: $retryCount}).")
           }
-          task.updateStatus phaseName, "Marked ${instanceId} in application $applicationName as '${discoveryStatus.value}' in discovery."
+        }
+      } catch (RetrofitError retrofitError) {
+        if (retrofitError.response?.status == 404 && discoveryStatus == DiscoveryStatus.Disable) {
+          task.updateStatus phaseName, "Could not find ${instanceId} in application $applicationName in discovery, skipping disable operation."
+        } else {
+          errors[instanceId] = retrofitError
         }
       } catch (ex) {
         errors[instanceId] = ex


### PR DESCRIPTION
also adding a check to avoid trying to fail a task twice

@cfieber @ajordens can you review this?
