### PR TITLE
Add base64 encoded user data passed from amazon deploy description

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -50,6 +50,7 @@ class AutoScalingWorker {
   private String instanceType
   private String iamRole
   private String keyPair
+  private String base64UserData
   private Boolean ignoreSequence
   private Boolean startDisabled
   private Boolean associatePublicIpAddress
@@ -116,6 +117,7 @@ class AutoScalingWorker {
       classicLinkVpcId: classicLinkVpcId,
       instanceType: instanceType,
       keyPair: keyPair,
+      base64UserData: base64UserData,
       associatePublicIpAddress: associatePublicIpAddress,
       kernelId: kernelId,
       ramdiskId: ramdiskId,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilder.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilder.groovy
@@ -183,7 +183,7 @@ class DefaultLaunchConfigurationBuilder implements LaunchConfigurationBuilder {
       udp.getUserData(asgName, launchConfigName, region, account, environment, accountType)
     }?.join("\n")
     String userDataDecoded = new String(base64UserData.decodeBase64())
-    data = [data, userDataDecoded]?.join("\n")
+    data = [data, userDataDecoded].findResults { it }.join("\n")
     if (data && data.startsWith("\n")) {
       data = data.substring(1)
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/LaunchConfigurationBuilder.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/LaunchConfigurationBuilder.groovy
@@ -37,6 +37,7 @@ interface LaunchConfigurationBuilder {
     List<String> classicLinkVPCSecurityGroups
     String instanceType
     String keyPair
+    String base64UserData
     Boolean associatePublicIpAddress
     String kernelId
     String ramdiskId

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -43,6 +43,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   String ramdiskId
   Boolean instanceMonitoring
   Boolean ebsOptimized
+  String base64UserData
 
   boolean ignoreSequence
   boolean startDisabled

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -167,7 +167,8 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         ramdiskId: description.ramdiskId,
         instanceMonitoring: description.instanceMonitoring,
         ebsOptimized: description.ebsOptimized,
-        regionScopedProvider: regionScopedProvider)
+        regionScopedProvider: regionScopedProvider,
+        base64UserData: description.base64UserData)
 
       def asgName = autoScalingWorker.deploy()
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilderSpec.groovy
@@ -118,6 +118,32 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
             base64UserData: 'ZXhwb3J0IFVTRVJEQVRBPTEK',
             securityGroups: securityGroups)
   }
+  
+  void "should add user data to launchconfig with user data provider if description userdata ommitted"() {
+    when:
+    builder.buildLaunchConfiguration(application, subnetType, settings)
+
+    then:
+    1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> application
+    1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
+      assert req.getUserData() == expectedUserData
+    }
+    0 * _
+
+    where:
+    application = 'foo'
+    subnetType = null
+    account = 'prod'
+    securityGroups = []
+    expectedGroups = [application]
+    expectedUserData = 'dXNlcmRhdGEK'
+    settings = new LaunchConfigurationBuilder.LaunchConfigurationSettings(
+            account: 'prod',
+            region: 'us-east-1',
+            baseName: 'fooapp-v001',
+            suffix: '20150515',
+            securityGroups: securityGroups)
+  }
 
   void "should create an application security group if none exists and no security groups provided"() {
     when:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilderSpec.groovy
@@ -31,7 +31,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
   def asgService = Mock(AsgService)
   def securityGroupService = Mock(SecurityGroupService)
   def userDataProvider = Stub(UserDataProvider) {
-    getUserData(_ as String, _ as String, _ as String, _ as String) >> 'userdata'
+    getUserData(_, _, _, _, _, _) >> 'userdata'
   }
 
   @Subject
@@ -90,6 +90,33 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
       baseName: 'fooapp-v001',
       suffix: '20150515',
       securityGroups: securityGroups)
+  }
+
+  void "should add user data to launchconfig with combination from user data provider and description"() {
+    when:
+    builder.buildLaunchConfiguration(application, subnetType, settings)
+
+    then:
+    1 * securityGroupService.getSecurityGroupForApplication(application, subnetType) >> application
+    1 * autoScaling.createLaunchConfiguration(_ as CreateLaunchConfigurationRequest) >> { CreateLaunchConfigurationRequest req ->
+      assert req.getUserData() == expectedUserData
+    }
+    0 * _
+
+    where:
+    application = 'foo'
+    subnetType = null
+    account = 'prod'
+    securityGroups = []
+    expectedGroups = [application]
+    expectedUserData = 'dXNlcmRhdGEKZXhwb3J0IFVTRVJEQVRBPTEK'
+    settings = new LaunchConfigurationBuilder.LaunchConfigurationSettings(
+            account: 'prod',
+            region: 'us-east-1',
+            baseName: 'fooapp-v001',
+            suffix: '20150515',
+            base64UserData: 'ZXhwb3J0IFVTRVJEQVRBPTEK',
+            securityGroups: securityGroups)
   }
 
   void "should create an application security group if none exists and no security groups provided"() {


### PR DESCRIPTION
Reasoning:
We would like to pass User Data from an earlier stage in the pipeline to the deploy stage. This adds the ability to edit the pipeline json and add `"base64UserData": "${userdata}"` as a key value pair. The base64 user data is appended after the UserDataProviders sets up any default user data so it can be used to override these values.

It is base64 encoded because it is easier to handle as a serialized format when passing through json. Later on, a fancy UI could be built to add User Data as a text field. For now, advanced users can pass through the pipeline stages editing the json.