### PR TITLE
Extract account configuration to clouddriver-google module.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,4 +88,4 @@ subprojects { project ->
 }
 
 tasks.checkSnapshotDependencies.enabled = false
-
+defaultTasks ':clouddriver-web:bootRun'

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -1,0 +1,6 @@
+dependencies {
+  spinnaker.group('google')
+  compile spinnaker.dependency('frigga')
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('bootWeb')
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/config/GoogleConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/config/GoogleConfig.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.config
+
+import com.netflix.spinnaker.amos.AccountCredentialsRepository
+import com.netflix.spinnaker.amos.gce.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.google.health.GoogleHealthIndicator
+import org.apache.log4j.Logger
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+import javax.annotation.PostConstruct
+
+@Configuration
+@EnableConfigurationProperties
+@EnableScheduling
+@ConditionalOnProperty('google.enabled')
+class GoogleConfig {
+  private static final Logger log = Logger.getLogger(this.class.simpleName)
+
+  @Autowired
+  AccountCredentialsRepository accountCredentialsRepository
+
+  @Bean
+  @ConfigurationProperties("google")
+  GoogleConfigurationProperties googleConfigurationProperties() {
+    new GoogleConfigurationProperties()
+  }
+
+  @Bean
+  GoogleHealthIndicator googleHealthIndicator() {
+    new GoogleHealthIndicator()
+  }
+
+  @PostConstruct
+  void init() {
+    def config = googleConfigurationProperties()
+    for (managedAccount in config.accounts) {
+      try {
+        accountCredentialsRepository.save(managedAccount.name, new GoogleNamedAccountCredentials(config.kmsServer, managedAccount.name, managedAccount.project))
+      } catch (e) {
+        log.info "Could not load account ${managedAccount.name} for Google", e
+      }
+    }
+  }
+}
+

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/config/GoogleConfigurationProperties.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/config/GoogleConfigurationProperties.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.config
+
+class GoogleConfigurationProperties {
+  public static final int POLLING_INTERVAL_SECONDS_DEFAULT = 60
+  public static final int ASYNC_OPERATION_TIMEOUT_SECONDS_DEFAULT = 300
+  public static final int ASYNC_OPERATION_MAX_POLLING_INTERVAL_SECONDS = 8
+
+  static class ManagedAccount {
+    String name
+    String project
+  }
+
+  String kmsServer
+  List<ManagedAccount> accounts = []
+  int pollingIntervalSeconds = POLLING_INTERVAL_SECONDS_DEFAULT
+  int asyncOperationTimeoutSecondsDefault = ASYNC_OPERATION_TIMEOUT_SECONDS_DEFAULT
+  int asyncOperationMaxPollingIntervalSeconds = ASYNC_OPERATION_MAX_POLLING_INTERVAL_SECONDS
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/health/GoogleHealthIndicator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/health/GoogleHealthIndicator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Google, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.oort.gce.health
+package com.netflix.spinnaker.clouddriver.google.health
 
 import com.netflix.spinnaker.amos.AccountCredentialsProvider
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
@@ -33,9 +33,9 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import java.util.concurrent.atomic.AtomicReference
 
 @Component
-class GceHealthIndicator implements HealthIndicator {
+class GoogleHealthIndicator implements HealthIndicator {
 
-  private static final Logger LOG = LoggerFactory.getLogger(GceHealthIndicator)
+  private static final Logger LOG = LoggerFactory.getLogger(GoogleHealthIndicator)
 
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
@@ -91,3 +91,4 @@ class GceHealthIndicator implements HealthIndicator {
   @InheritConstructors
   static class GoogleIOException extends RuntimeException {}
 }
+

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -76,7 +76,7 @@ aws:
   accounts: []
 
 
-gce:
+google:
   enabled: ${GCE_ENABLED:false}
   defaults:
     instanceTypePersistentDisks:

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.controllers.CredentialsController
 import com.netflix.spinnaker.clouddriver.core.CloudDriverConfig
 import com.netflix.spinnaker.clouddriver.core.RedisConfig
 import com.netflix.spinnaker.clouddriver.filters.SimpleCORSFilter
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfig
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.actuate.autoconfigure.ManagementSecurityAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -43,6 +44,7 @@ import java.security.Security
   WebConfig,
   CloudDriverConfig,
   AwsConfiguration,
+  GoogleConfig,
   com.netflix.spinnaker.kato.Main,
   com.netflix.spinnaker.mort.Main,
   com.netflix.spinnaker.oort.Main,

--- a/kato/kato-cf/src/test/groovy/com/netflix/spinnaker/kato/cf/deploy/handlers/CloudFoundryDeployHandlerUnitSpec.groovy
+++ b/kato/kato-cf/src/test/groovy/com/netflix/spinnaker/kato/cf/deploy/handlers/CloudFoundryDeployHandlerUnitSpec.groovy
@@ -27,6 +27,8 @@ import org.cloudfoundry.client.lib.domain.InstanceState
 import org.cloudfoundry.client.lib.domain.InstancesInfo
 import org.springframework.core.io.DefaultResourceLoader
 import org.springframework.core.io.ResourceLoader
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -111,6 +113,25 @@ class CloudFoundryDeployHandlerUnitSpec extends Specification {
     handler.handles description
   }
 
+  static boolean isOffline() {
+    Socket s
+    try {
+      s = new Socket('repo.spring.io', 80)
+      return false
+    } catch (e) {
+      return true
+    } finally {
+      if (s != null) {
+        try {
+          s.close()
+        } catch (ignored) {
+
+        }
+      }
+    }
+  }
+
+  @IgnoreIf({CloudFoundryDeployHandlerUnitSpec.isOffline()})
   void "handler handles cf deploy description with remote artifact"() {
     setup:
     handler = new CloudFoundryDeployHandler(new TestCloudFoundryClientFactory(stubClient: clientToTwoRunningInstances));

--- a/kato/kato-gce/kato-gce.gradle
+++ b/kato/kato-gce/kato-gce.gradle
@@ -16,6 +16,7 @@
 
 dependencies {
   compile project(":kato:kato-core")
+  compile project(":clouddriver-google")
   compile spinnaker.dependency("frigga")
 
   spinnaker.group("google")

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/config/GceConfig.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/config/GceConfig.groovy
@@ -17,7 +17,7 @@ class GceConfig {
   private static final long DISK_SIZE_GB = 100
 
   @Bean
-  @ConfigurationProperties('gce.defaults')
+  @ConfigurationProperties('google.defaults')
   DeployDefaults gceDeployDefaults() {
     new DeployDefaults()
   }

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/GoogleOperationPoller.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/GoogleOperationPoller.groovy
@@ -19,11 +19,10 @@ package com.netflix.spinnaker.kato.gce.deploy
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Operation
 import com.google.api.services.replicapool.Replicapool
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.kato.data.task.Task
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleOperationTimedOutException
-import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleResourceNotFoundException
 import org.springframework.beans.factory.annotation.Autowired
 
 class GoogleOperationPoller {
@@ -36,7 +35,7 @@ class GoogleOperationPoller {
   }
 
   @Autowired
-  GoogleConfig.GoogleConfigurationProperties googleConfigurationProperties
+  GoogleConfigurationProperties googleConfigurationProperties
 
   private ThreadSleeper threadSleeper = new ThreadSleeper()
 

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/config/GoogleConfig.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/config/GoogleConfig.groovy
@@ -17,57 +17,14 @@
 
 package com.netflix.spinnaker.kato.gce.deploy.config
 
-import com.netflix.spinnaker.amos.AccountCredentialsRepository
-import com.netflix.spinnaker.amos.gce.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
-import org.apache.log4j.Logger
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.stereotype.Component
 
-import javax.annotation.PostConstruct
-
 @Component
 class GoogleConfig {
-  private static final Logger log = Logger.getLogger(this.class.simpleName)
-
-  public static final int ASYNC_OPERATION_TIMEOUT_SECONDS_DEFAULT = 300
-  public static final int ASYNC_OPERATION_MAX_POLLING_INTERVAL_SECONDS = 8
-
-  @Autowired
-  AccountCredentialsRepository accountCredentialsRepository
-
   @Bean
   GoogleOperationPoller googleOperationPoller() {
     new GoogleOperationPoller()
-  }
-
-  static class ManagedAccount {
-    String name
-    String project
-  }
-
-  @Component
-  @ConfigurationProperties("google")
-  static class GoogleConfigurationProperties {
-    String kmsServer
-    List<ManagedAccount> accounts = []
-    int asyncOperationTimeoutSecondsDefault = ASYNC_OPERATION_TIMEOUT_SECONDS_DEFAULT
-    int asyncOperationMaxPollingIntervalSeconds = ASYNC_OPERATION_MAX_POLLING_INTERVAL_SECONDS
-  }
-
-  @Autowired
-  GoogleConfigurationProperties googleConfigurationProperties
-
-  @PostConstruct
-  void init() {
-    for (managedAccount in googleConfigurationProperties.accounts) {
-      try {
-        accountCredentialsRepository.save(managedAccount.name, new GoogleNamedAccountCredentials(googleConfigurationProperties.kmsServer, managedAccount.name, managedAccount.project))
-      } catch (e) {
-        log.info "Could not load account ${managedAccount.name} for Google", e
-      }
-    }
   }
 }

--- a/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/GoogleOperationPollerSpec.groovy
+++ b/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/GoogleOperationPollerSpec.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.kato.gce.deploy
 
 import com.google.api.services.compute.model.Operation
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import spock.lang.Specification
 
 class GoogleOperationPollerSpec extends Specification {
@@ -25,7 +25,7 @@ class GoogleOperationPollerSpec extends Specification {
   void "waitForOperation should query the operation at least once"() {
     setup:
       def googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     expect:
       googleOperationPoller.waitForOperation({return new Operation(status: "DONE")}, 0) == new Operation(status: "DONE")
@@ -34,7 +34,7 @@ class GoogleOperationPollerSpec extends Specification {
   void "waitForOperation should return null on timeout"() {
     setup:
       def googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     expect:
       googleOperationPoller.waitForOperation({return new Operation(status: "PENDING")}, 0) == null
@@ -45,7 +45,7 @@ class GoogleOperationPollerSpec extends Specification {
       def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
       def googleOperationPoller =
         new GoogleOperationPoller(
-            googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties(),
+            googleConfigurationProperties: new GoogleConfigurationProperties(),
             threadSleeper: threadSleeperMock)
 
     when:
@@ -73,7 +73,7 @@ class GoogleOperationPollerSpec extends Specification {
       def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
       def googleOperationPoller =
         new GoogleOperationPoller(
-            googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties(
+            googleConfigurationProperties: new GoogleConfigurationProperties(
                 asyncOperationMaxPollingIntervalSeconds: 3),
             threadSleeper: threadSleeperMock)
 

--- a/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/DeleteGoogleReplicaPoolAtomicOperationUnitSpec.groovy
+++ b/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/DeleteGoogleReplicaPoolAtomicOperationUnitSpec.groovy
@@ -21,10 +21,10 @@ import com.google.api.services.replicapool.Replicapool
 import com.google.api.services.replicapool.model.InstanceGroupManager
 import com.google.api.services.replicapool.model.Operation
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.kato.data.task.Task
 import com.netflix.spinnaker.kato.data.task.TaskRepository
 import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
 import com.netflix.spinnaker.kato.gce.deploy.description.DeleteGoogleReplicaPoolDescription
 import spock.lang.Specification
 import spock.lang.Subject
@@ -66,7 +66,7 @@ class DeleteGoogleReplicaPoolAtomicOperationUnitSpec extends Specification {
                                                                credentials: credentials)
       @Subject def operation = new DeleteGoogleReplicaPoolAtomicOperation(description, replicaPoolBuilderMock)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])

--- a/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec.groovy
+++ b/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec.groovy
@@ -28,11 +28,11 @@ import com.google.api.services.compute.model.Tags
 import com.google.api.services.replicapool.Replicapool
 import com.google.api.services.replicapool.model.InstanceGroupManager
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.kato.data.task.Task
 import com.netflix.spinnaker.kato.data.task.TaskRepository
 import com.netflix.spinnaker.kato.gce.deploy.GCEUtil
 import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
 import com.netflix.spinnaker.kato.gce.deploy.description.ModifyGoogleServerGroupInstanceTemplateDescription
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleOperationException
 import spock.lang.Specification
@@ -104,7 +104,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description, replicaPoolBuilderMock)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -169,7 +169,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description, replicaPoolBuilderMock)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -229,7 +229,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description, replicaPoolBuilderMock)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -282,7 +282,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description, replicaPoolBuilderMock)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -338,7 +338,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description, replicaPoolBuilderMock)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])

--- a/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/UpsertGoogleServerGroupTagsAtomicOperationUnitSpec.groovy
+++ b/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/UpsertGoogleServerGroupTagsAtomicOperationUnitSpec.groovy
@@ -28,10 +28,10 @@ import com.google.api.services.resourceviews.Resourceviews
 import com.google.api.services.resourceviews.model.ListResourceResponseItem
 import com.google.api.services.resourceviews.model.ZoneViewsListResourcesResponse
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.kato.data.task.Task
 import com.netflix.spinnaker.kato.data.task.TaskRepository
 import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
 import com.netflix.spinnaker.kato.gce.deploy.description.UpsertGoogleServerGroupTagsDescription
 import spock.lang.Specification
 import spock.lang.Subject
@@ -118,7 +118,7 @@ class UpsertGoogleServerGroupTagsAtomicOperationUnitSpec extends Specification {
                                                                    credentials: credentials)
       @Subject def operation = new UpsertGoogleServerGroupTagsAtomicOperation(description, replicaPoolBuilderMock, resourceViewsBuilderMock)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -226,7 +226,7 @@ class UpsertGoogleServerGroupTagsAtomicOperationUnitSpec extends Specification {
                                                                    credentials: credentials)
       @Subject def operation = new UpsertGoogleServerGroupTagsAtomicOperation(description, replicaPoolBuilderMock, resourceViewsBuilderMock)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])

--- a/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/loadbalancer/CreateGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/loadbalancer/CreateGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.kato.gce.deploy.ops.loadbalancer
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Operation
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.kato.data.task.Task
 import com.netflix.spinnaker.kato.data.task.TaskRepository
 import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
 import com.netflix.spinnaker.kato.gce.deploy.description.CreateGoogleHttpLoadBalancerDescription
 import spock.lang.Specification
 import spock.lang.Subject
@@ -91,7 +91,7 @@ class CreateGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       )
       @Subject def operation = new CreateGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
      operation.operate([])
@@ -179,7 +179,7 @@ class CreateGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       )
       @Subject def operation = new CreateGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])

--- a/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -23,10 +23,10 @@ import com.google.api.services.compute.model.Operation
 import com.google.api.services.compute.model.TargetHttpProxy
 import com.google.api.services.compute.model.UrlMap
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.kato.data.task.Task
 import com.netflix.spinnaker.kato.data.task.TaskRepository
 import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleOperationTimedOutException
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleResourceNotFoundException
@@ -110,7 +110,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -232,7 +232,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -373,7 +373,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -450,7 +450,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -532,7 +532,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])

