### PR TITLE
Use account name for environment and accountType when not explicitly-…

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -33,6 +33,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+import org.springframework.core.convert.ConversionService
+import org.springframework.core.convert.support.DefaultConversionService
 import org.springframework.web.client.RestTemplate
 
 @Configuration
@@ -86,5 +88,11 @@ class CloudDriverConfig {
   @ConditionalOnMissingBean(CloudProvider)
   CloudProvider noopCloudProvider() {
     new NoopCloudProvider()
+  }
+
+  // Allows @Value annotation to tokenize a list of strings.
+  @Bean
+  ConversionService conversionService() {
+    new DefaultConversionService()
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleCredentialsInitializer.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleCredentialsInitializer.groovy
@@ -71,8 +71,8 @@ class GoogleCredentialsInitializer implements CredentialsInitializerSynchronizab
       try {
         def jsonKey = GoogleCredentialsInitializer.getJsonKey(managedAccount)
         def googleAccount = new GoogleNamedAccountCredentials(managedAccount.name,
-                                                              managedAccount.environment,
-                                                              managedAccount.accountType,
+                                                              managedAccount.environment ?: managedAccount.name,
+                                                              managedAccount.accountType ?: managedAccount.name,
                                                               managedAccount.project,
                                                               jsonKey,
                                                               googleApplicationName)


### PR DESCRIPTION
…specified for Google accounts.

Configure Spring DefaultConversionService so we can tokenize lists of strings via @Value annotations.
Should be merged at the same time as: https://github.com/spinnaker/spinnaker/pull/634
@cfieber please review.