### PR TITLE
provider/kubernetes: Correctly assign load balancer type

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationDescription.groovy
@@ -33,7 +33,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationDescription extends KubernetesA
   String loadBalancerIp
   String sessionAffinity
 
-  String type
+  String serviceType
 }
 
 @AutoClone

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
@@ -105,7 +105,7 @@ class UpsertKubernetesLoadBalancerAtomicOperation implements AtomicOperation<Map
 
     task.updateStatus BASE_PHASE, "Setting type..."
 
-    def type = description.type != null ? description.type : existingService?.spec?.type
+    def type = description.serviceType != null ? description.serviceType : existingService?.spec?.type
     serviceBuilder = type ? serviceBuilder.withType(type) : serviceBuilder
 
     task.updateStatus BASE_PHASE, "Setting load balancer IP..."

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
@@ -27,7 +27,7 @@ class StandardKubernetesAttributeValidator {
   static final prefixPattern = /^[a-z0-9]+$/
   static final quantityPattern = /^([+-]?[0-9.]+)([eEimkKMGTP]*[-+]?[0-9]*)$/
   static final protocolList = ['TCP', 'UDP']
-  static final serviceTypeList = ['ClusterIp', 'NodePort', 'LoadBalancer']
+  static final serviceTypeList = ['ClusterIP', 'NodePort', 'LoadBalancer']
   static final sessionAffinityList = ['None', 'ClientIP']
   static final maxPort = (1 << 16) - 1
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
@@ -64,6 +64,6 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidator extends DescriptionVa
 
     helper.validateSessionAffinity(description.sessionAffinity, "sessionAffinity")
 
-    helper.validateServiceType(description.type, "type")
+    helper.validateServiceType(description.serviceType, "serviceType")
   }
 }


### PR DESCRIPTION
Turns out `type` was already a field in use by Orca.