### PR TITLE
Adds a migration path from legacy UDF to newer UDF for AWS UserData generation

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProperties.groovy
@@ -22,5 +22,5 @@ import org.springframework.stereotype.Component
 @ConfigurationProperties("udf")
 class LocalFileUserDataProperties {
   String udfRoot = '/apps/nflx-udf'
-  boolean useAccountNameAsEnvironment = true
+  boolean defaultLegacyUdf = true
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProviderSpec.groovy
@@ -17,42 +17,47 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.userdata
 
-import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProperties
-import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProvider
 import spock.lang.Specification
 
 class LocalFileUserDataProviderSpec extends Specification {
 
-  final String APP = 'app'
-  final String STACK = 'stack'
-  final String COUNTRIES = 'countries'
-  final String DEV_PHASE = 'devPhase'
-  final String HARDWARE = 'hardware'
-  final String PARTNERS = 'partners'
-  final String REVISION = 99
-  final String ZONE = 'zone'
-  final String REGION = 'region'
-  final String ACCOUNT = 'account'
-  final String ENVIRONMENT = 'environment'
-  final String ACCOUNT_TYPE = 'accountType'
+  static final String APP = 'app'
+  static final String STACK = 'stack'
+  static final String DETAIL = 'detail'
+  static final String COUNTRIES = 'countries'
+  static final String DEV_PHASE = 'devPhase'
+  static final String HARDWARE = 'hardware'
+  static final String PARTNERS = 'partners'
+  static final String REVISION = 99
+  static final String ZONE = 'zone'
+  static final String REGION = 'region'
+  static final String ACCOUNT = 'account'
+  static final String ENVIRONMENT = 'environment'
+  static final String ACCOUNT_TYPE = 'accountType'
 
-  final String ASG_NAME = "${APP}-${STACK}-c0${COUNTRIES}-d0${DEV_PHASE}-h0${HARDWARE}-p0${PARTNERS}-r0${REVISION}-z0${ZONE}"
-  final String LAUNCH_CONFIG_NAME = 'launchConfigName'
+  static final String ASG_NAME = "${APP}-${STACK}-${DETAIL}-c0${COUNTRIES}-d0${DEV_PHASE}-h0${HARDWARE}-p0${PARTNERS}-r0${REVISION}-z0${ZONE}"
+  static final String LAUNCH_CONFIG_NAME = 'launchConfigName'
 
   void "replaces expected strings"() {
     given:
     LocalFileUserDataProvider localFileUserDataProvider = GroovySpy()
     localFileUserDataProvider.localFileUserDataProperties = new LocalFileUserDataProperties()
-    localFileUserDataProvider.assembleUserData(_, _, _) >> getRawUserData()
+    localFileUserDataProvider.isLegacyUdf(_, _) >> legacyUdf
+    localFileUserDataProvider.assembleUserData(legacyUdf, _, _, _) >> getRawUserData()
 
     when:
     def userData = localFileUserDataProvider.getUserData(ASG_NAME, LAUNCH_CONFIG_NAME, REGION, ACCOUNT, ENVIRONMENT, ACCOUNT_TYPE)
 
     then:
-    userData == getFormattedUserData()
+    userData == getFormattedUserData(expectedEnvironment)
+
+    where:
+    legacyUdf | expectedEnvironment
+    true      | ACCOUNT
+    false     | ENVIRONMENT
   }
 
-  String getRawUserData() {
+  static String getRawUserData() {
     return [
       "export ACCOUNT=%%account%%",
       "export ACCOUNT_TYPE=%%accounttype%%",
@@ -68,15 +73,16 @@ class LocalFileUserDataProviderSpec extends Specification {
       "export ZONE=%%zone%%",
       "export CLUSTER=%%cluster%%",
       "export STACK=%%stack%%",
+      "export DETAIL=%%detail%%",
       "export LAUNCH_CONFIG=%%launchconfig%%",
     ].join('\n')
   }
 
-  String getFormattedUserData() {
+  static String getFormattedUserData(String expectedEnvironment) {
     return [
       "export ACCOUNT=${ACCOUNT}",
       "export ACCOUNT_TYPE=${ACCOUNT_TYPE}",
-      "export ENV=${ACCOUNT}",
+      "export ENV=${expectedEnvironment}",
       "export APP=${APP}",
       "export REGION=${REGION}",
       "export GROUP=${ASG_NAME}",
@@ -88,6 +94,7 @@ class LocalFileUserDataProviderSpec extends Specification {
       "export ZONE=${ZONE}",
       "export CLUSTER=${ASG_NAME}",
       "export STACK=${STACK}",
+      "export DETAIL=${DETAIL}",
       "export LAUNCH_CONFIG=${LAUNCH_CONFIG_NAME}",
     ].join('\n')
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
@@ -27,6 +27,9 @@ interface Front50Service {
   @GET('/{account}/applications/search')
   List<Map> searchByName(@Path('account') String account, @Query("name") String name)
 
+  @GET('/{account}/applications/name/{name}')
+  Map getApplication(@Path('account') String account, @Path('name') String name)
+
   @GET('/v2/projects/{project}')
   Map getProject(@Path('project') String project)
 


### PR DESCRIPTION
The legacy UDF mechanism supports assembling a UserData script customized by account/application/
environment. We are migrating away from this (it is generally not a good idea in the spirit of
immutable infrastructure to have logic in UserData), to a single UserData template file in which
we just token replace environment variables. The logic to customize behaviour based on those
values is baked into the image.

An application can explicitly opt in or out of the legacyUdf format by setting a legacyUdf flag
in the application metadata in front50. Additionally there is a global default when the preference
is unspecified for the application is configured via udf.defaultLegacyUdf property

@dstengle @AMeng I know you both have looked at UserData configuration - are you guys taking advantage at all of the current (what would be come the legacyUdf=true) behaviour of composing multiple files together to customize user data based on application or environment?

Once we finish migration our user data will just be a single file (udf0) that looks like:
````bash
NETFLIX_ACCOUNT="%%account%%"
NETFLIX_ACCOUNT_TYPE="%%accounttype%%"
NETFLIX_ENVIRONMENT="%%env%%"
NETFLIX_APP="%%app%%"
NETFLIX_STACK="%%stack%%"
NETFLIX_CLUSTER="%%cluster%%"
NETFLIX_DETAIL="%%detail%%"
NETFLIX_AUTO_SCALE_GROUP="%%autogrp%%"
NETFLIX_LAUNCH_CONFIG="%%launchconfig%%"
EC2_REGION="%%region%%"
````

@AMeng based on #224 I'm sort of assuming you are doing something similar (just environment variables)

@spinnaker/netflix-reviewers PTAL