### PR TITLE
First cut at Cloud Foundry OORT module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TestScript.groovy
 .idea/
 application.yml
 *.hprof
+README.html

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@
 
 Netflix, Inc  <*@netflix.com>
 Google, Inc <*@google.com>
+Pivotal, Inc <*@pivotal.io>

--- a/clouddriver-cf/README.adoc
+++ b/clouddriver-cf/README.adoc
@@ -1,0 +1,59 @@
+== Cloud Foundry on clouddriver
+
+=== Developing clouddriver-cf
+
+Need to run clouddriver locally for development? Here's what you need to setup and run:
+
+. git clone git@github.com:spinnaker/clouddriver.git
+. mkdir ~/.spinnaker
+. cd ~/.spinnaker
+. ln -s /path/to/clouddriver/clouddriver-web/config/clouddriver.yml
+. cd /path/to/clouddriver
+. CF_ENABLED=true CF_ACCOUNT_NAME=<your_cf_username> CF_PASSWORD=<your_cf_password> CF_API=<your_cf_api_endpoint> ./gradlew bootRun
+. curl -v localhost:7002/applications
+
+You can also run the `Main` in clouddriver-web with the same environment settings shown above. Then poke at localhost:7002/applications in your browser.
+
+NOTE: Get the https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc?hl=en[Chrome] or https://addons.mozilla.org/en-us/firefox/addon/jsonview/[Firefox] plugin to make JSON data easy to view.
+
+With this setup, you can also switch to running it in debug mode inside your IDE to test out various bits.
+
+=== Running CloudDriver on a CF setup
+
+CloudDriver isn't built as a Spring Boot uber JAR. Instead, NetFlix bundles it up into a Debian package. Nonetheless, the CloudFoundry Java buildpack can handle this.
+
+. ./gradlew clean buildDeb
+. Log into the CF environment where you want to host Spinnaker services. (NOTE: This is NOT the CF environment you monitor and deploy built artifacts.)
+. cf push clouddriver -p clouddriver-web/build/install/clouddriver/
+
+After this deploys, if it's the first time, will fail on startup. You need to configure some properties:
+
+* CF_ENABLED - true
+* CF_API - API URL for the instance of CF you are targeting
+* CF_ACCOUNT_NAME - your CF username
+* CF_PASSWORD - your CF password
+
+Restart the app and monitor it's logs. After a certain amount of time (1-2 minutes), visit <clouddriver-url>/applications and you should see a detailed listing of all the applications in your CF instance.
+
+=== Serving up CloudDriver through the Gate API
+
+While you don't need to make any edits to NetFlix's gate service, it is needed to serve data to the UI.
+
+. git clone git@github.com:spinnaker/gate.git
+. ./gradlew clean buildDeb
+. Log into the CF environment where you want to host Spinnaker services. (NOTE: This is NOT the CF environment you monitor and deploy built artifacts.)
+. cf push gate -p gate-web/build/install/gate/
+
+=== Viewing application data on the web
+
+To run the frontend UI, follow these steps:
+
+. git clone git@github.com:spinnaker/deck.git
+. cd deck
+. ./gradlew clean build
+. cf push deck -p build/webpack/ -b staticfile_buildpack
+
+This will push the static assets in their built/minimized form. Then set some env variables:
+
+* API_HOST - the URL for Gate app hosted earlier (without the 'http://' prefix)
+* PROTOCOL - *http*

--- a/clouddriver-cf/clouddriver-cf.gradle
+++ b/clouddriver-cf/clouddriver-cf.gradle
@@ -1,0 +1,7 @@
+dependencies {
+  compile project(":clouddriver-core")
+  spinnaker.group('cf')
+  compile spinnaker.dependency('frigga')
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('bootWeb')
+}

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/CloudFoundryCloudProvider.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/CloudFoundryCloudProvider.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cf
+
+import com.netflix.spinnaker.clouddriver.core.CloudProvider
+import org.springframework.stereotype.Component
+
+import java.lang.annotation.Annotation
+
+/**
+ * Cloud Foundry declaration as a {@link CloudProvider}
+ *
+ * @author Greg Turnquist
+ */
+@Component
+class CloudFoundryCloudProvider implements CloudProvider {
+	final String id = "cf"
+	final String displayName = "Cloud Foundry"
+	final Class<Annotation> operationAnnotationType = CloudFoundryOperation.class
+}

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/CloudFoundryOperation.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/CloudFoundryOperation.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cf
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * {@code CloudFoundryOperation}s specify implementation classes of Spinnaker AtomicOperations for Cloud Foundry
+ * operations.
+ *
+ * @author Greg Turnquist
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@interface CloudFoundryOperation {
+	String value()
+}

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/config/CloudFoundryConfig.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/config/CloudFoundryConfig.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cf.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+/**
+ * Configuration for Cloud Foundry provider.
+ *
+ * @author Greg Turnquist
+ */
+@Configuration
+@EnableConfigurationProperties
+@EnableScheduling
+@ConditionalOnProperty('cf.enabled')
+@ComponentScan(["com.netflix.spinnaker.clouddriver.cf"])
+class CloudFoundryConfig {
+
+	@Bean
+	@ConfigurationProperties("cf")
+	CloudFoundryConfigurationProperties cloudFoundryConfigurationProperties() {
+		new CloudFoundryConfigurationProperties()
+	}
+
+}

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/config/CloudFoundryConfigurationProperties.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/config/CloudFoundryConfigurationProperties.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cf.config
+
+/**
+ * @author Greg Turnquist
+ */
+class CloudFoundryConfigurationProperties {
+
+
+  public static final int POLLING_INTERVAL_SECONDS_DEFAULT = 600
+
+  String api
+  int pollingIntervalSeconds = POLLING_INTERVAL_SECONDS_DEFAULT
+
+}

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -168,8 +168,11 @@ titan:
   enabled: ${TITAN_ENABLED:false}
 
 cf:
