### PR TITLE
Configurable partitioning for caching redis interactions.

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.hash.Hashing;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.CacheFilter;
@@ -34,35 +34,54 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class RedisCache implements WriteableCache {
 
     public interface CacheMetrics {
-        void merge(String prefix, String type, int itemCount, int keysWritten, int relationshipCount, int hashMatches, int hashUpdates);
+        default void merge(String prefix,
+                           String type,
+                           int itemCount,
+                           int keysWritten,
+                           int relationshipCount,
+                           int hashMatches,
+                           int hashUpdates,
+                           int saddOperations,
+                           int msetOperations,
+                           int hmsetOperations,
+                           int pipelineOperations,
+                           int expireOperations) {
+            //noop
+        }
+
+        default void evict(String prefix,
+                           String type,
+                           int itemCount,
+                           int keysDeleted,
+                           int hashesDeleted,
+                           int delOperations,
+                           int hdelOperations,
+                           int sremOperations) {
+            //noop
+        }
+
+        default void get(String prefix,
+                         String type,
+                         int itemCount,
+                         int requestedSize,
+                         int keysRequested,
+                         int relationshipsRequested,
+                         int mgetOperationCount) {
+            //noop
+        }
+
         class NOOP implements CacheMetrics {
-            @Override
-            public void merge(String prefix, String type, int itemCount, int keysWritten, int relationshipCount, int hashMatches, int hashUpdates) {
-                //noop
-            }
         }
     }
 
     private static final String HASH_CHARSET = "UTF8";
-
-    private static final int DEFAULT_SCAN_SIZE = 50000;
 
     private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {
     };
@@ -72,28 +91,25 @@ public class RedisCache implements WriteableCache {
     private final String prefix;
     private final JedisSource source;
     private final ObjectMapper objectMapper;
-    private final int maxMsetSize;
-    private final int maxMergeCount;
     private final CacheMetrics cacheMetrics;
-    private final boolean enableHashing;
+    private final RedisCacheOptions options;
 
-    public RedisCache(String prefix, JedisSource source, ObjectMapper objectMapper, int maxMsetSize, int maxMergeCount, boolean enableHashing, CacheMetrics cacheMetrics) {
-        Preconditions.checkArgument(
-          maxMsetSize % 2 == 0, String.format("maxMsetSize must be even (%s)", maxMsetSize)
-        );
-
+    public RedisCache(String prefix, JedisSource source, ObjectMapper objectMapper, RedisCacheOptions options, CacheMetrics cacheMetrics) {
         this.prefix = prefix;
         this.source = source;
         this.objectMapper = objectMapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
-        this.maxMsetSize = maxMsetSize;
-        this.maxMergeCount = maxMergeCount;
-        this.enableHashing = enableHashing;
+        this.options = options;
         this.cacheMetrics = cacheMetrics == null ? new CacheMetrics.NOOP() : cacheMetrics;
     }
 
     @Override
+    public void merge(String type, CacheData item) {
+        mergeAll(type, Arrays.asList(item));
+    }
+
+    @Override
     public void mergeAll(String type, Collection<CacheData> items) {
-        for (List<CacheData> partition : Iterables.partition(items, maxMergeCount)) {
+        for (List<CacheData> partition : Iterables.partition(items, options.getMaxMergeBatchSize())) {
             mergeItems(type, partition);
         }
     }
@@ -110,7 +126,8 @@ public class RedisCache implements WriteableCache {
         int skippedWrites = 0;
 
         final Map<String, byte[]> hashes = getHashes(type, items);
-        final Map<byte[], byte[]> updatedHashes = new HashMap<>();
+
+        final NavigableMap<byte[], byte[]> updatedHashes = new TreeMap<>(new ByteArrayComparator());
 
         for (CacheData item : items) {
             MergeOp op = buildMergeOp(type, item, hashes);
@@ -127,39 +144,73 @@ public class RedisCache implements WriteableCache {
             }
         }
 
-        final String[] relationships = relationshipNames.toArray(new String[relationshipNames.size()]);
-        final String[] ids = idSet.toArray(new String[idSet.size()]);
-
+        int saddOperations = 0;
+        int msetOperations = 0;
+        int hmsetOperations = 0;
+        int pipelineOperations = 0;
+        int expireOperations = 0;
         if (keysToSet.size() > 0) {
             try (Jedis jedis = source.getJedis()) {
                 Pipeline pipeline = jedis.pipelined();
-                pipeline.sadd(allOfTypeReindex(type), ids);
-                pipeline.sadd(allOfTypeId(type), ids);
+                for (List<String> idPart : Iterables.partition(idSet, options.getMaxSaddSize())) {
+                    final String[] ids = idPart.toArray(new String[idPart.size()]);
+                    pipeline.sadd(allOfTypeReindex(type), ids);
+                    saddOperations++;
+                    pipeline.sadd(allOfTypeId(type), ids);
+                    saddOperations++;
+                }
 
-                for (List<String> keys : Iterables.partition(keysToSet, maxMsetSize)) {
+                for (List<String> keys : Lists.partition(keysToSet, options.getMaxMsetSize())) {
                     pipeline.mset(keys.toArray(new String[keys.size()]));
+                    msetOperations++;
                 }
 
-                if (relationships.length > 0) {
-                    pipeline.sadd(allRelationshipsId(type), relationships);
-                }
-
-                for (Map.Entry<String, Integer> ttlEntry : ttlSecondsByKey.entrySet()) {
-                    pipeline.expire(ttlEntry.getKey(), ttlEntry.getValue());
+                if (!relationshipNames.isEmpty()) {
+                    for (List<String> relNamesPart : Iterables.partition(relationshipNames, options.getMaxSaddSize())) {
+                        pipeline.sadd(allRelationshipsId(type), relNamesPart.toArray(new String[relNamesPart.size()]));
+                        saddOperations++;
+                    }
                 }
 
                 if (!updatedHashes.isEmpty()) {
-                    pipeline.hmset(hashesId(type), updatedHashes);
+                    for (List<byte[]> hashPart : Iterables.partition(updatedHashes.keySet(), options.getMaxHmsetSize())) {
+                        pipeline.hmset(hashesId(type), updatedHashes.subMap(hashPart.get(0), true, hashPart.get(hashPart.size() - 1), true));
+                        hmsetOperations++;
+                    }
                 }
                 pipeline.sync();
+                pipelineOperations++;
+            }
+            try (Jedis jedis = source.getJedis()) {
+                for (List<Map.Entry<String, Integer>> ttlPart : Iterables.partition(ttlSecondsByKey.entrySet(), options.getMaxPipelineSize())) {
+                    Pipeline pipeline = jedis.pipelined();
+                    for (Map.Entry<String, Integer> ttlEntry : ttlPart) {
+                        pipeline.expire(ttlEntry.getKey(), ttlEntry.getValue());
+                    }
+                    expireOperations += ttlPart.size();
+                    pipeline.sync();
+                    pipelineOperations++;
+                }
             }
         }
-        cacheMetrics.merge(prefix, type, items.size(), keysToSet.size() / 2, relationships.length, skippedWrites, updatedHashes.size());
+        cacheMetrics.merge(
+            prefix,
+            type,
+            items.size(),
+            keysToSet.size() / 2,
+            relationshipNames.size(),
+            skippedWrites,
+            updatedHashes.size(),
+            saddOperations,
+            msetOperations,
+            hmsetOperations,
+            pipelineOperations,
+            expireOperations);
     }
 
     @Override
-    public void merge(String type, CacheData item) {
-        mergeAll(type, Arrays.asList(item));
+    public void evict(String type, String id) {
+        evictAll(type, Arrays.asList(id));
     }
 
     @Override
@@ -167,34 +218,53 @@ public class RedisCache implements WriteableCache {
         if (identifiers.isEmpty()) {
             return;
         }
-        identifiers = new HashSet<>(identifiers);
-        final String[] ids = identifiers.toArray(new String[identifiers.size()]);
-        final Collection<String> allRelationships;
-        try (Jedis jedis = source.getJedis()) {
-            allRelationships = jedis.smembers(allRelationshipsId(type));
+        final Collection<String> allRelationships = scanMembers(allRelationshipsId(type));
+        for (List<String> items : Iterables.partition(new HashSet<>(identifiers), options.getMaxEvictBatchSize())) {
+            evictItems(type, items, allRelationships);
         }
+    }
 
-        Collection<String> delKeys = new ArrayList<>((allRelationships.size() + 1) * ids.length);
-        for (String id : ids) {
+    private void evictItems(String type, List<String> identifiers, Collection<String> allRelationships) {
+        List<String> delKeys = new ArrayList<>((allRelationships.size() + 1) * identifiers.size());
+        for (String id : identifiers) {
             for (String relationship : allRelationships) {
                 delKeys.add(relationshipId(type, id, relationship));
             }
             delKeys.add(attributesId(type, id));
         }
 
+        int delOperations = 0;
+        int hdelOperations = 0;
+        int sremOperations = 0;
         try (Jedis jedis = source.getJedis()) {
             Pipeline pipe = jedis.pipelined();
-            pipe.del(delKeys.toArray(new String[delKeys.size()]));
-            pipe.srem(allOfTypeId(type), ids);
-            pipe.srem(allOfTypeReindex(type), ids);
-            pipe.hdel(hashesId(type), stringsToBytes(delKeys));
+            for (List<String> delPartition : Lists.partition(delKeys, options.getMaxDelSize())) {
+                pipe.del(delPartition.toArray(new String[delPartition.size()]));
+                delOperations++;
+                pipe.hdel(hashesId(type), stringsToBytes(delPartition));
+                hdelOperations++;
+            }
+
+            for (List<String> idPartition : Lists.partition(identifiers, options.getMaxDelSize())) {
+                String[] ids = idPartition.toArray(new String[idPartition.size()]);
+                pipe.srem(allOfTypeId(type), ids);
+                sremOperations++;
+                pipe.srem(allOfTypeReindex(type), ids);
+                sremOperations++;
+            }
+
             pipe.sync();
         }
-    }
 
-    @Override
-    public void evict(String type, String id) {
-        evictAll(type, Arrays.asList(id));
+        cacheMetrics.evict(
+            prefix,
+            type,
+            identifiers.size(),
+            delKeys.size(),
+            delKeys.size(),
+            delOperations,
+            hdelOperations,
+            sremOperations);
     }
 
     @Override
@@ -211,56 +281,6 @@ public class RedisCache implements WriteableCache {
         return result.iterator().next();
     }
 
-    public Collection<CacheData> getAll(String type,
-                                        Collection<String> identifiers,
-                                        CacheFilter cacheFilter) {
-        if (identifiers.isEmpty()) {
-            return Collections.emptySet();
-        }
-        Collection<String> ids = new LinkedHashSet<>(identifiers);
-        final List<String> knownRels;
-        try (Jedis jedis = source.getJedis()) {
-            Set<String> allRelationships = jedis.smembers(allRelationshipsId(type));
-            if (cacheFilter == null) {
-                knownRels = new ArrayList<>(allRelationships);
-            } else {
-                knownRels = new ArrayList<>(cacheFilter.filter(CacheFilter.Type.RELATIONSHIP, allRelationships));
-            }
-        }
-
-        final int singleResultSize = knownRels.size() + 1;
-
-        final List<String> keysToGet = new ArrayList<>(singleResultSize * ids.size());
-        for (String id : ids) {
-            keysToGet.add(attributesId(type, id));
-            for (String rel : knownRels) {
-                keysToGet.add(relationshipId(type, id, rel));
-            }
-        }
-
-        final String[] mget = keysToGet.toArray(new String[keysToGet.size()]);
-
-        final List<String> keyResult;
-
-        try (Jedis jedis = source.getJedis()) {
-            keyResult = jedis.mget(mget);
-        }
-
-        if (keyResult.size() != mget.length) {
-            throw new RuntimeException("Expected same size result as request");
-        }
-
-        Collection<CacheData> results = new ArrayList<>(ids.size());
-        Iterator<String> idIterator = identifiers.iterator();
-        for (int ofs = 0; ofs < keyResult.size(); ofs += singleResultSize) {
-            CacheData item = extractItem(idIterator.next(), keyResult.subList(ofs, ofs + singleResultSize), knownRels);
-            if (item != null) {
-                results.add(item);
-            }
-        }
-        return results;
-    }
-
     @Override
     public Collection<CacheData> getAll(String type, Collection<String> identifiers) {
         return getAll(type, identifiers, null);
@@ -273,10 +293,7 @@ public class RedisCache implements WriteableCache {
 
     @Override
     public Collection<CacheData> getAll(String type, CacheFilter cacheFilter) {
-        final Set<String> allIds;
-        try (Jedis jedis = source.getJedis()) {
-            allIds = jedis.smembers(allOfTypeId(type));
-        }
+        final Set<String> allIds = scanMembers(allOfTypeId(type));
         return getAll(type, allIds, cacheFilter);
     }
 
@@ -286,21 +303,91 @@ public class RedisCache implements WriteableCache {
     }
 
     @Override
-    public Collection<String> getIdentifiers(String type) {
-        try (Jedis jedis = source.getJedis()) {
-            return jedis.smembers(allOfTypeId(type));
+    public Collection<CacheData> getAll(String type,
+                                        Collection<String> identifiers,
+                                        CacheFilter cacheFilter) {
+        if (identifiers.isEmpty()) {
+            return Collections.emptySet();
         }
+        Collection<String> ids = new LinkedHashSet<>(identifiers);
+        final List<String> knownRels;
+        Set<String> allRelationships = scanMembers(allRelationshipsId(type));
+        if (cacheFilter == null) {
+            knownRels = new ArrayList<>(allRelationships);
+        } else {
+            knownRels = new ArrayList<>(cacheFilter.filter(CacheFilter.Type.RELATIONSHIP, allRelationships));
+        }
+
+        Collection<CacheData> result = new ArrayList<>(ids.size());
+
+        for (List<String> idPart : Iterables.partition(ids, options.getMaxGetBatchSize())) {
+            result.addAll(getItems(type, idPart, knownRels));
+        }
+
+        return result;
+    }
+
+    private Collection<CacheData> getItems(String type, List<String> ids, List<String> knownRels) {
+
+        final int singleResultSize = knownRels.size() + 1;
+
+        final List<String> keysToGet = new ArrayList<>(singleResultSize * ids.size());
+        for (String id : ids) {
+            keysToGet.add(attributesId(type, id));
+            for (String rel : knownRels) {
+                keysToGet.add(relationshipId(type, id, rel));
+            }
+        }
+
+        final List<String> keyResult = new ArrayList<>(keysToGet.size());
+
+        int mgetOperations = 0;
+        try (Jedis jedis = source.getJedis()) {
+            for (List<String> part : Lists.partition(keysToGet, options.getMaxMgetSize())) {
+                mgetOperations++;
+                keyResult.addAll(jedis.mget(part.toArray(new String[part.size()])));
+            }
+        }
+
+        if (keyResult.size() != keysToGet.size()) {
+            throw new RuntimeException("Expected same size result as request");
+        }
+
+        Collection<CacheData> results = new ArrayList<>(ids.size());
+        Iterator<String> idIterator = ids.iterator();
+        for (int ofs = 0; ofs < keyResult.size(); ofs += singleResultSize) {
+            CacheData item = extractItem(idIterator.next(), keyResult.subList(ofs, ofs + singleResultSize), knownRels);
+            if (item != null) {
+                results.add(item);
+            }
+        }
+
+        cacheMetrics.get(prefix, type, results.size(), ids.size(), keysToGet.size(), knownRels.size(), mgetOperations);
+        return results;
+    }
+
+    @Override
+    public Collection<String> getIdentifiers(String type) {
+        return scanMembers(allOfTypeId(type));
     }
 
     @Override
     public Collection<String> filterIdentifiers(String type, String glob) {
+        return scanMembers(allOfTypeId(type), Optional.of(glob));
+    }
+
+    private Set<String> scanMembers(String setKey) {
+        return scanMembers(setKey, Optional.empty());
+    }
+
+    private Set<String> scanMembers(String setKey, Optional<String> glob) {
         try (Jedis jedis = source.getJedis()) {
             final Set<String> matches = new HashSet<>();
-            final ScanParams scanParams = new ScanParams().match(glob).count(DEFAULT_SCAN_SIZE);
-            final String allIdentifiersKey = allOfTypeId(type);
+            final ScanParams scanParams = new ScanParams().count(options.getScanSize());
+            glob.ifPresent(scanParams::match);
             String cursor = "0";
             while (true) {
-                final ScanResult<String> scanResult = jedis.sscan(allIdentifiersKey, cursor, scanParams);
+                final ScanResult<String> scanResult = jedis.sscan(setKey, cursor, scanParams);
                 matches.addAll(scanResult.getResult());
                 cursor = scanResult.getStringCursor();
                 if ("0".equals(cursor)) {
@@ -318,7 +405,7 @@ public class RedisCache implements WriteableCache {
         final byte[][] results = new byte[strings.size()][];
         int i = 0;
         for (String string : strings) {
-          results[i++] = stringToBytes(string);
+            results[i++] = stringToBytes(string);
         }
         return results;
     }
@@ -340,15 +427,16 @@ public class RedisCache implements WriteableCache {
     /**
      * Compares the hash of serializedValue against an existing hash, if they do not match adds
      * serializedValue to keys and the new hash to updatedHashes.
-     * @param hashes the existing hash values
-     * @param id the id of the item
+     *
+     * @param hashes          the existing hash values
+     * @param id              the id of the item
      * @param serializedValue the serialized value
-     * @param keys values to persist - if the hash does not match id and serializedValue are appended
-     * @param updatedHashes hashes to persist - if the hash does not match adds an entry of id -> computed hash
+     * @param keys            values to persist - if the hash does not match id and serializedValue are appended
+     * @param updatedHashes   hashes to persist - if the hash does not match adds an entry of id -> computed hash
      * @return true if the hash matched, false otherwise
      */
     private boolean hashCheck(Map<String, byte[]> hashes, String id, String serializedValue, List<String> keys, Map<byte[], byte[]> updatedHashes) {
-        if (enableHashing) {
+        if (options.isHashingEnabled()) {
             final byte[] hash = Hashing.sha1().newHasher().putBytes(stringToBytes(serializedValue)).hash().asBytes();
             final byte[] existingHash = hashes.get(id);
             if (Arrays.equals(hash, existingHash)) {
@@ -399,6 +487,15 @@ public class RedisCache implements WriteableCache {
         return new MergeOp(cacheData.getRelationships().keySet(), keysToSet, hashesToSet, skippedWrites);
     }
 
+    private boolean isHashingDisabled(String type) {
+        if (!options.isHashingEnabled()) {
+            return true;
+        }
+        try (Jedis jedis = source.getJedis()) {
+            return jedis.exists(hashesDisabled(type));
+        }
+    }
+
     private List<String> getKeys(String type, Collection<CacheData> cacheDatas) {
         final Collection<String> keys = new HashSet<>();
         for (CacheData cacheData : cacheDatas) {
@@ -414,15 +511,6 @@ public class RedisCache implements WriteableCache {
         return new ArrayList<>(keys);
     }
 
-    private boolean isHashingDisabled(String type) {
-        if (!enableHashing) {
-            return true;
-        }
-        try (Jedis jedis = source.getJedis()) {
-            return jedis.exists(hashesDisabled(type));
-        }
-    }
-
     private Map<String, byte[]> getHashes(String type, Collection<CacheData> items) {
         if (isHashingDisabled(type)) {
             return Collections.emptyMap();
@@ -433,11 +521,13 @@ public class RedisCache implements WriteableCache {
             return Collections.emptyMap();
         }
 
-        final List<byte[]> hashValues;
+        final List<byte[]> hashValues = new ArrayList<>(hashKeys.size());
         final byte[] hashesId = hashesId(type);
 
         try (Jedis jedis = source.getJedis()) {
-            hashValues = jedis.hmget(hashesId, stringsToBytes(hashKeys));
+            for (List<String> hashPart : Lists.partition(hashKeys, options.getMaxHmgetSize())) {
+                hashValues.addAll(jedis.hmget(hashesId, stringsToBytes(hashPart)));
+            }
         }
         if (hashValues.size() != hashKeys.size()) {
             throw new RuntimeException("Expected same size result as request");
@@ -504,4 +594,31 @@ public class RedisCache implements WriteableCache {
     private String allOfTypeReindex(String type) {
         return String.format("%s:%s:members.2", prefix, type);
     }
+
+    /**
+     * Comparator for lexical sort of byte arrays to enable a partitioning a
+     * sorted map of hash keys.
+     * <p>
+     * This is essentially String.compareTo implemented on a byte array.
+     */
+    private static class ByteArrayComparator implements Comparator<byte[]>, Serializable {
+        private static final long serialVersionUID = 42424242421L;
+        @Override
+        public int compare(byte[] v1, byte[] v2) {
+            final int len1 = v1.length;
+            final int len2 = v2.length;
+            final int lim = Math.min(v1.length, v2.length);
+
+            for (int i = 0; i < lim; i++) {
+                byte b1 = v1[i];
+                byte b2 = v2[i];
+                if (b1 != b2) {
+                    return b1 - b2;
+                }
+            }
+            return len1 - len2;
+        }
+    }
+
+
 }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCacheOptions.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCacheOptions.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.redis.cache;
+
+import com.google.common.base.Preconditions;
+
+public class RedisCacheOptions {
+    public static Builder builder() {
+        return new Builder();
+    }
+    private final int maxMsetSize;
+    private final int maxMgetSize;
+    private final int maxHmgetSize;
+    private final int maxHmsetSize;
+    private final int maxSaddSize;
+    private final int maxDelSize;
+    private final int maxPipelineSize;
+    private final int scanSize;
+    private final int maxMergeBatchSize;
+    private final int maxEvictBatchSize;
+    private final int maxGetBatchSize;
+    private final boolean hashingEnabled;
+
+    private static int posInt(String name, int value) {
+        Preconditions.checkArgument(value > 0, "%s must be a positive integer (%s)", name, value);
+        return value;
+    }
+
+    private static int posEven(String name, int value) {
+        Preconditions.checkArgument(value > 0 && value % 2 == 0, "%s must be a positive even integer (%s)", name, value);
+        return value;
+    }
+
+    public RedisCacheOptions(int maxMsetSize, int maxMgetSize, int maxHmgetSize, int maxHmsetSize, int maxSaddSize, int maxDelSize, int maxPipelineSize, int scanSize, int maxMergeBatchSize, int maxEvictBatchSize, int maxGetBatchSize, boolean hashingEnabled) {
+        this.maxMsetSize = posEven("maxMsetSize", maxMsetSize);
+        this.maxMgetSize = posInt("maxMgetSize", maxMgetSize);
+        this.maxHmgetSize = posInt("maxHmgetSize", maxHmgetSize);
+        this.maxHmsetSize = posInt("maxHmsetSize", maxHmsetSize);
+        this.maxSaddSize = posInt("maxSaddSize", maxSaddSize);
+        this.maxDelSize = posInt("maxDelSize", maxDelSize);
+        this.maxPipelineSize = posInt("maxPipelineSize", maxPipelineSize);
+        this.scanSize = posInt("scanSize", scanSize);
+        this.maxMergeBatchSize = posInt("maxMergeBatchSize", maxMergeBatchSize);
+        this.maxEvictBatchSize = posInt("maxEvictBatchSize", maxEvictBatchSize);
+        this.maxGetBatchSize = posInt("maxGetBatchSize", maxGetBatchSize);
+        this.hashingEnabled = hashingEnabled;
+    }
+
+    public int getMaxMsetSize() {
+        return maxMsetSize;
+    }
+
+    public int getMaxMgetSize() {
+        return maxMgetSize;
+    }
+
+    public int getMaxHmgetSize() {
+        return maxHmgetSize;
+    }
+
+    public int getMaxHmsetSize() {
+        return maxHmsetSize;
+    }
+
+    public int getMaxSaddSize() {
+        return maxSaddSize;
+    }
+
+    public int getMaxDelSize() {
+        return maxDelSize;
+    }
+
+    public int getMaxPipelineSize() {
+        return maxPipelineSize;
+    }
+
+    public int getScanSize() {
+        return scanSize;
+    }
+
+    public int getMaxMergeBatchSize() {
+        return maxMergeBatchSize;
+    }
+
+    public int getMaxEvictBatchSize() {
+        return maxEvictBatchSize;
+    }
+
+    public int getMaxGetBatchSize() {
+        return maxGetBatchSize;
+    }
+
+    public boolean isHashingEnabled() {
+        return hashingEnabled;
+    }
+
+    public static class Builder {
+        public static final int DEFAULT_MULTI_OP_SIZE = 10000;
+        public static final int DEFAULT_BATCH_SIZE = 5000;
+        public static final int DEFAULT_SCAN_SIZE = 25000;
+        public static final int DEFAULT_MAX_PIPELINE_SIZE = 5000;
+        public static final boolean DEFAULT_HASHING_ENABLED = true;
+
+        int maxMsetSize;
+        int maxMgetSize;
+        int maxHmgetSize;
+        int maxHmsetSize;
+        int maxSaddSize;
+        int maxDelSize;
+        int maxPipelineSize;
+        int scanSize;
+        int maxMergeBatchSize;
+        int maxEvictBatchSize;
+        int maxGetBatchSize;
+        boolean hashingEnabled;
+
+        public Builder() {
+            batchSize(DEFAULT_BATCH_SIZE);
+            scan(DEFAULT_SCAN_SIZE);
+            multiOp(DEFAULT_MULTI_OP_SIZE);
+            maxPipeline(DEFAULT_MAX_PIPELINE_SIZE);
+            hashing(DEFAULT_HASHING_ENABLED);
+        }
+
+        public Builder maxMergeBatch(int maxMergeBatch) {
+            this.maxMergeBatchSize = maxMergeBatch;
+            return this;
+        }
+
+        public Builder maxEvictBatch(int maxEvictBatch) {
+            this.maxEvictBatchSize = maxEvictBatch;
+            return this;
+        }
+
+        public Builder maxGetBatch(int maxGetBatch) {
+            this.maxGetBatchSize = maxGetBatch;
+            return this;
+        }
+
+        public Builder batchSize(int batchSize) {
+            return maxMergeBatch(batchSize).maxEvictBatch(batchSize).maxGetBatch(batchSize);
+        }
+
+        public Builder scan(int scanSize) {
+            this.scanSize = scanSize;
+            return this;
+        }
+
+        public Builder multiOp(int multiOpSize) {
+            return maxMkeyOp(multiOpSize).maxHmOp(multiOpSize).maxSadd(multiOpSize).maxDel(multiOpSize);
+        }
+
+        public Builder maxMset(int maxMset) {
+            this.maxMsetSize = maxMset;
+            return this;
+        }
+
+        public Builder maxMget(int maxMget) {
+            this.maxMgetSize = maxMget;
+            return this;
+        }
+
+        public Builder maxMkeyOp(int maxMkey) {
+            return maxMset(maxMkey).maxMget(maxMkey);
+        }
+
+        public Builder maxHmget(int maxHmget) {
+            this.maxHmgetSize = maxHmget;
+            return this;
+        }
+
+        public Builder maxHmset(int maxHmset) {
+            this.maxHmsetSize = maxHmset;
+            return this;
+        }
+
+        public Builder maxHmOp(int maxHmOp) {
+            return maxHmget(maxHmOp).maxHmset(maxHmOp);
+        }
+
+        public Builder maxSadd(int maxSadd) {
+            this.maxSaddSize = maxSadd;
+            return this;
+        }
+
+        public Builder maxDel(int maxDel) {
+            this.maxDelSize = maxDel;
+            return this;
+        }
+
+        public Builder maxPipeline(int maxPipeline) {
+            this.maxPipelineSize = maxPipeline;
+            return this;
+        }
+
+        public Builder hashing(boolean hashingEnabled) {
+            this.hashingEnabled = hashingEnabled;
+            return this;
+        }
+
+        public RedisCacheOptions build() {
+            return new RedisCacheOptions(maxMsetSize, maxMgetSize, maxHmgetSize, maxHmsetSize, maxSaddSize, maxDelSize, maxPipelineSize, scanSize, maxMergeBatchSize, maxEvictBatchSize, maxGetBatchSize, hashingEnabled);
+        }
+
+        public void setBatchSize(int batchSize) {
+            batchSize(batchSize);
+        }
+
+        public void setMultiOpSize(int multiOpSize) {
+            multiOp(multiOpSize);
+        }
+
+        public int getMaxMsetSize() {
+            return maxMsetSize;
+        }
+
+        public void setMaxMsetSize(int maxMsetSize) {
+            this.maxMsetSize = maxMsetSize;
+        }
+
+        public int getMaxMgetSize() {
+            return maxMgetSize;
+        }
+
+        public void setMaxMgetSize(int maxMgetSize) {
+            this.maxMgetSize = maxMgetSize;
+        }
+
+        public int getMaxHmgetSize() {
+            return maxHmgetSize;
+        }
+
+        public void setMaxHmgetSize(int maxHmgetSize) {
+            this.maxHmgetSize = maxHmgetSize;
+        }
+
+        public int getMaxHmsetSize() {
+            return maxHmsetSize;
+        }
+
+        public void setMaxHmsetSize(int maxHmsetSize) {
+            this.maxHmsetSize = maxHmsetSize;
+        }
+
+        public int getMaxSaddSize() {
+            return maxSaddSize;
+        }
+
+        public void setMaxSaddSize(int maxSaddSize) {
+            this.maxSaddSize = maxSaddSize;
+        }
+
+        public int getMaxDelSize() {
+            return maxDelSize;
+        }
+
+        public void setMaxDelSize(int maxDelSize) {
+            this.maxDelSize = maxDelSize;
+        }
+
+        public int getMaxPipelineSize() {
+            return maxPipelineSize;
+        }
+
+        public void setMaxPipelineSize(int maxPipelineSize) {
+            this.maxPipelineSize = maxPipelineSize;
+        }
+
+        public int getScanSize() {
+            return scanSize;
+        }
+
+        public void setScanSize(int scanSize) {
+            this.scanSize = scanSize;
+        }
+
+        public int getMaxMergeBatchSize() {
+            return maxMergeBatchSize;
+        }
+
+        public void setMaxMergeBatchSize(int maxMergeBatchSize) {
+            this.maxMergeBatchSize = maxMergeBatchSize;
+        }
+
+        public int getMaxEvictBatchSize() {
+            return maxEvictBatchSize;
+        }
+
+        public void setMaxEvictBatchSize(int maxEvictBatchSize) {
+            this.maxEvictBatchSize = maxEvictBatchSize;
+        }
+
+        public int getMaxGetBatchSize() {
+            return maxGetBatchSize;
+        }
+
+        public void setMaxGetBatchSize(int maxGetBatchSize) {
+            this.maxGetBatchSize = maxGetBatchSize;
+        }
+
+        public boolean isHashingEnabled() {
+            return hashingEnabled;
+        }
+
+        public void setHashingEnabled(boolean hashingEnabled) {
+            this.hashingEnabled = hashingEnabled;
+        }
+    }
+}

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactory.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactory.java
@@ -25,22 +25,18 @@ public class RedisNamedCacheFactory implements NamedCacheFactory {
 
     private final JedisSource jedisSource;
     private final ObjectMapper objectMapper;
-    private final int maxMsetSize;
-    private final int maxMergeCount;
-    private final boolean enableHashing;
+    private final RedisCacheOptions options;
     private final RedisCache.CacheMetrics cacheMetrics;
 
-    public RedisNamedCacheFactory(JedisSource jedisSource, ObjectMapper objectMapper, int maxMsetSize, int maxMergeCount, boolean enableHashing, RedisCache.CacheMetrics cacheMetrics) {
+    public RedisNamedCacheFactory(JedisSource jedisSource, ObjectMapper objectMapper, RedisCacheOptions options, RedisCache.CacheMetrics cacheMetrics) {
         this.jedisSource = jedisSource;
         this.objectMapper = objectMapper;
-        this.maxMsetSize = maxMsetSize;
-        this.maxMergeCount = maxMergeCount;
-        this.enableHashing = enableHashing;
+        this.options = options;
         this.cacheMetrics = cacheMetrics;
     }
 
     @Override
     public WriteableCache getCache(String name) {
-        return new RedisCache(name, jedisSource, objectMapper, maxMsetSize, maxMergeCount, enableHashing, cacheMetrics);
+        return new RedisCache(name, jedisSource, objectMapper, options, cacheMetrics);
     }
 }

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactorySpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactorySpec.groovy
@@ -44,7 +44,7 @@ class RedisNamedCacheFactorySpec extends Specification {
         }
 
         def mapper = new ObjectMapper();
-        factory = new RedisNamedCacheFactory(source, mapper, 2, 2, true, null)
+        factory = new RedisNamedCacheFactory(source, mapper, RedisCacheOptions.builder().build(), null)
     }
 
     def 'caches with the same name share content'() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.groovy
@@ -21,12 +21,14 @@ import com.netflix.spinnaker.cats.agent.AgentScheduler
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory
 import com.netflix.spinnaker.cats.redis.JedisPoolSource
 import com.netflix.spinnaker.cats.redis.JedisSource
+import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions
 import com.netflix.spinnaker.cats.redis.cache.RedisNamedCacheFactory
 import com.netflix.spinnaker.cats.redis.cluster.AgentIntervalProvider
 import com.netflix.spinnaker.cats.redis.cluster.ClusteredAgentScheduler
 import com.netflix.spinnaker.cats.redis.cluster.DefaultNodeIdentity
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import redis.clients.jedis.JedisPool
@@ -43,13 +45,22 @@ class RedisCacheConfig {
   }
 
   @Bean
+  @ConfigurationProperties("caching.redis")
+  RedisCacheOptions.Builder redisCacheOptionsBuilder() {
+    return RedisCacheOptions.builder();
+  }
+
+  @Bean
+  RedisCacheOptions redisCacheOptions(RedisCacheOptions.Builder redisCacheOptionsBuilder) {
+    return redisCacheOptionsBuilder.build()
+  }
+
+  @Bean
   NamedCacheFactory cacheFactory(
     JedisSource jedisSource,
     ObjectMapper objectMapper,
-    @Value('${redis.maxMsetSize:250000}') int maxMsetSize,
-    @Value('${caching.maxMergeCount:2500}') int maxMergeCount,
-    @Value('${caching.hashing.enabled:true}') boolean enableHashing) {
-    new RedisNamedCacheFactory(jedisSource, objectMapper, maxMsetSize, maxMergeCount, enableHashing, null)
+    RedisCacheOptions redisCacheOptions) {
+    new RedisNamedCacheFactory(jedisSource, objectMapper, redisCacheOptions, null)
   }
 
   @Bean


### PR DESCRIPTION
This partitions all the batch operations (partitioning at the `Collection<CacheData>` level), partitions all the redis multi-key operations (`mset`, `mget`, `sadd`, `hmset`), and removes all `smembers` calls and replaces them with `sscans`

Reworks redis caching configuration into a bindable bean and config prop's it under caching.redis.

Don't merge yet, still doing some manual validation.

cc: @ajordens @anotherchrisberry 