### PR TITLE
Add load balancers to CF

### DIFF
--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/converters/DeleteCloudFoundryLoadBalancerAtomicOperationConverter.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/converters/DeleteCloudFoundryLoadBalancerAtomicOperationConverter.groovy
@@ -1,0 +1,30 @@
+package com.netflix.spinnaker.kato.cf.deploy.converters
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryOperation
+import com.netflix.spinnaker.kato.cf.deploy.description.DeleteCloudFoundryLoadBalancerDescription
+import com.netflix.spinnaker.kato.cf.deploy.ops.loadbalancer.DeleteCloudFoundryLoadBalancerAtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
+import com.netflix.spinnaker.kato.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+/**
+ * @author Greg Turnquist
+ */
+@CloudFoundryOperation(AtomicOperations.DELETE_LOAD_BALANCER)
+@Component("deleteCloudFoundryLoadBalancerDescription")
+class DeleteCloudFoundryLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    new DeleteCloudFoundryLoadBalancerAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  Object convertDescription(Map input) {
+    new DeleteCloudFoundryLoadBalancerDescription([
+        loadBalancerName : input.loadBalancerName,
+        zone             : input.zone,
+        region           : input.region,
+        credentials      : getCredentialsObject(input.credentials as String)
+    ])
+  }
+}

--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/converters/UpsertCloudFoundryLoadBalancerAtomicOperationConverter.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/converters/UpsertCloudFoundryLoadBalancerAtomicOperationConverter.groovy
@@ -1,0 +1,31 @@
+package com.netflix.spinnaker.kato.cf.deploy.converters
+
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryOperation
+import com.netflix.spinnaker.kato.cf.deploy.description.UpsertCloudFoundryLoadBalancerDescription
+import com.netflix.spinnaker.kato.cf.deploy.ops.loadbalancer.UpsertCloudFoundryLoadBalancerAtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperation
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
+import com.netflix.spinnaker.kato.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+/**
+ * @author Greg Turnquist
+ */
+@CloudFoundryOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
+@Component("upsertCloudFoundryLoadBalancerDescription")
+class UpsertCloudFoundryLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    new UpsertCloudFoundryLoadBalancerAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  Object convertDescription(Map input) {
+    new UpsertCloudFoundryLoadBalancerDescription([
+        loadBalancerName : input.loadBalancerName,
+        zone             : input.zone,
+        region           : input.region,
+        credentials      : getCredentialsObject(input.credentials as String)
+    ])
+  }
+}

--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/description/DeleteCloudFoundryLoadBalancerDescription.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/description/DeleteCloudFoundryLoadBalancerDescription.groovy
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.kato.cf.deploy.description
+
+import com.netflix.spinnaker.kato.cf.security.CloudFoundryAccountCredentials
+
+/**
+ * @author Greg Turnquist
+ */
+class DeleteCloudFoundryLoadBalancerDescription {
+  String loadBalancerName
+  String region
+  String zone
+  String getAccountName() {
+    credentials?.name
+  }
+  CloudFoundryAccountCredentials credentials
+}

--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/description/UpsertCloudFoundryLoadBalancerDescription.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/description/UpsertCloudFoundryLoadBalancerDescription.groovy
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.kato.cf.deploy.description
+
+import com.netflix.spinnaker.kato.cf.security.CloudFoundryAccountCredentials
+
+/**
+ * @author Greg Turnquist
+ */
+class UpsertCloudFoundryLoadBalancerDescription {
+  String loadBalancerName
+  String region
+  String zone
+  String getAccountName() {
+    credentials?.name
+  }
+  CloudFoundryAccountCredentials credentials
+}

