### PR TITLE
Add Spring Cloud Config Server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ subprojects { project ->
 
   dependencies {
     compile spinnaker.dependency('groovy')
+    compile 'org.springframework.cloud:spring-cloud-starter-config:1.0.3.RELEASE'
     spinnaker.group('test')
   }
 }

--- a/clouddriver-web/src/main/resources/bootstrap.yml
+++ b/clouddriver-web/src/main/resources/bootstrap.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: clouddriver
+  cloud:
+    config:
+      uri: ${figUrl:http://localhost:8888}


### PR DESCRIPTION
Spring Cloud Config Server makes it possible to externalize and centralize property files with a single github repo.

For reference, see http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html

To run this, you need to run a separate config server. I have an app at https://github.com/gregturn/config-server. I suggest moving/copying this into github.com/spinnaker and rebudding as "fig". You just run it as:

```
SPRING_CLOUD_CONFIG_SERVER_GIT_URI=https://github.com/<gregturn>/<spinnaker-config>  ./gradlew bootRun
```

(See mine at https://github.com/gregturn/spinnaker-config/)

This server process runs locally on port 8888. Then, when you fire up clouddriver locally,it will reach out to that process and consume property files found inside that github repo as if they were local. In production, you can override "localhost:8888" via FIG_URL to talk to a production version of this config server.

This makes it possible to have all your properties files in one place and outside the actual source code, yet still under version control of each user of Spinnaker.

P.S. There are options to secure the config server as well as encrypt secrets inside the github repo.
