### PR TITLE
provider/google: Increase socket timeout to 3 minutes.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.clouddriver.google.security;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
@@ -82,6 +84,17 @@ public class GoogleNamedAccountCredentials implements AccountCredentials<GoogleC
       return credentials;
     }
 
+    private HttpRequestInitializer setHttpTimeout(final HttpRequestInitializer requestInitializer) {
+       return new HttpRequestInitializer() {
+         @Override
+         public void initialize(HttpRequest httpRequest) throws IOException {
+           requestInitializer.initialize(httpRequest);
+           httpRequest.setConnectTimeout(2 * 60000);  // 2 minutes connect timeout
+           httpRequest.setReadTimeout(2 * 60000);  // 2 minutes read timeout
+         }
+       };
+     }
+
     private GoogleCredentials buildCredentials() {
       JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
       HttpTransport httpTransport = buildHttpTransport();
@@ -91,7 +104,7 @@ public class GoogleNamedAccountCredentials implements AccountCredentials<GoogleC
           try (InputStream credentialStream = new ByteArrayInputStream(jsonKey.getBytes())) {
             // JSON key was specified in matching config on key server.
             GoogleCredential credential = GoogleCredential.fromStream(credentialStream, httpTransport, jsonFactory).createScoped(Collections.singleton(ComputeScopes.COMPUTE));
-            Compute compute = new Compute.Builder(httpTransport, jsonFactory, null).setApplicationName(applicationName).setHttpRequestInitializer(credential).build();
+            Compute compute = new Compute.Builder(httpTransport, jsonFactory, null).setApplicationName(applicationName).setHttpRequestInitializer(setHttpTimeout(credential)).build();
 
             return new GoogleCredentials(projectName, compute, imageProjects);
           }


### PR DESCRIPTION
@ewiseblatt @duftler 

Frequent socket timeout exceptions are causing clouddriver to fail. Increasing the timeout will hopefully fix this.