### PR TITLE
Couple DescriptionPreProcessors to correct legacy descriptions

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
@@ -17,10 +17,10 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
-  List<AsgDescription> asgs = []
+  List<AsgTargetDescription> asgs = []
 
   @Deprecated
-  String asgName
+  String serverGroupName
 
   @Deprecated
   List<String> regions = []
@@ -37,14 +37,12 @@ class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
     }
   }
 
-  static class AsgDescription {
-    String region
-    String asgName
+  static class AsgTargetDescription extends AsgDescription {
     Capacity capacity
 
     @Override
     String toString() {
-      "region: $region, asgName: $asgName, capacity: $capacity"
+      "region: $region, serverGroupName: $serverGroupName, capacity: $capacity"
     }
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/orchestration/AsgNameToServerGroupNameDescriptionPreProcessor.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/orchestration/AsgNameToServerGroupNameDescriptionPreProcessor.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.aws.orchestration
+
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationDescriptionPreProcessor
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+@Order(-1)
+@Component
+class AsgNameToServerGroupNameDescriptionPreProcessor implements AtomicOperationDescriptionPreProcessor {
+  @Override
+  boolean supports(Class descriptionClass, Map description) {
+    return description.containsKey("asgName")
+  }
+
+  @Override
+  Map process(Map description) {
+    description.serverGroupName = description.serverGroupName ?: description.asgName
+    return description
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/ResizeAsgAtomicOperationConverterUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/ResizeAsgAtomicOperationConverterUnitSpec.groovy
@@ -56,4 +56,29 @@ class ResizeAsgAtomicOperationConverterUnitSpec extends Specification {
     then:
     operation instanceof ResizeAsgAtomicOperation
   }
+
+  void "should convert legacy resize asg descriptions"() {
+    given:
+    def preProcessor = new ResizeAsgAtomicOperationConverter.ResizeAsgDescriptionPreProcessor()
+    def legacyDescription = [
+      regions        : ["us-east-1"],
+      serverGroupName: "s-v001",
+      asgName        : "s-v001",
+      capacity       : [
+        min    : 0,
+        max    : 0,
+        desired: 0
+      ]
+    ]
+
+    when:
+    def processedDescription = preProcessor.process(legacyDescription)
+
+    then:
+    processedDescription == [
+        asgs: [
+          [serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 0, max: 0, desired: 0]]
+        ]
+    ]
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationDescriptionPreProcessor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationDescriptionPreProcessor.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * Provides an extension point for manipulating an {@code AtomicOperation} context prior to execution.
  */
 public interface AtomicOperationDescriptionPreProcessor {
-  boolean supports(Class descriptionClass);
+  boolean supports(Class descriptionClass, Map description);
   Map process(Map description);
 
   default <T> T mapTo(ObjectMapper objectMapper, Map description, Class<T> clazz) throws IOException {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.controllers
 
+import com.google.common.collect.ImmutableMap
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidationErrors
@@ -189,7 +190,7 @@ class OperationsController {
                                      AtomicOperationConverter converter,
                                      Map descriptionInput) {
     def descriptionClass = converter.metaClass.methods.find { it.name == "convertDescription" }.returnType
-    descriptionPreProcessors.findAll { it.supports(descriptionClass) }.each {
+    descriptionPreProcessors.findAll { it.supports(descriptionClass, ImmutableMap.copyOf(descriptionInput)) }.each {
       descriptionInput = it.process(descriptionInput)
     }
 

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsControllerSpec.groovy
@@ -70,7 +70,7 @@ class OperationsControllerSpec extends Specification {
   @Shared
   def googlePreProcessor = new AtomicOperationDescriptionPreProcessor() {
     @Override
-    boolean supports(Class descriptionClass) {
+    boolean supports(Class descriptionClass, Map description) {
       return descriptionClass == BasicGoogleDeployDescription
     }
 
@@ -83,7 +83,7 @@ class OperationsControllerSpec extends Specification {
   @Shared
   def amazonPreProcessor = new AtomicOperationDescriptionPreProcessor() {
     @Override
-    boolean supports(Class descriptionClass) {
+    boolean supports(Class descriptionClass, Map description) {
       return descriptionClass == BasicAmazonDeployDescription
     }
 


### PR DESCRIPTION
- asgName -> serverGroupName
- ResizeAsgDescription now only supports the nested { asgs: [] } structure