### PR TITLE
Enable/Disable AWS operations should favor `serverGroupName` over `as…

### DIFF
--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/AsgDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/AsgDescription.groovy
@@ -17,6 +17,22 @@
 package com.netflix.spinnaker.kato.aws.deploy.description
 
 class AsgDescription {
-  String asgName
+  String serverGroupName
   String region
+
+  @Deprecated
+  String asgName
+
+  String getServerGroupName() {
+    return serverGroupName ?: this.asgName
+  }
+
+  @Deprecated
+  String getAsgName() {
+    return getServerGroupName()
+  }
+
+  public String toString() {
+    return "${region}:${getServerGroupName()}"
+  }
 }

--- a/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/EnableDisableAsgDescription.groovy
+++ b/kato/kato-aws/src/main/groovy/com/netflix/spinnaker/kato/aws/deploy/description/EnableDisableAsgDescription.groovy
@@ -25,9 +25,21 @@ package com.netflix.spinnaker.kato.aws.deploy.description
 class EnableDisableAsgDescription extends AbstractAmazonCredentialsDescription {
   List<AsgDescription> asgs = []
 
+  String serverGroupName
+
   @Deprecated
   String asgName
 
   @Deprecated
   List<String> regions = []
+
+  List<AsgDescription> getAsgs() {
+    if (asgs) {
+      return asgs
+    }
+
+    return regions.collect {
+      new AsgDescription(serverGroupName: (serverGroupName ?: asgName), region: it)
+    }
+  }
 }

--- a/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/description/AsgDescriptionSpec.groovy
+++ b/kato/kato-aws/src/test/groovy/com/netflix/spinnaker/kato/aws/deploy/description/AsgDescriptionSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.kato.aws.deploy.description
+
+import spock.lang.Specification
+
+class AsgDescriptionSpec extends Specification {
+  def "should favor `serverGroupName` over `asgName`"() {
+    expect:
+    aD("serverGroupName", "asgName").asgName == "serverGroupName"
+    aD("serverGroupName", "asgName").serverGroupName == "serverGroupName"
+
+    aD(null, "asgName").asgName == "asgName"
+    aD(null, "asgName").serverGroupName == "asgName"
+
+    aD("serverGroupName", "asgName").@serverGroupName == "serverGroupName"
+    aD("serverGroupName", "asgName").@asgName == "asgName"
+  }
+
+  private static AsgDescription aD(String serverGroupName, String asgName) {
+    return new AsgDescription(serverGroupName: serverGroupName, asgName: asgName)
+  }
+}


### PR DESCRIPTION
…gName`

- we can stop passing `region` and `asgName` through deck and orca (for enable/disable)