### PR TITLE
Massive removal of 'GoogleCloudProvider' instance object. Replaced with static call.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -46,8 +46,7 @@ class Keys {
     }
   }
 
-  // TODO(ttomsu): Remove GoogleCloudProvider from most if not all of the method signatures in this class.
-  static Map<String, String> parse(GoogleCloudProvider googleCloudProvider, String key) {
+  static Map<String, String> parse(String key) {
     def parts = key.split(':')
 
     if (parts.length < 2) {
@@ -55,10 +54,6 @@ class Keys {
     }
 
     def result = [provider: parts[0], type: parts[1]]
-
-    if (result.provider != googleCloudProvider.id) {
-      return null
-    }
 
     switch (result.type) {
       case Namespace.APPLICATIONS.ns:
@@ -146,65 +141,56 @@ class Keys {
     result
   }
 
-  static String getApplicationKey(GoogleCloudProvider googleCloudProvider,
-                                  String application) {
-    "$googleCloudProvider.id:${Namespace.APPLICATIONS}:${application}"
+  static String getApplicationKey(String application) {
+    "$GoogleCloudProvider.GCE:${Namespace.APPLICATIONS}:${application}"
   }
 
-  static String getClusterKey(GoogleCloudProvider googleCloudProvider,
-                              String account,
+  static String getClusterKey(String account,
                               String application,
                               String clusterName) {
-    "$googleCloudProvider.id:${Namespace.CLUSTERS}:${account}:${application}:${clusterName}"
+    "$GoogleCloudProvider.GCE:${Namespace.CLUSTERS}:${account}:${application}:${clusterName}"
   }
 
-  static String getImageKey(GoogleCloudProvider googleCloudProvider,
-                            String account,
+  static String getImageKey(String account,
                             String imageId) {
-    "$googleCloudProvider.id:${Namespace.IMAGES}:${account}:${imageId}"
+    "$GoogleCloudProvider.GCE:${Namespace.IMAGES}:${account}:${imageId}"
   }
 
-  static String getInstanceKey(GoogleCloudProvider googleCloudProvider,
-                               String account,
+  static String getInstanceKey(String account,
                                String region,
                                String name) {
-    "$googleCloudProvider.id:${Namespace.INSTANCES}:${account}:${region}:${name}"
+    "$GoogleCloudProvider.GCE:${Namespace.INSTANCES}:${account}:${region}:${name}"
   }
 
-  static String getLoadBalancerKey(GoogleCloudProvider googleCloudProvider,
-                                   String region,
+  static String getLoadBalancerKey(String region,
                                    String account,
                                    String loadBalancerName) {
-    "$googleCloudProvider.id:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}"
+    "$GoogleCloudProvider.GCE:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}"
   }
 
-  static String getNetworkKey(GoogleCloudProvider googleCloudProvider,
-                              String networkName,
+  static String getNetworkKey(String networkName,
                               String region,
                               String account) {
-    "$googleCloudProvider.id:${Namespace.NETWORKS}:${networkName}:${account}:${region}"
+    "$GoogleCloudProvider.GCE:${Namespace.NETWORKS}:${networkName}:${account}:${region}"
   }
 
-  static String getSecurityGroupKey(GoogleCloudProvider googleCloudProvider,
-                                    String securityGroupName,
+  static String getSecurityGroupKey(String securityGroupName,
                                     String securityGroupId,
                                     String region,
                                     String account) {
-    "$googleCloudProvider.id:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}"
+    "$GoogleCloudProvider.GCE:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}"
   }
 
-  static String getServerGroupKey(GoogleCloudProvider googleCloudProvider,
-                                  String managedInstanceGroupName,
+  static String getServerGroupKey(String managedInstanceGroupName,
                                   String account,
                                   String zone) {
     Names names = Names.parseName(managedInstanceGroupName)
-    "$googleCloudProvider.id:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${zone}:${names.group}"
+    "$GoogleCloudProvider.GCE:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${zone}:${names.group}"
   }
 
-  static String getSubnetKey(GoogleCloudProvider googleCloudProvider,
-                             String subnetName,
+  static String getSubnetKey(String subnetName,
                              String region,
                              String account) {
-    "$googleCloudProvider.id:${Namespace.SUBNETS}:${subnetName}:${account}:${region}"
+    "$GoogleCloudProvider.GCE:${Namespace.SUBNETS}:${subnetName}:${account}:${region}"
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
@@ -20,14 +20,12 @@ import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 
 import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.*
 
 class GoogleInfrastructureProvider extends AgentSchedulerAware implements SearchableProvider {
 
-  final GoogleCloudProvider googleCloudProvider
   final Collection<Agent> agents
   final String providerName = GoogleInfrastructureProvider.name
 
@@ -40,8 +38,7 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
       SERVER_GROUPS.ns,
   ].asImmutable()
 
-  GoogleInfrastructureProvider(GoogleCloudProvider googleCloudProvider, Collection<Agent> agents) {
-    this.googleCloudProvider = googleCloudProvider
+  GoogleInfrastructureProvider(Collection<Agent> agents) {
     this.agents = agents
   }
 
@@ -52,17 +49,15 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
   final Map<String, SearchableProvider.IdentifierExtractor> identifierExtractors = Collections.emptyMap()
 
   final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = [
-      (INSTANCES.ns): new InstanceSearchResultHydrator(googleCloudProvider: googleCloudProvider)
+      (INSTANCES.ns): new InstanceSearchResultHydrator()
   ]
 
   @Override
   Map<String, String> parseKey(String key) {
-    return Keys.parse(googleCloudProvider, key)
+    return Keys.parse(key)
   }
 
   private static class InstanceSearchResultHydrator implements SearchableProvider.SearchResultHydrator {
-
-    GoogleCloudProvider googleCloudProvider
 
     @Override
     Map<String, String> hydrateResult(Cache cacheView, Map<String, String> result, String id) {
@@ -71,7 +66,7 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
         return result
       }
 
-      def serverGroup = Keys.parse(googleCloudProvider, item.relationships[SERVER_GROUPS.ns].first())
+      def serverGroup = Keys.parse(item.relationships[SERVER_GROUPS.ns].first())
       return result + [
           application: serverGroup.application as String,
           cluster: serverGroup.cluster as String,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleCachingAgent.groovy
@@ -25,7 +25,6 @@ import com.google.api.services.compute.Compute
 import com.google.common.annotations.VisibleForTesting
 import com.netflix.spinnaker.cats.agent.AccountAware
 import com.netflix.spinnaker.cats.agent.CachingAgent
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.provider.GoogleInfrastructureProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 
@@ -35,7 +34,6 @@ abstract class AbstractGoogleCachingAgent implements CachingAgent, AccountAware 
 
   final String providerName = GoogleInfrastructureProvider.name
 
-  GoogleCloudProvider googleCloudProvider
   String googleApplicationName // "Spinnaker/${version}" HTTP header string
   GoogleNamedAccountCredentials credentials
   ObjectMapper objectMapper
@@ -43,11 +41,9 @@ abstract class AbstractGoogleCachingAgent implements CachingAgent, AccountAware 
   @VisibleForTesting
   AbstractGoogleCachingAgent() {}
 
-  AbstractGoogleCachingAgent(GoogleCloudProvider googleCloudProvider,
-                             String googleApplicationName,
+  AbstractGoogleCachingAgent(String googleApplicationName,
                              GoogleNamedAccountCredentials credentials,
                              ObjectMapper objectMapper) {
-    this.googleCloudProvider = googleCloudProvider
     this.googleApplicationName = googleApplicationName
     this.credentials = credentials
     this.objectMapper = objectMapper

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgent.groovy
@@ -19,16 +19,13 @@ package com.netflix.spinnaker.clouddriver.google.provider.agent
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback
-import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
-import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Image
 import com.google.api.services.compute.model.ImageList
 import com.netflix.servo.util.VisibleForTesting
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
@@ -52,14 +49,12 @@ class GoogleImageCachingAgent extends AbstractGoogleCachingAgent {
   @VisibleForTesting
   GoogleImageCachingAgent() {}
 
-  GoogleImageCachingAgent(GoogleCloudProvider googleCloudProvider,
-                          String googleApplicationName,
+  GoogleImageCachingAgent(String googleApplicationName,
                           GoogleNamedAccountCredentials credentials,
                           ObjectMapper objectMapper,
                           List<String> imageProjects,
                           List<String> baseImageProjects) {
-    super(googleCloudProvider,
-          googleApplicationName,
+    super(googleApplicationName,
           credentials,
           objectMapper)
     this.imageProjects = imageProjects
@@ -95,7 +90,7 @@ class GoogleImageCachingAgent extends AbstractGoogleCachingAgent {
     def cacheResultBuilder = new CacheResultBuilder()
 
     imageList.each { Image image ->
-      def imageKey = Keys.getImageKey(googleCloudProvider, accountName, image.getName())
+      def imageKey = Keys.getImageKey(accountName, image.getName())
 
       cacheResultBuilder.namespace(IMAGES.ns).get(imageKey).with {
         attributes.image = image

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInstanceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInstanceCachingAgent.groovy
@@ -16,25 +16,19 @@
 
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback
-import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
-import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Instance
 import com.google.api.services.compute.model.InstancesScopedList
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstance2
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.model.health.GoogleInstanceHealth
-import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentials
-import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 
@@ -74,7 +68,7 @@ class GoogleInstanceCachingAgent extends AbstractGoogleCachingAgent {
     CacheResultBuilder cacheResultBuilder = new CacheResultBuilder()
 
     googleInstances.each { GoogleInstance2 instance ->
-      def instanceKey = Keys.getInstanceKey(googleCloudProvider, accountName, instance.region, instance.name)
+      def instanceKey = Keys.getInstanceKey(accountName, instance.region, instance.name)
       cacheResultBuilder.namespace(INSTANCES.ns).get(instanceKey).with {
         attributes = objectMapper.convertValue(instance, ATTRIBUTES)
       }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -27,7 +27,6 @@ import com.google.api.services.compute.model.TargetPool
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
@@ -54,13 +53,11 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
 
   String agentType = "${accountName}/${region}/${GoogleLoadBalancerCachingAgent.simpleName}"
 
-  GoogleLoadBalancerCachingAgent(GoogleCloudProvider googleCloudProvider,
-                                 String googleApplicationName,
+  GoogleLoadBalancerCachingAgent(String googleApplicationName,
                                  GoogleNamedAccountCredentials credentials,
                                  ObjectMapper objectMapper,
                                  String region) {
-    super(googleCloudProvider,
-          googleApplicationName,
+    super(googleApplicationName,
           credentials,
           objectMapper)
     this.region = region
@@ -100,12 +97,11 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent {
     def cacheResultBuilder = new CacheResultBuilder()
 
     googleLoadBalancers.each { GoogleLoadBalancer2 loadBalancer ->
-      def loadBalancerKey = Keys.getLoadBalancerKey(googleCloudProvider,
-                                                    loadBalancer.region,
+      def loadBalancerKey = Keys.getLoadBalancerKey(loadBalancer.region,
                                                     loadBalancer.account,
                                                     loadBalancer.name)
       def instanceKeys = loadBalancer.healths.collect { GoogleLoadBalancerHealth health ->
-        Keys.getInstanceKey(googleCloudProvider, accountName, loadBalancer.region, health.instanceName)
+        Keys.getInstanceKey(accountName, loadBalancer.region, health.instanceName)
       }
 
       cacheResultBuilder.namespace(LOAD_BALANCERS.ns).get(loadBalancerKey).with {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleNetworkCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleNetworkCachingAgent.groovy
@@ -16,15 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.services.compute.model.Network
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
-import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 
@@ -57,7 +54,7 @@ class GoogleNetworkCachingAgent extends AbstractGoogleCachingAgent {
     def cacheResultBuilder = new CacheResultBuilder()
 
     networkList.each { Network network ->
-      def networkKey = Keys.getNetworkKey(googleCloudProvider, network.getName(), "global", accountName)
+      def networkKey = Keys.getNetworkKey(network.getName(), "global", accountName)
 
       cacheResultBuilder.namespace(NETWORKS.ns).get(networkKey).with {
         attributes.network = network

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Firewall
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.AgentDataType
@@ -50,16 +49,14 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
 
   String agentType = "${accountName}/global/${GoogleSecurityGroupCachingAgent.simpleName}"
 
-  GoogleSecurityGroupCachingAgent(GoogleCloudProvider googleCloudProvider,
-                                  String googleApplicationName,
+  GoogleSecurityGroupCachingAgent(String googleApplicationName,
                                   GoogleNamedAccountCredentials credentials,
                                   ObjectMapper objectMapper,
                                   Registry registry) {
-    super(googleCloudProvider,
-          googleApplicationName,
+    super(googleApplicationName,
           credentials,
           objectMapper)
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, googleCloudProvider.id + ":" + ON_DEMAND_TYPE)
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${GoogleCloudProvider.GCE}:${ON_DEMAND_TYPE}")
   }
 
   @Override
@@ -104,7 +101,7 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
 
   @Override
   boolean handles(String type, String cloudProvider) {
-    type == ON_DEMAND_TYPE && cloudProvider == googleCloudProvider.id
+    type == ON_DEMAND_TYPE && cloudProvider == GoogleCloudProvider.GCE
   }
 
   @Override
@@ -123,8 +120,7 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
     CacheResultBuilder cacheResultBuilder = new CacheResultBuilder()
 
     firewallList.collect { Firewall firewall ->
-      def securityGroupKey = Keys.getSecurityGroupKey(googleCloudProvider,
-                                                      firewall.getName(),
+      def securityGroupKey = Keys.getSecurityGroupKey(firewall.getName(),
                                                       firewall.getName(),
                                                       "global",
                                                       accountName)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleServerGroupCachingAgent.groovy
@@ -29,7 +29,6 @@ import com.netflix.frigga.Names
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstance2
@@ -57,13 +56,11 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent {
 
   String agentType = "${accountName}/${region}/${GoogleServerGroupCachingAgent.simpleName}"
 
-  GoogleServerGroupCachingAgent(GoogleCloudProvider googleCloudProvider,
-                                String googleApplicationName,
+  GoogleServerGroupCachingAgent(String googleApplicationName,
                                 GoogleNamedAccountCredentials credentials,
                                 ObjectMapper objectMapper,
                                 String region) {
-    super(googleCloudProvider,
-          googleApplicationName,
+    super(googleApplicationName,
           credentials,
           objectMapper)
     this.region = region
@@ -106,15 +103,13 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent {
       def applicationName = names.app
       def clusterName = names.cluster
 
-      def serverGroupKey = Keys.getServerGroupKey(googleCloudProvider,
-                                                  serverGroup.name,
+      def serverGroupKey = Keys.getServerGroupKey(serverGroup.name,
                                                   accountName,
                                                   serverGroup.region)
-      def clusterKey = Keys.getClusterKey(googleCloudProvider,
-                                          accountName,
+      def clusterKey = Keys.getClusterKey(accountName,
                                           applicationName,
                                           clusterName)
-      def appKey = Keys.getApplicationKey(googleCloudProvider, applicationName)
+      def appKey = Keys.getApplicationKey(applicationName)
       def instanceKeys = []
       def loadBalancerKeys = []
 
@@ -131,8 +126,7 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent {
       }
 
       serverGroup.instances.each { GoogleInstance2 partialInstance ->
-        def instanceKey = Keys.getInstanceKey(googleCloudProvider,
-                                              accountName,
+        def instanceKey = Keys.getInstanceKey(accountName,
                                               serverGroup.region,
                                               partialInstance.name)
         instanceKeys << instanceKey
@@ -143,8 +137,7 @@ class GoogleServerGroupCachingAgent extends AbstractGoogleCachingAgent {
       serverGroup.instances.clear()
 
       serverGroup.asg.loadBalancerNames.each { String loadBalancerName ->
-        loadBalancerKeys << Keys.getLoadBalancerKey(googleCloudProvider,
-                                                    region,
+        loadBalancerKeys << Keys.getLoadBalancerKey(region,
                                                     accountName,
                                                     loadBalancerName)
       }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
@@ -17,12 +17,10 @@
 package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Subnetwork
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
@@ -42,13 +40,11 @@ class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
 
   String agentType = "$accountName/$region/$GoogleSubnetCachingAgent.simpleName"
 
-  GoogleSubnetCachingAgent(GoogleCloudProvider googleCloudProvider,
-                           String googleApplicationName,
+  GoogleSubnetCachingAgent(String googleApplicationName,
                            GoogleNamedAccountCredentials credentials,
                            ObjectMapper objectMapper,
                            String region) {
-    super(googleCloudProvider,
-          googleApplicationName,
+    super(googleApplicationName,
           credentials,
           objectMapper)
     this.region = region
@@ -70,7 +66,7 @@ class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
     def cacheResultBuilder = new CacheResultBuilder()
 
     subnetList.each { Subnetwork subnet ->
-      def subnetKey = Keys.getSubnetKey(googleCloudProvider, subnet.getName(), region, accountName)
+      def subnetKey = Keys.getSubnetKey(subnet.getName(), region, accountName)
 
       cacheResultBuilder.namespace(SUBNETS.ns).get(subnetKey).with {
         attributes.subnet = subnet

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.groovy
@@ -43,9 +43,6 @@ class GoogleApplicationProvider implements ApplicationProvider {
   AccountCredentialsProvider accountCredentialsProvider
 
   @Autowired
-  GoogleCloudProvider googleCloudProvider
-
-  @Autowired
   Cache cacheView
 
   @Autowired
@@ -62,7 +59,7 @@ class GoogleApplicationProvider implements ApplicationProvider {
   @Override
   GoogleApplication2.View getApplication(String name) {
     CacheData cacheData = cacheView.get(APPLICATIONS.ns,
-                                        Keys.getApplicationKey(googleCloudProvider, name),
+                                        Keys.getApplicationKey(name),
                                         RelationshipCacheFilter.include(CLUSTERS.ns))
     if (cacheData) {
       return applicationFromCacheData(cacheData)
@@ -73,7 +70,7 @@ class GoogleApplicationProvider implements ApplicationProvider {
     GoogleApplication2.View applicationView = objectMapper.convertValue(cacheData.attributes, GoogleApplication2)?.view
 
     cacheData.relationships[CLUSTERS.ns].each { String clusterKey ->
-      def clusterKeyParsed = Keys.parse(googleCloudProvider, clusterKey)
+      def clusterKeyParsed = Keys.parse(clusterKey)
       applicationView.clusterNames[clusterKeyParsed.account] << clusterKeyParsed.name
     }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.model.GoogleApplication2
 import com.netflix.spinnaker.clouddriver.google.model.GoogleCluster2
@@ -40,8 +39,6 @@ import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.*
 @Component
 class GoogleClusterProvider implements ClusterProvider<GoogleCluster2.View> {
 
-  @Autowired
-  GoogleCloudProvider googleCloudProvider
   @Autowired
   Cache cacheView
   @Autowired
@@ -74,7 +71,7 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster2.View> {
     def clusterKeys = []
     application.clusterNames.each { String accountName, Set<String> clusterNames ->
       clusterNames.each { String clusterName ->
-        clusterKeys << Keys.getClusterKey(googleCloudProvider, accountName, applicationName, clusterName)
+        clusterKeys << Keys.getClusterKey(accountName, applicationName, clusterName)
       }
     }
 
@@ -101,7 +98,7 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster2.View> {
   @Override
   GoogleServerGroup2.View getServerGroup(String account, String region, String name) {
     def cacheData = cacheView.get(SERVER_GROUPS.ns,
-                                  Keys.getServerGroupKey(googleCloudProvider, name, account, region),
+                                  Keys.getServerGroupKey(name, account, region),
                                   RelationshipCacheFilter.include(INSTANCES.ns, LOAD_BALANCERS.ns))
     if (cacheData) {
       return serverGroupFromCacheData(cacheData)?.view

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleImageProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleImageProvider.groovy
@@ -39,15 +39,12 @@ class GoogleImageProvider implements ImageProvider {
   @Autowired
   Cache cacheView
 
-  @Autowired
-  GoogleCloudProvider googleCloudProvider
-
   Map<String, List<Image>> listImagesByAccount() {
     def filter = cacheView.filterIdentifiers(IMAGES.ns, "$GoogleCloudProvider.GCE:*")
     def result = [:].withDefault { _ -> []}
 
     cacheView.getAll(IMAGES.ns, filter).each { CacheData cacheData ->
-      def account = Keys.parse(googleCloudProvider, cacheData.id).account
+      def account = Keys.parse(cacheData.id).account
       result[account] << (cacheData.attributes.image as Image)
     }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
@@ -45,9 +45,6 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance2.View> {
   final Cache cacheView
 
   @Autowired
-  GoogleCloudProvider googleCloudProvider
-
-  @Autowired
   AccountCredentialsProvider accountCredentialsProvider
 
   @Autowired
@@ -61,7 +58,7 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance2.View> {
   @Override
   GoogleInstance2.View getInstance(String account, String region, String id) {
     Set<GoogleSecurityGroup> securityGroups = securityGroupProvider.getAll(false)
-    def key = Keys.getInstanceKey(googleCloudProvider, account, region, id)
+    def key = Keys.getInstanceKey(account, region, id)
     getInstanceCacheDatas([key])?.findResult { CacheData cacheData ->
       instanceFromCacheData(cacheData, securityGroups)?.view
     }
@@ -130,7 +127,7 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance2.View> {
 
     def serverGroupKey = cacheData.relationships[SERVER_GROUPS.ns]?.first()
     if (serverGroupKey) {
-      instance.serverGroup = Keys.parse(googleCloudProvider, serverGroupKey).serverGroup
+      instance.serverGroup = Keys.parse(serverGroupKey).serverGroup
     }
 
     instance.securityGroups = GoogleSecurityGroupProvider.getMatchingServerGroupNames(

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
@@ -20,11 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
-import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
-import com.netflix.spinnaker.clouddriver.google.model.GoogleInstance2
 import com.netflix.spinnaker.clouddriver.google.model.GoogleLoadBalancer2
-import com.netflix.spinnaker.clouddriver.google.model.GoogleSecurityGroup
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup2
 import com.netflix.spinnaker.clouddriver.google.model.health.GoogleLoadBalancerHealth
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance
@@ -41,8 +38,6 @@ import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.*
 class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalancer2.View> {
 
   @Autowired
-  GoogleCloudProvider googleCloudProvider
-  @Autowired
   Cache cacheView
   @Autowired
   ObjectMapper objectMapper
@@ -53,7 +48,7 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
 
   @Override
   Set<GoogleLoadBalancer2.View> getApplicationLoadBalancers(String application) {
-    def pattern = Keys.getLoadBalancerKey(googleCloudProvider, "*", "*", "${application}*")
+    def pattern = Keys.getLoadBalancerKey("*", "*", "${application}*")
     def identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, pattern)
 
     cacheView.getAll(LOAD_BALANCERS.ns,
@@ -83,7 +78,7 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
           instances: [])
 
       def instanceNames = serverGroupCacheData.relationships[INSTANCES.ns]?.collect {
-        Keys.parse(googleCloudProvider, it)?.name
+        Keys.parse(it)?.name
       }
 
       loadBalancer.healths.each { GoogleLoadBalancerHealth googleLoadBalancerHealth ->

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleNetworkProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleNetworkProvider.groovy
@@ -33,25 +33,20 @@ import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.NETW
 @Component
 class GoogleNetworkProvider implements NetworkProvider<GoogleNetwork> {
 
-  private final GoogleCloudProvider googleCloudProvider
   private final Cache cacheView
   final ObjectMapper objectMapper
 
+  final String cloudProvider = GoogleCloudProvider.GCE
+
   @Autowired
-  GoogleNetworkProvider(GoogleCloudProvider googleCloudProvider, Cache cacheView, ObjectMapper objectMapper) {
-    this.googleCloudProvider = googleCloudProvider
+  GoogleNetworkProvider(Cache cacheView, ObjectMapper objectMapper) {
     this.cacheView = cacheView
     this.objectMapper = objectMapper
   }
 
   @Override
-  String getCloudProvider() {
-    return googleCloudProvider.id
-  }
-
-  @Override
   Set<GoogleNetwork> getAll() {
-    getAllMatchingKeyPattern(Keys.getNetworkKey(googleCloudProvider, '*', '*', '*'))
+    getAllMatchingKeyPattern(Keys.getNetworkKey('*', '*', '*'))
   }
 
   Set<GoogleNetwork> getAllMatchingKeyPattern(String pattern) {
@@ -71,10 +66,10 @@ class GoogleNetworkProvider implements NetworkProvider<GoogleNetwork> {
     }
 
     Network network = objectMapper.convertValue(cacheData.attributes.network, Network)
-    Map<String, String> parts = Keys.parse(googleCloudProvider, cacheData.id)
+    Map<String, String> parts = Keys.parse(cacheData.id)
 
     new GoogleNetwork(
-      cloudProvider: googleCloudProvider.id,
+      cloudProvider: this.cloudProvider,
       id: network.name,
       name: network.name,
       account: parts.account,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProvider.groovy
@@ -36,51 +36,46 @@ import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.SECU
 @Component
 class GoogleSecurityGroupProvider implements SecurityGroupProvider<GoogleSecurityGroup> {
 
-  final GoogleCloudProvider googleCloudProvider
   final Cache cacheView
   final ObjectMapper objectMapper
 
+  String type = GoogleCloudProvider.GCE
+
   @Autowired
-  GoogleSecurityGroupProvider(GoogleCloudProvider googleCloudProvider, Cache cacheView, ObjectMapper objectMapper) {
-    this.googleCloudProvider = googleCloudProvider
+  GoogleSecurityGroupProvider(Cache cacheView, ObjectMapper objectMapper) {
     this.cacheView = cacheView
     this.objectMapper = objectMapper
   }
 
   @Override
-  String getType() {
-    return googleCloudProvider.id
-  }
-
-  @Override
   Set<GoogleSecurityGroup> getAll(boolean includeRules) {
-    getAllMatchingKeyPattern(Keys.getSecurityGroupKey(googleCloudProvider, '*', '*', '*', '*'), includeRules)
+    getAllMatchingKeyPattern(Keys.getSecurityGroupKey('*', '*', '*', '*'), includeRules)
   }
 
   @Override
   Set<GoogleSecurityGroup> getAllByRegion(boolean includeRules, String region) {
-    getAllMatchingKeyPattern(Keys.getSecurityGroupKey(googleCloudProvider, '*', '*', region, '*'), includeRules)
+    getAllMatchingKeyPattern(Keys.getSecurityGroupKey('*', '*', region, '*'), includeRules)
   }
 
   @Override
   Set<GoogleSecurityGroup> getAllByAccount(boolean includeRules, String account) {
-    getAllMatchingKeyPattern(Keys.getSecurityGroupKey(googleCloudProvider, '*', '*', '*', account), includeRules)
+    getAllMatchingKeyPattern(Keys.getSecurityGroupKey('*', '*', '*', account), includeRules)
   }
 
   @Override
   Set<GoogleSecurityGroup> getAllByAccountAndName(boolean includeRules, String account, String name) {
-    getAllMatchingKeyPattern(Keys.getSecurityGroupKey(googleCloudProvider, name, '*', '*', account), includeRules)
+    getAllMatchingKeyPattern(Keys.getSecurityGroupKey(name, '*', '*', account), includeRules)
   }
 
   @Override
   Set<GoogleSecurityGroup> getAllByAccountAndRegion(boolean includeRules, String account, String region) {
-    getAllMatchingKeyPattern(Keys.getSecurityGroupKey(googleCloudProvider, '*', '*', region, account), includeRules)
+    getAllMatchingKeyPattern(Keys.getSecurityGroupKey('*', '*', region, account), includeRules)
   }
 
   @Override
   GoogleSecurityGroup get(String account, String region, String name, String vpcId) {
     // We ignore vpcId here.
-    getAllMatchingKeyPattern(Keys.getSecurityGroupKey(googleCloudProvider, name, '*', region, account), true)[0]
+    getAllMatchingKeyPattern(Keys.getSecurityGroupKey(name, '*', region, account), true)[0]
   }
 
   Set<GoogleSecurityGroup> getAllMatchingKeyPattern(String pattern, boolean includeRules) {
@@ -101,7 +96,7 @@ class GoogleSecurityGroupProvider implements SecurityGroupProvider<GoogleSecurit
     }
 
     Firewall firewall = objectMapper.convertValue(cacheData.attributes.firewall, Firewall)
-    Map<String, String> parts = Keys.parse(googleCloudProvider, cacheData.id)
+    Map<String, String> parts = Keys.parse(cacheData.id)
 
     return convertToGoogleSecurityGroup(includeRules, firewall, parts.account, parts.region)
   }
@@ -110,7 +105,7 @@ class GoogleSecurityGroupProvider implements SecurityGroupProvider<GoogleSecurit
     List<Rule> inboundRules = includeRules ? buildInboundIpRangeRules(firewall) : []
 
     new GoogleSecurityGroup(
-      type: googleCloudProvider.id,
+      type: this.type,
       id: firewall.name,
       name: firewall.name,
       description: firewall.description,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSubnetProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSubnetProvider.groovy
@@ -34,25 +34,20 @@ import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.SUBN
 @Component
 class GoogleSubnetProvider implements SubnetProvider<GoogleSubnet> {
 
-  private final GoogleCloudProvider googleCloudProvider
   private final Cache cacheView
   final ObjectMapper objectMapper
 
+  final String type = GoogleCloudProvider.GCE
+
   @Autowired
-  GoogleSubnetProvider(GoogleCloudProvider googleCloudProvider, Cache cacheView, ObjectMapper objectMapper) {
-    this.googleCloudProvider = googleCloudProvider
+  GoogleSubnetProvider(Cache cacheView, ObjectMapper objectMapper) {
     this.cacheView = cacheView
     this.objectMapper = objectMapper
   }
 
   @Override
-  String getType() {
-    return googleCloudProvider.id
-  }
-
-  @Override
   Set<GoogleSubnet> getAll() {
-    getAllMatchingKeyPattern(Keys.getSubnetKey(googleCloudProvider, '*', '*', '*'))
+    getAllMatchingKeyPattern(Keys.getSubnetKey('*', '*', '*'))
   }
 
   Set<GoogleSubnet> getAllMatchingKeyPattern(String pattern) {
@@ -72,10 +67,10 @@ class GoogleSubnetProvider implements SubnetProvider<GoogleSubnet> {
     }
 
     Subnetwork subnet = objectMapper.convertValue(cacheData.attributes.subnet, Subnetwork)
-    Map<String, String> parts = Keys.parse(googleCloudProvider, cacheData.id)
+    Map<String, String> parts = Keys.parse(cacheData.id)
 
     new GoogleSubnet(
-      type: googleCloudProvider.id,
+      type: this.type,
       id: subnet.name,
       name: subnet.name,
       gatewayAddress: subnet.gatewayAddress,

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgentSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgentSpec.groovy
@@ -38,7 +38,6 @@ class GoogleSecurityGroupCachingAgentSpec extends Specification {
 
   void "should add security groups on initial run"() {
     setup:
-      def googleCloudProvider = new GoogleCloudProvider()
       def computeMock = Mock(Compute)
       def credentials = new GoogleNamedAccountCredentials(ACCOUNT_NAME, null, null, null, null, null, "testApplicationName")
       credentials.metaClass.credentials = new GoogleCredentials(PROJECT_NAME, computeMock)
@@ -46,13 +45,11 @@ class GoogleSecurityGroupCachingAgentSpec extends Specification {
       def firewallsListMock = Mock(Compute.Firewalls.List)
       def securityGroupA = new Firewall(name: 'name-a')
       def securityGroupB = new Firewall(name: 'name-b')
-      def keyGroupA = Keys.getSecurityGroupKey(googleCloudProvider,
-                                               securityGroupA.name as String,
+      def keyGroupA = Keys.getSecurityGroupKey(securityGroupA.name as String,
                                                securityGroupA.name as String,
                                                REGION,
                                                ACCOUNT_NAME)
-      def keyGroupB = Keys.getSecurityGroupKey(googleCloudProvider,
-                                               securityGroupB.name as String,
+      def keyGroupB = Keys.getSecurityGroupKey(securityGroupB.name as String,
                                                securityGroupB.name as String,
                                                REGION,
                                                ACCOUNT_NAME)
@@ -61,9 +58,9 @@ class GoogleSecurityGroupCachingAgentSpec extends Specification {
           securityGroupB
       ])
       def ProviderCache providerCache = Mock(ProviderCache)
-      @Subject GoogleSecurityGroupCachingAgent agent = new GoogleSecurityGroupCachingAgent(googleCloudProvider,
-                                                                                           "testApplicationName",
-                                                                                           credentials, new ObjectMapper(),
+      @Subject GoogleSecurityGroupCachingAgent agent = new GoogleSecurityGroupCachingAgent("testApplicationName",
+                                                                                           credentials,
+                                                                                           new ObjectMapper(),
                                                                                            Spectator.registry())
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProviderSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProviderSpec.groovy
@@ -38,12 +38,11 @@ class GoogleSecurityGroupProviderSpec extends Specification {
   @Subject
   GoogleSecurityGroupProvider provider
 
-  GoogleCloudProvider googleCloudProvider = new GoogleCloudProvider()
   WriteableCache cache = new InMemoryCache()
   ObjectMapper mapper = new ObjectMapper()
 
   def setup() {
-    provider = new GoogleSecurityGroupProvider(googleCloudProvider, cache, mapper)
+    provider = new GoogleSecurityGroupProvider(cache, mapper)
     cache.mergeAll(Keys.Namespace.SECURITY_GROUPS.ns, getAllGroups())
   }
 
@@ -306,7 +305,7 @@ class GoogleSecurityGroupProviderSpec extends Specification {
       regions.collect { String region, List<Firewall> firewalls ->
         firewalls.collect { Firewall firewall ->
           Map<String, Object> attributes = [firewall: firewall]
-          new DefaultCacheData(Keys.getSecurityGroupKey(googleCloudProvider, firewall.getName(), firewall.getName(), "global", account), attributes, [:])
+          new DefaultCacheData(Keys.getSecurityGroupKey(firewall.getName(), firewall.getName(), "global", account), attributes, [:])
         }
       }.flatten()
     }.flatten()


### PR DESCRIPTION
*Review second commit only*: This PR is based off of https://github.com/spinnaker/clouddriver/pull/434

This one has been on my list for a long time to clean up. @duftler @lwander PTAL.

tag: https://github.com/spinnaker/spinnaker/issues/712