### PR TITLE
kato asg operations can now specify multiple ASGs and multiple regions

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/DeleteAsgDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/DeleteAsgDescription.groovy
@@ -17,8 +17,22 @@
 
 package com.netflix.spinnaker.kato.aws.deploy.description
 
+import groovy.transform.ToString
+
 class DeleteAsgDescription extends AbstractAmazonCredentialsDescription {
-  String asgName
-  List<String> regions
+  List<AsgDescription> asgs = []
   Boolean forceDelete = Boolean.FALSE
+
+  @Deprecated
+  String asgName
+
+  @Deprecated
+  List<String> regions = []
+
+  @ToString
+  static class AsgDescription {
+    String region
+    String asgName
+  }
+
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/DeleteAsgTagsDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/DeleteAsgTagsDescription.groovy
@@ -15,8 +15,21 @@
  */
 package com.netflix.spinnaker.kato.aws.deploy.description
 
+import groovy.transform.ToString
+
 class DeleteAsgTagsDescription extends AbstractAmazonCredentialsDescription {
-  String asgName
-  List<String> regions
+  List<AsgDescription> asgs = []
   List<String> tagKeys
+
+  @Deprecated
+  String asgName
+
+  @Deprecated
+  List<String> regions = []
+
+  @ToString
+  static class AsgDescription {
+    String region
+    String asgName
+  }
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/DestroyAsgDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/DestroyAsgDescription.groovy
@@ -17,7 +17,21 @@
 
 package com.netflix.spinnaker.kato.aws.deploy.description
 
+import groovy.transform.ToString
+
 class DestroyAsgDescription extends AbstractAmazonCredentialsDescription {
+
+  List<AsgDescription> asgs = []
+
+  @Deprecated
   String asgName
-  List<String> regions
+
+  @Deprecated
+  List<String> regions = []
+
+  @ToString
+  static class AsgDescription {
+    String region
+    String asgName
+  }
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/EnableDisableAsgDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/EnableDisableAsgDescription.groovy
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.kato.aws.deploy.description
 
+import groovy.transform.ToString
+
 /**
  * Description for "enabling" a supplied ASG. "Enabling" means Resuming "AddToLoadBalancer", "Launch", and "Terminate" processes on an ASG. If Eureka/Discovery is available, setting a status
  * override will also be achieved.
@@ -23,6 +25,17 @@ package com.netflix.spinnaker.kato.aws.deploy.description
  * override will also be achieved.
  */
 class EnableDisableAsgDescription extends AbstractAmazonCredentialsDescription {
+  List<AsgDescription> asgs = []
+
+  @Deprecated
   String asgName
-  List<String> regions
+
+  @Deprecated
+  List<String> regions = []
+
+  @ToString
+  static class AsgDescription {
+    String region
+    String asgName
+  }
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/ResizeAsgDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/ResizeAsgDescription.groovy
@@ -17,14 +17,28 @@
 
 package com.netflix.spinnaker.kato.aws.deploy.description
 
+import groovy.transform.ToString
+
 class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
+  List<AsgDescription> asgs = []
+
+  @Deprecated
   String asgName
-  List<String> regions
+
+  @Deprecated
+  List<String> regions = []
   Capacity capacity = new Capacity()
 
+  @ToString
   static class Capacity {
     int min
     int max
     int desired
+  }
+
+  @ToString
+  static class AsgDescription {
+    String region
+    String asgName
   }
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/ResumeAsgProcessesDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/ResumeAsgProcessesDescription.groovy
@@ -15,8 +15,22 @@
  */
 package com.netflix.spinnaker.kato.aws.deploy.description
 
+import groovy.transform.ToString
+
 class ResumeAsgProcessesDescription extends AbstractAmazonCredentialsDescription {
-  String asgName
-  List<String> regions
+
+  List<AsgDescription> asgs
   List<String> processes
+
+  @Deprecated
+  String asgName
+
+  @Deprecated
+  List<String> regions
+
+  @ToString
+  static class AsgDescription {
+    String region
+    String asgName
+  }
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/SuspendAsgProcessesDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/SuspendAsgProcessesDescription.groovy
@@ -15,8 +15,21 @@
  */
 package com.netflix.spinnaker.kato.aws.deploy.description
 
+import groovy.transform.ToString
+
 class SuspendAsgProcessesDescription extends AbstractAmazonCredentialsDescription {
-  String asgName
-  List<String> regions
+  List<AsgDescription> asgs = []
   List<String> processes
+
+  @Deprecated
+  String asgName
+
+  @Deprecated
+  List<String> regions = []
+
+  @ToString
+  static class AsgDescription {
+    String region
+    String asgName
+  }
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/UpsertAsgTagsDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/UpsertAsgTagsDescription.groovy
@@ -17,8 +17,22 @@
 
 package com.netflix.spinnaker.kato.aws.deploy.description
 
+import groovy.transform.ToString
+
 class UpsertAsgTagsDescription extends AbstractAmazonCredentialsDescription {
-  String asgName
-  List<String> regions
+
+  List<AsgDescription> asgs = []
   Map<String, String> tags
+
+  @Deprecated
+  String asgName
+
+  @Deprecated
+  List<String> regions = []
+
+  @ToString
+  static class AsgDescription {
+    String region
+    String asgName
+  }
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/DestroyAsgAtomicOperation.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/DestroyAsgAtomicOperation.groovy
@@ -24,6 +24,7 @@ import com.amazonaws.services.autoscaling.model.DeleteLaunchConfigurationRequest
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest
 import com.netflix.amazoncomponents.security.AmazonClientProvider
+import com.netflix.spinnaker.amos.aws.NetflixAmazonCredentials
 import com.netflix.spinnaker.kato.aws.deploy.description.DestroyAsgDescription
 import com.netflix.spinnaker.kato.data.task.Task
 import com.netflix.spinnaker.kato.data.task.TaskRepository
@@ -49,47 +50,56 @@ class DestroyAsgAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    task.updateStatus BASE_PHASE, "Initializing ASG Destroy Operation..."
+    String descriptor = description.asgName ?: description.asgs.collect { it.toString() }
+    task.updateStatus BASE_PHASE, "Initializing ASG Destroy operation for $descriptor..."
     for (region in description.regions) {
-      def autoScaling = amazonClientProvider.getAutoScaling(description.credentials, region, true)
-      task.updateStatus BASE_PHASE, "Looking up instance ids for $description.asgName in $region..."
-
-      def result = autoScaling.describeAutoScalingGroups(
-              new DescribeAutoScalingGroupsRequest(autoScalingGroupNames: [description.asgName]))
-      if (!result.autoScalingGroups) {
-        return null // Okay, there is no auto scaling group. Let's be idempotent and not complain about that.
-      }
-      if (result.autoScalingGroups.size() > 1) {
-        throw new IllegalStateException(
-                "There should only be one ASG in ${description.credentials}:${region} named ${description.asgName}")
-      }
-      AutoScalingGroup autoScalingGroup = result.autoScalingGroups[0]
-      List<String> instanceIds = autoScalingGroup.instances.instanceId
-
-      task.updateStatus BASE_PHASE, "Force deleting $description.asgName in $region."
-      autoScaling.deleteAutoScalingGroup(new DeleteAutoScalingGroupRequest(
-              autoScalingGroupName: description.asgName, forceDelete: true))
-
-      if (autoScalingGroup.launchConfigurationName) {
-        task.updateStatus BASE_PHASE, "Deleting launch config ${autoScalingGroup.launchConfigurationName} in $region."
-        autoScaling.deleteLaunchConfiguration(new DeleteLaunchConfigurationRequest(
-            launchConfigurationName: autoScalingGroup.launchConfigurationName))
-      }
-      def ec2 = amazonClientProvider.getAmazonEC2(description.credentials, region, true)
-
-      for (int i = 0; i < instanceIds.size(); i += MAX_SIMULTANEOUS_TERMINATIONS) {
-        int end = Math.min(instanceIds.size(), i + MAX_SIMULTANEOUS_TERMINATIONS)
-        try {
-          task.updateStatus BASE_PHASE, "Issuing terminate instances request for ${end - i} instances."
-          ec2.terminateInstances(new TerminateInstancesRequest().withInstanceIds(instanceIds.subList(i, end)))
-        } catch (AmazonClientException e) {
-          task.updateStatus BASE_PHASE, "Unable to terminate instances, reason: '${e.message}'"
-        }
-      }
+      deleteAsg(description.asgName, region)
+    }
+    for (asg in description.asgs) {
+      deleteAsg(asg.asgName, asg.region)
     }
 
-    task.updateStatus BASE_PHASE, "Done destroying $description.asgName in $description.regions."
+    task.updateStatus BASE_PHASE, "Finished Destroy ASG operation for $descriptor."
     null
+  }
+
+  private void deleteAsg(String asgName, String region) {
+    def credentials = description.credentials
+    def autoScaling = amazonClientProvider.getAutoScaling(credentials, region, true)
+    task.updateStatus BASE_PHASE, "Looking up instance ids for $asgName in $region..."
+
+    def result = autoScaling.describeAutoScalingGroups(
+        new DescribeAutoScalingGroupsRequest(autoScalingGroupNames: [asgName]))
+    if (!result.autoScalingGroups) {
+      return // Okay, there is no auto scaling group. Let's be idempotent and not complain about that.
+    }
+    if (result.autoScalingGroups.size() > 1) {
+      throw new IllegalStateException(
+          "There should only be one ASG in ${credentials}:${region} named ${asgName}")
+    }
+    AutoScalingGroup autoScalingGroup = result.autoScalingGroups[0]
+    List<String> instanceIds = autoScalingGroup.instances.instanceId
+
+    task.updateStatus BASE_PHASE, "Force deleting $asgName in $region."
+    autoScaling.deleteAutoScalingGroup(new DeleteAutoScalingGroupRequest(
+        autoScalingGroupName: asgName, forceDelete: true))
+
+    if (autoScalingGroup.launchConfigurationName) {
+      task.updateStatus BASE_PHASE, "Deleting launch config ${autoScalingGroup.launchConfigurationName} in $region."
+      autoScaling.deleteLaunchConfiguration(new DeleteLaunchConfigurationRequest(
+          launchConfigurationName: autoScalingGroup.launchConfigurationName))
+    }
+    def ec2 = amazonClientProvider.getAmazonEC2(credentials, region, true)
+
+    for (int i = 0; i < instanceIds.size(); i += MAX_SIMULTANEOUS_TERMINATIONS) {
+      int end = Math.min(instanceIds.size(), i + MAX_SIMULTANEOUS_TERMINATIONS)
+      try {
+        task.updateStatus BASE_PHASE, "Issuing terminate instances request for ${end - i} instances."
+        ec2.terminateInstances(new TerminateInstancesRequest().withInstanceIds(instanceIds.subList(i, end)))
+      } catch (AmazonClientException e) {
+        task.updateStatus BASE_PHASE, "Unable to terminate instances, reason: '${e.message}'"
+      }
+    }
   }
 
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/SuspendAsgProcessesAtomicOperation.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/SuspendAsgProcessesAtomicOperation.groovy
@@ -41,25 +41,34 @@ class SuspendAsgProcessesAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    task.updateStatus BASE_PHASE, "Initializing Suspend ASG Processes operation for '$description.asgName'..."
-    def processTypes = description.processes.collect { AutoScalingProcessType.parse(it) }
+    String descriptor = description.asgName ?: description.asgs.collect { it.toString() }
+    task.updateStatus BASE_PHASE, "Initializing Suspend ASG Processes operation for $descriptor..."
     for (region in description.regions) {
-      try {
-        def regionScopedProvider = regionScopedProviderFactory.forRegion(description.credentials, region)
-        def asgService = regionScopedProvider.asgService
-        def asg = asgService.getAutoScalingGroup(description.asgName)
-        if (!asg) {
-          task.updateStatus BASE_PHASE, "No ASG named '$description.asgName' found in $region."
-          continue
-        }
-        task.updateStatus BASE_PHASE, "Suspending ASG processes (${processTypes*.name().join(", ")}) for '$description.asgName' in $region..."
-        asgService.suspendProcesses(description.asgName, processTypes)
-      } catch (e) {
-        task.updateStatus BASE_PHASE, "Could not suspend processes for ASG '$description.asgName' in region $region! Reason: $e.message"
-      }
+      suspendProcesses(description.asgName, region)
     }
-    task.updateStatus BASE_PHASE, "Done suspending ASG processes for '$description.asgName'."
+    for (asg in description.asgs) {
+      suspendProcesses(asg.asgName, asg.region)
+    }
+    task.updateStatus BASE_PHASE, "Finished Suspend ASG Processes operation for $descriptor."
     null
+  }
+
+  private void suspendProcesses(String asgName, String region) {
+    try {
+      def processTypes = description.processes.collect { AutoScalingProcessType.parse(it) }
+      def regionScopedProvider = regionScopedProviderFactory.forRegion(description.credentials, region)
+      def asgService = regionScopedProvider.asgService
+      def asg = asgService.getAutoScalingGroup(asgName)
+      if (!asg) {
+        task.updateStatus BASE_PHASE, "No ASG named '$asgName' found in $region."
+        return
+      }
+      task.updateStatus BASE_PHASE, "Suspending ASG processes (${processTypes*.name().join(", ")}) for $asgName in $region..."
+      asgService.suspendProcesses(asgName, processTypes)
+
+    } catch (e) {
+      task.updateStatus BASE_PHASE, "Could not suspend processes for ASG '$asgName' in region $region! Reason: $e.message"
+    }
   }
 
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/AmazonDescriptionValidationSupport.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/AmazonDescriptionValidationSupport.groovy
@@ -27,8 +27,14 @@ public  abstract class AmazonDescriptionValidationSupport<T extends AbstractAmaz
 
 
   void validateAsgNameAndRegions(T description, Errors errors) {
-    validateAsgName description, errors
-    validateRegions description, errors
+    if (!description.asgs) {
+      validateAsgName description, errors
+      validateRegions description, errors
+    } else {
+      if (!description.asgs.size()) {
+        errors.rejectValue("asgs", "${description.getClass().simpleName}.empty")
+      }
+    }
 
   }
 

--- a/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/ResumeAsgProcessesAtomicOperationSpec.groovy
+++ b/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/ResumeAsgProcessesAtomicOperationSpec.groovy
@@ -56,10 +56,10 @@ class ResumeAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Resume ASG Processes operation for 'asg1'...",
-      "Resuming ASG processes (Launch, Terminate) for 'asg1' in us-west-1...",
-      "Resuming ASG processes (Launch, Terminate) for 'asg1' in us-east-1...",
-      "Done resuming ASG processes for 'asg1'."
+      "Initializing Resume ASG Processes operation for asg1...",
+      "Resuming ASG processes (Launch, Terminate) for asg1 in us-west-1...",
+      "Resuming ASG processes (Launch, Terminate) for asg1 in us-east-1...",
+      "Finished Resume ASG Processes operation for asg1."
     ]
     0 * mockAsgService._
   }
@@ -79,10 +79,10 @@ class ResumeAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Resume ASG Processes operation for 'asg1'...",
+      "Initializing Resume ASG Processes operation for asg1...",
       "No ASG named 'asg1' found in us-west-1.",
-      "Resuming ASG processes (Launch, Terminate) for 'asg1' in us-east-1...",
-      "Done resuming ASG processes for 'asg1'."
+      "Resuming ASG processes (Launch, Terminate) for asg1 in us-east-1...",
+      "Finished Resume ASG Processes operation for asg1."
     ]
     0 * mockAsgService._
   }
@@ -105,11 +105,11 @@ class ResumeAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Resume ASG Processes operation for 'asg1'...",
-      "Resuming ASG processes (Launch, Terminate) for 'asg1' in us-west-1...",
+      "Initializing Resume ASG Processes operation for asg1...",
+      "Resuming ASG processes (Launch, Terminate) for asg1 in us-west-1...",
       "Could not resume processes for ASG 'asg1' in region us-west-1! Reason: Uh oh!",
-      "Resuming ASG processes (Launch, Terminate) for 'asg1' in us-east-1...",
-      "Done resuming ASG processes for 'asg1'."
+      "Resuming ASG processes (Launch, Terminate) for asg1 in us-east-1...",
+      "Finished Resume ASG Processes operation for asg1."
     ]
     0 * mockAsgService._
   }

