### PR TITLE
provider/docker: Cache & expose docker images

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/DockerRegistryCloudProvider.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/DockerRegistryCloudProvider.groovy
@@ -27,7 +27,7 @@ import java.lang.annotation.Annotation
  *       Instead, the intent is to provide an interface to query for docker tags hosted by the supplied docker registry.
  */
 @Component
-class DockerRegistryProvider implements CloudProvider {
+class DockerRegistryCloudProvider implements CloudProvider {
   final String id = "dockerRegistry"
   final String displayName = "Docker Registry"
   // The docker registry is only used for caching, so none of the op/ endpoints will be hit.

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -35,12 +35,10 @@ class DockerRegistryClient {
   public String address
   private DockerRegistryService registryService
   private GsonConverter converter
-  private RequestResource requester
 
   DockerRegistryClient(String address, String email, String username, String password) {
     this.tokenService = new DockerBearerTokenService(username, password)
-    this.registryService = new RestAdapter.Builder().setEndpoint(address).setLogLevel(RestAdapter.LogLevel.BASIC).build().create(DockerRegistryService)
-    this.requester = new RequestResource()
+    this.registryService = new RestAdapter.Builder().setEndpoint(address).setLogLevel(RestAdapter.LogLevel.NONE).build().create(DockerRegistryService)
     this.converter = new GsonConverter(new GsonBuilder().create())
     this.address = address
   }
@@ -108,28 +106,5 @@ class DockerRegistryClient {
       }
     }
     return true
-  }
-
-  private class RequestResource<T> {
-    Callback<T> Request(Closure store, Closure<T> retry) {
-      return new Callback<T>() {
-        @Override
-        void success(T t, Response response) {
-          T convertedResult = (T) converter.fromBody(response.body, T)
-          store(convertedResult)
-        }
-
-        @Override
-        void failure(RetrofitError error) {
-          if (error.response.status == 401) {
-            def tokenResponse = tokenService.getToken(error.response.headers)
-            def token = tokenResponse.bearer_token ?: tokenResponse.token
-            store(retry(token))
-          } else {
-            throw error
-          }
-        }
-      }
-    }
   }
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/cache/DefaultCacheDataBuilder.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/cache/DefaultCacheDataBuilder.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.cache
+
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+
+class DefaultCacheDataBuilder {
+  String id = ''
+  int ttlSeconds = -1
+  Map<String, Object> attributes = [:]
+  Map<String, Collection<String>> relationships = [:].withDefault({ _ -> [] as Set })
+
+  public DefaultCacheData build() {
+    new DefaultCacheData(id, ttlSeconds, attributes, relationships)
+  }
+
+  public static Map<String, DefaultCacheDataBuilder> defaultCacheDataBuilderMap() {
+    return [:].withDefault { String id -> new DefaultCacheDataBuilder(id: id) }
+  }
+}

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/cache/Keys.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/cache/Keys.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.cache
+
+class Keys {
+  static enum Namespace {
+    TAGGED_IMAGE,
+
+    static String provider = "dockerRegistry"
+
+    final String ns
+
+    private Namespace() {
+      def parts = name().split('_')
+
+      ns = parts.tail().inject(new StringBuilder(parts.head().toLowerCase())) { val, next -> val.append(next.charAt(0)).append(next.substring(1).toLowerCase()) }
+    }
+
+    String toString() {
+      ns
+    }
+  }
+
+  static Map<String, String> parse(String key) {
+    def parts = key.split(':')
+
+    if (parts.length < 2) {
+      return null
+    }
+
+    def result = [provider: parts[0], type: parts[1]]
+
+    if (result.provider != Namespace.provider) {
+      return null
+    }
+
+    switch (result.type) {
+      case Namespace.TAGGED_IMAGE.ns:
+        result << [account: parts[2], repository: parts[3], tag: parts[4]]
+        break
+      default:
+        return null
+        break
+    }
+
+    result
+  }
+
+  static String getTaggedImageKey(String account, String repository, String tag) {
+    "${Namespace.provider}:${Namespace.TAGGED_IMAGE}:${account}:${repository}:${tag}"
+  }
+}

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.controllers
+
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.clouddriver.docker.registry.cache.Keys
+import com.netflix.spinnaker.clouddriver.docker.registry.provider.DockerRegistryProviderUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/dockerRegistry/images")
+class DockerRegistryImageLookupController {
+  @Autowired
+  private final Cache cacheView
+
+  @RequestMapping(value = '/find', method = RequestMethod.GET)
+  List<Map> find(LookupOptions lookupOptions) {
+    def account = ""
+    def image = ""
+    def tag = ""
+
+    if (lookupOptions.account) {
+      account = lookupOptions.account
+    }
+
+    if (lookupOptions.q) {
+      def lastColon = lookupOptions.q.lastIndexOf(':')
+      if (lastColon != -1) {
+        image = lookupOptions.q.substring(0, lastColon)
+        tag = lookupOptions.q.(lastColon + 1)
+      } else {
+        image = lookupOptions.q
+      }
+    }
+
+    image = image ?: '*'
+    account = account ?: '*'
+    tag = tag ?: '*'
+
+    print ",, image = $image, account = $account, tag = $tag\n"
+
+    def key = Keys.getTaggedImageKey(account, image, tag)
+
+    print ",, key = $key\n"
+
+    Set<CacheData> images = DockerRegistryProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.TAGGED_IMAGE.ns, key)
+
+    return images.collect({
+      [imageName: (String) it.attributes.name,
+       account: it.attributes.account]
+    })
+  }
+
+  private static class LookupOptions {
+    String q
+    String account
+    String region
+  }
+}

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/DockerRegistryProvider.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/DockerRegistryProvider.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.provider
+
+import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
+import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
+import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider
+import com.netflix.spinnaker.clouddriver.docker.registry.cache.Keys
+
+class DockerRegistryProvider extends AgentSchedulerAware implements SearchableProvider {
+  public static final String PROVIDER_NAME = DockerRegistryProvider.name
+
+  final Set<String> defaultCaches = Collections.emptySet()
+
+  final Map<String, String> urlMappingTemplates = Collections.emptyMap()
+
+  final Collection<Agent> agents
+  final DockerRegistryCloudProvider cloudProvider
+
+  DockerRegistryProvider(DockerRegistryCloudProvider cloudProvider, Collection<Agent> agents) {
+    this.cloudProvider = cloudProvider
+    this.agents = agents
+  }
+
+  @Override
+  String getProviderName() {
+    return PROVIDER_NAME
+  }
+
+  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+
+  final Map<String, SearchableProvider.IdentifierExtractor> identifierExtractors = Collections.emptyMap()
+
+  @Override
+  Map<String, String> parseKey(String key) {
+    return Keys.parse(key)
+  }
+}
+

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/DockerRegistryProviderUtils.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/DockerRegistryProviderUtils.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.provider
+
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+
+class DockerRegistryProviderUtils {
+  static Set<CacheData> getAllMatchingKeyPattern(Cache cacheView, String namespace, String pattern) {
+    loadResults(cacheView, namespace, cacheView.filterIdentifiers(namespace, pattern))
+  }
+
+  private static Set<CacheData> loadResults(Cache cacheView, String namespace, Collection<String> identifiers) {
+    cacheView.getAll(namespace, identifiers, RelationshipCacheFilter.none())
+  }
+}

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.provider.agent
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.*
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
+import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider
+import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryTags
+import com.netflix.spinnaker.clouddriver.docker.registry.cache.DefaultCacheDataBuilder
+import com.netflix.spinnaker.clouddriver.docker.registry.cache.Keys
+import com.netflix.spinnaker.clouddriver.docker.registry.provider.DockerRegistryProvider
+import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryCredentials
+import groovy.util.logging.Slf4j
+
+import static java.util.Collections.unmodifiableSet
+
+@Slf4j
+class DockerRegistryImageCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
+  @Deprecated
+  private static final String LEGACY_ON_DEMAND_TYPE = 'DockerRegistryTaggedImage'
+
+  private static final String ON_DEMAND_TYPE = 'TaggedImage'
+
+  static final Set<AgentDataType> types = unmodifiableSet([
+    AgentDataType.Authority.AUTHORITATIVE.forType(Keys.Namespace.TAGGED_IMAGE.ns)
+  ] as Set)
+
+  private DockerRegistryCredentials credentials
+  private DockerRegistryCloudProvider dockerRegistryCloudProvider
+  private String accountName
+  private OnDemandMetricsSupport metricsSupport
+
+  DockerRegistryImageCachingAgent(DockerRegistryCloudProvider dockerRegistryCloudProvider,
+                                  String accountName,
+                                  DockerRegistryCredentials credentials,
+                                  Registry registry) {
+    this.dockerRegistryCloudProvider = dockerRegistryCloudProvider
+    this.accountName = accountName
+    this.credentials = credentials
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${Keys.Namespace.provider}:${ON_DEMAND_TYPE}".toString())
+  }
+
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    return types
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    Map<String, Set<String>> tags = loadTags()
+
+    buildCacheResult(tags)
+  }
+
+  @Override
+  String getAgentType() {
+    "${accountName}/${DockerRegistryImageCachingAgent.simpleName}"
+  }
+
+  @Override
+  String getProviderName() {
+    DockerRegistryProvider.PROVIDER_NAME
+  }
+
+  @Override
+  String getOnDemandAgentType() {
+    "${getAgentType()}-OnDemand"
+  }
+
+  @Override
+  OnDemandMetricsSupport getMetricsSupport() {
+    return metricsSupport
+  }
+
+  @Override
+  boolean handles(String type) {
+    type == LEGACY_ON_DEMAND_TYPE
+  }
+
+  @Override
+  boolean handles(String type, String cloudProvider) {
+    cloudProvider == Keys.Namespace.provider && type == ON_DEMAND_TYPE
+  }
+
+  @Override
+  OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data) {
+    if (data.account != accountName) {
+      return null
+    }
+
+    Map<String, Set<String>> mapRepositoryToTags = metricsSupport.readData {
+      loadTags()
+    }
+
+    CacheResult result = metricsSupport.transformData {
+      buildCacheResult(mapRepositoryToTags)
+    }
+
+    new OnDemandAgent.OnDemandResult(
+      sourceAgentType: getAgentType(),
+      cacheResult: result
+    )
+  }
+
+  private Map<String, Set<String>> loadTags() {
+    def res = new HashMap<String, Set<String>>().withDefault({ _ -> [] as Set })
+    credentials.repositories.forEach({ repository ->
+      DockerRegistryTags tags = credentials.client.getTags(repository)
+      res[tags.name].addAll(tags.tags)
+    })
+    return res
+  }
+
+  @Override
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    return [:]
+  }
+
+  @Override
+  String getAccountName() {
+    return accountName
+  }
+
+  private CacheResult buildCacheResult(Map<String, Set<String>> tagMap) {
+    log.info("Describing items in ${agentType}")
+
+    Map<String, DefaultCacheDataBuilder> cachedTags = DefaultCacheDataBuilder.defaultCacheDataBuilderMap()
+
+    tagMap.forEach { repository, tags ->
+      tags.forEach { tag ->
+        def tagKey = Keys.getTaggedImageKey(accountName, repository, tag)
+        cachedTags[tagKey].with {
+          attributes.name = "${repository}:${tag}".toString()
+          attributes.account = accountName
+        }
+      }
+
+      null
+    }
+
+    log.info("Caching ${cachedTags.size()} tagged images in ${agentType}")
+
+    new DefaultCacheResult([
+      (Keys.Namespace.TAGGED_IMAGE.ns): cachedTags.values().collect({ builder -> builder.build() }),
+    ])
+  }
+}

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/config/DockerRegistryProviderConfig.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/config/DockerRegistryProviderConfig.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.provider.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
+import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider
+import com.netflix.spinnaker.clouddriver.docker.registry.provider.DockerRegistryProvider
+import com.netflix.spinnaker.clouddriver.docker.registry.provider.agent.DockerRegistryImageCachingAgent
+import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.ProviderUtils
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.DependsOn
+import org.springframework.context.annotation.Scope
+
+import java.util.concurrent.ConcurrentHashMap
+
+@Configuration
+class DockerRegistryProviderConfig {
+  @Bean
+  @DependsOn('dockerRegistryNamedAccountCredentials')
+  DockerRegistryProvider dockerRegistryProvider(DockerRegistryCloudProvider dockerRegistryCloudProvider,
+                                                AccountCredentialsRepository accountCredentialsRepository,
+                                                ObjectMapper objectMapper,
+                                                Registry registry) {
+    def dockerRegistryProvider = new DockerRegistryProvider(dockerRegistryCloudProvider, Collections.newSetFromMap(new ConcurrentHashMap<Agent, Boolean>()))
+
+    synchronizeDockerRegistryProvider(dockerRegistryProvider, dockerRegistryCloudProvider, accountCredentialsRepository, objectMapper, registry)
+
+    dockerRegistryProvider
+  }
+
+  @Bean
+  DockerRegistryProviderSynchronizerTypeWrapper dockerRegistryProviderSynchronizerTypeWrapper() {
+    new DockerRegistryProviderSynchronizerTypeWrapper()
+  }
+
+  class DockerRegistryProviderSynchronizerTypeWrapper implements ProviderSynchronizerTypeWrapper {
+    @Override
+    Class getSynchronizerType() {
+      return DockerRegistryProviderSynchronizer
+    }
+  }
+
+  class DockerRegistryProviderSynchronizer {}
+
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  @Bean
+  DockerRegistryProviderSynchronizer synchronizeDockerRegistryProvider(DockerRegistryProvider dockerRegistryProvider,
+                                                                       DockerRegistryCloudProvider dockerRegistryCloudProvider,
+                                                                       AccountCredentialsRepository accountCredentialsRepository,
+                                                                       ObjectMapper objectMapper,
+                                                                       Registry registry) {
+    def scheduledAccounts = ProviderUtils.getScheduledAccounts(dockerRegistryProvider)
+    def allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, DockerRegistryNamedAccountCredentials)
+
+    allAccounts.each { DockerRegistryNamedAccountCredentials credentials ->
+      if (!scheduledAccounts.contains(credentials.accountName)) {
+        def newlyAddedAgents = []
+
+        newlyAddedAgents << new DockerRegistryImageCachingAgent(dockerRegistryCloudProvider, credentials.accountName, credentials.credentials, registry)
+
+        // If there is an agent scheduler, then this provider has been through the AgentController in the past.
+        // In that case, we need to do the scheduling here (because accounts have been added to a running system).
+        if (dockerRegistryProvider.agentScheduler) {
+          ProviderUtils.rescheduleAgents(dockerRegistryProvider, newlyAddedAgents)
+        }
+
+        dockerRegistryProvider.agents.addAll(newlyAddedAgents)
+      }
+    }
+
+    new DockerRegistryProviderSynchronizer()
+  }
+}

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
@@ -42,10 +42,8 @@ class DockerRegistryCredentialsInitializer implements CredentialsInitializerSync
   @Autowired
   ApplicationContext appContext;
 
-  /*
   @Autowired
   List<ProviderSynchronizerTypeWrapper> providerSynchronizerTypeWrappers
-  */
 
   @Bean
   List<? extends DockerRegistryNamedAccountCredentials> dockerRegistryNamedAccountCredentials(
@@ -82,14 +80,9 @@ class DockerRegistryCredentialsInitializer implements CredentialsInitializerSync
 
     ProviderUtils.unscheduleAndDeregisterAgents(namesOfDeletedAccounts, catsModule)
 
-    /*
-     * Uncomment this when we are ready to add support for loading DockerRegistry
-     * accounts without restarting clouddriver
-     * TODO(lwander)
     if (accountsToAdd && catsModule) {
       ProviderUtils.synchronizeAgentProviders(appContext, providerSynchronizerTypeWrappers)
     }
-    */
 
     accountCredentialsRepository.all.findAll {
       it instanceof DockerRegistryNamedAccountCredentials


### PR DESCRIPTION
This PR caches every image tag in Redis (using cats) for each repository configured with an account of type `dockerRegistry`. These images are then accessible via `/docker/registry/{account}/images`. The goal is to allow Deck to query every docker account that a container deployment solution has configured to present user with a searchable list of images.