### PR TITLE
Allow CachingAgents to explicitly provide evictions.

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CacheResult.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CacheResult.java
@@ -19,8 +19,25 @@ package com.netflix.spinnaker.cats.agent;
 import com.netflix.spinnaker.cats.cache.CacheData;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
+/**
+ * The result of a CachingAgent run.
+ */
 public interface CacheResult {
-    Map<String, Collection<CacheData>> getCacheResults();
+  /**
+   * @return The CacheDatas to cache, keyed by item type.
+   */
+  Map<String, Collection<CacheData>> getCacheResults();
+
+  /**
+   * Provides a means to explicitly evict items as a result of a CachingAgent execution.
+   *
+   * Note: Eviction will already occur based on the values in getCacheResults for all the types
+   *       that the CachingAgent authoritatively caches - this collection is for additional items
+   *       that were potentially cached out of band of a complete caching run.
+   * @return The ids of items that should be explicitly evicted.
+   */
+  default Map<String, Collection<String>> getEvictions() { return Collections.emptyMap(); }
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultCacheResult.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultCacheResult.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.cats.agent;
 import com.netflix.spinnaker.cats.cache.CacheData;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -26,13 +27,23 @@ import java.util.Map;
  */
 public class DefaultCacheResult implements CacheResult {
     private final Map<String, Collection<CacheData>> cacheResults;
+    private final Map<String, Collection<String>> evictions;
 
     public DefaultCacheResult(Map<String, Collection<CacheData>> cacheResults) {
+      this(cacheResults, Collections.emptyMap());
+    }
+    public DefaultCacheResult(Map<String, Collection<CacheData>> cacheResults, Map<String, Collection<String>> evictions) {
         this.cacheResults = cacheResults;
+        this.evictions = evictions;
     }
 
     @Override
     public Map<String, Collection<CacheData>> getCacheResults() {
         return cacheResults;
+    }
+
+    @Override
+    public Map<String, Collection<String>> getEvictions() {
+        return evictions;
     }
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderCache.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderCache.java
@@ -120,6 +120,7 @@ public class DefaultProviderCache implements ProviderCache {
     public void putCacheResult(String sourceAgentType, Collection<String> authoritativeTypes, CacheResult cacheResult) {
         Set<String> allTypes = new HashSet<>(cacheResult.getCacheResults().keySet());
         allTypes.addAll(authoritativeTypes);
+        allTypes.addAll(cacheResult.getEvictions().keySet());
         validateTypes(allTypes);
 
         for (String type : allTypes) {
@@ -127,13 +128,16 @@ public class DefaultProviderCache implements ProviderCache {
             if (authoritativeTypes.contains(type)) {
                 previousSet = getExistingSourceIdentifiers(type, sourceAgentType);
             } else {
-                previousSet = Collections.emptySet();
+                previousSet = new HashSet<>();
             }
             if (cacheResult.getCacheResults().containsKey(type)) {
                 cacheDataType(type, sourceAgentType, cacheResult.getCacheResults().get(type));
                 for (CacheData data : cacheResult.getCacheResults().get(type)) {
                     previousSet.remove(data.getId());
                 }
+            }
+            if (cacheResult.getEvictions().containsKey(type)) {
+              previousSet.addAll(cacheResult.getEvictions().get(type));
             }
             evictDeletedItems(type, previousSet);
         }

--- a/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/provider/DefaultProviderCacheSpec.groovy
+++ b/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/provider/DefaultProviderCacheSpec.groovy
@@ -39,6 +39,27 @@ class DefaultProviderCacheSpec extends CacheSpec {
         getCache() as DefaultProviderCache
     }
 
+    def 'explicit evictions are removed from the cache'() {
+        setup:
+        String agent = 'agent'
+        CacheResult result = new DefaultCacheResult(test: [new DefaultCacheData('id', [id: 'id'], [:])])
+        defaultProviderCache.putCacheResult(agent, [], result)
+
+        when:
+        def data = defaultProviderCache.get('test', 'id')
+
+        then:
+        data != null
+        data.id == 'id'
+
+        when:
+        defaultProviderCache.putCacheResult(agent, [], new DefaultCacheResult([:], [test: ['id']]))
+        data = defaultProviderCache.get('test', 'id')
+
+        then:
+        data == null
+    }
+
     def 'multiple agents can cache the same data type'() {
         setup:
         String usEast1Agent = 'AwsProvider:test/us-east-1/ClusterCachingAgent'

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.groovy
@@ -72,16 +72,16 @@ class CatsOnDemandCacheUpdater implements OnDemandCacheUpdater {
         def providerCache = catsModule.getProviderRegistry().getProviderCache(agent.providerName)
         OnDemandAgent.OnDemandResult result = agent.handle(providerCache, data)
         if (result) {
+          if (result.cacheResult) {
+            agent.metricsSupport.cacheWrite {
+              providerCache.putCacheResult(result.sourceAgentType, result.authoritativeTypes, result.cacheResult)
+            }
+          }
           if (result.evictions) {
             agent.metricsSupport.cacheEvict {
               result.evictions.each { String evictType, Collection<String> ids ->
                 providerCache.evictDeletedItems(evictType, ids)
               }
-            }
-          }
-          if (result.cacheResult) {
-            agent.metricsSupport.cacheWrite {
-              providerCache.putCacheResult(result.sourceAgentType, result.authoritativeTypes, result.cacheResult)
             }
           }
           final long elapsed = System.nanoTime() - startTime


### PR DESCRIPTION
Our agents that cache on_demand items need to clean those up when they expire. This doesn't line up with the authoritative / informative notion for agent data sets.  Instead of the caching agent manually calling evictDeletedItems while building a result, this moves the eviction set into the CacheResult so that it can be deleted during (but after) the cache write for a data type.
