### PR TITLE
Makes LoadBalancer interface use proper objects.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonLoadBalancer.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonLoadBalancer.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.model
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import groovy.transform.CompileStatic
 
 @CompileStatic
@@ -28,7 +29,7 @@ class AmazonLoadBalancer implements LoadBalancer {
   String name
   String region
   String vpcId
-  Set<Map<String, Object>> serverGroups = []
+  Set<LoadBalancerServerGroup> serverGroups = []
 
   private Map<String, Object> dynamicProperties = new HashMap<String, Object>()
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancer.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancer.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 
 class AzureLoadBalancer implements LoadBalancer {
 
@@ -27,7 +28,7 @@ class AzureLoadBalancer implements LoadBalancer {
   String region
   String vnet
   String type = AZURE_LOAD_BALANCER_TYPE
-  Set<Map<String, Object>> serverGroups = new HashSet<>()
+  Set<LoadBalancerServerGroup> serverGroups = new HashSet<>()
 
   private static final AZURE_LOAD_BALANCER_TYPE = "azure"
 

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/cache/CacheUtils.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/cache/CacheUtils.groovy
@@ -26,6 +26,8 @@ import com.netflix.spinnaker.clouddriver.cf.model.CloudFoundryLoadBalancer
 import com.netflix.spinnaker.clouddriver.cf.model.CloudFoundryServerGroup
 import com.netflix.spinnaker.clouddriver.cf.model.CloudFoundryService
 import com.netflix.spinnaker.clouddriver.cf.provider.ProviderUtils
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import org.cloudfoundry.client.lib.domain.CloudApplication
 import org.cloudfoundry.client.lib.domain.CloudDomain
 import org.cloudfoundry.client.lib.domain.CloudRoute
@@ -136,12 +138,18 @@ class CacheUtils {
     }
 
     serverGroup.nativeLoadBalancers.each {
-      it.serverGroups.add([
+      it.serverGroups.add(new LoadBalancerServerGroup(
           name      :        serverGroup.name,
           isDisabled:        serverGroup.isDisabled(),
-          instances :        serverGroup.instances,
-          detachedInstances: [] as Set
-      ])
+          detachedInstances: [] as Set,
+          instances :        serverGroup.instances.collect {
+            new LoadBalancerInstance(
+                id: it.name,
+                zone: it.zone,
+                health: it.health?.get(0)
+            )
+          },
+      ))
     }
 
     serverGroup

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryLoadBalancer.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryLoadBalancer.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.cf.model
 
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import org.cloudfoundry.client.lib.domain.CloudRoute
@@ -30,7 +31,7 @@ class CloudFoundryLoadBalancer implements LoadBalancer {
 
   String name
   String type = 'cf'
-  Set<Map<String, Object>> serverGroups = new HashSet<>()
+  Set<LoadBalancerServerGroup> serverGroups = new HashSet<>()
   String region
   String account
   CloudRoute nativeRoute

--- a/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/provider/view/CloudFoundryLoadBalancerProviderSpec.groovy
+++ b/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/provider/view/CloudFoundryLoadBalancerProviderSpec.groovy
@@ -116,7 +116,7 @@ class CloudFoundryLoadBalancerProviderSpec extends Specification {
 		loadBalancerByAppName[0].serverGroups[0].name == 'testapp-production-v001'
 		loadBalancerByAppName[0].serverGroups[0].isDisabled == true
 		loadBalancerByAppName[0].serverGroups[0].instances.size() == 1
-		loadBalancerByAppName[0].serverGroups[0].instances[0].name == 'testapp-production-v001(0)'
+		loadBalancerByAppName[0].serverGroups[0].instances[0].id == 'testapp-production-v001(0)'
 		loadBalancerByAppName[0].serverGroups[0].detachedInstances.size() == 0
 
 		1 * client.spaces >> {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancer.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancer.groovy
@@ -45,5 +45,5 @@ interface LoadBalancer {
    * @return set of names or an empty set if none exist
    */
   @Empty
-  Set<Map<String, Object>> getServerGroups()
+  Set<LoadBalancerServerGroup> getServerGroups()
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerInstance.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerInstance.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+import groovy.transform.Canonical
+
+@Canonical
+class LoadBalancerInstance {
+  String id
+  String zone
+  Map<String, String> health
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerServerGroup.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerServerGroup.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+import groovy.transform.Canonical
+
+@Canonical
+class LoadBalancerServerGroup {
+  String name
+  Boolean isDisabled
+  Set<String> detachedInstances
+  Set<LoadBalancerInstance> instances
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancer.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancer.groovy
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 
 @Deprecated
 class GoogleLoadBalancer implements LoadBalancer {
@@ -30,7 +31,7 @@ class GoogleLoadBalancer implements LoadBalancer {
   String account
   String name
   String region
-  Set<Map<String, Object>> serverGroups = new HashSet<>()
+  Set<LoadBalancerServerGroup> serverGroups = new HashSet<>()
 
   Long createdTime
   String ipAddress

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleResourceRetriever.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleResourceRetriever.groovy
@@ -35,6 +35,8 @@ import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleSecurityGroupProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.apache.log4j.Logger
 import org.springframework.beans.factory.annotation.Autowired
@@ -274,24 +276,22 @@ class GoogleResourceRetriever {
                                description: "Unable to determine load balancer health."
                              ]
 
-                instances << [
+                instances << new LoadBalancerInstance(
                   id    : instance.name,
                   zone  : Utils.getLocalName(instance.getZone()),
                   health: health
-                ]
+                )
               } else {
                 detachedInstances << instance.name
               }
             }
 
-            def serverGroupSummary = [
-              name      :        serverGroup.name,
-              isDisabled:        serverGroup.isDisabled(),
-              instances :        instances,
-              detachedInstances: detachedInstances
-            ]
-
-            loadBalancer.serverGroups << serverGroupSummary
+            loadBalancer.serverGroups << new LoadBalancerServerGroup(
+                name      :        serverGroup.name,
+                isDisabled:        serverGroup.isDisabled(),
+                instances :        instances,
+                detachedInstances: detachedInstances
+            )
           }
         }
       }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleResourceRetrieverSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleResourceRetrieverSpec.groovy
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.clouddriver.google.model
 
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.model.HealthState
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -294,29 +296,29 @@ class GoogleResourceRetrieverSpec extends Specification {
             region: "us-central1",
             account: "some-account-name",
             serverGroups: [
-              [
+              new LoadBalancerServerGroup(
                 name: "roscoapp1-dev-v001",
                 isDisabled: false,
+                detachedInstances: ["roscoapp1-dev-v001-efgh"] as Set,
                 instances: [
-                  [
+                  new LoadBalancerInstance(
                     id: "roscoapp1-dev-v001-abcd",
                     zone: "us-central1-a",
                     health: [
                       state: "InService",
                       description: null
                     ]
-                  ],
-                  [
+                  ),
+                  new LoadBalancerInstance(
                     id: "roscoapp1-dev-v001-ijkl",
                     zone: "us-central1-a",
                     health: [
                       state: "InService",
                       description: null
                     ]
-                  ]
-                ] as Set,
-                detachedInstances: ["roscoapp1-dev-v001-efgh"] as Set
-              ]
+                  ),
+                ] as Set
+              )
             ],
             instanceNames: ["roscoapp1-dev-v001-abcd", "roscoapp1-dev-v001-ijkl"]
           ],

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstance.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstance.groovy
@@ -44,17 +44,18 @@ class KubernetesInstance implements Instance, Serializable {
     this.name = pod.metadata?.name
     this.launchTime = KubernetesModelUtil.translateTime(pod.status?.startTime)
     this.zone = pod.metadata?.namespace
-    this.health = []
     this.pod = pod
     this.yaml = SerializationUtils.dumpWithoutRuntimeStateAsYaml(pod)
-    pod.status?.containerStatuses?.forEach {
-      this.health << [name: it.name,
-                      state: convertContainerState(it.state).toString(),
-                      image: it.image,
-                      ready: it.ready.toString(),
-                      running: it.state?.running?.toString(),
-                      waiting: it.state?.waiting?.toString(),
-                      terminated: it.state?.terminated?.toString()]
+    this.health = pod.status?.containerStatuses?.collect {
+      [
+        name      : it.name,
+        state     : convertContainerState(it.state).toString(),
+        image     : it.image,
+        ready     : it.ready.toString(),
+        running   : it.state?.running?.toString(),
+        waiting   : it.state?.waiting?.toString(),
+        terminated: it.state?.terminated?.toString()
+      ]
     }
 
     def phase = pod.status?.phase


### PR DESCRIPTION
Replaces two maps with LoadBalancerServerGroup and LoadBalancerInstance POGOs across all providers.

Tested against GCE, K8S, and AWS. 

@duftler @lwander @gregturn @rguthriemsft @ajordens FYI