--- a/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/loadbalancer/DeleteGoogleNetworkLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/loadbalancer/DeleteGoogleNetworkLoadBalancerAtomicOperationUnitSpec.groovy
@@ -21,10 +21,10 @@ import com.google.api.services.compute.model.ForwardingRule
 import com.google.api.services.compute.model.Operation
 import com.google.api.services.compute.model.TargetPool
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.kato.data.task.Task
 import com.netflix.spinnaker.kato.data.task.TaskRepository
 import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleOperationTimedOutException
 import com.netflix.spinnaker.kato.gce.deploy.exception.GoogleResourceNotFoundException
@@ -84,7 +84,7 @@ class DeleteGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new DeleteGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -141,7 +141,7 @@ class DeleteGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new DeleteGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -215,7 +215,7 @@ class DeleteGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new DeleteGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -259,7 +259,7 @@ class DeleteGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new DeleteGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -310,7 +310,7 @@ class DeleteGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new DeleteGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])

--- a/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/loadbalancer/UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/kato/kato-gce/src/test/groovy/com/netflix/spinnaker/kato/gce/deploy/ops/loadbalancer/UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec.groovy
@@ -28,10 +28,10 @@ import com.google.api.services.compute.model.Operation
 import com.google.api.services.compute.model.TargetPool
 import com.google.api.services.compute.model.TargetPoolList
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.kato.data.task.Task
 import com.netflix.spinnaker.kato.data.task.TaskRepository
 import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.kato.gce.deploy.config.GoogleConfig
 import com.netflix.spinnaker.kato.gce.deploy.description.UpsertGoogleNetworkLoadBalancerDescription
 import spock.lang.Specification
 import spock.lang.Subject
