### PR TITLE
Speed up security group reads.

### DIFF
--- a/mort/mort-aws/src/test/groovy/com/netflix/spinnaker/mort/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
+++ b/mort/mort-aws/src/test/groovy/com/netflix/spinnaker/mort/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.mort.aws.provider.view
 
-import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult
 import com.amazonaws.services.ec2.model.IpPermission
 import com.amazonaws.services.ec2.model.SecurityGroup
 import com.amazonaws.services.ec2.model.UserIdGroupPair
@@ -50,7 +49,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
 
   void "getAll lists all"() {
     when:
-    def result = provider.getAll()
+    def result = provider.getAll(false)
 
     then:
     result.size() == 8
@@ -58,7 +57,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
 
   void "getAllByRegion lists only those in supplied region"() {
     when:
-    def result = provider.getAllByRegion(region)
+    def result = provider.getAllByRegion(false, region)
 
     then:
     result.size() == 4
@@ -72,7 +71,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
 
   void "getAllByAccount lists only those in supplied account"() {
     when:
-    def result = provider.getAllByAccount(account)
+    def result = provider.getAllByAccount(false, account)
 
     then:
     result.size() == 4
@@ -86,7 +85,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
 
   void "getAllByAccountAndRegion lists only those in supplied account and region"() {
     when:
-    def result = provider.getAllByAccountAndRegion(account, region)
+    def result = provider.getAllByAccountAndRegion(false, account, region)
 
     then:
     result.size() == 2
@@ -102,7 +101,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
 
   void "getAllByAccountAndName lists only those in supplied account with supplied name"() {
     when:
-    def result = provider.getAllByAccountAndName(account, name)
+    def result = provider.getAllByAccountAndName(false, account, name)
 
     then:
     result.size() == 2

--- a/mort/mort-core/src/main/groovy/com/netflix/spinnaker/mort/model/NoopSecurityGroupProvider.groovy
+++ b/mort/mort-core/src/main/groovy/com/netflix/spinnaker/mort/model/NoopSecurityGroupProvider.groovy
@@ -23,32 +23,32 @@ class NoopSecurityGroupProvider implements SecurityGroupProvider {
     }
 
     @Override
-    Set<SecurityGroup> getAll() {
+    Set<SecurityGroup> getAll(boolean includeRules) {
         Collections.emptySet()
     }
 
     @Override
-    Set<SecurityGroup> getAllByRegion(String region) {
+    Set<SecurityGroup> getAllByRegion(boolean includeRules, String region) {
         Collections.emptySet()
     }
 
     @Override
-    Set<SecurityGroup> getAllByAccount(String account) {
+    Set<SecurityGroup> getAllByAccount(boolean includeRules, String account) {
         Collections.emptySet()
     }
 
     @Override
-    Set<SecurityGroup> getAllByAccountAndName(String account, String name) {
+    Set<SecurityGroup> getAllByAccountAndName(boolean includeRules, String account, String name) {
         Collections.emptySet()
     }
 
     @Override
-    Set<SecurityGroup> getAllByAccountAndRegion(String account, String region) {
+    Set<SecurityGroup> getAllByAccountAndRegion(boolean includeRules, String account, String region) {
         Collections.emptySet()
     }
 
     @Override
     SecurityGroup get(String account, String region, String name, String vpcId) {
-        Collections.emptySet()
+        null
     }
 }

--- a/mort/mort-core/src/main/groovy/com/netflix/spinnaker/mort/model/SecurityGroupProvider.groovy
+++ b/mort/mort-core/src/main/groovy/com/netflix/spinnaker/mort/model/SecurityGroupProvider.groovy
@@ -20,15 +20,15 @@ interface SecurityGroupProvider<T extends SecurityGroup> {
 
   String getType()
 
-  Set<T> getAll()
+  Set<T> getAll(boolean includeRules)
 
-  Set<T> getAllByRegion(String region)
+  Set<T> getAllByRegion(boolean includeRules, String region)
 
-  Set<T> getAllByAccount(String account)
+  Set<T> getAllByAccount(boolean includeRules, String account)
 
-  Set<T> getAllByAccountAndName(String account, String name)
+  Set<T> getAllByAccountAndName(boolean includeRules, String account, String name)
 
-  Set<T> getAllByAccountAndRegion(String account, String region)
+  Set<T> getAllByAccountAndRegion(boolean includeRule, String account, String region)
 
   T get(String account, String region, String name, String vpcId)
 


### PR DESCRIPTION
- Use getAll in SecurityGroupProvider instead of loading security groups by account (fewer read roundtrips)
- Add an includeRules flag in SecurityGroupProvider - for most list cases we are only rendering summary info so it saves a bunch of expensive transformations (arguably those transforms could be done while caching...)

@anotherchrisberry or @claymccoy mind taking a gander at this?
