### PR TITLE
provider/kubernetes: Segregate probe by probe type

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -217,9 +217,22 @@ class KubernetesApiAdaptor {
     kubernetesProbe.periodSeconds = probe.periodSeconds ?: 0
     kubernetesProbe.initialDelaySeconds = probe.initialDelaySeconds ?: 0
     kubernetesProbe.handler = new KubernetesHandler()
-    kubernetesProbe.handler.execAction = fromExecAction(probe.exec)
-    kubernetesProbe.handler.tcpSocketAction = fromTcpSocketAction(probe.tcpSocket)
-    kubernetesProbe.handler.httpGetAction = fromHttpGetAction(probe.httpGet)
+
+    if (probe.exec) {
+      kubernetesProbe.handler.execAction = fromExecAction(probe.exec)
+      kubernetesProbe.handler.type = KubernetesHandlerType.EXEC
+    }
+
+    if (probe.tcpSocket) {
+      kubernetesProbe.handler.tcpSocketAction = fromTcpSocketAction(probe.tcpSocket)
+      kubernetesProbe.handler.type = KubernetesHandlerType.TCP
+    }
+
+    if (probe.httpGet) {
+      kubernetesProbe.handler.httpGetAction = fromHttpGetAction(probe.httpGet)
+      kubernetesProbe.handler.type = KubernetesHandlerType.HTTP
+    }
+
     return kubernetesProbe
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -76,9 +76,14 @@ class KubernetesProbe {
   int failureThreshold
 }
 
+enum KubernetesHandlerType {
+  EXEC, TCP, HTTP
+}
+
 @AutoClone
 @Canonical
 class KubernetesHandler {
+  KubernetesHandlerType type
   KubernetesExecAction execAction
   KubernetesHttpGetAction httpGetAction
   KubernetesTcpSocketAction tcpSocketAction

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/KubernetesContainerValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/KubernetesContainerValidator.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesHandlerType
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesProbe
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 
@@ -84,29 +85,23 @@ class KubernetesContainerValidator {
       helper.validatePositive(probe.failureThreshold, "${prefix}.failureThreshold")
     }
 
-    int handlers = 0;
-
     helper.validateNotEmpty(probe.handler, "${prefix}.handler")
+    helper.validateNotEmpty(probe.handler?.type, "${prefix}.handler.type")
 
-    if (probe.handler?.execAction) {
-      helper.validateNotEmpty(probe.handler.execAction.commands, "${prefix}.handler.execAction.commands")
-      handlers++
+    if (probe.handler?.type == KubernetesHandlerType.EXEC) {
+      helper.validateNotEmpty(probe.handler?.execAction?.commands, "${prefix}.handler.execAction.commands")
     }
 
-    if (probe.handler?.tcpSocketAction) {
-      helper.validatePort(probe.handler.tcpSocketAction.port, "${prefix}.handler.tcpSocketAction.port")
-      handlers++
+    if (probe.handler?.type == KubernetesHandlerType.TCP) {
+      helper.validatePort(probe.handler?.tcpSocketAction?.port, "${prefix}.handler.tcpSocketAction.port")
     }
 
-    if (probe.handler?.httpGetAction) {
-      helper.validatePort(probe.handler.httpGetAction.port, "${prefix}.handler.httpGetAction.port")
+    if (probe.handler?.type == KubernetesHandlerType.HTTP) {
+      helper.validatePort(probe.handler?.httpGetAction?.port, "${prefix}.handler.httpGetAction.port")
 
-      if (probe.handler.httpGetAction.uriScheme) {
-        helper.validateUriScheme(probe.handler.httpGetAction.uriScheme, "${prefix}.handler.httpGetAction.uriScheme")
+      if (probe.handler?.httpGetAction?.uriScheme) {
+        helper.validateUriScheme(probe.handler?.httpGetAction?.uriScheme, "${prefix}.handler.httpGetAction.uriScheme")
       }
-      handlers++
     }
-
-    helper.validatePositive(handlers, "${prefix}.handler.size")
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesHandler
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesHandlerType
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesProbe
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesResourceDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesTcpSocketAction
@@ -101,6 +102,7 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
     def livenessProbe = new KubernetesProbe([
       periodSeconds: PERIOD_SECONDS,
       handler: new KubernetesHandler([
+        type: KubernetesHandlerType.TCP,
         tcpSocketAction: new KubernetesTcpSocketAction([
           port: PORT
         ])

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
@@ -139,6 +139,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         successThreshold: POSITIVE_NUMBER,
         failureThreshold: POSITIVE_NUMBER,
         handler: new KubernetesHandler(
+            type: KubernetesHandlerType.HTTP,
             httpGetAction: fullValidHttpGetAction
         )
     )
@@ -180,6 +181,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
         successThreshold: NEGATIVE_NUMBER,
         failureThreshold: NEGATIVE_NUMBER,
         handler: new KubernetesHandler(
+            type: KubernetesHandlerType.HTTP,
             httpGetAction:  partialInvalidHttpGetAction
         )
     )
@@ -387,7 +389,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].livenessProbe.successThreshold", "${DESCRIPTION}.container[0].livenessProbe.successThreshold.notPositive")
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].livenessProbe.failureThreshold", "${DESCRIPTION}.container[0].livenessProbe.failureThreshold.notPositive")
       1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].livenessProbe.handler.httpGetAction.uriScheme", "${DESCRIPTION}.container[0].livenessProbe.handler.httpGetAction.uriScheme.invalid (Must be one of ${StandardKubernetesAttributeValidator.uriSchemeList})")
-      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].readinessProbe.handler.size", "${DESCRIPTION}.container[0].readinessProbe.handler.size.notPositive")
+      1 * errorsMock.rejectValue("${DESCRIPTION}.container[0].readinessProbe.handler.type", "${DESCRIPTION}.container[0].readinessProbe.handler.type.empty")
       0 * errorsMock._
   }
 


### PR DESCRIPTION
@duftler - this makes it easier to keep the data model between Deck and Clouddriver the same, since deck needs to keep track of which handler the user has submitted.