--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/ops/loadbalancer/DeleteCloudFoundryLoadBalancerAtomicOperation.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/ops/loadbalancer/DeleteCloudFoundryLoadBalancerAtomicOperation.groovy
@@ -1,0 +1,41 @@
+package com.netflix.spinnaker.kato.cf.deploy.ops.loadbalancer
+import com.netflix.spinnaker.kato.cf.deploy.description.DeleteCloudFoundryLoadBalancerDescription
+import com.netflix.spinnaker.kato.cf.security.CloudFoundryClientFactory
+import com.netflix.spinnaker.kato.data.task.Task
+import com.netflix.spinnaker.kato.data.task.TaskRepository
+import com.netflix.spinnaker.kato.orchestration.AtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
+/**
+ * @author Greg Turnquist
+ */
+class DeleteCloudFoundryLoadBalancerAtomicOperation implements AtomicOperation<Void> {
+
+  private static final String BASE_PHASE = "DELETE_LOAD_BALANCER"
+
+  @Autowired
+  CloudFoundryClientFactory cloudFoundryClientFactory
+
+  private final DeleteCloudFoundryLoadBalancerDescription description
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  DeleteCloudFoundryLoadBalancerAtomicOperation(DeleteCloudFoundryLoadBalancerDescription description) {
+    this.description = description
+  }
+
+  @Override
+  Void operate(List priorOutputs) {
+    task.updateStatus BASE_PHASE, "Initializing deletion of load balancer $description.loadBalancerName in $description.region..."
+
+    def client = cloudFoundryClientFactory.createCloudFoundryClient(description.credentials, true)
+
+    client.deleteRoute(description.loadBalancerName, client.defaultDomain.name)
+
+    task.updateStatus BASE_PHASE, "Done deleting load balancer $description.loadBalancerName."
+
+    null
+  }
+
+}

--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/ops/loadbalancer/UpsertCloudFoundryLoadBalancerAtomicOperation.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/ops/loadbalancer/UpsertCloudFoundryLoadBalancerAtomicOperation.groovy
@@ -1,0 +1,41 @@
+package com.netflix.spinnaker.kato.cf.deploy.ops.loadbalancer
+import com.netflix.spinnaker.kato.cf.deploy.description.UpsertCloudFoundryLoadBalancerDescription
+import com.netflix.spinnaker.kato.cf.security.CloudFoundryClientFactory
+import com.netflix.spinnaker.kato.data.task.Task
+import com.netflix.spinnaker.kato.data.task.TaskRepository
+import com.netflix.spinnaker.kato.orchestration.AtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
+/**
+ * @author Greg Turnquist
+ */
+class UpsertCloudFoundryLoadBalancerAtomicOperation implements AtomicOperation<Map> {
+
+  private static final String BASE_PHASE = "UPSERT_LOAD_BALANCER"
+
+  @Autowired
+  CloudFoundryClientFactory cloudFoundryClientFactory
+
+  private final UpsertCloudFoundryLoadBalancerDescription description
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  UpsertCloudFoundryLoadBalancerAtomicOperation(UpsertCloudFoundryLoadBalancerDescription description) {
+    this.description = description
+  }
+
+  @Override
+  Map operate(List priorOutputs) {
+    task.updateStatus BASE_PHASE, "Initializing creation of load balancer $description.loadBalancerName in $description.region..."
+
+    def client = cloudFoundryClientFactory.createCloudFoundryClient(description.credentials, true)
+
+    client.addRoute(description.loadBalancerName, client.defaultDomain.name)
+
+    task.updateStatus BASE_PHASE, "Done creating load balancer $description.loadBalancerName."
+
+    [loadBalancers: [(description.region): [name: description.loadBalancerName]]]
+  }
+
+}

--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/validators/DeleteCloudFoundryLoadBalancerDescriptionValidator.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/validators/DeleteCloudFoundryLoadBalancerDescriptionValidator.groovy
@@ -1,0 +1,29 @@
+package com.netflix.spinnaker.kato.cf.deploy.validators
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryOperation
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.kato.cf.deploy.description.DeleteCloudFoundryLoadBalancerDescription
+import com.netflix.spinnaker.kato.deploy.DescriptionValidator
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.validation.Errors
+/**
+ * @author Greg Turnquist
+ */
+@CloudFoundryOperation(AtomicOperations.DELETE_LOAD_BALANCER)
+@Component("deleteCloudFoundryLoadBalancerDescriptionValidator")
+class DeleteCloudFoundryLoadBalancerDescriptionValidator extends DescriptionValidator<DeleteCloudFoundryLoadBalancerDescription> {
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Override
+  void validate(List priorDescriptions, DeleteCloudFoundryLoadBalancerDescription description, Errors errors) {
+    def helper = new StandardCfAttributeValidator("deleteCloudFoundryLoadBalancerDescription", errors)
+
+    helper.validateCredentials(description.accountName, accountCredentialsProvider)
+    helper.validateNotEmpty(description.loadBalancerName, "loadBalancerName.empty")
+//    helper.validateZone(description.zone)
+
+  }
+}

