### PR TITLE
provider/kubernetes: Allow for more flexible resource requests/limits.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/CloneKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/CloneKubernetesAtomicOperation.groovy
@@ -92,14 +92,28 @@ class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult
     newDescription.securityGroups = description.securityGroups != null ? description.securityGroups : KubernetesUtil.getDescriptionSecurityGroups(ancestorServerGroup)
     if (!description.containers) {
       newDescription.containers = []
-      ancestorServerGroup.spec?.template?.spec?.containers?.each {
+      ancestorServerGroup.spec?.template?.spec?.containers?.each { it ->
         def newLimits
         def newRequests
         if (it.resources?.limits) {
-          newLimits = new KubernetesResourceDescription(it.resources.limits.memory, it.resources.limits.cpu)
+          newLimits = new KubernetesResourceDescription()
+          if (it.resources.limits.memory) {
+            newLimits.memory = it.resources.limits.memory.amount
+          }
+
+          if (it.resources.limits.cpu) {
+            newLimits.cpu = it.resources.limits.cpu.amount
+          }
         }
         if (it.resources?.requests) {
-          newRequests = new KubernetesResourceDescription(it.resources.requests.memory, it.resources.requests.cpu)
+          newRequests = new KubernetesResourceDescription()
+          if (it.resources.requests.memory) {
+            newRequests.memory = it.resources.requests.memory.amount
+          }
+
+          if (it.resources.requests.cpu) {
+            newRequests.cpu = it.resources.requests.cpu.amount
+          }
         }
         def newContainer = new KubernetesContainerDescription(it.name, it.image, newRequests, newLimits)
         newDescription.containers.push(newContainer)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/DeployKubernetesAtomicOperation.groovy
@@ -124,15 +124,29 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
 
       replicationControllerBuilder = replicationControllerBuilder.withNewResources()
       if (container.requests) {
-        def requests = [memory: container.requests.memory,
-                        cpu: container.requests.cpu]
+        def requests = [:]
+
+        if (container.requests.memory) {
+          requests.memory = container.requests.memory
+        }
+
+        if (container.requests.cpu) {
+          requests.cpu = container.requests.cpu
+        }
         task.updateStatus BASE_PHASE, "Setting resource requests..."
         replicationControllerBuilder = replicationControllerBuilder.withRequests(requests)
       }
 
       if (container.limits) {
-        def limits = [memory: container.limits.memory,
-                      cpu: container.limits.cpu]
+        def limits = [:]
+
+        if (container.limits.memory) {
+          limits.memory = container.limits.memory
+        }
+
+        if (container.limits.cpu) {
+          limits.cpu = container.limits.cpu
+        }
         task.updateStatus BASE_PHASE, "Setting resource limits..."
         replicationControllerBuilder = replicationControllerBuilder.withLimits(limits)
       }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
@@ -24,8 +24,7 @@ class StandardKubernetesAttributeValidator {
   static final namePattern = /^[a-z0-9]+([-a-z0-9]*[a-z0-9])?$/
   static final credentialsPattern = /^[a-z0-9]+([-a-z0-9_]*[a-z0-9])?$/
   static final prefixPattern = /^[a-z0-9]+$/
-  static final cpuPattern = /^(\d+m)?$/
-  static final memoryPattern = /^(\d+(Mi|Gi))?$/
+  static final quantityPattern = /^([+-]?[0-9.]+)([eEimkKMGTP]*[-+]?[0-9]*)$/
 
   String context
 
@@ -48,7 +47,7 @@ class StandardKubernetesAttributeValidator {
   }
 
   def validateDetails(String value, String attribute) {
-    /* Details are optional */
+    // Details are optional
     if (!value) {
       return true
     } else {
@@ -81,11 +80,21 @@ class StandardKubernetesAttributeValidator {
   }
 
   def validateCpu(String value, String attribute) {
-    return validateByRegex(value, attribute, cpuPattern)
+    // CPU is optional
+    if (!value) {
+      return true
+    } else {
+      return validateByRegex(value, attribute, quantityPattern)
+    }
   }
 
   def validateMemory(String value, String attribute) {
-    return validateByRegex(value, attribute, memoryPattern)
+    // Memory is optional
+    if (!value) {
+      return true
+    } else {
+      return validateByRegex(value, attribute, quantityPattern)
+    }
   }
 
   def validateNotEmpty(Object value, String attribute) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/CloneKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/CloneKubernetesAtomicOperationValidatorSpec.groovy
@@ -36,8 +36,10 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
   private static final VALID_TARGET_SIZE = 3
   private static final VALID_IMAGE = "container-image"
   private static final VALID_NAME = "a-name"
-  private static final VALID_MEMORY = "200Mi"
-  private static final VALID_CPU = "200m"
+  private static final VALID_MEMORY1 = "200"
+  private static final VALID_MEMORY2 = "200Mi"
+  private static final VALID_CPU1 = "200"
+  private static final VALID_CPU2 = "200m"
   private static final VALID_CREDENTIALS = "auto"
   private static final VALID_LOAD_BALANCERS = ["x", "y"]
   private static final VALID_SECURITY_GROUPS = ["a-1", "b-2"]
@@ -49,8 +51,8 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
   private static final INVALID_TARGET_SIZE = -7
   private static final INVALID_IMAGE = ""
   private static final INVALID_NAME = "a?name"
-  private static final INVALID_MEMORY = "200M"
-  private static final INVALID_CPU = "-1m"
+  private static final INVALID_MEMORY = "200asdf"
+  private static final INVALID_CPU = "-1_"
   private static final INVALID_CREDENTIALS = "valid"
   private static final INVALID_LOAD_BALANCERS = [" ", "--"]
   private static final INVALID_SECURITY_GROUPS = [" ", "--"]
@@ -69,18 +71,24 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
     validator.accountCredentialsProvider = credentialsProvider
   }
 
-  KubernetesContainerDescription fullValidContainerDescription
+  KubernetesContainerDescription fullValidContainerDescription1
+  KubernetesContainerDescription fullValidContainerDescription2
   KubernetesContainerDescription partialValidContainerDescription
-  KubernetesResourceDescription fullValidResourceDescription
+  KubernetesResourceDescription fullValidResourceDescription1
+  KubernetesResourceDescription fullValidResourceDescription2
+  KubernetesResourceDescription partialValidResourceDescription
 
   KubernetesContainerDescription fullInvalidContainerDescription
   KubernetesContainerDescription partialInvalidContainerDescription
   KubernetesResourceDescription fullInvalidResourceDescription
 
   void setup() {
-    fullValidResourceDescription = new KubernetesResourceDescription(memory: VALID_MEMORY, cpu: VALID_CPU)
-    fullValidContainerDescription = new KubernetesContainerDescription(name: VALID_NAME, image: VALID_IMAGE, limits: fullValidResourceDescription, requests: fullValidResourceDescription)
-    partialValidContainerDescription = new KubernetesContainerDescription(name: VALID_NAME, image: VALID_IMAGE)
+    fullValidResourceDescription1 = new KubernetesResourceDescription(memory: VALID_MEMORY1, cpu: VALID_CPU1)
+    fullValidResourceDescription2 = new KubernetesResourceDescription(memory: VALID_MEMORY2, cpu: VALID_CPU2)
+    partialValidResourceDescription = new KubernetesResourceDescription(memory: VALID_MEMORY1)
+    fullValidContainerDescription1 = new KubernetesContainerDescription(name: VALID_NAME, image: VALID_IMAGE, limits: fullValidResourceDescription1, requests: fullValidResourceDescription1)
+    fullValidContainerDescription2 = new KubernetesContainerDescription(name: VALID_NAME, image: VALID_IMAGE, limits: fullValidResourceDescription2, requests: fullValidResourceDescription2)
+    partialValidContainerDescription = new KubernetesContainerDescription(name: VALID_NAME, image: VALID_IMAGE, limits: partialValidResourceDescription)
 
     fullInvalidResourceDescription = new KubernetesResourceDescription(memory: INVALID_MEMORY, cpu: INVALID_CPU)
     fullInvalidContainerDescription = new KubernetesContainerDescription(name: INVALID_NAME, image: INVALID_IMAGE, limits: fullInvalidResourceDescription, requests: fullInvalidResourceDescription)
@@ -94,8 +102,8 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         freeFormDetails: VALID_STACK,
         targetSize: VALID_TARGET_SIZE,
         containers: [
-          fullValidContainerDescription,
-          fullValidContainerDescription
+          fullValidContainerDescription1,
+          fullValidContainerDescription2
         ],
         loadBalancers: VALID_LOAD_BALANCERS,
         securityGroups: VALID_SECURITY_GROUPS,
@@ -243,10 +251,10 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
     then:
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].name", "${DESCRIPTION}.container[0].name.invalid (Must match ${StandardKubernetesAttributeValidator.namePattern})")
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].image", "${DESCRIPTION}.container[0].image.empty")
-      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].requests.memory", "${DESCRIPTION}.container[0].requests.memory.invalid (Must match ${StandardKubernetesAttributeValidator.memoryPattern})")
-      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].limits.memory", "${DESCRIPTION}.container[0].limits.memory.invalid (Must match ${StandardKubernetesAttributeValidator.memoryPattern})")
-      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].requests.cpu", "${DESCRIPTION}.container[0].requests.cpu.invalid (Must match ${StandardKubernetesAttributeValidator.cpuPattern})")
-      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].limits.cpu", "${DESCRIPTION}.container[0].limits.cpu.invalid (Must match ${StandardKubernetesAttributeValidator.cpuPattern})")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].requests.memory", "${DESCRIPTION}.container[0].requests.memory.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].limits.memory", "${DESCRIPTION}.container[0].limits.memory.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].requests.cpu", "${DESCRIPTION}.container[0].requests.cpu.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].limits.cpu", "${DESCRIPTION}.container[0].limits.cpu.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
       0 * errorsMock._
   }
 
