### PR TITLE
provider/docker: Replace empty repository list with _catalog results.

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
@@ -136,7 +136,7 @@ class DockerBearerTokenService {
     def tokenService = realmToService.get(realm)
 
     if (tokenService == null) {
-      def builder = new RestAdapter.Builder().setEndpoint(realm).setLogLevel(RestAdapter.LogLevel.FULL).build()
+      def builder = new RestAdapter.Builder().setEndpoint(realm).setLogLevel(RestAdapter.LogLevel.NONE).build()
       tokenService = builder.create(TokenService.class)
       realmToService[realm] = tokenService
     }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
@@ -66,14 +66,18 @@ class DockerRegistryImageLookupController {
 
     return images.collect({
       def credentials = (DockerRegistryNamedAccountCredentials) accountCredentialsProvider.getCredentials((String) it.attributes.account)
-      def parse = Keys.parse(it.id)
-      return [
-        repository: (String) parse.repository,
-        tag: (String) parse.tag,
-        account: it.attributes.account,
-        registry: credentials.registry,
-        digest: it.attributes.digest,
-      ]
+      if (!credentials) {
+        return [:]
+      } else {
+        def parse = Keys.parse(it.id)
+        return [
+            repository: (String) parse.repository,
+            tag       : (String) parse.tag,
+            account   : it.attributes.account,
+            registry  : credentials.registry,
+            digest    : it.attributes.digest,
+        ]
+      }
     })
   }
 

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/exception/DockerRegistryConfigException.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/exception/DockerRegistryConfigException.groovy
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client
+package com.netflix.spinnaker.clouddriver.docker.registry.exception
 
-import groovy.transform.ToString
+import groovy.transform.InheritConstructors
 
-@ToString(includeNames = true)
-class DockerRegistryTags {
-  String name
-  List<String> tags
-}
-
-@ToString(includeNames = true)
-class DockerRegistryCatalog {
-  List<String> repositories
-}
-
+@InheritConstructors
+class DockerRegistryConfigException extends RuntimeException {}

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
@@ -14,17 +14,24 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.docker.registry.security;
+package com.netflix.spinnaker.clouddriver.docker.registry.security
 
-import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryClient;
+import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryClient
 
 public class DockerRegistryCredentials {
   private final DockerRegistryClient client;
-  private final List<String> repositories;
+  private List<String> repositories;
+  private final boolean reloadRepositories;
 
   public DockerRegistryCredentials(DockerRegistryClient client, List<String> repositories) {
     this.client = client;
-    this.repositories = repositories;
+    if (!repositories) {
+      this.reloadRepositories = true
+      this.repositories = client.getCatalog()?.repositories;
+    } else {
+      this.reloadRepositories = false
+      this.repositories = repositories
+    }
   }
 
   public DockerRegistryClient getClient() {
@@ -32,6 +39,9 @@ public class DockerRegistryCredentials {
   }
 
   public List<String> getRepositories() {
-    return repositories;
+    if (reloadRepositories) {
+      repositories = client.getCatalog()?.repositories;
+    }
+    return repositories
   }
 }


### PR DESCRIPTION
@duftler 

Just for you, @tomaslin :wink: 

When a user omits the `repositories` field of a `dockerRegistry` config in `clouddriver.yml`, clouddriver will now try to populate the list of repositories by calling the `/_catalog` endpoint of the docker registry.