### PR TITLE
If the instance is one of these types, we should prefer the config.

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -107,8 +107,9 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         }
       }
 
-      if (!description.blockDevices) {
-        description.blockDevices = BlockDeviceConfig.blockDevicesByInstanceType[description.instanceType]
+      def blockDeviceMappingForInstanceType = BlockDeviceConfig.blockDevicesByInstanceType[description.instanceType]
+      if (blockDeviceMappingForInstanceType) {
+        description.blockDevices = blockDeviceMappingForInstanceType
       }
 
       // find by 1) result of a previous step (we performed allow launch)


### PR DESCRIPTION
It is likely better than whatever is being passed in. If someone switches instance types then the would inherit the wrong mappings. This gets a little tricky because you can inherit these settings even if you don't clone an ASG, if there is a previous ASG in the cluster you get them even on a create. This seems like a totally different problem though.
