### PR TITLE
provider/kubernetes: Retrieve credentials for server group

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/KubernetesAtomicOperationConverterHelper.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/KubernetesAtomicOperationConverterHelper.groovy
@@ -23,9 +23,9 @@ class KubernetesAtomicOperationConverterHelper {
   static Object convertDescription(Map input,
                                    AbstractAtomicOperationsCredentialsSupport credentialsSupport,
                                    Class targetDescriptionType) {
-    def rawcreds = input.credentials as String
+    def account = input.account as String
     // Save these to re-assign after ObjectMapper does its work.
-    def credentials = credentialsSupport.getCredentialsObject(rawcreds as String)?.getCredentials()
+    def credentials = credentialsSupport.getCredentialsObject(account as String)?.getCredentials()
 
     def converted = credentialsSupport.objectMapper
       .copy()
@@ -33,7 +33,7 @@ class KubernetesAtomicOperationConverterHelper {
       .convertValue(input, targetDescriptionType)
 
     // Re-assign the credentials.
-    converted.kubernetesCredentials = credentials
+    converted.credentials = credentials
 
     converted
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/KubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/KubernetesAtomicOperationDescription.groovy
@@ -25,6 +25,6 @@ import groovy.transform.Canonical
 @AutoClone
 @Canonical
 class KubernetesAtomicOperationDescription implements DeployDescription {
-  String credentials
-  KubernetesCredentials kubernetesCredentials 
+  String account
+  KubernetesCredentials credentials
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
@@ -39,14 +39,14 @@ class UpsertKubernetesLoadBalancerAtomicOperation implements AtomicOperation<Map
   }
 
   /*
-   * curl -X POST -H "Content-Type: application/json" -d  '[ {  "upsertLoadBalancer": { "name": "service",  "ports": [ { "name": "http", "port": 80, "targetPort": 9376 } ], "credentials":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
+   * curl -X POST -H "Content-Type: application/json" -d  '[ {  "upsertLoadBalancer": { "name": "service",  "ports": [ { "name": "http", "port": 80, "targetPort": 9376 } ], "account":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
   */
   @Override
   Map operate(List priorOutputs) {
     task.updateStatus BASE_PHASE, "Initializing upsert of load balancer $description.name..."
     task.updateStatus BASE_PHASE, "Looking up provided namespace..."
 
-    def credentials = description.kubernetesCredentials
+    def credentials = description.credentials
     def namespace = KubernetesUtil.validateNamespace(credentials, description.namespace)
     def name = description.name
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
@@ -43,8 +43,8 @@ class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult
   CloneKubernetesAtomicOperationDescription description
 
   /*
-   * curl -X POST -H "Content-Type: application/json" -d  '[ { "cloneServerGroup": { "source": { "serverGroupName": "kub-test-v000" }, "credentials":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
-   * curl -X POST -H "Content-Type: application/json" -d  '[ { "cloneServerGroup": { "stack": "prod", "freeFormDetails": "mdservice", "targetSize": "4", "source": { "serverGroupName": "kub-test-v000" }, "credentials":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
+   * curl -X POST -H "Content-Type: application/json" -d  '[ { "cloneServerGroup": { "source": { "serverGroupName": "kub-test-v000" }, "account":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
+   * curl -X POST -H "Content-Type: application/json" -d  '[ { "cloneServerGroup": { "stack": "prod", "freeFormDetails": "mdservice", "targetSize": "4", "source": { "serverGroupName": "kub-test-v000" }, "account":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
   */
   @Override
   DeploymentResult operate(List priorOutputs) {
@@ -71,7 +71,7 @@ class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult
 
     task.updateStatus BASE_PHASE, "Reading ancestor server group ${description.source.serverGroupName}..."
 
-    def credentials = description.kubernetesCredentials
+    def credentials = description.credentials
 
     description.source.namespace = description.source.namespace ?: "default"
     ReplicationController ancestorServerGroup = credentials.apiAdaptor.getReplicationController(description.source.namespace, description.source.serverGroupName)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
@@ -39,9 +39,9 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
   DeployKubernetesAtomicOperationDescription description
 
   /*
-   * curl -X POST -H "Content-Type: application/json" -d  '[ {  "createServerGroup": { "application": "kub", "stack": "test",  "targetSize": "3", "securityGroups": [], "loadBalancers":  [],  "containers": [ { "name": "nginx", "image": "nginx" } ], "credentials":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
+   * curl -X POST -H "Content-Type: application/json" -d  '[ {  "createServerGroup": { "application": "kub", "stack": "test",  "targetSize": "3", "securityGroups": [], "loadBalancers":  [],  "containers": [ { "name": "nginx", "image": "nginx" } ], "account":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
    *
-   * curl -X POST -H "Content-Type: application/json" -d  '[ {  "createServerGroup": { "application": "kub", "stack": "test",  "targetSize": "3", "loadBalancers":  ["frontend-lb"],  "containers": [ { "name": "nginx", "image": "nginx", "ports": [ { "containerPort": "80", "hostPort": "80", "name": "http", "protocol": "TCP", "hostIp": "10.239.18.11" } ] } ], "credentials":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
+   * curl -X POST -H "Content-Type: application/json" -d  '[ {  "createServerGroup": { "application": "kub", "stack": "test",  "targetSize": "3", "loadBalancers":  ["frontend-lb"],  "containers": [ { "name": "nginx", "image": "nginx", "ports": [ { "containerPort": "80", "hostPort": "80", "name": "http", "protocol": "TCP", "hostIp": "10.239.18.11" } ] } ], "account":  "my-kubernetes-account" } } ]' localhost:7002/kubernetes/ops
   */
   @Override
   DeploymentResult operate(List priorOutputs) {
@@ -57,7 +57,7 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
     task.updateStatus BASE_PHASE, "Initializing creation of replication controller."
     task.updateStatus BASE_PHASE, "Looking up provided namespace..."
 
-    def credentials = description.kubernetesCredentials
+    def credentials = description.credentials
     def namespace = KubernetesUtil.validateNamespace(credentials, description.namespace)
 
     def clusterName = KubernetesUtil.combineAppStackDetail(description.application, description.stack, description.freeFormDetails)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
@@ -37,11 +37,11 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidator extends DescriptionVa
   void validate(List priorDescriptions, UpsertKubernetesLoadBalancerAtomicOperationDescription description, Errors errors) {
     def helper = new StandardKubernetesAttributeValidator("upsertKubernetesLoadBalancerAtomicOperationDescription", errors)
 
-    if (!helper.validateCredentials(description.credentials, accountCredentialsProvider)) {
+    if (!helper.validateCredentials(description.account, accountCredentialsProvider)) {
       return
     }
 
-    KubernetesCredentials credentials = (KubernetesCredentials) accountCredentialsProvider.getCredentials(description.credentials).credentials
+    KubernetesCredentials credentials = (KubernetesCredentials) accountCredentialsProvider.getCredentials(description.account).credentials
 
     helper.validateName(description.name, "name")
     helper.validateNamespace(credentials, description.namespace, "namespace")

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidator.groovy
@@ -36,11 +36,11 @@ class CloneKubernetesAtomicOperationValidator extends DescriptionValidator<Clone
   @Override
   void validate(List priorDescriptions, CloneKubernetesAtomicOperationDescription description, Errors errors) {
     def helper = new StandardKubernetesAttributeValidator("cloneKubernetesAtomicOperationDescription", errors)
-    if (!helper.validateCredentials(description.credentials, accountCredentialsProvider)) {
+    if (!helper.validateCredentials(description.account, accountCredentialsProvider)) {
       return
     }
 
-    KubernetesCredentials credentials = (KubernetesCredentials) accountCredentialsProvider.getCredentials(description.credentials).credentials
+    KubernetesCredentials credentials = (KubernetesCredentials) accountCredentialsProvider.getCredentials(description.account).credentials
 
     helper.validateCloneSource(description.source, "source")
     if (description.application) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidator.groovy
@@ -37,11 +37,11 @@ class DeployKubernetesAtomicOperationValidator extends DescriptionValidator<Depl
   void validate(List priorDescriptions, DeployKubernetesAtomicOperationDescription description, Errors errors) {
     def helper = new StandardKubernetesAttributeValidator("deployKubernetesAtomicOperationDescription", errors)
 
-    if (!helper.validateCredentials(description.credentials, accountCredentialsProvider)) {
+    if (!helper.validateCredentials(description.account, accountCredentialsProvider)) {
       return
     }
 
-    KubernetesCredentials credentials = (KubernetesCredentials) accountCredentialsProvider.getCredentials(description.credentials).credentials
+    KubernetesCredentials credentials = (KubernetesCredentials) accountCredentialsProvider.getCredentials(description.account).credentials
 
     helper.validateApplication(description.application, "application")
     helper.validateStack(description.stack, "stack")

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -30,6 +30,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
   String name
   String type = "kubernetes"
   String region
+  String account
   Long createdTime
   Integer replicas = 0
   Set<String> zones
@@ -50,8 +51,9 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
     this.region = namespace
   }
 
-  KubernetesServerGroup(ReplicationController replicationController, Set<KubernetesInstance> instances) {
+  KubernetesServerGroup(ReplicationController replicationController, Set<KubernetesInstance> instances, String account) {
     this.name = replicationController.metadata?.name
+    this.account = account
     this.region = replicationController.metadata?.namespace
     this.createdTime = KubernetesModelUtil.translateTime(replicationController.metadata?.creationTimestamp)
     this.zones = [this.region] as Set

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -127,7 +127,8 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
     Map<String, Set<KubernetesServerGroup>> serverGroups = [:].withDefault { _ -> [] as Set }
     serverGroupData.forEach {
       def replicationController = objectMapper.convertValue(it.attributes.replicationController, ReplicationController)
-      def serverGroup = new KubernetesServerGroup(replicationController, instances[(String) it.attributes.name])
+      def parse = Keys.parse(it.id)
+      def serverGroup = new KubernetesServerGroup(replicationController, instances[(String) it.attributes.name], parse.account)
       serverGroups[Names.parseName(serverGroup.name).cluster].add(serverGroup)
     }
 
@@ -163,6 +164,6 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
     Set<CacheData> instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.INSTANCES.ns, Keys.getInstanceKey(account, namespace, name, "*"))
 
     def replicationController = objectMapper.convertValue(serverGroupData.attributes.replicationController, ReplicationController)
-    serverGroupData ? new KubernetesServerGroup(replicationController, KubernetesProviderUtils.serverGroupToInstanceMap(objectMapper, instances)[name]) : null
+    serverGroupData ? new KubernetesServerGroup(replicationController, KubernetesProviderUtils.serverGroupToInstanceMap(objectMapper, instances)[name], account) : null
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesLoadBalancerProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesLoadBalancerProvider.groovy
@@ -74,7 +74,8 @@ class KubernetesLoadBalancerProvider implements LoadBalancerProvider<KubernetesL
 
     Map<String, KubernetesServerGroup> serverGroupMap = allServerGroups.collectEntries { serverGroupData ->
       ReplicationController replicationController = objectMapper.convertValue(serverGroupData.attributes.replicationController, ReplicationController)
-      [(serverGroupData.id): new KubernetesServerGroup(replicationController, instanceMap[(String)serverGroupData.attributes.name])]
+      def parse = Keys.parse(serverGroupData.id)
+      [(serverGroupData.id): new KubernetesServerGroup(replicationController, instanceMap[(String)serverGroupData.attributes.name], parse.account)]
     }
 
     return loadBalancers.collect {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverterSpec.groovy
@@ -25,7 +25,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class UpsertKubernetesLoadBalancerAtomicOperationConverterSpec extends Specification {
-  private static final CREDENTIALS = "my-test-account"
+  private static final ACCOUNT = "my-test-account"
   private static final NAME = "johanson"
 
   @Shared
@@ -48,7 +48,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationConverterSpec extends Specifica
   void "UpsertKubernetesLoadBalancerAtomicOperationSpec matches type signature of parent method"() {
     setup:
       def input = [name: NAME,
-                   credentials: CREDENTIALS]
+                   account: ACCOUNT]
     when:
       def description = converter.convertDescription(input)
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverterSpec.groovy
@@ -25,7 +25,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class CloneKubernetesAtomicOperationConverterSpec extends Specification {
-  private static final CREDENTIALS = "my-test-account"
+  private static final ACCOUNT = "my-test-account"
   private static final APPLICATION = "app"
   private static final STACK = "stack"
   private static final DETAILS = "details"
@@ -52,7 +52,7 @@ class CloneKubernetesAtomicOperationConverterSpec extends Specification {
       def input = [app: APPLICATION,
                    stack: STACK,
                    freeFormDetails: DETAILS,
-                   credentials: CREDENTIALS]
+                   account: ACCOUNT]
     when:
       def description = converter.convertDescription(input)
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/DeployKubernetesAtomicOperationConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/DeployKubernetesAtomicOperationConverterSpec.groovy
@@ -26,7 +26,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class DeployKubernetesAtomicOperationConverterSpec extends Specification {
-  private static final CREDENTIALS = "my-test-account"
+  private static final ACCOUNT = "my-test-account"
   private static final APPLICATION = "app"
   private static final STACK = "stack"
   private static final DETAILS = "details"
@@ -53,7 +53,7 @@ class DeployKubernetesAtomicOperationConverterSpec extends Specification {
       def input = [app: APPLICATION,
                    stack: STACK,
                    freeFormDetails: DETAILS,
-                   credentials: CREDENTIALS]
+                   account: ACCOUNT]
     when:
       def description = converter.convertDescription(input)
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
@@ -62,7 +62,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
 
   void "should upsert a new loadbalancer"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], kubernetesCredentials: credentials, namespace: NAMESPACE)
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], credentials: credentials, namespace: NAMESPACE)
       def resultServiceMock = Mock(Service)
 
       @Subject def operation = new UpsertKubernetesLoadBalancerAtomicOperation(description)
@@ -90,7 +90,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
 
   void "should upsert a new loadbalancer, and overwrite port data"() {
     setup:
-    def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], kubernetesCredentials: credentials, namespace: NAMESPACE)
+    def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], credentials: credentials, namespace: NAMESPACE)
       def resultServiceMock = Mock(Service)
       def existingServiceMock = Mock(Service)
       def servicePortMock = Mock(ServicePort)
@@ -127,7 +127,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
 
   void "should upsert a new loadbalancer, and insert port data"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], kubernetesCredentials: credentials, namespace: NAMESPACE)
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], credentials: credentials, namespace: NAMESPACE)
       def resultServiceMock = Mock(Service)
       def existingServiceMock = Mock(Service)
       def servicePortMock = Mock(ServicePort)
@@ -163,7 +163,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
 
   void "should upsert a new loadbalancer, and insert ip data"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, kubernetesCredentials: credentials, namespace: NAMESPACE)
+      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, credentials: credentials, namespace: NAMESPACE)
       def resultServiceMock = Mock(Service)
       def existingServiceMock = Mock(Service)
       def serviceSpecMock = Mock(ServiceSpec)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -132,7 +132,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
     setup:
       def inputDescription = new CloneKubernetesAtomicOperationDescription(
         source: [serverGroupName: ANCESTOR_SERVER_GROUP_NAME, namespace: NAMESPACE1],
-        kubernetesCredentials: credentials
+        credentials: credentials
       )
 
       @Subject def operation = new CloneKubernetesAtomicOperation(inputDescription)
@@ -171,7 +171,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
         loadBalancers: LOAD_BALANCER_NAMES,
         securityGroups: SECURITY_GROUP_NAMES,
         containers: containers,
-        kubernetesCredentials: credentials,
+        credentials: credentials,
         source: [serverGroupName: ANCESTOR_SERVER_GROUP_NAME, namespace: NAMESPACE2]
       )
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
@@ -119,7 +119,7 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
         loadBalancers: LOAD_BALANCER_NAMES,
         securityGroups: SECURITY_GROUP_NAMES,
         containers: containers,
-        kubernetesCredentials: credentials
+        credentials: credentials
       )
 
       @Subject def operation = new DeployKubernetesAtomicOperation(description)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
@@ -40,7 +40,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
   final static String INVALID_NAME = "bad name ?"
   final static String VALID_IP = "127.0.0.1"
   final static String INVALID_IP = "0.127.0.0.1"
-  final static String VALID_CREDENTIALS = "my-kubernetes-account"
+  final static String VALID_ACCOUNT = "my-kubernetes-account"
 
   UpsertKubernetesLoadBalancerAtomicOperationValidator validator
 
@@ -60,9 +60,9 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     def accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
 
     def credentials = new KubernetesCredentials(apiMock, NAMESPACES, [], accountCredentialsRepositoryMock)
-    namedCredentialsMock.getName() >> VALID_CREDENTIALS
+    namedCredentialsMock.getName() >> VALID_ACCOUNT
     namedCredentialsMock.getCredentials() >> credentials
-    credentialsRepo.save(VALID_CREDENTIALS, namedCredentialsMock)
+    credentialsRepo.save(VALID_ACCOUNT, namedCredentialsMock)
     validator.accountCredentialsProvider = credentialsProvider
 
     validPort = new KubernetesNamedServicePort(name: VALID_NAME, port: VALID_PORT, protocol: VALID_PROTOCOL)
@@ -76,7 +76,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
       def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
         externalIps: [VALID_IP],
         ports: [validPort],
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         namespace: NAMESPACE)
       def errorsMock = Mock(Errors)
 
