### PR TITLE
consider createdTime on server groups when determining ancestor

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/services/AsgService.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/services/AsgService.groovy
@@ -53,7 +53,7 @@ class AsgService {
         }
       }
     }.retrieve(new DescribeAutoScalingGroupsRequest()).max { a, b ->
-      a.autoScalingGroupName <=> b.autoScalingGroupName
+      a.createdTime <=> b.createdTime
     } ?: null
   }
 


### PR DESCRIPTION
Orca does a nice job of considering createdTime when determining which server groups to disable/destroy/use as source; kato should do the same, since we use this to determine the name of the next server group.

@cfieber or @sthadeshwar can you verify this is not a stupid thing to do?
