### PR TITLE
Fix getServerGroup TODO that was causing a busted UI with new GCE Redis Impl

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -27,9 +27,9 @@ class Keys {
     INSTANCES,
     LOAD_BALANCERS,
     NETWORKS,
-    SUBNETS,
     SECURITY_GROUPS,
     SERVER_GROUPS,
+    SUBNETS,
 
     final String ns
 
@@ -96,13 +96,6 @@ class Keys {
             region : parts[4]
         ]
         break
-      case Namespace.SUBNETS.ns:
-        result << [
-            id     : parts[2],
-            account: parts[3],
-            region : parts[4]
-        ]
-        break
       case Namespace.SECURITY_GROUPS.ns:
         def names = Names.parseName(parts[2])
         result << [
@@ -124,6 +117,13 @@ class Keys {
             stack      : names.stack,
             detail     : names.detail,
             sequence   : names.sequence?.toString()
+        ]
+        break
+      case Namespace.SUBNETS.ns:
+        result << [
+            id     : parts[2],
+            account: parts[3],
+            region : parts[4]
         ]
         break
       default:
@@ -166,13 +166,6 @@ class Keys {
     "$googleCloudProvider.id:${Namespace.NETWORKS}:${networkName}:${account}:${region}"
   }
 
-  static String getSubnetKey(GoogleCloudProvider googleCloudProvider,
-                             String subnetName,
-                             String region,
-                             String account) {
-    "$googleCloudProvider.id:${Namespace.SUBNETS}:${subnetName}:${account}:${region}"
-  }
-
   static String getSecurityGroupKey(GoogleCloudProvider googleCloudProvider,
                                     String securityGroupName,
                                     String securityGroupId,
@@ -184,8 +177,15 @@ class Keys {
   static String getServerGroupKey(GoogleCloudProvider googleCloudProvider,
                                   String managedInstanceGroupName,
                                   String account,
-                                  String region) {
+                                  String zone) {
     Names names = Names.parseName(managedInstanceGroupName)
-    "$googleCloudProvider.id:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}"
+    "$googleCloudProvider.id:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${zone}:${names.group}"
+  }
+
+  static String getSubnetKey(GoogleCloudProvider googleCloudProvider,
+                             String subnetName,
+                             String region,
+                             String account) {
+    "$googleCloudProvider.id:${Namespace.SUBNETS}:${subnetName}:${account}:${region}"
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup2.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup2.groovy
@@ -39,6 +39,8 @@ class GoogleServerGroup2 {
   Map buildInfo
   Boolean disabled = false
 
+  Set<GoogleLoadBalancer2> loadBalancers = []
+
   private Map<String, Object> dynamicProperties = [:]
 
   @JsonAnyGetter

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
@@ -110,7 +110,7 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent {
       def serverGroupKey = Keys.getServerGroupKey(googleCloudProvider,
                                                   serverGroup.name,
                                                   accountName,
-                                                  serverGroup.zones[0])
+                                                  serverGroup.region)
       def clusterKey = Keys.getClusterKey(googleCloudProvider,
                                           accountName,
                                           applicationName,

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/LoggingExceptionHandler.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/LoggingExceptionHandler.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers
+
+import groovy.util.logging.Slf4j
+import org.apache.commons.lang.exception.ExceptionUtils
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+import javax.servlet.http.HttpServletRequest
+
+@Slf4j
+@ControllerAdvice
+class LoggingExceptionHandler {
+
+  @ExceptionHandler(value = Exception.class)
+  def defaultErrorHandler(HttpServletRequest request, Exception e) {
+    log.error("Error occurred handling request for ${request.requestURL}: ${ExceptionUtils.getFullStackTrace(e)}")
+  }
+}


### PR DESCRIPTION
Also usefully (and finally) prints all request exceptions to the logs in Clouddriver.

@duftler @lwander FYI