### PR TITLE
Improve calculation of disabled property on Google server group.

### DIFF
--- a/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/GoogleServerGroup.groovy
+++ b/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/GoogleServerGroup.groovy
@@ -36,7 +36,7 @@ class GoogleServerGroup implements ServerGroup, Serializable {
   Map<String, Object> asg
   Set<String> securityGroups
   Map buildInfo
-  Boolean disabled = true
+  Boolean disabled = false
 
   private Map<String, Object> dynamicProperties = new HashMap<String, Object>()
 

--- a/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/callbacks/MIGSCallback.groovy
+++ b/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/callbacks/MIGSCallback.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Google, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,8 @@ class MIGSCallback<InstanceGroupManagerList> extends JsonBatchCallback<InstanceG
                                                                                                instanceGroupsCallback)
 
         def localInstanceTemplateName = Utils.getLocalName(instanceGroupManager.instanceTemplate)
-        def instanceTemplatesCallback = new InstanceTemplatesCallback(googleServerGroup,
+        def instanceTemplatesCallback = new InstanceTemplatesCallback(instanceGroupManager,
+                                                                      googleServerGroup,
                                                                       cluster,
                                                                       googleSecurityGroups,
                                                                       imageMap,
@@ -102,12 +103,6 @@ class MIGSCallback<InstanceGroupManagerList> extends JsonBatchCallback<InstanceG
         compute.instanceTemplates().get(project,
                                         localInstanceTemplateName).queue(instanceGroupsBatch,
                                                                          instanceTemplatesCallback)
-
-        // The isDisabled property of a server group is set based on whether there are associated target pools.
-        def targetPoolLoadBalancerNames =
-          Utils.deriveNetworkLoadBalancerNamesFromTargetPoolUrls(instanceGroupManager.getTargetPools())
-
-        googleServerGroup.setDisabled(targetPoolLoadBalancerNames.empty)
 
         // oort.aws puts a com.amazonaws.services.autoscaling.model.AutoScalingGroup here. More importantly, deck expects it.
         googleServerGroup.setProperty("asg", [minSize          : instanceGroupManager.targetSize,


### PR DESCRIPTION
If a server group is not associated with any load balancers, it can never be considered disabled.
@ttomsu please review.
