### PR TITLE
When merging items into the cache, perform the operation in batches

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactory.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactory.java
@@ -26,19 +26,21 @@ public class RedisNamedCacheFactory implements NamedCacheFactory {
     private final JedisSource jedisSource;
     private final ObjectMapper objectMapper;
     private final int maxMsetSize;
+    private final int maxMergeCount;
     private final boolean enableHashing;
     private final RedisCache.CacheMetrics cacheMetrics;
 
-    public RedisNamedCacheFactory(JedisSource jedisSource, ObjectMapper objectMapper, int maxMsetSize, boolean enableHashing, RedisCache.CacheMetrics cacheMetrics) {
+    public RedisNamedCacheFactory(JedisSource jedisSource, ObjectMapper objectMapper, int maxMsetSize, int maxMergeCount, boolean enableHashing, RedisCache.CacheMetrics cacheMetrics) {
         this.jedisSource = jedisSource;
         this.objectMapper = objectMapper;
         this.maxMsetSize = maxMsetSize;
+        this.maxMergeCount = maxMergeCount;
         this.enableHashing = enableHashing;
         this.cacheMetrics = cacheMetrics;
     }
 
     @Override
     public WriteableCache getCache(String name) {
-        return new RedisCache(name, jedisSource, objectMapper, maxMsetSize, enableHashing, cacheMetrics);
+        return new RedisCache(name, jedisSource, objectMapper, maxMsetSize, maxMergeCount, enableHashing, cacheMetrics);
     }
 }

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
@@ -31,6 +31,7 @@ import spock.lang.Unroll
 @IgnoreIf({ LocalRedisCheck.redisUnavailable() })
 class RedisCacheSpec extends WriteableCacheSpec {
     static int MAX_MSET_SIZE = 2
+    static int MAX_MERGE_COUNT = 1
 
     RedisCache.CacheMetrics cacheMetrics = Mock(RedisCache.CacheMetrics)
     JedisPool pool
@@ -48,7 +49,7 @@ class RedisCacheSpec extends WriteableCacheSpec {
         }
 
         def mapper = new ObjectMapper();
-        return new RedisCache('test', source, mapper, MAX_MSET_SIZE, true, cacheMetrics)
+        return new RedisCache('test', source, mapper, MAX_MSET_SIZE, MAX_MERGE_COUNT, true, cacheMetrics)
     }
 
     @Unroll
@@ -114,7 +115,7 @@ class RedisCacheSpec extends WriteableCacheSpec {
 
     def 'should fail if maxMsetSize is not even'() {
         when:
-        new RedisCache('test', null, null, 7, true, null)
+        new RedisCache('test', null, null, 7, MAX_MERGE_COUNT, true, null)
 
         then:
         thrown(IllegalArgumentException)
@@ -159,6 +160,26 @@ class RedisCacheSpec extends WriteableCacheSpec {
 
         then:
         1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0)
+    }
+
+    def 'should merge #mergeCount items at a time'() {
+        setup:
+        def cache = new RedisCache('test', new JedisPoolSource(pool), new ObjectMapper(), 1000000, mergeCount, false, cacheMetrics)
+
+        when:
+        cache.mergeAll('foo', items)
+
+        then:
+
+        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0)
+        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0)
+
+        where:
+        mergeCount << [ 1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 100, 101, 131 ]
+        items = (0..100).collect { createData("blerp-$it") }
+        fullMerges = items.size() / mergeCount
+        finalMerge = items.size() % mergeCount
+        finalMergeCount = finalMerge > 0 ? 1 : 0
     }
 
     private static class Bean {

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactorySpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactorySpec.groovy
@@ -44,7 +44,7 @@ class RedisNamedCacheFactorySpec extends Specification {
         }
 
         def mapper = new ObjectMapper();
-        factory = new RedisNamedCacheFactory(source, mapper, 2, true, null)
+        factory = new RedisNamedCacheFactory(source, mapper, 2, 2, true, null)
     }
 
     def 'caches with the same name share content'() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.groovy
@@ -47,8 +47,9 @@ class RedisCacheConfig {
     JedisSource jedisSource,
     ObjectMapper objectMapper,
     @Value('${redis.maxMsetSize:250000}') int maxMsetSize,
+    @Value('${caching.maxMergeCount:2500}') int maxMergeCount,
     @Value('${caching.hashing.enabled:true}') boolean enableHashing) {
-    new RedisNamedCacheFactory(jedisSource, objectMapper, maxMsetSize, enableHashing, null)
+    new RedisNamedCacheFactory(jedisSource, objectMapper, maxMsetSize, maxMergeCount, enableHashing, null)
   }
 
   @Bean


### PR DESCRIPTION
* reduce redis operation size (time to execute the op on the redis size)
* reduce the computed redis operation memory footprint (on the client side)

@ajordens PTAL

This probably eliminates the need to also paginate msets but I left that in there