### PR TITLE
provider/kubernetes: Instance caching agent

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -40,6 +40,10 @@ class KubernetesApiAdaptor {
     client.pods().inNamespace(namespace).withLabel(KubernetesUtil.REPLICATION_CONTROLLER_LABEL, replicationControllerName).list().items
   }
 
+  List<Pod> getPods(String namespace) {
+    client.pods().inNamespace(namespace).list().items
+  }
+
   ReplicationController getReplicationController(String namespace, String serverGroupName) {
     client.replicationControllers().inNamespace(namespace).withName(serverGroupName).get()
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
@@ -42,6 +42,8 @@ class Keys {
     }
   }
 
+  static final String DETACHED_POD = '__DETACHED__'
+
   static Map<String, String> parse(String key) {
     def parts = key.split(':')
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.*
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.view.MutableCacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import groovy.util.logging.Slf4j
+import io.fabric8.kubernetes.api.model.Pod
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+
+@Slf4j
+class KubernetesInstanceCachingAgent implements  CachingAgent, AccountAware {
+  static final Set<AgentDataType> types = Collections.unmodifiableSet([
+      AUTHORITATIVE.forType(Keys.Namespace.INSTANCES.ns),
+  ] as Set)
+
+  final KubernetesCloudProvider kubernetesCloudProvider
+  final String accountName
+  final String namespace
+  final KubernetesCredentials credentials
+  final ObjectMapper objectMapper
+  final Registry registry
+
+  KubernetesInstanceCachingAgent(KubernetesCloudProvider kubernetesCloudProvider,
+                                 String accountName,
+                                 KubernetesCredentials credentials,
+                                 String namespace,
+                                 ObjectMapper objectMapper,
+                                 Registry registry) {
+    this.kubernetesCloudProvider = kubernetesCloudProvider
+    this.accountName = accountName
+    this.credentials = credentials
+    this.objectMapper = objectMapper
+    this.namespace = namespace
+    this.registry = registry
+  }
+
+  @Override
+  String getAccountName() {
+    return null
+  }
+
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    return types
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    log.info("Loading pods in $agentType")
+
+    def pods = credentials.apiAdaptor.getPods(namespace)
+
+    buildCacheResult(pods)
+  }
+
+  private CacheResult buildCacheResult(List<Pod> pods) {
+    log.info("Describing items in ${agentType}")
+
+    Map<String, MutableCacheData> cachedInstances = MutableCacheData.mutableCacheMap()
+
+    pods.each { pod ->
+      def rc = pod.metadata.labels[KubernetesUtil.REPLICATION_CONTROLLER_LABEL] ?: Keys.DETACHED_POD
+
+      def key = Keys.getInstanceKey(accountName, namespace, rc, pod.metadata.name)
+
+      cachedInstances[key].with {
+        attributes.name = pod.metadata.name
+        attributes.pod = pod
+      }
+    }
+
+    log.info("Caching ${cachedInstances.size()} instances in ${agentType}")
+
+    new DefaultCacheResult([
+        (Keys.Namespace.INSTANCES.ns): cachedInstances.values()
+    ], [:])
+  }
+
+  @Override
+  String getAgentType() {
+    "${accountName}/${namespace}/${KubernetesInstanceCachingAgent.simpleName}"
+  }
+
+  @Override
+  String getProviderName() {
+    KubernetesProvider.PROVIDER_NAME
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
@@ -18,13 +18,8 @@ package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.frigga.Names
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.cats.agent.AccountAware
-import com.netflix.spinnaker.cats.agent.AgentDataType
-import com.netflix.spinnaker.cats.agent.CacheResult
-import com.netflix.spinnaker.cats.agent.CachingAgent
-import com.netflix.spinnaker.cats.agent.DefaultCacheResult
+import com.netflix.spinnaker.cats.agent.*
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
@@ -90,6 +85,7 @@ class KubernetesLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent,
   String getAccountName() {
     accountName
   }
+
   @Override
   Collection<AgentDataType> getProvidedDataTypes() {
     return types

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -60,7 +60,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
     INFORMATIVE.forType(Keys.Namespace.CLUSTERS.ns),
     INFORMATIVE.forType(Keys.Namespace.LOAD_BALANCERS.ns),
     AUTHORITATIVE.forType(Keys.Namespace.SERVER_GROUPS.ns),
-    AUTHORITATIVE.forType(Keys.Namespace.INSTANCES.ns),
+    INFORMATIVE.forType(Keys.Namespace.INSTANCES.ns),
   ] as Set)
 
   KubernetesServerGroupCachingAgent(KubernetesCloudProvider kubernetesCloudProvider,
@@ -303,8 +303,6 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
           def key = Keys.getInstanceKey(accountName, namespace, replicationControllerName, pod.metadata.name)
           instanceKeys << key
           cachedInstances[key].with {
-            attributes.name = pod.metadata.name
-            attributes.pod = pod
             relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
             relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
             relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesInstanceCachingAgent
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesLoadBalancerCachingAgent
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
@@ -82,6 +83,7 @@ class KubernetesProviderConfig {
         credentials.credentials.namespaces.forEach({ namespace ->
           newlyAddedAgents << new KubernetesServerGroupCachingAgent(kubernetesCloudProvider, credentials.accountName, credentials.credentials, namespace, objectMapper, registry)
           newlyAddedAgents << new KubernetesLoadBalancerCachingAgent(kubernetesCloudProvider, credentials.accountName, credentials.credentials, namespace, objectMapper, registry)
+          newlyAddedAgents << new KubernetesInstanceCachingAgent(kubernetesCloudProvider, credentials.accountName, credentials.credentials, namespace, objectMapper, registry)
         })
 
         // If there is an agent scheduler, then this provider has been through the AgentController in the past.

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -21,14 +21,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryC
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.internal.KubeConfigUtils;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -109,7 +109,6 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
       result.cacheResults.serverGroups.relationships.applications[0][0] == applicationKey
       result.cacheResults.serverGroups.relationships.instances[0][0] == instanceKey
 
-      result.cacheResults.instances.attributes.name == [POD]
       result.cacheResults.instances.relationships.clusters[0][0] == clusterKey
       result.cacheResults.instances.relationships.applications[0][0] == applicationKey
       result.cacheResults.instances.relationships.serverGroups[0][0] == serverGroupKey


### PR DESCRIPTION
Needed for instances that are detached from any server group. Will be useful for operations like abandon, and searching for pods not managed by replication controllers.

@duftler 