### PR TITLE
Make CatsSearchProvider work with cached GCE data in Redis

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleConfiguration.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleConfiguration.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.health.GoogleHealthIndicator
 import com.netflix.spinnaker.clouddriver.google.model.GoogleDisk
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstanceTypeDisk
-import com.netflix.spinnaker.clouddriver.google.model.GoogleResourceRetriever
 import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentialsInitializer
 import groovy.transform.ToString
 import org.springframework.beans.factory.annotation.Value
@@ -65,11 +64,6 @@ class GoogleConfiguration {
   @Bean
   String googleApplicationName(@Value('${Implementation-Version:Unknown}') String implementationVersion) {
     "Spinnaker/$implementationVersion"
-  }
-
-  @Bean
-  GoogleResourceRetriever googleResourceRetriever() {
-    new GoogleResourceRetriever()
   }
 
   @Bean

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.clouddriver.google.cache
 
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
+import groovy.util.logging.Slf4j
 
+@Slf4j
 class Keys {
   static enum Namespace {
     APPLICATIONS,
@@ -68,6 +70,7 @@ class Keys {
             application: parts[3],
             account    : parts[2],
             name       : parts[4],
+            cluster    : parts[4],
             stack      : names.stack,
             detail     : names.detail
         ]
@@ -80,15 +83,22 @@ class Keys {
         break
       case Namespace.INSTANCES.ns:
         result << [
-            account: parts[2],
-            name   : parts[3]
+            account   : parts[2],
+            region    : parts[3],
+            name      : parts[4],
+            instanceId: parts[4],
         ]
         break
       case Namespace.LOAD_BALANCERS.ns:
+        def names = Names.parseName(parts[4])
         result << [
-            account: parts[2],
-            region : parts[3],
-            name   : parts[4]
+            account     : parts[2],
+            region      : parts[3],
+            name        : parts[4],
+            loadBalancer: parts[4],
+            application : names.app,
+            stack       : names.stack,
+            detail      : names.detail,
         ]
         break
       case Namespace.NETWORKS.ns:
@@ -156,8 +166,9 @@ class Keys {
 
   static String getInstanceKey(GoogleCloudProvider googleCloudProvider,
                                String account,
+                               String region,
                                String name) {
-    "$googleCloudProvider.id:${Namespace.INSTANCES}:${account}:${name}"
+    "$googleCloudProvider.id:${Namespace.INSTANCES}:${account}:${region}:${name}"
   }
 
   static String getLoadBalancerKey(GoogleCloudProvider googleCloudProvider,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance2.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance2.groovy
@@ -41,6 +41,7 @@ class GoogleInstance2 {
   String instanceType
   Long launchTime
   String zone
+  String region
   GoogleInstanceHealth instanceHealth
   List<GoogleLoadBalancerHealth> loadBalancerHealths = []
   List<NetworkInterface> networkInterfaces
@@ -76,6 +77,7 @@ class GoogleInstance2 {
     String instanceType = GoogleInstance2.this.instanceType
     Long launchTime = GoogleInstance2.this.launchTime
     String zone = GoogleInstance2.this.zone
+    String region = GoogleInstance2.this.region
     Map placement = ["availabilityZone": GoogleInstance2.this.zone]
     List<NetworkInterface> networkInterfaces = GoogleInstance2.this.networkInterfaces
     Metadata metadata = GoogleInstance2.this.metadata

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleCachingAgent.groovy
@@ -26,16 +26,20 @@ import com.netflix.spinnaker.cats.agent.AccountAware
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.provider.GoogleInfrastructureProvider
+import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentials
+import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 
 abstract class AbstractGoogleCachingAgent implements CachingAgent, AccountAware {
 
   final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
 
-  final String providerName = GoogleInfrastructureProvider.PROVIDER_NAME
+  final String providerName = GoogleInfrastructureProvider.name
 
   GoogleCloudProvider googleCloudProvider
   String googleApplicationName // "Spinnaker/${version}" HTTP header string
   String accountName
+  GoogleNamedAccountCredentials credentials
+  // TODO(ttomsu): Make project and compute dynamic getters from credentials object.
   String project
   Compute compute
   ObjectMapper objectMapper

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -111,7 +111,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
                                                     loadBalancer.account,
                                                     loadBalancer.name)
       def instanceKeys = loadBalancer.healths.collect { GoogleLoadBalancerHealth health ->
-        Keys.getInstanceKey(googleCloudProvider, accountName, health.instanceName)
+        Keys.getInstanceKey(googleCloudProvider, accountName, loadBalancer.region, health.instanceName)
       }
 
       cacheResultBuilder.namespace(LOAD_BALANCERS.ns).get(loadBalancerKey).with {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
@@ -138,6 +138,7 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent {
       serverGroup.instances.each { GoogleInstance2 partialInstance ->
         def instanceKey = Keys.getInstanceKey(googleCloudProvider,
                                               accountName,
+                                              serverGroup.region,
                                               partialInstance.name)
         instanceKeys << instanceKey
         cacheResultBuilder.namespace(INSTANCES.ns).get(instanceKey).with {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
@@ -134,6 +134,7 @@ class GoogleInfrastructureProviderConfig {
           newlyAddedAgents << new GoogleInstanceCachingAgent(googleCloudProvider,
                                                              googleConfiguration.googleApplicationName(),
                                                              credentials.accountName,
+                                                             credentials,
                                                              credentials.credentials.project,
                                                              credentials.credentials.compute,
                                                              objectMapper)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
@@ -59,9 +59,9 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance2.View> {
   final String platform = GoogleCloudProvider.GCE
 
   @Override
-  GoogleInstance2.View getInstance(String account, String _ /*region*/, String id) {
+  GoogleInstance2.View getInstance(String account, String region, String id) {
     Set<GoogleSecurityGroup> securityGroups = securityGroupProvider.getAll(false)
-    def key = Keys.getInstanceKey(googleCloudProvider, account, id)
+    def key = Keys.getInstanceKey(googleCloudProvider, account, region, id)
     getInstanceCacheDatas([key])?.findResult { CacheData cacheData ->
       instanceFromCacheData(cacheData, securityGroups)?.view
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/search/GoogleSearchProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/search/GoogleSearchProvider.groovy
@@ -28,8 +28,10 @@ import groovy.text.SimpleTemplateEngine
 import groovy.text.Template
 import org.apache.log4j.Logger
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
+@ConditionalOnProperty(value = "google.providerImpl", havingValue = "old", matchIfMissing = true)
 @Component
 class GoogleSearchProvider implements SearchProvider {
   protected static final Logger log = Logger.getLogger(this)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.java
@@ -81,6 +81,18 @@ public class GoogleNamedAccountCredentials implements AccountCredentials<GoogleC
       return regionToZonesMap;
     }
 
+    public String regionFromZone(String zone) {
+      if (zone == null || regionToZonesMap == null) {
+        return null;
+      }
+      for (String region : regionToZonesMap.keySet()) {
+        if (regionToZonesMap.get(region).contains(zone)) {
+          return region;
+        }
+      }
+      return null;
+    }
+
     public GoogleCredentials getCredentials() {
       return credentials;
     }


### PR DESCRIPTION
I needed to add `region` back into the instance key because it's needed to form the target URL.

@duftler @lwander PTAL.

tag: https://github.com/spinnaker/spinnaker/issues/712
