### PR TITLE
Makes two Google caching agents extend the common abstract class

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInstanceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInstanceCachingAgent.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback
 import com.google.api.client.googleapis.json.GoogleJsonError
@@ -32,13 +31,14 @@ import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstance2
-import com.netflix.spinnaker.clouddriver.google.model.health.GoogleInstanceHealth
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
+import com.netflix.spinnaker.clouddriver.google.model.health.GoogleInstanceHealth
 import groovy.util.logging.Slf4j
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
-import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.*
+import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.INSTANCES
+import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.SERVER_GROUPS
 
 @Slf4j
 class GoogleInstanceCachingAgent extends AbstractGoogleCachingAgent {
@@ -60,7 +60,7 @@ class GoogleInstanceCachingAgent extends AbstractGoogleCachingAgent {
     this.accountName = accountName
     this.project = project
     this.compute = compute
-    this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    this.objectMapper = objectMapper
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback
 import com.google.api.client.googleapis.json.GoogleJsonError
@@ -70,7 +69,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
     this.region = region
     this.project = project
     this.compute = compute
-    this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    this.objectMapper = objectMapper
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleNetworkCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleNetworkCachingAgent.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Network
 import com.netflix.spinnaker.cats.agent.AgentDataType
@@ -51,7 +50,7 @@ class GoogleNetworkCachingAgent extends AbstractGoogleCachingAgent {
     this.accountName = accountName
     this.project = project
     this.compute = compute
-    this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    this.objectMapper = objectMapper
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
@@ -100,7 +100,7 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent {
 
   CacheResult buildCacheResult(ProviderCache _, List<GoogleServerGroup2> serverGroups) {
 
-    def cacheResultBuilder = new CacheResultBuilder();
+    def cacheResultBuilder = new CacheResultBuilder()
 
     serverGroups.each { GoogleServerGroup2 serverGroup ->
       def names = Names.parseName(serverGroup.name)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback
 import com.google.api.client.googleapis.json.GoogleJsonError
@@ -70,7 +69,7 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent {
     this.region = region
     this.project = project
     this.compute = compute
-    this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    this.objectMapper = objectMapper
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Subnetwork
 import com.netflix.spinnaker.cats.agent.AgentDataType
@@ -55,7 +54,7 @@ class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
     this.region = region
     this.project = project
     this.compute = compute
-    this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    this.objectMapper = objectMapper
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
@@ -17,92 +17,72 @@
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Subnetwork
-import com.netflix.spinnaker.cats.agent.*
-import com.netflix.spinnaker.cats.cache.CacheData
-import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
+import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
-import com.netflix.spinnaker.clouddriver.google.provider.GoogleInfrastructureProvider
-import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentials
 import groovy.util.logging.Slf4j
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.SUBNETS
 
 @Slf4j
-class GoogleSubnetCachingAgent implements CachingAgent, AccountAware {
+class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
 
   final String region
 
-  final GoogleCloudProvider googleCloudProvider
-  final String accountName
-  final GoogleCredentials credentials
-  final ObjectMapper objectMapper
+  final Set<AgentDataType> providedDataTypes = [
+      AUTHORITATIVE.forType(SUBNETS.ns)
+  ] as Set
 
-  static final Set<AgentDataType> types = Collections.unmodifiableSet([
-    AUTHORITATIVE.forType(Keys.Namespace.SUBNETS.ns)
-  ] as Set)
+  String agentType = "$accountName/$region/$GoogleSubnetCachingAgent.simpleName"
 
   GoogleSubnetCachingAgent(GoogleCloudProvider googleCloudProvider,
+                           String googleApplicationName,
                            String accountName,
                            String region,
-                           GoogleCredentials credentials,
+                           String project,
+                           Compute compute,
                            ObjectMapper objectMapper) {
     this.googleCloudProvider = googleCloudProvider
+    this.googleApplicationName = googleApplicationName
     this.accountName = accountName
     this.region = region
-    this.credentials = credentials
-    this.objectMapper = objectMapper
-  }
-
-  @Override
-  String getProviderName() {
-    GoogleInfrastructureProvider.PROVIDER_NAME
-  }
-
-  @Override
-  String getAgentType() {
-    "$accountName/$region/$GoogleSubnetCachingAgent.simpleName"
-  }
-
-  @Override
-  String getAccountName() {
-    accountName
-  }
-
-  @Override
-  Collection<AgentDataType> getProvidedDataTypes() {
-    return types
+    this.project = project
+    this.compute = compute
+    this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
   }
 
   @Override
   CacheResult loadData(ProviderCache providerCache) {
     List<Subnetwork> subnetList = loadSubnets()
-
     buildCacheResult(providerCache, subnetList)
   }
 
   List<Subnetwork> loadSubnets() {
-    def compute = credentials.compute
-    def project = credentials.project
-
-    compute.subnetworks().list(project, region).execute().items
+    compute.subnetworks().list(project, region).execute().items as List
   }
 
-  private CacheResult buildCacheResult(ProviderCache providerCache, List<Subnetwork> subnetList) {
+  private CacheResult buildCacheResult(ProviderCache _, List<Subnetwork> subnetList) {
     log.info("Describing items in ${agentType}")
 
-    List<CacheData> data = subnetList.collect { Subnetwork subnet ->
-      Map<String, Object> attributes = [subnet: subnet]
+    def cacheResultBuilder = new CacheResultBuilder()
 
-      new DefaultCacheData(Keys.getSubnetKey(googleCloudProvider, subnet.getName(), region, accountName),
-                           attributes,
-                           [:])
+    subnetList.each { Subnetwork subnet ->
+      def subnetKey = Keys.getSubnetKey(googleCloudProvider, subnet.getName(), region, accountName)
+
+      cacheResultBuilder.namespace(SUBNETS.ns).get(subnetKey).with {
+        attributes.subnet = subnet
+      }
     }
 
-    log.info("Caching ${data.size()} items in ${agentType}")
+    log.info("Caching ${cacheResultBuilder.namespace(SUBNETS.ns).size()} items in ${agentType}")
 
-    new DefaultCacheResult([(Keys.Namespace.SUBNETS.ns): data])
+    cacheResultBuilder.build()
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
@@ -110,8 +110,10 @@ class GoogleInfrastructureProviderConfig {
                                                                 objectMapper,
                                                                 registry)
         newlyAddedAgents << new GoogleNetworkCachingAgent(googleCloudProvider,
+                                                          googleConfiguration.googleApplicationName(),
                                                           credentials.accountName,
-                                                          credentials.credentials,
+                                                          credentials.credentials.project,
+                                                          credentials.credentials.compute,
                                                           objectMapper)
 
         credentials.regions.keySet().each { String region ->

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
@@ -118,9 +118,11 @@ class GoogleInfrastructureProviderConfig {
 
         credentials.regions.keySet().each { String region ->
           newlyAddedAgents << new GoogleSubnetCachingAgent(googleCloudProvider,
+                                                           googleConfiguration.googleApplicationName(),
                                                            credentials.accountName,
                                                            region,
-                                                           credentials.credentials,
+                                                           credentials.credentials.project,
+                                                           credentials.credentials.compute,
                                                            objectMapper)
         }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.provider.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
@@ -98,6 +99,8 @@ class GoogleInfrastructureProviderConfig {
     def scheduledAccounts = ProviderUtils.getScheduledAccounts(googleInfrastructureProvider)
     def allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository,
                                                                  GoogleNamedAccountCredentials)
+
+    objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     allAccounts.each { GoogleNamedAccountCredentials credentials ->
       if (!scheduledAccounts.contains(credentials.accountName)) {


### PR DESCRIPTION
Includes Network & Subnet caching agents.

Enables WRITE_DATES_AS_TIMESTAMP serialization feature only once, instead of within each caching agent.

@duftler @lwander PTAL

tag:  https://github.com/spinnaker/spinnaker/issues/712