### PR TITLE
Handle apps that have empty times

### DIFF
--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryServerGroup.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryServerGroup.groovy
@@ -64,7 +64,7 @@ class CloudFoundryServerGroup implements ServerGroup, Serializable {
     if (this.instances.size() > 0) {
       this.instances.first().launchTime
     } else {
-      nativeApplication.meta.updated.time
+      nativeApplication?.meta?.updated?.time
     }
   }
 


### PR DESCRIPTION
When looking up the created time, it's possible that for a given cluster, there are no instances and the updated time is null.
