### PR TITLE
add endpoint to get cluster data for a project

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
@@ -27,6 +27,9 @@ interface Front50Service {
   @GET('/{account}/applications/search')
   List<Map> searchByName(@Path('account') String account, @Query("name") String name)
 
+  @GET('/v2/projects/{project}')
+  Map getProject(@Path('project') String project)
+
   @GET('/v2/projects/search')
   HalList searchForProjects(@Query("q") String query)
 

--- a/oort/oort-core/src/main/groovy/com/netflix/spinnaker/oort/model/ServerGroup.groovy
+++ b/oort/oort-core/src/main/groovy/com/netflix/spinnaker/oort/model/ServerGroup.groovy
@@ -126,32 +126,32 @@ interface ServerGroup {
     /**
      * Total number of instances in the server group
      */
-    Integer total
+    Integer total = 0
 
     /**
      * Total number of "Up" instances (all health indicators report "Up" or "Unknown")
      */
-    Integer up
+    Integer up = 0
 
     /**
      * Total number of "Down" instances (at least one health indicator reports "Down")
      */
-    Integer down
+    Integer down = 0
 
     /**
      * Total number of "Unknown" instances (all health indicators report "Unknown", or no health indicators reported)
      */
-    Integer unknown
+    Integer unknown = 0
 
     /**
      * Total number of "OutOfService" instances (at least one health indicator reports "OutOfService", none are "Down"
      */
-    Integer outOfService
+    Integer outOfService = 0
 
     /**
      * Total number of "Starting" instances (where any health indicator reports "Starting" and none are "Down" or "OutOfService")
      */
-    Integer starting
+    Integer starting = 0
   }
 
   static class Capacity {

--- a/oort/oort-web/src/main/groovy/com/netflix/spinnaker/oort/controllers/ProjectController.groovy
+++ b/oort/oort-web/src/main/groovy/com/netflix/spinnaker/oort/controllers/ProjectController.groovy
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort.controllers
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.oort.model.Cluster
+import com.netflix.spinnaker.oort.model.ClusterProvider
+import com.netflix.spinnaker.oort.model.ServerGroup
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.MessageSource
+import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.http.HttpStatus
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import rx.Observable
+import rx.Scheduler
+import rx.schedulers.Schedulers
+
+import com.netflix.spinnaker.oort.model.ServerGroup.InstanceCounts as InstanceCounts
+
+@Slf4j
+@RestController
+@RequestMapping("/projects/{project}")
+class ProjectController {
+
+  private final Scheduler queryClusterScheduler
+
+  @Autowired
+  ProjectController(@Value('${threadPool.queryCluster:25}') int threadPoolSize) {
+    this(Schedulers.from(newFixedThreadPool(threadPoolSize)))
+  }
+
+  ProjectController(Scheduler queryClusterScheduler) {
+    this.queryClusterScheduler = queryClusterScheduler
+  }
+
+  @Autowired
+  Front50Service front50Service
+
+  @Autowired
+  MessageSource messageSource
+
+  @Autowired
+  List<ClusterProvider> clusterProviders
+
+  @RequestMapping(method= RequestMethod.GET, value = "/clusters")
+  List<ClusterModel> getClusters(@PathVariable String project) {
+    Map projectConfig = null
+    try {
+      projectConfig = front50Service.getProject(project)
+    } catch (e) {
+      log.error("Unable to fetch project (${project})", e)
+      throw new ProjectNotFoundException(name: project)
+    }
+
+    if (projectConfig.config.clusters.size() == 0) {
+      return []
+    }
+
+    List<String> applicationsToRetrieve = projectConfig.config.applications ?: []
+    Map<String, Set<Cluster>> allClusters = retrieveClusters(applicationsToRetrieve)
+
+    projectConfig.config.clusters.findResults { Map projectCluster ->
+      List<String> applications = projectCluster.applications ?: projectConfig.config.applications
+      def applicationModels = applications.findResults { String application ->
+        def appClusters = allClusters[application]
+        Set<Cluster> clusterMatches = findClustersForProject(appClusters, projectCluster)
+        new ApplicationClusterModel(application, clusterMatches)
+      }
+      new ClusterModel(
+          account: projectCluster.account,
+          stack: projectCluster.stack,
+          detail: projectCluster.detail,
+          applications: applicationModels
+      )
+    }
+  }
+
+  private static HashSet<Cluster> findClustersForProject(Set<Cluster> appClusters, Map projectCluster) {
+    if (!appClusters) {
+      return []
+    }
+    appClusters.findAll { appCluster ->
+      Names clusterNameParts = Names.parseName(appCluster.name)
+      appCluster.accountName == projectCluster.account &&
+          nameMatches("stack", clusterNameParts, projectCluster) &&
+          nameMatches("detail", clusterNameParts, projectCluster)
+    }
+  }
+
+  private Map<String, Set<Cluster>> retrieveClusters(List<String> applications) {
+    Map<String, Set<Cluster>> allClusters = [:]
+    def retrievedClusters = Observable.from(applications)
+        .flatMap { application ->
+      retrieveApplication(application).subscribeOn(queryClusterScheduler)
+    }
+    .observeOn(queryClusterScheduler).toList().toBlocking().single()
+
+    retrievedClusters.each {
+      if (!allClusters.containsKey(it.application)) {
+        allClusters.put(it.application, new HashSet<Cluster>())
+      }
+      allClusters[it.application].addAll(it.clusters)
+    }
+
+    allClusters
+  }
+
+  private Observable retrieveApplication(String application) {
+    return Observable.from(clusterProviders).flatMap({
+      Observable.from((it.getClusterDetails(application) ?: [:]).findResults {
+        new RetrievedClusters(application: application, clusters: it.value)
+      })
+    });
+  }
+
+  static boolean nameMatches(String field, Names clusterName, Map projectCluster) {
+    return projectCluster[field] == clusterName[field] || projectCluster[field] == "*" ||
+        (!projectCluster[field] && !clusterName[field])
+  }
+
+
+  // Internal model - used to return all clusters for a given application
+  static class RetrievedClusters {
+    String application
+    Set<Cluster> clusters
+  }
+
+
+  // Represents all the data needed to render a specific project cluster view
+  static class ClusterModel {
+    String account
+    String stack
+    String detail
+    List<ApplicationClusterModel> applications = []
+    InstanceCounts getInstanceCounts() {
+      Set<InstanceCounts> clusterCounts = applications.clusters.flatten().instanceCounts
+      new InstanceCounts(
+          total: (Integer) clusterCounts.total.sum(),
+          down: (Integer) clusterCounts.down.sum(),
+          outOfService: (Integer) clusterCounts.outOfService.sum(),
+          up: (Integer) clusterCounts.up.sum(),
+          unknown: (Integer) clusterCounts.unknown.sum(),
+          starting: (Integer) clusterCounts.starting.sum()
+      )
+    }
+  }
+
+  // Represents the cluster data for a particular application
+  static class ApplicationClusterModel {
+    String application
+    Set<RegionClusterModel> clusters = []
+    Long getLastPush() {
+      clusters.lastPush.max()
+    }
+
+    ApplicationClusterModel(String applicationName, Set<Cluster> appClusters) {
+      application = applicationName
+      Map<String, RegionClusterModel> regionClusters = [:]
+      appClusters.serverGroups.flatten().findAll {
+        !it.isDisabled() && it.instanceCounts.total > 0
+      }.each { serverGroup ->
+        if (!regionClusters.containsKey(serverGroup.region)) {
+          regionClusters.put(serverGroup.region, new RegionClusterModel(region: serverGroup.region))
+        }
+        RegionClusterModel regionCluster = regionClusters.get(serverGroup.region)
+        incrementInstanceCounts(serverGroup, regionCluster.instanceCounts)
+        def buildNumber = serverGroup.imageSummary?.buildInfo?.jenkins?.number ?: "0"
+        def host = serverGroup.imageSummary?.buildInfo?.jenkins?.host
+        def job = serverGroup.imageSummary?.buildInfo?.jenkins?.name
+        def existingBuild = regionCluster.builds.find {
+          it.buildNumber == buildNumber && it.host == host && it.job == job
+        }
+        if (!existingBuild) {
+          regionCluster.builds << new DeployedBuild(
+              host: host,
+              job: job,
+              buildNumber: buildNumber,
+              deployed: serverGroup.createdTime)
+        } else {
+          existingBuild.deployed = Math.max(existingBuild.deployed, serverGroup.createdTime)
+        }
+      }
+      clusters = regionClusters.values()
+    }
+  }
+
+  // Represents the cluster data for a particular application in a particular region
+  static class RegionClusterModel {
+    String region
+    List<DeployedBuild> builds = []
+    InstanceCounts instanceCounts = new InstanceCounts(total: 0, up: 0, down: 0, starting: 0, outOfService: 0, unknown: 0)
+    Long getLastPush() {
+      builds.deployed.max()
+    }
+  }
+
+  static class DeployedBuild {
+    String host
+    String job
+    String buildNumber
+    Long deployed
+  }
+
+
+  private static void incrementInstanceCounts(ServerGroup source, InstanceCounts target) {
+    InstanceCounts sourceCounts = source.instanceCounts
+    target.total += sourceCounts.total
+    target.down += sourceCounts.down
+    target.up += sourceCounts.up
+    target.outOfService += sourceCounts.outOfService
+    target.starting += sourceCounts.starting
+    target.unknown += sourceCounts.unknown
+  }
+
+
+  private static ThreadPoolTaskExecutor newFixedThreadPool(int threadPoolSize) {
+    def executor = new ThreadPoolTaskExecutor(maxPoolSize: threadPoolSize, corePoolSize: threadPoolSize)
+    executor.afterPropertiesSet()
+    executor
+  }
+
+  @ExceptionHandler
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  Map projectNotFoundExceptionHandler(ProjectNotFoundException ex) {
+    def message = messageSource.getMessage("project.not.found", [ex.name] as String[], "project.not.found", LocaleContextHolder.locale)
+    [error: "project.not.found", message: message, status: HttpStatus.NOT_FOUND]
+  }
+
+  static class ProjectNotFoundException extends RuntimeException {
+    String name
+  }
+}

--- a/oort/oort-web/src/test/groovy/com/netflix/spinnaker/oort/ProjectControllerSpec.groovy
+++ b/oort/oort-web/src/test/groovy/com/netflix/spinnaker/oort/ProjectControllerSpec.groovy
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.oort
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.oort.aws.model.AmazonServerGroup
+import com.netflix.spinnaker.oort.controllers.ProjectController
+import com.netflix.spinnaker.oort.documentation.Empty
+import com.netflix.spinnaker.oort.model.Cluster
+import com.netflix.spinnaker.oort.model.ClusterProvider
+import com.netflix.spinnaker.oort.model.Instance
+import com.netflix.spinnaker.oort.model.LoadBalancer
+import com.netflix.spinnaker.oort.model.ServerGroup
+import retrofit.RetrofitError
+import spock.lang.Shared
+import spock.lang.Specification
+
+import com.netflix.spinnaker.oort.model.ServerGroup.InstanceCounts as InstanceCounts
+
+class ProjectControllerSpec extends Specification {
+
+  @Shared
+  ProjectController projectController
+
+  @Shared
+  Front50Service front50Service
+
+  @Shared
+  ClusterProvider clusterProvider
+  
+  @Shared
+  String projectName
+  
+  @Shared
+  Map projectConfig
+
+  def setup() {
+    projectController = new ProjectController(1)
+
+    front50Service = Mock(Front50Service)
+    projectController.front50Service = front50Service
+
+    clusterProvider = Mock(ClusterProvider)
+    projectController.clusterProviders = [clusterProvider]
+    
+    projectName = "Spinnaker"
+
+    projectConfig = [
+        config: [
+            applications: ["orca", "deck"],
+            clusters    : []
+        ]
+    ]
+  }
+
+  void "throws ProjectNotFoundException when project config read fails"() {
+    setup:
+    projectName = "Spinnakers"
+
+    when:
+    projectController.getClusters(projectName)
+
+    then:
+    1 * front50Service.getProject(projectName) >> { throw new RetrofitError("a", null, null, null, null, null, null) }
+    thrown ProjectController.ProjectNotFoundException
+  }
+
+  void "returns an empty list without trying to retrieve applications when no clusters are configured"() {
+    when:
+    def clusters = projectController.getClusters(projectName)
+
+    then:
+    clusters == []
+    1 * front50Service.getProject(projectName) >> projectConfig
+    0 * _
+  }
+
+  void "builds the very specific model we probably want for the project dashboard"() {
+    projectConfig.config.clusters = [
+        [account: "prod", stack: "main"]
+    ]
+
+    when:
+    def clusters = projectController.getClusters(projectName)
+
+    then:
+    clusters.size() == 1
+    clusters[0].account == "prod"
+    clusters[0].stack == "main"
+    clusters[0].detail == null
+
+    clusters[0].applications[0].application == "orca"
+    clusters[0].applications[0].lastPush == 2L
+    clusters[0].applications[0].clusters[0].region == "us-east-1"
+    clusters[0].applications[0].clusters[0].lastPush == 2L
+    clusters[0].applications[0].clusters[0].instanceCounts.total == 1
+    clusters[0].applications[0].clusters[0].instanceCounts.up == 1
+
+    clusters[0].applications[1].application == "deck"
+    clusters[0].applications[1].lastPush == 1L
+    clusters[0].applications[1].clusters[0].region == "us-west-1"
+    clusters[0].applications[1].clusters[0].lastPush == 1L
+    clusters[0].applications[1].clusters[0].instanceCounts.total == 2
+    clusters[0].applications[1].clusters[0].instanceCounts.down == 1
+    clusters[0].applications[1].clusters[0].instanceCounts.up == 1
+
+    1 * front50Service.getProject(projectName) >> projectConfig
+    1 * clusterProvider.getClusterDetails("orca") >> [
+        prod: [new TestCluster(
+            name: "orca-main",
+            accountName: "prod",
+            serverGroups: [
+                makeServerGroup("prod", "orca-main-v001", "us-east-1", 3, 2L, new InstanceCounts(total: 1, up: 1))
+            ]
+        )]
+    ]
+    1 * clusterProvider.getClusterDetails("deck") >> [
+        prod: [new TestCluster(
+            name: "deck-main",
+            accountName: "prod",
+            serverGroups: [
+                makeServerGroup("prod", "deck-main-v001", "us-west-1", 31, 1L, new InstanceCounts(total: 2, up: 1, down: 1))
+            ]
+        )]
+    ]
+  }
+
+  void "includes all applications if none specified for a cluster"() {
+    given:
+    projectConfig.config.clusters = [
+        [account: "prod", stack: "main"]
+    ]
+
+    when:
+    def clusters = projectController.getClusters(projectName)
+
+    then:
+    clusters.size() == 1
+    clusters[0].applications.application == ["orca", "deck"]
+    1 * front50Service.getProject(projectName) >> projectConfig
+    1 * clusterProvider.getClusterDetails("orca") >> [
+        prod: [new TestCluster(
+            name: "orca-main",
+            accountName: "prod",
+            serverGroups: [
+                makeServerGroup("prod", "orca-main-v001", "us-east-1", 3, 1L, new InstanceCounts(total: 1, up: 1))
+            ]
+        )]
+    ]
+    1 * clusterProvider.getClusterDetails("deck") >> [
+        prod: [new TestCluster(
+            name: "deck-main",
+            accountName: "prod",
+            serverGroups: [
+                makeServerGroup("prod", "deck-main-v001", "us-west-1", 31, 1L, new InstanceCounts(total: 2, up: 1, down: 1))
+            ]
+        )]
+    ]
+  }
+
+  void "only returns specified applications if declared in cluster config"() {
+    projectConfig.config.clusters = [
+        [account: "prod", stack: "main", applications: ["deck"]]
+    ]
+
+    when:
+    def clusters = projectController.getClusters(projectName)
+
+    then:
+    clusters.size() == 1
+    clusters[0].applications.application == ["deck"]
+    1 * front50Service.getProject(projectName) >> projectConfig
+    1 * clusterProvider.getClusterDetails("orca") >> [
+        prod: [new TestCluster(
+            name: "orca-main",
+            accountName: "prod",
+            serverGroups: [
+                makeServerGroup("prod", "orca-main-v001", "us-east-1", 3, 1L, new InstanceCounts(total: 1, up: 1))
+            ]
+        )]
+    ]
+    1 * clusterProvider.getClusterDetails("deck") >> [
+        prod: [new TestCluster(
+            name: "deck-main",
+            accountName: "prod",
+            serverGroups: [
+                makeServerGroup("prod", "deck-main-v001", "us-west-1", 31, 1L, new InstanceCounts(total: 2, up: 1, down: 1))
+            ]
+        )]
+    ]
+  }
+
+  void "includes all clusters on stack wildcard"() {
+    projectConfig.config.clusters = [
+        [account: "prod", stack: "*", applications: ["orca"]]
+    ]
+
+    when:
+    def clusters = projectController.getClusters(projectName)
+
+    then:
+    clusters.size() == 1
+    clusters[0].applications.application == ["orca"]
+    clusters[0].applications[0].lastPush == 5L
+    clusters[0].applications[0].clusters.size() == 2
+    clusters[0].instanceCounts.total == 2
+    clusters[0].instanceCounts.up == 2
+    clusters[0].instanceCounts.starting == 0
+
+
+    1 * front50Service.getProject(projectName) >> projectConfig
+    1 * clusterProvider.getClusterDetails("orca") >> [
+        prod: [
+            new TestCluster(
+              name: "orca-main",
+              accountName: "prod",
+              serverGroups: [
+                  makeServerGroup("prod", "orca-main-v001", "us-east-1", 3, 1L, new InstanceCounts(total: 1, up: 1))
+              ]),
+            new TestCluster(
+                name: "orca-test",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca-test-v001", "us-west-1", 3, 5L, new InstanceCounts(total: 1, up: 1))
+                ]),
+            new TestCluster(
+                name: "orca--foo",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca--foo-v001", "us-west-1", 3, 3L, new InstanceCounts(total: 1, starting: 1))
+                ]),
+        ]
+    ]
+  }
+
+  void "includes all clusters on detail wildcard"() {
+    projectConfig.config.clusters = [
+        [account: "prod", detail: "*", applications: ["orca"]]
+    ]
+
+    when:
+    def clusters = projectController.getClusters(projectName)
+
+    then:
+    clusters.size() == 1
+    clusters[0].applications.application == ["orca"]
+    clusters[0].applications[0].lastPush == 5L
+    clusters[0].applications[0].clusters.size() == 2
+    clusters[0].instanceCounts.total == 2
+    clusters[0].instanceCounts.up == 2
+    clusters[0].instanceCounts.starting == 0
+
+
+    1 * front50Service.getProject(projectName) >> projectConfig
+    1 * clusterProvider.getClusterDetails("orca") >> [
+        prod: [
+            new TestCluster(
+                name: "orca--foo",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca--foo-v001", "us-east-1", 3, 1L, new InstanceCounts(total: 1, up: 1))
+                ]),
+            new TestCluster(
+                name: "orca--bar",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca--bar-v001", "us-west-1", 3, 5L, new InstanceCounts(total: 1, up: 1))
+                ]),
+            new TestCluster(
+                name: "orca-foo",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca-foo-v001", "us-west-1", 3, 3L, new InstanceCounts(total: 1, starting: 1))
+                ]),
+        ]
+    ]
+  }
+
+  void "excludes disabled server groups"() {
+    projectConfig.config.clusters = [
+        [account: "prod", stack: "main", applications: ["orca"]]
+    ]
+    
+    TestServerGroup disabledServerGroup = makeServerGroup("prod", "orca-main-v003", "us-east-1", 5, 5L, new InstanceCounts(total: 1, up: 1))
+    disabledServerGroup.disabled = true
+
+    when:
+    def clusters = projectController.getClusters(projectName)
+
+    then:
+    clusters.size() == 1
+    clusters[0].applications.application == ["orca"]
+    clusters[0].applications[0].lastPush == 4L
+    clusters[0].applications[0].clusters.size() == 1
+    clusters[0].instanceCounts.total == 2
+    clusters[0].instanceCounts.up == 2
+
+    1 * front50Service.getProject(projectName) >> projectConfig
+    1 * clusterProvider.getClusterDetails("orca") >> [
+        prod: [
+            new TestCluster(
+                name: "orca-main",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca-main-v001", "us-east-1", 3, 1L, new InstanceCounts(total: 1, up: 1)),
+                    makeServerGroup("prod", "orca-main-v002", "us-east-1", 4, 4L, new InstanceCounts(total: 1, up: 1)),
+                    disabledServerGroup
+                ]),
+        ]
+    ]
+  }
+
+  void "includes exactly matched clusters"() {
+    projectConfig.config.clusters = [
+        [account: "prod", stack: "main", detail: "foo", applications: ["orca"]]
+    ]
+
+    when:
+    def clusters = projectController.getClusters(projectName)
+
+    then:
+    clusters.size() == 1
+    clusters[0].applications.application == ["orca"]
+    clusters[0].applications[0].lastPush == 1L
+    clusters[0].applications[0].clusters.size() == 1
+    clusters[0].instanceCounts.total == 1
+    clusters[0].instanceCounts.up == 1
+
+    1 * front50Service.getProject(projectName) >> projectConfig
+    1 * clusterProvider.getClusterDetails("orca") >> [
+        prod: [
+            new TestCluster(
+                name: "orca-main-foo",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca-main-foo-v001", "us-east-1", 3, 1L, new InstanceCounts(total: 1, up: 1)),
+                ]),
+            new TestCluster(
+                name: "orca-main-bar",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca-main-bar-v002", "us-east-1", 4, 5L, new InstanceCounts(total: 1, up: 1)),
+                ]),
+            new TestCluster(
+                name: "orca-main",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca-main-v002", "us-east-1", 4, 6L, new InstanceCounts(total: 1, up: 1)),
+                ]),
+            new TestCluster(
+                name: "orca--foo",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca--foo-v002", "us-east-1", 4, 7L, new InstanceCounts(total: 1, up: 1)),
+                ]),
+        ]
+    ]
+  }
+
+  void "includes all builds per region with latest deployment date, ignoring disabled server groups"() {
+    given:
+    projectConfig.config.clusters = [
+        [account: "prod", stack: "main", detail: "foo", applications: ["orca"]]
+    ]
+    def disabledServerGroup = makeServerGroup("prod", "orca-main-foo-v005", "us-west-1", 6, 7L, new InstanceCounts(total: 1, up: 1))
+    disabledServerGroup.disabled = true
+
+    when:
+    def clusters = projectController.getClusters(projectName)
+    def eastCluster = clusters[0].applications[0].clusters.find { it.region == "us-east-1"}
+    def westCluster = clusters[0].applications[0].clusters.find { it.region == "us-west-1"}
+
+    then:
+    clusters.size() == 1
+    clusters[0].applications.application == ["orca"]
+    clusters[0].applications[0].lastPush == 6L
+    clusters[0].applications[0].clusters.size() == 2
+
+    eastCluster.lastPush == 1L
+    eastCluster.builds.size() == 1
+    eastCluster.builds[0].buildNumber == "3"
+    eastCluster.builds[0].deployed == 1L
+
+    westCluster.lastPush == 6L
+    westCluster.builds.size() == 2
+    westCluster.builds[0].buildNumber == "4"
+    westCluster.builds[0].deployed == 2L
+    westCluster.builds[1].buildNumber == "5"
+    westCluster.builds[1].deployed == 6L
+
+    clusters[0].instanceCounts.total == 4
+    clusters[0].instanceCounts.up == 4
+
+    eastCluster.instanceCounts.total == 1
+    eastCluster.instanceCounts.up == 1
+
+    westCluster.instanceCounts.total == 3
+    westCluster.instanceCounts.up == 3
+
+    1 * front50Service.getProject(projectName) >> projectConfig
+    1 * clusterProvider.getClusterDetails("orca") >> [
+        prod: [
+            new TestCluster(
+                name: "orca-main-foo",
+                accountName: "prod",
+                serverGroups: [
+                    makeServerGroup("prod", "orca-main-foo-v001", "us-east-1", 3, 1L, new InstanceCounts(total: 1, up: 1)),
+                    makeServerGroup("prod", "orca-main-foo-v003", "us-west-1", 4, 2L, new InstanceCounts(total: 1, up: 1)),
+                    makeServerGroup("prod", "orca-main-foo-v004", "us-west-1", 5, 3L, new InstanceCounts(total: 1, up: 1)),
+                    makeServerGroup("prod", "orca-main-foo-v005", "us-west-1", 5, 6L, new InstanceCounts(total: 1, up: 1)),
+                    disabledServerGroup
+                ])
+        ]
+    ]
+  }
+
+
+  TestServerGroup makeServerGroup(String account, String name, String region, Integer buildNumber, Long createdTime, InstanceCounts instanceCounts) {
+    new TestServerGroup(
+        name: name,
+        accountName: account,
+        region: region,
+        imageSummary: new TestImageSummary(buildInfo: [jenkins: [name: 'job', host: 'host', number: buildNumber.toString()]]),
+        createdTime: createdTime,
+        instanceCounts: instanceCounts,
+    )
+  }
+
+  static class TestImageSummary implements ServerGroup.ImageSummary {
+    String getServerGroupName() { null }
+    String getImageId() { null }
+    String getImageName() { null }
+
+    Map<String, Object> getImage() { null }
+
+    Map<String, Object> buildInfo
+  }
+
+  static class TestServerGroup implements ServerGroup {
+    String name
+    String accountName
+    ServerGroup.ImageSummary imageSummary
+    Long createdTime
+    InstanceCounts instanceCounts
+    String type = "test"
+    String region
+    Boolean disabled
+    Set<String> instances = []
+    Set<String> loadBalancers
+    Set<String> securityGroups
+    Map<String, Object> launchConfig
+    ServerGroup.Capacity capacity
+    Set<String> zones
+
+    Boolean isDisabled() { disabled }
+  }
+
+  static class TestCluster implements Cluster {
+    String name
+    String type = "test"
+    String accountName
+    Set<ServerGroup> serverGroups
+    Set<LoadBalancer> loadBalancers
+  }
+
+}


### PR DESCRIPTION
Returns all the data needed to render project clusters in a single call.

I don't write a lot of Java or Groovy these days - any suggestions are welcome.

This will require a big refactor in Deck, which I have in flight; however, I'd like to get this deployed to test out performance and make sure it's not a dog.

Test coverage could be more comprehensive, but if we're being honest, this is a lot more testing than we have done in the past on controllers - even ones with this much logic.

@ajordens @robfletcher or anyone else, please review when you have time.