### PR TITLE
Avoid setting all instances to OUT_OF_SERVICE if there are no instanc…

### DIFF
--- a/kato/kato-aws/kato-aws.gradle
+++ b/kato/kato-aws/kato-aws.gradle
@@ -17,6 +17,7 @@
 dependencies {
   compile project(":clouddriver-aws")
   compile project(":kato:kato-core")
+  compile project(":oort:oort-core")
   compile spinnaker.dependency('frigga')
   compile spinnaker.dependency('rxJava')
   compile spinnaker.dependency('bootActuator')


### PR DESCRIPTION
…es UP in discovery
- Optimization based on the fact that discovery will automatically set all instances to OUT_OF_SERVICE if the ASG has AddToLoadBalancer disabled
- If any instances have been explicitly set UP (ie. overridden), discovery will never mark them OUT_OF_SERVICE automatically

@dzapata I'd like to try this out on your push tomorrow, in theory it should make things faster.
