### PR TITLE
Consolidate AWS AMI lookup logic.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -122,19 +122,9 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
       if (description.blockDevices == null) {
         description.blockDevices = BlockDeviceConfig.blockDevicesByInstanceType[description.instanceType]
       }
-
-      // find by 1) result of a previous step (we performed allow launch)
-      //         2) explicitly granted launch permission
-      //            (making this the default because AllowLaunch will always
-      //             stick an explicit launch permission on the image)
-      //         3) owner
-      //         4) global
       ResolvedAmiResult ami = priorOutputs.find({
         it instanceof ResolvedAmiResult && it.region == region && it.amiName == description.amiName
-      }) ?:
-        AmiIdResolver.resolveAmiId(amazonEC2, region, description.amiName, null, description.credentials.accountId) ?:
-          AmiIdResolver.resolveAmiId(amazonEC2, region, description.amiName, description.credentials.accountId) ?:
-            AmiIdResolver.resolveAmiId(amazonEC2, region, description.amiName, null, null)
+      }) ?: AmiIdResolver.resolveAmiIdFromAllSources(amazonEC2, region, description.amiName, description.credentials.accountId)
 
       if (!ami) {
         throw new IllegalArgumentException("unable to resolve AMI imageId from $description.amiName")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
@@ -60,7 +60,7 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
     def sourceAmazonEC2 = amazonClientProvider.getAmazonEC2(description.credentials, description.region, true)
     def targetAmazonEC2 = amazonClientProvider.getAmazonEC2(targetCredentials, description.region, true)
 
-    ResolvedAmiResult resolvedAmi = AmiIdResolver.resolveAmiId(sourceAmazonEC2, description.region, description.amiName, description.credentials.accountId)
+    ResolvedAmiResult resolvedAmi = AmiIdResolver.resolveAmiIdFromAllSources(sourceAmazonEC2, description.region, description.amiName, description.credentials.accountId)
     if (!resolvedAmi) {
       throw new IllegalArgumentException("unable to resolve AMI imageId from $description.amiName")
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperation.groovy
@@ -76,19 +76,10 @@ class ModifyAsgLaunchConfigurationOperation implements AtomicOperation<Void> {
 
 
     if (description.amiName) {
-      // find by 1) result of a previous step (we performed allow launch)
-      //         2) explicitly granted launch permission
-      //            (making this the default because AllowLaunch will always
-      //             stick an explicit launch permission on the image)
-      //         3) owner
-      //         4) global
       def amazonEC2 = regionScopedProvider.amazonEC2
       ResolvedAmiResult ami = priorOutputs.find({
         it instanceof ResolvedAmiResult && it.region == description.region && it.amiName == description.amiName
-      }) ?:
-        AmiIdResolver.resolveAmiId(amazonEC2, description.region, description.amiName, null, description.credentials.accountId) ?:
-          AmiIdResolver.resolveAmiId(amazonEC2, description.region, description.amiName, description.credentials.accountId) ?:
-            AmiIdResolver.resolveAmiId(amazonEC2, description.region, description.amiName, null, null)
+      }) ?: AmiIdResolver.resolveAmiIdFromAllSources(amazonEC2, description.region, description.amiName, description.credentials.accountId)
 
       props.ami = ami.amiId
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolverSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolverSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy
+
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.model.*
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
+import spock.lang.Specification
+
+class AmiIdResolverSpec extends Specification {
+
+  private final String amiId = 'ami-12345'
+  private final String accountId = '98765'
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  void "looks up AMI in three ways in order"() {
+    setup:
+    def ec2 = Mock(AmazonEC2)
+
+    when:
+    AmiIdResolver.resolveAmiIdFromAllSources(ec2, 'us-east-1', amiId, accountId)
+
+    then:
+    1 * ec2.describeImages(_) >> { DescribeImagesRequest dir ->
+      assert dir.imageIds == [amiId]
+      assert dir.owners == []
+      assert dir.executableUsers == [accountId]
+    }
+
+    then:
+    1 * ec2.describeImages(_) >> { DescribeImagesRequest dir ->
+      assert dir.imageIds == [amiId]
+      assert dir.owners == [accountId]
+      assert dir.executableUsers == []
+    }
+
+    then:
+    1 * ec2.describeImages(_) >> { DescribeImagesRequest dir ->
+      assert dir.imageIds == [amiId]
+      assert dir.owners == []
+      assert dir.executableUsers == []
+    }
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperationUnitSpec.groovy
@@ -47,7 +47,6 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
       getAccountId() >> '67890'
     }
 
-
     def creds = Stub(AccountCredentialsProvider) {
       getCredentials('target') >> target
     }
@@ -61,9 +60,9 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     then:
     ec2.describeTags(_) >> new DescribeTagsResult()
     1 * ec2.describeImages(_) >> { DescribeImagesRequest dir ->
-        assert dir.owners
-        assert dir.owners.size() == 1
-        assert dir.owners.first() == '67890'
+        assert dir.executableUsers
+        assert dir.executableUsers.size() == 1
+        assert dir.executableUsers.first() == '67890'
         assert dir.filters
         assert dir.filters.size() == 1
         assert dir.filters.first().name == 'name'


### PR DESCRIPTION
Currently AMI lookups happen in three different places. Two of them have duplicated logic, and the third looks up the AMI in a different way. This consolidates them all to lookup the AMI the same way by using a new method.

The important fix here is to allow the deploy pipeline stage to lookup AMIs that are accessible to the account, but not necessarily owned by the account. This was previously not possible and would give an error:

![image](https://cloud.githubusercontent.com/assets/192336/12464919/cb102dae-bf88-11e5-8873-4562056799ed.png)

This happens even though the account is able to view the AMI in the AWS console, as it is shared with the account. 