@@ -91,7 +91,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     setup:
       def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
         ports: [validPort],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -104,7 +104,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     setup:
       def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
         ports: [invalidProtocolPort],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -118,7 +118,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     setup:
       def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
         ports: [invalidNamePort],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -132,7 +132,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     setup:
       def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
         ports: [invalidPortPort],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -147,7 +147,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
       def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
         ports: [validPort],
         externalIps: [INVALID_IP],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
@@ -49,7 +49,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
   private static final VALID_MEMORY2 = "200Mi"
   private static final VALID_CPU1 = "200"
   private static final VALID_CPU2 = "200m"
-  private static final VALID_CREDENTIALS = "auto"
+  private static final VALID_ACCOUNT = "auto"
   private static final VALID_LOAD_BALANCERS = ["x", "y"]
   private static final VALID_SECURITY_GROUPS = ["a-1", "b-2"]
   private static final VALID_SOURCE_SERVER_GROUP_NAME = "myapp-test-v000"
@@ -63,7 +63,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
   private static final INVALID_NAME = "a?name"
   private static final INVALID_MEMORY = "200asdf"
   private static final INVALID_CPU = "-1_"
-  private static final INVALID_CREDENTIALS = "valid"
+  private static final INVALID_ACCOUNT = "valid"
   private static final INVALID_LOAD_BALANCERS = [" ", "--"]
   private static final INVALID_SECURITY_GROUPS = [" ", "--"]
 
