### PR TITLE
provider/kubernetes: Cache applications, server groups, clusters and instances

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.cache
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+
+class Keys {
+  static enum Namespace {
+    APPLICATIONS,
+    CLUSTERS,
+    SERVER_GROUPS,
+    INSTANCES,
+    LOAD_BALANCERS,
+
+    static String provider = "kubernetes"
+
+    final String ns
+
+    private Namespace() {
+      def parts = name().split('_')
+
+      ns = parts.tail().inject(new StringBuilder(parts.head().toLowerCase())) { val, next -> val.append(next.charAt(0)).append(next.substring(1).toLowerCase()) }
+    }
+
+    String toString() {
+      ns
+    }
+  }
+
+  static Map<String, String> parse(String key) {
+    def parts = key.split(':')
+
+    if (parts.length < 2) {
+      return null
+    }
+
+    def result = [provider: parts[0], type: parts[1]]
+
+    if (result.provider != Namespace.provider) {
+      return null
+    }
+
+    switch (result.type) {
+      case Namespace.APPLICATIONS.ns:
+        result << [application: parts[2]]
+        break
+      case Namespace.CLUSTERS.ns:
+        def names = Names.parseName(parts[4])
+        result << [application: parts[3], account: parts[2], name: parts[4], stack: names.stack, detail: names.detail]
+        break
+      case Namespace.SERVER_GROUPS.ns:
+        def names = Names.parseName(parts[4])
+        result << [application: names.app, account: parts[2], name: parts[4], namespace: parts[3], stack: names.stack, cluster: names.cluster, detail: names.detail, sequence: names.sequence?.toString()]
+        break
+      case Namespace.LOAD_BALANCERS.ns:
+        def names = Names.parseName(parts[4])
+        result << [application: names.app, account: parts[2], name: parts[4], namespace: parts[3], stack: names.stack, detail: names.detail]
+        break
+      case Namespace.INSTANCES.ns:
+        def names = Names.parseName(parts[4])
+        result << [application: names.app, account: parts[2], serverGroup: parts[4], namespace: parts[3], name: parts[5]]
+        break
+      default:
+        return null
+        break
+    }
+
+    result
+  }
+
+  static String getApplicationKey(String application) {
+    "${Namespace.provider}:${Namespace.APPLICATIONS}:${application}"
+  }
+
+  static String getClusterKey(String account, String application, String clusterName) {
+    "${Namespace.provider}:${Namespace.CLUSTERS}:${account}:${application}:${clusterName}"
+  }
+
+  static String getServerGroupKey(String account, String namespace, String replicationControllerName) {
+    "${Namespace.provider}:${Namespace.SERVER_GROUPS}:${account}:${namespace}:${replicationControllerName}"
+  }
+
+  static String getLoadBalancerKey(String account, String namespace, String serviceName) {
+    "${Namespace.provider}:${Namespace.LOAD_BALANCERS}:${account}:${namespace}:${serviceName}"
+  }
+
+  static String getInstanceKey(String account, String namespace, String replicationControllerName, String name) {
+    "${Namespace.provider}:${Namespace.INSTANCES}:${account}:${namespace}:${replicationControllerName}:${name}"
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -19,19 +19,25 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy
 import com.netflix.frigga.NameValidation
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import io.fabric8.kubernetes.api.model.PodList
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.ReplicationControllerList
 import io.fabric8.kubernetes.api.model.Service
 
 class KubernetesUtil {
 
-  private static String SECURITY_GROUP_LABEL_PREFIX = "security-group-"
-  private static String LOAD_BALANCER_LABEL_PREFIX = "load-balancer-"
+  static String SECURITY_GROUP_LABEL_PREFIX = "security-group-"
+  static String LOAD_BALANCER_LABEL_PREFIX = "load-balancer-"
+  static String REPLICATION_CONTROLLER_LABEL = "replication-controller"
   private static int SECURITY_GROUP_LABEL_PREFIX_LENGTH = SECURITY_GROUP_LABEL_PREFIX.length()
   private static int LOAD_BALANCER_LABEL_PREFIX_LENGTH = LOAD_BALANCER_LABEL_PREFIX.length()
 
   ReplicationControllerList getReplicationControllers(KubernetesCredentials credentials, String namespace) {
     credentials.client.replicationControllers().inNamespace(namespace).list()
+  }
+
+  PodList getPods(KubernetesCredentials credentials, String namespace, String replicationControllerName) {
+    credentials.client.pods().inNamespace(namespace).withLabel(REPLICATION_CONTROLLER_LABEL, replicationControllerName).list()
   }
 
   ReplicationController getReplicationController(KubernetesCredentials credentials, String namespace, String serverGroupName) {
@@ -68,11 +74,15 @@ class KubernetesUtil {
   static List<String> getDescriptionLoadBalancers(ReplicationController rc) {
     def loadBalancers = []
     rc.spec?.template?.metadata?.labels?.each { key, val ->
-      if (key.startsWith(LOAD_BALANCER_LABEL_PREFIX)) {
+      if (isLoadBalancerLabel(key)) {
         loadBalancers.push(key.substring(LOAD_BALANCER_LABEL_PREFIX_LENGTH, key.length()))
       }
     }
     return loadBalancers
+  }
+
+  static Boolean isLoadBalancerLabel(String key) {
+    key.startsWith(LOAD_BALANCER_LABEL_PREFIX)
   }
 
   static List<String> getDescriptionSecurityGroups(ReplicationController rc) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/DeployKubernetesAtomicOperationDescription.groovy
@@ -41,7 +41,6 @@ class KubernetesContainerDescription {
   String image
   KubernetesResourceDescription requests
   KubernetesResourceDescription limits
-
 }
 
 @AutoClone

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/DeployKubernetesAtomicOperation.groovy
@@ -53,7 +53,8 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
 
     ReplicationController rc = deployDescription()
     DeploymentResult deploymentResult = new DeploymentResult()
-    deploymentResult.serverGroupNames = Arrays.asList(rc.metadata.name)
+    deploymentResult.serverGroupNames = Arrays.asList("${rc.metadata.namespace}:${rc.metadata.name}".toString())
+    deploymentResult.serverGroupNameByRegion[rc.metadata.namespace] = rc.metadata.name
     return deploymentResult
   }
 
@@ -98,7 +99,7 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
 
     task.updateStatus BASE_PHASE, "Setting replication controller metadata labels..."
 
-    replicationControllerBuilder = replicationControllerBuilder.addToLabels(sequenceIndex, "true")
+    replicationControllerBuilder = replicationControllerBuilder.addToLabels(KubernetesUtil.REPLICATION_CONTROLLER_LABEL, replicationControllerName)
 
     for (def securityGroup : description.securityGroups) {
       replicationControllerBuilder = replicationControllerBuilder.addToLabels(KubernetesUtil.securityGroupKey(securityGroup), "true")
@@ -118,7 +119,7 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
 
     task.updateStatus BASE_PHASE, "Setting replication controller spec labels..."
     // Metadata in spec and replication controller need to match, hence the apparent duplication
-    replicationControllerBuilder = replicationControllerBuilder.addToLabels(sequenceIndex, "true")
+    replicationControllerBuilder = replicationControllerBuilder.addToLabels(KubernetesUtil.REPLICATION_CONTROLLER_LABEL, replicationControllerName)
 
     for (def securityGroup : description.securityGroups) {
       replicationControllerBuilder = replicationControllerBuilder.addToLabels(KubernetesUtil.securityGroupKey(securityGroup), "true")

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesApplication.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesApplication.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.netflix.spinnaker.clouddriver.model.Application
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+
+@CompileStatic
+@EqualsAndHashCode(includes = ["name"])
+class KubernetesApplication implements Application, Serializable {
+  public static final TypeReference<Map<String, String>> ATTRIBUTES = new TypeReference<Map<String, String>>() {}
+  final String name
+  final Map<String, String> attributes
+  final Map<String, Set<String>> clusterNames
+
+  KubernetesApplication(String name, Map<String, String> attributes, Map<String, Set<String>> clusterNames) {
+    this.name = name
+    this.attributes = attributes
+    this.clusterNames = clusterNames
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesCluster.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesCluster.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.model.Cluster
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+
+@CompileStatic
+@EqualsAndHashCode(includes = ["name", "accountName"])
+class KubernetesCluster implements Cluster, Serializable {
+  String name
+  String type = Keys.Namespace.provider
+  String accountName
+  Set<KubernetesServerGroup> serverGroups = Collections.synchronizedSet(new HashSet<KubernetesServerGroup>())
+  Set<KubernetesLoadBalancer> loadBalancers = Collections.synchronizedSet(new HashSet<KubernetesLoadBalancer>())
+}
+

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesImageSummary.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesImageSummary.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
+
+class KubernetesImageSummary implements ServerGroup.ImageSummary, Serializable {
+  String serverGroupName
+  String imageId
+  String imageName
+  Map<String, Object> image
+  Map<String, Object> buildInfo
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstance.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstance.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.model.HealthState
+import com.netflix.spinnaker.clouddriver.model.Instance
+import io.fabric8.kubernetes.api.model.ContainerState
+import io.fabric8.kubernetes.api.model.Pod
+
+class KubernetesInstance implements Instance, Serializable {
+  String name
+  HealthState healthState
+  Long launchTime
+  String zone
+  List<Map<String, String>> health
+  String serverGroupName
+
+  static HealthState convertContainerState(ContainerState state) {
+    state?.running ? HealthState.Up :
+    state?.waiting ? HealthState.Starting :
+    state?.terminated ? HealthState.Down :
+    HealthState.Unknown
+  }
+
+  KubernetesInstance(Pod pod) {
+    this.name = pod.metadata?.name
+    this.launchTime = KubernetesModelUtil.translateTime(pod.status?.startTime)
+    this.zone = pod.metadata?.namespace
+    this.health = []
+    pod.status?.containerStatuses?.forEach {
+      this.health << [name: it.name,
+                      state: convertContainerState(it.state).toString(),
+                      image: it.image,
+                      ready: it.ready.toString(),
+                      running: it.state?.running?.toString(),
+                      waiting: it.state?.waiting?.toString(),
+                      terminated: it.state?.terminated?.toString(),
+      ]
+    }
+
+    def phase = pod.status?.phase
+    if (!phase) {
+      healthState = HealthState.Unknown
+    } else {
+      healthState = phase == "Running" ? HealthState.Up :
+        phase == "Pending" ? HealthState.Starting :
+        phase == "Succeeded" ? HealthState.Down : // TODO(lwander): this needs a special designation
+        phase == "Failed" ? HealthState.Down: HealthState.Unknown
+    }
+
+    this.serverGroupName = pod.metadata?.labels?.get(KubernetesUtil.REPLICATION_CONTROLLER_LABEL)
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.netflix.spinnaker.clouddriver.model.LoadBalancer
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+
+@CompileStatic
+@EqualsAndHashCode(includes = ["name", "accountName"])
+class KubernetesLoadBalancer implements LoadBalancer, Serializable {
+  String name
+  String type = "kubernetes"
+  String region
+  String accountName
+  Set<Map<String, Object>> serverGroups
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesModelUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesModelUtil.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import java.text.SimpleDateFormat
+
+class KubernetesModelUtil {
+  static long translateTime(String time) {
+    time ? (new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse(time)).getTime() : 0
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.model.HealthState
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import io.fabric8.kubernetes.api.model.Container
+import io.fabric8.kubernetes.api.model.ReplicationController
+
+@CompileStatic
+@EqualsAndHashCode(includes = ["name"])
+class KubernetesServerGroup implements ServerGroup, Serializable {
+  String name
+  String type = "kubernetes"
+  String region
+  Long createdTime
+  Integer replicas = 0
+  Set<String> zones
+  Set<KubernetesInstance> instances
+  Set<String> loadBalancers
+  Set<String> securityGroups
+  Map<String, Object> launchConfig
+  Map<String, String> labels = [:]
+  List<Container> containers
+
+  Boolean isDisabled() {
+    this.labels ? !(this.labels.any { key, value -> KubernetesUtil.isLoadBalancerLabel(key) && value == "true" }) : false
+  }
+
+  KubernetesServerGroup(String name, String namespace) {
+    this.name = name
+    this.region = namespace
+  }
+
+  KubernetesServerGroup(ReplicationController replicationController, Set<KubernetesInstance> instances) {
+    this.name = replicationController.metadata?.name
+    this.region = replicationController.metadata?.namespace
+    this.createdTime = KubernetesModelUtil.translateTime(replicationController.metadata?.creationTimestamp)
+    this.zones = [this.region] as Set
+    this.instances = instances
+    this.securityGroups = []
+    this.replicas = replicationController.spec?.replicas ?: 0
+    this.loadBalancers = KubernetesUtil.getDescriptionLoadBalancers(replicationController) as Set
+    this.launchConfig = [:]
+    this.labels = replicationController.spec?.template?.metadata?.labels
+    this.containers = replicationController.spec?.template?.spec?.containers
+  }
+
+  @Override
+  ServerGroup.InstanceCounts getInstanceCounts() {
+    new ServerGroup.InstanceCounts(
+      down: (Integer) instances?.count { it.healthState == HealthState.Down } ?: 0,
+      outOfService: (Integer) instances?.count { it.healthState == HealthState.OutOfService } ?: 0,
+      up: (Integer) instances?.count { it.healthState == HealthState.Up } ?: 0,
+      starting: (Integer) instances?.count { it.healthState == HealthState.Starting } ?: 0,
+      unknown: (Integer) instances?.count { it.healthState == HealthState.Unknown } ?: 0
+    )
+  }
+
+  @Override
+  ServerGroup.Capacity getCapacity() {
+    new ServerGroup.Capacity(min: replicas, max: replicas, desired: replicas)
+  }
+
+  @Override
+  ServerGroup.ImageSummary getImageSummary() {
+    // TODO(lwander): Massage into more kubernetes native format (multiple images per server group).
+    return new KubernetesImageSummary(
+      image: containers?.collectEntries { [(it.name): it.image] },
+      serverGroupName: this.name,
+      imageName: containers[0]?.image // TODO(lwander): See above.
+    )
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesProvider.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider
+
+import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
+import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+
+class KubernetesProvider extends AgentSchedulerAware implements SearchableProvider {
+  public static final String PROVIDER_NAME = KubernetesProvider.name
+
+  final Set<String> defaultCaches = Collections.emptySet()
+
+  final Map<String, String> urlMappingTemplates = Collections.emptyMap()
+
+  final Collection<Agent> agents
+  final KubernetesCloudProvider cloudProvider
+
+  KubernetesProvider(KubernetesCloudProvider cloudProvider, Collection<Agent> agents) {
+    this.cloudProvider = cloudProvider
+    this.agents = agents
+  }
+
+  @Override
+  String getProviderName() {
+    return PROVIDER_NAME
+  }
+
+  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+
+  final Map<String, SearchableProvider.IdentifierExtractor> identifierExtractors = Collections.emptyMap()
+
+  @Override
+  Map<String, String> parseKey(String key) {
+    return Keys.parse(key)
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.frigga.Names
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.AccountAware
+import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.CacheResult
+import com.netflix.spinnaker.cats.agent.CachingAgent
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.view.MutableCacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import groovy.util.logging.Slf4j
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.ReplicationController
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
+
+@Slf4j
+class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
+
+  @Deprecated
+  private static final String LEGACY_ON_DEMAND_TYPE = 'KubernetesCluster'
+
+  private static final String ON_DEMAND_TYPE = 'Cluster'
+
+  final KubernetesCloudProvider kubernetesCloudProvider
+  final String accountName
+  final String namespace
+  final KubernetesCredentials credentials
+  final KubernetesUtil util
+  final ObjectMapper objectMapper
+
+  final OnDemandMetricsSupport metricsSupport
+
+  static final Set<AgentDataType> types = Collections.unmodifiableSet([
+    INFORMATIVE.forType(Keys.Namespace.APPLICATIONS.ns),
+    INFORMATIVE.forType(Keys.Namespace.CLUSTERS.ns),
+    AUTHORITATIVE.forType(Keys.Namespace.SERVER_GROUPS.ns),
+    AUTHORITATIVE.forType(Keys.Namespace.INSTANCES.ns),
+  ] as Set)
+
+  KubernetesServerGroupCachingAgent(KubernetesCloudProvider kubernetesCloudProvider,
+                                    String accountName,
+                                    KubernetesCredentials credentials,
+                                    String namespace,
+                                    ObjectMapper objectMapper,
+                                    Registry registry,
+                                    KubernetesUtil util) {
+    this.kubernetesCloudProvider = kubernetesCloudProvider
+    this.accountName = accountName
+    this.credentials = credentials
+    this.objectMapper = objectMapper
+    this.namespace = namespace
+    this.util = util
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, kubernetesCloudProvider.id + ":" + ON_DEMAND_TYPE)
+  }
+
+  @Override
+  String getProviderName() {
+    KubernetesProvider.PROVIDER_NAME
+  }
+
+  @Override
+  String getAgentType() {
+    "${accountName}/${namespace}/${KubernetesServerGroupCachingAgent.simpleName}"
+  }
+
+  @Override
+  String getAccountName() {
+    accountName
+  }
+
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    return types
+  }
+
+  @Override
+  String getOnDemandAgentType() {
+    "${getAgentType()}-OnDemand"
+  }
+
+  @Override
+  OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data) {
+    if (data.account != accountName) {
+      return null
+    }
+
+    if (data.namespace != namespace) {
+      return null
+    }
+
+    List<ReplicationController> replicationControllerList = metricsSupport.readData {
+      loadReplicationControllers()
+    }
+
+    CacheResult result = metricsSupport.transformData {
+      buildCacheResult(replicationControllerList)
+    }
+
+    new OnDemandAgent.OnDemandResult(
+      sourceAgentType: getAgentType(),
+      authoritativeTypes: [Keys.Namespace.SERVER_GROUPS.ns],
+      cacheResult: result
+    )
+  }
+
+  @Override
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    return []
+  }
+
+  @Override
+  boolean handles(String type) {
+    type == LEGACY_ON_DEMAND_TYPE
+  }
+
+  @Override
+  boolean handles(String type, String cloudProvider) {
+    type == ON_DEMAND_TYPE && cloudProvider == kubernetesCloudProvider.id
+  }
+
+  List<ReplicationController> loadReplicationControllers() {
+    util.getReplicationControllers(credentials, namespace).items
+  }
+
+  List<Pod> loadPods(String replicationControllerName) {
+    util.getPods(credentials, namespace, replicationControllerName).items
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    List<ReplicationController> replicationControllerList = loadReplicationControllers()
+
+    buildCacheResult(replicationControllerList)
+  }
+
+  private CacheResult buildCacheResult(List<ReplicationController> replicationControllers) {
+    log.info("Describing items in ${agentType}")
+
+    Map<String, MutableCacheData> cachedApplications = MutableCacheData.mutableCacheMap()
+    Map<String, MutableCacheData> cachedClusters = MutableCacheData.mutableCacheMap()
+    Map<String, MutableCacheData> cachedServerGroups = MutableCacheData.mutableCacheMap()
+    Map<String, MutableCacheData> cachedInstances = MutableCacheData.mutableCacheMap()
+
+    replicationControllers.forEach { ReplicationController replicationController ->
+      def replicationControllerName = replicationController.metadata.name
+      def pods = loadPods(replicationControllerName)
+      def names = Names.parseName(replicationControllerName)
+      def applicationName = names.app
+      def clusterName = names.cluster
+
+      def serverGroupKey = Keys.getServerGroupKey(accountName, namespace, replicationControllerName)
+      def applicationKey = Keys.getApplicationKey(applicationName)
+      def clusterKey = Keys.getClusterKey(accountName, applicationName, clusterName)
+      def instanceKeys = []
+      def loadBalancerKeys = util.getDescriptionLoadBalancers(replicationController).collect({
+        Keys.getLoadBalancerKey(accountName, namespace, it)
+      })
+
+      cachedApplications[applicationKey].with {
+        attributes.name = applicationName
+        relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
+        relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)
+        relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
+      }
+
+      cachedClusters[clusterKey].with {
+        attributes.name = clusterName
+        relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
+        relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)
+        relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
+      }
+
+      pods.forEach { pod ->
+        def key = Keys.getInstanceKey(accountName, namespace, replicationControllerName, pod.metadata.name)
+        instanceKeys << key
+        cachedInstances[key].with {
+          attributes.name = pod.metadata.name
+          attributes.pod = pod
+          relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
+          relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
+          relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)
+          relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
+        }
+      }
+
+      cachedServerGroups[serverGroupKey].with {
+        attributes.name = replicationControllerName
+        attributes.replicationController = replicationController
+        relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
+        relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
+        relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
+        relationships[Keys.Namespace.INSTANCES.ns].addAll(instanceKeys)
+      }
+
+      null
+    }
+
+    log.info("Caching ${cachedApplications.size()} applications in ${agentType}")
+    log.info("Caching ${cachedClusters.size()} clusters in ${agentType}")
+    log.info("Caching ${cachedServerGroups.size()} server groups in ${agentType}")
+    log.info("Caching ${cachedInstances.size()} instances in ${agentType}")
+
+    new DefaultCacheResult([
+      (Keys.Namespace.APPLICATIONS.ns): cachedApplications.values(),
+      (Keys.Namespace.CLUSTERS.ns): cachedClusters.values(),
+      (Keys.Namespace.SERVER_GROUPS.ns): cachedServerGroups.values(),
+      (Keys.Namespace.INSTANCES.ns): cachedInstances.values(),
+    ])
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.ProviderUtils
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.DependsOn
+import org.springframework.context.annotation.Scope
+
+import java.util.concurrent.ConcurrentHashMap
+
+@Configuration
+class KubernetesProviderConfig {
+  @Bean
+  @DependsOn('kubernetesNamedAccountCredentials')
+  KubernetesProvider kubernetesProvider(KubernetesCloudProvider kubernetesCloudProvider,
+                                        AccountCredentialsRepository accountCredentialsRepository,
+                                        ObjectMapper objectMapper,
+                                        Registry registry) {
+    def kubernetesProvider = new KubernetesProvider(kubernetesCloudProvider, Collections.newSetFromMap(new ConcurrentHashMap<Agent, Boolean>()))
+
+    synchronizeKubernetesProvider(kubernetesProvider, kubernetesCloudProvider, accountCredentialsRepository, objectMapper, registry)
+
+    kubernetesProvider
+  }
+
+  @Bean
+  KubernetesProviderSynchronizerTypeWrapper kubernetesProviderSynchronizerTypeWrapper() {
+    new KubernetesProviderSynchronizerTypeWrapper()
+  }
+
+  class KubernetesProviderSynchronizerTypeWrapper implements ProviderSynchronizerTypeWrapper {
+    @Override
+    Class getSynchronizerType() {
+      return KubernetesProviderSynchronizer
+    }
+  }
+
+  class KubernetesProviderSynchronizer {}
+
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  @Bean
+  KubernetesProviderSynchronizer synchronizeKubernetesProvider(KubernetesProvider kubernetesProvider,
+                                                               KubernetesCloudProvider kubernetesCloudProvider,
+                                                               AccountCredentialsRepository accountCredentialsRepository,
+                                                               ObjectMapper objectMapper,
+                                                               Registry registry) {
+    def scheduledAccounts = ProviderUtils.getScheduledAccounts(kubernetesProvider)
+    def allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, KubernetesNamedAccountCredentials)
+
+    def util = new KubernetesUtil()
+    allAccounts.each { KubernetesNamedAccountCredentials credentials ->
+      if (!scheduledAccounts.contains(credentials.accountName)) {
+        def newlyAddedAgents = []
+
+        credentials.credentials.namespaces.forEach({ namespace ->
+          newlyAddedAgents << new KubernetesServerGroupCachingAgent(kubernetesCloudProvider, credentials.accountName, credentials.credentials, namespace, objectMapper, registry, util)
+        })
+
+        // If there is an agent scheduler, then this provider has been through the AgentController in the past.
+        // In that case, we need to do the scheduling here (because accounts have been added to a running system).
+        if (kubernetesProvider.agentScheduler) {
+          ProviderUtils.rescheduleAgents(kubernetesProvider, newlyAddedAgents)
+        }
+
+        kubernetesProvider.agents.addAll(newlyAddedAgents)
+      }
+    }
+
+    new KubernetesProviderSynchronizer()
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesApplicationProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesApplicationProvider.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesApplication
+import com.netflix.spinnaker.clouddriver.model.Application
+import com.netflix.spinnaker.clouddriver.model.ApplicationProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import static com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys.Namespace.*
+
+@Component
+class KubernetesApplicationProvider implements ApplicationProvider {
+  private final KubernetesCloudProvider kubernetesCloudProvider
+  private final Cache cacheView
+  private final ObjectMapper objectMapper
+
+  @Autowired
+  KubernetesApplicationProvider(KubernetesCloudProvider kubernetesCloudProvider, Cache cacheView, ObjectMapper objectMapper) {
+    this.kubernetesCloudProvider = kubernetesCloudProvider
+    this.cacheView = cacheView
+    this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+  }
+
+  @Override
+  Set<Application> getApplications(boolean expand) {
+    def relationships = expand ? RelationshipCacheFilter.include(CLUSTERS.ns) : RelationshipCacheFilter.none()
+    Collection<CacheData> applications = cacheView.getAll(APPLICATIONS.ns, cacheView.filterIdentifiers(APPLICATIONS.ns, "${kubernetesCloudProvider.id}:*"), relationships)
+    applications.collect this.&translate
+  }
+
+  @Override
+  Application getApplication(String name) {
+    translate(cacheView.get(APPLICATIONS.ns, Keys.getApplicationKey(name)))
+  }
+
+  Application translate(CacheData cacheData) {
+    if (cacheData == null) {
+      return null
+    }
+
+    String name = Keys.parse(cacheData.id).application
+    Map<String, String> attributes = objectMapper.convertValue(cacheData.attributes, KubernetesApplication.ATTRIBUTES)
+    Map<String, Set<String>> clusterNames = [:].withDefault { new HashSet<String>() }
+    for (String clusterId : cacheData.relationships[CLUSTERS.ns]) {
+      Map<String, String> cluster = Keys.parse(clusterId)
+      if (cluster.account && cluster.name) {
+        clusterNames[cluster.account].add(cluster.name)
+      }
+    }
+
+    new KubernetesApplication(name, attributes, clusterNames)
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.CacheFilter
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesCluster
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesInstance
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesLoadBalancer
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesServerGroup
+import com.netflix.spinnaker.clouddriver.model.ClusterProvider
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.ReplicationController
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
+  private final Cache cacheView
+  private final ObjectMapper objectMapper
+
+  @Autowired
+  KubernetesClusterProvider(Cache cacheView, ObjectMapper objectMapper) {
+    this.cacheView = cacheView
+    this.objectMapper = objectMapper
+  }
+
+  @Override
+  Set<KubernetesCluster> getClusters(String applicationName, String account) {
+    CacheData application = cacheView.get(Keys.Namespace.APPLICATIONS.ns, Keys.getApplicationKey(applicationName), RelationshipCacheFilter.include(Keys.Namespace.CLUSTERS.ns))
+    if (application == null) {
+      return [] as Set
+    }
+
+    Collection<String> clusterKeys = application.relationships[Keys.Namespace.CLUSTERS.ns].findAll { Keys.parse(it).account == account }
+    Collection<CacheData> clusters = cacheView.getAll(Keys.Namespace.CLUSTERS.ns, clusterKeys)
+    translateClusters(clusters, true) as Set<KubernetesCluster>
+  }
+
+  @Override
+  Map<String, Set<KubernetesCluster>> getClusterSummaries(String applicationName) {
+    CacheData application = cacheView.get(Keys.Namespace.APPLICATIONS.ns, Keys.getApplicationKey(applicationName))
+    application ? mapResponse(translateClusters(resolveRelationshipData(application, Keys.Namespace.CLUSTERS.ns), false)) : null
+  }
+
+  private Collection<CacheData> resolveRelationshipData(CacheData source, String relationship) {
+    resolveRelationshipData(source, relationship) { true }
+  }
+
+  private Collection<CacheData> resolveRelationshipData(CacheData source, String relationship, Closure<Boolean> relFilter) {
+    Collection<String> filteredRelationships = source.relationships[relationship]?.findAll(relFilter)
+    filteredRelationships ? cacheView.getAll(relationship, filteredRelationships) : []
+  }
+
+  @Override
+  Map<String, Set<KubernetesCluster>> getClusterDetails(String applicationName) {
+    CacheData application = cacheView.get(Keys.Namespace.APPLICATIONS.ns, Keys.getApplicationKey(applicationName))
+    application ? mapResponse(translateClusters(resolveRelationshipData(application, Keys.Namespace.CLUSTERS.ns), true)) : null
+  }
+
+  @Override
+  KubernetesCluster getCluster(String applicationName, String account, String name) {
+    CacheData cluster = cacheView.get(Keys.Namespace.CLUSTERS.ns, Keys.getClusterKey(account, applicationName, name))
+    cluster ? translateClusters([cluster], true)[0] : null
+  }
+
+  private Collection<CacheData> resolveRelationshipDataForCollection(Collection<CacheData> sources, String relationship, CacheFilter cacheFilter = null) {
+    Collection<String> relationships = sources?.findResults { it.relationships[relationship]?: [] }?.flatten() ?: []
+    relationships ? cacheView.getAll(relationship, relationships, cacheFilter) : []
+  }
+
+  private Collection<KubernetesCluster> translateClusters(Collection<CacheData> clusterData, boolean includeDetails) {
+    Map<String, KubernetesLoadBalancer> loadBalancers
+    Map<String, Set<KubernetesServerGroup>> serverGroups
+
+    if (includeDetails) {
+      // TODO(lwander): this is unnecessary, and should only query the relevant load balancers/server groups
+      Collection<CacheData> allLoadBalancers = resolveRelationshipDataForCollection(clusterData, Keys.Namespace.LOAD_BALANCERS.ns)
+      Collection<CacheData> allServerGroups = resolveRelationshipDataForCollection(clusterData, Keys.Namespace.SERVER_GROUPS.ns, RelationshipCacheFilter.include(Keys.Namespace.INSTANCES.ns))
+
+      loadBalancers = translateLoadBalancers(allLoadBalancers)
+      serverGroups = translateServerGroups(allServerGroups)
+    }
+
+    Collection<KubernetesCluster> clusters = clusterData.collect { CacheData clusterDataEntry ->
+      Map<String, String> clusterKey = Keys.parse(clusterDataEntry.id)
+
+      def cluster = new KubernetesCluster()
+      cluster.accountName = clusterKey.account
+      cluster.name = clusterKey.name
+      if (includeDetails) {
+        cluster.loadBalancers = clusterDataEntry.relationships[Keys.Namespace.LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) }
+        cluster.serverGroups = serverGroups.get(cluster.name)
+      } else {
+        cluster.loadBalancers = clusterDataEntry.relationships[Keys.Namespace.LOAD_BALANCERS.ns]?.collect { loadBalancerKey ->
+          Map parts = Keys.parse(loadBalancerKey)
+          new KubernetesLoadBalancer(name: parts.loadBalancer, region: parts.namespace)
+        }
+
+        cluster.serverGroups = clusterDataEntry.relationships[Keys.Namespace.SERVER_GROUPS.ns]?.collect { serverGroupKey ->
+          Map parts = Keys.parse(serverGroupKey)
+          new KubernetesServerGroup(parts.name, parts.namespace)
+        }
+      }
+      cluster
+    }
+
+    clusters
+  }
+
+  private Map<String, Set<KubernetesInstance>> translateInstances(Collection<CacheData> instanceData) {
+    Map<String, Set<KubernetesInstance>> instances = [:].withDefault { _ -> [] as Set }
+    instanceData?.forEach {
+      def pod = objectMapper.convertValue(it.attributes.pod, Pod)
+      KubernetesInstance instance = new KubernetesInstance(pod)
+      instances[instance.serverGroupName].add(instance)
+    }
+
+    instances
+  }
+
+  private Map<String, Set<KubernetesServerGroup>> translateServerGroups(Collection<CacheData> serverGroupData) {
+    Collection<CacheData> allInstances = resolveRelationshipDataForCollection(serverGroupData, Keys.Namespace.INSTANCES.ns, RelationshipCacheFilter.none())
+
+    Map<String, Set<KubernetesInstance>> instances = translateInstances(allInstances)
+
+    Map<String, Set<KubernetesServerGroup>> serverGroups = [:].withDefault { _ -> [] as Set }
+    serverGroupData.forEach {
+      def replicationController = objectMapper.convertValue(it.attributes.replicationController, ReplicationController)
+      def serverGroup = new KubernetesServerGroup(replicationController, instances[(String) it.attributes.name])
+      serverGroups[Names.parseName(serverGroup.name).cluster].add(serverGroup)
+    }
+
+    serverGroups
+  }
+
+  private static Map<String, KubernetesLoadBalancer> translateLoadBalancers(Collection<CacheData> loadBalancerData) {
+    loadBalancerData.collectEntries { loadBalancerEntry ->
+      Map<String, String> parts = Keys.parse(loadBalancerEntry.id)
+      [(loadBalancerEntry.id) : new KubernetesLoadBalancer(name: parts.loadBalancer, account: parts.account, region: parts.namespace)]
+    }
+  }
+
+  @Override
+  Map<String, Set<KubernetesCluster>> getClusters() {
+    print ",, get em all!!"
+    Collection<CacheData> clusterData = cacheView.getAll(Keys.Namespace.CLUSTERS.ns)
+    Collection<KubernetesCluster> clusters = translateClusters(clusterData, true)
+    mapResponse(clusters)
+  }
+
+  private static Map<String, Set<KubernetesCluster>> mapResponse(Collection<KubernetesCluster> clusters) {
+    clusters.groupBy { it.accountName }.collectEntries { k, v -> [k, new HashSet(v)] }
+  }
+
+  @Override
+  ServerGroup getServerGroup(String account, String namespace, String name) {
+    String serverGroupKey = Keys.getServerGroupKey(account, namespace, name)
+    CacheData serverGroupData = cacheView.get(Keys.Namespace.SERVER_GROUPS.ns, serverGroupKey)
+    Set<CacheData> instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.INSTANCES.ns, Keys.getInstanceKey(account, namespace, name, "*"))
+
+    def replicationController = objectMapper.convertValue(serverGroupData.attributes.replicationController, ReplicationController)
+    serverGroupData ? new KubernetesServerGroup(replicationController, translateInstances(instances)[name]) : null
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesInstance
+import com.netflix.spinnaker.clouddriver.model.InstanceProvider
+import io.fabric8.kubernetes.api.model.Pod
+import org.springframework.beans.factory.annotation.Autowired
+
+class KubernetesInstanceProvider implements InstanceProvider<KubernetesInstance> {
+  private final Cache cacheView
+  private final ObjectMapper objectMapper
+
+  @Autowired
+  KubernetesInstanceProvider(Cache cacheView, ObjectMapper objectMapper) {
+    this.cacheView = cacheView
+    this.objectMapper = objectMapper
+  }
+
+  String platform = Keys.Namespace.provider
+
+  @Override
+  KubernetesInstance getInstance(String account, String namespace, String name) {
+    Set<CacheData> instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.INSTANCES.ns, Keys.getInstanceKey(account, namespace, "*", name))
+    if (!instances || instances.size() == 0) {
+      return null
+    }
+
+    if (instances.size() > 1) {
+      throw new IllegalStateException("Multiple kubernetes pods with name $name in namespace $namespace exist.")
+    }
+
+    CacheData instanceData = instances.toArray()[0]
+
+    def pod = objectMapper.convertValue(instanceData.attributes.replicationController, Pod)
+
+    return new KubernetesInstance(pod)
+  }
+
+  @Override
+  String getConsoleOutput(String account, String region, String id) {
+    return null
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesProviderUtils.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesProviderUtils.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
+
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+
+class KubernetesProviderUtils {
+  static Set<CacheData> getAllMatchingKeyPattern(Cache cacheView, String namespace, String pattern) {
+    loadResults(cacheView, namespace, cacheView.filterIdentifiers(namespace, pattern))
+  }
+
+  private static Set<CacheData> loadResults(Cache cacheView, String namespace, Collection<String> identifiers) {
+    cacheView.getAll(namespace, identifiers, RelationshipCacheFilter.none())
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/MutableCacheData.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/MutableCacheData.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.cats.cache.CacheData
+
+/* TODO(lwander) this was taken from the netflix cluster caching, and should probably be shared between all providers. */
+class MutableCacheData implements CacheData {
+  final String id
+  int ttlSeconds = -1
+  final Map<String, Object> attributes = [:]
+  final Map<String, Collection<String>> relationships = [:].withDefault { [] as Set }
+
+  public MutableCacheData(String id) {
+    this.id = id
+  }
+
+  @JsonCreator
+  public MutableCacheData(@JsonProperty("id") String id,
+                          @JsonProperty("attributes") Map<String, Object> attributes,
+                          @JsonProperty("relationships") Map<String, Collection<String>> relationships) {
+    this(id);
+    this.attributes.putAll(attributes);
+    this.relationships.putAll(relationships);
+  }
+
+  public static Map<String, MutableCacheData> mutableCacheMap() {
+    return [:].withDefault { String id -> new MutableCacheData(id) }
+  }
+}
+

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
@@ -42,10 +42,8 @@ class KubernetesCredentialsInitializer implements CredentialsInitializerSynchron
   @Autowired
   ApplicationContext appContext;
 
-  /*
   @Autowired
   List<ProviderSynchronizerTypeWrapper> providerSynchronizerTypeWrappers
-  */
 
   @Bean
   List<? extends KubernetesNamedAccountCredentials> kubernetesNamedAccountCredentials(
@@ -62,9 +60,9 @@ class KubernetesCredentialsInitializer implements CredentialsInitializerSynchron
   @Bean
   List<?> synchronizeKubernetesAccounts(KubernetesConfigurationProperties kubernetesConfigurationProperties, CatsModule catsModule) {
     def (ArrayList<KubernetesConfigurationProperties.ManagedAccount> accountsToAdd, List<String> namesOfDeletedAccounts) =
-      ProviderUtils.calculateAccountDeltas(accountCredentialsRepository,
-                                           KubernetesNamedAccountCredentials,
-                                           kubernetesConfigurationProperties.accounts)
+    ProviderUtils.calculateAccountDeltas(accountCredentialsRepository,
+                                         KubernetesNamedAccountCredentials,
+                                         kubernetesConfigurationProperties.accounts)
 
     accountsToAdd.each { KubernetesConfigurationProperties.ManagedAccount managedAccount ->
       try {
@@ -84,14 +82,9 @@ class KubernetesCredentialsInitializer implements CredentialsInitializerSynchron
 
     ProviderUtils.unscheduleAndDeregisterAgents(namesOfDeletedAccounts, catsModule)
 
-    /*
-     * Uncomment this when we are ready to add support for loading Kubernetes
-     * accounts without restarting clouddriver
-     * TODO(lwander)
     if (accountsToAdd && catsModule) {
       ProviderUtils.synchronizeAgentProviders(appContext, providerSynchronizerTypeWrappers)
     }
-    */
 
     accountCredentialsRepository.all.findAll {
       it instanceof KubernetesNamedAccountCredentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/DeployKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/DeployKubernetesAtomicOperationSpec.groovy
@@ -165,7 +165,7 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
           assert(rc.spec.template.spec.containers[0][idx].resources.limits.memory == LIMIT_MEMORY[idx])
         }
       }) >> replicationControllerMock
-      2 * replicationControllerMock.getMetadata() >> metadataMock
-      2 * metadataMock.getName() >> replicationControllerName
+      5 * replicationControllerMock.getMetadata() >> metadataMock
+      3 * metadataMock.getName() >> replicationControllerName
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.model.HealthState
+import io.fabric8.kubernetes.api.model.ContainerState
+import io.fabric8.kubernetes.api.model.ContainerStateRunning
+import io.fabric8.kubernetes.api.model.ContainerStateTerminated
+import io.fabric8.kubernetes.api.model.ContainerStateWaiting
+import io.fabric8.kubernetes.api.model.ObjectMeta
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.PodStatus
+import spock.lang.Specification
+
+class KubernetesInstanceSpec extends Specification {
+  private final static String REPLICATION_CONTROLLER = "arcim"
+
+  ContainerState containerStateAsRunningMock
+  ContainerState containerStateAsTerminatedMock
+  ContainerState containerStateAsWaitingMock
+  ContainerState containerStateAsNoneMock
+
+  PodStatus podStatusMock
+  ObjectMeta metadataMock
+  Pod podMock
+
+  def setup() {
+
+    containerStateAsRunningMock = Mock(ContainerState)
+    containerStateAsRunningMock.getRunning() >> new ContainerStateRunning()
+    containerStateAsRunningMock.getTerminated() >> null
+    containerStateAsRunningMock.getWaiting() >> null
+
+    containerStateAsTerminatedMock = Mock(ContainerState)
+    containerStateAsTerminatedMock.getRunning() >> null
+    containerStateAsTerminatedMock.getTerminated() >> new ContainerStateTerminated()
+    containerStateAsTerminatedMock.getWaiting() >> null
+
+    containerStateAsWaitingMock = Mock(ContainerState)
+    containerStateAsWaitingMock.getRunning() >> null
+    containerStateAsWaitingMock.getTerminated() >> null
+    containerStateAsWaitingMock.getWaiting() >> new ContainerStateWaiting()
+
+    containerStateAsNoneMock = Mock(ContainerState)
+    containerStateAsNoneMock.getRunning() >> null
+    containerStateAsNoneMock.getTerminated() >> null
+    containerStateAsNoneMock.getWaiting() >> null
+
+    podStatusMock = Mock(PodStatus)
+    metadataMock = Mock(ObjectMeta)
+    podMock = Mock(Pod)
+
+    podMock.getStatus() >> podStatusMock
+    podMock.getMetadata() >> metadataMock
+
+    // There is nothing interesting to test here, it is already handled by the
+    // convertContainerState(..) tests.
+    podStatusMock.getContainerStatuses() >> []
+  }
+
+  void "Should report state as Up"() {
+    when:
+      def state = KubernetesInstance.convertContainerState(containerStateAsRunningMock)
+
+    then:
+      state == HealthState.Up
+  }
+
+  void "Should report state as Down"() {
+    when:
+      def state = KubernetesInstance.convertContainerState(containerStateAsTerminatedMock)
+
+    then:
+      state == HealthState.Down
+  }
+
+  void "Should report state as Starting"() {
+    when:
+      def state = KubernetesInstance.convertContainerState(containerStateAsWaitingMock)
+
+    then:
+      state == HealthState.Starting
+  }
+
+  void "Should report state as Unknown"() {
+    when:
+      def state = KubernetesInstance.convertContainerState(containerStateAsNoneMock)
+
+    then:
+      state == HealthState.Unknown
+
+    when:
+      state = KubernetesInstance.convertContainerState(null)
+
+    then:
+      state == HealthState.Unknown
+  }
+
+  void "Should report pod state as Up"() {
+    setup:
+      podStatusMock.getPhase() >> "Running"
+
+    when:
+      def instance = new KubernetesInstance(podMock)
+
+    then:
+      instance.healthState == HealthState.Up
+  }
+
+  void "Should report pod state as Down"() {
+    setup:
+      podStatusMock.getPhase() >> "Failed"
+
+    when:
+      def instance = new KubernetesInstance(podMock)
+
+    then:
+      instance.healthState == HealthState.Down
+  }
+
+  void "Should report pod state as Starting"() {
+    setup:
+      podStatusMock.getPhase() >> "Pending"
+
+    when:
+      def instance = new KubernetesInstance(podMock)
+
+    then:
+      instance.healthState == HealthState.Starting
+  }
+
+  void "Should report pod state as Unknown"() {
+    setup:
+      podStatusMock.getPhase() >> "floof"
+
+    when:
+      def instance = new KubernetesInstance(podMock)
+
+    then:
+      instance.healthState == HealthState.Unknown
+  }
+
+  void "Should report pod controller"() {
+    setup:
+      metadataMock.getLabels() >> ["foo": "bar", (KubernetesUtil.REPLICATION_CONTROLLER_LABEL): REPLICATION_CONTROLLER]
+
+    when:
+      def instance = new KubernetesInstance(podMock)
+
+    then:
+      instance.serverGroupName == REPLICATION_CONTROLLER
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroupSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroupSpec.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.model.HealthState
+import io.fabric8.kubernetes.api.model.ReplicationController
+import spock.lang.Specification
+
+class KubernetesServerGroupSpec extends Specification {
+  KubernetesInstance upInstanceMock
+  KubernetesInstance downInstanceMock
+  KubernetesInstance startingInstanceMock
+  KubernetesInstance unknownInstanceMock
+  KubernetesInstance outOfServiceInstanceMock
+
+  def setup() {
+    upInstanceMock = Mock(KubernetesInstance)
+    downInstanceMock = Mock(KubernetesInstance)
+    startingInstanceMock = Mock(KubernetesInstance)
+    unknownInstanceMock = Mock(KubernetesInstance)
+    outOfServiceInstanceMock = Mock(KubernetesInstance)
+
+    upInstanceMock.getHealthState() >> HealthState.Up
+    downInstanceMock.getHealthState() >> HealthState.Down
+    startingInstanceMock.getHealthState() >> HealthState.Starting
+    unknownInstanceMock.getHealthState() >> HealthState.Unknown
+    outOfServiceInstanceMock.getHealthState() >> HealthState.OutOfService
+  }
+
+  void "Should return 1 up instances"() {
+    when:
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock] as Set)
+
+    then:
+      serverGroup.instanceCounts.up == 1
+      serverGroup.instanceCounts.down == 0
+      serverGroup.instanceCounts.unknown == 0
+      serverGroup.instanceCounts.outOfService == 0
+      serverGroup.instanceCounts.starting == 0
+  }
+
+  void "Should return 1 up, 1 down, 1 starting, 1 oos, 1 unknown instances"() {
+    when:
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock, downInstanceMock, startingInstanceMock, unknownInstanceMock, outOfServiceInstanceMock] as Set)
+
+    then:
+      serverGroup.instanceCounts.up == 1
+      serverGroup.instanceCounts.down == 1
+      serverGroup.instanceCounts.unknown == 1
+      serverGroup.instanceCounts.outOfService == 1
+      serverGroup.instanceCounts.starting == 1
+  }
+
+  void "Should list servergroup with no load balancers as disabled"() {
+    when:
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set)
+      serverGroup.labels = ["hi": "there"]
+
+    then:
+      serverGroup.isDisabled()
+  }
+
+  void "Should list servergroup with no enabled load balancers as disabled"() {
+    when:
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set)
+      serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "false"]
+
+    then:
+      serverGroup.isDisabled()
+  }
+
+  void "Should list servergroup with enabled load balancers as enabled"() {
+    when:
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set)
+      serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "true"]
+
+    then:
+      !serverGroup.isDisabled()
+  }
+
+  void "Should list servergroup with mix of load balancers as enabled"() {
+    when:
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set)
+      serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "true", (KubernetesUtil.loadBalancerKey("2")): "false"]
+
+    then:
+      !serverGroup.isDisabled()
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.CacheResult
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import io.fabric8.kubernetes.api.model.ObjectMeta
+import io.fabric8.kubernetes.api.model.PodList
+import io.fabric8.kubernetes.api.model.ReplicationController
+import io.fabric8.kubernetes.api.model.ReplicationControllerList
+import spock.lang.Specification
+
+class KubernetesServerGroupCachingAgentSpec extends Specification {
+  static final private String NAMESPACE = "default"
+  static final private String ACCOUNT_NAME = "account1"
+  static final private String APP = "app"
+  static final private String CLUSTER = "$APP-cluster"
+  static final private String REPLICATION_CONTROLLER = "$CLUSTER-v000"
+  static final private String POD = "$REPLICATION_CONTROLLER-instance"
+
+  KubernetesServerGroupCachingAgent cachingAgent
+  ReplicationControllerList replicationControllerList
+  PodList podList
+  KubernetesUtil utilMock
+  Registry registryMock
+
+  String applicationKey
+  String clusterKey
+  String serverGroupKey
+  String instanceKey
+
+  def setup() {
+    registryMock = Mock(Registry)
+    registryMock.get('id') >>  'id'
+    registryMock.timer(_) >> null
+
+    replicationControllerList = Mock(ReplicationControllerList)
+    podList = Mock(PodList)
+
+    utilMock = Mock(KubernetesUtil)
+    utilMock.getReplicationControllers(_, NAMESPACE) >> replicationControllerList
+    utilMock.getPods(_, NAMESPACE, _) >> podList
+
+    applicationKey = Keys.getApplicationKey(APP)
+    clusterKey = Keys.getClusterKey(ACCOUNT_NAME, APP, CLUSTER)
+    serverGroupKey = Keys.getServerGroupKey(ACCOUNT_NAME, NAMESPACE, REPLICATION_CONTROLLER)
+    instanceKey = Keys.getInstanceKey(ACCOUNT_NAME, NAMESPACE, REPLICATION_CONTROLLER, POD)
+
+    cachingAgent = new KubernetesServerGroupCachingAgent(new KubernetesCloudProvider(), ACCOUNT_NAME, null, NAMESPACE, new ObjectMapper(), registryMock, utilMock)
+  }
+
+  void "Should store a single replication controller object and relationships"() {
+    setup:
+      def replicationControllerMock = Mock(ReplicationController)
+      def replicationControllerMetadataMock = Mock(ObjectMeta)
+      replicationControllerMetadataMock.getName() >> REPLICATION_CONTROLLER
+      replicationControllerMock.getMetadata() >> replicationControllerMetadataMock
+
+      def podMock = Mock(ReplicationController)
+      def podMetadataMock = Mock(ObjectMeta)
+      podMetadataMock.getName() >> POD
+      podMock.getMetadata() >> podMetadataMock
+
+    when:
+      replicationControllerList.getItems() >> [replicationControllerMock]
+      podList.getItems() >> [podMock]
+      def result = cachingAgent.loadData(null)
+
+    then:
+      result.cacheResults.applications.attributes.name == [APP]
+      result.cacheResults.applications.relationships.serverGroups[0][0] == serverGroupKey
+      result.cacheResults.applications.relationships.clusters[0][0] == clusterKey
+
+      result.cacheResults.clusters.attributes.name == [CLUSTER]
+      result.cacheResults.clusters.relationships.serverGroups[0][0] == serverGroupKey
+      result.cacheResults.clusters.relationships.applications[0][0] == applicationKey
+
+      result.cacheResults.serverGroups.attributes.name == [REPLICATION_CONTROLLER]
+      result.cacheResults.serverGroups.relationships.clusters[0][0] == clusterKey
+      result.cacheResults.serverGroups.relationships.applications[0][0] == applicationKey
+      result.cacheResults.serverGroups.relationships.instances[0][0] == instanceKey
+
+      result.cacheResults.instances.attributes.name == [POD]
+      result.cacheResults.instances.relationships.clusters[0][0] == clusterKey
+      result.cacheResults.instances.relationships.applications[0][0] == applicationKey
+      result.cacheResults.instances.relationships.serverGroups[0][0] == serverGroupKey
+  }
+}


### PR DESCRIPTION
This PR caches server groups (replication controllers), instances (pods), clusters (spinnaker concept) and applications (spinnaker concept). It collects all replication controllers and their pods by namespace in `KubernetesServerGroupCaching` agent, determines what clusters and applications they are associated with, and stores them and their relationships using `cats`. `KubernetesClusterProvider`, `KubernetesInstanceProvider`, and `KubernetesApplicationProvider` then provide an interface to retrieve these cached objects. This saturates the endpoints hit by Deck to display clusters.