### PR TITLE
Adds proper server group list to GCE load balancer's new provider impl.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -73,13 +73,9 @@ class Keys {
         ]
         break
       case Namespace.INSTANCES.ns:
-        def names = Names.parseName(parts[4])
         result << [
-            application: names.app,
             account    : parts[2],
-            serverGroup: parts[4],
-            namespace  : parts[3],
-            name       : parts[5]
+            name       : parts[3]
         ]
         break
       case Namespace.LOAD_BALANCERS.ns:

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancer2.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleLoadBalancer2.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.model.health.GoogleLoadBalancerHealth
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import groovy.transform.Canonical
 
 @Canonical
@@ -53,6 +54,6 @@ class GoogleLoadBalancer2 {
     String portRange = GoogleLoadBalancer2.this.portRange
     GoogleHealthCheck.View healthCheck = GoogleLoadBalancer2.this.healthCheck?.view
 
-    Set<Map<String, Object>> serverGroups = new HashSet<>()
+    Set<LoadBalancerServerGroup> serverGroups = new HashSet<>()
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
@@ -43,6 +43,12 @@ class Utils {
     return lastIndex != -1 ? fullUrl.substring(lastIndex + 1) : fullUrl
   }
 
+  static String getZoneFromInstanceUrl(String fullUrl) {
+    def zones = "zones/"
+    fullUrl.substring(fullUrl.indexOf(zones) + zones.length(),
+                      fullUrl.indexOf("instances/") - 1)
+  }
+
   // TODO(duftler): Consolidate this method with the same one from kato/GCEUtil and move to a common library.
   static Map<String, String> buildMapFromMetadata(Metadata metadata) {
     metadata.items?.collectEntries { Metadata.Items metadataItems ->

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleLoadBalancerHealth.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleLoadBalancerHealth.groovy
@@ -25,6 +25,7 @@ import groovy.transform.Canonical
 class GoogleLoadBalancerHealth {
 
   String instanceName
+  String instanceZone
 
   List<LBHealthSummary> lbHealthSummaries
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -232,7 +232,8 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
       targetPool?.instances?.each { String instanceUrl ->
         def instanceReference = new InstanceReference(instance: instanceUrl)
         def instanceHealthCallback = new TargetPoolInstanceHealthCallback(googleLoadBalancer: googleLoadBalancer,
-                                                                          instanceName: Utils.getLocalName(instanceUrl))
+                                                                          instanceName: Utils.getLocalName(instanceUrl),
+                                                                          instanceZone: Utils.getZoneFromInstanceUrl(instanceUrl))
 
         compute.targetPools().getHealth(project,
                                         region,
@@ -247,6 +248,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
 
     GoogleLoadBalancer2 googleLoadBalancer
     String instanceName
+    String instanceZone
 
 
     @Override
@@ -263,6 +265,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
 
         googleLoadBalancer.healths << new GoogleLoadBalancerHealth(
             instanceName: instanceName,
+            instanceZone: instanceZone,
             status: googleLBHealthStatus,
             lbHealthSummaries: [
                 new GoogleLoadBalancerHealth.LBHealthSummary(

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/UtilsSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/UtilsSpec.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleCluster
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstance
 import com.netflix.spinnaker.clouddriver.google.model.GoogleLoadBalancer
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
-import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import spock.lang.Specification
 
 class UtilsSpec extends Specification {
@@ -223,5 +222,15 @@ class UtilsSpec extends Specification {
 
     then:
       !(retrievedCopyClusterDev.serverGroups.find { it.name == SERVER_GROUP_NAME }.isDisabled())
+  }
+
+  def "should get zone from instance URL"() {
+    expect:
+      expected == Utils.getZoneFromInstanceUrl(input)
+
+    where:
+      input                                                                                                                        || expected
+      "https://content.googleapis.com/compute/v1/projects/ttomsu-dev-spinnaker/zones/us-central1-c/instances/sekret-gce-v070-z8mh" || "us-central1-c"
+      "projects/ttomsu-dev-spinnaker/zones/us-central1-c/instances/sekret-gce-v070-z8mh"                                           || "us-central1-c"
   }
 }


### PR DESCRIPTION
Fixes a handful of other issues found during testing, like when relationship keys are missing.

For convenience, I'm caching the instance name AND instance zone. Zone is only required to support filtering in the UI.

@duftler @lwander PTAL.

tag: https://github.com/spinnaker/spinnaker/issues/712