### PR TITLE
Allows a CustomScheduledAgent to indicate it should use the system schedule.

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/AgentIntervalProvider.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/AgentIntervalProvider.java
@@ -18,6 +18,9 @@ package com.netflix.spinnaker.cats.redis.cluster;
 
 import com.netflix.spinnaker.cats.agent.Agent;
 
+/**
+ * Provides a poll interval and timeout for an Agent.
+ */
 public interface AgentIntervalProvider {
     public static class Interval {
         final long interval;
@@ -28,10 +31,16 @@ public interface AgentIntervalProvider {
             this.timeout = timeout;
         }
 
+        /**
+         * @return how frequently the Agent should run in milliseconds
+         */
         public long getInterval() {
             return interval;
         }
 
+        /**
+         * @return the maximum amount of time in milliseconds for an Agent to complete its run before the run is rescheduled
+         */
         public long getTimeout() {
             return timeout;
         }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/DefaultAgentIntervalProvider.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/DefaultAgentIntervalProvider.java
@@ -35,4 +35,12 @@ public class DefaultAgentIntervalProvider implements AgentIntervalProvider {
     public Interval getInterval(Agent agent) {
         return new Interval(interval, timeout);
     }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.groovy
@@ -58,11 +58,18 @@ class AmazonInstanceTypeCachingAgent implements CachingAgent, CustomScheduledAge
     AUTHORITATIVE.forType(INSTANCE_TYPES.ns)
   ] as Set)
 
+  private static long getDefaultIfNonEdda(NetflixAmazonCredentials account, long defaultIfNonEdda) {
+    if (account.eddaEnabled) {
+      return -1
+    }
+    return defaultIfNonEdda
+  }
+
   AmazonInstanceTypeCachingAgent(AmazonCloudProvider amazonCloudProvider,
                                  AmazonClientProvider amazonClientProvider,
                                  NetflixAmazonCredentials account,
                                  String region) {
-    this(amazonCloudProvider, amazonClientProvider, account, region, DEFAULT_POLL_INTERVAL_MILLIS, DEFAULT_TIMEOUT_MILLIS)
+    this(amazonCloudProvider, amazonClientProvider, account, region, getDefaultIfNonEdda(account, DEFAULT_POLL_INTERVAL_MILLIS), getDefaultIfNonEdda(account, DEFAULT_TIMEOUT_MILLIS))
   }
 
   AmazonInstanceTypeCachingAgent(AmazonCloudProvider amazonCloudProvider,

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CustomSchedulableAgentIntervalProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CustomSchedulableAgentIntervalProvider.groovy
@@ -31,8 +31,14 @@ class CustomSchedulableAgentIntervalProvider extends DefaultAgentIntervalProvide
   @Override
   AgentIntervalProvider.Interval getInterval(Agent agent) {
     if (agent instanceof CustomScheduledAgent) {
-      return new AgentIntervalProvider.Interval(agent.pollIntervalMillis, agent.timeoutMillis)
+      return getCustomInterval(agent)
     }
     return super.getInterval(agent)
+  }
+
+  AgentIntervalProvider.Interval getCustomInterval(CustomScheduledAgent agent) {
+    final long pollInterval = agent.pollIntervalMillis == -1 ? super.interval : agent.pollIntervalMillis
+    final long timeoutMillis = agent.timeoutMillis == -1 ? super.timeout : agent.timeoutMillis
+    return new AgentIntervalProvider.Interval(pollInterval, timeoutMillis)
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CustomScheduledAgent.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CustomScheduledAgent.groovy
@@ -18,7 +18,17 @@ package com.netflix.spinnaker.clouddriver.cache
 
 import com.netflix.spinnaker.cats.agent.Agent
 
+/**
+ * Allows an Agent to customize it's poll interval.
+ */
 interface CustomScheduledAgent extends Agent {
+  /**
+   * @return the interval in milliseconds, or -1 to use the system default poll interval
+   */
   long getPollIntervalMillis()
+
+  /**
+   * @return the timeout in milliseconds, or -1 to use the system default timeout
+   */
   long getTimeoutMillis()
 }


### PR DESCRIPTION
Updates AmazonInstanceTypeCachingAgent to use the system schedule if the account is reading through an Edda cache.