--- a/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/SuspendAsgProcessesAtomicOperationSpec.groovy
+++ b/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/SuspendAsgProcessesAtomicOperationSpec.groovy
@@ -55,10 +55,10 @@ class SuspendAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Suspend ASG Processes operation for 'asg1'...",
-      "Suspending ASG processes (Launch, Terminate) for 'asg1' in us-west-1...",
-      "Suspending ASG processes (Launch, Terminate) for 'asg1' in us-east-1...",
-      "Done suspending ASG processes for 'asg1'."
+      "Initializing Suspend ASG Processes operation for asg1...",
+      "Suspending ASG processes (Launch, Terminate) for asg1 in us-west-1...",
+      "Suspending ASG processes (Launch, Terminate) for asg1 in us-east-1...",
+      "Finished Suspend ASG Processes operation for asg1."
     ]
     0 * mockAsgService._
   }
@@ -78,10 +78,10 @@ class SuspendAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Suspend ASG Processes operation for 'asg1'...",
+      "Initializing Suspend ASG Processes operation for asg1...",
       "No ASG named 'asg1' found in us-west-1.",
-      "Suspending ASG processes (Launch, Terminate) for 'asg1' in us-east-1...",
-      "Done suspending ASG processes for 'asg1'."
+      "Suspending ASG processes (Launch, Terminate) for asg1 in us-east-1...",
+      "Finished Suspend ASG Processes operation for asg1."
     ]
     0 * mockAsgService._
   }
