### PR TITLE
Fixes health check bug in new GCE Redis provider impl. Also fixes bug…

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance2.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance2.groovy
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.google.model
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter
-import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup2.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup2.groovy
@@ -34,9 +34,9 @@ class GoogleServerGroup2 {
   Set<String> zones = []
   Set<GoogleInstance2> instances = []
   Set health = []
-  Map<String, Object> launchConfig
-  Map<String, Object> asg
-  Set<String> securityGroups
+  Map<String, Object> launchConfig = [:]
+  Map<String, Object> asg = [:]
+  Set<String> securityGroups = []
   Map buildInfo
   Boolean disabled = false
   String networkName

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -148,7 +148,10 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster2.View> {
     if (instanceKeys) {
       serverGroup.instances = instanceProvider.getInstances(instanceKeys as List, securityGroups) as Set
       serverGroup.instances.each { GoogleInstance2 instance ->
-        instance.loadBalancerHealths = getLoadBalancerHealths(instance.name, loadBalancers)
+        def foundHealths = getLoadBalancerHealths(instance.name, loadBalancers)
+        if (foundHealths) {
+          instance.loadBalancerHealths = foundHealths
+        }
       }
     }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
@@ -109,8 +109,20 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance2.View> {
     def loadBalancerKeys = cacheData.relationships[LOAD_BALANCERS.ns]
     cacheView.getAll(LOAD_BALANCERS.ns, loadBalancerKeys).each { CacheData loadBalancerCacheData ->
       GoogleLoadBalancer2 loadBalancer = objectMapper.convertValue(loadBalancerCacheData.attributes, GoogleLoadBalancer2)
-      instance.loadBalancerHealths << loadBalancer.healths.findAll { GoogleLoadBalancerHealth health ->
+      def foundHealths = loadBalancer.healths.findAll { GoogleLoadBalancerHealth health ->
         health.instanceName == instance.name
+      }
+      if (foundHealths) {
+        // TODO(ttomsu): Instances attached to a load balancer without a health check will be marked as HEALTHY,
+        // but this ignores the platform health state (RUNNING, STARTING, STOPPING, etc). According to the docs,
+        // (https://cloud.google.com/compute/docs/load-balancing/health-checks#overview):
+        //   "Health checks ensure that Compute Engine forwards new connections only to instances that are up and ready
+        //   to receive them."
+        // This implies that the load balancer state should be UNHEALTHY in cases where the platform health state is
+        // not RUNNING.
+        //
+        // See com.netflix.spinnaker.clouddriver.google.provider.agent.GoogleLoadBalancerCachingAgent.TargetPoolInstanceHealthCallback.onSuccess
+        instance.loadBalancerHealths.addAll(foundHealths)
       }
     }
 
@@ -126,6 +138,4 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance2.View> {
     
     instance
   }
-
-
 }


### PR DESCRIPTION
… in instance provider.

This PR makes two concurrent GCE requests (TargetPoolInstanceHealth and HttpHealthCheck) become serial requests, because the target pool instance health must be coerced to `HEALTHY` in the case of a missing HttpHealthCheck. 

Additionally, in testing this, I found a bug in the instance provider where an empty list was being appended to the list of loadBalancerHealth checks.

@duftler @lwander PTAL.

tag: https://github.com/spinnaker/spinnaker/issues/712