### PR TITLE
Unnecessary to check for instance/asg existence when disabling in dis…

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/discovery/DiscoverySupport.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/discovery/DiscoverySupport.groovy
@@ -95,11 +95,6 @@ class DiscoverySupport {
         retry(task, discoveryRetry) { retryCount ->
           task.updateStatus phaseName, "Attempting to mark ${instanceId} as '${discoveryStatus.value}' in discovery (attempt: ${retryCount})."
 
-          if (discoveryStatus == DiscoveryStatus.Disable && !verifyInstanceAndAsgExist(amazonEC2, asgService, instanceId, description.asgName)) {
-            task.updateStatus phaseName, "Instance (${instanceId}) or ASG (${description.asgName}) no longer exist, skipping"
-            return
-          }
-
           Response resp = eureka.updateInstanceStatus(applicationName, instanceId, discoveryStatus.value)
           if (resp.status != 200) {
             throw new RetryableException("Non HTTP 200 response from discovery for instance ${instanceId}, will retry (attempt: $retryCount}).")


### PR DESCRIPTION
…covery
- We no longer fail on a 404 so this hardening isn't valuable and potentially adding execution time