--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/validators/UpsertCloudFoundryLoadBalancerDescriptionValidator.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/deploy/validators/UpsertCloudFoundryLoadBalancerDescriptionValidator.groovy
@@ -1,0 +1,30 @@
+package com.netflix.spinnaker.kato.cf.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryOperation
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.kato.cf.deploy.description.UpsertCloudFoundryLoadBalancerDescription
+import com.netflix.spinnaker.kato.deploy.DescriptionValidator
+import com.netflix.spinnaker.kato.orchestration.AtomicOperations
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.validation.Errors
+/**
+ * @author Greg Turnquist
+ */
+@CloudFoundryOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
+@Component("upsertCloudFoundryLoadBalancerDescriptionValidator")
+class UpsertCloudFoundryLoadBalancerDescriptionValidator extends DescriptionValidator<UpsertCloudFoundryLoadBalancerDescription> {
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Override
+  void validate(List priorDescriptions, UpsertCloudFoundryLoadBalancerDescription description, Errors errors) {
+    def helper = new StandardCfAttributeValidator("upsertCloudFoundryLoadBalancerDescription", errors)
+
+    helper.validateCredentials(description.accountName, accountCredentialsProvider)
+    helper.validateNotEmpty(description.loadBalancerName, "loadBalancerName.empty")
+//    helper.validateZone(description.zone)
+
+  }
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/controllers/CloudFoundryLoadBalancerController.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/controllers/CloudFoundryLoadBalancerController.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.cf.controllers
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.oort.cf.model.CloudFoundryLoadBalancer
+import com.netflix.spinnaker.oort.cf.model.CloudFoundryResourceRetriever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/cf/loadBalancers")
+class CloudFoundryLoadBalancerController {
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Autowired
+  CloudFoundryResourceRetriever cfResourceRetriever
+
+  @RequestMapping(method = RequestMethod.GET)
+  List<CloudFoundryLoadBalancerAccount> list() {
+    getSummaryForLoadBalancers(cfResourceRetriever.loadBalancersByAccount).values() as List
+  }
+
+  @RequestMapping(value = "/{name:.+}", method = RequestMethod.GET)
+  CloudFoundryLoadBalancerSummary get(@PathVariable String name) {
+    getSummaryForLoadBalancers(cfResourceRetriever.loadBalancersByAccount).get(name)
+  }
+
+  @RequestMapping(value = "/{account}/{region}/{name:.+}", method = RequestMethod.GET)
+  List<Map> getDetailsInAccountAndRegionByName(@PathVariable String account, @PathVariable String region, @PathVariable String name) {
+    def accountMap = cfResourceRetriever.loadBalancersByAccount[account]
+
+    if (accountMap) {
+      def regionList = accountMap
+
+      if (regionList) {
+        def cfLoadBalancer = regionList.find {
+          it.name == name
+        }
+
+        if (cfLoadBalancer) {
+          def loadBalancerDetail = [
+            loadBalancerName: name
+          ]
+
+          loadBalancerDetail.ipAddress = cfLoadBalancer.nativeRoute.host
+
+          // TODO(duftler): Remove this when we have a CF-specific details pane in deck.
+          loadBalancerDetail.dnsname = cfLoadBalancer.nativeRoute.host
+
+          return [ loadBalancerDetail ]
+        }
+      }
+    }
+
+    return []
+  }
+
+  public static Map<String, CloudFoundryLoadBalancerSummary> getSummaryForLoadBalancers(
+      Map<String, Set<CloudFoundryLoadBalancer>> networkLoadBalancerMap) {
+    Map<String, CloudFoundryLoadBalancerSummary> map = [:]
+
+    networkLoadBalancerMap?.each() { account, loadBalancerList ->
+      loadBalancerList.each { CloudFoundryLoadBalancer loadBalancer ->
+        def summary = map.get(loadBalancer.name)
+
+        if (!summary) {
+          summary = new CloudFoundryLoadBalancerSummary(name: loadBalancer.name)
+          map.put loadBalancer.name, summary
+        }
+
+        def loadBalancerDetail =
+          new CloudFoundryLoadBalancerDetail(account: account, region: 'unknown', name: loadBalancer.name)
+
+        //summary.getOrCreateAccount(account).getOrCreateRegion(region).loadBalancers << loadBalancerDetail
+      }
+    }
+
+    map
+  }
+
+  static class CloudFoundryLoadBalancerSummary {
+    private Map<String, CloudFoundryLoadBalancerAccount> mappedAccounts = [:]
+    String name
+
+    CloudFoundryLoadBalancerAccount getOrCreateAccount(String name) {
+      if (!mappedAccounts.containsKey(name)) {
+        mappedAccounts.put(name, new CloudFoundryLoadBalancerAccount(name: name))
+      }
+      mappedAccounts[name]
+    }
+
+    @JsonProperty("accounts")
+    List<CloudFoundryLoadBalancerAccount> getAccounts() {
+      mappedAccounts.values() as List
+    }
+  }
+
+  static class CloudFoundryLoadBalancerAccount {
+    private Map<String, CloudFoundryLoadBalancerAccountRegion> mappedRegions = [:]
+    String name
+
+    CloudFoundryLoadBalancerAccountRegion getOrCreateRegion(String name) {
+      if (!mappedRegions.containsKey(name)) {
+        mappedRegions.put(name, new CloudFoundryLoadBalancerAccountRegion(name: name, loadBalancers: []))
+      }
+      mappedRegions[name]
+    }
+
+    @JsonProperty("regions")
+    List<CloudFoundryLoadBalancerAccountRegion> getRegions() {
+      mappedRegions.values() as List
+    }
+  }
+
+  static class CloudFoundryLoadBalancerAccountRegion {
+    String name
+    List<CloudFoundryLoadBalancerDetail> loadBalancers
+  }
+
+  static class CloudFoundryLoadBalancerDetail {
+    String account
+    String region
+    String name
+    String type = 'cf'
+  }
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationInstance.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationInstance.groovy
@@ -33,6 +33,7 @@ class CloudFoundryApplicationInstance implements Instance, Serializable {
   CloudApplication nativeApplication
   List<Map<String, String>> health = []
   InstanceInfo nativeInstance
+  String type = 'cf'
 
   @Override
   Long getLaunchTime() {

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryCluster.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryCluster.groovy
@@ -15,9 +15,7 @@
  */
 
 package com.netflix.spinnaker.oort.cf.model
-
 import com.netflix.spinnaker.oort.model.Cluster
-import com.netflix.spinnaker.oort.model.LoadBalancer
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 /**
@@ -33,10 +31,6 @@ class CloudFoundryCluster implements Cluster, Serializable {
   String type = 'cf'
   String accountName
   Set<CloudFoundryServerGroup> serverGroups = [] as Set<CloudFoundryServerGroup>
-
-  @Override
-  Set<LoadBalancer> getLoadBalancers() {
-    Collections.emptySet()
-  }
+  Set<CloudFoundryLoadBalancer> loadBalancers = [] as Set<CloudFoundryLoadBalancer>
 
 }

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryLoadBalancer.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryLoadBalancer.groovy
@@ -1,0 +1,22 @@
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spinnaker.oort.model.LoadBalancer
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import org.cloudfoundry.client.lib.domain.CloudRoute
+
+/**
+ * @author Greg Turnquist
+ */
+@CompileStatic
+@EqualsAndHashCode(includes = ["name"])
+class CloudFoundryLoadBalancer implements LoadBalancer {
+
+  String name
+  String type = 'cf'
+  Set<Map<String, Object>> serverGroups = new HashSet<>()
+  String region
+  String account
+  CloudRoute nativeRoute
+
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryLoadBalancerProvider.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryLoadBalancerProvider.groovy
@@ -1,0 +1,54 @@
+package com.netflix.spinnaker.oort.cf.model
+
+import com.netflix.spinnaker.oort.model.LoadBalancerProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * @author Greg Turnquist
+ */
+@Component
+class CloudFoundryLoadBalancerProvider implements LoadBalancerProvider<CloudFoundryLoadBalancer> {
+
+  @Autowired
+  CloudFoundryResourceRetriever cloudFoundryResourceRetriever
+
+  @Override
+  Map<String, Set<CloudFoundryLoadBalancer>> getLoadBalancers() {
+    cloudFoundryResourceRetriever.loadBalancersByAccount
+  }
+
+  @Override
+  Set<CloudFoundryLoadBalancer> getLoadBalancers(String account) {
+    cloudFoundryResourceRetriever.loadBalancersByAccount[account]
+  }
+
+  @Override
+  Set<CloudFoundryLoadBalancer> getLoadBalancers(String account, String cluster) {
+    cloudFoundryResourceRetriever.loadBalancersByAccountAndClusterName[account][cluster]
+  }
+
+  @Override
+  Set<CloudFoundryLoadBalancer> getLoadBalancers(String account, String cluster, String type) {
+    cloudFoundryResourceRetriever.loadBalancersByAccountAndClusterName[account][cluster]
+  }
+
+  @Override
+  Set<CloudFoundryLoadBalancer> getLoadBalancer(String account, String cluster, String type, String loadBalancerName) {
+    cloudFoundryResourceRetriever.loadBalancersByAccountAndClusterName[account][cluster].findAll{
+      it.name == loadBalancerName
+    } as Set<CloudFoundryLoadBalancer>
+  }
+
+  @Override
+  CloudFoundryLoadBalancer getLoadBalancer(String account, String cluster, String type, String loadBalancerName, String region) {
+    cloudFoundryResourceRetriever.loadBalancersByAccountAndClusterName[account][cluster].findAll{
+      it.name == loadBalancerName
+    } as Set<CloudFoundryLoadBalancer>
+  }
+
+  @Override
+  Set<CloudFoundryLoadBalancer> getApplicationLoadBalancers(String application) {
+    cloudFoundryResourceRetriever.loadBalancersByApplication[application]
+  }
+}

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryServerGroup.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryServerGroup.groovy
@@ -39,6 +39,8 @@ class CloudFoundryServerGroup implements ServerGroup, Serializable {
   Set<CloudFoundryService> services = [] as Set<CloudFoundryService>
   Map<String, Object> envVariables = new HashMap<>()
   Map<String, Object> cfSettings = new HashMap<>() // scaling, memory, etc.
+  Set<CloudFoundryLoadBalancer> nativeLoadBalancers
+  Map buildInfo
 
   @Override
   String getRegion() {
@@ -70,7 +72,7 @@ class CloudFoundryServerGroup implements ServerGroup, Serializable {
 
   @Override
   Set<String> getLoadBalancers() {
-    Collections.emptySet()
+    nativeLoadBalancers.collect {it.name} as Set<String>
   }
 
   @Override
@@ -118,7 +120,7 @@ class CloudFoundryServerGroup implements ServerGroup, Serializable {
 
   @Override
   ServerGroup.ImageSummary getImageSummary() {
-    // TODO(gturnquist): Implement
+    def bi = buildInfo
     return new ServerGroup.ImageSummary() {
       String serverGroupName = name
       String imageName
@@ -126,12 +128,12 @@ class CloudFoundryServerGroup implements ServerGroup, Serializable {
 
       @Override
       Map<String, Object> getBuildInfo() {
-        return null
+        buildInfo
       }
 
       @Override
       Map<String, Object> getImage() {
-        return null
+        return [:]
       }
     }
   }

--- a/oort/oort-core/src/main/groovy/com/netflix/spinnaker/oort/model/LoadBalancer.groovy
+++ b/oort/oort-core/src/main/groovy/com/netflix/spinnaker/oort/model/LoadBalancer.groovy
@@ -45,5 +45,5 @@ interface LoadBalancer {
    * @return set of names or an empty set if none exist
    */
   @Empty
-  Set<String> getServerGroups()
+  Set<Map<String, Object>> getServerGroups()
 }


### PR DESCRIPTION
Model CF routes as load balancers, given routes can be assigned to multiple CF apps (server groups) and used to effectively load balancer between different versions of an app.