-  enabled: ${CF_ENABLED:false}
-
+  enabled: false
+  accounts:
+    -
+      name: ${CF_ACCOUNT_NAME}
+      password: ${CF_PASSWORD}
 
 ---
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2014-2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
 import com.netflix.spinnaker.clouddriver.titan.TitanConfiguration
+import com.netflix.spinnaker.clouddriver.cf.config.CloudFoundryConfig
 import com.netflix.spinnaker.clouddriver.config.RetrofitConfig
 import com.netflix.spinnaker.clouddriver.core.CloudDriverConfig
 import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
@@ -43,6 +44,7 @@ import java.security.Security
   AwsConfiguration,
   TitanConfiguration,
   GoogleConfiguration,
+  CloudFoundryConfig,
   com.netflix.spinnaker.kato.Main,
   com.netflix.spinnaker.mort.Main,
   com.netflix.spinnaker.oort.Main
@@ -86,7 +88,6 @@ class Main extends SpringBootServletInitializer {
   SpringApplicationBuilder configure(SpringApplicationBuilder application) {
     application.sources Main
   }
-
 
 }
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.web.filter.ShallowEtagHeaderFilter
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
@@ -67,4 +68,11 @@ public class WebConfig extends WebMvcConfigurerAdapter {
   Filter corsFilter() {
     new SimpleCORSFilter()
   }
+
+  @Override
+  void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+    super.configureContentNegotiation(configurer)
+    configurer.favorPathExtension(false);
+  }
+
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.groovy
@@ -45,7 +45,7 @@ class CredentialsController {
     }
   }
 
-  @RequestMapping(value = "/{name}", method = RequestMethod.GET)
+  @RequestMapping(value = "/{name:.+}", method = RequestMethod.GET)
   AccountCredentials getAccount(@PathVariable("name") String name) {
     accountCredentialsProvider.getCredentials name
   }

--- a/kato/kato-cf/kato-cf.gradle
+++ b/kato/kato-cf/kato-cf.gradle
@@ -1,13 +1,7 @@
 dependencies {
-    def cloudFoundryClientVersion = '1.1.0'
+  def cloudFoundryClientVersion = '1.1.3'
 
-    compile project(":kato:kato-core")
-    compile spinnaker.dependency('bootActuator')
-    compile ("org.cloudfoundry:cloudfoundry-client-lib:${cloudFoundryClientVersion}")
-    compile ("org.cloudfoundry:cf-gradle-plugin:${cloudFoundryClientVersion}") {
-      exclude module: 'groovy'
-    }
-    compile ("org.cloudfoundry:cf-maven-plugin:${cloudFoundryClientVersion}") {
-      exclude module: 'slf4j-jdk14'
-    }
+  compile project(":kato:kato-core")
+  compile spinnaker.dependency('bootActuator')
+  compile("org.cloudfoundry:cloudfoundry-client-lib:${cloudFoundryClientVersion}")
 }

