### PR TITLE
Don't clone the properties that are calculated on-demand.

### DIFF
--- a/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/GoogleServerGroup.groovy
+++ b/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/GoogleServerGroup.groovy
@@ -53,7 +53,8 @@ class GoogleServerGroup implements ServerGroup, Serializable {
         originalGoogleServerGroup.instances.each { originalInstance ->
           copyGoogleServerGroup.instances << GoogleInstance.newInstance((GoogleInstance) originalInstance)
         }
-      } else {
+      } else if (!["loadBalancers", "instanceCounts", "capacity"].contains(propertyName)) {
+        // We only want to clone the properties that are not calculated on-demand.
         def valueCopy = Utils.getImmutableCopy(originalGoogleServerGroup.getProperty(propertyName))
 
         if (valueCopy) {


### PR DESCRIPTION
@ttomsu please review.
I was seeing an issue where clouddriver would return to orca Google server group representations with content like:

```
  "instanceCounts" : "com.netflix.spinnaker.oort.model.ServerGroup$InstanceCounts@4e50b19",
  "loadBalancers" : [ "roscoapp-dev-frontend", "testlb1" ],
  "createdTime" : 1443794980454,
  "type" : "gce",
  "class" : "class com.netflix.spinnaker.oort.gce.model.GoogleServerGroup",
  "capacity" : "com.netflix.spinnaker.oort.model.ServerGroup$Capacity@6d65c9b"
```

This would only happen immediately following a server group force cache refresh.

It turns out the culprit is this cloning code where I was (inadvertently) cloning dynamically-calculated properties. This would manifest as orca trying to dereference `min` and `desired` properties on a `String` (a string like: `com.netflix.spinnaker.oort.model.ServerGroup$Capacity@6d65c9b`).
