### PR TITLE
provider/kubernetes: Reassign missing credentials field

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
@@ -179,11 +179,11 @@ class StandardKubernetesAttributeValidator {
   }
 
   def validateCredentials(String credentials, AccountCredentialsProvider accountCredentialsProvider) {
-    def result = validateNotEmpty(credentials, "credentials")
+    def result = validateNotEmpty(credentials, "account")
     if (result) {
       def kubernetesCredentials = accountCredentialsProvider.getCredentials(credentials)
       if (!(kubernetesCredentials?.credentials instanceof KubernetesCredentials)) {
-        errors.rejectValue("${context}.credentials",  "${context}.credentials.notFound")
+        errors.rejectValue("${context}.account",  "${context}.account.notFound")
         result = false
       }
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/ResizeKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/ResizeKubernetesAtomicOperationValidator.groovy
@@ -34,7 +34,7 @@ class ResizeKubernetesAtomicOperationValidator extends DescriptionValidator<Resi
 
   @Override
   void validate(List priorDescriptions, ResizeKubernetesAtomicOperationDescription description, Errors errors) {
-    def helper = new StandardKubernetesAttributeValidator("deployKubernetesAtomicOperationDescription", errors)
+    def helper = new StandardKubernetesAttributeValidator("resizeKubernetesAtomicOperationDescription", errors)
 
     if (!helper.validateCredentials(description.account, accountCredentialsProvider)) {
       return

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -36,6 +36,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
   String name
   String type = "kubernetes"
   String region
+  String namespace
   String account
   Long createdTime
   Integer replicas = 0
@@ -56,12 +57,14 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
   KubernetesServerGroup(String name, String namespace) {
     this.name = name
     this.region = namespace
+    this.namespace = namespace
   }
 
   KubernetesServerGroup(ReplicationController replicationController, Set<KubernetesInstance> instances, String account) {
     this.name = replicationController.metadata?.name
     this.account = account
     this.region = replicationController.metadata?.namespace
+    this.namespace = this.region
     this.createdTime = KubernetesModelUtil.translateTime(replicationController.metadata?.creationTimestamp)
     this.zones = [this.region] as Set
     this.instances = instances

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
@@ -212,13 +212,13 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
     when:
       validator.validateCredentials(null, accountCredentialsProvider)
     then:
-      1 * errorsMock.rejectValue("${DECORATOR}.credentials", "${DECORATOR}.credentials.empty")
+      1 * errorsMock.rejectValue("${DECORATOR}.account", "${DECORATOR}.account.empty")
       0 * errorsMock._
 
     when:
       validator.validateCredentials("", accountCredentialsProvider)
     then:
-      1 * errorsMock.rejectValue("${DECORATOR}.credentials", "${DECORATOR}.credentials.empty")
+      1 * errorsMock.rejectValue("${DECORATOR}.account", "${DECORATOR}.account.empty")
       0 * errorsMock._
   }
 
@@ -230,7 +230,7 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
     when:
       validator.validateCredentials("You-don't-know-me", accountCredentialsProvider)
     then:
-      1 * errorsMock.rejectValue("${DECORATOR}.credentials", "${DECORATOR}.credentials.notFound")
+      1 * errorsMock.rejectValue("${DECORATOR}.account", "${DECORATOR}.account.notFound")
       0 * errorsMock._
   }
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
@@ -175,7 +175,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
     when:
       validator.validate([], description, errorsMock)
     then:
-      1 * errorsMock.rejectValue("${DESCRIPTION}.credentials", "${DESCRIPTION}.credentials.empty")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.account", "${DESCRIPTION}.account.empty")
       0 * errorsMock._
   }
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
@@ -177,7 +177,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
     when:
       validator.validate([], description, errorsMock)
     then:
-      1 * errorsMock.rejectValue("${DESCRIPTION}.credentials", "${DESCRIPTION}.credentials.empty")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.account", "${DESCRIPTION}.account.empty")
       0 * errorsMock._
   }
 


### PR DESCRIPTION
When `.convert(input, ...)` is called multiple times on the same request, and `input` only provides `credentials`, and not the `account` field, the second call to `convert` will fail since the first call deletes `credentials`. This fixes that.

Also, I added a namespace field to the Kubernetes server group model to make it easier to lookup.

@duftler 