### PR TITLE
fix for cache items not showing up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     maven { url "http://dl.bintray.com/spinnaker/gradle" }
   }
   dependencies {
-    classpath 'com.netflix.spinnaker:spinnaker-gradle-project:1.12.105'
+    classpath 'com.netflix.spinnaker:spinnaker-gradle-project:1.12.106'
     classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
   }
 }


### PR DESCRIPTION
previous rev of amazoncomponents was not picking up last-modified headers so the ON_DEMAND items would never get replaced until they TTL'd
on_demand TTL was set to 60 minutes (not set to 10 minutes)
now explicitly checks whether an account is eddaEnabled and if so, expects/warns lastModified if so, uses current time if not

cc: @duftler @ttomsu this _should_ address the delays you are seeing as well as fix our issues that were caused by losing edda response headers
