### PR TITLE
a pass over cloudprovider annotations in use

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/converters/TerminateInstancesAtomicOperationConverter.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/converters/TerminateInstancesAtomicOperationConverter.groovy
@@ -15,12 +15,15 @@
  */
 package com.netflix.spinnaker.kato.aws.deploy.converters
 
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.kato.aws.deploy.description.TerminateInstancesDescription
 import com.netflix.spinnaker.kato.aws.deploy.ops.TerminateInstancesAtomicOperation
 import com.netflix.spinnaker.kato.orchestration.AtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import com.netflix.spinnaker.kato.security.AbstractAtomicOperationsCredentialsSupport
 import org.springframework.stereotype.Component
 
+@AmazonOperation(AtomicOperations.TERMINATE_INSTANCES)
 @Component("terminateInstancesDescription")
 class TerminateInstancesAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Override

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/converters/UpsertSecurityGroupAtomicOperationConverter.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/converters/UpsertSecurityGroupAtomicOperationConverter.groovy
@@ -18,12 +18,15 @@ package com.netflix.spinnaker.kato.aws.deploy.converters
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.kato.aws.deploy.description.UpsertSecurityGroupDescription
 import com.netflix.spinnaker.kato.aws.deploy.ops.UpsertSecurityGroupAtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import com.netflix.spinnaker.kato.security.AbstractAtomicOperationsCredentialsSupport
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
+@AmazonOperation(AtomicOperations.UPSERT_SECURITY_GROUP)
 @Component("upsertSecurityGroupDescription")
 class UpsertSecurityGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Autowired

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
@@ -19,8 +19,10 @@ package com.netflix.spinnaker.kato.aws.deploy.validators
 
 import com.netflix.spinnaker.amos.AccountCredentialsProvider
 import com.netflix.spinnaker.amos.aws.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.kato.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.kato.aws.deploy.description.BasicAmazonDeployDescription
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
 @Component("basicAmazonDeployDescriptionValidator")
+@AmazonOperation(AtomicOperations.CREATE_SERVER_GROUP)
 class BasicAmazonDeployDescriptionValidator extends AmazonDescriptionValidationSupport<BasicAmazonDeployDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/TerminateInstancesDescriptionValidator.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/TerminateInstancesDescriptionValidator.groovy
@@ -15,10 +15,13 @@
  */
 package com.netflix.spinnaker.kato.aws.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.kato.aws.deploy.description.TerminateInstancesDescription
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
+@AmazonOperation(AtomicOperations.TERMINATE_INSTANCES)
 @Component("terminateInstancesDescriptionValidator")
 class TerminateInstancesDescriptionValidator extends AmazonDescriptionValidationSupport<TerminateInstancesDescription> {
   @Override

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/UpsertSecurityGroupDescriptionValidator.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/UpsertSecurityGroupDescriptionValidator.groovy
@@ -16,13 +16,16 @@
 
 package com.netflix.spinnaker.kato.aws.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.kato.aws.deploy.description.UpsertSecurityGroupDescription
 import com.netflix.spinnaker.kato.aws.model.SecurityGroupNotFoundException
 import com.netflix.spinnaker.kato.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
+@AmazonOperation(AtomicOperations.UPSERT_SECURITY_GROUP)
 @Component("upsertSecurityGroupDescriptionValidator")
 class UpsertSecurityGroupDescriptionValidator extends AmazonDescriptionValidationSupport<UpsertSecurityGroupDescription> {
   @Autowired

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/converters/BasicGoogleDeployAtomicOperationConverter.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/converters/BasicGoogleDeployAtomicOperationConverter.groovy
@@ -16,12 +16,15 @@
 
 package com.netflix.spinnaker.kato.gce.deploy.converters
 
+import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.kato.deploy.DeployAtomicOperation
 import com.netflix.spinnaker.kato.gce.deploy.description.BasicGoogleDeployDescription
 import com.netflix.spinnaker.kato.orchestration.AtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import com.netflix.spinnaker.kato.security.AbstractAtomicOperationsCredentialsSupport
 import org.springframework.stereotype.Component
 
+@GoogleOperation(AtomicOperations.CREATE_SERVER_GROUP)
 @Component("basicGoogleDeployDescription")
 class BasicGoogleDeployAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   AtomicOperation convertOperation(Map input) {

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/validators/BasicGoogleDeployDescriptionValidator.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/validators/BasicGoogleDeployDescriptionValidator.groovy
@@ -17,12 +17,15 @@
 package com.netflix.spinnaker.kato.gce.deploy.validators
 
 import com.netflix.spinnaker.amos.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.kato.deploy.DescriptionValidator
 import com.netflix.spinnaker.kato.gce.deploy.description.BasicGoogleDeployDescription
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
+@GoogleOperation(AtomicOperations.CREATE_SERVER_GROUP)
 @Component("basicGoogleDeployDescriptionValidator")
 class BasicGoogleDeployDescriptionValidator extends DescriptionValidator<BasicGoogleDeployDescription> {
   @Autowired

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/validators/ResizeGoogleReplicaPoolDescriptionValidator.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/validators/ResizeGoogleReplicaPoolDescriptionValidator.groovy
@@ -17,12 +17,15 @@
 package com.netflix.spinnaker.kato.gce.deploy.validators
 
 import com.netflix.spinnaker.amos.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.kato.deploy.DescriptionValidator
 import com.netflix.spinnaker.kato.gce.deploy.description.ResizeGoogleReplicaPoolDescription
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
+@GoogleOperation(AtomicOperations.RESIZE_SERVER_GROUP)
 @Component("resizeGoogleReplicaPoolDescriptionValidator")
 class ResizeGoogleReplicaPoolDescriptionValidator extends DescriptionValidator<ResizeGoogleReplicaPoolDescription> {
   @Autowired


### PR DESCRIPTION
fix some missed applications of the annotation on the validator for an annotated converter
added some annotations that were in use on other cloudproviders

cc: @duftler touched a couple google ops in here
- resize was missing the annotation on its Validator
- deploy wasn't annotated (orca's deploy is calling createServerGroup now it seems)

cc: @sthadeshwar - I'm tempted to change the behaviour to fail if we can't find the validator for an operation (you'd need to write some validators in titan). I feel like the annotation approach makes it easy to accidentally not annotate something (as evidenced by the two missing Validator annotations in this changeset) and its probably better to explode rather than silently accepting any input when someone thinks they wrote validation. Alternatively I'd rather see us annotate one thing that has the reference to both the converter and validator.  Thoughts?