@@ -90,9 +90,9 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
     })
 
     def credentials = new KubernetesCredentials(apiMock, NAMESPACES, DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock)
-    namedCredentialsMock.getName() >> VALID_CREDENTIALS
+    namedCredentialsMock.getName() >> VALID_ACCOUNT
     namedCredentialsMock.getCredentials() >> credentials
-    credentialsRepo.save(VALID_CREDENTIALS, namedCredentialsMock)
+    credentialsRepo.save(VALID_ACCOUNT, namedCredentialsMock)
     validator.accountCredentialsProvider = credentialsProvider
   }
 
@@ -132,7 +132,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         ],
         loadBalancers: VALID_LOAD_BALANCERS,
         securityGroups: VALID_SECURITY_GROUPS,
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ])
@@ -149,7 +149,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
     when:
       validator.validate([], description, errorsMock)
@@ -184,7 +184,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ])
@@ -204,7 +204,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ])
@@ -225,7 +225,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ])
@@ -245,7 +245,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialInvalidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ])
@@ -266,7 +266,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           fullInvalidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ])
@@ -292,7 +292,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
           partialValidContainerDescription
         ],
         loadBalancers: INVALID_LOAD_BALANCERS,
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ])
@@ -314,7 +314,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
           partialValidContainerDescription
         ],
         securityGroups: INVALID_SECURITY_GROUPS,
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: VALID_SOURCE_SERVER_GROUP_NAME
         ])
