### PR TITLE
performance improvements around OnDemand handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     maven { url "http://dl.bintray.com/spinnaker/gradle" }
   }
   dependencies {
-    classpath 'com.netflix.spinnaker:spinnaker-gradle-project:1.12.106'
+    classpath 'com.netflix.spinnaker:spinnaker-gradle-project:1.12.107'
     classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
   }
 }

--- a/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/agent/ClusterCachingAgent.groovy
@@ -186,12 +186,6 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent {
     )
     providerCache.putCacheData(ON_DEMAND.ns, cacheData)
 
-    cacheResult.cacheResults.values().each { Collection<CacheData> cacheDatas ->
-      cacheDatas.each {
-        ((MutableCacheData) it).ttlSeconds = 60
-      }
-    }
-
     Map<String, Collection<String>> evictions = asgs ? [:] : [
       (SERVER_GROUPS.ns): [
         Keys.getServerGroupKey(asgName, account.name, region)

--- a/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/agent/LoadBalancerCachingAgent.groovy
+++ b/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/agent/LoadBalancerCachingAgent.groovy
@@ -152,12 +152,6 @@ class LoadBalancerCachingAgent  implements CachingAgent, OnDemandAgent {
     )
     providerCache.putCacheData(ON_DEMAND.ns, cacheData)
 
-    cacheResult.cacheResults.values().each { Collection<CacheData> cacheDatas ->
-      cacheDatas.each {
-        ((MutableCacheData) it).ttlSeconds = 60
-      }
-    }
-
     Map<String, Collection<String>> evictions = loadBalancers ? [:] : [
       (LOAD_BALANCERS.ns): [
         Keys.getLoadBalancerKey(data.loadBalancerName as String, account.name, region, data.vpcId as String)


### PR DESCRIPTION
no longer TTLing the on demand cached items
picks up newer cats that pipelines merge
