### PR TITLE
Azure load balancer bug fixes

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureResourceRetriever.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureResourceRetriever.groovy
@@ -86,8 +86,11 @@ class AzureResourceRetriever {
             if (!tmpLoadBalancerMap[accountName].containsKey(appName)) {
               tmpLoadBalancerMap[accountName].put(appName, new HashSet<AzureLoadBalancerDescription>())
             }
+            def resourceGroupName = AzureUtilities.getResourceGroupNameFromResourceId(lb.id)
             def loadBalancer = getDescriptionForLoadBalancer(lb)
             loadBalancer.appName = appName
+            loadBalancer.tags = lb.tags
+            loadBalancer.dnsName = networkClient.getDnsNameForLoadBalancer(azureCredentials, resourceGroupName, lb.name)
             tmpLoadBalancerMap[accountName][appName].add(loadBalancer)
           }
         }
@@ -182,7 +185,7 @@ class AzureResourceRetriever {
       def r = new AzureLoadBalancerDescription.AzureLoadBalancingRule(ruleName: rule.name)
       r.externalPort = rule.frontendPort
       r.backendPort = rule.backendPort
-      r.probeName = getResourceNameFromID(rule.probe.id)
+      r.probeName = AzureUtilities.getNameFromResourceId(rule.probe.id)
       r.persistence = rule.loadDistribution;
       r.idleTimeout = rule.idleTimeoutInMinutes;
 
@@ -216,13 +219,5 @@ class AzureResourceRetriever {
     }
 
     description
-  }
-
-  private String getResourceNameFromID(String resourceId) {
-    int idx = resourceId.lastIndexOf('/')
-    if (idx > 0) {
-      return resourceId.substring(idx + 1)
-    }
-    resourceId
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
@@ -16,24 +16,62 @@
 
 package com.netflix.spinnaker.clouddriver.azure.common
 
-import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
+import com.microsoft.azure.management.resources.ResourceManagementClient
+import com.netflix.spinnaker.clouddriver.azure.resources.common.AzureResourceOpsDescription
 
 class AzureUtilities {
 
+  static final String PATH_SEPARATOR = "/"
+  static final String NAME_SEPARATOR = "-"
+  static final String VNET_NAME_PREFIX = "vnet-"
+  static final String PUBLICIP_NAME_PREFIX = "pip-"
+  static final String LBFRONTEND_NAME_PREFIX = "fe-"
+  static final String DNS_NAME_PREFIX = "dns-"
+  static final String IPCONFIG_NAME_PREFIX = "ipc-"
+
   static String getResourceNameFromID(String resourceId) {
-    int idx = resourceId.lastIndexOf('/')
+    int idx = resourceId.lastIndexOf(PATH_SEPARATOR)
     if (idx > 0) {
       return resourceId.substring(idx + 1)
     }
     resourceId
   }
 
-  static String getResourceGroupName(AzureLoadBalancerDescription description) {
-    description.appName + "_" + description.region
+  static String getResourceGroupName(AzureResourceOpsDescription description) {
+    description.appName + NAME_SEPARATOR + description.region
   }
 
   static String getResourceGroupName(String appName, String region) {
-    appName + "_" + region.replace(' ', '').toLowerCase()
+    appName + NAME_SEPARATOR + region.replace(' ', '').toLowerCase()
   }
 
+  static String getResourceGroupLocation(AzureResourceOpsDescription description) {
+    def resourceGroupName = getResourceGroupName(description)
+
+    description.credentials.getResourceManagerClient().getResourceGroupLocation(resourceGroupName, description.getCredentials())
+  }
+
+  static String getResourceGroupNameFromResourceId(String resourceId) {
+    def parts = resourceId.split(PATH_SEPARATOR)
+    def idx = parts.findIndexOf {it == "resourceGroups"}
+    def resourceGroupName = "unknown"
+
+    if (idx > 0) {
+      resourceGroupName = parts[idx + 1]
+    }
+
+    resourceGroupName
+  }
+
+  static String getAppNameFromResourceId(String resourceId) {
+    getResourceGroupNameFromResourceId(resourceId).split(NAME_SEPARATOR).first()
+  }
+
+  static String getLocationFromResourceId(String resourceId) {
+    getResourceGroupNameFromResourceId(resourceId).split(NAME_SEPARATOR).last()
+  }
+
+  static String getNameFromResourceId(String resourceId) {
+    resourceId.split(PATH_SEPARATOR).last()
+  }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
@@ -26,6 +26,7 @@ class AzureLoadBalancerDescription extends AzureResourceOpsDescription {
   List<AzureLoadBalancerProbe> probes = []
   List<AzureLoadBalancingRule> loadBalancingRules = []
   List<AzureLoadBalancerInboundNATRule> inboundNATRules = []
+  Map<String,String> tags = [:]
 
   static class AzureLoadBalancerProbe {
     enum AzureLoadBalancerProbesType {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/DeleteAzureLoadBalancerDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/DeleteAzureLoadBalancerDescription.groovy
@@ -21,4 +21,5 @@ import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
 
 class DeleteAzureLoadBalancerDescription extends AzureResourceOpsDescription {
   String loadBalancerName
+  List<String> regions
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/DeleteAzureLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/DeleteAzureLoadBalancerAtomicOperation.groovy
@@ -40,25 +40,26 @@ class DeleteAzureLoadBalancerAtomicOperation implements AtomicOperation<Void> {
    */
   @Override
   Void operate(List priorOutputs) {
-    task.updateStatus BASE_PHASE, "Initializing deletion of load balancer $description.loadBalancerName " +
-      "in $description.region..."
+    task.updateStatus BASE_PHASE, "Initializing Delete Azure Load Balancer Operation..."
+    for (region in description.regions) {
+      task.updateStatus BASE_PHASE, "Deleting ${description.loadBalancerName} " + "in ${region}..."
 
-    if (!description.credentials) {
-      throw new IllegalArgumentException("Unable to resolve credentials for the selected Azure account.")
-    }
+      if (!description.credentials) {
+        throw new IllegalArgumentException("Unable to resolve credentials for the selected Azure account.")
+      }
 
-    try {
-      //TODO: insert real call to Azure resource manager object to delete the selected load balancer
-      String resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, description.region)
+      try {
+        String resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, region)
 
-      def op = description.credentials.networkClient.deleteLoadBalancer(description.credentials,
-                                                                        resourceGroupName,
-                                                                        description.loadBalancerName)
+        def op = description.credentials.networkClient.deleteLoadBalancer(description.credentials,
+          resourceGroupName,
+          description.loadBalancerName)
 
-      task.updateStatus BASE_PHASE, "Done deleting load balancer $description.loadBalancerName in $description.region."
-    } catch (Exception e) {
-      task.updateStatus BASE_PHASE, String.format("Deployment of load balancer $description.loadBalancerName failed: %s", e.message)
-      throw e
+        task.updateStatus BASE_PHASE, "Deletion of Azure load balancer $description.loadBalancerName in ${region} has succeeded."
+      } catch (Exception e) {
+        task.updateStatus BASE_PHASE, String.format("Deletion of load balancer ${description.loadBalancerName} failed: %s", e.message)
+        throw e
+      }
     }
 
     null

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/UpsertAzureLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/UpsertAzureLoadBalancerAtomicOperation.groovy
@@ -57,7 +57,7 @@ class UpsertAzureLoadBalancerAtomicOperation implements AtomicOperation<Map> {
       task.updateStatus(BASE_PHASE, "Beginning load balancer deployment")
 
       String resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, description.region)
-      DeploymentExtended deployment = description.credentials.resourceManagerClient.createLoadBalancerFromTemplate(description.credentials,
+      DeploymentExtended deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(description.credentials,
         AzureLoadBalancerResourceTemplate.getTemplate(description),
         resourceGroupName,
         description.region,
@@ -71,13 +71,13 @@ class UpsertAzureLoadBalancerAtomicOperation implements AtomicOperation<Map> {
             resourceCompletedState[d.id] = false
           }
           if (d.properties.provisioningState == AzureResourceManagerClient.DeploymentState.SUCCEEDED) {
-            if (resourceCompletedState[d.id] == false) {
+            if (!resourceCompletedState[d.id]) {
               task.updateStatus BASE_PHASE, String.format("Resource %s created", d.properties.targetResource.resourceName)
               resourceCompletedState[d.id] = true
             }
           }
           else if (d.properties.provisioningState == AzureResourceManagerClient.DeploymentState.FAILED) {
-            if (resourceCompletedState[d.id] == false) {
+            if (!resourceCompletedState[d.id]) {
               task.updateStatus BASE_PHASE, String.format("Failed to create resource %s: %s", d.properties.targetResource.resourceName, d.properties.statusMessage)
               resourceCompletedState[d.id] = true
             }
@@ -94,7 +94,7 @@ class UpsertAzureLoadBalancerAtomicOperation implements AtomicOperation<Map> {
     [loadBalancers: [(description.region): [name: description.loadBalancerName]]]
   }
 
-  private boolean deploymentIsRunning(String deploymentState) {
+  private static boolean deploymentIsRunning(String deploymentState) {
     deploymentState != AzureResourceManagerClient.DeploymentState.CANCELED &&
       deploymentState != AzureResourceManagerClient.DeploymentState.DELETED &&
       deploymentState != AzureResourceManagerClient.DeploymentState.FAILED &&

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/UpsertAzureLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/UpsertAzureLoadBalancerAtomicOperationConverter.groovy
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component
 @AzureOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
 @Component("upsertAzureLoadBalancerDescription")
 class UpsertAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
-  public UpsertAzureLoadBalancerAtomicOperationConverter() {
+  UpsertAzureLoadBalancerAtomicOperationConverter() {
     log.info("Constructor....UpsertAzureLoadBalancerAtomicOperationConverter")
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerController.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerController.groovy
@@ -86,6 +86,7 @@ class AzureLoadBalancerController {
       lbDetail.securityGroups = azureLoadBalancerDescription.securityGroups
       lbDetail.loadBalancingRules = azureLoadBalancerDescription.loadBalancingRules
       lbDetail.inboundNATRules = azureLoadBalancerDescription.inboundNATRules
+      lbDetail.tags = azureLoadBalancerDescription.tags
 
       return [lbDetail]
     }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureLoadBalancerResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureLoadBalancerResourceTemplate.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.azure.templates
 
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.UpsertAzureLoadBalancerDescription
 import org.codehaus.jackson.map.ObjectMapper
@@ -64,13 +65,14 @@ class AzureLoadBalancerResourceTemplate {
 
     LoadBalancerTemplateVariables(UpsertAzureLoadBalancerDescription description){
       String regionName = description.region.replace(' ', '').toLowerCase()
+      String resourceGroupName = AzureUtilities.getResourceGroupName(description)
 
-      loadBalancerName = description.loadBalancerName
-      virtualNetworkName = "vnet-" + regionName + "-" + description.loadBalancerName
-      publicIPAddressName = "publicIp-" + regionName + "-" + description.loadBalancerName
-      loadBalancerFrontEnd = "lbFrontEnd-" + regionName + "-" + description.loadBalancerName
-      dnsNameForLBIP = "dns-" + regionName.toLowerCase() + "-" + description.loadBalancerName.toLowerCase()
-      ipConfigName = "ipConfig-" + regionName + "-" + description.loadBalancerName
+      loadBalancerName = description.loadBalancerName.toLowerCase()
+      virtualNetworkName = AzureUtilities.VNET_NAME_PREFIX + resourceGroupName.toLowerCase()
+      publicIPAddressName = AzureUtilities.PUBLICIP_NAME_PREFIX + description.loadBalancerName.toLowerCase()
+      loadBalancerFrontEnd = AzureUtilities.LBFRONTEND_NAME_PREFIX + description.loadBalancerName.toLowerCase()
+      dnsNameForLBIP = AzureUtilities.DNS_NAME_PREFIX + description.appName.toLowerCase()
+      ipConfigName = AzureUtilities.IPCONFIG_NAME_PREFIX + description.loadBalancerName.toLowerCase()
     }
   }
 
@@ -80,7 +82,6 @@ class AzureLoadBalancerResourceTemplate {
 
   static class Location{
     String type = "string"
-    ArrayList<String> allowedValues = ["East US", "eastus", "West US", "westus", "West Europe", "westeurope", "East Asia", "eastasia", "Southeast Asia", "southeastasia"]
     Map<String, String> metadata = ["description":"Location to deploy"]
   }
 
@@ -97,7 +98,6 @@ class AzureLoadBalancerResourceTemplate {
 
       properties = new LoadBalancerProperties(description)
     }
-
   }
 
   private static class AzureProbe {

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/deploy/templates/AzureLoadBalancerResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/deploy/templates/AzureLoadBalancerResourceTemplateSpec.groovy
@@ -51,7 +51,7 @@ class AzureLoadBalancerResourceTemplateSpec extends Specification {
     description.loadBalancerName = 'azureMASM-st1-d11'
     description.stack = 'st1'
     description.detail = 'd11'
-    description.region = 'West US'
+    description.region = 'westus'
     description.vnet = null
     description.probes = new ArrayList<AzureLoadBalancerDescription.AzureLoadBalancerProbe>()
 
@@ -98,20 +98,19 @@ class AzureLoadBalancerResourceTemplateSpec extends Specification {
   "parameters" : {
     "location" : {
       "type" : "string",
-      "allowedValues" : [ "East US", "eastus", "West US", "westus", "West Europe", "westeurope", "East Asia", "eastasia", "Southeast Asia", "southeastasia" ],
       "metadata" : {
         "description" : "Location to deploy"
       }
     }
   },
   "variables" : {
-    "loadBalancerName" : "azureMASM-st1-d11",
-    "virtualNetworkName" : "vnet-westus-azureMASM-st1-d11",
-    "publicIPAddressName" : "publicIp-westus-azureMASM-st1-d11",
+    "loadBalancerName" : "azuremasm-st1-d11",
+    "virtualNetworkName" : "vnet-azuremasm-westus",
+    "publicIPAddressName" : "pip-azuremasm-st1-d11",
     "publicIPAddressType" : "Dynamic",
-    "loadBalancerFrontEnd" : "lbFrontEnd-westus-azureMASM-st1-d11",
-    "dnsNameForLBIP" : "dns-westus-azuremasm-st1-d11",
-    "ipConfigName" : "ipConfig-westus-azureMASM-st1-d11",
+    "loadBalancerFrontEnd" : "fe-azuremasm-st1-d11",
+    "dnsNameForLBIP" : "dns-azuremasm",
+    "ipConfigName" : "ipc-azuremasm-st1-d11",
     "loadBalancerID" : "[resourceID('Microsoft.Network/loadBalancers',variables('loadBalancerName'))]",
     "publicIPAddressID" : "[resourceID('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
     "frontEndIPConfig" : "[concat(variables('loadBalancerID'),'/frontendIPConfigurations/',variables('loadBalancerFrontEnd'))]"


### PR DESCRIPTION
- change the deployment method of a given template to be more generic
- create an azure virtual network per given resource group that will be later associated with the rest of the resources
- retrieve the dns associated with to a load balancer (via a public IP)
- retrieve the tags property of a given azure load balancer
- bug fix corresponding to the deck changes when deleting a given azure load balancer
- change the internal naming convention for the azure resources associated with a given load balancer