@@ -339,7 +339,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         ],
         loadBalancers: VALID_LOAD_BALANCERS,
         securityGroups: VALID_SECURITY_GROUPS,
-        credentials: VALID_CREDENTIALS
+        account: VALID_ACCOUNT
       )
       def errorsMock = Mock(Errors)
     when:
@@ -361,7 +361,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
         ],
         loadBalancers: VALID_LOAD_BALANCERS,
         securityGroups: VALID_SECURITY_GROUPS,
-        credentials: VALID_CREDENTIALS,
+        account: VALID_ACCOUNT,
         source: [
           serverGroupName: ""
         ]

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
@@ -50,7 +50,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
   private static final VALID_MEMORY2 = "200Mi"
   private static final VALID_CPU1 = "200"
   private static final VALID_CPU2 = "200m"
-  private static final VALID_CREDENTIALS = "auto"
+  private static final VALID_ACCOUNT = "auto"
   private static final VALID_LOAD_BALANCERS = ["x", "y"]
   private static final VALID_SECURITY_GROUPS = ["a-1", "b-2"]
   private static final VALID_NAMESPACE = NAMESPACES[0]
@@ -64,7 +64,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
   private static final INVALID_NAME = "a?name"
   private static final INVALID_MEMORY = "200?"
   private static final INVALID_CPU = "9z"
