### PR TITLE
dependency update to fix empty body PUT to eureka for status change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   apply plugin: 'groovy'
 
   spinnaker {
-    dependenciesVersion = "0.19.0"
+    dependenciesVersion = "0.26.0"
   }
   test {
     testLogging {

--- a/kato/kato-aws/kato-aws.gradle
+++ b/kato/kato-aws/kato-aws.gradle
@@ -19,6 +19,7 @@ dependencies {
   compile spinnaker.dependency('frigga')
   compile spinnaker.dependency('rxJava')
   compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('okHttpApache')
   spinnaker.group('amazon')
   compile 'com.aestasit.infrastructure.sshoogr:sshoogr:0.9.15'
   compile spinnaker.dependency('httpclient')


### PR DESCRIPTION
fixes an error caused by kubernetes-client transitively upgrading okhttp to a version that errors on an empty body PUT with the default client
