### PR TITLE
prefer [] to 404 when no image search results found

### DIFF
--- a/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/controllers/AmazonNamedImageLookupController.groovy
+++ b/oort/oort-aws/src/main/groovy/com/netflix/spinnaker/oort/aws/controllers/AmazonNamedImageLookupController.groovy
@@ -99,9 +99,6 @@ class AmazonNamedImageLookupController {
   }
 
   private List<NamedImage> render(Collection<CacheData> namedImages, Collection<CacheData> images, Collection<CacheData> imageTags, String requestedName = null, String requiredRegion = null) {
-    if (!namedImages && !images) {
-      throw new ImageNotFoundException('Not found')
-    }
     Map<String, NamedImage> byImageName = [:].withDefault { new NamedImage(imageName: it) }
     for (CacheData data : namedImages) {
       Map<String, String> keyParts = Keys.parse(data.id)
@@ -135,9 +132,6 @@ class AmazonNamedImageLookupController {
     }
 
     List<NamedImage> results = byImageName.values().findAll { requiredRegion ? it.amis.containsKey(requiredRegion) : true }
-    if (!results) {
-      throw new ImageNotFoundException('Not found')
-    }
     results.sort { a, b ->
       int a1, b1
       if (requestedName) {


### PR DESCRIPTION
Since the response for the methods in this controller are all lists, we should just return an empty list if that's what we find.

Throwing a 404 confuses Gate, which responds with a 429, which is misleading at best.