@@ -301,8 +309,8 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         freeFormDetails: VALID_STACK,
         targetSize: VALID_TARGET_SIZE,
         containers: [
-          fullValidContainerDescription,
-          fullValidContainerDescription
+          fullValidContainerDescription1,
+          fullValidContainerDescription2
         ],
         loadBalancers: VALID_LOAD_BALANCERS,
         securityGroups: VALID_SECURITY_GROUPS,
@@ -323,8 +331,8 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         freeFormDetails: VALID_STACK,
         targetSize: VALID_TARGET_SIZE,
         containers: [
-          fullValidContainerDescription,
-          fullValidContainerDescription
+          fullValidContainerDescription1,
+          fullValidContainerDescription2
         ],
         loadBalancers: VALID_LOAD_BALANCERS,
         securityGroups: VALID_SECURITY_GROUPS,

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
@@ -256,7 +256,7 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       validator.validateDetails("-", label)
     then:
       1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.namePattern})")
-      0 * errorsMock._ 
+      0 * errorsMock._
 
     when:
       validator.validateDetails("a space", label)
@@ -274,7 +274,7 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       validator.validateDetails("-k-e-b-a-b-", label)
     then:
       1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.namePattern})")
-      0 * errorsMock._ 
+      0 * errorsMock._
   }
 
   void "name accept"() {
@@ -309,7 +309,7 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       validator.validateName("-", label)
     then:
       1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.namePattern})")
