### PR TITLE
Make docker registry integration great again

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -33,6 +33,7 @@ swagger:
     - .*kubernetes.*
     - .*instances.*
     - .*reports.*
+    - .*docker.*
 
 default:
   # legacyServerPort is a non-ssl listener, if ssl is enabled. -1 to disable


### PR DESCRIPTION
- change manifest endpoint to @HEAD from @GET
- allow configurable timeout for docker registry client calls
- add docker endpoint to swagger