### PR TITLE
core: Make `ImagesSummary` endpoint alongside `ImageSummary`

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
@@ -118,24 +118,34 @@ class AmazonServerGroup implements ServerGroup, Serializable {
   }
 
   @Override
-  ServerGroup.ImageSummary getImageSummary() {
+  ServerGroup.ImagesSummary getImagesSummary() {
     def i = image
     def bi = buildInfo
-    return new ServerGroup.ImageSummary() {
-      String serverGroupName = name
-      String imageName = i?.name
-      String imageId = i?.imageId
-
+    return new ServerGroup.ImagesSummary() {
       @Override
-      Map<String, Object> getBuildInfo() {
-        return bi
-      }
+      List<ServerGroup.ImageSummary> getSummaries() {
+        return [new ServerGroup.ImageSummary() {
+          String serverGroupName = name
+          String imageName = i?.name
+          String imageId = i?.imageId
 
-      @Override
-      Map<String, Object> getImage() {
-        return i
+          @Override
+          Map<String, Object> getBuildInfo() {
+            return bi
+          }
+
+          @Override
+          Map<String, Object> getImage() {
+            return i
+          }
+        }]
       }
     }
+  }
+
+    @Override
+  ServerGroup.ImageSummary getImageSummary() {
+    imagesSummary?.summaries?.get(0)
   }
 
   static Collection<Instance> filterInstancesByHealthState(Set<Instance> instances, HealthState healthState) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy
@@ -417,6 +417,7 @@ class DiscoverySupportUnitSpec extends Specification {
     ServerGroup.InstanceCounts instanceCounts
     ServerGroup.Capacity capacity
     Boolean isDisabled() {disabled}
-    ServerGroup.ImageSummary getImageSummary() {null}
+    ServerGroup.ImageSummary getImageSummary() {}
+    ServerGroup.ImagesSummary getImagesSummary() {}
   }
 }

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryServerGroup.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryServerGroup.groovy
@@ -120,28 +120,38 @@ class CloudFoundryServerGroup implements ServerGroup, Serializable {
   }
 
   @Override
-  ServerGroup.ImageSummary getImageSummary() {
-    def bi = buildInfo
-    return new ServerGroup.ImageSummary() {
-      String serverGroupName = name
-      String imageName = launchConfig?."${CloudFoundryConstants.ARTIFACT}"
-      String imageId = launchConfig?."${CloudFoundryConstants.REPOSITORY}" +
-          "::" + launchConfig?."${CloudFoundryConstants.ARTIFACT}" +
-          "::" + launchConfig?."${CloudFoundryConstants.ACCOUNT}"
-
+  ServerGroup.ImagesSummary getImagesSummary() {
+    return new ServerGroup.ImagesSummary() {
       @Override
-      Map<String, Object> getBuildInfo() {
-        bi
-      }
+      List<ServerGroup.ImageSummary> getSummaries() {
+        def bi = buildInfo
+        return [new ServerGroup.ImageSummary() {
+          String serverGroupName = name
+          String imageName = launchConfig?."${CloudFoundryConstants.ARTIFACT}"
+          String imageId = launchConfig?."${CloudFoundryConstants.REPOSITORY}" +
+            "::" + launchConfig?."${CloudFoundryConstants.ARTIFACT}" +
+            "::" + launchConfig?."${CloudFoundryConstants.ACCOUNT}"
 
-      @Override
-      Map<String, Object> getImage() {
-        return [
-            imageName: imageName,
-            imageId: imageId
-        ]
+          @Override
+          Map<String, Object> getBuildInfo() {
+            bi
+          }
+
+          @Override
+          Map<String, Object> getImage() {
+            return [
+              imageName: imageName,
+              imageId  : imageId
+            ]
+          }
+        }]
       }
     }
+  }
+
+  @Override
+  ServerGroup.ImageSummary getImageSummary() {
+    imagesSummary?.summaries?.get(0)
   }
 
   static Collection<Instance> filterInstancesByHealthState(Set<CloudFoundryApplicationInstance> instances,

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.groovy
@@ -116,10 +116,19 @@ interface ServerGroup {
   Capacity getCapacity()
 
   /**
-   * An ImageSummary is collection of data related to the build and VM image of the server group. This is merely a view
-   * of data from other parts of this object.
+   * This represents all images deployed to the server group. For most providers, this will be a singleton.
    */
   @JsonIgnore
+  ImagesSummary getImagesSummary()
+
+  /**
+   * An ImageSummary is collection of data related to the build and VM image of the server group. This is merely a view
+   * of data from other parts of this object.
+   *
+   * Deprecated in favor of getImagesSummary, which is a more generic getImageSummary.
+   */
+  @JsonIgnore
+  @Deprecated
   ImageSummary getImageSummary()
 
   static class InstanceCounts {
@@ -175,6 +184,7 @@ interface ServerGroup {
 
   /**
    * Cloud provider-specific data related to the build and VM image of the server group.
+   * Deprecated in favor of Images summary
    */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   interface ImageSummary extends Summary {
@@ -186,6 +196,14 @@ interface ServerGroup {
 
     @Empty
     Map<String, Object> getBuildInfo()
+  }
+
+  /**
+   * Cloud provider-specific data related to the build and VM image of the server group.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  interface ImagesSummary extends Summary {
+    List<ImageSummary> getSummaries()
   }
 
   static class SimpleServerGroup implements ServerGroup {
@@ -202,6 +220,7 @@ interface ServerGroup {
     ServerGroup.InstanceCounts instanceCounts
     ServerGroup.Capacity capacity
     ServerGroup.ImageSummary imageSummary
+    ServerGroup.ImagesSummary imagesSummary
 
     @Override
     Boolean isDisabled() {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
@@ -129,23 +129,33 @@ class GoogleServerGroup implements ServerGroup, Serializable {
   }
 
   @Override
-  ServerGroup.ImageSummary getImageSummary() {
+  ServerGroup.ImagesSummary getImagesSummary() {
     def bi = buildInfo
-    return new ServerGroup.ImageSummary() {
-      String serverGroupName = name
-      String imageName = launchConfig?.instanceTemplate?.name
-      String imageId = launchConfig?.imageId
-
+    return new ServerGroup.ImagesSummary() {
       @Override
-      Map<String, Object> getBuildInfo() {
-        return bi
-      }
+      List<ServerGroup.ImageSummary> getSummaries() {
+      return [new ServerGroup.ImageSummary() {
+          String serverGroupName = name
+          String imageName = launchConfig?.instanceTemplate?.name
+          String imageId = launchConfig?.imageId
 
-      @Override
-      Map<String, Object> getImage() {
-        return launchConfig?.instanceTemplate
+          @Override
+          Map<String, Object> getBuildInfo() {
+            return bi
+          }
+
+          @Override
+          Map<String, Object> getImage() {
+            return launchConfig?.instanceTemplate
+          }
+        }]
       }
     }
+  }
+
+  @Override
+  ServerGroup.ImageSummary getImageSummary() {
+    imagesSummary?.summaries?.get(0)
   }
 
   static Collection<Instance> filterInstancesByHealthState(Set<Instance> instances, HealthState healthState) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup2.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup2.groovy
@@ -100,23 +100,33 @@ class GoogleServerGroup2 {
     }
 
     @Override
-    ServerGroup.ImageSummary getImageSummary() {
+    ServerGroup.ImagesSummary getImagesSummary() {
       def bi = GoogleServerGroup2.this.buildInfo
-      return new ServerGroup.ImageSummary() {
-        String serverGroupName = name
-        String imageName = launchConfig?.instanceTemplate?.name
-        String imageId = launchConfig?.imageId
-
+      return new ServerGroup.ImagesSummary() {
         @Override
-        Map<String, Object> getBuildInfo() {
-          return bi
-        }
+        List<ServerGroup.ImageSummary> getSummaries() {
+          return [new ServerGroup.ImageSummary() {
+            String serverGroupName = name
+            String imageName = launchConfig?.instanceTemplate?.name
+            String imageId = launchConfig?.imageId
 
-        @Override
-        Map<String, Object> getImage() {
-          return launchConfig?.instanceTemplate
+            @Override
+            Map<String, Object> getBuildInfo() {
+              return bi
+            }
+
+            @Override
+            Map<String, Object> getImage() {
+              return launchConfig?.instanceTemplate
+            }
+          }]
         }
       }
+    }
+
+    @Override
+    ServerGroup.ImageSummary getImageSummary() {
+      imagesSummary?.summaries?.get(0)
     }
 
     @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
@@ -48,8 +48,8 @@ class KubernetesLoadBalancer implements LoadBalancer, Serializable {
     this.region = this.namespace
     this.account = accountName
     this.createdTime = KubernetesModelUtil.translateTime(service.metadata?.creationTimestamp)
-    this.serverGroups = serverGroupList.collect {
-      [name: it.name, serverGroup: it]
+    this.serverGroups = serverGroupList?.collect {
+      [name: it?.name, serverGroup: it]
     } as Set
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -84,12 +84,33 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
   }
 
   @Override
+  ServerGroup.ImagesSummary getImagesSummary() {
+    return new ServerGroup.ImagesSummary() {
+      @Override
+      List<ServerGroup.ImageSummary> getSummaries () {
+        containers.collect({ Container it ->
+          new ServerGroup.ImageSummary() {
+            String serverGroupName = name
+            String imageName = it.name
+            String imageId = it.image
+
+            @Override
+            Map<String, Object> getBuildInfo() {
+              return it.additionalProperties
+            }
+
+            @Override
+            Map<String, Object> getImage() {
+              return [image: it.image, name: it.name]
+            }
+          }
+        })
+      }
+    }
+  }
+
+  @Override
   ServerGroup.ImageSummary getImageSummary() {
-    // TODO(lwander): Massage into more kubernetes native format (multiple images per server group).
-    return new KubernetesImageSummary(
-      image: containers?.collectEntries { [(it.name): it.image] },
-      serverGroupName: this.name,
-      imageName: containers[0]?.image // TODO(lwander): See above.
-    )
+    imagesSummary?.summaries?.get(0)
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
@@ -115,25 +115,35 @@ class TitusServerGroup implements ServerGroup, Serializable {
   }
 
   @Override
-  ServerGroup.ImageSummary getImageSummary() {
+  ServerGroup.ImagesSummary getImagesSummary() {
     def i = image
-    return new ServerGroup.ImageSummary() {
-      String serverGroupName = name
-      // TODO(sthadeshwar): Give these values
-      String imageName
-      String imageId
-
+    return new ServerGroup.ImagesSummary() {
       @Override
-      Map<String, Object> getBuildInfo() {
-        // TODO(sthadeshwar): Where to get build info?
-        return null
-      }
+      List<ServerGroup.ImageSummary> getSummaries() {
+        return [new ServerGroup.ImageSummary() {
+          String serverGroupName = name
+          // TODO(sthadeshwar): Give these values
+          String imageName
+          String imageId
 
-      @Override
-      Map<String, Object> getImage() {
-        return i
+          @Override
+          Map<String, Object> getBuildInfo() {
+            // TODO(sthadeshwar): Where to get build info?
+            return null
+          }
+
+          @Override
+          Map<String, Object> getImage() {
+            return i
+          }
+        }]
       }
     }
+  }
+
+  @Override
+  ServerGroup.ImageSummary getImageSummary() {
+    imagesSummary?.summaries?.get(0)
   }
 
   static Set filterInstancesByHealthState(Set instances, HealthState healthState) {

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectControllerSpec.groovy
@@ -450,6 +450,7 @@ class ProjectControllerSpec extends Specification {
     String name
     String accountName
     ServerGroup.ImageSummary imageSummary
+    ServerGroup.ImagesSummary imagesSummary
     Long createdTime
     InstanceCounts instanceCounts
     String type = "test"


### PR DESCRIPTION
I deprecated `ServerGroup.getImageSummary` in favor of `ServerGroup.getImagesSummary`. Providers supporting only a single image per server group will return a singleton image in the  `ServerGroup.ImageSummary` type. For now, the `/{account:.+}/{clusterName:.+}/{cloudProvider}/{scope}/serverGroups/target/{target:.+}/{summaryType:.+}` clouddriver endpoint still supports searching for a single image (`summaryType == Image`), which will return the first image in `ServerGroup.ImagesSummary` to avoid changing Clouddriver's behavior.

The motivation is the allow find images to pick among multiple Kubernetes Images.

@duftler, @cfieber PTAL