### PR TITLE
Use a Jackson serializer that will write null collections as empty ar…

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Cluster.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Cluster.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.model
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.netflix.spinnaker.clouddriver.documentation.Empty
 
 /**
@@ -51,6 +52,7 @@ interface Cluster {
    * @return a set of {@link ServerGroup} objects or an empty set if none exist
    */
   @Empty
+  @JsonSerialize(nullsUsing = NullCollectionSerializer)
   Set<ServerGroup> getServerGroups()
 
   /**
@@ -59,5 +61,6 @@ interface Cluster {
    * @return a set of {@link LoadBalancer} objects or an empty set if none exist
    */
   @Empty
+  @JsonSerialize(nullsUsing = NullCollectionSerializer)
   Set<LoadBalancer> getLoadBalancers()
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NullCollectionSerializer.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NullCollectionSerializer.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.model
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+
+class NullCollectionSerializer extends JsonSerializer<Collection> {
+  @Override
+  void serialize(Collection value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+    gen.writeStartArray()
+    gen.writeEndArray()
+  }
+}

--- a/oort/oort-aws/src/test/groovy/com/netflix/spinnaker/oort/aws/model/AmazonClusterSpec.groovy
+++ b/oort/oort-aws/src/test/groovy/com/netflix/spinnaker/oort/aws/model/AmazonClusterSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.oort.aws.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+
+class AmazonClusterSpec extends Specification {
+  void "should serialize null loadBalancers and serverGroups as empty arrays"() {
+    def objectMapper = new ObjectMapper()
+
+    when:
+    def nullCluster = objectMapper.convertValue(
+      new AmazonCluster(loadBalancers: null, serverGroups: null), Map
+    )
+
+    then:
+    nullCluster.loadBalancers.isEmpty()
+    nullCluster.serverGroups.isEmpty()
+
+    when:
+    def nonNullCluster = objectMapper.convertValue(
+      new AmazonCluster(
+        loadBalancers: [new AmazonLoadBalancer(account: "account", name: "loadBalancer1", region: "region")],
+        serverGroups: [new AmazonServerGroup(name: "serverGroup1", instances: [])]
+      ),
+      Map
+    )
+
+    then:
+    nonNullCluster.loadBalancers*.name == ["loadBalancer1"]
+    nonNullCluster.serverGroups*.name == ["serverGroup1"]
+  }
+}


### PR DESCRIPTION
…rays (quick fix)

- Addresses a situation where cloud driver was unexpected emitting null cached values (rather than empty lists)