### PR TITLE
Application searches should be performed directly against Front50

### DIFF
--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -1,4 +1,6 @@
 dependencies {
+  spinnaker.group('retrofitDefault')
+
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootDataRest')
   compile spinnaker.dependency('amos')

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -90,6 +90,9 @@ class CatsSearchProvider implements SearchProvider {
 
   @Override
   SearchResultSet search(String query, List<String> types, Integer pageNumber, Integer pageSize, Map<String, String> filters) {
+    // ensure we're only searching for types supported by the backing providers
+    types = defaultCaches.intersect(types)
+
     List<String> matches = findMatches(query, types, filters)
     generateResultSet(query, matches, pageNumber, pageSize)
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -23,8 +23,11 @@ import com.netflix.spinnaker.amos.MapBackedAccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.cache.CacheConfig
 import com.netflix.spinnaker.clouddriver.cache.NoopOnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.clouddriver.search.ApplicationSearchProvider
 import com.netflix.spinnaker.clouddriver.search.NoopSearchProvider
 import com.netflix.spinnaker.clouddriver.search.SearchProvider
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -64,5 +67,11 @@ class CloudDriverConfig {
   @ConditionalOnMissingBean(SearchProvider)
   NoopSearchProvider noopSearchProvider() {
     new NoopSearchProvider()
+  }
+
+  @Bean
+  @ConditionalOnExpression('${services.front50.enabled:true}')
+  ApplicationSearchProvider applicationSearchProvider(Front50Service front50Service) {
+    new ApplicationSearchProvider(front50Service)
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.core.services
+
+import retrofit.http.*
+
+interface Front50Service {
+  @GET("/credentials")
+  List<Map> getCredentials()
+
+  @GET('/{account}/applications/search')
+  List<Map> searchByName(@Path('account') String account, @Query("name") String name)
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/ApplicationSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/ApplicationSearchProvider.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.search
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import groovy.transform.Canonical
+
+@Canonical
+class ApplicationSearchProvider implements SearchProvider {
+  private final String APPLICATIONS_TYPE = "applications"
+
+  Front50Service front50Service
+
+  @Override
+  String getPlatform() {
+    return "front50"
+  }
+
+  @Override
+  SearchResultSet search(String query, Integer pageNumber, Integer pageSize) {
+    return search(query, [APPLICATIONS_TYPE], pageNumber, pageSize, Collections.emptyMap())
+  }
+
+  @Override
+  SearchResultSet search(String query, Integer pageNumber, Integer pageSize, Map<String, String> filters) {
+    return search(query, [APPLICATIONS_TYPE], pageNumber, pageSize, filters)
+  }
+
+  @Override
+  SearchResultSet search(String query, List<String> types, Integer pageNumber, Integer pageSize) {
+    return search(query, types, pageNumber, pageSize, Collections.emptyMap())
+  }
+
+  @Override
+  SearchResultSet search(String query, List<String> types, Integer pageNumber, Integer pageSize, Map<String, String> filters) {
+    if (!types.contains(APPLICATIONS_TYPE)) {
+      return new SearchResultSet(totalMatches: 0)
+    }
+
+    // TODO-AJ Front50 v2 APIs should not be account-specific
+    def account = front50Service.credentials.find { it.global == true }?.name as String
+    def results = front50Service.searchByName(account, query).collect {
+      it.application = it.name.toString().toLowerCase()
+      it.type = APPLICATIONS_TYPE
+      it.url = "/applications/${it.application}".toString()
+
+      return it
+    }
+    return new SearchResultSet(results.size(), pageNumber, pageSize, getPlatform(), query, results)
+  }
+}

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -6,6 +6,10 @@ server:
 redis:
   connection: redis://localhost:6379
 
+services:
+  front50:
+    baseUrl: http://localhost:8080
+
 swagger:
   enabled: true
   title: clouddriver

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -17,11 +17,8 @@
 package com.netflix.spinnaker.clouddriver
 
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
-import com.netflix.spinnaker.clouddriver.controllers.CacheController
-import com.netflix.spinnaker.clouddriver.controllers.CredentialsController
+import com.netflix.spinnaker.clouddriver.config.RetrofitConfig
 import com.netflix.spinnaker.clouddriver.core.CloudDriverConfig
-import com.netflix.spinnaker.clouddriver.core.RedisConfig
-import com.netflix.spinnaker.clouddriver.filters.SimpleCORSFilter
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfig
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.actuate.autoconfigure.ManagementSecurityAutoConfiguration
@@ -31,7 +28,6 @@ import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAuto
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.web.SpringBootServletInitializer
-import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -43,6 +39,7 @@ import java.security.Security
 @Import([
   WebConfig,
   CloudDriverConfig,
+  RetrofitConfig,
   AwsConfiguration,
   GoogleConfig,
   com.netflix.spinnaker.kato.Main,

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/config/RetrofitConfig.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/config/RetrofitConfig.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.config
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.config.OkHttpClientConfiguration
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import retrofit.RestAdapter
+import retrofit.client.OkClient
+import retrofit.converter.JacksonConverter
+
+import static retrofit.Endpoints.newFixedEndpoint
+
+@Configuration
+class RetrofitConfig {
+  @Autowired
+  OkHttpClientConfiguration okHttpClientConfig
+
+  @Bean RestAdapter.LogLevel retrofitLogLevel(@Value('${retrofit.logLevel:BASIC}') String retrofitLogLevel) {
+    return RestAdapter.LogLevel.valueOf(retrofitLogLevel)
+  }
+
+  @Bean
+  OkClient okClient() {
+    return new OkClient(okHttpClientConfig.create())
+  }
+
+  @Bean
+  @ConditionalOnExpression('${services.front50.enabled:true}')
+  Front50Service front50Service(@Value('${services.front50.baseUrl}') String front50BaseUrl, RestAdapter.LogLevel retrofitLogLevel) {
+    def endpoint = newFixedEndpoint(front50BaseUrl)
+    new RestAdapter.Builder()
+      .setEndpoint(endpoint)
+      .setClient(okClient())
+      .setConverter(new JacksonConverter())
+      .setLogLevel(retrofitLogLevel)
+      .setLog(new Slf4jRetrofitLogger(Front50Service))
+      .build()
+      .create(Front50Service)
+  }
+
+  static class Slf4jRetrofitLogger implements RestAdapter.Log {
+    private final Logger logger
+
+    public Slf4jRetrofitLogger(Class type) {
+      this(LoggerFactory.getLogger(type))
+    }
+
+    public Slf4jRetrofitLogger(Logger logger) {
+      this.logger = logger
+    }
+
+    @Override
+    void log(String message) {
+      logger.info(message)
+    }
+  }
+}

--- a/kato/kato-web/src/test/groovy/com/netflix/spinnaker/kato/com/netflix/asgard/kato/controllers/CloudFoundryOperationsSpec.groovy
+++ b/kato/kato-web/src/test/groovy/com/netflix/spinnaker/kato/com/netflix/asgard/kato/controllers/CloudFoundryOperationsSpec.groovy
@@ -67,7 +67,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
  */
 @WebAppConfiguration
 @ContextConfiguration(classes = [TestConfiguration])
-@IntegrationTest('cf.enabled:true')
+@IntegrationTest(['cf.enabled:true', 'services.front50.enabled:false'])
 class CloudFoundryOperationsSpec extends Specification {
 
   @Autowired

--- a/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/AwsProvider.groovy
+++ b/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/AwsProvider.groovy
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired
 
 import java.util.regex.Pattern
 
-import static com.netflix.spinnaker.oort.aws.data.Keys.Namespace.APPLICATIONS
 import static com.netflix.spinnaker.oort.aws.data.Keys.Namespace.CLUSTERS
 import static com.netflix.spinnaker.oort.aws.data.Keys.Namespace.INSTANCES
 import static com.netflix.spinnaker.oort.aws.data.Keys.Namespace.LOAD_BALANCERS
@@ -38,9 +37,7 @@ class AwsProvider implements SearchableProvider {
 
   public static final String PROVIDER_NAME = AwsProvider.name
 
-
   final Set<String> defaultCaches = [
-    APPLICATIONS.ns,
     LOAD_BALANCERS.ns,
     CLUSTERS.ns,
     SERVER_GROUPS.ns,
@@ -50,8 +47,7 @@ class AwsProvider implements SearchableProvider {
   final Map<String, String> urlMappingTemplates = [
     (SERVER_GROUPS.ns): '/applications/${application.toLowerCase()}/clusters/$account/$cluster/aws/serverGroups/$serverGroup?region=$region',
     (LOAD_BALANCERS.ns): '/aws/loadBalancers/$loadBalancer',
-    (CLUSTERS.ns): '/applications/${application.toLowerCase()}/clusters/$account/$cluster',
-    (APPLICATIONS.ns): '/applications/${application.toLowerCase()}'
+    (CLUSTERS.ns): '/applications/${application.toLowerCase()}/clusters/$account/$cluster'
   ].asImmutable()
 
   final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = [


### PR DESCRIPTION
- Treat Front50 as the owner of Application (and Project) data
- CatsSearchProvider will no longer search against local cached Application keys
