### PR TITLE
More work on avoiding naming collisions between aws and other providers.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -22,6 +22,8 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class Keys {
 
+  public static final PROVIDER = "aws"
+
   static enum Namespace {
     IMAGES,
     NAMED_IMAGES,
@@ -56,6 +58,10 @@ class Keys {
     }
 
     def result = [provider: parts[0], type: parts[1]]
+
+    if (result.provider != PROVIDER) {
+      return null
+    }
 
     switch (result.type) {
       case Namespace.IMAGES.ns:
@@ -98,39 +104,39 @@ class Keys {
   }
 
   static String getImageKey(String imageId, String account, String region) {
-    "aws:${Namespace.IMAGES}:${account}:${region}:${imageId}"
+    "${PROVIDER}:${Namespace.IMAGES}:${account}:${region}:${imageId}"
   }
 
   static String getNamedImageKey(String account, String imageName) {
-    "aws:${Namespace.NAMED_IMAGES}:${account}:${imageName}"
+    "${PROVIDER}:${Namespace.NAMED_IMAGES}:${account}:${imageName}"
   }
 
   static String getServerGroupKey(String autoScalingGroupName, String account, String region) {
     Names names = Names.parseName(autoScalingGroupName)
-    "aws:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}"
+    "${PROVIDER}:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}"
   }
 
   static String getInstanceKey(String instanceId, String account, String region) {
-    "aws:${Namespace.INSTANCES}:${account}:${region}:${instanceId}"
+    "${PROVIDER}:${Namespace.INSTANCES}:${account}:${region}:${instanceId}"
   }
 
   static String getLaunchConfigKey(String launchConfigName, String account, String region) {
-    "aws:${Namespace.LAUNCH_CONFIGS}:${account}:${region}:${launchConfigName}"
+    "${PROVIDER}:${Namespace.LAUNCH_CONFIGS}:${account}:${region}:${launchConfigName}"
   }
 
   static String getLoadBalancerKey(String loadBalancerName, String account, String region, String vpcId) {
-    "aws:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}${vpcId ? ':' + vpcId : ''}"
+    "${PROVIDER}:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}${vpcId ? ':' + vpcId : ''}"
   }
 
   static String getClusterKey(String clusterName, String application, String account) {
-    "aws:${Namespace.CLUSTERS}:${application.toLowerCase()}:${account}:${clusterName}"
+    "${PROVIDER}:${Namespace.CLUSTERS}:${application.toLowerCase()}:${account}:${clusterName}"
   }
 
   static String getApplicationKey(String application) {
-    "aws:${Namespace.APPLICATIONS}:${application.toLowerCase()}"
+    "${PROVIDER}:${Namespace.APPLICATIONS}:${application.toLowerCase()}"
   }
 
   static String getInstanceHealthKey(String instanceId, String account, String region, String provider) {
-    "aws:${Namespace.HEALTH}:${instanceId}:${account}:${region}:${provider}"
+    "${PROVIDER}:${Namespace.HEALTH}:${instanceId}:${account}:${region}:${provider}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
@@ -95,7 +95,7 @@ class AmazonLoadBalancerInstanceStateCachingAgent implements CachingAgent,Health
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
     def loadBalancing = amazonClientProvider.getAmazonElasticLoadBalancing(account, region)
-    def loadBalancerKeys = getCacheView().getIdentifiers(LOAD_BALANCERS.ns)
+    def loadBalancerKeys = getCacheView().filterIdentifiers(LOAD_BALANCERS.ns, Keys.getLoadBalancerKey('*', '*', '*', '*'))
 
     Collection<CacheData> lbHealths = []
     Collection<CacheData> instances = []

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
@@ -61,7 +61,7 @@ class Keys {
         break
       case Namespace.CLUSTERS.ns:
         def names = Names.parseName(parts[4])
-        result << [application: parts[3], account: parts[2], name: parts[4], stack: names.stack, detail: names.detail]
+        result << [application: parts[3], account: parts[2], name: parts[4], cluster: parts[4], stack: names.stack, detail: names.detail]
         break
       case Namespace.SERVER_GROUPS.ns:
         def names = Names.parseName(parts[4])
@@ -69,7 +69,7 @@ class Keys {
         break
       case Namespace.LOAD_BALANCERS.ns:
         def names = Names.parseName(parts[4])
-        result << [application: names.app, account: parts[2], name: parts[4], namespace: parts[3], stack: names.stack, detail: names.detail]
+        result << [application: names.app, account: parts[2], name: parts[4], loadBalancer: parts[4], namespace: parts[3], stack: names.stack, detail: names.detail]
         break
       case Namespace.INSTANCES.ns:
         def names = Names.parseName(parts[4])


### PR DESCRIPTION
Add additional attributes to parsed Kubernetes cats keys to allow them to be used in search results.