### PR TITLE
provide cloud metrics endpoints, interfaces for providers

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricDatapoint.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricDatapoint.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.netflix.spinnaker.clouddriver.model.CloudMetricDatapoint
+import groovy.transform.Immutable
+
+@Immutable
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class AmazonMetricDatapoint implements CloudMetricDatapoint {
+  Date timestamp
+  Double average
+  Double sum
+  Double sampleCount
+  Double minimum
+  Double maximum
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricDescriptor.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricDescriptor.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model
+
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.amazonaws.services.cloudwatch.model.Metric
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.netflix.spinnaker.clouddriver.model.CloudMetricDescriptor
+import groovy.transform.Immutable
+
+@Immutable
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class AmazonMetricDescriptor implements CloudMetricDescriptor {
+  final String cloudProvider = 'aws'
+  final String namespace
+  final String name
+  final List<Dimension> dimensions
+
+  static AmazonMetricDescriptor from(Metric metric) {
+    new AmazonMetricDescriptor('aws', metric.namespace, metric.metricName, metric.dimensions)
+  }
+
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricStatistics.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricStatistics.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model
+
+import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.netflix.spinnaker.clouddriver.model.CloudMetricStatistics
+import groovy.transform.Immutable
+
+@Immutable
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class AmazonMetricStatistics implements CloudMetricStatistics<AmazonMetricDatapoint> {
+
+  String unit
+  List<AmazonMetricDatapoint> datapoints
+
+  static AmazonMetricStatistics from(GetMetricStatisticsResult result) {
+    def datapoints = result.datapoints
+        .sort { a, b -> a.timestamp <=> b.timestamp }
+        .findResults {
+          new AmazonMetricDatapoint(it.timestamp, it.average, it.sum, it.sampleCount, it.minimum, it.maximum)
+        } as List
+    def unit = result.datapoints ? result.datapoints[0].unit : null
+
+    new AmazonMetricStatistics(unit, datapoints)
+  }
+
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProvider.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.view
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.amazonaws.services.cloudwatch.model.DimensionFilter
+import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest
+import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult
+import com.amazonaws.services.cloudwatch.model.ListMetricsRequest
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricDatapoint
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricDescriptor
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricStatistics
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.model.CloudMetricProvider
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class AmazonCloudMetricProvider implements CloudMetricProvider<AmazonMetricDescriptor> {
+
+  final AmazonClientProvider amazonClientProvider
+  final AccountCredentialsProvider accountCredentialsProvider
+  final AmazonCloudProvider amazonCloudProvider
+
+  @Autowired
+  AmazonCloudMetricProvider(AmazonClientProvider amazonClientProvider,
+                            AccountCredentialsProvider accountCredentialsProvider,
+                            AmazonCloudProvider amazonCloudProvider) {
+    this.amazonClientProvider = amazonClientProvider
+    this.accountCredentialsProvider = accountCredentialsProvider
+    this.amazonCloudProvider = amazonCloudProvider
+  }
+
+  @Override
+  String getCloudProvider() {
+    amazonCloudProvider.id
+  }
+
+  @Override
+  AmazonMetricDescriptor getMetricDescriptor(String account, String region, Map<String, String> filters) {
+    def cloudWatch = getCloudWatch(account, region)
+    def request = new ListMetricsRequest()
+        .withNamespace(filters.namespace)
+        .withMetricName(filters.metricName)
+    def results = cloudWatch.listMetrics(request).metrics
+    if (!results) {
+      return null
+    }
+    if (results.size() > 1) {
+      throw new IllegalArgumentException("Multiple metric descriptors (${results.size()}) found for provided filters")
+    }
+    return AmazonMetricDescriptor.from(results[0])
+  }
+
+  @Override
+  List<AmazonMetricDescriptor> findMetricDescriptors(String account, String region, Map<String, String> filters) {
+    def cloudWatch = getCloudWatch(account, region)
+    def request = new ListMetricsRequest()
+    if (filters.namespace) {
+      request.withNamespace(filters.namespace)
+    }
+    if (filters.name) {
+      request.withMetricName(filters.name)
+    }
+
+    request.withDimensions(filters.findResults {
+      if (it.key != "namespace" && it.key != "name") {
+        new DimensionFilter().withName(it.key).withValue(it.value)
+      } else {
+        null
+      }
+    })
+    def results = cloudWatch.listMetrics(request).metrics
+    return results.findResults { AmazonMetricDescriptor.from(it) }
+  }
+
+  @Override
+  AmazonMetricStatistics getStatistics(String account, String region, String metricName, Map<String, String> filters,
+                                       Long startTime, Long endTime) {
+    List<String> requiredFilters = ["namespace"]
+    List<String> optionalFilters = ["statistics", "period"]
+    if (!filters || !requiredFilters.every({ filters.containsKey(it)})) {
+      throw new IllegalArgumentException("Not all required filters (${requiredFilters.join(', ')}) are present")
+    }
+    AmazonCloudWatch cloudWatch = getCloudWatch(account, region)
+    GetMetricStatisticsRequest request = new GetMetricStatisticsRequest()
+      .withNamespace(filters.namespace)
+      .withMetricName(metricName)
+      .withStartTime(new Date(startTime))
+      .withEndTime(new Date(endTime))
+      .withStatistics(filters.statistics ? filters.statistics.split(",") : "Average")
+      .withPeriod(filters.period ? Integer.parseInt(filters.period) : 600)
+      .withDimensions(filters.findResults {
+        if (!requiredFilters.contains(it.key) && !optionalFilters.contains(it.key)) {
+          new Dimension().withName(it.key).withValue(it.value)
+        } else {
+          null
+        }
+      })
+    GetMetricStatisticsResult results = cloudWatch.getMetricStatistics(request)
+    return AmazonMetricStatistics.from(results)
+  }
+
+  private AmazonCloudWatch getCloudWatch(String account, String region) {
+    def credentials = accountCredentialsProvider.getCredentials(account)
+    if (!(credentials instanceof NetflixAmazonCredentials)) {
+      throw new IllegalArgumentException("Invalid credentials: ${account}:${region}")
+    }
+    amazonClientProvider.getCloudWatch(credentials, region)
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricStatisticsSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonMetricStatisticsSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model
+
+import com.amazonaws.services.cloudwatch.model.Datapoint
+import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult
+import spock.lang.Specification
+
+class AmazonMetricStatisticsSpec extends Specification {
+
+  void "should sort metrics by timestamp"() {
+    given:
+    GetMetricStatisticsResult amazonResult = new GetMetricStatisticsResult()
+    .withDatapoints(
+        new Datapoint().withTimestamp(new Date(4)).withAverage(3.0),
+        new Datapoint().withTimestamp(new Date(0)).withAverage(1.0),
+        new Datapoint().withTimestamp(new Date(1)).withAverage(2.0),
+        new Datapoint().withTimestamp(new Date(3)).withAverage(1.0)
+    )
+    when:
+    AmazonMetricStatistics result = AmazonMetricStatistics.from(amazonResult)
+
+    then:
+    result.datapoints.timestamp.time == [0, 1, 3, 4]
+    result.datapoints.average == [1.0, 2.0, 1.0, 3.0]
+  }
+
+  void "should add any statistics provided by datapoints"() {
+    given:
+    GetMetricStatisticsResult amazonResult = new GetMetricStatisticsResult()
+        .withDatapoints(
+        new Datapoint().withTimestamp(new Date(0)).withAverage(3.0),
+        new Datapoint().withTimestamp(new Date(1)).withMaximum(1.0),
+        new Datapoint().withTimestamp(new Date(2)).withMinimum(2.0),
+        new Datapoint().withTimestamp(new Date(3)).withSampleCount(1.0),
+        new Datapoint().withTimestamp(new Date(3)).withSum(6.0)
+    )
+    when:
+    AmazonMetricStatistics result = AmazonMetricStatistics.from(amazonResult)
+
+    then:
+    result.datapoints.average == [3.0, null, null, null, null]
+    result.datapoints.maximum == [null, 1.0, null, null, null]
+    result.datapoints.minimum == [null, null, 2.0, null, null]
+    result.datapoints.sampleCount == [null, null, null, 1.0, null]
+    result.datapoints.sum == [null, null, null, null, 6.0]
+  }
+
+  void "should add unit from first datapoint"() {
+    given:
+    GetMetricStatisticsResult amazonResult = new GetMetricStatisticsResult()
+        .withDatapoints(
+        new Datapoint().withTimestamp(new Date(4)).withAverage(3.0).withUnit("hectares"),
+        new Datapoint().withTimestamp(new Date(0)).withAverage(1.0).withUnit("stone"),
+        new Datapoint().withTimestamp(new Date(1)).withAverage(2.0).withUnit("siriometers"),
+        new Datapoint().withTimestamp(new Date(3)).withAverage(1.0).withUnit("metric ounces")
+    )
+    when:
+    AmazonMetricStatistics result = AmazonMetricStatistics.from(amazonResult)
+
+    then:
+    result.unit == "stone"
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudMetricProviderSpec.groovy
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.view
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsRequest
+import com.amazonaws.services.cloudwatch.model.GetMetricStatisticsResult
+import com.amazonaws.services.cloudwatch.model.ListMetricsResult
+import com.amazonaws.services.cloudwatch.model.Metric
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonMetricDescriptor
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class AmazonCloudMetricProviderSpec extends Specification {
+
+  @Subject
+  AmazonCloudMetricProvider provider
+
+  @Shared
+  AmazonCloudWatch cloudWatch
+
+  def setup() {
+    cloudWatch = Mock(AmazonCloudWatch)
+    AccountCredentialsProvider accountCredentialsProvider = Stub(AccountCredentialsProvider) {
+      getCredentials(_) >> Stub(NetflixAmazonCredentials)
+    }
+    AmazonClientProvider amazonClientProvider = Stub(AmazonClientProvider) {
+      getCloudWatch(_, _) >> cloudWatch
+    }
+    AmazonCloudProvider amazonCloudProvider = Mock(AmazonCloudProvider)
+    provider = new AmazonCloudMetricProvider(amazonClientProvider, accountCredentialsProvider, amazonCloudProvider)
+  }
+
+  void "getMetric returns null when none found"() {
+    when:
+    def result = provider.getMetricDescriptor("test", "us-east-1", [:])
+
+    then:
+    result == null
+    1 * cloudWatch.listMetrics(_) >> new ListMetricsResult().withMetrics([])
+  }
+
+  void "getMetrics throws exception when multiple results found"() {
+    when:
+    provider.getMetricDescriptor("test", "us-east-1", [:])
+
+    then:
+    thrown(IllegalArgumentException)
+    1 * cloudWatch.listMetrics(_) >> new ListMetricsResult().withMetrics([ new Metric(), new Metric() ])
+  }
+
+  void "getMetrics returns a metric when one found"() {
+    given:
+    Dimension dimension = new Dimension().withName("AutoScalingGroupName").withValue("asg-v001")
+    def filters = [name: "expectedMetric", namespace: "space"]
+
+    when:
+    AmazonMetricDescriptor result = provider.getMetricDescriptor("test", "us-east-1", filters)
+
+    then:
+    result.cloudProvider == "aws"
+    result.name == "expectedMetric"
+    result.namespace == "space"
+    result.dimensions == [ dimension ]
+    1 * cloudWatch.listMetrics(_) >> new ListMetricsResult().withMetrics([
+        new Metric()
+            .withMetricName("expectedMetric")
+            .withNamespace("space")
+            .withDimensions(dimension)
+    ])
+  }
+
+  void "getStatistics sends defaults for statistics, period"() {
+    given:
+    GetMetricStatisticsRequest request
+    def filters = [namespace: "space"]
+
+    when:
+    provider.getStatistics("test", "us-east-1", "expectedMetric", filters, 0, 1)
+
+    then:
+    1 * cloudWatch.getMetricStatistics(_) >> { arguments ->
+      request = arguments[0]
+      return new GetMetricStatisticsResult().withDatapoints([])
+    }
+    request != null
+    request.startTime == new Date(0)
+    request.endTime == new Date(1)
+    request.period == 600
+    request.statistics == ["Average"]
+  }
+
+  void "getStatistics throws exception if namespace is missing"() {
+    when:
+    provider.getStatistics("test", "us-east-1", "someMetric", [:], null, null)
+
+    then:
+    thrown(IllegalArgumentException)
+  }
+
+  void "getStatistics treats all other filter values as dimensions"() {
+    given:
+    GetMetricStatisticsRequest request
+    def filters = [
+        namespace: "space",
+        period: "100",
+        statistics: "Average,Sum",
+        someDimension: "dimension!"
+    ]
+
+    when:
+    provider.getStatistics("test", "us-east-1", "expectedMetric", filters, 0, 50)
+
+    then:
+    1 * cloudWatch.getMetricStatistics(_) >> { arguments ->
+      request = arguments[0]
+      return new GetMetricStatisticsResult().withDatapoints([])
+    }
+    request != null
+    request.dimensions.size() == 1
+    request.dimensions[0].name == "someDimension"
+    request.dimensions[0].value == "dimension!"
+  }
+
+
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/CloudMetricDatapoint.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/CloudMetricDatapoint.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+interface CloudMetricDatapoint {
+
+
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/CloudMetricDescriptor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/CloudMetricDescriptor.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+/**
+ * Describes a metric reported by a cloud provider.
+ *
+ * Implementations should add any fields necessary to uniquely identify a particular metric; for example, AWS
+ * supplies a "namespace" field, as well as a collection of "dimensions"
+ */
+interface CloudMetricDescriptor {
+
+  String name
+
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/CloudMetricProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/CloudMetricProvider.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+interface CloudMetricProvider<T extends CloudMetricDescriptor> {
+
+  /**
+   * Returns the platform of the provider
+   * @return a String, e.g. 'aws', 'gcp'
+   */
+  String getCloudProvider()
+
+  /**
+   * Returns a specific metric descriptor
+   * @param account the account
+   * @param region the region
+   * @param filters a collection of identifiers used to uniquely identify a metric
+   * @return a metric descriptor if one is found; should throw an exception if multiple metric descriptors are found
+   * for the supplied filters
+   */
+  T getMetricDescriptor(String account, String region, Map<String, String> filters)
+
+  /**
+   * Returns a list of metric descriptors matching the supplied filters
+   * @param account the account
+   * @param region the region
+   * @param filters a collection of identifiers used to select a subset of all metrics in the account and region
+   * @return a list of metric descriptors matching the filters
+   */
+  List<T> findMetricDescriptors(String account, String region, Map<String, String> filters)
+
+  /**
+   * Returns a statistic set for the metric descriptor uniquely identified by the supplied filters
+   * @param account the account
+   * @param region the region
+   * @param name the name of the target metric
+   * @param filters a collection of identifiers used to uniquely identify a metric
+   * @param startTime an inclusive timestamp to determine the oldest datapoint to return
+   * @param endTime an exclusive timestamp to determine the newest datapoint to return
+   * @return a CloudMetricStatistics object, describing the statistics with timestamps
+   */
+  CloudMetricStatistics getStatistics(String account, String region, String metricName, Map<String, String> filters,
+                                      Long startTime, Long endTime)
+
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/CloudMetricStatistics.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/CloudMetricStatistics.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+interface CloudMetricStatistics<T extends CloudMetricDatapoint> {
+  /**
+   * Unit of measurement for all datapoints; should be the plural form of the unit if applicable,
+   * e.g. "Bytes", "Percent", "Kilobytes/Second"
+   */
+  String unit
+
+  /**
+   * List of statistical datapoints; at least one statistic (average, sum, sampleCount, minimum, maximum) should be
+   * populated, as well as the timestamp
+   */
+  List<T> datapoints
+
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopCloudMetricProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopCloudMetricProvider.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+class NoopCloudMetricProvider implements CloudMetricProvider<CloudMetricDescriptor> {
+
+  @Override
+  String getCloudProvider() {
+    'noop'
+  }
+
+  @Override
+  CloudMetricDescriptor getMetricDescriptor(String account, String region, Map<String, String> filters) {
+    null
+  }
+
+  @Override
+  List<CloudMetricDescriptor> findMetricDescriptors(String account, String region, Map<String, String> filters) {
+    Collections.emptySet()
+  }
+
+  @Override
+  CloudMetricStatistics getStatistics(String account, String region, String metricName, Map<String, String> filters,
+                                      Long startTime, Long endTime) {
+    null
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CloudMetricController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CloudMetricController.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers
+
+import static java.time.temporal.ChronoUnit.HOURS
+
+import com.netflix.spinnaker.clouddriver.model.CloudMetricDescriptor
+import com.netflix.spinnaker.clouddriver.model.CloudMetricProvider
+import com.netflix.spinnaker.clouddriver.model.CloudMetricStatistics
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.Clock
+
+@RequestMapping("/cloudMetrics")
+@RestController
+class CloudMetricController {
+
+  @Autowired
+  final List<CloudMetricProvider> metricProviders
+
+  final Clock clock
+
+  @RequestMapping(method = RequestMethod.GET, value = "/{cloudProvider}/{account}/{region}")
+  List<CloudMetricDescriptor> findAll(@PathVariable String cloudProvider,
+                        @PathVariable String account,
+                        @PathVariable String region,
+                        @RequestParam Map<String, String> filters) {
+
+    getProvider(cloudProvider).findMetricDescriptors(account, region, filters)
+  }
+
+  CloudMetricController(List<CloudMetricProvider> metricProviders, Clock clock) {
+    this.clock = clock;
+    this.metricProviders = metricProviders
+  }
+
+  @Autowired
+  CloudMetricController(List<CloudMetricProvider> metricProviders) {
+    this(metricProviders, Clock.systemDefaultZone())
+  }
+
+  /**
+   * Returns a data set describing the metric over the specified period of time. If start and end times are not provided,
+   * they will be defaulted to 24 hours ago and now, respectively
+   * @param cloudProvider the provider, e.g. "aws", "gce", etc.
+   * @param account the account of the provider
+   * @param region the region applicable to the metric
+   * @param metricName the name of the metric
+   * @param startTime start time (inclusive)
+   * @param endTime end time (exclusive)
+   * @param filters any provider-specific filters used to create the data set
+   * @return the set of statistics
+   */
+  @RequestMapping(method = RequestMethod.GET, value = "/{cloudProvider}/{account}/{region}/{metricName}/statistics")
+  CloudMetricStatistics getStatistics(@PathVariable String cloudProvider,
+                                      @PathVariable String account,
+                                      @PathVariable String region,
+                                      @PathVariable String metricName,
+                                      @RequestParam(required = false) Long startTime,
+                                      @RequestParam(required = false) Long endTime,
+                                      @RequestParam Map<String, String> filters) {
+
+    // Spring will map all request parameters into the filters map, so it's best to remove the declared ones
+    filters.remove("startTime")
+    filters.remove("endTime")
+
+    Long start = startTime ?: clock.instant().minus(24, HOURS).toEpochMilli()
+    Long end = endTime ?: clock.millis()
+
+    getProvider(cloudProvider).getStatistics(account, region, metricName, filters, start, end)
+  }
+
+  private CloudMetricProvider getProvider(String cloudProvider) {
+    CloudMetricProvider provider = metricProviders.findResult {
+      it.cloudProvider == cloudProvider ? it : null
+    }
+
+    if (!provider) {
+      throw new IllegalArgumentException("No provider found named '${cloudProvider}' that supports cloud metrics")
+    }
+
+    provider
+  }
+}

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CloudMetricControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CloudMetricControllerSpec.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers
+
+import com.netflix.spinnaker.clouddriver.model.CloudMetricProvider
+import spock.lang.Shared
+import spock.lang.Specification
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class CloudMetricControllerSpec extends Specification {
+
+  @Shared
+  CloudMetricController controller
+
+  @Shared
+  CloudMetricProvider provider
+
+  def setup() {
+    provider = Mock(CloudMetricProvider)
+    controller = new CloudMetricController(
+        [provider],
+        Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault()))
+  }
+
+  void "getStatistics sends defaults for start/end time"() {
+    when:
+    controller.getStatistics("aws", "test", "us-east-1", "theMetric", null, null, [:])
+
+    then:
+    provider.getCloudProvider() >> "aws"
+    1 * provider.getStatistics("test", "us-east-1", "theMetric", [:], 0 - 24 * 60 * 60 * 1000, 0) >> null
+  }
+
+  void "getStatistics removes startTime/endTime fields from filters if present"() {
+    when:
+    Map<String, String> filters = [ startTime: "0", endTime: "1", other: 'filter']
+    controller.getStatistics("aws", "test", "us-east-1", "theMetric", 1, 2, filters)
+
+    then:
+    provider.getCloudProvider() >> "aws"
+    1 * provider.getStatistics("test", "us-east-1", "theMetric", [other: 'filter'], 1, 2) >> null
+  }
+}


### PR DESCRIPTION
Introducing a new controller, `/cloudMetrics`, to support retrieval of metrics and sets of metric statistics.

New model interfaces:
 * `CloudMetric`
 * `CloudMetricProvider`
 * `CloudMetricStatistics`

I tried to write these interfaces and controller methods as generically as possible, since I do not know what GCP or Azure metrics might look like, and wanted to keep it flexible. I assume it'll be easier to provide more shape to the `CloudMetric`, and then the other interfaces, once they've been implemented.

I wrote this all in Groovy but was told by @ajordens the interfaces and implementations should be in Java, so would love feedback on how to convert some of the groovy bits.

@spinnaker/reviewers PTAL. I would especially like feedback on the right way to handle errors and the shapes of these endpoints and interfaces.