### PR TITLE
Allow for a wider range of ip protocol values (including numbers).

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/UpsertSecurityGroupDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/UpsertSecurityGroupDescription.groovy
@@ -25,14 +25,14 @@ class UpsertSecurityGroupDescription extends AbstractAmazonCredentialsDescriptio
   List<SecurityGroupIngress> securityGroupIngress
   List<IpIngress> ipIngress
 
-  enum IngressType {
-    tcp, udp, icmp
-  }
-
   static abstract class Ingress {
     Integer startPort
     Integer endPort
-    IngressType type
+    String ipProtocol
+
+    @Deprecated void setType(String ipProtocol) {
+      this.ipProtocol = ipProtocol
+    }
   }
 
   static class SecurityGroupIngress extends Ingress {

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/UpsertSecurityGroupAtomicOperation.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/UpsertSecurityGroupAtomicOperation.groovy
@@ -145,7 +145,7 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   static IpPermission map(UpsertSecurityGroupDescription.Ingress ingress) {
-    new IpPermission().withIpProtocol(ingress.type.name()).withFromPort(ingress.startPort).withToPort(ingress.endPort)
+    new IpPermission().withIpProtocol(ingress.ipProtocol).withFromPort(ingress.startPort).withToPort(ingress.endPort)
   }
 
   @VisibleForTesting

--- a/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
+++ b/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/ops/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
@@ -49,7 +49,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         name = "bar"
         startPort = 111
         endPort = 112
-        type = UpsertSecurityGroupDescription.IngressType.tcp
+        type = "tcp"
         it
       }
     ]
@@ -93,21 +93,21 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
       name = "bar"
       startPort = 25
       endPort = 25
-      type = UpsertSecurityGroupDescription.IngressType.tcp
+      type = "tcp"
       it
     }
     description.securityGroupIngress << new SecurityGroupIngress().with {
       name = "bar"
       startPort = 80
       endPort = 81
-      type = UpsertSecurityGroupDescription.IngressType.tcp
+      type = "tcp"
       it
     }
     description.ipIngress = [new IpIngress().with {
       cidr = "10.0.0.1/32"
       startPort = 80
       endPort = 81
-      type = UpsertSecurityGroupDescription.IngressType.tcp
+      ipProtocol = "tcp"
       it
     }]
     op.operate([])

--- a/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/UpsertSecurityGroupDescriptionValidatorSpec.groovy
+++ b/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/UpsertSecurityGroupDescriptionValidatorSpec.groovy
@@ -46,7 +46,7 @@ class UpsertSecurityGroupDescriptionValidatorSpec extends Specification {
         name = "bar"
         startPort = 111
         endPort = 111
-        type = UpsertSecurityGroupDescription.IngressType.tcp
+        type = "tcp"
         it
       }
     ]


### PR DESCRIPTION
Also change attribute name to something more descriptive and that is never a language keyword, but maintain backward compatibility.
