### PR TITLE
Rename kato/GoogleConfig and oort/GoogleConfig to KatoGoogleConfig an…

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -69,7 +69,7 @@ aws:
      - us-west-2a
      - us-west-2b
      - us-west-2c
-  defaultKeyPairTemplate: {{name}}-keypair
+  defaultKeyPairTemplate: '{{name}}-keypair'
 
   # an empty list means we are directly managing the AWS account we have credentials for (named default.account.env)
   # see prod profile section below for an example configuration to manage other accounts via STS assume role
@@ -207,7 +207,3 @@ bastion:
 
 redis:
   connection: redis://localhost:6379
-
-
-server:
-  port: 8081

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/config/KatoGoogleConfig.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/config/KatoGoogleConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.oort.config
+package com.netflix.spinnaker.kato.gce.deploy.config
 
-import com.netflix.spinnaker.oort.gce.model.GoogleResourceRetriever
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
 
-
-@Configuration
-@ConditionalOnProperty('google.enabled')
-@ComponentScan('com.netflix.spinnaker.oort.gce')
-class GoogleConfig {
+@Component
+class KatoGoogleConfig {
   @Bean
-  GoogleResourceRetriever googleResourceRetriever() {
-    new GoogleResourceRetriever()
+  GoogleOperationPoller googleOperationPoller() {
+    new GoogleOperationPoller()
   }
 }

--- a/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/config/OortGoogleConfig.groovy
+++ b/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/config/OortGoogleConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
+package com.netflix.spinnaker.oort.config
 
-package com.netflix.spinnaker.kato.gce.deploy.config
-
-import com.netflix.spinnaker.kato.gce.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.oort.gce.model.GoogleResourceRetriever
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
-import org.springframework.stereotype.Component
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
 
-@Component
-class GoogleConfig {
+@Configuration
+@ConditionalOnProperty('google.enabled')
+@ComponentScan('com.netflix.spinnaker.oort.gce')
+class OortGoogleConfig {
   @Bean
-  GoogleOperationPoller googleOperationPoller() {
-    new GoogleOperationPoller()
+  GoogleResourceRetriever googleResourceRetriever() {
+    new GoogleResourceRetriever()
   }
 }


### PR DESCRIPTION
…d OortGoogleConfig to remove ambiguity from Spring bean resolution.
Fixup yaml.
@cfieber I'm guessing the 2nd `server.port` was extraneous.