-  private static final INVALID_CREDENTIALS = "valid"
+  private static final INVALID_ACCOUNT = "valid"
   private static final INVALID_LOAD_BALANCERS = [" ", "--"]
   private static final INVALID_SECURITY_GROUPS = [" ", "--"]
   private static final INVALID_NAMESPACE = "!default"
@@ -92,9 +92,9 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
     })
 
     def credentials = new KubernetesCredentials(apiMock, NAMESPACES, DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock)
-    namedCredentialsMock.getName() >> VALID_CREDENTIALS
+    namedCredentialsMock.getName() >> VALID_ACCOUNT
     namedCredentialsMock.getCredentials() >> credentials
-    credentialsRepo.save(VALID_CREDENTIALS, namedCredentialsMock)
+    credentialsRepo.save(VALID_ACCOUNT, namedCredentialsMock)
     validator.accountCredentialsProvider = credentialsProvider
   }
 
@@ -135,7 +135,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         ],
         loadBalancers: VALID_LOAD_BALANCERS,
         securityGroups: VALID_SECURITY_GROUPS,
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -152,7 +152,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -185,7 +185,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -203,7 +203,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -221,7 +221,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -240,7 +240,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -258,7 +258,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialValidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -276,7 +276,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           partialInvalidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -295,7 +295,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         containers: [
           fullInvalidContainerDescription
         ],
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -319,7 +319,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
           partialValidContainerDescription
         ],
         loadBalancers: INVALID_LOAD_BALANCERS,
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:
@@ -339,7 +339,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
           partialValidContainerDescription
         ],
         securityGroups: INVALID_SECURITY_GROUPS,
