### PR TITLE
provider/kubernetes: Upsert load balancer

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -54,12 +54,12 @@ class KubernetesApiAdaptor {
     client.services().inNamespace(namespace).withName(service).get()
   }
 
-  Service getSecurityGroup(String namespace, String securityGroup) {
-    getService(namespace, securityGroup)
+  Service createService(String namespace, Service service) {
+    client.services().inNamespace(namespace).create(service)
   }
 
-  Service getLoadBalancer(String namespace, String loadBalancer) {
-    getService(namespace, loadBalancer)
+  Service replaceService(String namespace, String name, Service service) {
+    client.services().inNamespace(namespace).withName(name).replace(service)
   }
 
   Secret getSecret(String namespace, String secret) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverter.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.loadbalancer
+
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+@KubernetesOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
+@Component
+class UpsertKubernetesLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  AtomicOperation convertOperation(Map input) {
+    new UpsertKubernetesLoadBalancerAtomicOperation(convertDescription(input))
+  }
+
+  UpsertKubernetesLoadBalancerAtomicOperationDescription convertDescription(Map input) {
+    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, UpsertKubernetesLoadBalancerAtomicOperationDescription)
+  }
+}
+

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverter.groovy
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.servergroup
 
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.CloneKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.CloneKubernetesAtomicOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup.CloneKubernetesAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/DeployKubernetesAtomicOperationConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/DeployKubernetesAtomicOperationConverter.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Google, Inc.
+ * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.servergroup
 
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.DeployKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.DeployKubernetesAtomicOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup.DeployKubernetesAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationDescription.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer
+
+import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesAtomicOperationDescription
+import groovy.transform.AutoClone
+import groovy.transform.Canonical
+
+@AutoClone
+@Canonical
+class UpsertKubernetesLoadBalancerAtomicOperationDescription extends KubernetesAtomicOperationDescription implements DeployDescription {
+  String name
+  String namespace
+
+  List<KubernetesNamedServicePort> ports
+  List<String> externalIps
+
+  String type
+}
+
+@AutoClone
+@Canonical
+class KubernetesNamedServicePort {
+  String name
+  String protocol
+  int port
+  int targetPort
+  int nodePort
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/CloneKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/CloneKubernetesAtomicOperationDescription.groovy
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup
 
 import groovy.transform.Canonical
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Google, Inc.
+ * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup
 
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesAtomicOperationDescription
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.loadbalancer
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesNamedServicePort
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import io.fabric8.kubernetes.api.model.ServiceBuilder
+import io.fabric8.kubernetes.api.model.ServicePort
+
+class UpsertKubernetesLoadBalancerAtomicOperation implements AtomicOperation<Map> {
+  private static final String BASE_PHASE = "UPSERT_LOAD_BALANCER"
+
+  UpsertKubernetesLoadBalancerAtomicOperationDescription description
+
+  UpsertKubernetesLoadBalancerAtomicOperation(UpsertKubernetesLoadBalancerAtomicOperationDescription description) {
+    this.description = description
+  }
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  /*
+   * curl -X POST -H "Content-Type: application/json" -d  '[ {  "upsertLoadBalancer": { "name": "service",  "ports": [ { "name": "http", "port": 80, "targetPort": 9376 } ], "credentials":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
+  */
+  @Override
+  Map operate(List priorOutputs) {
+    task.updateStatus BASE_PHASE, "Initializing upsert of load balancer $description.name..."
+    task.updateStatus BASE_PHASE, "Looking up provided namespace..."
+
+    def credentials = description.kubernetesCredentials
+    def namespace = KubernetesUtil.validateNamespace(credentials, description.namespace)
+    def name = description.name
+
+    task.updateStatus BASE_PHASE, "Looking up existing load balancer..."
+    def existingService = credentials.apiAdaptor.getService(namespace, name)
+
+    if (existingService) {
+      task.updateStatus BASE_PHASE, "Found existing load balancer with name $description.name."
+    }
+
+    def serviceBuilder = new ServiceBuilder()
+
+    serviceBuilder = serviceBuilder.withNewMetadata().withName(name).endMetadata()
+
+    task.updateStatus BASE_PHASE, "Setting label selectors..."
+
+    serviceBuilder = serviceBuilder.withNewSpec()
+
+    serviceBuilder = serviceBuilder.addToSelector(KubernetesUtil.loadBalancerKey(name), 'true')
+
+    task.updateStatus BASE_PHASE, "Adding ports..."
+
+    List<KubernetesNamedServicePort> ports = []
+
+    for (ServicePort port : existingService?.spec?.ports) {
+      def namedPort = new KubernetesNamedServicePort()
+      port.name ? namedPort.name = port.name : null
+      port.nodePort ? namedPort.nodePort = port.nodePort : null
+      port.port ? namedPort.port = port.port : null
+      port.targetPort ? namedPort.targetPort = port.targetPort?.intVal : null
+      port.protocol ? namedPort.protocol = port.protocol : null
+      ports << namedPort
+    }
+
+    ports = description.ports != null ? description.ports : ports
+
+    for (def port : ports) {
+      serviceBuilder = serviceBuilder.addNewPort()
+
+      serviceBuilder = port.name ? serviceBuilder.withName(port.name) : serviceBuilder
+      serviceBuilder = port.targetPort ? serviceBuilder.withNewTargetPort(port.targetPort) : serviceBuilder
+      serviceBuilder = port.port ? serviceBuilder.withPort(port.targetPort) : serviceBuilder
+      serviceBuilder = port.nodePort ? serviceBuilder.withNodePort(port.targetPort) : serviceBuilder
+      serviceBuilder = port.protocol ? serviceBuilder.withProtocol(port.protocol) : serviceBuilder
+
+      serviceBuilder = serviceBuilder.endPort()
+    }
+
+    task.updateStatus BASE_PHASE, "Adding external IPs..."
+
+    def externalIps = description.externalIps != null ? description.externalIps : existingService?.spec?.externalIPs
+
+    for (def ip: externalIps) {
+      serviceBuilder = serviceBuilder.addToExternalIPs(ip)
+    }
+
+    task.updateStatus BASE_PHASE, "Setting type..."
+
+    def type = description.type != null ? description.type : existingService?.spec?.type
+
+    serviceBuilder = type ? serviceBuilder.withType(type) : serviceBuilder
+
+    serviceBuilder = serviceBuilder.endSpec()
+
+    def service = existingService ?
+      credentials.apiAdaptor.replaceService(namespace, name, serviceBuilder.build()) :
+      credentials.apiAdaptor.createService(namespace, serviceBuilder.build())
+
+    task.updateStatus BASE_PHASE, "Finished upserting load balancer $description.name."
+
+    [loadBalancers: [(service.metadata.namespace): [name: service.metadata.name]]]
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup
 
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.CloneKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesContainerDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesResourceDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.exception.KubernetesResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import io.fabric8.kubernetes.api.model.ReplicationController
-import org.springframework.beans.factory.annotation.Autowired
 
 class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult> {
   private static final String BASE_PHASE = "CLONE_SERVER_GROUP"

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Google, Inc.
+ * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.DeployKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.exception.KubernetesIllegalArgumentException
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder
@@ -56,22 +55,10 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
 
   ReplicationController deployDescription() {
     task.updateStatus BASE_PHASE, "Initializing creation of replication controller."
-
-
     task.updateStatus BASE_PHASE, "Looking up provided namespace..."
 
     def credentials = description.kubernetesCredentials
-    def namespace = description.namespace ? description.namespace : "default"
-
-    if (!credentials.isRegisteredNamespace(namespace)) {
-      def error = "Registered namespaces are ${credentials.getNamespaces()}."
-      if (description.namespace) {
-        error = "Namespace '$namespace' was not registered with account '$description.credentials'. $error"
-      } else {
-        error = "No provided namespace assumed to mean 'default' was not registered with account '$description.credentials'. $error"
-      }
-      throw new KubernetesIllegalArgumentException(error)
-    }
+    def namespace = KubernetesUtil.validateNamespace(credentials, description.namespace)
 
     def clusterName = KubernetesUtil.combineAppStackDetail(description.application, description.stack, description.freeFormDetails)
     task.updateStatus BASE_PHASE, "Looking up next sequence index..."

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.loadbalancer
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.validation.Errors
+
+@KubernetesOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
+@Component
+class UpsertKubernetesLoadBalancerAtomicOperationValidator extends DescriptionValidator<UpsertKubernetesLoadBalancerAtomicOperationDescription>{
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Override
+  void validate(List priorDescriptions, UpsertKubernetesLoadBalancerAtomicOperationDescription description, Errors errors) {
+    def helper = new StandardKubernetesAttributeValidator("upsertKubernetesLoadBalancerAtomicOperationDescription", errors)
+
+    if (!helper.validateCredentials(description.credentials, accountCredentialsProvider)) {
+      return
+    }
+
+    KubernetesCredentials credentials = (KubernetesCredentials) accountCredentialsProvider.getCredentials(description.credentials).credentials
+
+    helper.validateName(description.name, "name")
+    helper.validateNamespace(credentials, description.namespace, "namespace")
+
+    description.ports.eachWithIndex { port, idx ->
+      helper.validateName(port.name, "ports[$idx].name")
+      helper.validateProtocol(port.protocol, "ports[$idx].protocol")
+      port.nodePort ? helper.validatePort(port.nodePort, "ports[$idx].nodePort") : null
+      port.port ? helper.validatePort(port.port, "ports[$idx].port") : null
+      port.targetPort ? helper.validatePort(port.targetPort, "ports[$idx].targetPort") : null
+    }
+
+    description.externalIps.eachWithIndex { ip, idx ->
+      helper.validateIpv4(ip, "externalIps[$idx]")
+    }
+
+    helper.validateServiceType(description.type, "type")
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidator.groovy
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.CloneKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidator.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Google, Inc.
+ * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.DeployKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/KubernetesContainerValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/KubernetesContainerValidator.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Google, Inc.
+ * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,16 +14,10 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup
 
-import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesContainerDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 
 class KubernetesContainerValidator {
   static void validate(KubernetesContainerDescription description, StandardKubernetesAttributeValidator helper, String prefix) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverterSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Google, Inc.
+ * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,32 +14,30 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.loadbalancer
 
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.DeployKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.DeployKubernetesAtomicOperation
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Shared
 import spock.lang.Specification
 
-class DeployKubernetesAtomicOperationConverterSpec extends Specification {
+class UpsertKubernetesLoadBalancerAtomicOperationConverterSpec extends Specification {
   private static final CREDENTIALS = "my-test-account"
-  private static final APPLICATION = "app"
-  private static final STACK = "stack"
-  private static final DETAILS = "details"
+  private static final NAME = "johanson"
 
   @Shared
   ObjectMapper mapper = new ObjectMapper()
 
   @Shared
-  DeployKubernetesAtomicOperationConverter converter
+  UpsertKubernetesLoadBalancerAtomicOperationConverter converter
 
   def mockCredentials
 
   def setupSpec() {
-    converter = new DeployKubernetesAtomicOperationConverter(objectMapper: mapper)
+    converter = new UpsertKubernetesLoadBalancerAtomicOperationConverter(objectMapper: mapper)
   }
 
   def setup() {
@@ -47,24 +45,22 @@ class DeployKubernetesAtomicOperationConverterSpec extends Specification {
     converter.accountCredentialsProvider = Mock(AccountCredentialsProvider)
   }
 
-  void "DeployKubernetesAtomicOperationConverter type returns DeployKubernetesAtomicOperation and DeployKubernetesAtomicOperationDescription"() {
+  void "UpsertKubernetesLoadBalancerAtomicOperationSpec matches type signature of parent method"() {
     setup:
-      def input = [app: APPLICATION,
-                   stack: STACK,
-                   freeFormDetails: DETAILS,
+      def input = [name: NAME,
                    credentials: CREDENTIALS]
     when:
       def description = converter.convertDescription(input)
 
     then:
       1 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
-      description instanceof DeployKubernetesAtomicOperationDescription 
+      description instanceof UpsertKubernetesLoadBalancerAtomicOperationDescription
 
     when:
       def operation = converter.convertOperation(input)
 
     then:
       1 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
-      operation instanceof DeployKubernetesAtomicOperation 
+      operation instanceof UpsertKubernetesLoadBalancerAtomicOperation
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverterSpec.groovy
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.servergroup
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.CloneKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.CloneKubernetesAtomicOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup.CloneKubernetesAtomicOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import spock.lang.Shared

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/DeployKubernetesAtomicOperationConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/DeployKubernetesAtomicOperationConverterSpec.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.servergroup
+
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.servergroup.DeployKubernetesAtomicOperationConverter
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup.DeployKubernetesAtomicOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DeployKubernetesAtomicOperationConverterSpec extends Specification {
+  private static final CREDENTIALS = "my-test-account"
+  private static final APPLICATION = "app"
+  private static final STACK = "stack"
+  private static final DETAILS = "details"
+
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared
+  DeployKubernetesAtomicOperationConverter converter
+
+  def mockCredentials
+
+  def setupSpec() {
+    converter = new DeployKubernetesAtomicOperationConverter(objectMapper: mapper)
+  }
+
+  def setup() {
+    mockCredentials = Mock(KubernetesNamedAccountCredentials)
+    converter.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+  }
+
+  void "DeployKubernetesAtomicOperationConverter type returns DeployKubernetesAtomicOperation and DeployKubernetesAtomicOperationDescription"() {
+    setup:
+      def input = [app: APPLICATION,
+                   stack: STACK,
+                   freeFormDetails: DETAILS,
+                   credentials: CREDENTIALS]
+    when:
+      def description = converter.convertDescription(input)
+
+    then:
+      1 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
+      description instanceof DeployKubernetesAtomicOperationDescription
+
+    when:
+      def operation = converter.convertOperation(input)
+
+    then:
+      1 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
+      operation instanceof DeployKubernetesAtomicOperation
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.loadbalancer
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesNamedServicePort
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import io.fabric8.kubernetes.api.model.Service
+import io.fabric8.kubernetes.api.model.ServicePort
+import io.fabric8.kubernetes.api.model.ServiceSpec
+import spock.lang.Specification
+import spock.lang.Subject
+
+class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
+  final static List<String> NAMESPACES = ['default', 'prod']
+  final static String NAMESPACE = 'prod'
+  final static int VALID_PORT1 = 80
+  final static int VALID_PORT2 = 7002
+  final static int INVALID_PORT = 0
+  final static String VALID_PROTOCOL1 = "TCP"
+  final static String VALID_PROTOCOL2 = "UDP"
+  final static String INVALID_PROTOCOL = "PCT"
+  final static String VALID_NAME1 = "name"
+  final static String VALID_NAME2 = "eman"
+  final static String INVALID_NAME = "bad name ?"
+  final static String VALID_IP1 = "127.0.0.1"
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  def apiMock
+  def accountCredentialsRepositoryMock
+  def credentials
+  KubernetesNamedServicePort namedPort1
+
+  def setup() {
+    apiMock = Mock(KubernetesApiAdaptor)
+    accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
+    credentials = new KubernetesCredentials(apiMock, NAMESPACES, [], accountCredentialsRepositoryMock)
+
+    namedPort1 = new KubernetesNamedServicePort(name: VALID_NAME1, port: VALID_PORT1, targetPort: VALID_PORT1, nodePort: VALID_PORT1, protocol: VALID_PROTOCOL1)
+  }
+
+  void "should upsert a new loadbalancer"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], kubernetesCredentials: credentials, namespace: NAMESPACE)
+      def resultServiceMock = Mock(Service)
+
+      @Subject def operation = new UpsertKubernetesLoadBalancerAtomicOperation(description)
+
+    when:
+      operation.operate([])
+
+    then:
+      1 * apiMock.getService(NAMESPACE, VALID_NAME1) >> null
+      1 * apiMock.createService(NAMESPACE, { service ->
+        service.metadata.name == description.name
+        service.spec.externalIPs.eachWithIndex { ip, idx ->
+          ip == description.externalIps[idx]
+        }
+        def port = service.spec.ports[0]
+        port.port == namedPort1.port
+        port.name == namedPort1.name
+        port.targetPort.intVal == namedPort1.targetPort
+        port.nodePort == namedPort1.nodePort
+        port.protocol == namedPort1.protocol
+      }) >> resultServiceMock
+      resultServiceMock.getMetadata() >> [name: '', namespace: '']
+  }
+
+
+  void "should upsert a new loadbalancer, and overwrite port data"() {
+    setup:
+    def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], kubernetesCredentials: credentials, namespace: NAMESPACE)
+      def resultServiceMock = Mock(Service)
+      def existingServiceMock = Mock(Service)
+      def servicePortMock = Mock(ServicePort)
+      def serviceSpecMock = Mock(ServiceSpec)
+
+      existingServiceMock.getSpec() >> serviceSpecMock
+      serviceSpecMock.getPorts() >> [servicePortMock]
+      servicePortMock.getPort() >> VALID_PORT2
+      servicePortMock.getName() >> VALID_NAME2
+      servicePortMock.getNodePort() >> VALID_PORT2
+      servicePortMock.getProtocol() >> VALID_PROTOCOL2
+
+      @Subject def operation = new UpsertKubernetesLoadBalancerAtomicOperation(description)
+
+    when:
+      operation.operate([])
+
+    then:
+      1 * apiMock.getService(NAMESPACE, VALID_NAME1) >> existingServiceMock
+      1 * apiMock.replaceService(NAMESPACE, VALID_NAME1, { service ->
+        service.metadata.name == description.name
+        service.spec.externalIPs.eachWithIndex { ip, idx ->
+          ip == description.externalIps[idx]
+        }
+        def port = service.spec.ports[0]
+        port.port == namedPort1.port
+        port.name == namedPort1.name
+        port.targetPort.intVal == namedPort1.targetPort
+        port.nodePort == namedPort1.nodePort
+        port.protocol == namedPort1.protocol
+      }) >> resultServiceMock
+      resultServiceMock.getMetadata() >> [name: '', namespace: '']
+  }
+
+  void "should upsert a new loadbalancer, and insert port data"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], kubernetesCredentials: credentials, namespace: NAMESPACE)
+      def resultServiceMock = Mock(Service)
+      def existingServiceMock = Mock(Service)
+      def servicePortMock = Mock(ServicePort)
+      def serviceSpecMock = Mock(ServiceSpec)
+
+      existingServiceMock.getSpec() >> serviceSpecMock
+      serviceSpecMock.getPorts() >> [servicePortMock]
+      servicePortMock.getPort() >> VALID_PORT2
+      servicePortMock.getName() >> VALID_NAME2
+      servicePortMock.getNodePort() >> VALID_PORT2
+      servicePortMock.getProtocol() >> VALID_PROTOCOL2
+
+      @Subject def operation = new UpsertKubernetesLoadBalancerAtomicOperation(description)
+
+    when:
+      operation.operate([])
+
+    then:
+      1 * apiMock.getService(NAMESPACE, VALID_NAME1) >> existingServiceMock
+      1 * apiMock.replaceService(NAMESPACE, VALID_NAME1, { service ->
+        service.metadata.name == description.name
+        service.spec.externalIPs.eachWithIndex { ip, idx ->
+          ip == description.externalIps[idx]
+        }
+        def port = service.spec.ports[0]
+        port.port == VALID_PORT2
+        port.name == VALID_NAME2
+        port.nodePort == VALID_PORT2
+        port.protocol == VALID_PROTOCOL2
+      }) >> resultServiceMock
+      resultServiceMock.getMetadata() >> [name: '', namespace: '']
+  }
+
+  void "should upsert a new loadbalancer, and insert ip data"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, kubernetesCredentials: credentials, namespace: NAMESPACE)
+      def resultServiceMock = Mock(Service)
+      def existingServiceMock = Mock(Service)
+      def serviceSpecMock = Mock(ServiceSpec)
+
+      existingServiceMock.getSpec() >> serviceSpecMock
+      serviceSpecMock.getExternalIPs() >> [VALID_IP1]
+
+      @Subject def operation = new UpsertKubernetesLoadBalancerAtomicOperation(description)
+
+    when:
+      operation.operate([])
+
+    then:
+      1 * apiMock.getService(NAMESPACE, VALID_NAME1) >> existingServiceMock
+      1 * apiMock.replaceService(NAMESPACE, VALID_NAME1, { service ->
+        service.metadata.name == description.name
+        service.spec.externalIPs[0] = VALID_IP1
+      }) >> resultServiceMock
+      resultServiceMock.getMetadata() >> [name: '', namespace: '']
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.CloneKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesContainerDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesResourceDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.*

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Google, Inc.
+ * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -22,9 +22,9 @@ import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.DeployKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesContainerDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesResourceDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.*

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
@@ -626,4 +626,87 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.notRegistered")
       0 * errorsMock._
   }
+
+  void "port accept"() {
+    setup:
+      def errorsMock = Mock(Errors)
+      def validator = new StandardKubernetesAttributeValidator(DECORATOR, errorsMock)
+      def label = "label"
+
+    when:
+      validator.validatePort(80, label)
+    then:
+      0 * errorsMock._
+
+    when:
+      validator.validatePort(111, label)
+    then:
+      0 * errorsMock._
+
+    when:
+      validator.validatePort(65535, label)
+    then:
+      0 * errorsMock._
+  }
+
+  void "port reject"() {
+    setup:
+      def errorsMock = Mock(Errors)
+      def validator = new StandardKubernetesAttributeValidator(DECORATOR, errorsMock)
+      def label = "label"
+
+    when:
+      validator.validatePort(0, label)
+    then:
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must be in range [1, $StandardKubernetesAttributeValidator.maxPort])")
+      0 * errorsMock._
+
+    when:
+      validator.validatePort(-1, label)
+    then:
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must be in range [1, $StandardKubernetesAttributeValidator.maxPort])")
+      0 * errorsMock._
+
+    when:
+      validator.validatePort(65536, label)
+    then:
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must be in range [1, $StandardKubernetesAttributeValidator.maxPort])")
+      0 * errorsMock._
+  }
+
+  void "protocol accept"() {
+    setup:
+      def errorsMock = Mock(Errors)
+      def validator = new StandardKubernetesAttributeValidator(DECORATOR, errorsMock)
+      def label = "label"
+
+    when:
+      validator.validateProtocol('TCP', label)
+    then:
+      0 * errorsMock._
+
+    when:
+      validator.validateProtocol('UDP', label)
+    then:
+      0 * errorsMock._
+  }
+
+  void "protocol reject"() {
+    setup:
+      def errorsMock = Mock(Errors)
+      def validator = new StandardKubernetesAttributeValidator(DECORATOR, errorsMock)
+      def label = "label"
+
+    when:
+      validator.validateProtocol('', label)
+    then:
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.empty")
+      0 * errorsMock._
+
+    when:
+      validator.validateProtocol('UPD', label)
+    then:
+      1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must be one of $StandardKubernetesAttributeValidator.protocolList)")
+      0 * errorsMock._
+  }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.loadbalancer
+
+import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesNamedServicePort
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
+import org.springframework.validation.Errors
+import spock.lang.Specification
+
+class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specification {
+  final static DESCRIPTION = "upsertKubernetesLoadBalancerAtomicOperationDescription"
+  final static List<String> NAMESPACES = ['default', 'prod']
+  final static String NAMESPACE = 'prod'
+  final static int VALID_PORT = 80
+  final static int INVALID_PORT = 104729
+  final static String VALID_PROTOCOL = "TCP"
+  final static String INVALID_PROTOCOL = "PCT"
+  final static String VALID_NAME = "name"
+  final static String INVALID_NAME = "bad name ?"
+  final static String VALID_IP = "127.0.0.1"
+  final static String INVALID_IP = "0.127.0.0.1"
+  final static String VALID_CREDENTIALS = "my-kubernetes-account"
+
+  UpsertKubernetesLoadBalancerAtomicOperationValidator validator
+
+  def credentials
+  def validPort
+  def invalidPortPort
+  def invalidNamePort
+  def invalidProtocolPort
+
+  void setup() {
+    validator = new UpsertKubernetesLoadBalancerAtomicOperationValidator()
+    def credentialsRepo = new MapBackedAccountCredentialsRepository()
+    def credentialsProvider = new DefaultAccountCredentialsProvider(credentialsRepo)
+    def namedCredentialsMock = Mock(KubernetesNamedAccountCredentials)
+
+    def apiMock = Mock(KubernetesApiAdaptor)
+    def accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
+
+    def credentials = new KubernetesCredentials(apiMock, NAMESPACES, [], accountCredentialsRepositoryMock)
+    namedCredentialsMock.getName() >> VALID_CREDENTIALS
+    namedCredentialsMock.getCredentials() >> credentials
+    credentialsRepo.save(VALID_CREDENTIALS, namedCredentialsMock)
+    validator.accountCredentialsProvider = credentialsProvider
+
+    validPort = new KubernetesNamedServicePort(name: VALID_NAME, port: VALID_PORT, protocol: VALID_PROTOCOL)
+    invalidNamePort = new KubernetesNamedServicePort(name: INVALID_NAME, protocol: VALID_PROTOCOL, port: VALID_PORT)
+    invalidPortPort = new KubernetesNamedServicePort(name: VALID_NAME, port: INVALID_PORT, protocol: VALID_PROTOCOL)
+    invalidProtocolPort = new KubernetesNamedServicePort(name: VALID_NAME, protocol: INVALID_PROTOCOL, port: VALID_PORT)
+  }
+
+  void "validation accept (all fields filled)"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+        externalIps: [VALID_IP],
+        ports: [validPort],
+        credentials: VALID_CREDENTIALS,
+        namespace: NAMESPACE)
+      def errorsMock = Mock(Errors)
+
+    when:
+      validator.validate([], description, errorsMock)
+
+    then:
+      0 * errorsMock._
+  }
+
+  void "validation accept (some fields filled)"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+        ports: [validPort],
+        credentials: VALID_CREDENTIALS)
+      def errorsMock = Mock(Errors)
+
+    when:
+      validator.validate([], description, errorsMock)
+
+    then:
+      0 * errorsMock._
+  }
+  void "validation reject (bad protocol)"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+        ports: [invalidProtocolPort],
+        credentials: VALID_CREDENTIALS)
+      def errorsMock = Mock(Errors)
+
+    when:
+      validator.validate([], description, errorsMock)
+
+    then:
+      1 * errorsMock.rejectValue(_, "${DESCRIPTION}.ports[0].protocol.invalid (Must be one of $StandardKubernetesAttributeValidator.protocolList)")
+  }
+
+  void "validation reject (bad port name)"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+        ports: [invalidNamePort],
+        credentials: VALID_CREDENTIALS)
+      def errorsMock = Mock(Errors)
+
+    when:
+      validator.validate([], description, errorsMock)
+
+    then:
+      1 * errorsMock.rejectValue(_, "${DESCRIPTION}.ports[0].name.invalid (Must match ${StandardKubernetesAttributeValidator.namePattern})")
+  }
+
+  void "validation reject (bad port value)"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+        ports: [invalidPortPort],
+        credentials: VALID_CREDENTIALS)
+      def errorsMock = Mock(Errors)
+
+    when:
+      validator.validate([], description, errorsMock)
+
+    then:
+      1 * errorsMock.rejectValue(_, "${DESCRIPTION}.ports[0].port.invalid (Must be in range [1, $StandardKubernetesAttributeValidator.maxPort])")
+  }
+
+  void "validation reject (bad ip value)"() {
+    setup:
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+        ports: [validPort],
+        externalIps: [INVALID_IP],
+        credentials: VALID_CREDENTIALS)
+      def errorsMock = Mock(Errors)
+
+    when:
+      validator.validate([], description, errorsMock)
+
+    then:
+      1 * errorsMock.rejectValue(_, "${DESCRIPTION}.externalIps[0].invalid (Not valid IPv4 address)")
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.CloneKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesContainerDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesResourceDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Google, Inc.
+ * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,14 +15,15 @@
  */
 
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.DeployKubernetesAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesContainerDescription
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.KubernetesResourceDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository


### PR DESCRIPTION
Implements upsert load balancer for kubernetes.

Load balancers are represented as kuberentes services (and can optionally be backed by a cloud provider's load balancer, when possible). 

Relationships between load balancers and instances (pods) are maintained using labels & selectors.

@duftler 