### PR TITLE
Weaves together instance and load balancer healths

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -18,13 +18,12 @@ package com.netflix.spinnaker.clouddriver.google.cache
 
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
-import com.netflix.spinnaker.clouddriver.google.model.GoogleHealth
+import com.netflix.spinnaker.clouddriver.google.model.health.GoogleHealth
 
 class Keys {
   static enum Namespace {
     APPLICATIONS,
     CLUSTERS,
-    HEALTH,
     INSTANCES,
     LOAD_BALANCERS,
     NETWORKS,
@@ -71,13 +70,6 @@ class Keys {
             name       : parts[4],
             stack      : names.stack,
             detail     : names.detail
-        ]
-        break
-      case Namespace.HEALTH.ns:
-        result << [
-            account   : parts[2],
-            healthType: parts[3],
-            name      : parts[4]
         ]
         break
       case Namespace.INSTANCES.ns:
@@ -154,18 +146,10 @@ class Keys {
     "$googleCloudProvider.id:${Namespace.CLUSTERS}:${account}:${application}:${clusterName}"
   }
 
-  static String getHealthKey(GoogleCloudProvider googleCloudProvider,
-                             String account,
-                             GoogleHealth.Type type,
-                             String instanceName) {
-    "$googleCloudProvider.id:${Namespace.HEALTH}:${account}:${type}:${instanceName}"
-  }
-
   static String getInstanceKey(GoogleCloudProvider googleCloudProvider,
                                String account,
-                               String location,
                                String name) {
-    "$googleCloudProvider.id:${Namespace.INSTANCES}:${account}:${location}:${name}"
+    "$googleCloudProvider.id:${Namespace.INSTANCES}:${account}:${name}"
   }
 
   static String getLoadBalancerKey(GoogleCloudProvider googleCloudProvider,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleClusterProvider.groovy
@@ -23,12 +23,16 @@ import com.netflix.spinnaker.clouddriver.model.ClusterProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 import javax.annotation.PostConstruct
 import java.util.concurrent.Callable
 
 @Deprecated
+@ConditionalOnProperty(value = "google.providerImpl", havingValue = "old", matchIfMissing = true)
 @Component
 @CompileStatic
 class GoogleClusterProvider implements ClusterProvider<GoogleCluster> {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleHealthCheck.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleHealthCheck.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.model
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import groovy.transform.Canonical
+
+@Canonical
+class GoogleHealthCheck {
+  String requestPath
+  int port
+
+  // Attributes
+  int checkIntervalSec
+  int timeoutSec
+  int unhealthyThreshold
+  int healthyThreshold
+
+  @JsonIgnore
+  View getView() {
+    new View()
+  }
+
+  class View implements Serializable {
+    int checkIntervalSec = checkIntervalSec
+    int timeoutSec = timeoutSec
+    int unhealthyThreshold = unhealthyThreshold
+    int healthyThreshold = healthyThreshold
+
+    String getTarget() {
+      port ? "HTTP:${port}${requestPath ?: '/'}" : null
+    }
+
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstanceProvider.groovy
@@ -21,9 +21,13 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentials
 import com.netflix.spinnaker.clouddriver.model.InstanceProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Conditional
 import org.springframework.stereotype.Component
 
 @Deprecated
+@ConditionalOnProperty(value = "google.providerImpl", havingValue = "old", matchIfMissing = true)
 @Component
 class GoogleInstanceProvider implements InstanceProvider<GoogleInstance> {
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancer.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancer.groovy
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
 
+@Deprecated
 class GoogleLoadBalancer implements LoadBalancer {
 
   private static final String GOOGLE_LOAD_BALANCER_TYPE = "gce"

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancer2.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancer2.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.model
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.clouddriver.google.model.health.GoogleLoadBalancerHealth
+import com.netflix.spinnaker.clouddriver.model.LoadBalancer
+import groovy.transform.Canonical
+
+@Canonical
+class GoogleLoadBalancer2 {
+
+  String name
+  String account
+  String region
+  Long createdTime
+  String ipAddress
+  String ipProtocol
+  String portRange
+  GoogleHealthCheck healthCheck
+  List<GoogleLoadBalancerHealth> healths
+
+  @JsonIgnore
+  View getView() {
+    new View()
+  }
+
+  class View implements LoadBalancer {
+    final String type = "gce"
+
+    String name = GoogleLoadBalancer2.this.name
+    String account = GoogleLoadBalancer2.this.account
+    String region = GoogleLoadBalancer2.this.region
+    Long createdTime = GoogleLoadBalancer2.this.createdTime
+    String ipAddress = GoogleLoadBalancer2.this.ipAddress
+    String ipProtocol = GoogleLoadBalancer2.this.ipProtocol
+    String portRange = GoogleLoadBalancer2.this.portRange
+    GoogleHealthCheck.View healthCheck = GoogleLoadBalancer2.this.healthCheck?.view
+
+    Set<Map<String, Object>> serverGroups = new HashSet<>()
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancerProvider.groovy
@@ -19,9 +19,12 @@ package com.netflix.spinnaker.clouddriver.google.model
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Deprecated
+@ConditionalOnProperty(value = "google.providerImpl", havingValue = "old", matchIfMissing = true)
 @Component
 class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalancer> {
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleHealth.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleHealth.groovy
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.google.model
+package com.netflix.spinnaker.clouddriver.google.model.health
 
 import com.netflix.spinnaker.clouddriver.model.Health
-import com.netflix.spinnaker.clouddriver.model.HealthState
 
-class GoogleHealth implements Health, Serializable {
-  Type type
-  HealthClass healthClass
-  HealthState state
+abstract class GoogleHealth implements Health, Serializable {
 
   enum Type {
     Google,
     LoadBalancer,
   }
 
+  abstract Type getType()
+
   enum HealthClass {
     platform
   }
+
+  abstract HealthClass getHealthClass()
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleInstanceHealth.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleInstanceHealth.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.model.health
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.clouddriver.model.Health
+import com.netflix.spinnaker.clouddriver.model.HealthState
+import groovy.transform.Canonical
+
+@Canonical
+class GoogleInstanceHealth extends GoogleHealth implements Health, Serializable {
+
+  final Type type = Type.Google
+  final HealthClass healthClass = HealthClass.platform
+
+  Status status
+
+  enum Status {
+    PROVISIONING,
+    STAGING,
+    RUNNING,
+    STOPPING,
+    STOPPED,
+    TERMINATED,
+    SUSPENDING,
+    SUSPENDED
+
+    HealthState toHealthState() {
+      switch (this) {
+        case PROVISIONING:
+        case STAGING:
+          return HealthState.Starting
+        case RUNNING:
+          return HealthState.Unknown
+        default:
+          return HealthState.Down
+      }
+    }
+  }
+
+  @JsonIgnore
+  HealthState getState() {
+    status?.toHealthState()
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleLoadBalancerHealth.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleLoadBalancerHealth.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.model.health
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.clouddriver.model.Health
+import com.netflix.spinnaker.clouddriver.model.HealthState
+import groovy.transform.Canonical
+
+@Canonical
+class GoogleLoadBalancerHealth {
+
+  String instanceName
+
+  List<LBHealthSummary> lbHealthSummaries
+
+  PlatformStatus status
+
+  enum PlatformStatus {
+    HEALTHY,
+    UNHEALTHY
+
+    HealthState toHeathState() {
+      switch (this) {
+        case HEALTHY:
+          return HealthState.Up
+        default:
+          return HealthState.Down
+      }
+    }
+
+    LBHealthSummary.ServiceStatus toServiceStatus() {
+      switch(this) {
+        case HEALTHY:
+          return LBHealthSummary.ServiceStatus.InService
+        default:
+          return LBHealthSummary.ServiceStatus.OutOfService
+      }
+    }
+  }
+
+  static class LBHealthSummary {
+    // These aren't the most descriptive names, but it's what's expected in Deck.
+    String loadBalancerName
+    String instanceId
+    ServiceStatus state
+
+    String getDescription() {
+      state == ServiceStatus.OutOfService ?
+          "Instance has failed at least the Unhealthy Threshold number of health checks consecutively." :
+          null
+    }
+
+    enum ServiceStatus {
+      InService,
+      OutOfService
+    }
+  }
+
+  @JsonIgnore
+  View getView() {
+    new View()
+  }
+
+  class View extends GoogleHealth implements Health {
+    final Type type = Type.LoadBalancer
+    final HealthClass healthClass = null
+
+    List<LBHealthSummary> loadBalancers = GoogleLoadBalancerHealth.this.lbHealthSummaries
+
+    HealthState getState() {
+      GoogleLoadBalancerHealth.this.status?.toHeathState()
+    }
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -24,30 +24,35 @@ import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.ForwardingRule
+import com.google.api.services.compute.model.HealthStatus
+import com.google.api.services.compute.model.InstanceReference
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
-import com.netflix.spinnaker.cats.agent.DefaultCacheResult
-import com.netflix.spinnaker.cats.cache.CacheData
-import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
+import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
-import com.netflix.spinnaker.clouddriver.google.model.GoogleLoadBalancer
-import com.netflix.spinnaker.clouddriver.google.model.GoogleResourceRetriever
+import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
+import com.netflix.spinnaker.clouddriver.google.model.GoogleLoadBalancer2
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
-import groovy.transform.TupleConstructor
+import com.netflix.spinnaker.clouddriver.google.model.health.GoogleLoadBalancerHealth
 import groovy.util.logging.Slf4j
+import org.slf4j.LoggerFactory
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
+import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.LOAD_BALANCERS
 
 @Slf4j
 class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
 
   final String region
 
-  final Set<AgentDataType> providedDataTypes = Collections.unmodifiableSet([
-    AUTHORITATIVE.forType(Keys.Namespace.LOAD_BALANCERS.ns)
-  ] as Set)
+  final Set<AgentDataType> providedDataTypes = [
+      AUTHORITATIVE.forType(LOAD_BALANCERS.ns),
+      INFORMATIVE.forType(INSTANCES.ns),
+  ] as Set
 
   String agentType = "${accountName}/${region}/${GoogleLoadBalancerCachingAgent.simpleName}"
 
@@ -69,63 +74,175 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
 
   @Override
   CacheResult loadData(ProviderCache providerCache) {
-    List<GoogleLoadBalancer> loadBalancers = getLoadBalancers()
+    List<GoogleLoadBalancer2> loadBalancers = getLoadBalancers()
     buildCacheResult(providerCache, loadBalancers)
   }
 
-  List<GoogleLoadBalancer> getLoadBalancers() {
-    List<GoogleLoadBalancer> loadBalancers = new ArrayList<GoogleLoadBalancer>()
+  List<GoogleLoadBalancer2> getLoadBalancers() {
+    List<GoogleLoadBalancer2> loadBalancers = new ArrayList<GoogleLoadBalancer2>()
 
-    BatchRequest forwardingRulesRequest = GoogleResourceRetriever.buildBatchRequest(compute, googleApplicationName)
+    BatchRequest forwardingRulesRequest = buildBatchRequest()
+    BatchRequest targetPoolsRequest = buildBatchRequest()
+    BatchRequest instanceHealthRequest = buildBatchRequest()
+    BatchRequest httpHealthChecksRequest = buildBatchRequest()
 
-    ForwardingRulesCallback callback = new ForwardingRulesCallback(loadBalancers)
+    ForwardingRulesCallback callback = new ForwardingRulesCallback(loadBalancers: loadBalancers,
+                                                                   targetPoolsRequest: targetPoolsRequest,
+                                                                   instanceHealthRequest: instanceHealthRequest,
+                                                                   httpHealthChecksRequest: httpHealthChecksRequest)
     compute.forwardingRules().list(project, region).queue(forwardingRulesRequest, callback)
 
-    GoogleResourceRetriever.executeIfRequestsAreQueued(forwardingRulesRequest)
+    executeIfRequestsAreQueued(forwardingRulesRequest)
+    executeIfRequestsAreQueued(targetPoolsRequest)
+    executeIfRequestsAreQueued(instanceHealthRequest)
+    executeIfRequestsAreQueued(httpHealthChecksRequest)
 
     return loadBalancers
   }
 
-  CacheResult buildCacheResult(ProviderCache providerCache, List<GoogleLoadBalancer> loadBalancers) {
+  CacheResult buildCacheResult(ProviderCache providerCache, List<GoogleLoadBalancer2> googleLoadBalancers) {
     log.info "Describing items in ${agentType}"
 
-    List<CacheData> data = loadBalancers.collect { GoogleLoadBalancer loadBalancer ->
-      Map<String, Object> attributes = objectMapper.convertValue(loadBalancer, ATTRIBUTES)
-      def key = Keys.getLoadBalancerKey(googleCloudProvider,
-                                        loadBalancer.region,
-                                        loadBalancer.account,
-                                        loadBalancer.name)
-      // TODO(ttomsu): Add server group relationship here.
-      new DefaultCacheData(key, attributes, [:])
+    def crb = new CacheResultBuilder()
+
+    googleLoadBalancers.each { GoogleLoadBalancer2 loadBalancer ->
+      def loadBalancerKey = Keys.getLoadBalancerKey(googleCloudProvider,
+                                                    loadBalancer.region,
+                                                    loadBalancer.account,
+                                                    loadBalancer.name)
+      def instanceKeys = loadBalancer.healths.collect { GoogleLoadBalancerHealth health ->
+        Keys.getInstanceKey(googleCloudProvider, accountName, health.instanceName)
+      }
+
+      crb.namespace(LOAD_BALANCERS.ns).get(loadBalancerKey).with {
+        attributes = objectMapper.convertValue(loadBalancer, ATTRIBUTES)
+      }
+      instanceKeys.each { String instanceKey ->
+        crb.namespace(INSTANCES.ns).get(instanceKey).with {
+          relationships[LOAD_BALANCERS.ns].add(loadBalancerKey)
+        }
+      }
     }
 
-    log.info "Caching ${data.size()} items in ${agentType}"
+    log.info "Caching ${crb.namespace(LOAD_BALANCERS.ns).size()} load balancers in ${agentType}"
+    log.info "Caching ${crb.namespace(INSTANCES.ns).size()} instance relationsihps in ${agentType}"
 
-    new DefaultCacheResult([(Keys.Namespace.LOAD_BALANCERS.ns): data])
+    crb.build()
   }
 
-  @TupleConstructor
-  class ForwardingRulesCallback<ForwardingRuleList> extends JsonBatchCallback<ForwardingRuleList> {
+  class ForwardingRulesCallback<ForwardingRuleList> extends JsonBatchCallback<ForwardingRuleList> implements FailureLogger {
 
-    List<GoogleLoadBalancer> loadBalancers
+    List<GoogleLoadBalancer2> loadBalancers
+    BatchRequest targetPoolsRequest
+
+    // Pass through objects
+    BatchRequest instanceHealthRequest
+    BatchRequest httpHealthChecksRequest
 
     @Override
     void onSuccess(ForwardingRuleList forwardingRuleList, HttpHeaders responseHeaders) throws IOException {
       forwardingRuleList?.items?.each { ForwardingRule forwardingRule ->
-        loadBalancers << new GoogleLoadBalancer(
+        def newLoadBalancer = new GoogleLoadBalancer2(
             name: forwardingRule.name,
             account: accountName,
             region: region,
             createdTime: Utils.getTimeFromTimestamp(forwardingRule.creationTimestamp),
             ipAddress: forwardingRule.IPAddress,
             ipProtocol: forwardingRule.IPProtocol,
-            portRange: forwardingRule.portRange)
+            portRange: forwardingRule.portRange,
+            healths: [])
+        loadBalancers << newLoadBalancer
+
+        if (forwardingRule.target) {
+          def targetPoolName = Utils.getLocalName(forwardingRule.target)
+          def targetPoolsCallback = new TargetPoolCallback(googleLoadBalancer: newLoadBalancer,
+                                                           instanceHealthRequest: instanceHealthRequest,
+                                                           httpHealthChecksRequest: httpHealthChecksRequest)
+
+          compute.targetPools().get(project, region, targetPoolName).queue(targetPoolsRequest, targetPoolsCallback)
+        }
       }
     }
+  }
+
+  class TargetPoolCallback<TargetPool> extends JsonBatchCallback<TargetPool> implements FailureLogger {
+
+    GoogleLoadBalancer2 googleLoadBalancer
+
+    BatchRequest instanceHealthRequest
+    BatchRequest httpHealthChecksRequest
 
     @Override
+    void onSuccess(TargetPool targetPool, HttpHeaders responseHeaders) throws IOException {
+      def region = Utils.getLocalName(targetPool.region)
+      def targetPoolName = targetPool.name as String
+
+      targetPool?.instances?.each { String instanceUrl ->
+        def instanceReference = new InstanceReference(instance: instanceUrl)
+        def instanceHealthCallback = new TargetPoolInstanceHealthCallback(googleLoadBalancer: googleLoadBalancer,
+                                                                          instanceName: Utils.getLocalName(instanceUrl))
+
+        compute.targetPools().getHealth(project,
+                                        region,
+                                        targetPoolName,
+                                        instanceReference).queue(instanceHealthRequest, instanceHealthCallback)
+      }
+
+      targetPool?.healthChecks?.each { def healthCheckUrl ->
+        def localHealthCheckName = Utils.getLocalName(healthCheckUrl)
+        def httpHealthCheckCallback = new HttpHealthCheckCallback(googleLoadBalancer: googleLoadBalancer)
+
+        compute.httpHealthChecks().get(project, localHealthCheckName).queue(httpHealthChecksRequest, httpHealthCheckCallback)
+      }
+    }
+  }
+
+  class TargetPoolInstanceHealthCallback<TargetPoolInstanceHealth> extends JsonBatchCallback<TargetPoolInstanceHealth> implements FailureLogger {
+
+    GoogleLoadBalancer2 googleLoadBalancer
+    String instanceName
+
+
+    @Override
+    void onSuccess(TargetPoolInstanceHealth targetPoolInstanceHealth, HttpHeaders responseHeaders) throws IOException {
+      targetPoolInstanceHealth?.healthStatus?.each { HealthStatus healthStatus ->
+        def googleLBHealthStatus = GoogleLoadBalancerHealth.PlatformStatus.valueOf(healthStatus.healthState)
+
+        googleLoadBalancer.healths << new GoogleLoadBalancerHealth(
+            instanceName: instanceName,
+            status: googleLBHealthStatus,
+            lbHealthSummaries: [
+                new GoogleLoadBalancerHealth.LBHealthSummary(
+                    loadBalancerName: googleLoadBalancer.name,
+                    instanceId: instanceName,
+                    state: googleLBHealthStatus.toServiceStatus())
+            ])
+      }
+    }
+  }
+
+  class HttpHealthCheckCallback<HttpHealthCheck> extends JsonBatchCallback<HttpHealthCheck> implements FailureLogger {
+
+    GoogleLoadBalancer2 googleLoadBalancer
+
+    @Override
+    void onSuccess(HttpHealthCheck httpHealthCheck, HttpHeaders responseHeaders) throws IOException {
+      if (httpHealthCheck) {
+        googleLoadBalancer.healthCheck = new GoogleHealthCheck(
+            port: httpHealthCheck.port,
+            requestPath: httpHealthCheck.requestPath,
+            checkIntervalSec: httpHealthCheck.checkIntervalSec,
+            timeoutSec: httpHealthCheck.timeoutSec,
+            unhealthyThreshold: httpHealthCheck.unhealthyThreshold,
+            healthyThreshold: httpHealthCheck.healthyThreshold)
+      }
+    }
+  }
+
+  @Slf4j
+  trait FailureLogger {
     void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
-      log.error e.getMessage()
+      LoggerFactory.getLogger(GoogleLoadBalancerCachingAgent.class).warn e.getMessage()
     }
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -28,10 +28,10 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
-@ConditionalOnMissingClass(com.netflix.spinnaker.clouddriver.google.model.GoogleClusterProvider.class)
+@ConditionalOnProperty(value = "google.providerImpl", havingValue = "new")
 @Component
 class GoogleClusterProvider implements ClusterProvider<GoogleCluster> {
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
@@ -21,17 +21,17 @@ import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
-import com.netflix.spinnaker.clouddriver.google.model.GoogleLoadBalancer
+import com.netflix.spinnaker.clouddriver.google.model.GoogleLoadBalancer2
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.LOAD_BALANCERS
 
-@ConditionalOnMissingClass(com.netflix.spinnaker.clouddriver.google.model.GoogleLoadBalancerProvider.class)
+@ConditionalOnProperty(value = "google.providerImpl", havingValue = "new")
 @Component
-class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalancer> {
+class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalancer2.View> {
 
   @Autowired
   final GoogleCloudProvider googleCloudProvider
@@ -41,12 +41,12 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
   final ObjectMapper objectMapper
 
   @Override
-  Set<GoogleLoadBalancer> getApplicationLoadBalancers(String application) {
+  Set<GoogleLoadBalancer2.View> getApplicationLoadBalancers(String application) {
     def pattern = Keys.getLoadBalancerKey(googleCloudProvider, "*", "*", "${application}*")
     def identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, pattern)
 
     cacheView.getAll(LOAD_BALANCERS.ns, identifiers, RelationshipCacheFilter.none()).collect {
-      objectMapper.convertValue(it.attributes, GoogleLoadBalancer)
+      objectMapper.convertValue(it.attributes, GoogleLoadBalancer2).view
     }
   }
 }

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -98,6 +98,7 @@ azure:
 
 google:
   enabled: false
+  providerImpl: old # or new
   baseImageProjects:
   - centos-cloud
   - coreos-cloud


### PR DESCRIPTION
This PR includes numerous changes:

1. Introduces model objects to represent instance health and load balancer health (see `c.n.s.c.google.model.health` package)
1. Updates the LoadBalancerCachingAgent and InstanceCachingAgent to use these models 
1. Wires them together in the GoogleInstanceProvider to actually be presented to client users
1. Removes the HEALTH namespace, as it's no longer used.
1. Introduces a new providerImpl property to allow easy switching between old and new providers to help speed development.

@duftler @lwander PTAL. It's kind of a mishmash of changes (and changes in my mind) that have accumulated over the week. 
