### PR TITLE
Adding support for AWS AutoScaling Group Tags

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy
 import com.amazonaws.services.autoscaling.model.CreateAutoScalingGroupRequest
 import com.amazonaws.services.autoscaling.model.SuspendProcessesRequest
+import com.amazonaws.services.autoscaling.model.Tag
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
 import com.amazonaws.services.ec2.model.DescribeSubnetsResult
 import com.amazonaws.services.ec2.model.Subnet
@@ -69,6 +70,7 @@ class AutoScalingWorker {
   private List<String> securityGroups
   private List<String> availabilityZones
   private List<AmazonBlockDevice> blockDevices
+  private Map<String, String> tags
 
   private int minInstances
   private int maxInstances
@@ -179,6 +181,13 @@ class AutoScalingWorker {
       .withHealthCheckGracePeriod(healthCheckGracePeriod)
       .withHealthCheckType(healthCheckType)
       .withTerminationPolicies(terminationPolicies)
+
+    tags?.each { key, value ->
+      request.withTags(new Tag()
+                        .withKey(key)
+                        .withValue(value)
+                        .withPropagateAtLaunch(true))
+    }
 
     // Favor subnetIds over availability zones
     def subnetIds = subnetIds?.join(',')

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -57,7 +57,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   Map<String, List<String>> availabilityZones = [:]
   Capacity capacity = new Capacity()
   Source source = new Source()
-  Map<String, String> tags = [:]
+  Map<String, String> tags
 
   @Canonical
   static class Capacity {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -57,6 +57,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   Map<String, List<String>> availabilityZones = [:]
   Capacity capacity = new Capacity()
   Source source = new Source()
+  Map<String, String> tags = [:]
 
   @Canonical
   static class Capacity {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -168,7 +168,8 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         instanceMonitoring: description.instanceMonitoring,
         ebsOptimized: description.ebsOptimized,
         regionScopedProvider: regionScopedProvider,
-        base64UserData: description.base64UserData)
+        base64UserData: description.base64UserData,
+        tags: description.tags)
 
       def asgName = autoScalingWorker.deploy()
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -131,7 +131,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
       newDescription.ebsOptimized = description.ebsOptimized != null ? description.ebsOptimized : ancestorLaunchConfiguration.ebsOptimized
       newDescription.classicLinkVpcId = description.classicLinkVpcId != null ? description.classicLinkVpcId : ancestorLaunchConfiguration.classicLinkVPCId
       newDescription.classicLinkVPCSecurityGroups = description.classicLinkVPCSecurityGroups != null ? description.classicLinkVPCSecurityGroups : ancestorLaunchConfiguration.classicLinkVPCSecurityGroups
-      newDescription.tags = description.tags ?: ancestorAsg.tags.collectEntries { [(it.getKey()): it.getValue()] }
+      newDescription.tags = description.tags != null ? description.tags : ancestorAsg.tags.collectEntries { [(it.getKey()): it.getValue()] }
 
       task.updateStatus BASE_PHASE, "Initiating deployment."
       def thisResult = basicAmazonDeployHandler.handle(newDescription, priorOutputs)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -131,6 +131,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
       newDescription.ebsOptimized = description.ebsOptimized != null ? description.ebsOptimized : ancestorLaunchConfiguration.ebsOptimized
       newDescription.classicLinkVpcId = description.classicLinkVpcId != null ? description.classicLinkVpcId : ancestorLaunchConfiguration.classicLinkVPCId
       newDescription.classicLinkVPCSecurityGroups = description.classicLinkVPCSecurityGroups != null ? description.classicLinkVPCSecurityGroups : ancestorLaunchConfiguration.classicLinkVPCSecurityGroups
+      newDescription.tags = description.tags ?: ancestorAsg.tags.collectEntries { [(it.getKey()): it.getValue()] }
 
       task.updateStatus BASE_PHASE, "Initiating deployment."
       def thisResult = basicAmazonDeployHandler.handle(newDescription, priorOutputs)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperationUnitSpec.groovy
@@ -23,6 +23,7 @@ import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsRequ
 import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsResult
 import com.amazonaws.services.autoscaling.model.Ebs
 import com.amazonaws.services.autoscaling.model.LaunchConfiguration
+import com.amazonaws.services.autoscaling.model.TagDescription
 import com.amazonaws.services.ec2.AmazonEC2
 import com.netflix.spinnaker.clouddriver.aws.deploy.AWSServerGroupNameResolver
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -74,6 +75,7 @@ class CopyLastAsgAtomicOperationUnitSpec extends Specification {
       new BasicAmazonDeployDescription(application: 'asgard', stack: 'stack', keyPair: 'key-pair-name',
         securityGroups: ['someGroupName', 'sg-12345a'], availabilityZones: [(region): null],
         capacity: new BasicAmazonDeployDescription.Capacity(min: 1, max: 3, desired: 5),
+        tags: [Name: 'name-tag'],
         source: new BasicAmazonDeployDescription.Source(
           asgName: "asgard-stack-v000",
           account: 'baz',
@@ -100,6 +102,7 @@ class CopyLastAsgAtomicOperationUnitSpec extends Specification {
       mockAsg.getMaxSize() >> 2
       mockAsg.getDesiredCapacity() >> 4
       mockAsg.getLaunchConfigurationName() >> "foo"
+      mockAsg.getTags() >> [new TagDescription().withKey('Name').withValue('name-tag')]
       new DescribeAutoScalingGroupsResult().withAutoScalingGroups([mockAsg])
     }
     2 * serverGroupNameResolver.resolveLatestServerGroupName("asgard-stack") >> { "asgard-stack-v000" }


### PR DESCRIPTION
Creates autoscaling groups with `tags` defined from a key-value map. Not sure
how y`all want to handle exceptions here, but if the user passes in more than
allowed the AWS API throws a LimitExceededException. Could handle it at a
validator side, but would rather not hard-code to a limit that might change.