-        credentials: VALID_CREDENTIALS)
+        account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
 
     when:

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroupSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroupSpec.groovy
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.ReplicationController
 import spock.lang.Specification
 
 class KubernetesServerGroupSpec extends Specification {
+  final private String ACCOUNT = "account"
   KubernetesInstance upInstanceMock
   KubernetesInstance downInstanceMock
   KubernetesInstance startingInstanceMock
@@ -44,7 +45,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should return 1 up instances"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock] as Set)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock] as Set, ACCOUNT)
 
     then:
       serverGroup.instanceCounts.up == 1
@@ -56,7 +57,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should return 1 up, 1 down, 1 starting, 1 oos, 1 unknown instances"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock, downInstanceMock, startingInstanceMock, unknownInstanceMock, outOfServiceInstanceMock] as Set)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock, downInstanceMock, startingInstanceMock, unknownInstanceMock, outOfServiceInstanceMock] as Set, ACCOUNT)
 
     then:
       serverGroup.instanceCounts.up == 1
@@ -68,7 +69,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with no load balancers as disabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT)
       serverGroup.labels = ["hi": "there"]
 
     then:
@@ -77,7 +78,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with no enabled load balancers as disabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT)
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "false"]
 
     then:
@@ -86,7 +87,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with enabled load balancers as enabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT)
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "true"]
 
     then:
@@ -95,7 +96,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with mix of load balancers as enabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT)
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "true", (KubernetesUtil.loadBalancerKey("2")): "false"]
 
     then:


### PR DESCRIPTION
The `credentials` field is needed for clone server group operations to resolve valid images for the given namespace. 

@duftler 