### PR TITLE
dedupe instance types in AWS

### DIFF
--- a/mort/mort-aws/src/main/groovy/com/netflix/spinnaker/mort/aws/cache/Keys.groovy
+++ b/mort/mort-aws/src/main/groovy/com/netflix/spinnaker/mort/aws/cache/Keys.groovy
@@ -84,8 +84,8 @@ class Keys {
       "${Namespace.KEY_PAIRS}:${keyName}:${account}:${region}"
   }
 
-  static String getInstanceTypeKey(String instanceOfferingId, String region, String account) {
-      "${Namespace.INSTANCE_TYPES}:${instanceOfferingId}:${account}:${region}"
+  static String getInstanceTypeKey(String instanceType, String region, String account) {
+      "${Namespace.INSTANCE_TYPES}:${instanceType}:${account}:${region}"
   }
 
   static String getElasticIpKey(String ipAddress, String region, String account) {

--- a/mort/mort-aws/src/main/groovy/com/netflix/spinnaker/mort/aws/model/AmazonInstanceType.groovy
+++ b/mort/mort-aws/src/main/groovy/com/netflix/spinnaker/mort/aws/model/AmazonInstanceType.groovy
@@ -26,7 +26,4 @@ class AmazonInstanceType implements InstanceType {
     String account
     String region
     String name
-    String availabilityZone
-    String productDescription
-    Long durationSeconds
 }

--- a/mort/mort-aws/src/test/groovy/com/netflix/spinnaker/mort/aws/provider/view/AmazonInstanceTypeProviderSpec.groovy
+++ b/mort/mort-aws/src/test/groovy/com/netflix/spinnaker/mort/aws/provider/view/AmazonInstanceTypeProviderSpec.groovy
@@ -42,46 +42,35 @@ class AmazonInstanceTypeProviderSpec extends Specification {
         account: 'test',
         region: 'us-east-1',
         name: 'm1.large',
-        availabilityZone: 'us-east-1a',
-        productDescription: 'sweet instance',
-        durationSeconds: 9001
       ),
       new AmazonInstanceType(
         account: 'prod',
         region: 'us-west-1',
         name: 'm1.medium',
-        availabilityZone: 'us-west-1b',
-        productDescription: 'sweet instance',
-        durationSeconds: 9001
       )
     ] as Set
 
     and:
     1 * cache.getAll(Keys.Namespace.INSTANCE_TYPES.ns, _ as CacheFilter) >> [
-      itData('1', [
+      itData('m1.large', [
         account         : 'test',
         region          : 'us-east-1',
-        name            : 'm1.large',
-        availabilityZone: 'us-east-1a']),
-      itData('2', [
+        name            : 'm1.large']),
+      itData('m1.medium', [
         account         : 'prod',
         region          : 'us-west-1',
-        name            : 'm1.medium',
-        availabilityZone: 'us-west-1b'])
+        name            : 'm1.medium']),
     ]
   }
 
-  private CacheData itData(String offeringId, Map params) {
+  private CacheData itData(String instanceType, Map params) {
     def defaults = [
       account           : 'prod',
       region            : 'us-east-1',
       name              : 'm1.xlarge',
-      availabilityZone  : 'us-east-1a',
-      productDescription: 'sweet instance',
-      durationSeconds   : 9001
     ]
 
     def attributes = defaults + params
-    new DefaultCacheData(Keys.getInstanceTypeKey(offeringId, attributes.region, attributes.account), attributes, [:])
+    new DefaultCacheData(Keys.getInstanceTypeKey(instanceType, attributes.region, attributes.account), attributes, [:])
   }
 }


### PR DESCRIPTION
the data source we use to cache instance types in amamzon generates a ton of duplicates that we filter later on. we really care about what the set of types available in an account/region
