### PR TITLE
Detached instances will now be tagged (spinnaker:Detached + spinnaker…

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/DetachInstancesDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/DetachInstancesDescription.groovy
@@ -23,5 +23,6 @@ class DetachInstancesDescription extends AbstractAmazonCredentialsDescription {
   List<String> instanceIds
   boolean decrementDesiredCapacity
   boolean terminateDetachedInstances
+  boolean adjustMinIfNecessary
 }
 

--- a/kato/kato-manual/src/asciidoc/ops/detachInstancesDescription.adoc
+++ b/kato/kato-manual/src/asciidoc/ops/detachInstancesDescription.adoc
@@ -31,5 +31,6 @@ This description detaches (and optionally terminates) selected instances from an
 |region                     | string  | true     | The region that the asg/regions exist in.
 |terminateDetachedInstances | boolean | false    | Should the detached instances should be terminated.
 |decrementDesiredCapacity   | boolean | false    | Should the desired ASG capacity be decremented by # of instances detached.
+|adjustMinIfNecessary       | boolean | false    | Should the minimum size of the ASG be adjusted to reflect # of instances detached.
 |credentials                | string  | true     | The named account credentials that are to be used for this operation.
 |======================


### PR DESCRIPTION
…:PendingTermination)
- Subsequent PR will introduce a poller that will pickup any instances that failed to terminate
- Support for adjusting ASG minSize (required if enough instances are detached that desired capacity would drop below min)