--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/config/KatoCloudFoundryConfig.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/config/KatoCloudFoundryConfig.groovy
@@ -46,7 +46,7 @@ class KatoCloudFoundryConfig {
   // TODO Add other critical beans needed at the top (cloudfoundry beans?)
 
   @Bean
-  CloudFoundryConfigurationProperties cloudFoundryConfigurationProperties() {
+  CloudFoundryConfigurationProperties cfConfigurationProperties() {
     new CloudFoundryConfigurationProperties();
   }
 
@@ -74,14 +74,14 @@ class KatoCloudFoundryConfig {
 
   static class CloudFoundryCredentialsInitializer {
     @Autowired
-    CloudFoundryConfigurationProperties cloudFoundryConfigurationProperties
+    CloudFoundryConfigurationProperties cfConfigurationProperties
 
     @Autowired
     AccountCredentialsRepository accountCredentialsRepository
 
     @PostConstruct
     void init() {
-      cloudFoundryConfigurationProperties?.accounts?.each { account ->
+      cfConfigurationProperties?.accounts?.each { account ->
         accountCredentialsRepository?.save(account.name, account)
       }
     }

--- a/oort/oort-cf/README.adoc
+++ b/oort/oort-cf/README.adoc
@@ -1,0 +1,96 @@
+== Cloud Foundry - OORT Concepts
+
+OORT has a set of interfaces. The idea is to map Cloud Foundry concepts onto this model to get maximum support when plugging into the rest of spinnaker.
+
+.OORT/Cloud Foundry relationships
+[cols="2,2a,5a"]
+|===
+| OORT object | Details | Cloud Foundry object
+
+|`Application`
+|contains:
+
+* 0..N `Cluster`
+
+|Aggregation of all blue/green parts or single part of singular app.
+
+* my-app
+
+|`Cluster`
+|contains: 
+
+* 0..N `ServerGroup`
+* 0..N `LoadBalancer`
+* 1 account name
+
+
+|Sides of a green/blue deployment, or None when not using that.
+
+* my-app/blue
+* my-app/green
+
+or
+
+* my-app
+
+|`ServerGroup`
+|contains:
+
+* 0..N `Instance`
+* 0..N `LoadBalancer`
+* 0..N `SecurityGroup`
+* 1 region
+* 0..N zones
+* 0..N launchConfig
+
+|
+
+* my-app/blue 
+** Region(org): FrameworksAndRuntimes 
+** Zone(space): development
+** LoadBalancers(services): redis-service, mongodb-service
+** launchConfig: CF env variables like SPRING_PROFILES_ACTIVE=production
+
+
+|`LoadBalancer`
+|contains:
+
+* 0..N `ServerGroup`
+
+|Services? CF apps have services, which can bind to multiple apps. Since `LoadBalancer` can map to multiple `ServerGroup`, this would fit the relationship, even if semantically it doesn't sound right. Possible to rebrand in the UI via metadata???
+
+* redis-service => my-app/blue, my-app/green
+
+
+|`Instance`
+|contains:
+
+* 0..N `ServerGroup`
+* 0..1 zone
+
+|Number of scaled instances of an app, whether blue/green/none type.
+
+* my-app/blue #0 FrameworksAndRuntimes
+* my-app/blue #1 FrameworksAndRuntimes
+
+
+|`SecurityGroup`
+|Part of MORT
+|N/A
+
+
+|Region
+|The region in which the instances of this server group are known to exist
+
+* contains 1..N zones
+|Org
+
+* https://console.run.pivotal.io/organizations/47027c3d-5d72-4429-b3ab-0e3936e916f2[FrameworksAndRuntimes] (Spring team demo org)
+
+
+|Zone
+|The zones within a region that the instances within this server group occupy.
+|Space
+
+* https://console.run.pivotal.io/organizations/47027c3d-5d72-4429-b3ab-0e3936e916f2/spaces/3a2dbac3-baa6-474e-8eb9-82f9182d5457[development] (Spring team demo space)
+|===

--- a/oort/oort-cf/oort-cf.gradle
+++ b/oort/oort-cf/oort-cf.gradle
@@ -1,0 +1,10 @@
+dependencies {
+  compile project(":kato:kato-cf")
+  compile project(":oort:oort-core")
+  compile project(":clouddriver-cf")
+
+  spinnaker.group("bootWeb")
+  spinnaker.group("cf")
+
+  compile spinnaker.dependency("frigga")
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplication.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplication.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spinnaker.oort.model.Application
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import org.cloudfoundry.client.lib.domain.CloudApplication
+/**
+ * A Cloud Foundry application with all parts (blue/green/complete).
+ *
+ * @author Greg Turnquist
+ */
+@CompileStatic
+@EqualsAndHashCode(includes = ["name"])
+class CloudFoundryApplication implements Application, Serializable {
+
+	String name
+  Map<String, String> attributes = [:].withDefault {[] as Set<String>}
+
+  CloudApplication nativeApplication
+
+  Map<String, Set<CloudFoundryCluster>> applicationClusters = [:].withDefault {[] as Set<CloudFoundryCluster>}
+
+	@Override
+	Map<String, Set<String>> getClusterNames() {
+		Map<String, Set<String>> clusterNames = [:].withDefault {[] as Set<String>}
+
+    applicationClusters.each { String k, Set<CloudFoundryCluster> v ->
+      clusterNames.get(k).addAll(v.collect {it.name})
+    }
+
+    clusterNames
+	}
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationInstance.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationInstance.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spinnaker.oort.model.HealthState
+import com.netflix.spinnaker.oort.model.Instance
+import org.cloudfoundry.client.lib.domain.CloudApplication
+import org.cloudfoundry.client.lib.domain.InstanceInfo
+
+/**
+ * @author Greg Turnquist
+ */
+class CloudFoundryApplicationInstance implements Instance, Serializable {
+
+  String name
+  HealthState healthState
+  CloudApplication nativeApplication
+  List<Map<String, String>> health = []
+  InstanceInfo nativeInstance
+
+  @Override
+  Long getLaunchTime() {
+    nativeInstance.since.time
+  }
+
+  @Override
+  String getZone() {
+    nativeApplication.space?.organization?.name
+  }
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationInstanceProvider.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationInstanceProvider.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
+import com.netflix.spinnaker.amos.AccountCredentialsProvider
+import com.netflix.spinnaker.kato.cf.security.CloudFoundryAccountCredentials
+import com.netflix.spinnaker.oort.model.InstanceProvider
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
+import java.util.concurrent.Callable
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+@CompileStatic
+class CloudFoundryApplicationInstanceProvider implements InstanceProvider<CloudFoundryApplicationInstance> {
+
+  @Autowired
+  Registry registry
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  String platform = 'cf'
+
+  @Autowired
+  CloudFoundryResourceRetriever cloudFoundryResourceRetriever
+
+  Timer instancesByAccountRegionId
+
+  @PostConstruct
+  void init() {
+    String[] tags = ['className', this.class.simpleName]
+    instancesByAccountRegionId = registry.timer('instancesByAccountRegionId', tags)
+  }
+
+
+  @Override
+  CloudFoundryApplicationInstance getInstance(String account, String region, String id) {
+    instancesByAccountRegionId.record({
+      cloudFoundryResourceRetriever.instances[account].find { instance -> instance.name == id }
+    } as Callable<CloudFoundryApplicationInstance>)
+  }
+
+  @Override
+  String getConsoleOutput(String account, String region, String id) {
+    def accountCredentials = accountCredentialsProvider.getCredentials(account)
+
+    if (!(accountCredentials?.credentials instanceof CloudFoundryAccountCredentials)) {
+      throw new IllegalArgumentException("Invalid credentials: ${account}:${region}")
+    }
+
+    // TODO: Figure out how to talk to loggregator?
+
+    return null
+  }
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationProvider.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationProvider.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
+import com.netflix.spinnaker.oort.model.Application
+import com.netflix.spinnaker.oort.model.ApplicationProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
+import java.util.concurrent.Callable
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+class CloudFoundryApplicationProvider implements ApplicationProvider {
+
+  @Autowired
+  Registry registry
+
+  @Autowired
+  CloudFoundryResourceRetriever cloudFoundryResourceRetriever
+
+  Timer applications
+
+  Timer applicationByName
+
+  @PostConstruct
+  void init() {
+    String[] tags = ['className', this.class.simpleName]
+    applications = registry.timer('applications', tags)
+    applicationByName = registry.timer('applicationByName', tags)
+  }
+
+  @Override
+  Set<? extends Application> getApplications() {
+    applications.record({
+      Collections.unmodifiableSet(
+        cloudFoundryResourceRetriever.applicationByName.values() as Set)
+    } as Callable<Set<? extends Application>>)
+  }
+
+  @Override
+  Application getApplication(String name) {
+    applicationByName.record({
+      cloudFoundryResourceRetriever.applicationByName[name]
+    } as Callable<Application>)
+  }
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryCluster.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryCluster.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spinnaker.oort.model.Cluster
+import com.netflix.spinnaker.oort.model.LoadBalancer
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+
+/**
+ * One part of a Cloud Foundry application (like blue or green).
+ *
+ * @author Greg Turnquist
+ */
+@CompileStatic
+@EqualsAndHashCode(includes = ["name", "accountName"])
+class CloudFoundryCluster implements Cluster, Serializable {
+
+  String name
+  String type = 'cf'
+  String accountName
+  Set<CloudFoundryServerGroup> serverGroups = [] as Set<CloudFoundryServerGroup>
+  Set<CloudFoundryService> services = [] as Set<CloudFoundryService>
+
+  @Override
+  Set<LoadBalancer> getLoadBalancers() {
+    services
+  }
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryClusterProvider.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryClusterProvider.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
+import com.netflix.spinnaker.oort.model.ClusterProvider
+import com.netflix.spinnaker.oort.model.ServerGroup
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
+import java.util.concurrent.Callable
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+class CloudFoundryClusterProvider implements ClusterProvider<CloudFoundryCluster> {
+
+  @Autowired
+  Registry registry
+
+  @Autowired
+  CloudFoundryResourceRetriever cloudFoundryResourceRetriever
+
+  Timer clusters
+
+  Timer clusterSummaries
+
+  Timer clustersByApplicationAccount
+
+  Timer serverGroup
+
+  @PostConstruct
+  void init() {
+    String[] tags = ['className', this.class.simpleName]
+    clusters = registry.timer('clusters', tags)
+    clusterSummaries = registry.timer('clusterSummaries', tags)
+    clustersByApplicationAccount = registry.timer('clustersByApplicationAccount', tags)
+    serverGroup = registry.timer('serverGroup', tags)
+  }
+
+  @Override
+  Map<String, Set<CloudFoundryCluster>> getClusters() {
+    clusters.record({
+      Collections.unmodifiableMap(
+        cloudFoundryResourceRetriever.clustersByAccount
+      )
+    } as Callable<Map<String, Set<CloudFoundryCluster>>>)
+  }
+
+  @Override
+  Map<String, Set<CloudFoundryCluster>> getClusterSummaries(String application) {
+    clusterSummaries.record({
+      Collections.unmodifiableMap(
+        cloudFoundryResourceRetriever.clustersByApplicationAndAccount[application]
+      )
+    } as Callable<Map<String, Set<CloudFoundryCluster>>>)
+  }
+
+  @Override
+  Map<String, Set<CloudFoundryCluster>> getClusterDetails(String application) {
+    this.getClusterSummaries(application)
+  }
+
+  @Override
+  Set<CloudFoundryCluster> getClusters(String application, String account) {
+    clustersByApplicationAccount.record({
+      Collections.unmodifiableSet(
+          cloudFoundryResourceRetriever.clustersByApplicationAndAccount[application][account]
+      )
+    } as Callable<Set<CloudFoundryCluster>>)
+  }
+
+  @Override
+  CloudFoundryCluster getCluster(String application, String account, String name) {
+    this.getClusters(application, account).find {it.name == name}
+  }
+
+  @Override
+  ServerGroup getServerGroup(String account, String region, String name) {
+    serverGroup.record({
+      cloudFoundryResourceRetriever.clustersByAccountAndClusterName[account][name].serverGroups.find {
+        it.nativeApplication.space.organization.name == region
+      }
+    } as Callable<ServerGroup>)
+  }
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryResourceRetriever.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryResourceRetriever.groovy
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spinnaker.amos.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.cf.config.CloudFoundryConfigurationProperties
+import com.netflix.spinnaker.kato.cf.security.CloudFoundryAccountCredentials
+import com.netflix.spinnaker.oort.model.HealthState
+import groovy.util.logging.Slf4j
+import org.cloudfoundry.client.lib.CloudFoundryClient
+import org.cloudfoundry.client.lib.domain.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.client.HttpServerErrorException
+
+import javax.annotation.PostConstruct
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * @author Greg Turnquist
+ */
+@Slf4j
+class CloudFoundryResourceRetriever {
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Autowired
+  CloudFoundryConfigurationProperties cloudFoundryConfigurationProperties
+
+  protected Lock cacheLock = new ReentrantLock()
+
+  Map<String, CloudSpace> spaceCache = new HashMap<>()
+  Map<String, Set<CloudService>> serviceCache = [:].withDefault { [] as Set<CloudService> }
+
+  Map<String, Set<CloudFoundryServerGroup>> serverGroupsByAccount = [:].withDefault {[] as Set<CloudFoundryServerGroup>}
+  Map<String, Map<String, CloudFoundryServerGroup>> serverGroupsByAccountAndServerGroupName = [:].withDefault {[:]}
+  Map<String, Map<String, Set<CloudFoundryServerGroup>>> serverGroupsByAccountAndClusterName =
+      [:].withDefault {[:].withDefault {[] as Set<CloudFoundryServerGroup>}}
+
+  Map<String, Set<CloudFoundryCluster>> clustersByApplicationName = [:].withDefault {[] as Set<CloudFoundryCluster>}
+  Map<String, Map<String, Set<CloudFoundryCluster>>> clustersByApplicationAndAccount =
+      [:].withDefault {[:].withDefault {[] as Set<CloudFoundryCluster>}}
+  Map<String, Map<String, CloudFoundryCluster>> clustersByAccountAndClusterName =
+      [:].withDefault {[:].withDefault {new CloudFoundryCluster()}}
+  Map<String, Set<CloudFoundryCluster>> clustersByAccount = [:].withDefault {[] as Set<CloudFoundryCluster>}
+
+  Map<String, Set<CloudFoundryService>> servicesByAccount = [:].withDefault {[] as Set<CloudFoundryService>}
+
+  Map<String, CloudFoundryApplication> applicationByName = [:].withDefault {new CloudFoundryApplication()}
+
+  Map<String, Set<CloudFoundryApplicationInstance>> instances = [:].withDefault {[] as Set<CloudFoundryApplicationInstance>}
+
+
+  @PostConstruct
+  void init() {
+    log.info "Initializing CloudFoundryResourceRetriever thread..."
+
+    int initialTimeToLoadSeconds = 15
+
+    Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate({
+      try {
+        load()
+      } catch (Throwable t) {
+        t.printStackTrace()
+      }
+    }, initialTimeToLoadSeconds, cloudFoundryConfigurationProperties.pollingIntervalSeconds, TimeUnit.SECONDS)
+  }
+
+  private void load() {
+    log.info "Loading CF resources..."
+
+    cacheLock.lock()
+
+    log.info "Acquired cacheLock for reloading cache."
+
+    try {
+
+      accountCredentialsProvider.all.each { accountCredentials ->
+        try {
+          if (accountCredentials instanceof CloudFoundryAccountCredentials) {
+            log.info "Logging in to ${cloudFoundryConfigurationProperties.api} as ${accountCredentials.name}"
+
+            CloudFoundryAccountCredentials credentials = (CloudFoundryAccountCredentials) accountCredentials
+
+            def client = new CloudFoundryClient(credentials.credentials, cloudFoundryConfigurationProperties.api.toURL())
+
+            /**
+             * In spinnaker terms:
+             * sagan is an app
+             * sagan is a cluster in an app in a location spring.io/production
+             * sagan-blue is a server group in the sagan cluster in the sagan app
+             * sagan-blue:0, sagan-blue:1, etc. are instances inside the sagan-blue server group
+             */
+
+            log.info "Looking up spaces..."
+            client.spaces.each { space ->
+              if (!spaceCache.containsKey(space.meta.guid)) {
+                spaceCache.put(space.meta.guid, space)
+              }
+            }
+
+            log.info "Looking up services..."
+            spaceCache.values().each { space ->
+              def conn = new CloudFoundryClient(credentials.credentials, cloudFoundryConfigurationProperties.api.toURL(),
+                  space)
+              conn.services.each { service ->
+                serviceCache.get(space.meta.guid).add(service)
+              }
+              conn.logout()
+            }
+
+            log.info "Look up all applications..."
+            def cfApplications = client.applications
+
+            cfApplications.each { app ->
+
+              def space = spaceCache.get(app.space.meta.guid)
+              app.space = space
+              def account = space?.organization?.name + ':' + space?.name
+
+              def serverGroup = new CloudFoundryServerGroup([
+                  name: app.name,
+                  nativeApplication: app,
+                  services: app.services as Set,
+                  nativeServices: app.services.collect { name -> name == serviceCache[space.meta.guid].name }
+              ])
+
+              serverGroupsByAccount[account].add(serverGroup)
+
+              serverGroupsByAccountAndServerGroupName[account][app.name] = serverGroup
+
+              def clusterName = clusterName(app.name)
+
+              serverGroupsByAccountAndClusterName[account][clusterName].add(serverGroup)
+
+              def cluster = clustersByAccountAndClusterName[account][clusterName]
+              cluster.name = clusterName
+              cluster.accountName = account
+              cluster.serverGroups.add(serverGroup)
+              cluster.services.addAll(serviceCache[space.meta.guid].findAll {serverGroup.services.contains(it.name)}
+                  .collect {new CloudFoundryService([
+                      name: it.name,
+                      type: it.label,
+                      nativeService: it
+                  ])})
+
+              cluster.services.each { service ->
+                service.serverGroups.add(serverGroup.name)
+              }
+
+              clustersByApplicationName[cluster.name].add(cluster)
+
+              clustersByApplicationAndAccount[cluster.name][account].add(cluster)
+
+              clustersByAccount[account].add(cluster)
+              servicesByAccount[account].addAll(cluster.services)
+
+              def application = applicationByName[cluster.name]
+              application.name = cluster.name
+              application.applicationClusters[account].add(cluster)
+              application.clusterNames[account].add(cluster.name)
+
+              try {
+                serverGroup.instances = client.getApplicationInstances(app)?.instances.collect {
+                  new CloudFoundryApplicationInstance([
+                      name             : "${app.name}:${it.index}",
+                      healthState      : instanceStateToHealthState(it.state),
+                      nativeApplication: app,
+                      nativeInstance:   it
+                  ])
+                } as Set<CloudFoundryApplicationInstance>
+
+                instances[account].addAll(serverGroup.instances)
+              } catch (HttpServerErrorException e) {
+                log.warn "Unable to retrieve instance data about ${app.name} in ${account} => ${e.message}"
+              }
+
+            }
+
+            log.info "Done loading new version of data"
+
+          }
+        } catch (e) {
+          log.error "Squashed exception ${e.getClass().getName()} thrown by ${accountCredentials}."
+        }
+      }
+
+    } finally {
+      cacheLock.unlock()
+    }
+
+    log.info "Finished loading CF resources."
+
+  }
+
+  String clusterName(String serverGroupName) {
+    def variants = ['-blue', '-green']
+
+    for (String variant : variants) {
+      if (serverGroupName.endsWith(variant)) {
+        return serverGroupName - variant
+      }
+    }
+
+    serverGroupName
+  }
+/**
+   * Convert from {@link InstanceState} to {@link HealthState}.
+   *
+   * @param instanceState
+   * @return
+   */
+  private HealthState instanceStateToHealthState(InstanceState instanceState) {
+    switch (instanceState) {
+      case InstanceState.DOWN:
+        return HealthState.Down
+      case InstanceState.STARTING:
+        return HealthState.Starting
+      case InstanceState.RUNNING:
+        return HealthState.Up
+      case InstanceState.CRASHED:
+        return HealthState.Down
+      case InstanceState.FLAPPING:
+        return HealthState.Unknown
+      case InstanceState.UNKNOWN:
+        return HealthState.Unknown
+    }
+  }
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryServerGroup.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryServerGroup.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spinnaker.oort.model.HealthState
+import com.netflix.spinnaker.oort.model.Instance
+import com.netflix.spinnaker.oort.model.ServerGroup
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import org.cloudfoundry.client.lib.domain.CloudApplication
+import org.cloudfoundry.client.lib.domain.CloudService
+
+/**
+ * A Cloud Foundry application combined with its org/space coordinates.
+ *
+ * @author Greg Turnquist
+ */
+@CompileStatic
+@EqualsAndHashCode(includes = ["name"])
+class CloudFoundryServerGroup implements ServerGroup, Serializable {
+
+  String name
+  String type = 'cf'
+  CloudApplication nativeApplication
+  Boolean disabled = false
+  Set<CloudFoundryApplicationInstance> instances = new HashSet<>()
+  Set<String> services = new HashSet<>()
+  Set<String> securityGroups = new HashSet<>()
+  Map<String, Object> envVariables = new HashMap<>()
+  Map<String, Object> cfSettings = new HashMap<>() // scaling, memory, etc.
+
+  Set<CloudService> nativeServices = new HashSet<>()
+
+  @Override
+  String getRegion() {
+    nativeApplication.space.organization.name
+  }
+
+  @Override
+  Boolean isDisabled() {
+    disabled
+  }
+
+  /**
+   * Return an instance's "since" attribute if it exists. Otherwise, fallback to "updated"
+   * @return
+   */
+  @Override
+  Long getCreatedTime() {
+    if (this.instances.size() > 0) {
+      this.instances.first().launchTime
+    } else {
+      nativeApplication.meta.updated.time
+    }
+  }
+
+  @Override
+  Set<String> getZones() {
+    Collections.singleton(nativeApplication.space.name)
+  }
+
+  @Override
+  Set<String> getLoadBalancers() {
+    services
+  }
+
+  @Override
+  Map<String, Object> getLaunchConfig() {
+    envVariables
+  }
+
+  @Override
+  ServerGroup.InstanceCounts getInstanceCounts() {
+    Set<CloudFoundryApplicationInstance> instances = getInstances()
+    new ServerGroup.InstanceCounts(
+        total: instances.size(),
+        up: filterInstancesByHealthState(instances, HealthState.Up)?.size() ?: 0,
+        down: filterInstancesByHealthState(instances, HealthState.Down)?.size() ?: 0,
+        unknown: filterInstancesByHealthState(instances, HealthState.Unknown)?.size() ?: 0,
+        starting: filterInstancesByHealthState(instances, HealthState.Starting)?.size() ?: 0,
+        outOfService: filterInstancesByHealthState(instances, HealthState.OutOfService)?.size() ?: 0
+    )
+  }
+
+  @Override
+  ServerGroup.Capacity getCapacity() {
+    return null
+  }
+
+  static Collection<Instance> filterInstancesByHealthState(Set<CloudFoundryApplicationInstance> instances,
+                                                           HealthState healthState) {
+    instances.findAll { CloudFoundryApplicationInstance it -> it.getHealthState() == healthState }
+  }
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryService.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryService.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spinnaker.oort.model.LoadBalancer
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import org.cloudfoundry.client.lib.domain.CloudService
+
+/**
+ * Representation for a Cloud Foundry service.
+ *
+ * @author Greg Turnquist
+ */
+@CompileStatic
+@EqualsAndHashCode(includes = ["name"])
+class CloudFoundryService implements LoadBalancer, Serializable {
+
+  String name
+  String type
+  Set<String> serverGroups = new HashSet<>()
+
+  CloudService nativeService
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryServiceProvider.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryServiceProvider.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.model
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
+import com.netflix.spinnaker.oort.model.LoadBalancerProvider
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
+import java.util.concurrent.Callable
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+@CompileStatic
+class CloudFoundryServiceProvider implements LoadBalancerProvider<CloudFoundryService> {
+
+  @Autowired
+  Registry registry
+
+  @Autowired
+  CloudFoundryResourceRetriever cloudFoundryResourceRetriever
+
+  Timer loadBalancers
+  Timer loadBalancersByAccountCluster
+  Timer applicationLoadBalancers
+
+  @PostConstruct
+  void init() {
+    String[] tags = ['className', this.class.simpleName]
+    loadBalancers = registry.timer('loadBalancers', tags)
+    loadBalancersByAccountCluster = registry.timer('loadBalancersByAccountCluster', tags)
+    applicationLoadBalancers = registry.timer('applicationLoadBalancers', tags)
+  }
+
+  @Override
+  Map<String, Set<CloudFoundryService>> getLoadBalancers() {
+    loadBalancers.record({
+      Collections.unmodifiableMap(
+        cloudFoundryResourceRetriever.servicesByAccount
+      )
+    } as Callable<Map<String, Set<CloudFoundryService>>>)
+  }
+
+  @Override
+  Set<CloudFoundryService> getLoadBalancers(String account) {
+    this.getLoadBalancers()[account]
+  }
+
+  @Override
+  Set<CloudFoundryService> getLoadBalancers(String account, String cluster) {
+    loadBalancersByAccountCluster.record({
+      Collections.unmodifiableSet(
+        cloudFoundryResourceRetriever.clustersByAccountAndClusterName[account][cluster].services
+      )
+    } as Callable<Set<CloudFoundryService>>)
+  }
+
+  @Override
+  Set<CloudFoundryService> getLoadBalancers(String account, String cluster, String type) {
+    new HashSet<>(getLoadBalancers(account, cluster).findAll { it.type == type })
+  }
+
+  @Override
+  Set<CloudFoundryService> getLoadBalancer(String account, String cluster, String type, String loadBalancerName) {
+    new HashSet<>(getLoadBalancers(account, cluster, type).findAll { it.name == loadBalancerName })
+  }
+
+  @Override
+  CloudFoundryService getLoadBalancer(String account, String cluster, String type, String loadBalancerName, String region) {
+    getLoadBalancer(account, cluster, type, loadBalancerName).find {}
+  }
+
+  @Override
+  Set<CloudFoundryService> getApplicationLoadBalancers(String application) {
+    applicationLoadBalancers.record({
+      Set<CloudFoundryService> services = new HashSet<>()
+      cloudFoundryResourceRetriever.clustersByApplicationName[application].each { cluster ->
+        services.addAll(cluster.services)
+      }
+      Collections.unmodifiableSet(
+          services
+      )
+    } as Callable<Set<CloudFoundryService>>)
+  }
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/config/OortCloudFoundryConfig.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/config/OortCloudFoundryConfig.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.config
+
+import com.netflix.spinnaker.oort.cf.model.CloudFoundryResourceRetriever
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+
+/**
+ * @author Greg Turnquist
+ */
+@Configuration
+@ConditionalOnProperty('cf.enabled')
+@ComponentScan('com.netflix.spinnaker.oort.cf')
+class OortCloudFoundryConfig {
+
+  @Bean
+  CloudFoundryResourceRetriever cloudFoundryResourceRetriever() {
+    new CloudFoundryResourceRetriever()
+  }
+
+}

--- a/oort/oort-core/src/main/groovy/com/netflix/spinnaker/oort/model/ApplicationProvider.groovy
+++ b/oort/oort-core/src/main/groovy/com/netflix/spinnaker/oort/model/ApplicationProvider.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2014-2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.oort.documentation.Nullable
  * known applications.
  *
  * @author Dan Woods
+ * @author Greg Turnquist
  */
 interface ApplicationProvider {
   /**
@@ -32,7 +33,7 @@ interface ApplicationProvider {
    * @return a set of applications or an empty set if none are known to this provider
    */
   @Empty
-  Set<Application> getApplications()
+  Set<? extends Application> getApplications()
 
   /**
    * Looks up a particular application by name

--- a/oort/oort-web/oort-web.gradle
+++ b/oort/oort-web/oort-web.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile project(":oort:oort-aws")
   compile project(":oort:oort-gce")
   compile project(":oort:oort-titan")
+  compile project(":oort:oort-cf")
 
   runtime spinnaker.dependency("kork")
   compile spinnaker.dependency("korkWeb")

--- a/oort/oort-web/src/main/groovy/com/netflix/spinnaker/oort/controllers/ClusterController.groovy
+++ b/oort/oort-web/src/main/groovy/com/netflix/spinnaker/oort/controllers/ClusterController.groovy
@@ -55,7 +55,7 @@ class ClusterController {
     clusterNames
   }
 
-  @RequestMapping(value = "/{account}")
+  @RequestMapping(value = "/{account:.+}")
   Set<ClusterViewModel> getForAccount(@PathVariable String application, @PathVariable String account) {
     def clusters = (Set<ClusterViewModel>) clusterProviders.collect {
       def clusters = (Set<Cluster>) it.getClusters(application, account)
@@ -76,7 +76,7 @@ class ClusterController {
   }
 
 
-  @RequestMapping(value = "/{account}/{name:.+}", method = RequestMethod.GET)
+  @RequestMapping(value = "/{account:.+}/{name:.+}", method = RequestMethod.GET)
   Set<Cluster> getForAccountAndName(@PathVariable String application,
                                     @PathVariable String account,
                                     @PathVariable String name) {
@@ -90,7 +90,7 @@ class ClusterController {
     clusters
   }
 
-  @RequestMapping(value = "/{account}/{name}/{type}", method = RequestMethod.GET)
+  @RequestMapping(value = "/{account:.+}/{name:.+}/{type}", method = RequestMethod.GET)
   Cluster getForAccountAndNameAndType(@PathVariable String application,
                                       @PathVariable String account,
                                       @PathVariable String name,
@@ -103,7 +103,7 @@ class ClusterController {
     cluster
   }
 
-  @RequestMapping(value = "/{account}/{clusterName}/{type}/serverGroups", method = RequestMethod.GET)
+  @RequestMapping(value = "/{account:.+}/{clusterName:.+}/{type}/serverGroups", method = RequestMethod.GET)
   Set<ServerGroup> getServerGroups(@PathVariable String application,
                                    @PathVariable String account,
                                    @PathVariable String clusterName,
@@ -114,7 +114,7 @@ class ClusterController {
     results ?: []
   }
 
-  @RequestMapping(value = "/{account}/{clusterName}/{type}/serverGroups/{serverGroupName:.+}", method = RequestMethod.GET)
+  @RequestMapping(value = "/{account:.+}/{clusterName:.+}/{type}/serverGroups/{serverGroupName:.+}", method = RequestMethod.GET)
   def getServerGroup(@PathVariable String application,
                      @PathVariable String account,
                      @PathVariable String clusterName,
@@ -135,7 +135,7 @@ class ClusterController {
    * @param scope Should be either a region or zone, depending on the cloud provider.
    * @return A dynamically determined server group using a {@code TargetServerGroup} specifier.
    */
-  @RequestMapping(value = "/{account}/{clusterName}/{cloudProvider}/{scope}/serverGroups/target/{target:.+}", method = RequestMethod.GET)
+  @RequestMapping(value = "/{account:.+}/{clusterName:.+}/{cloudProvider}/{scope}/serverGroups/target/{target:.+}", method = RequestMethod.GET)
   ServerGroup getTargetServerGroup(@PathVariable String application,
                                    @PathVariable String account,
                                    @PathVariable String clusterName,

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,12 +18,12 @@ rootProject.name="clouddriver"
 
 def subs = [
   kato: ["kato-core", "kato-web", "kato-aws", "kato-gce", "kato-manual", "kato-jedis", "kato-docker", "kato-cf", "kato-titan"],
-  oort: ["oort-core", "oort-web", "oort-aws", "oort-gce", "oort-bench", "oort-titan"],
+  oort: ["oort-core", "oort-web", "oort-aws", "oort-gce", "oort-bench", "oort-titan", "oort-cf"],
   mort: ["mort-web", "mort-core", "mort-aws", "mort-gce"],
   cats: ["cats-core", "cats-redis"]
 ]
 
-def topLevels = [ 'clouddriver-core', 'clouddriver-web', 'clouddriver-aws', 'clouddriver-titan', 'clouddriver-google' ]
+def topLevels = [ 'clouddriver-core', 'clouddriver-web', 'clouddriver-aws', 'clouddriver-titan', 'clouddriver-google', 'clouddriver-cf' ]
 
 String[] allmodules = (topLevels +  subs.collect { String sub, List<String> children -> [sub] + children.collect { sub + ':' + it } }.flatten()).toArray()
 


### PR DESCRIPTION
- Defined Cloud Foundry model objects
- Coded providers to draw information from CF
- Verified manually via curl /applications
- Add docs to get going
- Updated ApplicationProvider's getApplications return type to Set<? extends Application>

> **TODO:** Handle clusters specially given they don't map natively into CF