@@ -104,11 +104,11 @@ class SuspendAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Suspend ASG Processes operation for 'asg1'...",
-      "Suspending ASG processes (Launch, Terminate) for 'asg1' in us-west-1...",
+      "Initializing Suspend ASG Processes operation for asg1...",
+      "Suspending ASG processes (Launch, Terminate) for asg1 in us-west-1...",
       "Could not suspend processes for ASG 'asg1' in region us-west-1! Reason: Uh oh!",
-      "Suspending ASG processes (Launch, Terminate) for 'asg1' in us-east-1...",
-      "Done suspending ASG processes for 'asg1'."
+      "Suspending ASG processes (Launch, Terminate) for asg1 in us-east-1...",
+      "Finished Suspend ASG Processes operation for asg1."
     ]
     0 * mockAsgService._
   }


### PR DESCRIPTION
It's pretty rare that you're going to have two ASGs with the same name in different regions and want to operate on them at the same time.

These changes provide a backwards-compatible way to handle this. Instead of providing a structure such as

``` javascript
{ "asgName":"foo-v001", "regions":["us-east-1","us-west-1"] }
```

we can specify a list of ASGs

``` javascript
{ "asgs": [ 
  { "region": "us-east-1", "asgName": "foo-v001" },
  { "region": "us-west-1", "asgName": "foo-v003" }
]}
```

Also normalizing the task logging messages a bit.