-      0 * errorsMock._ 
+      0 * errorsMock._
 
     when:
       validator.validateName("an_underscore", label)
@@ -362,7 +362,7 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       validator.validateApplication("l-l", label)
     then:
       1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.prefixPattern})")
-      0 * errorsMock._ 
+      0 * errorsMock._
 
     when:
       validator.validateApplication("?application", label)
@@ -409,7 +409,7 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       validator.validateStack("l-l", label)
     then:
       1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.prefixPattern})")
-      0 * errorsMock._ 
+      0 * errorsMock._
 
     when:
       validator.validateStack("?stack", label)
@@ -453,21 +453,21 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       def label = "label"
 
     when:
-      validator.validateMemory("100", label)
+      validator.validateMemory("   100", label)
     then:
-      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.memoryPattern})")
-      0 * errorsMock._ 
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
+      0 * errorsMock._
 
     when:
       validator.validateMemory("x100Gi", label)
     then:
-      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.memoryPattern})")
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
       0 * errorsMock._
 
     when:
-      validator.validateMemory("1Ti", label)
+      validator.validateMemory("1Tt!i", label)
     then:
-      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.memoryPattern})")
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
       0 * errorsMock._
   }
 
@@ -500,21 +500,21 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       def label = "label"
 
     when:
-      validator.validateCpu("100", label)
+      validator.validateCpu("100z", label)
     then:
-      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.cpuPattern})")
-      0 * errorsMock._ 
-
-    when:
-      validator.validateCpu("10M", label)
-    then:
-      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.cpuPattern})")
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
       0 * errorsMock._
 
     when:
-      validator.validateCpu("1G", label)
+      validator.validateCpu("?", label)
     then:
-      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.cpuPattern})")
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
+      0 * errorsMock._
+
+    when:
+      validator.validateCpu("- ", label)
+    then:
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
       0 * errorsMock._
   }
 }


### PR DESCRIPTION
Turns out you can submit requests/limits that omit either CPU or memory, and don't supply a `m/Mi/Gi` suffix. @duftler @skim1420 