### PR TITLE
provider/docker: Allow user to specify password file

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
@@ -188,7 +188,7 @@ class DockerBearerTokenService {
     @Headers([
       "Docker-Distribution-API-Version: registry/2.0"
     ])
-    DockerBearerToken getToken(@Path(value="path") String path,
+    DockerBearerToken getToken(@Path(value="path", encode=false) String path,
                                @Query(value="service") String service, @Query(value="scope") String scope,
                                @retrofit.http.Header("User-Agent") String agent)
 
@@ -196,7 +196,7 @@ class DockerBearerTokenService {
     @Headers([
       "Docker-Distribution-API-Version: registry/2.0"
     ])
-    DockerBearerToken getToken(@Path(value="path") String path, @Query(value="service") String service,
+    DockerBearerToken getToken(@Path(value="path", encode=false) String path, @Query(value="service") String service,
                                @Query(value="scope") String scope, @retrofit.http.Header("Authorization") String basic,
                                @retrofit.http.Header("User-Agent") String agent)
   }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
@@ -29,6 +29,8 @@ class DockerRegistryConfigurationProperties {
     String username
     // Docker registry password.
     String password
+    // File containing docker password.
+    String passwordFile
     // Docker registry user email address.
     String email
     // Address of the registry.

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
@@ -69,7 +69,7 @@ class DockerRegistryCredentialsInitializer implements CredentialsInitializerSync
           managedAccount.environment ?: managedAccount.name,
           managedAccount.accountType ?: managedAccount.name,
           managedAccount.address, managedAccount.username,
-          managedAccount.password, managedAccount.email,
+          managedAccount.password, managedAccount.passwordFile, managedAccount.email,
           managedAccount.cacheThreads, managedAccount.repositories)
 
         accountCredentialsRepository.save(managedAccount.name, dockerRegistryAccount)

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
@@ -21,15 +21,19 @@ import com.netflix.spinnaker.clouddriver.docker.registry.exception.DockerRegistr
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import retrofit.RetrofitError
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+
 public class DockerRegistryNamedAccountCredentials implements AccountCredentials<DockerRegistryCredentials> {
   public DockerRegistryNamedAccountCredentials(String accountName, String environment, String accountType,
-                                               String address, String username, String password, String email,
+                                               String address, String username, String password, String passwordFile, String email,
                                                int cacheThreads, List<String> repositories) {
-    this(accountName, environment, accountType, address, username, password, email, repositories, cacheThreads, null)
+    this(accountName, environment, accountType, address, username, password, passwordFile, email, repositories, cacheThreads, null)
   }
 
   public DockerRegistryNamedAccountCredentials(String accountName, String environment, String accountType,
-                                               String address, String username, String password, String email,
+                                               String address, String username, String password, String passwordFile, String email,
                                                List<String> repositories, int cacheThreads, List<String> requiredGroupMembership) {
     if (!accountName) {
       throw new IllegalArgumentException("Docker Registry account must be provided with a name.")
@@ -62,6 +66,10 @@ public class DockerRegistryNamedAccountCredentials implements AccountCredentials
       this.registry = address
     }
     this.username = username
+    if (!password && passwordFile) {
+      byte[] contents = Files.readAllBytes(Paths.get(passwordFile))
+      password = new String(contents, StandardCharsets.UTF_8)
+    }
     this.password = password
     this.email = email
     this.requiredGroupMembership = requiredGroupMembership == null ? Collections.emptyList() : Collections.unmodifiableList(requiredGroupMembership)


### PR DESCRIPTION
This makes authenticating with gcr.io easier, since it requires your full GCP json key.