### PR TITLE
use trusty VM for travis build instead of container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 jdk:
 - oraclejdk8
-sudo: false
+sudo: required
+dist: trusty
 install: gradle/installViaTravis.sh
 script: gradle/buildViaTravis.sh
 before_cache: gradle/prepCaches.sh


### PR DESCRIPTION
based on a recommendation from travis-ci support to deal with build timeouts