### PR TITLE
provider/kubernetes: Split imageId into registry, repository and tag.

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
@@ -34,7 +34,7 @@ class DockerBearerTokenService {
     cachedTokens = new HashMap<String, DockerBearerToken>()
     if (username) {
       basicAuth = new String(Base64.encoder.encode(("${username}:${password}").bytes))
-      basicAuth = "Basic $basicAuth"
+      basicAuth = "$basicAuth"
     } else {
       basicAuth = null
     }
@@ -169,7 +169,7 @@ class DockerBearerTokenService {
     def tokenService = getTokenService(authenticateDetails.realm)
     def token
     if (basicAuth) {
-      token = tokenService.getToken(authenticateDetails.path, authenticateDetails.service, authenticateDetails.scope, basicAuth)
+      token = tokenService.getToken(authenticateDetails.path, authenticateDetails.service, authenticateDetails.scope, "Basic $basicAuth")
     }
     else {
       token = tokenService.getToken(authenticateDetails.path, authenticateDetails.service, authenticateDetails.scope)

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.docker.registry.provider.DockerRegistry
 import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
@@ -65,11 +64,12 @@ class DockerRegistryImageLookupController {
 
     Set<CacheData> images = DockerRegistryProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.TAGGED_IMAGE.ns, key)
 
-
     return images.collect({
       def credentials = (DockerRegistryNamedAccountCredentials) accountCredentialsProvider.getCredentials((String) it.attributes.account)
+      def parse = Keys.parse(it.id)
       return [
-        imageName: (String) it.attributes.name,
+        repository: (String) parse.repository,
+        tag: (String) parse.tag,
         account: it.attributes.account,
         registry: credentials.registry,
       ]

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -32,12 +32,7 @@ import groovy.util.logging.Slf4j
 import static java.util.Collections.unmodifiableSet
 
 @Slf4j
-class DockerRegistryImageCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'DockerRegistryTaggedImage'
-
-  private static final String ON_DEMAND_TYPE = 'TaggedImage'
-
+class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware {
   static final Set<AgentDataType> types = unmodifiableSet([
     AgentDataType.Authority.AUTHORITATIVE.forType(Keys.Namespace.TAGGED_IMAGE.ns)
   ] as Set)
@@ -45,16 +40,13 @@ class DockerRegistryImageCachingAgent implements CachingAgent, OnDemandAgent, Ac
   private DockerRegistryCredentials credentials
   private DockerRegistryCloudProvider dockerRegistryCloudProvider
   private String accountName
-  private OnDemandMetricsSupport metricsSupport
 
   DockerRegistryImageCachingAgent(DockerRegistryCloudProvider dockerRegistryCloudProvider,
                                   String accountName,
-                                  DockerRegistryCredentials credentials,
-                                  Registry registry) {
+                                  DockerRegistryCredentials credentials) {
     this.dockerRegistryCloudProvider = dockerRegistryCloudProvider
     this.accountName = accountName
     this.credentials = credentials
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${Keys.Namespace.provider}:${ON_DEMAND_TYPE}".toString())
   }
 
   @Override
@@ -79,56 +71,11 @@ class DockerRegistryImageCachingAgent implements CachingAgent, OnDemandAgent, Ac
     DockerRegistryProvider.PROVIDER_NAME
   }
 
-  @Override
-  String getOnDemandAgentType() {
-    "${getAgentType()}-OnDemand"
-  }
-
-  @Override
-  OnDemandMetricsSupport getMetricsSupport() {
-    return metricsSupport
-  }
-
-  @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    cloudProvider == Keys.Namespace.provider && type == ON_DEMAND_TYPE
-  }
-
-  @Override
-  OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data) {
-    if (data.account != accountName) {
-      return null
-    }
-
-    Map<String, Set<String>> mapRepositoryToTags = metricsSupport.readData {
-      loadTags()
-    }
-
-    CacheResult result = metricsSupport.transformData {
-      buildCacheResult(mapRepositoryToTags)
-    }
-
-    new OnDemandAgent.OnDemandResult(
-      sourceAgentType: getAgentType(),
-      cacheResult: result
-    )
-  }
-
   private Map<String, Set<String>> loadTags() {
     credentials.repositories.collectEntries {
       DockerRegistryTags tags = credentials.client.getTags(it)
       tags ? [(tags.name): tags.tags ?: []] : [:]
     }
-  }
-
-  @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
-    return [:]
   }
 
   @Override

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/config/DockerRegistryProviderConfig.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/config/DockerRegistryProviderConfig.groovy
@@ -77,7 +77,7 @@ class DockerRegistryProviderConfig {
       if (!scheduledAccounts.contains(credentials.accountName)) {
         def newlyAddedAgents = []
 
-        newlyAddedAgents << new DockerRegistryImageCachingAgent(dockerRegistryCloudProvider, credentials.accountName, credentials.credentials, registry)
+        newlyAddedAgents << new DockerRegistryImageCachingAgent(dockerRegistryCloudProvider, credentials.accountName, credentials.credentials)
 
         // If there is an agent scheduler, then this provider has been through the AgentController in the past.
         // In that case, we need to do the scheduling here (because accounts have been added to a running system).

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -27,7 +27,7 @@ class KubernetesConfigurationProperties {
     String accountType
     String cluster
     String user
-    String kubeConfigFile
+    String kubeconfigFile
     List<String> namespaces
     List<LinkedDockerRegistryConfiguration> dockerRegistries
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -18,14 +18,18 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy
 
 import com.netflix.frigga.NameValidation
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesImageDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.exception.KubernetesIllegalArgumentException
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import io.fabric8.kubernetes.api.model.ReplicationController
+import org.springframework.beans.factory.annotation.Value
 
 class KubernetesUtil {
   static String SECURITY_GROUP_LABEL_PREFIX = "security-group-"
   static String LOAD_BALANCER_LABEL_PREFIX = "load-balancer-"
   static String REPLICATION_CONTROLLER_LABEL = "replication-controller"
+  @Value(value = "#{kubernetes.defaultRegistry:gcr.io}")
+  static String DEFAULT_REGISTRY
   private static int SECURITY_GROUP_LABEL_PREFIX_LENGTH = SECURITY_GROUP_LABEL_PREFIX.length()
   private static int LOAD_BALANCER_LABEL_PREFIX_LENGTH = LOAD_BALANCER_LABEL_PREFIX.length()
 
@@ -46,6 +50,59 @@ class KubernetesUtil {
 
   static List<String> getImagePullSecrets(ReplicationController rc) {
     rc.spec?.template?.spec?.imagePullSecrets?.collect({ it.name })
+  }
+
+  static KubernetesImageDescription buildImageDescription(String image) {
+    def sIndex = image.indexOf('/')
+    def result = new KubernetesImageDescription()
+
+    // No slash means we only provided a repository name & optional tag.
+    if (sIndex < 0) {
+      result.repository = image
+    } else {
+      def sPrefix = image.substring(0, sIndex)
+
+      // Check if the content before the slash is a registry (either localhost, or a URL)
+      if (sPrefix.startsWith('localhost') || sPrefix.contains('.')) {
+        result.registry = sPrefix
+
+        image = image.substring(sIndex + 1)
+      }
+    }
+
+    def cIndex = image.indexOf(':')
+
+    if (cIndex < 0) {
+      result.repository = image
+    } else {
+      result.tag = image.substring(cIndex + 1)
+      result.repository = image.subSequence(0, cIndex)
+    }
+
+    normalizeImageDescription(result)
+    result
+  }
+
+  static Void normalizeImageDescription(KubernetesImageDescription image) {
+    if (!image.registry) {
+      image.registry = DEFAULT_REGISTRY
+    }
+
+    if (!image.tag) {
+      image.tag = "latest"
+    }
+
+    if (!image.repository) {
+      throw new IllegalArgumentException("Image descriptions must provide a repository.")
+    }
+  }
+
+  static String getImageId(KubernetesImageDescription image) {
+    return getImageId(image.registry, image.repository, image.tag)
+  }
+
+  static String getImageId(String registry, String repository, String tag) {
+    "$registry/$repository:$tag"
   }
 
   static String validateNamespace(KubernetesCredentials credentials, String namespace) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -46,9 +46,17 @@ class KubernetesContainerPort {
 
 @AutoClone
 @Canonical
+class KubernetesImageDescription {
+  String repository
+  String tag
+  String registry
+}
+
+@AutoClone
+@Canonical
 class KubernetesContainerDescription {
   String name
-  String image
+  KubernetesImageDescription imageDescription
   KubernetesResourceDescription requests
   KubernetesResourceDescription limits
   List<KubernetesContainerPort> ports

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.CloneKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerPort
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesImageDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.exception.KubernetesResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
@@ -129,11 +130,12 @@ class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult
 
         def newContainer = new KubernetesContainerDescription([
           name: it.name,
-          image: it.image,
+          imageDescription: KubernetesUtil.buildImageDescription(it.image),
           requests: newRequests,
           limits: newLimits,
           ports: newPorts,
         ])
+
         newDescription.containers.push(newContainer)
       }
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/KubernetesContainerValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/KubernetesContainerValidator.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKu
 class KubernetesContainerValidator {
   static void validate(KubernetesContainerDescription description, StandardKubernetesAttributeValidator helper, String prefix) {
     helper.validateName(description.name, "${prefix}.name")
-    helper.validateNotEmpty(description.image, "${prefix}.image")
+    helper.validateNotEmpty(description.imageDescription, "${prefix}.imageDescription")
 
     if (description.limits) {
       helper.validateCpu(description.limits.cpu, "${prefix}.limits.cpu")

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesConfigParser.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesConfigParser.groovy
@@ -23,9 +23,9 @@ import io.fabric8.kubernetes.client.Config
 import io.fabric8.kubernetes.client.internal.KubeConfigUtils
 
 class KubernetesConfigParser {
-  static Config parse(String kubeConfigFile, String cluster, String user, List<String> namespaces) {
+  static Config parse(String kubeconfigFile, String cluster, String user, List<String> namespaces) {
 
-    def kubeConfig = KubeConfigUtils.parseConfig(new File(kubeConfigFile))
+    def kubeConfig = KubeConfigUtils.parseConfig(new File(kubeconfigFile))
     Config config = new Config()
 
     Context currentContext = KubeConfigUtils.getCurrentContext(kubeConfig)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
@@ -75,7 +75,7 @@ class KubernetesCredentialsInitializer implements CredentialsInitializerSynchron
                                                                       managedAccount.accountType ?: managedAccount.name,
                                                                       managedAccount.cluster,
                                                                       managedAccount.user,
-                                                                      managedAccount.kubeConfigFile,
+                                                                      managedAccount.kubeconfigFile,
                                                                       managedAccount.namespaces,
                                                                       managedAccount.dockerRegistries)
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -39,10 +39,10 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
                                            String accountType,
                                            String cluster,
                                            String user,
-                                           String kubeConfigFile,
+                                           String kubeconfigFile,
                                            List<String> namespaces,
                                            List<LinkedDockerRegistryConfiguration> dockerRegistries) {
-    this(accountCredentialsRepository, accountName, environment, accountType, cluster, user, kubeConfigFile, namespaces, dockerRegistries, null);
+    this(accountCredentialsRepository, accountName, environment, accountType, cluster, user, kubeconfigFile, namespaces, dockerRegistries, null);
   }
 
   public KubernetesNamedAccountCredentials(AccountCredentialsRepository accountCredentialsRepository,
@@ -51,7 +51,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
                                            String accountType,
                                            String cluster,
                                            String user,
-                                           String kubeConfigFile,
+                                           String kubeconfigFile,
                                            List<String> namespaces,
                                            List<LinkedDockerRegistryConfiguration> dockerRegistries,
                                            List<String> requiredGroupMembership) {
@@ -66,8 +66,8 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
     this.accountType = accountType;
     this.cluster = cluster;
     this.user = user;
-    this.kubeConfigFile = kubeConfigFile != null && kubeConfigFile.length() > 0 ?
-      kubeConfigFile : System.getProperty("user.home") + "/.kube/config";
+    this.kubeconfigFile = kubeconfigFile != null && kubeconfigFile.length() > 0 ?
+      kubeconfigFile : System.getProperty("user.home") + "/.kube/config";
     this.namespaces = namespaces;
     // TODO(lwander): what is this?
     this.requiredGroupMembership = requiredGroupMembership == null ? Collections.emptyList() : Collections.unmodifiableList(requiredGroupMembership);
@@ -110,7 +110,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
   }
 
   private KubernetesCredentials buildCredentials() {
-    Config config = KubernetesConfigParser.parse(kubeConfigFile, cluster, user, namespaces);
+    Config config = KubernetesConfigParser.parse(kubeconfigFile, cluster, user, namespaces);
     if (namespaces == null || namespaces.isEmpty()) {
       namespaces = Collections.singletonList(config.getNamespace());
     }
@@ -154,7 +154,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
   private final String accountType;
   private final String cluster;
   private final String user;
-  private final String kubeConfigFile;
+  private final String kubeconfigFile;
   private List<String> namespaces;
   private final KubernetesCredentials credentials;
   private final List<String> requiredGroupMembership;

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/KubernetesUtilSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/KubernetesUtilSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class KubernetesUtilSpec extends Specification {
+  private static final String REGISTRY1 = 'gcr.io'
+  private static final String REGISTRY2 = 'localhost:5000'
+  private static final String REPOSITORY1 = 'ubuntu'
+  private static final String REPOSITORY2 = 'library/nginx'
+  private static final String TAG1 = '1.0'
+  private static final String TAG2 = 'mytag'
+
+  @Unroll
+  void "should correctly build an image description 1"() {
+    when:
+      def imageDescription = KubernetesUtil.buildImageDescription("$registry/$repository:$tag")
+
+    then:
+      imageDescription.registry == registry
+      imageDescription.repository == repository
+      imageDescription.tag == tag
+
+    where:
+      registry  | repository  | tag
+      REGISTRY1 | REPOSITORY1 | TAG1
+      REGISTRY1 | REPOSITORY1 | TAG2
+      REGISTRY1 | REPOSITORY2 | TAG1
+      REGISTRY1 | REPOSITORY2 | TAG2
+      REGISTRY2 | REPOSITORY1 | TAG1
+      REGISTRY2 | REPOSITORY1 | TAG2
+      REGISTRY2 | REPOSITORY2 | TAG1
+      REGISTRY2 | REPOSITORY2 | TAG2
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergro
 import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
@@ -110,16 +111,18 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
   KubernetesResourceDescription fullInvalidResourceDescription
 
   void setup() {
+    def imageDescription = KubernetesUtil.buildImageDescription(VALID_IMAGE)
+
     fullValidResourceDescription1 = new KubernetesResourceDescription(memory: VALID_MEMORY1, cpu: VALID_CPU1)
     fullValidResourceDescription2 = new KubernetesResourceDescription(memory: VALID_MEMORY2, cpu: VALID_CPU2)
     partialValidResourceDescription = new KubernetesResourceDescription(memory: VALID_MEMORY1)
-    fullValidContainerDescription1 = new KubernetesContainerDescription(name: VALID_NAME, image: VALID_IMAGE, limits: fullValidResourceDescription1, requests: fullValidResourceDescription1)
-    fullValidContainerDescription2 = new KubernetesContainerDescription(name: VALID_NAME, image: VALID_IMAGE, limits: fullValidResourceDescription2, requests: fullValidResourceDescription2)
-    partialValidContainerDescription = new KubernetesContainerDescription(name: VALID_NAME, image: VALID_IMAGE, limits: partialValidResourceDescription)
+    fullValidContainerDescription1 = new KubernetesContainerDescription(name: VALID_NAME, imageDescription: imageDescription, limits: fullValidResourceDescription1, requests: fullValidResourceDescription1)
+    fullValidContainerDescription2 = new KubernetesContainerDescription(name: VALID_NAME, imageDescription: imageDescription, limits: fullValidResourceDescription2, requests: fullValidResourceDescription2)
+    partialValidContainerDescription = new KubernetesContainerDescription(name: VALID_NAME, imageDescription: imageDescription, limits: partialValidResourceDescription)
 
     fullInvalidResourceDescription = new KubernetesResourceDescription(memory: INVALID_MEMORY, cpu: INVALID_CPU)
-    fullInvalidContainerDescription = new KubernetesContainerDescription(name: INVALID_NAME, image: INVALID_IMAGE, limits: fullInvalidResourceDescription, requests: fullInvalidResourceDescription)
-    partialInvalidContainerDescription = new KubernetesContainerDescription(name: INVALID_NAME, image: INVALID_IMAGE)
+    fullInvalidContainerDescription = new KubernetesContainerDescription(name: INVALID_NAME, limits: fullInvalidResourceDescription, requests: fullInvalidResourceDescription)
+    partialInvalidContainerDescription = new KubernetesContainerDescription(name: INVALID_NAME)
   }
 
   void "validation accept (all fields filled)"() {
@@ -283,7 +286,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
       validator.validate([], description, errorsMock)
     then:
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].name", "${DESCRIPTION}.container[0].name.invalid (Must match ${StandardKubernetesAttributeValidator.namePattern})")
-      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].image", "${DESCRIPTION}.container[0].image.empty")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].imageDescription", "${DESCRIPTION}.container[0].imageDescription.empty")
       0 * errorsMock._
   }
 
@@ -302,7 +305,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
       validator.validate([], description, errorsMock)
     then:
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].name", "${DESCRIPTION}.container[0].name.invalid (Must match ${StandardKubernetesAttributeValidator.namePattern})")
-      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].image", "${DESCRIPTION}.container[0].image.empty")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].imageDescription", "${DESCRIPTION}.container[0].imageDescription.empty")
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].requests.memory", "${DESCRIPTION}.container[0].requests.memory.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].limits.memory", "${DESCRIPTION}.container[0].limits.memory.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].requests.cpu", "${DESCRIPTION}.container[0].requests.cpu.invalid (Must match ${StandardKubernetesAttributeValidator.quantityPattern})")


### PR DESCRIPTION
The purpose of this is to always display the registry an image came from in Deck.

@duftler 