### PR TITLE
Initial migration to Azure SDK for Java 1.0.

### DIFF
--- a/clouddriver-azure/clouddriver-azure.gradle
+++ b/clouddriver-azure/clouddriver-azure.gradle
@@ -3,14 +3,11 @@ dependencies {
   compile spinnaker.dependency('frigga')
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
-  compile 'com.microsoft.azure:adal4j:1.1.1'
-  compile 'com.microsoft.azure:azure-mgmt-utility:0.9.0'
-  compile 'com.microsoft.azure:azure-mgmt-resources:0.9.0'
-  compile 'com.microsoft.azure:azure-core:0.9.0'
-  compile 'com.microsoft.azure:azure-mgmt-compute:0.9.0'
-  compile 'com.microsoft.azure:azure-svc-mgmt-storage:0.9.0'
-  compile 'com.microsoft.azure:azure-svc-mgmt-compute:0.9.0'
-  compile 'com.microsoft.azure:azure-svc-mgmt:0.9.0'
-  compile 'com.microsoft.azure:azure-mgmt-storage:0.9.0'
-  compile 'com.microsoft.azure:azure-svc-mgmt-network:0.9.0'
+  compile 'com.microsoft.azure:adal4j:1.1.2'
+  compile 'com.microsoft.azure:azure:1.0.0-beta1'
+  compile 'com.microsoft.azure:azure-mgmt-compute:1.0.0-beta1'
+  compile 'com.microsoft.azure:azure-mgmt-network:1.0.0-beta1'
+  compile 'com.microsoft.azure:azure-mgmt-storage:1.0.0-beta1'
+  compile 'com.microsoft.azure:azure-mgmt-resources:1.0.0-beta1'
+  compile 'com.microsoft.azure:azure-client-authentication:1.0.0-beta1'
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -16,23 +16,24 @@
 
 package com.netflix.spinnaker.clouddriver.azure.client
 
+import com.microsoft.azure.credentials.ApplicationTokenCredentials
 import com.microsoft.azure.management.compute.ComputeManagementClient
-import com.microsoft.azure.management.compute.ComputeManagementService
-import com.microsoft.azure.management.compute.models.VirtualMachineImageListOffersParameters
-import com.microsoft.azure.management.compute.models.VirtualMachineImageListParameters
-import com.microsoft.azure.management.compute.models.VirtualMachineImageListPublishersParameters
-import com.microsoft.azure.management.compute.models.VirtualMachineImageListSkusParameters
-import com.microsoft.azure.management.compute.models.VirtualMachineImageResource
+import com.microsoft.azure.management.compute.ComputeManagementClientImpl
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureVMImage
-import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
-import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import groovy.transform.CompileStatic
+import okhttp3.logging.HttpLoggingInterceptor
+
 
 @Slf4j
 @CompileStatic
 public class AzureComputeClient extends AzureBaseClient {
-  AzureComputeClient(String subscriptionId) {
+  private final ComputeManagementClient client
+
+  AzureComputeClient(String subscriptionId, ApplicationTokenCredentials credentials) {
     super(subscriptionId)
+    this.client = this.initialize(credentials)
+
   }
 
   /**
@@ -40,41 +41,33 @@ public class AzureComputeClient extends AzureBaseClient {
    * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @return an instance of the Azure ComputeManagementClient
    */
-  protected ComputeManagementClient getComputeClient(AzureCredentials creds) {
-    ComputeManagementService.create(this.buildConfiguration(creds))
+  private ComputeManagementClient initialize(ApplicationTokenCredentials tokenCredentials) {
+    ComputeManagementClient computeClient = new ComputeManagementClientImpl(tokenCredentials)
+    computeClient.setSubscriptionId(this.subscriptionId)
+    computeClient.setLogLevel(HttpLoggingInterceptor.Level.NONE)
+    computeClient
   }
 
-  List<AzureVMImage> getVMImagesAll(AzureCredentials creds, String location){
+  /**
+   * Return list of available VM images
+   * @param location - filter for images to given location
+   * @return List of AzureVMImages
+   */
+  List<AzureVMImage> getVMImagesAll(String location){
     def result = [] as List<AzureVMImage>
 
     try {
-      ComputeManagementClient computeManagementClient = getComputeClient(creds)
-      VirtualMachineImageListPublishersParameters paramsPublishers = new VirtualMachineImageListPublishersParameters()
-      paramsPublishers.location = location
-      def vmImagesOps = computeManagementClient.getVirtualMachineImagesOperations()
-      def listPublishers = vmImagesOps.listPublishers(paramsPublishers)?.resources
-      listPublishers.each { VirtualMachineImageResource itemVMPublisher ->
-        def paramsOffers = new VirtualMachineImageListOffersParameters(itemVMPublisher.name, location)
-
-        def listOffers = vmImagesOps.listOffers(paramsOffers)?.resources
-        listOffers.each {itemVMOffers ->
-          def paramsSkus = new VirtualMachineImageListSkusParameters(itemVMOffers.name, itemVMPublisher.name, location)
-
-          def listSkus = vmImagesOps.listSkus(paramsSkus)?.resources
-          listSkus.each { itemVMSku ->
-            def params = new VirtualMachineImageListParameters()
-            params.location = location
-            params.publisherName = itemVMPublisher.name
-            params.offer = itemVMOffers.name
-            params.skus = itemVMSku.name
-
-            def listVersions = vmImagesOps.list(params)?.resources
-            listVersions.each { itemVMImage ->
-              result += new AzureVMImage(
-                publisher: itemVMPublisher.name,
-                offer: itemVMOffers.name,
-                sku: itemVMSku.name,
-                version: itemVMImage.name)
+      def vmImagesOps = client.getVirtualMachineImagesOperations()
+      vmImagesOps?.listPublishers(location)?.body?.each { itemVMPublisher ->
+        vmImagesOps?.listOffers(location, itemVMPublisher.name)?.body?.each { itemVMOffers ->
+          vmImagesOps?.listSkus(location, itemVMPublisher.name, itemVMOffers.name)?.body?.each { itemVMSku ->
+            vmImagesOps?.list(location, itemVMPublisher.name, itemVMOffers.name,
+              itemVMSku.name, null, 100, "")?.body?.each { itemVMImage ->
+                result += new AzureVMImage(
+                  publisher: itemVMPublisher.name,
+                  offer: itemVMOffers.name,
+                  sku: itemVMSku.name,
+                  version: itemVMImage.name)
             }
           }
         }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -16,59 +16,72 @@
 
 package com.netflix.spinnaker.clouddriver.azure.client
 
+import com.microsoft.azure.CloudException
+import com.microsoft.azure.credentials.ApplicationTokenCredentials
+import com.microsoft.azure.management.network.NetworkManagementClient
+import com.microsoft.azure.management.network.NetworkManagementClientImpl
 import com.microsoft.azure.management.network.models.AddressSpace
+import com.microsoft.azure.management.network.models.DhcpOptions
 import com.microsoft.azure.management.network.models.LoadBalancer
 import com.microsoft.azure.management.network.models.NetworkSecurityGroup
-import com.microsoft.azure.management.network.models.PublicIpAddress
+import com.microsoft.azure.management.network.models.PublicIPAddress
 import com.microsoft.azure.management.network.models.Subnet
 import com.microsoft.azure.management.network.models.VirtualNetwork
-import com.microsoft.azure.management.network.NetworkResourceProviderClient
-import com.microsoft.azure.management.network.NetworkResourceProviderService
-import com.microsoft.windowsazure.core.OperationResponse
-import com.microsoft.windowsazure.exception.ServiceException
+
+import com.microsoft.rest.ServiceResponse
+
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.network.model.AzureVirtualNetworkDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.model.AzureSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.subnet.model.AzureSubnetDescription
-import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import okhttp3.logging.HttpLoggingInterceptor
 
 @Slf4j
 @CompileStatic
 class AzureNetworkClient extends AzureBaseClient {
-  AzureNetworkClient(String subscriptionId) {
+
+  private final NetworkManagementClient client
+
+  AzureNetworkClient(String subscriptionId, ApplicationTokenCredentials credentials) {
     super(subscriptionId)
+    this.client = initializeClient(credentials)
   }
 
   /**
    * Retrieve a collection of all load balancer for a give set of credentials and the location
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param region the location of the virtual network
    * @return a Collection of objects which represent a Load Balancer in Azure
    */
-  Collection<AzureLoadBalancerDescription> getLoadBalancersAll(AzureCredentials creds, String region) {
+  Collection<AzureLoadBalancerDescription> getLoadBalancersAll(String region) {
     def result = new ArrayList<AzureLoadBalancerDescription>()
 
     try {
-      def loadBalancers = this.getNetworkResourceProviderClient(creds).getLoadBalancersOperations().listAll().getLoadBalancers()
+      def loadBalancers = this.client.getLoadBalancersOperations().listAll().body
       def currentTime = System.currentTimeMillis()
       loadBalancers.each {item ->
         if (item.location == region) {
-          def lbItem = getDescriptionForLoadBalancer(item)
-          lbItem.appName = AzureUtilities.getAppNameFromResourceId(item.id)
-          lbItem.tags = item.tags
-          lbItem.dnsName = getDnsNameForLoadBalancer(creds, AzureUtilities.getResourceGroupNameFromResourceId(item.id), item.name)
+          try {
+            def lbItem = getDescriptionForLoadBalancer(item)
+            lbItem.appName = AzureUtilities.getAppNameFromResourceId(item.id)
+            lbItem.tags = item.tags
+            lbItem.dnsName = getDnsNameForLoadBalancer(AzureUtilities.getResourceGroupNameFromResourceId(item.id), item.name)
 
-          // TODO: investigate and add code to handle changes to publicIP resource associate with current load balancer
-          // There's a small probability that the publicIP resources associated with the current load balancer has changed
-          //  from the time we read the load balancer current properties at the beginning of the current closure/loop
-          //  and we should reflect that in the lastReadTime property.
-          // We currently don't use any of the publicIp properties other than the DNS so we don't need to address that now
+            // TODO: investigate and add code to handle changes to publicIP resource associate with current load balancer
+            // There's a small probability that the publicIP resources associated with the current load balancer has changed
+            //  from the time we read the load balancer current properties at the beginning of the current closure/loop
+            //  and we should reflect that in the lastReadTime property.
+            // We currently don't use any of the publicIp properties other than the DNS so we don't need to address that now
 
-          lbItem.lastReadTime = currentTime
-          result += lbItem
+            lbItem.lastReadTime = currentTime
+            result += lbItem
+          } catch (RuntimeException re) {
+            // if we get a runtime exception here, log it but keep processing the rest of the
+            // load balancers
+            log.error("Unable to process load balancer ${item.name}: ${re.message}")
+          }
         }
       }
     } catch (Exception e) {
@@ -80,20 +93,19 @@ class AzureNetworkClient extends AzureBaseClient {
 
   /**
    * Retrieve an Azure load balancer for a give set of credentials, resource group and name
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param resourceGroupName the name of the resource group to look into
    * @param loadBalancerName the of the load balancer
    * @return a description object which represent a Load Balancer in Azure or null if Load Balancer could not be retrieved
    */
-  AzureLoadBalancerDescription getLoadBalancer(AzureCredentials creds, String resourceGroupName, String loadBalancerName) {
+  AzureLoadBalancerDescription getLoadBalancer(String resourceGroupName, String loadBalancerName) {
     try {
       def currentTime = System.currentTimeMillis()
-      def item = this.getNetworkResourceProviderClient(creds).getLoadBalancersOperations().get(resourceGroupName, loadBalancerName).loadBalancer
+      def item = this.client.getLoadBalancersOperations().get(resourceGroupName, loadBalancerName, null).body
       if (item) {
         def lbItem = getDescriptionForLoadBalancer(item)
         lbItem.appName = AzureUtilities.getAppNameFromResourceId(item.id)
         lbItem.tags = item.tags
-        lbItem.dnsName = getDnsNameForLoadBalancer(creds, AzureUtilities.getResourceGroupNameFromResourceId(item.id), item.name)
+        lbItem.dnsName = getDnsNameForLoadBalancer(AzureUtilities.getResourceGroupNameFromResourceId(item.id), item.name)
 
         // TODO: investigate and add code to handle changes to publicIP resource associate with current load balancer
         // There's a small probability that the publicIP resources associated with the current load balancer has changed
@@ -104,8 +116,8 @@ class AzureNetworkClient extends AzureBaseClient {
         lbItem.lastReadTime = currentTime
         return lbItem
       }
-    } catch (ServiceException e) {
-      log.error("getLoadBalancer(${resourceGroupName},${loadBalancerName}) -> Service Exception ", e)
+    } catch (CloudException e) {
+      log.error("getLoadBalancer(${resourceGroupName},${loadBalancerName}) -> Cloud Exception ", e)
     }
 
     null
@@ -113,8 +125,8 @@ class AzureNetworkClient extends AzureBaseClient {
 
   private static AzureLoadBalancerDescription getDescriptionForLoadBalancer(LoadBalancer azureLoadBalancer) {
     AzureLoadBalancerDescription description = new AzureLoadBalancerDescription(loadBalancerName: azureLoadBalancer.name)
-    description.stack = azureLoadBalancer.tags["stack"]
-    description.detail = azureLoadBalancer.tags["detail"]
+    description.stack = azureLoadBalancer.tags ? ["stack"] : ""
+    description.detail = azureLoadBalancer.tags ? ["detail"] : ""
     description.region = azureLoadBalancer.location
 
     for (def rule : azureLoadBalancer.loadBalancingRules) {
@@ -159,52 +171,61 @@ class AzureNetworkClient extends AzureBaseClient {
 
   /**
    * Delete a load balancer in Azure
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param resourceGroupName name of the resource group where the load balancer was created (see application name and region/location)
    * @param loadBalancerName name of the load balancer to delete
-   * @return an OperationResponse object
+   * @return a ServiceResponse object
    */
-  OperationResponse deleteLoadBalancer(AzureCredentials creds, String resourceGroupName, String loadBalancerName) {
-    def loadBalancer = getNetworkResourceProviderClient(creds).getLoadBalancersOperations().get(resourceGroupName, loadBalancerName).getLoadBalancer()
+  ServiceResponse deleteLoadBalancer(String resourceGroupName, String loadBalancerName) {
+    def loadBalancer = client.getLoadBalancersOperations().get(resourceGroupName, loadBalancerName, null).body
 
-    if (loadBalancer.frontendIpConfigurations.size() != 1) {
+    if (loadBalancer.frontendIPConfigurations.size() != 1) {
       throw new RuntimeException("Unexpected number of public IP addresses associated with the load balancer (should be only one)!")
     }
 
-    def publicIpAddressName = AzureUtilities.getResourceNameFromID(loadBalancer.frontendIpConfigurations.first().getPublicIpAddress().id)
-    this.getNetworkResourceProviderClient(creds).getLoadBalancersOperations().delete(resourceGroupName, loadBalancerName)
+    def publicIpAddressName = AzureUtilities.getResourceNameFromID(loadBalancer.frontendIPConfigurations.first().getPublicIPAddress().id)
+    client.getLoadBalancersOperations().delete(resourceGroupName, loadBalancerName)
 
-    this.getNetworkResourceProviderClient(creds).getPublicIpAddressesOperations().delete(resourceGroupName, publicIpAddressName)
+    client.getPublicIPAddressesOperations().delete(resourceGroupName, publicIpAddressName)
   }
 
   /**
    * Delete a network security group in Azure
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param resourceGroupName name of the resource group where the security group was created (see application name and region/location)
    * @param securityGroupName name of the Azure network security group to delete
    * @return an OperationResponse object
    */
-  OperationResponse deleteSecurityGroup(AzureCredentials creds, String resourceGroupName, String securityGroupName) {
-    this.getNetworkResourceProviderClient(creds).getNetworkSecurityGroupsOperations().delete(resourceGroupName, securityGroupName)
+  ServiceResponse deleteSecurityGroup(String resourceGroupName, String securityGroupName) {
+    client.getNetworkSecurityGroupsOperations().delete(resourceGroupName, securityGroupName)
   }
 
   /**
    * Create an Azure virtual network resource
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param resourceGroupName name of the resource group where the load balancer was created
    * @param virtualNetworkName name of the virtual network to create
    * @param region region to create the resource in
    */
-  void createVirtualNetwork(AzureCredentials creds, String resourceGroupName, String virtualNetworkName, String region, String addressPrefix = "10.0.0.0/16") {
+  void createVirtualNetwork(String resourceGroupName, String virtualNetworkName, String region, String addressPrefix = "10.0.0.0/16") {
     try {
+      List<Subnet> subnets = []
 
-      def virtualNetwork = new VirtualNetwork(region)
+      // Define address space
+      List<String> addressPrefixes = []
+      addressPrefixes.add(addressPrefix)
       AddressSpace addressSpace = new AddressSpace()
-      addressSpace.addressPrefixes.add(addressPrefix)
+      addressSpace.setAddressPrefixes(addressPrefixes)
+
+      // Define DHCP Options
+      DhcpOptions dhcpOptions = new DhcpOptions()
+      dhcpOptions.dnsServers = []
+
+      VirtualNetwork virtualNetwork = new VirtualNetwork()
+      virtualNetwork.setLocation(region)
+      virtualNetwork.setDhcpOptions(dhcpOptions)
+      virtualNetwork.setSubnets(subnets)
       virtualNetwork.setAddressSpace(addressSpace)
 
       //Create the virtual network for the resource group
-      this.getNetworkResourceProviderClient(creds).
+      client.
         getVirtualNetworksOperations().
         createOrUpdate(resourceGroupName, virtualNetworkName, virtualNetwork)
     }
@@ -213,36 +234,58 @@ class AzureNetworkClient extends AzureBaseClient {
     }
   }
 
-  void createSubnet(AzureCredentials creds, String resourceGroupName, String virtualNetworkName, String subnetName, String addressPrefix = '10.0.0.0/24') {
+  /**
+   * Create a new subnet in the virtual network specified
+   * @param resourceGroupName Resource Group in Azure where vNet and Subnet will exist
+   * @param virtualNetworkName Virtual Network to create the subnet in
+   * @param subnetName Name of subnet to create
+   * @param addressPrefix - Address Prefix to use for Subnet defaults to 10.0.0.0/24
+   * @throws RuntimeException Throws RuntimeException if operation response indicates failure
+   * @returns Resource ID of subnet created
+   */
+  String createSubnet(String resourceGroupName, String virtualNetworkName, String subnetName, String addressPrefix = '10.0.0.0/24') {
+    Subnet subnet = new Subnet()
+    subnet.setAddressPrefix(addressPrefix)
+
+    //This will throw an exception if the it fails. If it returns then the call was successful
+    //Log the error Let it bubble up to the caller to handle as they see fit
     try {
-      def subnet = new Subnet(addressPrefix)
-      this.getNetworkResourceProviderClient(creds).
-        getSubnetsOperations().
-        createOrUpdate(resourceGroupName, virtualNetworkName, subnetName, subnet)
-      // TODO can we return the ID of the resulting subnet somehow?
-    }
-    catch (e) {
-      throw new RuntimeException("Unable to create subnet ${subnetName} in Resource Group ${resourceGroupName}", e)
+      def op = client
+        .getSubnetsOperations()
+        .createOrUpdate(resourceGroupName, virtualNetworkName, subnetName, subnet)
+
+      // Return the resource Id
+      op.body.id
+
+    } catch (Exception e) {
+      // Add something to the log to show that the subnet creation failed then rethrow the exception
+      log.error("Unable to create subnet ${subnetName} in Resource Group ${resourceGroupName}")
+      throw e
     }
   }
 
   /**
    * Retrieve a collection of all network security groups for a give set of credentials and the location
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param region the location of the network security group
    * @return a Collection of objects which represent a Network Security Group in Azure
    */
-  Collection<AzureSecurityGroupDescription> getNetworkSecurityGroupsAll(AzureCredentials creds, String region) {
+  Collection<AzureSecurityGroupDescription> getNetworkSecurityGroupsAll(String region) {
     def result = new ArrayList<AzureSecurityGroupDescription>()
 
     try {
-      def securityGroups = this.getNetworkResourceProviderClient(creds).getNetworkSecurityGroupsOperations().listAll().networkSecurityGroups
+      def securityGroups = this.client.getNetworkSecurityGroupsOperations().listAll().body
       def currentTime = System.currentTimeMillis()
       securityGroups.each { item ->
         if (item.location == region) {
-          def sgItem = getAzureSecurityGroupDescription(item)
-          sgItem.lastReadTime = currentTime
-          result += sgItem
+          try {
+            def sgItem = getAzureSecurityGroupDescription(item)
+            sgItem.lastReadTime = currentTime
+            result += sgItem
+          } catch (RuntimeException re) {
+            // if we get a runtime exception here, log it but keep processing the rest of the
+            // NSGs
+            log.error("Unable to process network security group ${item.name}: ${re.message}")
+          }
         }
       }
     } catch (Exception e) {
@@ -254,14 +297,13 @@ class AzureNetworkClient extends AzureBaseClient {
 
   /**
    * Retrieve an Azure network security group for a give set of credentials, resource group and network security group name
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param resourceGroupName name of the resource group where the security group was created (see application name and region/location)
    * @param securityGroupName name of the Azure network security group to be retrieved
    * @return a description object which represent a Network Security Group in Azure
    */
-  AzureSecurityGroupDescription getNetworkSecurityGroup(AzureCredentials creds, String resourceGroupName, String securityGroupName) {
+  AzureSecurityGroupDescription getNetworkSecurityGroup(String resourceGroupName, String securityGroupName) {
     try {
-      def securityGroup = this.getNetworkResourceProviderClient(creds).getNetworkSecurityGroupsOperations().get(resourceGroupName, securityGroupName).networkSecurityGroup
+      def securityGroup = this.client.getNetworkSecurityGroupsOperations().get(resourceGroupName, securityGroupName, null).body
       def currentTime = System.currentTimeMillis()
       def sgItem = getAzureSecurityGroupDescription(securityGroup)
       sgItem.lastReadTime = currentTime
@@ -328,7 +370,7 @@ class AzureNetworkClient extends AzureBaseClient {
       subnetItem.resourceId = itemSubnet.id
       subnetItem.id = itemSubnet.name
       subnetItem.addressPrefix = itemSubnet.addressPrefix
-      itemSubnet.ipConfigurations.each {resourceId -> subnetItem.ipConfigurations += resourceId.id}
+      itemSubnet.ipConfigurations?.each {resourceId -> subnetItem.ipConfigurations += resourceId.id}
       subnetItem.networkSecurityGroup = itemSubnet.networkSecurityGroup?.id
       subnetItem.routeTable = itemSubnet.routeTable?.id
       subnetItem.lastReadTime = currentTime
@@ -340,106 +382,70 @@ class AzureNetworkClient extends AzureBaseClient {
 
   /**
    * Retrieve a collection of all subnets for a give set of credentials and the location
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param region the location of the virtual network
    * @return a Collection of objects which represent a Subnet in Azure
    */
-  Collection<AzureSubnetDescription> getSubnetsInRegion(AzureCredentials creds, String region) {
+  Collection<AzureSubnetDescription> getSubnetsInRegion(String region) {
     def result = new ArrayList<AzureSubnetDescription>()
 
     try {
-      def vnets = this.getNetworkResourceProviderClient(creds).getVirtualNetworksOperations().listAll().virtualNetworks
+      def vnets = this.client.getVirtualNetworksOperations().listAll().body
       def currentTime = System.currentTimeMillis()
       vnets.each { item->
         if (item.location == region) {
-          getSubnetForVirtualNetwork(item).each { AzureSubnetDescription subnet ->
-            subnet.lastReadTime = currentTime
-            result += subnet
+          try {
+            getSubnetForVirtualNetwork(item).each { AzureSubnetDescription subnet ->
+              subnet.lastReadTime = currentTime
+              result += subnet
+            }
+          } catch (RuntimeException re) {
+            // if we get a runtime exception here, log it but keep processing the rest of the
+            // subnets
+            log.error("Unable to process subnets for virtual network ${item.name}", re)
           }
         }
       }
     } catch (Exception e) {
       log.error("getSubnetsAll -> Unexpected exception ", e)
     }
-
     result
-  }
-
-  /**
-   * Retrieve a collection of all subnets for a give set of credentials, regardless of region, optionally
-   * filtered for a given resource group
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
-   * @param resourceGroupName specify the resource group that is used to filter subnets; only
-   * @return a Collection of objects which represent a Subnet in Azure
-   */
-  Collection<AzureSubnetDescription> getSubnetsInResourceGroup(AzureCredentials creds, String resourceGroupName) {
-
-    def result = new ArrayList<AzureSubnetDescription>()
-
-    try {
-      List<VirtualNetwork> vnetList
-
-      if (resourceGroupName && !resourceGroupName.isEmpty()) {
-        vnetList = this.getNetworkResourceProviderClient(creds).getVirtualNetworksOperations().list(resourceGroupName).virtualNetworks
-      } else {
-        vnetList = this.getNetworkResourceProviderClient(creds).getVirtualNetworksOperations().listAll().virtualNetworks
-      }
-      def currentTime = System.currentTimeMillis()
-      vnetList.each { item->
-        getSubnetForVirtualNetwork(item).each { AzureSubnetDescription subnet ->
-          subnet.lastReadTime = currentTime
-          result += subnet
-        }
-      }
-    } catch (Exception e) {
-      log.error("getSubnetsAll -> Unexpected exception ", e)
-    }
-
-    result
-  }
-
-  /**
-   * Retrieves a particular subnet from a given resource group based on its name
-   * @param creds
-   * @param resourceGroupName
-   * @param subnetName
-   * @return an AzureSubnetDescription instance containing the details of the given subnet
-   */
-  AzureSubnetDescription getSubnet(AzureCredentials creds, String resourceGroupName, String subnetName) {
-    getSubnetsInResourceGroup(creds, resourceGroupName).find {it.name == subnetName}
   }
 
   /**
    * Gets a virtual network object instance by name, or null if the virtual network does not exist
-   * @param creds the credentials to use when communicating with Azure subscription(s)
    * @param resourceGroupName name of the resource group to look in for a virtual network
    * @param virtualNetworkName name of the virtual network to get
    * @return virtual network instance, or null if it does not exist
    */
-  VirtualNetwork getVirtualNetwork(AzureCredentials creds, String resourceGroupName, String virtualNetworkName) {
-    this.getNetworkResourceProviderClient(creds).
-      getVirtualNetworksOperations().
-      get(resourceGroupName, virtualNetworkName).
-      getVirtualNetwork()
+  VirtualNetwork getVirtualNetwork(String resourceGroupName, String virtualNetworkName) {
+    client
+      .getVirtualNetworksOperations()
+      .get(resourceGroupName, virtualNetworkName, null)
+      .body
   }
 
   /**
    * Retrieve a collection of all virtual networks for a give set of credentials and the location
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param region the location of the virtual network
    * @return a Collection of objects which represent a Virtual Network in Azure
    */
-  Collection<AzureVirtualNetworkDescription> getVirtualNetworksAll(AzureCredentials creds, String region) {
+  Collection<AzureVirtualNetworkDescription> getVirtualNetworksAll(String region){
     def result = new ArrayList<AzureVirtualNetworkDescription>()
 
     try {
-      def vnetList = this.getNetworkResourceProviderClient(creds).getVirtualNetworksOperations().listAll().virtualNetworks
+      def vnetList = this.client.getVirtualNetworksOperations().listAll().body
       def currentTime = System.currentTimeMillis()
       vnetList.each { item ->
         if (item.location == region) {
-          def vnet = getAzureVirtualNetworkDescription(item)
-          vnet.lastReadTime = currentTime
-          result += vnet
+          try {
+            def vnet = getAzureVirtualNetworkDescription(item)
+            vnet.lastReadTime = currentTime
+            result += vnet
+          } catch (RuntimeException re) {
+            // if we get a runtime exception here, log it but keep processing the rest of the
+            // virtual networks
+            log.error("Unable to process virtual network ${item.name}", re)
+          }
         }
       }
     } catch (Exception e) {
@@ -472,23 +478,26 @@ class AzureNetworkClient extends AzureBaseClient {
 
   /**
    * get the dns name associated with a load balancer in Azure
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
    * @param resourceGroupName name of the resource group where the load balancer was created (see application name and region/location)
    * @param loadBalancerName the name of the load balancer in Azure
    * @return the dns name of the given load balancer
    */
-  String getDnsNameForLoadBalancer(AzureCredentials creds, String resourceGroupName, String loadBalancerName) {
+  String getDnsNameForLoadBalancer(String resourceGroupName, String loadBalancerName) {
     String dnsName = "none"
 
     try {
-      def loadBalancer = this.getNetworkResourceProviderClient(creds).getLoadBalancersOperations().get(resourceGroupName, loadBalancerName).getLoadBalancer()
-      if (loadBalancer.frontendIpConfigurations) {
-        if (loadBalancer.frontendIpConfigurations.size() != 1) {
+      def loadBalancer = client.getLoadBalancersOperations().get(resourceGroupName, loadBalancerName, null).body
+      if (loadBalancer.frontendIPConfigurations) {
+        if (loadBalancer.frontendIPConfigurations.size() != 1) {
           log.info("getDnsNameForLoadBalancer -> Unexpected number of public IP addresses associated with the load balancer (should be only one)!")
         }
 
-        def publicIpResource = loadBalancer.frontendIpConfigurations.first()?.getPublicIpAddress()?.id
-        PublicIpAddress publicIp = publicIpResource ? this.getNetworkResourceProviderClient(creds).getPublicIpAddressesOperations().get(resourceGroupName, AzureUtilities.getNameFromResourceId(publicIpResource))?.publicIpAddress : null
+        def publicIpResource = loadBalancer.frontendIPConfigurations.first()?.getPublicIPAddress()?.id
+        PublicIPAddress publicIp = publicIpResource ?
+          client
+            .getPublicIPAddressesOperations()
+            .get(resourceGroupName, AzureUtilities.getNameFromResourceId(publicIpResource), null)?.body
+          : null
         dnsName = publicIp ? publicIp.dnsSettings?.fqdn : "none"
       }
     } catch (Exception e) {
@@ -498,13 +507,11 @@ class AzureNetworkClient extends AzureBaseClient {
     dnsName
   }
 
-  /**
-   * get the NetworkResourceProviderClient which will be used for all interaction related to network resources in Azure
-   * @param creds the credentials to use when communicating to the Azure subscription(s)
-   * @return an instance of the Azure NetworkResourceProviderClient
-   */
-  protected NetworkResourceProviderClient getNetworkResourceProviderClient(AzureCredentials creds) {
-    NetworkResourceProviderService.create(this.buildConfiguration(creds))
+  private NetworkManagementClient initializeClient(ApplicationTokenCredentials tokenCredentials) {
+    NetworkManagementClient networkManagementClient = new NetworkManagementClientImpl(tokenCredentials)
+    networkManagementClient.setSubscriptionId(this.subscriptionId)
+    networkManagementClient.setLogLevel(HttpLoggingInterceptor.Level.NONE)
+    networkManagementClient
   }
 
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.azure.common
 
-import com.microsoft.windowsazure.core.utils.CollectionStringBuilder
 import com.netflix.spinnaker.clouddriver.azure.resources.common.AzureResourceOpsDescription
 
 import java.util.regex.Matcher
@@ -54,13 +53,6 @@ class AzureUtilities {
     description.appName + NAME_SEPARATOR + description.region
   }
 
-  static String getVirtualNetworkName(AzureResourceOpsDescription description) {
-    if (description == null) {
-      return null
-    }
-    VNET_NAME_PREFIX + getResourceGroupName(description)
-  }
-
   static String getVirtualNetworkName(String resourceGroupName) {
     if (resourceGroupName == null) {
       return null
@@ -82,18 +74,6 @@ class AzureUtilities {
       return null
     }
     appName + NAME_SEPARATOR + region.replace(' ', '').toLowerCase()
-  }
-
-  static String getResourceGroupLocation(AzureResourceOpsDescription description) {
-    if (description == null) {
-      return null
-    }
-    def resourceGroupName = getResourceGroupName(description)
-    if (resourceGroupName == null) {
-      return null
-    }
-
-    description.credentials.getResourceManagerClient().getResourceGroupLocation(resourceGroupName, description.getCredentials())
   }
 
   static String getResourceGroupNameFromResourceId(String resourceId) {
@@ -126,14 +106,6 @@ class AzureUtilities {
     }
 
     getResourceGroupNameFromResourceId(resourceId).split(NAME_SEPARATOR).first()
-  }
-
-  static String getLocationFromResourceGroupName(String resourceId) {
-    if (resourceId == null) {
-      return null
-    }
-
-    getResourceGroupNameFromResourceId(resourceId).split(NAME_SEPARATOR).last()
   }
 
   static String getNameFromResourceId(String resourceId) {
@@ -240,26 +212,5 @@ class AzureUtilities {
       throw new ArithmeticException("Overflow occurred getting next valid subnet after $subnetAddrPrefix within vnet $vnetAddrPrefix")
     }
     return resultPrefix
-  }
-
-  public static String getAzureRESTUrl(String subscriptionId, String baseUrl, String targetUrl, List<String> queryParameters) {
-    String url = baseUrl
-    // Trim '/' character from the end of baseUrl.
-    if (url && url.charAt(url.length() - 1) == (char) '/') {
-      url = url.substring(0, (url.length() - 1) + 0)
-    }
-    url += "/subscriptions/"
-    if (subscriptionId != null) {
-      url = url + URLEncoder.encode(subscriptionId, "UTF-8")
-    }
-    if (targetUrl && targetUrl.charAt(0) != (char) '/')
-      url += "/"
-    url += targetUrl
-    if (queryParameters && queryParameters.size() > 0) {
-      url = url + "?" + CollectionStringBuilder.join(queryParameters, "&")
-    }
-    url = url.replace(" ", "%20")
-
-    url
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/health/AzureHealthIndicator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/health/AzureHealthIndicator.groovy
@@ -68,7 +68,7 @@ class AzureHealthIndicator implements HealthIndicator {
       for (AzureNamedAccountCredentials accountCredentials in azureCredentialsSet) {
         try {
           // This verifies that the specified credentials are sufficient to access the referenced project.
-          accountCredentials.credentials.getResourceManagerClient().healthCheck(accountCredentials.getCredentials())
+          accountCredentials.credentials.resourceManagerClient.healthCheck()
         } catch (IOException e) {
           throw new AzureIOException(e)
         }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/cache/AzureLoadBalancerCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/cache/AzureLoadBalancerCachingAgent.groovy
@@ -131,7 +131,7 @@ class AzureLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, Acco
 
     try {
       updatedLoadBalancer = metricsSupport.readData {
-        creds.networkClient.getLoadBalancer(creds, resourceGroupName, loadBalancerName)
+        creds.networkClient.getLoadBalancer(resourceGroupName, loadBalancerName)
       }
     } catch (Exception e ) {
       log.error("handle->Unexpected exception", e)
@@ -170,8 +170,7 @@ class AzureLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, Acco
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
     def currentTime = System.currentTimeMillis()
-
-    buildCacheResult(providerCache, creds.networkClient.getLoadBalancersAll(creds, region), currentTime, null, null)
+    buildCacheResult(providerCache, creds.networkClient.getLoadBalancersAll(region), currentTime, null, null)
   }
 
   @WithWriteLock

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/DeleteAzureLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/DeleteAzureLoadBalancerAtomicOperation.groovy
@@ -52,9 +52,10 @@ class DeleteAzureLoadBalancerAtomicOperation implements AtomicOperation<Void> {
       try {
         String resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, region)
 
-        description.credentials.networkClient.deleteLoadBalancer(description.credentials,
-          resourceGroupName,
-          description.loadBalancerName)
+        description
+          .credentials
+          .networkClient
+          .deleteLoadBalancer(resourceGroupName, description.loadBalancerName)
 
         task.updateStatus(BASE_PHASE, "Deletion of Azure load balancer ${description.loadBalancerName} in ${region} has succeeded.")
       } catch (Exception e) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/cache/AzureNetworkCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/cache/AzureNetworkCachingAgent.groovy
@@ -83,7 +83,9 @@ class AzureNetworkCachingAgent implements CachingAgent, AccountAware {
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
 
-    def networks = creds.networkClient.getVirtualNetworksAll(creds, region)
+    def networks = creds
+      .networkClient
+      .getVirtualNetworksAll(region)
 
     List<CacheData> data = networks.collect() { AzureVirtualNetworkDescription network ->
       Map<String, Object> attributes = [network: network]

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
@@ -131,7 +131,7 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
 
     try {
       updatedSecurityGroup = metricsSupport.readData {
-        creds.networkClient.getNetworkSecurityGroup(creds, resourceGroupName, securityGroupName)
+        creds.networkClient.getNetworkSecurityGroup(resourceGroupName, securityGroupName)
       }
     } catch (Exception e ) {
       log.error("handle->Unexpected exception", e)
@@ -170,7 +170,7 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
     log.info("Describing items in ${agentType}")
     def currentTime = System.currentTimeMillis()
 
-    buildCacheResult(providerCache, creds.networkClient.getNetworkSecurityGroupsAll(creds, region), currentTime, null, null)
+    buildCacheResult(providerCache, creds.networkClient.getNetworkSecurityGroupsAll(region), currentTime, null, null)
   }
 
   @WithWriteLock
@@ -232,7 +232,6 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
         // Attempt to add entry into the OnDemand respective cache
         if (updateCache(providerCache, updatedSecurityGroup, "OnDemandUpdated")) {
           CacheData data = buildCacheData(updatedSecurityGroup)
-
           log.info("Caching 1 OnDemand updated item in ${agentType}")
           return new DefaultCacheResult([(Keys.Namespace.SECURITY_GROUPS.ns): [data]])
         } else {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/subnet/cache/AzureSubnetCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/subnet/cache/AzureSubnetCachingAgent.groovy
@@ -84,7 +84,9 @@ class AzureSubnetCachingAgent implements CachingAgent, AccountAware {
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
 
-    def subnets = creds.networkClient.getSubnetsInRegion(creds, region)
+    def subnets = creds
+      .networkClient
+      .getSubnetsInRegion(region)
 
     List<CacheData> data = subnets.collect() { AzureSubnetDescription subnet ->
       Map<String, Object> attributes = [ subnet: subnet]

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/cache/AzureVMImageCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/cache/AzureVMImageCachingAgent.groovy
@@ -83,7 +83,7 @@ class AzureVMImageCachingAgent implements CachingAgent, AccountAware {
   CacheResult loadData(ProviderCache providerCache) {
     log.info("Describing items in ${agentType}")
 
-    def vmImages = creds.getComputeClient().getVMImagesAll(creds, region)
+    def vmImages = creds.computeClient.getVMImagesAll(region)
 
     List<CacheData> data = vmImages.collect() { AzureVMImage vmImage ->
       Map<String, Object> attributes = [vmimage: vmImage]

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentials.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentials.groovy
@@ -16,71 +16,37 @@
 
 package com.netflix.spinnaker.clouddriver.azure.security
 
-import com.microsoft.aad.adal4j.AuthenticationResult
-import com.microsoft.azure.utility.AuthHelper
+import com.netflix.spinnaker.clouddriver.azure.client.AzureBaseClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureComputeClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureNetworkClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureResourceManagerClient
-import org.apache.log4j.Logger
-
-import java.util.concurrent.locks.Lock
-import java.util.concurrent.locks.ReentrantLock
 
 class AzureCredentials {
-  static final String MANAGEMENT_URL = "https://management.core.windows.net/"
-  static final String AAD_URL = "https://login.windows.net/"
-
-  AuthenticationResult authenticationResult
-  protected Lock cacheLock = new ReentrantLock()
 
   final String tenantId
   final String clientId
   final String appKey
   final String project
+  final String subscriptionId
 
   final AzureResourceManagerClient resourceManagerClient
   final AzureNetworkClient networkClient
   final AzureComputeClient computeClient
 
-  AzureCredentials(String tenantId, String clientId, String appKey,
-                   AzureResourceManagerClient resourceManagerClient,
-                   AzureNetworkClient networkClient,
-                   AzureComputeClient computeClient) {
+  AzureCredentials(String tenantId, String clientId, String appKey, String subscriptionId) {
     this.tenantId = tenantId
     this.clientId = clientId
     this.appKey = appKey
+    this.subscriptionId = subscriptionId
     this.project = "AzureProject"
-    this.resourceManagerClient = resourceManagerClient
-    this.networkClient = networkClient
-    this.computeClient = computeClient
 
-  }
+    resourceManagerClient = new AzureResourceManagerClient(this.subscriptionId,
+      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
 
-  String getAccessToken() {
-    try {
-      cacheLock.lock()
-      if (!authenticationResult || nearExpiry(authenticationResult)) {
-        try {
-          authenticationResult = AuthHelper.getAccessTokenFromServicePrincipalCredentials(
-            MANAGEMENT_URL,
-            AAD_URL,
-            this.tenantId,
-            this.clientId,
-            this.appKey)
-        } catch (Exception e) {
-          throw new RuntimeException("Failed to create AccessTokenFromServicePrincipalCredentials", e)
-        }
-      }
-    } finally {
-      cacheLock.unlock()
-    }
-    authenticationResult.accessToken
-  }
+    networkClient = new AzureNetworkClient(this.subscriptionId,
+      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
 
-  private static boolean nearExpiry(AuthenticationResult result) {
-    Calendar today = Calendar.getInstance()
-    today.add(Calendar.MINUTE, 5)
-    Date now = today.getTime()
-    !now.before(result.getExpiresOnDate())
+    computeClient = new AzureComputeClient(this.subscriptionId,
+      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureNamedAccountCredentials.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureNamedAccountCredentials.groovy
@@ -16,9 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.azure.security
 
-import com.netflix.spinnaker.clouddriver.azure.client.AzureComputeClient
-import com.netflix.spinnaker.clouddriver.azure.client.AzureNetworkClient
-import com.netflix.spinnaker.clouddriver.azure.client.AzureResourceManagerClient
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureVMImage
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import groovy.transform.CompileStatic
@@ -81,11 +78,8 @@ public class AzureNamedAccountCredentials implements AccountCredentials<AzureCre
   }
 
   private AzureCredentials buildCredentials() {
-    AzureResourceManagerClient rmClient = new AzureResourceManagerClient(this.subscriptionId)
-    AzureNetworkClient networkClient = new AzureNetworkClient(this.subscriptionId)
-    AzureComputeClient computeClient = new AzureComputeClient(this.subscriptionId)
 
-    return new AzureCredentials(this.tenantId, this.clientId, this.appKey, rmClient, networkClient, computeClient)
+    return new AzureCredentials(this.tenantId, this.clientId, this.appKey, this.subscriptionId)
   }
 
   private static List<AzureRegion> buildRegions(List<String> regions) {

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilitiesSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilitiesSpec.groovy
@@ -118,18 +118,4 @@ class AzureUtilitiesSpec extends Specification {
     '254.255.255.0/24'    | '254.255.255.0/24'
   }
 
-  def "Get Azure REST URL"() {
-    expect:
-    AzureUtilities.getAzureRESTUrl(subscriptionId, baseUrl, targetUrl, qParams) == url
-
-    where:
-    subscriptionId  | baseUrl                         | targetUrl                                                                              | qParams                    |  url
-    '12345'         | 'https://management.azure.com'  | 'resourceGroups/rg1/providers/Microsoft.Resources/deployments/deploy12345/operations'  | ['api-version=2015-11-01'] | 'https://management.azure.com/subscriptions/12345/resourceGroups/rg1/providers/Microsoft.Resources/deployments/deploy12345/operations?api-version=2015-11-01'
-    '12345'         | 'https://management.azure.com/' | '/resourceGroups/rg1/providers/Microsoft.Resources/deployments/deploy12345/operations' | ['api-version=2015-11-01'] | 'https://management.azure.com/subscriptions/12345/resourceGroups/rg1/providers/Microsoft.Resources/deployments/deploy12345/operations?api-version=2015-11-01'
-    '1'             | 'a.b.com'                       | '/c/d/e'                                                                               | ['1=1', '2=2']             | 'a.b.com/subscriptions/1/c/d/e?1=1&2=2'
-    '1'             | 'a.b.com'                       | '/c/d/e'                                                                               | []                         | 'a.b.com/subscriptions/1/c/d/e'
-    null            | 'a.b.com'                       | '/c/d/e'                                                                               | ['1=1', '2=2']             | 'a.b.com/subscriptions//c/d/e?1=1&2=2'
-    null            | 'a.b.com'                       | '/c/d/e'                                                                               | ['1 1', '2=2']             | 'a.b.com/subscriptions//c/d/e?1%201&2=2'
-    null            | null                            | null                                                                                   | null                       | 'null/subscriptions/null'
-  }
 }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/deploy/validators/UpsertAzureLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/deploy/validators/UpsertAzureLoadBalancerDescriptionValidatorSpec.groovy
@@ -36,6 +36,7 @@ class UpsertAzureLoadBalancerDescriptionValidatorSpec extends Specification {
   private static final ACCOUNT_CLIENTID = "azureclientid"
   private static final ACCOUNT_TENANTID = "azuretenantid1"
   private static final ACCOUNT_APPKEY = "azureappkey1"
+  private static final SUBSCRIPTION_ID = "azuresubscriptionid1"
   private static final APP_NAME = "azureapp1"
   private static final STACK = "st1"
   private static final DETAIL = "d1"
@@ -78,7 +79,7 @@ class UpsertAzureLoadBalancerDescriptionValidatorSpec extends Specification {
   UpsertAzureLoadBalancerDescriptionValidator validator
 
   void setupSpec() {
-    azureCredentials = new AzureCredentials(ACCOUNT_CLIENTID, ACCOUNT_TENANTID, ACCOUNT_APPKEY, null, null, null)
+    azureCredentials = new AzureCredentials(ACCOUNT_CLIENTID, ACCOUNT_TENANTID, ACCOUNT_APPKEY, SUBSCRIPTION_ID)
 
     def credentialsRepo = new MapBackedAccountCredentialsRepository()
     def credentials = Mock(AzureNamedAccountCredentials)


### PR DESCRIPTION
Migrate Clouddriver-azure to use the 1.0 version of the Azure SDK for Java.

The SDK introduces dependencies on the squareup.retrofit2:2.0.0-beta4, squareup.okhttp3:3.1.2, and fasterxml.jackson:2.7.0  libraries (we are forcing the dependency to 2.7.1 due to a known compatibility issue between the 2.7.0 version and earlier versions of the Spring framework)

@spinnaker/netflix-reviewers @duftler @ajordens  PTAL