### PR TITLE
Define new useAmiBlockDeviceMappings attribute on BasicAmazonDeployDe…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolver.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolver.groovy
@@ -25,7 +25,7 @@ class AmiIdResolver {
     }
     Image resolvedImage = amazonEC2.describeImages(req)?.images?.getAt(0)
     if (resolvedImage) {
-      return new ResolvedAmiResult(nameOrId, region, resolvedImage.imageId, resolvedImage.virtualizationType)
+      return new ResolvedAmiResult(nameOrId, region, resolvedImage.imageId, resolvedImage.virtualizationType, resolvedImage.blockDeviceMappings)
     }
 
     return null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ResolvedAmiResult.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ResolvedAmiResult.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy
 
+import com.amazonaws.services.ec2.model.BlockDeviceMapping
 import groovy.transform.Immutable
 
 /**
@@ -27,4 +28,5 @@ class ResolvedAmiResult {
   String region
   String amiId
   String virtualizationType
+  List<BlockDeviceMapping> blockDeviceMappings
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -52,6 +52,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   boolean startDisabled
 
   List<AmazonBlockDevice> blockDevices
+  Boolean useAmiBlockDeviceMappings
   List<String> loadBalancers
   List<String> securityGroups
   Map<String, List<String>> availabilityZones = [:]

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -134,6 +134,10 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         throw new IllegalArgumentException("Unsupported account type ${account.class.simpleName} for this operation")
       }
 
+      if (description.useAmiBlockDeviceMappings) {
+        description.blockDevices = convertBlockDevices(ami.blockDeviceMappings)
+      }
+
       def autoScalingWorker = new AutoScalingWorker(
         application: description.application,
         region: region,


### PR DESCRIPTION
…scription.

If set, the AMI block device mappings are used for the newly-provisioned server group.