### PR TITLE
Bug fix for Azure SDK deployment operations

### DIFF
--- a/clouddriver-azure/clouddriver-azure.gradle
+++ b/clouddriver-azure/clouddriver-azure.gradle
@@ -1,3 +1,7 @@
+repositories {
+  maven { url "http://adxsnapshots.azurewebsites.net" }
+}
+
 dependencies {
   compile project(":clouddriver-core")
   compile spinnaker.dependency('frigga')
@@ -11,4 +15,11 @@ dependencies {
   compile 'com.microsoft.azure:azure-mgmt-resources:1.0.0-beta1'
   compile 'com.microsoft.azure:azure-client-authentication:1.0.0-beta1'
   compile 'com.microsoft.azure:azure-storage:3.1.0'
+  compile 'com.microsoft.rest:client-runtime:1.0.0-20160309.002843-19'
 }
+
+configurations.all {
+  resolutionStrategy.force 'com.microsoft.rest:client-runtime:1.0.0-20160309.002843-19'
+}
+
+

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -12,6 +12,11 @@ tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
 configurations.all {
   exclude group: 'javax.servlet', module: 'servlet-api'
   exclude group: "org.slf4j", module: "slf4j-log4j12"
+  resolutionStrategy.force 'com.microsoft.rest:client-runtime:1.0.0-20160309.002843-19'
+}
+
+repositories {
+  maven { url "http://adxsnapshots.azurewebsites.net" }
 }
 
 dependencies {


### PR DESCRIPTION
Use specific version of Azure SDK client-runtime library from SNAPSHOT repo. This version contains fix for bug in template deployment operations.

This is a temporary solution until the bug fix is released as part of the upcoming beta2 release.