### PR TITLE
updates RedisCache to use hashing to eliminate writes

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactory.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactory.java
@@ -26,15 +26,17 @@ public class RedisNamedCacheFactory implements NamedCacheFactory {
     private final JedisSource jedisSource;
     private final ObjectMapper objectMapper;
     private final int maxMsetSize;
+    private final RedisCache.CacheMetrics cacheMetrics;
 
-    public RedisNamedCacheFactory(JedisSource jedisSource, ObjectMapper objectMapper, int maxMsetSize) {
+    public RedisNamedCacheFactory(JedisSource jedisSource, ObjectMapper objectMapper, int maxMsetSize, RedisCache.CacheMetrics cacheMetrics) {
         this.jedisSource = jedisSource;
         this.objectMapper = objectMapper;
         this.maxMsetSize = maxMsetSize;
+        this.cacheMetrics = cacheMetrics;
     }
 
     @Override
     public WriteableCache getCache(String name) {
-        return new RedisCache(name, jedisSource, objectMapper, maxMsetSize);
+        return new RedisCache(name, jedisSource, objectMapper, maxMsetSize, cacheMetrics);
     }
 }

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactorySpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactorySpec.groovy
@@ -44,7 +44,7 @@ class RedisNamedCacheFactorySpec extends Specification {
         }
 
         def mapper = new ObjectMapper();
-        factory = new RedisNamedCacheFactory(source, mapper, 2)
+        factory = new RedisNamedCacheFactory(source, mapper, 2, null)
     }
 
     def 'caches with the same name share content'() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.groovy
@@ -47,7 +47,7 @@ class RedisCacheConfig {
     JedisSource jedisSource,
     ObjectMapper objectMapper,
     @Value('${redis.maxMsetSize:250000}') int maxMsetSize) {
-    new RedisNamedCacheFactory(jedisSource, objectMapper, maxMsetSize)
+    new RedisNamedCacheFactory(jedisSource, objectMapper, maxMsetSize, null)
   }
 
   @Bean


### PR DESCRIPTION
I went with the approach of keeping the hashing logic all contained inside RedisCache - it has the advantage of being nicely behind the black box, but the disadvantage that a client of the cache can't take advantage of the hash info to figure out if it can avoid doing work.

This change is mostly backwards compatible with an older clouddriver running in parallel - the one edge case I could see is

1. new code caches something + computes the value
2. value changes, old code caches it and doesn't update the hashes
3. value changes back to original
4. new code runs and doesn't update the value because the hash matches

it seems pretty edge-casey but I would still delete the `*:hashes` keys after rolling this in 

@ajordens @duftler PTAL