### PR TITLE
Add load balancers to CF

### DIFF
--- a/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/security/CloudFoundryAccountCredentials.groovy
+++ b/kato/kato-cf/src/main/groovy/com/netflix/spinnaker/kato/cf/security/CloudFoundryAccountCredentials.groovy
@@ -28,6 +28,7 @@ class CloudFoundryAccountCredentials implements AccountCredentials<CloudCredenti
 
   String name
   String api
+  String console
   String org
   String space
   String username

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationInstance.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryApplicationInstance.groovy
@@ -33,6 +33,7 @@ class CloudFoundryApplicationInstance implements Instance, Serializable {
   CloudApplication nativeApplication
   List<Map<String, String>> health = []
   InstanceInfo nativeInstance
+  String logsLink
 
   @Override
   Long getLaunchTime() {

--- a/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryResourceRetriever.groovy
+++ b/oort/oort-cf/src/main/groovy/com/netflix/spinnaker/oort/cf/model/CloudFoundryResourceRetriever.groovy
@@ -200,7 +200,8 @@ class CloudFoundryResourceRetriever {
                           healthState      : healthState,
                           health           : health,
                           nativeApplication: app,
-                          nativeInstance:   it
+                          nativeInstance:   it,
+                          logsLink         : "${credentials.console}/organizations/${space.organization.meta.guid}/spaces/${space.meta.guid}/applications/${app.meta.guid}/tailing_logs"
                   ])
                   if (tempInstancesByAccountAndId[account][instance.name]?.healthState != instance.healthState) {
                     log.info "Updating ${account}/${instance.name} to ${instance.healthState}"


### PR DESCRIPTION
- Model CF routes as load balancers, given routes can be assigned to multiple CF apps (server groups) and used to effectively load balancer between different versions of an app.
- Create op to create a CF load balancer
- Also create op to delete CF load balancer, but not wired into UI
