### PR TITLE
Add 'healthClass' field to platform healths with a value of 'platform…

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/converters/RebootInstancesAtomicOperationConverter.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/converters/RebootInstancesAtomicOperationConverter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,15 @@
 
 package com.netflix.spinnaker.kato.aws.deploy.converters
 
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.kato.aws.deploy.description.RebootInstancesDescription
 import com.netflix.spinnaker.kato.aws.deploy.ops.RebootInstancesAtomicOperation
 import com.netflix.spinnaker.kato.orchestration.AtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import com.netflix.spinnaker.kato.security.AbstractAtomicOperationsCredentialsSupport
 import org.springframework.stereotype.Component
 
+@AmazonOperation(AtomicOperations.REBOOT_INSTANCES)
 @Component("rebootInstancesDescription")
 class RebootInstancesAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Override

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/RebootInstancesDescriptionValidator.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/validators/RebootInstancesDescriptionValidator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@
 
 package com.netflix.spinnaker.kato.aws.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.kato.aws.deploy.description.RebootInstancesDescription
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
+@AmazonOperation(AtomicOperations.REBOOT_INSTANCES)
 @Component("rebootInstancesDescriptionValidator")
 class RebootInstancesDescriptionValidator extends AmazonDescriptionValidationSupport<RebootInstancesDescription> {
   @Override

--- a/kato/kato-core/src/main/groovy/com/netflix/spinnaker/kato/orchestration/AtomicOperations.groovy
+++ b/kato/kato-core/src/main/groovy/com/netflix/spinnaker/kato/orchestration/AtomicOperations.groovy
@@ -31,6 +31,7 @@ final class AtomicOperations {
   public static final String RESIZE_SERVER_GROUP = "resizeServerGroup"
 
   // Instance operations
+  public static final String REBOOT_INSTANCES = "rebootInstances"
   public static final String TERMINATE_INSTANCES = "terminateInstances"
   public static final String TERMINATE_INSTANCE_AND_DECREMENT = "terminateInstanceAndDecrementServerGroup"
 

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/converters/RebootGoogleInstancesAtomicOperationConverter.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/converters/RebootGoogleInstancesAtomicOperationConverter.groovy
@@ -16,13 +16,16 @@
 
 package com.netflix.spinnaker.kato.gce.deploy.converters
 
+import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.kato.gce.deploy.description.RebootGoogleInstancesDescription
 import com.netflix.spinnaker.kato.gce.deploy.ops.RebootGoogleInstancesAtomicOperation
 import com.netflix.spinnaker.kato.orchestration.AtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import com.netflix.spinnaker.kato.security.AbstractAtomicOperationsCredentialsSupport
 import org.springframework.stereotype.Component
 
-@Component("rebootGoogleInstancesDescription")
+@GoogleOperation(AtomicOperations.REBOOT_INSTANCES)
+@Component
 class RebootGoogleInstancesAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Override
   AtomicOperation convertOperation(Map input) {

--- a/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/validators/RebootGoogleInstancesDescriptionValidator.groovy
+++ b/kato/kato-gce/src/main/groovy/com/netflix/spinnaker/kato/gce/deploy/validators/RebootGoogleInstancesDescriptionValidator.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,16 @@
 package com.netflix.spinnaker.kato.gce.deploy.validators
 
 import com.netflix.spinnaker.amos.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.kato.deploy.DescriptionValidator
 import com.netflix.spinnaker.kato.gce.deploy.description.RebootGoogleInstancesDescription
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
-@Component("rebootGoogleInstancesDescriptionValidator")
+@GoogleOperation(AtomicOperations.REBOOT_INSTANCES)
+@Component
 class RebootGoogleInstancesDescriptionValidator extends DescriptionValidator<RebootGoogleInstancesDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider

--- a/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/agent/InstanceCachingAgent.groovy
+++ b/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/provider/agent/InstanceCachingAgent.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,7 +187,11 @@ class InstanceCachingAgent implements CachingAgent {
     InstanceState state = instance.state
     StateReason stateReason = instance.stateReason
     HealthState amazonState = state?.code == 16 ? HealthState.Unknown : HealthState.Down
-    Map<String, String> awsInstanceHealth = [type: 'Amazon', state: amazonState.toString()]
+    Map<String, String> awsInstanceHealth = [
+      type: 'Amazon',
+      healthClass: 'platform',
+      state: amazonState.toString()
+    ]
     if (stateReason) {
       awsInstanceHealth.description = stateReason.message
     }

--- a/oort/oort-aws/src/test/groovy/com/netflix/spinnaker/oort/aws/model/AmazonInstanceSpec.groovy
+++ b/oort/oort-aws/src/test/groovy/com/netflix/spinnaker/oort/aws/model/AmazonInstanceSpec.groovy
@@ -34,7 +34,7 @@ class AmazonInstanceSpec extends Specification {
 
   def "getHealthState for ALL UP health states"() {
     given:
-      instance.health = [[type: "Amazon", state: "Unknown"], [type: "Discovery", state: 'Up'], [type: "LoadBalancer", state: "Up"]]
+      instance.health = [[type: "Amazon", healthClass: 'platform', state: "Unknown"], [type: "Discovery", state: 'Up'], [type: "LoadBalancer", state: "Up"]]
     when:
       HealthState healthState = instance.getHealthState()
     then:
@@ -43,7 +43,7 @@ class AmazonInstanceSpec extends Specification {
 
   def "getHealthState for ONE DOWN & ONE UP health state"() {
     given:
-      instance.health = [[type: "Amazon", state: "Unknown"], [type: "Discovery", state: "Up"], [type: "LoadBalancer", state: "Down"]]
+      instance.health = [[type: "Amazon", healthClass: 'platform', state: "Unknown"], [type: "Discovery", state: "Up"], [type: "LoadBalancer", state: "Down"]]
     when:
       HealthState heathState = instance.getHealthState()
     then:
@@ -52,7 +52,7 @@ class AmazonInstanceSpec extends Specification {
 
   def "getHealthState for ALL DOWN health state"() {
     given:
-    instance.health = [[type: "Amazon", state: "Unknown"], [type: "Discovery", state: "Down"], [type: "LoadBalancer", state: "Down"]]
+    instance.health = [[type: "Amazon", healthClass: 'platform', state: "Unknown"], [type: "Discovery", state: "Down"], [type: "LoadBalancer", state: "Down"]]
     when:
     HealthState heathState = instance.getHealthState()
     then:
@@ -61,7 +61,7 @@ class AmazonInstanceSpec extends Specification {
 
   def "getHealthState for unhealthy with no UP or DOWN health status"() {
     given:
-      instance.health = [[type: "Amazon", state: "Unknown"]]
+      instance.health = [[type: "Amazon", healthClass: 'platform', state: "Unknown"]]
 
     when:
       HealthState heathState = instance.getHealthState()
@@ -83,7 +83,7 @@ class AmazonInstanceSpec extends Specification {
 
   def "getHealthState for ONE STARTING"() {
     given:
-      instance.health = [[type: "Amazon", state: "Unknown"], [type: "Discovery", state: "Starting"]]
+      instance.health = [[type: "Amazon", healthClass: 'platform', state: "Unknown"], [type: "Discovery", state: "Starting"]]
     when:
       HealthState heathState = instance.getHealthState()
     then:
@@ -92,7 +92,7 @@ class AmazonInstanceSpec extends Specification {
 
   def "getHealthState for ONE STARTING and ONE DOWN"() {
     given:
-      instance.health = [[type: "Amazon", state: "Unknown"], [type: "Discovery", state: "Starting"], [type: "LoadBalancer", state: "Down"]]
+      instance.health = [[type: "Amazon", healthClass: 'platform', state: "Unknown"], [type: "Discovery", state: "Starting"], [type: "LoadBalancer", state: "Down"]]
     when:
       HealthState heathState = instance.getHealthState()
     then:
@@ -101,7 +101,7 @@ class AmazonInstanceSpec extends Specification {
 
   def "getHealthState for ONE STARTING and ONE OUTOFSERVICE"() {
     given:
-      instance.health = [[type: "Amazon", state: "Unknown"], [type: "Discovery", state: "Starting"], [type: "LoadBalancer", state: "OutOfService"]]
+      instance.health = [[type: "Amazon", healthClass: 'platform', state: "Unknown"], [type: "Discovery", state: "Starting"], [type: "LoadBalancer", state: "OutOfService"]]
     when:
       HealthState heathState = instance.getHealthState()
     then:
@@ -111,7 +111,7 @@ class AmazonInstanceSpec extends Specification {
   def "getHealthState for ONE OUTOFSERVICE, and ONE DOWN"() {
     given:
     instance.health = [
-      [type: "Amazon", state: "Unknown"],
+      [type: "Amazon", healthClass: 'platform', state: "Unknown"],
       [type: "LoadBalancer", state: "OutOfService"],
       [type: "HowDoWeHaveFourHealthIndicators?", state: "Down"]
     ]

--- a/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/callbacks/InstanceAggregatedListCallback.groovy
+++ b/oort/oort-gce/src/main/groovy/com/netflix/spinnaker/oort/gce/model/callbacks/InstanceAggregatedListCallback.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Google, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,7 @@ class InstanceAggregatedListCallback<InstanceAggregatedList> extends JsonBatchCa
   static Map buildGCEHealthState(String instanceStatus) {
     [
       type : "GCE",
+      healthClass: "platform",
       state: deriveInstanceGCEHealthState(instanceStatus)
     ]
   }

--- a/oort/oort-gce/src/test/groovy/com/netflix/spinnaker/oort/gce/model/callbacks/InstanceAggregatedListCallbackSpec.groovy
+++ b/oort/oort-gce/src/test/groovy/com/netflix/spinnaker/oort/gce/model/callbacks/InstanceAggregatedListCallbackSpec.groovy
@@ -30,6 +30,7 @@ class InstanceAggregatedListCallbackSpec extends Specification {
 
     then:
       gceHealthState.type == "GCE"
+      gceHealthState.healthClass == "platform"
       gceHealthState.state == spinnakerHealthState
 
     where:


### PR DESCRIPTION
…'. This is so we can avoid hard-coding 'Amazon' and 'GCE' when seeking platform health providers in orca.
Make rebootInstances generic.
@cfieber or @ajordens please review.
