### PR TITLE
Adds GoogleImageCachingAgent, Provider & test.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -18,12 +18,12 @@ package com.netflix.spinnaker.clouddriver.google.cache
 
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
-import com.netflix.spinnaker.clouddriver.google.model.health.GoogleHealth
 
 class Keys {
   static enum Namespace {
     APPLICATIONS,
     CLUSTERS,
+    IMAGES,
     INSTANCES,
     LOAD_BALANCERS,
     NETWORKS,
@@ -72,10 +72,16 @@ class Keys {
             detail     : names.detail
         ]
         break
+      case Namespace.IMAGES.ns:
+        result << [
+            account: parts[2],
+            imageId: parts[3]
+        ]
+        break
       case Namespace.INSTANCES.ns:
         result << [
-            account    : parts[2],
-            name       : parts[3]
+            account: parts[2],
+            name   : parts[3]
         ]
         break
       case Namespace.LOAD_BALANCERS.ns:
@@ -140,6 +146,12 @@ class Keys {
                               String application,
                               String clusterName) {
     "$googleCloudProvider.id:${Namespace.CLUSTERS}:${account}:${application}:${clusterName}"
+  }
+
+  static String getImageKey(GoogleCloudProvider googleCloudProvider,
+                            String account,
+                            String imageId) {
+    "$googleCloudProvider.id:${Namespace.IMAGES}:${account}:${imageId}"
   }
 
   static String getInstanceKey(GoogleCloudProvider googleCloudProvider,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleResourceRetriever.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleResourceRetriever.groovy
@@ -21,10 +21,12 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpRequest
 import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.services.compute.model.HealthStatus
+import com.google.api.services.compute.model.Image
 import com.google.api.services.compute.model.InstanceGroupManager
 import com.google.api.services.compute.model.InstanceGroupManagerList
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
+import com.netflix.spinnaker.clouddriver.google.controllers.GoogleNamedImageLookupController
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.AutoscalerAggregatedListCallback
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.ImagesCallback
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.InstanceAggregatedListCallback
@@ -41,6 +43,7 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.apache.log4j.Logger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
 
 import javax.annotation.PostConstruct
 import java.util.concurrent.Executors
@@ -48,7 +51,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 
-class GoogleResourceRetriever {
+@Deprecated
+@Component
+class GoogleResourceRetriever implements GoogleNamedImageLookupController.ImageProvider {
   protected final Logger log = Logger.getLogger(GoogleResourceRetriever.class)
 
   @Autowired
@@ -499,6 +504,10 @@ class GoogleResourceRetriever {
 
   Map<String, List<Map>> getImageMap() {
     return imageMap
+  }
+
+  Map<String, List<Image>> listImagesByAccount() {
+    getImageMap()
   }
 
   Map<String, Map<String, List<GoogleLoadBalancer>>> getNetworkLoadBalancerMap() {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/ImagesCallback.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/ImagesCallback.groovy
@@ -66,8 +66,18 @@ class ImagesCallback<ImageList> extends JsonBatchCallback<ImageList> {
       debian-7-wheezy-v20141108
 
       Should result in this map:
-      {backports-debian-7-wheezy: [backports-debian-7-wheezy-v20141017, backports-debian-7-wheezy-v20141021, backports-debian-7-wheezy-v20141108],
-       debian-7-wheezy: [debian-7-wheezy-v20141017, debian-7-wheezy-v20141021, debian-7-wheezy-v20141108]}
+      {
+        backports-debian-7-wheezy: [
+          backports-debian-7-wheezy-v20141017,
+          backports-debian-7-wheezy-v20141021,
+          backports-debian-7-wheezy-v20141108
+        ],
+        debian-7-wheezy: [
+          debian-7-wheezy-v20141017,
+          debian-7-wheezy-v20141021,
+          debian-7-wheezy-v20141108
+        ]
+      }
       Each item in the lists above will be a full image representation; just the names are shown here.
      */
     Map<String, Set<String>> map = new HashMap<String, Set<String>>()

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgent.groovy
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.api.client.googleapis.batch.BatchRequest
+import com.google.api.client.googleapis.batch.json.JsonBatchCallback
+import com.google.api.client.googleapis.json.GoogleJsonError
+import com.google.api.client.http.HttpHeaders
+import com.google.api.services.compute.Compute
+import com.google.api.services.compute.model.Image
+import com.google.api.services.compute.model.ImageList
+import com.netflix.servo.util.VisibleForTesting
+import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.CacheResult
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
+import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
+import com.netflix.spinnaker.clouddriver.google.cache.Keys
+import groovy.util.logging.Slf4j
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.IMAGES
+
+@Slf4j
+class GoogleImageCachingAgent extends AbstractGoogleCachingAgent {
+
+  final Set<AgentDataType> providedDataTypes = [
+      AUTHORITATIVE.forType(IMAGES.ns)
+  ] as Set
+
+  String agentType = "$accountName/$GoogleImageCachingAgent.simpleName"
+
+  List<String> imageProjects
+  List<String> baseImageProjects
+
+  @VisibleForTesting
+  GoogleImageCachingAgent(){}
+
+  GoogleImageCachingAgent(GoogleCloudProvider googleCloudProvider,
+                          String googleApplicationName,
+                          String accountName,
+                          List<String> imageProjects,
+                          List<String> baseImageProjects,
+                          String project,
+                          Compute compute,
+                          ObjectMapper objectMapper) {
+    this.googleCloudProvider = googleCloudProvider
+    this.googleApplicationName = googleApplicationName
+    this.accountName = accountName
+    this.imageProjects = imageProjects
+    this.baseImageProjects = baseImageProjects
+    this.project = project
+    this.compute = compute
+    this.objectMapper = objectMapper
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    List<Image> imageList = loadImages()
+    buildCacheResult(providerCache, imageList)
+  }
+
+  List<Image> loadImages() {
+    List<Image> imageList = []
+
+    BatchRequest imageRequest = buildBatchRequest()
+
+    compute.images().list(project).queue(imageRequest, new AllImagesCallback(imageList: imageList))
+    imageProjects.each {
+      compute.images().list(it).queue(imageRequest, new AllImagesCallback(imageList: imageList))
+    }
+    baseImageProjects.each {
+      compute.images().list(it).queue(imageRequest, new LatestImagesCallback<ImageList>(imageList: imageList))
+    }
+    executeIfRequestsAreQueued(imageRequest)
+
+    imageList
+  }
+
+  private CacheResult buildCacheResult(ProviderCache _, List<Image> imageList) {
+    log.info("Describing items in ${agentType}")
+
+    def cacheResultBuilder = new CacheResultBuilder()
+
+    imageList.each { Image image ->
+      def imageKey = Keys.getImageKey(googleCloudProvider, accountName, image.getName())
+
+      cacheResultBuilder.namespace(IMAGES.ns).get(imageKey).with {
+        attributes.image = image
+      }
+    }
+
+    log.info("Caching ${cacheResultBuilder.namespace(IMAGES.ns).size()} items in ${agentType}")
+
+    cacheResultBuilder.build()
+  }
+
+  static List<Image> filterDeprecatedImages(ImageList imageListResult) {
+    imageListResult?.items?.findAll { Image image ->
+      !image.deprecated?.state
+    } ?: []
+  }
+
+  class AllImagesCallback<ImageList> extends JsonBatchCallback<ImageList> {
+
+    List<Image> imageList
+
+    @Override
+    void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
+      log.warn(e.getMessage())
+    }
+
+    @Override
+    void onSuccess(ImageList imageListResult, HttpHeaders responseHeaders) throws IOException {
+      def nonDeprecatedImages = filterDeprecatedImages(imageListResult)
+      if (nonDeprecatedImages) {
+        imageList.addAll(nonDeprecatedImages)
+      }
+    }
+  }
+
+  class LatestImagesCallback<ImageList> extends JsonBatchCallback<ImageList> {
+
+    List<Image> imageList
+
+    @Override
+    void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
+      log.warn(e.getMessage())
+    }
+
+    @Override
+    void onSuccess(ImageList imageListResult, HttpHeaders responseHeaders) throws IOException {
+      def nonDeprecatedImages = filterDeprecatedImages(imageListResult)
+      if (!nonDeprecatedImages) {
+        return
+      }
+
+      def nameWithoutDate = { Image image ->
+        String fullImageName = image.name
+        // Public coreos images break the naming convention of the others.
+        int delimiter = fullImageName.startsWith("coreos-") ?
+            fullImageName.indexOf('-', 7) :
+            fullImageName.lastIndexOf('-')
+        delimiter != -1 ? fullImageName.substring(0, delimiter) : fullImageName
+      }
+
+      List latestImages = nonDeprecatedImages.groupBy(nameWithoutDate).findResults { String _, List<Image> images ->
+        images.sort { it.name }.last()
+      }
+
+      if (latestImages){
+        imageList.addAll(latestImages)
+      }
+    }
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.provider.GoogleInfrastructureProvider
+import com.netflix.spinnaker.clouddriver.google.provider.agent.GoogleImageCachingAgent
 import com.netflix.spinnaker.clouddriver.google.provider.agent.GoogleInstanceCachingAgent
 import com.netflix.spinnaker.clouddriver.google.provider.agent.GoogleLoadBalancerCachingAgent
 import com.netflix.spinnaker.clouddriver.google.provider.agent.GoogleNetworkCachingAgent
@@ -136,6 +137,14 @@ class GoogleInfrastructureProviderConfig {
                                                              credentials.credentials.project,
                                                              credentials.credentials.compute,
                                                              objectMapper)
+          newlyAddedAgents << new GoogleImageCachingAgent(googleCloudProvider,
+                                                          googleConfiguration.googleApplicationName(),
+                                                          credentials.accountName,
+                                                          credentials.imageProjects,
+                                                          googleConfiguration.googleConfigurationProperties().baseImageProjects,
+                                                          credentials.credentials.project,
+                                                          credentials.credentials.compute,
+                                                          objectMapper)
           credentials.regions.keySet().each { String region ->
             newlyAddedAgents << new GoogleLoadBalancerCachingAgent(googleCloudProvider,
                                                                    googleConfiguration.googleApplicationName(),

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleImageProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleImageProvider.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.provider.view
+
+import com.google.api.services.compute.model.Image
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
+import com.netflix.spinnaker.clouddriver.google.cache.Keys
+import com.netflix.spinnaker.clouddriver.google.controllers.GoogleNamedImageLookupController.ImageProvider
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+
+import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.IMAGES
+
+@Slf4j
+@ConditionalOnProperty(value = "google.providerImpl", havingValue = "new")
+@Primary // TODO(ttomsu): Delete when GoogleResourceRetriever is deleted.
+@Component
+class GoogleImageProvider implements ImageProvider {
+
+  @Autowired
+  Cache cacheView
+
+  @Autowired
+  GoogleCloudProvider googleCloudProvider
+
+  Map<String, List<Image>> listImagesByAccount() {
+    def filter = cacheView.filterIdentifiers(IMAGES.ns, "$GoogleCloudProvider.GCE:*")
+    def result = [:].withDefault { _ -> []}
+
+    cacheView.getAll(IMAGES.ns, filter).each { CacheData cacheData ->
+      def account = Keys.parse(googleCloudProvider, cacheData.id).account
+      result[account] << (cacheData.attributes.image as Image)
+    }
+
+    result
+  }
+}

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgentSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgentSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.provider.agent
+
+import com.google.api.services.compute.model.DeprecationStatus
+import com.google.api.services.compute.model.Image
+import com.google.api.services.compute.model.ImageList
+import com.netflix.spinnaker.clouddriver.google.model.callbacks.ImagesCallback
+import spock.lang.Specification
+
+class GoogleImageCachingAgentSpec extends Specification {
+
+  void "public image lists are filtered such that the latest non-deprecated image in each image group is retained"() {
+    setup:
+      def imageList = new ArrayList<Image>()
+      def imagesCallback1 = new GoogleImageCachingAgent.LatestImagesCallback(new GoogleImageCachingAgent())
+      imagesCallback1.imageList = imageList
+      def imageListResult1 = new ImageList()
+      imageListResult1.setItems([buildImage("backports-debian-7-wheezy-v20141017", false),
+                                 buildImage("backports-debian-7-wheezy-v20141021", false),
+                                 buildImage("backports-debian-7-wheezy-v20141108", false),
+                                 buildImage("debian-7-wheezy-v20141017", false),
+                                 buildImage("debian-7-wheezy-v20141021", false),
+                                 buildImage("debian-7-wheezy-v20141108", false),
+                                 buildImage("someos-8-something-v20141021", false),
+                                 buildImage("someos-8-something-v20141108", true),
+                                 buildImage("otheros-9-something-v20141021", true),
+                                 buildImage("otheros-9-something-v20141108", true)])
+
+      def imagesCallback2 = new ImagesCallback(imageList, true)
+      def imageListResult2 = new ImageList()
+      imageListResult2.setItems([buildImage("ubuntu-1404-trusty-v20141028", false),
+                                 buildImage("ubuntu-1404-trusty-v20141029", true),
+                                 buildImage("ubuntu-1404-trusty-v20141031a", false)])
+
+    when:
+      imagesCallback1.onSuccess(imageListResult1, null)
+      imagesCallback2.onSuccess(imageListResult2, null)
+
+    then:
+      imageList == [buildImage("backports-debian-7-wheezy-v20141108", false),
+                    buildImage("debian-7-wheezy-v20141108", false),
+                    buildImage("someos-8-something-v20141021", false),
+                    buildImage("ubuntu-1404-trusty-v20141031a", false)]
+  }
+
+  void "public images with no deprecated struct are not filtered out"() {
+    setup:
+      def imageList = new ArrayList<String>()
+      def imagesCallback1 = new GoogleImageCachingAgent.LatestImagesCallback(new GoogleImageCachingAgent())
+      imagesCallback1.imageList = imageList
+      def imageListResult1 = new ImageList()
+      imageListResult1.setItems([new Image(name: "backports-debian-7-wheezy-v20141108"),
+                                 new Image(name: "debian-7-wheezy-v20141108"),
+                                 new Image(name: "someos-8-something-v20141108"),
+                                 new Image(name: "otheros-9-something-v20141108")])
+
+      def imagesCallback2 = new GoogleImageCachingAgent.LatestImagesCallback(new GoogleImageCachingAgent())
+      imagesCallback2.imageList = imageList
+      def imageListResult2 = new ImageList()
+      imageListResult2.setItems([new Image(name: "ubuntu-1404-trusty-v20141028"),
+                                 buildImage("ubuntu-1404-trusty-v20141029", true),
+                                 new Image(name: "ubuntu-1404-trusty-v20141031a")])
+
+    when:
+      imagesCallback1.onSuccess(imageListResult1, null)
+      imagesCallback2.onSuccess(imageListResult2, null)
+
+    then:
+      imageList == [new Image(name: "backports-debian-7-wheezy-v20141108"),
+                    new Image(name: "debian-7-wheezy-v20141108"),
+                    new Image(name: "someos-8-something-v20141108"),
+                    new Image(name: "otheros-9-something-v20141108"),
+                    new Image(name: "ubuntu-1404-trusty-v20141031a")]
+  }
+
+  void "project image lists are not filtered for latest, but are filtered for non-deprecated images"() {
+    setup:
+      def imageList = new ArrayList<String>()
+      def imagesCallback = new GoogleImageCachingAgent.AllImagesCallback(new GoogleImageCachingAgent())
+      imagesCallback.imageList = imageList
+      def imageListResult = new ImageList()
+      imageListResult.setItems([buildImage("my-image-1", false),
+                                buildImage("my-image-2", true),
+                                buildImage("my-image-3", false),
+                                buildImage("my-other-image-1", false),
+                                buildImage("my-other-image-2", false),
+                                buildImage("my-other-image-3", true)])
+
+    when:
+      imagesCallback.onSuccess(imageListResult, null)
+
+    then:
+      imageList == [buildImage("my-image-1", false),
+                    buildImage("my-image-3", false),
+                    buildImage("my-other-image-1", false),
+                    buildImage("my-other-image-2", false)]
+  }
+
+  static Image buildImage(String imageName, boolean deprecated) {
+    return new Image(name: imageName, deprecated: new DeprecationStatus(state: deprecated ? "DEPRECATED" : null))
+  }
+}


### PR DESCRIPTION
There is no `ImageProvider` interface, so I created one and made the old `GoogleResourceRetriever` implement it. The `@Primary` annotation on the new impl (`GoogleImageProvider`) tells spring to use it as the ImageProvider when both it and the GRR are available.

@duftler @lwander PTAL

tag: https://github.com/spinnaker/spinnaker/issues/712