### PR TITLE
k8s deploy & clone return DeploymentResult. Autowire kubeutil

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/KubernetesConfiguration.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/KubernetesConfiguration.groovy
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurati
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.health.KubernetesHealthIndicator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentialsInitializer
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -29,7 +28,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.context.annotation.PropertySource
 import org.springframework.context.annotation.Scope
 import org.springframework.scheduling.annotation.EnableScheduling
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -18,13 +18,11 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy
 
 import com.netflix.frigga.NameValidation
 import com.netflix.frigga.Names
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.ReplicationControllerList
 import io.fabric8.kubernetes.api.model.Service
 
-// TODO(stevenkim): make all methods non-static and wire in as bean for usage.
 class KubernetesUtil {
 
   private static String SECURITY_GROUP_LABEL_PREFIX = "security-group-"
@@ -32,32 +30,7 @@ class KubernetesUtil {
   private static int SECURITY_GROUP_LABEL_PREFIX_LENGTH = SECURITY_GROUP_LABEL_PREFIX.length()
   private static int LOAD_BALANCER_LABEL_PREFIX_LENGTH = LOAD_BALANCER_LABEL_PREFIX.length()
 
-  static def securityGroupKey(String securityGroup) {
-    return String.format("$SECURITY_GROUP_LABEL_PREFIX%s", securityGroup)
-  }
-
-  static def loadBalancerKey(String loadBalancer) {
-    return String.format("$LOAD_BALANCER_LABEL_PREFIX%s", loadBalancer)
-  }
-
-  static def combineAppStackDetail(String appName, String stack, String detail) {
-    NameValidation.notEmpty(appName, "appName");
-
-    // Use empty strings, not null references that output "null"
-    stack = stack != null ? stack : "";
-
-    if (detail != null && !detail.isEmpty()) {
-      return appName + "-" + stack + "-" + detail;
-    }
-
-    if (!stack.isEmpty()) {
-      return appName + "-" + stack;
-    }
-
-    return appName;
-  }
-
-  static ReplicationControllerList getReplicationControllers(KubernetesCredentials credentials) {
+  ReplicationControllerList getReplicationControllers(KubernetesCredentials credentials) {
     credentials.client.replicationControllers().inNamespace(credentials.namespace).list()
   }
 
@@ -65,19 +38,19 @@ class KubernetesUtil {
     credentials.client.replicationControllers().inNamespace(credentials.namespace).withName(serverGroupName).get()
   }
 
-  static Service getService(KubernetesCredentials credentials, String service) {
+  Service getService(KubernetesCredentials credentials, String service) {
     credentials.client.services().inNamespace(credentials.namespace).withName(service).get()
   }
 
-  static Service getSecurityGroup(KubernetesCredentials credentials, String securityGroup) {
+  Service getSecurityGroup(KubernetesCredentials credentials, String securityGroup) {
     getService(credentials, securityGroup)
   }
 
-  static Service getLoadBalancer(KubernetesCredentials credentials, String loadBalancer) {
+  Service getLoadBalancer(KubernetesCredentials credentials, String loadBalancer) {
     getService(credentials, loadBalancer)
   }
 
-  static def getNextSequence(String clusterName, KubernetesCredentials credentials) {
+  String getNextSequence(String clusterName, KubernetesCredentials credentials) {
     def maxSeqNumber = -1
     def replicationControllers = getReplicationControllers(credentials)
 
@@ -110,6 +83,31 @@ class KubernetesUtil {
       }
     }
     return securityGroups
+  }
+
+  static String securityGroupKey(String securityGroup) {
+    return String.format("$SECURITY_GROUP_LABEL_PREFIX%s", securityGroup)
+  }
+
+  static String loadBalancerKey(String loadBalancer) {
+    return String.format("$LOAD_BALANCER_LABEL_PREFIX%s", loadBalancer)
+  }
+
+  static String combineAppStackDetail(String appName, String stack, String detail) {
+    NameValidation.notEmpty(appName, "appName");
+
+    // Use empty strings, not null references that output "null"
+    stack = stack != null ? stack : "";
+
+    if (detail != null && !detail.isEmpty()) {
+      return appName + "-" + stack + "-" + detail;
+    }
+
+    if (!stack.isEmpty()) {
+      return appName + "-" + stack;
+    }
+
+    return appName;
   }
 
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/CloneKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/CloneKubernetesAtomicOperation.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.CloneKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesContainerDescription
@@ -28,7 +29,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import io.fabric8.kubernetes.api.model.ReplicationController
 import org.springframework.beans.factory.annotation.Autowired
 
-class CloneKubernetesAtomicOperation implements AtomicOperation<Void> {
+class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult> {
   private static final String BASE_PHASE = "CLONE_SERVER_GROUP"
 
   @Autowired
@@ -48,18 +49,25 @@ class CloneKubernetesAtomicOperation implements AtomicOperation<Void> {
    * curl -X POST -H "Content-Type: application/json" -d  '[ { "cloneServerGroup": { "source": { "serverGroupName": "k8s-test-v000" }, "credentials":  "my-k8s-account" } } ]' localhost:7002/kubernetes/ops
    * curl -X POST -H "Content-Type: application/json" -d  '[ { "cloneServerGroup": { "stack": "prod", "freeFormDetails": "mdservice", "targetSize": "4", "source": { "serverGroupName": "k8s-test-v000" }, "credentials":  "my-k8s-account" } } ]' localhost:7002/kubernetes/ops
   */
-  // TODO(stevenkim): should return DeploymentResult object
   @Override
-  Void operate(List priorOutputs) {
+  DeploymentResult operate(List priorOutputs) {
     CloneKubernetesAtomicOperationDescription newDescription = cloneAndOverrideDescription()
 
     task.updateStatus BASE_PHASE, "Initializing copy of server group for " +
       "${description.source.serverGroupName}..."
 
-    new DeployKubernetesAtomicOperation(newDescription).operate(priorOutputs)
+    DeployKubernetesAtomicOperation deployer = new DeployKubernetesAtomicOperation(newDescription)
+    deployer.kubernetesUtil = kubernetesUtil
+    DeploymentResult deploymentResult = deployer.operate(priorOutputs)
 
     task.updateStatus BASE_PHASE, "Finished copying server group for " +
       "${description.source.serverGroupName}."
+
+    task.updateStatus BASE_PHASE, "Finished copying server group for " +
+      "${description.source.serverGroupName}. " +
+      "New server group = ${deploymentResult.serverGroupNames[0]}."
+
+    return deploymentResult
   }
 
   CloneKubernetesAtomicOperationDescription cloneAndOverrideDescription() {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtilSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtilSpec.groovy
@@ -36,6 +36,7 @@ class KubernetesUtilSpec extends Specification {
   private static final SERVICE = "service"
 
   def kubernetesClientMock
+  def kubernetesUtil
   def credentials
   def replicationControllerOperationsMock
   def replicationControllerListMock
@@ -51,6 +52,7 @@ class KubernetesUtilSpec extends Specification {
   }
 
   def setup() {
+    kubernetesUtil = new KubernetesUtil()
     kubernetesClientMock = Mock(KubernetesClient)
     credentials = new KubernetesCredentials(NAMESPACE, kubernetesClientMock)
     replicationControllerOperationsMock = Mock(ReplicationControllerOperationsImpl)
@@ -65,7 +67,7 @@ class KubernetesUtilSpec extends Specification {
 
   void "list replication controllers"() {
     when:
-      KubernetesUtil.getReplicationControllers(credentials)
+      kubernetesUtil.getReplicationControllers(credentials)
 
     then:
       1 * kubernetesClientMock.replicationControllers() >> replicationControllerOperationsMock
@@ -75,7 +77,7 @@ class KubernetesUtilSpec extends Specification {
 
   void "get service"() {
     when:
-      KubernetesUtil.getService(credentials, SERVICE)
+      kubernetesUtil.getService(credentials, SERVICE)
 
     then:
       1 * kubernetesClientMock.services() >> serviceOperationsMock
@@ -86,7 +88,7 @@ class KubernetesUtilSpec extends Specification {
 
   void "get security group"() {
     when:
-      KubernetesUtil.getSecurityGroup(credentials, SERVICE)
+      kubernetesUtil.getSecurityGroup(credentials, SERVICE)
 
     then:
       1 * kubernetesClientMock.services() >> serviceOperationsMock
@@ -97,7 +99,7 @@ class KubernetesUtilSpec extends Specification {
 
   void "get load balancer"() {
     when:
-      KubernetesUtil.getLoadBalancer(credentials, SERVICE)
+      kubernetesUtil.getLoadBalancer(credentials, SERVICE)
 
     then:
       1 * kubernetesClientMock.services() >> serviceOperationsMock

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/CloneKubernetesAtomicOperationSpec.groovy
@@ -34,15 +34,14 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
   private static final APPLICATION = "myapp"
   private static final STACK = "test"
   private static final DETAIL = "mdservice"
+  private static final SEQUENCE = "v000"
   private static final TARGET_SIZE = 2
   private static final LOAD_BALANCER_NAMES = ["lb1", "lb2"]
   private static final SECURITY_GROUP_NAMES = ["sg1", "sg2"]
   private static final LABELS = ["load-balancer-lb1": true, "load-balancer-lb2": true, "security-group-sg1": true, "security-group-sg2": true]
   private static final CONTAINER_NAMES = ["c1", "c2"]
-  private static final ANCESTOR_SERVER_GROUP_NAME = "$APPLICATION-$STACK-$DETAIL-v000"
+  private static final ANCESTOR_SERVER_GROUP_NAME = "$APPLICATION-$STACK-$DETAIL-$SEQUENCE"
 
-  def loadBalancers
-  def securityGroups
   def containers
   def ancestorNames
   def expectedResultDescription
@@ -52,6 +51,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
   def objectMetadata
   def podSpec
   def replicationControllerContainers
+
   def kubernetesUtilMock
 
   def setupSpec() {
@@ -61,8 +61,6 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
   def setup() {
     kubernetesUtilMock = Mock(KubernetesUtil)
 
-    loadBalancers = LOAD_BALANCER_NAMES
-    securityGroups = SECURITY_GROUP_NAMES
     containers = []
     CONTAINER_NAMES.each { name ->
       containers = containers << new KubernetesContainerDescription(name: name, image: name)
@@ -78,8 +76,8 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
       stack: STACK,
       freeFormDetails: DETAIL,
       targetSize: TARGET_SIZE,
-      loadBalancers: loadBalancers,
-      securityGroups: securityGroups,
+      loadBalancers: LOAD_BALANCER_NAMES,
+      securityGroups: SECURITY_GROUP_NAMES,
       containers: containers
     )
 
@@ -140,8 +138,8 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
         stack: STACK,
         freeFormDetails: DETAIL,
         targetSize: TARGET_SIZE,
-        loadBalancers: loadBalancers,
-        securityGroups: securityGroups,
+        loadBalancers: LOAD_BALANCER_NAMES,
+        securityGroups: SECURITY_GROUP_NAMES,
         containers: containers,
         source: [serverGroupName: ANCESTOR_SERVER_GROUP_NAME]
       )

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/DeployKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/DeployKubernetesAtomicOperationSpec.groovy
@@ -21,8 +21,8 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.DeployKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesContainerDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
-import io.fabric8.kubernetes.client.KubernetesClient;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.IntOrString
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.ReplicationControllerList
@@ -30,12 +30,11 @@ import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.api.model.ServiceList
 import io.fabric8.kubernetes.api.model.ServicePort
 import io.fabric8.kubernetes.api.model.ServiceSpec
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.internal.ReplicationControllerOperationsImpl
 import io.fabric8.kubernetes.client.dsl.internal.ServiceOperationsImpl
 import spock.lang.Subject
 import spock.lang.Specification
-
-import java.util.ArrayList
 
 class DeployKubernetesAtomicOperationSpec extends Specification {
   private static final NAMESPACE = "default"
@@ -50,9 +49,8 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
   private static final TARGET_PORT = 80
 
   def kubernetesClientMock
+  def kubernetesUtilMock
   def credentials
-  def loadBalancers
-  def securityGroups
   def containers
   def description
   def replicationControllerOperationsMock
@@ -64,9 +62,9 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
   def serviceMock
   def serviceSpecMock
   def servicePortMock
+  def metadataMock
 
   def intOrStringMock
-  def arrayListMock
 
   def clusterName
   def replicationControllerName
@@ -77,70 +75,62 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
 
   def setup() {
     kubernetesClientMock = Mock(KubernetesClient)
-    credentials = new KubernetesCredentials(NAMESPACE, kubernetesClientMock)
+    kubernetesUtilMock = Mock(KubernetesUtil)
     replicationControllerOperationsMock = Mock(ReplicationControllerOperationsImpl)
     replicationControllerListMock = Mock(ReplicationControllerList)
     replicationControllerMock = Mock(ReplicationController)
-
-    clusterName = KubernetesUtil.combineAppStackDetail(APPLICATION, STACK, DETAILS)
-    replicationControllerName = String.format("%s-v%s", clusterName, SEQUENCE)
-
     serviceOperationsMock = Mock(ServiceOperationsImpl)
     serviceListMock = Mock(ServiceList)
     serviceMock = Mock(Service)
     serviceSpecMock = Mock(ServiceSpec)
     servicePortMock = Mock(ServicePort)
-
+    metadataMock = Mock(ObjectMeta)
     intOrStringMock = Mock(IntOrString)
-    arrayListMock = Mock(ArrayList)
 
-    loadBalancers = LOAD_BALANCER_NAMES
-    securityGroups = SECURITY_GROUP_NAMES
+    credentials = new KubernetesCredentials(NAMESPACE, kubernetesClientMock)
+    clusterName = KubernetesUtil.combineAppStackDetail(APPLICATION, STACK, DETAILS)
+    replicationControllerName = String.format("%s-v%s", clusterName, SEQUENCE)
+
     containers = []
-    
     CONTAINER_NAMES.each { name ->
       containers = containers << new KubernetesContainerDescription(name: name, image: name)
-    } 
+    }
 
-    description = new DeployKubernetesAtomicOperationDescription(application: APPLICATION,
-                                                                 stack: STACK,
-                                                                 freeFormDetails: DETAILS,
-                                                                 targetSize: TARGET_SIZE,
-                                                                 loadBalancers: loadBalancers,
-                                                                 securityGroups: securityGroups,
-                                                                 containers: containers,
-                                                                 kubernetesCredentials: credentials)
   }
 
   void "should deploy a replication controller"() {
     setup:
+      description = new DeployKubernetesAtomicOperationDescription(
+        application: APPLICATION,
+        stack: STACK,
+        freeFormDetails: DETAILS,
+        targetSize: TARGET_SIZE,
+        loadBalancers: LOAD_BALANCER_NAMES,
+        securityGroups: SECURITY_GROUP_NAMES,
+        containers: containers,
+        kubernetesCredentials: credentials
+      )
+
       @Subject def operation = new DeployKubernetesAtomicOperation(description)
+      operation.kubernetesUtil = kubernetesUtilMock
 
     when:
       operation.operate([])
 
     then:
-      1 * kubernetesClientMock.replicationControllers() >> replicationControllerOperationsMock
-      1 * replicationControllerOperationsMock.inNamespace(NAMESPACE) >> replicationControllerOperationsMock
-      1 * replicationControllerOperationsMock.list() >> replicationControllerListMock
-      1 * replicationControllerListMock.getItems() >> []
-
-    then:
+      1 * kubernetesUtilMock.getNextSequence(_, _) >> SEQUENCE
       SECURITY_GROUP_NAMES.each { name ->
-        1 * kubernetesClientMock.services() >> serviceOperationsMock
-        1 * serviceOperationsMock.inNamespace(NAMESPACE) >> serviceOperationsMock
-        1 * serviceOperationsMock.withName(name) >> serviceOperationsMock
-        1 * serviceOperationsMock.get() >> serviceMock
+        1 * kubernetesUtilMock.getSecurityGroup(credentials, name) >> serviceMock
         1 * serviceMock.getSpec() >> serviceSpecMock
         1 * serviceSpecMock.getPorts() >> [servicePortMock]
         1 * servicePortMock.getTargetPort() >> intOrStringMock
         1 * intOrStringMock.getIntVal() >> TARGET_PORT
       }
-     
+
     then:
       1 * kubernetesClientMock.replicationControllers() >> replicationControllerOperationsMock
       1 * replicationControllerOperationsMock.inNamespace(NAMESPACE) >> replicationControllerOperationsMock
-      1 * replicationControllerOperationsMock.create({ rc -> 
+      1 * replicationControllerOperationsMock.create({ rc ->
         LOAD_BALANCER_NAMES.each { name ->
           assert(rc.metadata.labels[KubernetesUtil.loadBalancerKey(name)])
         }
@@ -165,6 +155,8 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
           assert(rc.spec.template.spec.containers[0][idx].ports[0].containerPort == TARGET_PORT)
         }
       }) >> replicationControllerMock
+      2 * replicationControllerMock.getMetadata() >> metadataMock
+      2 * metadataMock.getName() >> replicationControllerName
   }
 
 }


### PR DESCRIPTION
@spinnaker/google 
1. Updates k8s deploy & clone ops to return DeploymentResult type rather than Void.
2. Changes kubeutil to make API wrapper methods non-static, and autowired into deploy. Updates the deploy spec accordingly.