### PR TITLE
Remove monitoring code from CF deployment task

### DIFF
--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/description/CloudFoundryDeployDescription.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/description/CloudFoundryDeployDescription.groovy
@@ -67,6 +67,6 @@ class CloudFoundryDeployDescription implements DeployDescription {
 
   Map<String, Object> targetPackage
 
-  String targetHost
+  String serverGroupName
 
 }

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryResourceRetriever.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryResourceRetriever.groovy
@@ -164,9 +164,17 @@ class CloudFoundryResourceRetriever {
 
               try {
                 serverGroup.instances = client.getApplicationInstances(app)?.instances.collect {
+                  def healthState = instanceStateToHealthState(it.state)
+                  def health = [[
+                          state      : healthState.toString(),
+                          type       : 'serverGroup',
+                          description: 'State of the CF server group'
+                  ]]
+
                   def instance = new CloudFoundryApplicationInstance([
                           name             : "${app.name}:${it.index}",
-                          healthState      : instanceStateToHealthState(it.state),
+                          healthState      : healthState,
+                          health           : health,
                           nativeApplication: app,
                           nativeInstance:   it
                   ])


### PR DESCRIPTION
With proper health data in place, Spinnaker's monitor task in orca can watch CF-based server groups come up properly. No need to monitor it in both places.
