### PR TITLE
allow load balancer name specification when modify instance load bala…

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/InstanceLoadBalancerRegistrationDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/InstanceLoadBalancerRegistrationDescription.groovy
@@ -18,5 +18,6 @@
 package com.netflix.spinnaker.kato.aws.deploy.description
 
 class InstanceLoadBalancerRegistrationDescription extends AbstractRegionAsgInstanceIdsDescription {
+  List<String> loadBalancerNames
 }
 

--- a/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/InstanceLoadBalancerRegistrationUnitSpecSupport.groovy
+++ b/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/InstanceLoadBalancerRegistrationUnitSpecSupport.groovy
@@ -58,7 +58,7 @@ class InstanceLoadBalancerRegistrationUnitSpecSupport extends Specification {
     op.regionScopedProviderFactory = rspf
 
     def provider = Mock(AmazonClientProvider) {
-      1 * getAmazonElasticLoadBalancing(_, _, true) >> loadBalancing
+      getAmazonElasticLoadBalancing(_, _, true) >> loadBalancing
     }
     op.amazonClientProvider = provider
   }

--- a/kato/kato-manual/src/asciidoc/ops/deregisterInstancesFromLoadBalancerDescription.adoc
+++ b/kato/kato-manual/src/asciidoc/ops/deregisterInstancesFromLoadBalancerDescription.adoc
@@ -6,11 +6,13 @@
 
 ====== Description
 
-This description provides the inputs necessary to deregister the specified instances from all load balancers associated with the specified auto scaling group.
+This description provides the inputs necessary to deregister the specified instances from load balancers.
 
-NOTE: If no auto scaling group is specified, the ASG associated with each instance will be used.
+NOTE: If an auto scaling group _is_ specified, instances will be deregistered from all load balancers associated with that auto scaling group. +
+If an auto scaling group _is not_ specified and a list of load balancers _is_ specified, instances will be deregistered from those load balancers.
 
-====== Example Request Body
+
+====== Example Request Body (specifying all load balancers in an ASG)
 [source,javascript]
 ----
 [{
@@ -23,12 +25,26 @@ NOTE: If no auto scaling group is specified, the ASG associated with each instan
 }]
 ----
 
+====== Example Request Body (specifying selected load balancers)
+[source,javascript]
+----
+[{
+    "deregisterInstancesFromLoadBalancerDescription": {
+        "loadBalancerNames": ["kato--frontend", "kato-api-frontend"],
+        "instanceIds": ["i-123456", "i-234567"],
+        "region": "us-west-1",
+        "credentials": "test"
+    }
+}]
+----
+
 ====== Description of inputs
 
 [width="100%",frame="topbot",options="header,footer"]
 |======================
 |Key               | Type   | Required | Value
-|asgName           | string | false    | The name of the asg in which the instances reside.
+|asgName           | string | false    | The name of the asg in which the instances reside. If not specified, "loadBalancerNames" will be used to determine load balancers to target.
+|loadBalancerNames | array  | false    | The load balancers from which the instances will be deregistered. If not specified, all load balancers associated with the ASG specified in "asgName" will be used.
 |instanceIds       | array  | true     | The ids of the instances that are to be deregistered as part of this operation.
 |region            | string | true     | The region in which the instances live.
 |credentials       | string | true     | The named account credentials that are to be used for this operation.

--- a/kato/kato-manual/src/asciidoc/ops/registerInstancesWithLoadBalancerDescription.adoc
+++ b/kato/kato-manual/src/asciidoc/ops/registerInstancesWithLoadBalancerDescription.adoc
@@ -6,11 +6,13 @@
 
 ====== Description
 
-This description provides the inputs necessary to register the specified instances with all load balancers associated with the specified auto scaling group.
+This description provides the inputs necessary to register the specified instances with all load balancers.
 
-NOTE: If no auto scaling group is specified, the ASG associated with each instance will be used.
+NOTE: If an auto scaling group _is_ specified, instances will be registered with all load balancers associated with that auto scaling group. +
+If an auto scaling group _is not_ specified and a list of load balancers _is_ specified, instances will be registered with those load balancers.
 
-====== Example Request Body
+
+====== Example Request Body (specifying all load balancers in an ASG)
 [source,javascript]
 ----
 [{
@@ -23,12 +25,26 @@ NOTE: If no auto scaling group is specified, the ASG associated with each instan
 }]
 ----
 
+====== Example Request Body (specifying selected load balancers)
+[source,javascript]
+----
+[{
+    "registerInstancesWithLoadBalancerDescription": {
+        "loadBalancerNames": ["kato--frontend"],
+        "instanceIds": ["i-123456", "i-234567"],
+        "region": "us-west-1",
+        "credentials": "test"
+    }
+}]
+----
+
 ====== Description of inputs
 
 [width="100%",frame="topbot",options="header,footer"]
 |======================
 |Key               | Type   | Required | Value
-|asgName           | string | false    | The name of the asg in which the instances reside.
+|asgName           | string | false    | The name of the asg in which the instances reside. If not specified, "loadBalancerNames" will be used to determine load balancers to target.
+|loadBalancerNames | array  | false    | The load balancers with which the instances will be registered. If not specified, all load balancers associated with the ASG specified in "asgName" will be used.
 |instanceIds       | array  | true     | The ids of the instances that are to be registered as part of this operation.
 |region            | string | true     | The region in which the instances live.
 |credentials       | string | true     | The named account credentials that are to be used for this operation.


### PR DESCRIPTION
…ncer registration

Not sure how folks feel about the API proposed here. All current calls will work without modification, but end users can specify a list of `loadBalancerNames` _instead of_ an `asgName` to remove instances from specific load balancers. If both fields are provided, `asgName` is used.
