### PR TITLE
Merge sequence-handling logic from GCEUtil into AbstractServerGroupNa…

### DIFF
--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolverSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolverSpec.groovy
@@ -16,39 +16,116 @@
 
 package com.netflix.spinnaker.clouddriver.helpers
 
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import static AbstractServerGroupNameResolver.TakenSlot
 
 class AbstractServerGroupNameResolverSpec extends Specification {
 
   static class TestServerGroupNameResolver extends AbstractServerGroupNameResolver {
-    private final String serverGroupName
+    private final List<TakenSlot> takenSlots
 
-    TestServerGroupNameResolver(String serverGroupName) {
-      this.serverGroupName = serverGroupName
+    TestServerGroupNameResolver(List<TakenSlot> takenSlots) {
+      this.takenSlots = takenSlots
     }
 
     @Override
-    String getPreviousServerGroupName(String clusterName) {
-      return serverGroupName
+    String getPhase() {
+      return 'TEST-DEPLOY'
+    }
+
+    @Override
+    String getRegion() {
+      return 'test-region'
+    }
+
+    @Override
+    List<TakenSlot> getTakenSlots(String clusterName) {
+      return takenSlots
     }
   }
 
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
   @Unroll
-  void "next ASG name should be #expected when previous is #previousServerGroupName and application is 'app', stack is '#stack', and details is '#details'"() {
+  void "next server group name should be #expected when takenSlots is #takenSlots and application is 'app', stack is '#stack', and details is '#details'"() {
     when:
-    def serverGroupNameResolver = new TestServerGroupNameResolver(previousServerGroupName)
+    def serverGroupNameResolver = new TestServerGroupNameResolver(takenSlots)
 
     then:
     serverGroupNameResolver.resolveNextServerGroupName('app', stack, details, false) == expected
 
     where:
-    stack   | details     | previousServerGroupName   | expected
-    null    | null        | 'app-v000'                | 'app-v001'
-    'new'   | null        | null                      | 'app-new-v000'
-    'test'  | null        | 'app-test-v009'           | 'app-test-v010'
-    'dev'   | 'detail'    | 'app-dev-detail-v015'     | 'app-dev-detail-v016'
-    'prod'  | 'c0usca'    | 'app-prod-c0usca-v000'    | 'app-prod-c0usca-v001'
+    stack   | details     | takenSlots                               | expected
+    null    | null        | [buildTakenSlot('app-v000')]             | 'app-v001'
+    'new'   | null        | null                                     | 'app-new-v000'
+    'new'   | null        | []                                       | 'app-new-v000'
+    'test'  | null        | [buildTakenSlot('app-test-v009')]        | 'app-test-v010'
+    'dev'   | 'detail'    | [buildTakenSlot('app-dev-detail-v015')]  | 'app-dev-detail-v016'
+    'prod'  | 'c0usca'    | [buildTakenSlot('app-prod-c0usca-v000')] | 'app-prod-c0usca-v001'
+  }
+
+
+  void "resolveNextServerGroupName should handle roll-over properly"() {
+    setup:
+    def takenSlots = [
+      buildTakenSlot('app-dev-v997', 997),
+      buildTakenSlot('app-dev-v998', 998),
+      buildTakenSlot('app-dev-v999', 999),
+      buildTakenSlot('app-dev-v000', 000)
+    ]
+    def serverGroupNameResolver = new TestServerGroupNameResolver(takenSlots)
+
+    when:
+    def nextServerGroupName = serverGroupNameResolver.resolveNextServerGroupName('app', 'dev', null, false)
+
+    then:
+    nextServerGroupName == 'app-dev-v001'
+  }
+
+  void "resolveNextServerGroupName should throw exception when namespace is exhausted"() {
+    setup:
+    def takenSlots = (0..999).collect {
+      def sequenceNumber = String.format('%03d', it)
+      buildTakenSlot("app-dev-v$sequenceNumber", it)
+    }
+    def serverGroupNameResolver = new TestServerGroupNameResolver(takenSlots)
+
+    when:
+    serverGroupNameResolver.resolveNextServerGroupName('app', 'dev', null, false)
+
+    then:
+    IllegalArgumentException exc = thrown()
+    exc.message == "All server group names for cluster app-dev in test-region are taken."
+  }
+
+  void "resolveNextServerGroupName should yield v001 when most recent server group does not define sequence number"() {
+    setup:
+    def takenSlots = [
+      buildTakenSlot('app-dev-v997', 997),
+      buildTakenSlot('app-dev', 998),
+    ]
+    def serverGroupNameResolver = new TestServerGroupNameResolver(takenSlots)
+
+    when:
+    def nextServerGroupName = serverGroupNameResolver.resolveNextServerGroupName('app', 'dev', null, false)
+
+    then:
+    nextServerGroupName == 'app-dev-v001'
+  }
+
+  private buildTakenSlot(String serverGroupName, long createdTime = 0) {
+    return new TakenSlot(
+      serverGroupName: serverGroupName,
+      sequence: Names.parseName(serverGroupName).sequence,
+      createdTime: new Date(createdTime)
+    )
   }
 
   void "should fail for invalid characters in the asg name"() {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEServerGroupNameResolver.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEServerGroupNameResolver.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.deploy
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
+import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.helpers.AbstractServerGroupNameResolver
+
+class GCEServerGroupNameResolver extends AbstractServerGroupNameResolver {
+
+  private static final String GCE_PHASE = "GCE_DEPLOY"
+
+  private final String project
+  private final String region
+  private final GoogleCredentials credentials
+
+  GCEServerGroupNameResolver(String project, String region, GoogleCredentials credentials) {
+    this.project = project
+    this.region = region
+    this.credentials = credentials
+  }
+
+  @Override
+  String getPhase() {
+    return GCE_PHASE
+  }
+
+  @Override
+  String getRegion() {
+    return region
+  }
+
+  @Override
+  List<AbstractServerGroupNameResolver.TakenSlot> getTakenSlots(String clusterName) {
+    def managedInstanceGroups = GCEUtil.queryManagedInstanceGroups(project, region, credentials)
+
+    return managedInstanceGroups.findResults { managedInstanceGroup ->
+      def names = Names.parseName(managedInstanceGroup.name)
+
+      if (names.cluster == clusterName) {
+        return new AbstractServerGroupNameResolver.TakenSlot(
+          serverGroupName: managedInstanceGroup.name,
+          sequence       : names.sequence,
+          createdTime    : new Date(Utils.getTimeFromTimestamp(managedInstanceGroup.creationTimestamp))
+        )
+      } else {
+        return null
+      }
+    }
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -47,7 +47,6 @@ class GCEUtil {
   private static final String DISK_TYPE_SCRATCH = "SCRATCH"
 
   public static final String TARGET_POOL_NAME_PREFIX = "tp"
-  public static final int SEQUENTIAL_NUMBERING_NAMESPACE_SIZE = 1000
 
   // TODO(duftler): This list should not be static, but should also not be built on each call.
   static final List<String> baseImageProjects = ["centos-cloud", "coreos-cloud", "debian-cloud", "google-containers",
@@ -471,66 +470,6 @@ class GCEUtil {
     } else {
       return []
     }
-  }
-
-  static def getNextSequence(String clusterName,
-                             String project,
-                             String region,
-                             GoogleCredentials credentials) {
-    def nextSequenceNumber = 0
-    def managedInstanceGroups = queryManagedInstanceGroups(project, region, credentials)
-    // Build a collection containing the sequence number and createdTime of each server group in this cluster/region.
-    def takenSequenceNumbers = managedInstanceGroups.findResults { managedInstanceGroup ->
-      def names = Names.parseName(managedInstanceGroup.name)
-
-      if (names.cluster == clusterName) {
-        return [
-          sequenceNumber: names.sequence,
-          createdTime: Utils.getTimeFromTimestamp(managedInstanceGroup.creationTimestamp)
-        ]
-      } else {
-        return null
-      }
-    }
-
-    // Attempt to find the server group created most recently.
-    def latestServerGroup = takenSequenceNumbers.max { a, b ->
-      a.createdTime <=> b.createdTime
-    }
-
-    if (latestServerGroup) {
-      // The server group name may not have the sequence number portion specified.
-      nextSequenceNumber = ((latestServerGroup.sequenceNumber ?: 0) + 1) % SEQUENTIAL_NUMBERING_NAMESPACE_SIZE
-    }
-
-    // Keep increasing the number until we find one that is not already taken. Stop if we circle back to the starting point.
-    def stepCounter = 0
-    while (takenSequenceNumbers.find { it.sequenceNumber == nextSequenceNumber } && ++stepCounter < SEQUENTIAL_NUMBERING_NAMESPACE_SIZE) {
-      nextSequenceNumber = ++nextSequenceNumber % SEQUENTIAL_NUMBERING_NAMESPACE_SIZE
-    }
-
-    if (stepCounter == SEQUENTIAL_NUMBERING_NAMESPACE_SIZE) {
-      throw new IllegalArgumentException("All server group names in $region are taken.")
-    }
-
-    return String.format("%03d", nextSequenceNumber)
-  }
-
-  static def combineAppStackDetail(String appName, String stack, String detail) {
-    NameValidation.notEmpty(appName, "appName");
-
-    // Use empty strings, not null references that output "null"
-    stack = stack != null ? stack : "";
-
-    if (detail != null && !detail.isEmpty()) {
-      return appName + "-" + stack + "-" + detail;
-    }
-
-    if (!stack.isEmpty()) {
-      return appName + "-" + stack;
-    }
-
-    return appName;
   }
 
   private static void updateStatusAndThrowNotFoundException(String errorMsg, Task task, String phase) {


### PR DESCRIPTION
…meResolver.

Will still handle the rollover from v999 to v000 properly, but will also handle the situation where the slot immediately following the most recently created server group is already taken.
This routine will hunt for the first available slot following the most recently created server group.
Will throw an exception if the namespace is exhausted.
Refactored AbstractServerGroupNameResolver a bit to make it easy for providers to reuse this logic.
Applied to GCE, AWS & Titan.