### PR TITLE
Cherry-pick: Allow for customizing block devices

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -107,9 +107,8 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         }
       }
 
-      def blockDeviceMappingForInstanceType = BlockDeviceConfig.blockDevicesByInstanceType[description.instanceType]
-      if (blockDeviceMappingForInstanceType) {
-        description.blockDevices = blockDeviceMappingForInstanceType
+      if (description.blockDevices == null) {
+        description.blockDevices = BlockDeviceConfig.blockDevicesByInstanceType[description.instanceType]
       }
 
       // find by 1) result of a previous step (we performed allow launch)


### PR DESCRIPTION
Currently the defaults are hardcoded and unable to be bypassed. This commit
allows for passing down custom block devices if they are specified in the pipeline json description.