@@ -110,7 +110,7 @@ class UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new UpsertGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -186,7 +186,7 @@ class UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new UpsertGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -243,7 +243,7 @@ class UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new UpsertGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -290,7 +290,7 @@ class UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
           credentials: credentials)
       @Subject def operation = new UpsertGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -560,7 +560,7 @@ class UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
         credentials: credentials)
       @Subject def operation = new UpsertGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -643,7 +643,7 @@ class UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
         credentials: credentials)
       @Subject def operation = new UpsertGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])
@@ -733,7 +733,7 @@ class UpsertGoogleNetworkLoadBalancerAtomicOperationUnitSpec extends Specificati
         credentials: credentials)
       @Subject def operation = new UpsertGoogleNetworkLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfig.GoogleConfigurationProperties())
+        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
 
     when:
       operation.operate([])

--- a/oort/oort-gce/oort-gce.gradle
+++ b/oort/oort-gce/oort-gce.gradle
@@ -1,5 +1,6 @@
 dependencies {
   compile project(":oort:oort-core")
+  compile project(":clouddriver-google")
 
   spinnaker.group("bootWeb")
   spinnaker.group("google")

--- a/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/config/GoogleConfig.groovy
+++ b/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/config/GoogleConfig.groovy
@@ -16,61 +16,17 @@
 
 package com.netflix.spinnaker.oort.config
 
-import com.netflix.spinnaker.amos.AccountCredentialsRepository
-import com.netflix.spinnaker.amos.gce.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.oort.gce.model.GoogleResourceRetriever
-import org.apache.log4j.Logger
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 
-import javax.annotation.PostConstruct
 
 @Configuration
-@EnableConfigurationProperties
 @ConditionalOnProperty('google.enabled')
 @ComponentScan('com.netflix.spinnaker.oort.gce')
 class GoogleConfig {
-  private static final Logger log = Logger.getLogger(this.class.simpleName)
-
-  public static final int POLLING_INTERVAL_SECONDS_DEFAULT = 60
-
-  @Autowired
-  AccountCredentialsRepository accountCredentialsRepository
-
-  static class ManagedAccount {
-    String name
-    String project
-  }
-
-  static class GoogleConfigurationProperties {
-    String kmsServer
-    List<ManagedAccount> accounts = []
-    int pollingIntervalSeconds = POLLING_INTERVAL_SECONDS_DEFAULT
-  }
-
-  @Bean
-  @ConfigurationProperties("google")
-  GoogleConfigurationProperties googleConfigurationProperties() {
-    new GoogleConfigurationProperties()
-  }
-
-  @PostConstruct
-  void init() {
-    def config = googleConfigurationProperties()
-    for (managedAccount in config.accounts) {
-      try {
-        accountCredentialsRepository.save(managedAccount.name, new GoogleNamedAccountCredentials(config.kmsServer, managedAccount.name, managedAccount.project))
-      } catch (e) {
-        log.info "Could not load account ${managedAccount.name} for Google", e
-      }
-    }
-  }
-
   @Bean
   GoogleResourceRetriever googleResourceRetriever() {
     new GoogleResourceRetriever()

--- a/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/GoogleResourceRetriever.groovy
+++ b/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/GoogleResourceRetriever.groovy
@@ -27,7 +27,7 @@ import com.google.api.services.replicapool.model.InstanceGroupManagerList
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.amos.AccountCredentialsProvider
 import com.netflix.spinnaker.amos.gce.GoogleCredentials
-import com.netflix.spinnaker.oort.config.GoogleConfig.GoogleConfigurationProperties
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.oort.gce.model.callbacks.ImagesCallback
 import com.netflix.spinnaker.oort.gce.model.callbacks.InstanceAggregatedListCallback
 import com.netflix.spinnaker.oort.gce.model.callbacks.MIGSCallback
@@ -231,12 +231,12 @@ class GoogleResourceRetriever {
                 it.loadBalancerName == loadBalancerName
               }
 
-              def health = loadBalancerHealth
-                           ? [
+              def health = loadBalancerHealth ?
+                           [
                              state      : loadBalancerHealth.state,
                              description: loadBalancerHealth.description
-                           ]
-                           : [
+                           ] :
+                           [
                              state      : "Unknown",
                              description: "Unable to determine load balancer health."
                            ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,7 @@ def subs = [
   oort: ['oort-core', 'oort-web', 'oort-aws', 'oort-gce', 'oort-bench'],
   mort: ["mort-web", "mort-core", "mort-aws"]
 ]
-def topLevels = [ 'clouddriver-core', 'clouddriver-aws', 'clouddriver-web' ]
+def topLevels = [ 'clouddriver-core', 'clouddriver-web', 'clouddriver-aws', 'clouddriver-google' ]
 String[] allmodules = (topLevels +  subs.collect { String sub, List<String> children -> [sub] + children.collect { sub + ':' + it } }.flatten()).toArray()
 
 include allmodules


### PR DESCRIPTION
Also adds a defaultTask to bootRun clouddriver-web

cc: @ewiseblatt This adds :clouddriver-web:bootRun as the default tasks

Also of note is the configuration properties, I changed the namespace from gce to google (this lines up with setting google.enabled) so in any customized .yml file the gce.defaults (for instanceTypePersistentDisks ) would become google.defaults

This is 'tested' in as much as it compiles and tests still pass..
