### PR TITLE
provider/kubernetes: Load Balancer controller & full kubernetes service support

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/controllers/KubernetesLoadBalancerController.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/controllers/KubernetesLoadBalancerController.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.controllers
+
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesLoadBalancer
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/kubernetes/loadBalancers")
+class KubernetesLoadBalancerController {
+  private final Cache cacheView
+
+  @Autowired
+  KubernetesLoadBalancerController(Cache cacheView) {
+    this.cacheView = cacheView
+  }
+
+  @RequestMapping(method = RequestMethod.GET)
+  List<KubernetesLoadBalancer> list() {
+    Collection<String> loadBalancers = cacheView.getIdentifiers(Keys.Namespace.LOAD_BALANCERS.ns)
+    loadBalancers.findResults {
+      def parse = Keys.parse(it)
+      parse ? new KubernetesLoadBalancer(parse.name, parse.namespace, parse.account) : null
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationDescription.groovy
@@ -29,6 +29,9 @@ class UpsertKubernetesLoadBalancerAtomicOperationDescription extends KubernetesA
 
   List<KubernetesNamedServicePort> ports
   List<String> externalIps
+  String clusterIp
+  String loadBalancerIp
+  String sessionAffinity
 
   String type
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
@@ -88,8 +88,8 @@ class UpsertKubernetesLoadBalancerAtomicOperation implements AtomicOperation<Map
 
       serviceBuilder = port.name ? serviceBuilder.withName(port.name) : serviceBuilder
       serviceBuilder = port.targetPort ? serviceBuilder.withNewTargetPort(port.targetPort) : serviceBuilder
-      serviceBuilder = port.port ? serviceBuilder.withPort(port.targetPort) : serviceBuilder
-      serviceBuilder = port.nodePort ? serviceBuilder.withNodePort(port.targetPort) : serviceBuilder
+      serviceBuilder = port.port ? serviceBuilder.withPort(port.port) : serviceBuilder
+      serviceBuilder = port.nodePort ? serviceBuilder.withNodePort(port.nodePort) : serviceBuilder
       serviceBuilder = port.protocol ? serviceBuilder.withProtocol(port.protocol) : serviceBuilder
 
       serviceBuilder = serviceBuilder.endPort()
@@ -106,8 +106,22 @@ class UpsertKubernetesLoadBalancerAtomicOperation implements AtomicOperation<Map
     task.updateStatus BASE_PHASE, "Setting type..."
 
     def type = description.type != null ? description.type : existingService?.spec?.type
-
     serviceBuilder = type ? serviceBuilder.withType(type) : serviceBuilder
+
+    task.updateStatus BASE_PHASE, "Setting load balancer IP..."
+
+    def loadBalancerIp = description.loadBalancerIp != null ? description.loadBalancerIp : existingService?.spec?.loadBalancerIP
+    serviceBuilder = loadBalancerIp ? serviceBuilder.withLoadBalancerIP(loadBalancerIp) : serviceBuilder
+
+    task.updateStatus BASE_PHASE, "Setting cluster IP..."
+
+    def clusterIp = description.clusterIp != null ? description.clusterIp : existingService?.spec?.clusterIP
+    serviceBuilder = clusterIp ? serviceBuilder.withClusterIP(clusterIp) : serviceBuilder
+
+    task.updateStatus BASE_PHASE, "Setting session affinity..."
+
+    def sessionAffinity = description.sessionAffinity != null ? description.sessionAffinity : existingService?.spec?.sessionAffinity
+    serviceBuilder = sessionAffinity ? serviceBuilder.withSessionAffinity(sessionAffinity) : serviceBuilder
 
     serviceBuilder = serviceBuilder.endSpec()
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
@@ -27,7 +27,8 @@ class StandardKubernetesAttributeValidator {
   static final prefixPattern = /^[a-z0-9]+$/
   static final quantityPattern = /^([+-]?[0-9.]+)([eEimkKMGTP]*[-+]?[0-9]*)$/
   static final protocolList = ['TCP', 'UDP']
-  static final serviceTypeList= ['LoadBalancer']
+  static final serviceTypeList = ['ClusterIp', 'NodePort', 'LoadBalancer']
+  static final sessionAffinityList = ['None', 'ClientIP']
   static final maxPort = (1 << 16) - 1
 
   String context
@@ -84,6 +85,10 @@ class StandardKubernetesAttributeValidator {
     } else {
       return false
     }
+  }
+
+  def validateSessionAffinity(String value, String attribute) {
+    value ? validateByContainment(value, attribute, sessionAffinityList) : null
   }
 
   def validateIpv4(String value, String attribute) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
@@ -58,6 +58,12 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidator extends DescriptionVa
       helper.validateIpv4(ip, "externalIps[$idx]")
     }
 
+    description.clusterIp ? helper.validateIpv4(description.clusterIp, "clusterIp")  : null
+
+    description.loadBalancerIp ? helper.validateIpv4(description.loadBalancerIp, "loadBalancerIp")  : null
+
+    helper.validateSessionAffinity(description.sessionAffinity, "sessionAffinity")
+
     helper.validateServiceType(description.type, "type")
   }
 }


### PR DESCRIPTION
Exposes load balancers through `kubernetes/loadBalancers` endpoint (this should be cleaned up between providers), and implements remaining features needed for full kubernetes service support.

@duftler.