### PR TITLE
don't skip edda just because we make modify call to AWS

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/SecurityGroupLookupFactory.groovy
@@ -59,7 +59,7 @@ class SecurityGroupLookupFactory {
       if (description.vpcId) {
         request.withVpcId(description.vpcId)
       }
-      final amazonEC2 = amazonClientProvider.getAmazonEC2(credentials, region, true)
+      final amazonEC2 = amazonClientProvider.getAmazonEC2(credentials, region)
       final result = amazonEC2.createSecurityGroup(request)
       final newSecurityGroup = new SecurityGroup(ownerId: credentials.accountId, groupId: result.groupId,
         groupName: description.name, description: description.description, vpcId: description.vpcId)
@@ -69,7 +69,7 @@ class SecurityGroupLookupFactory {
     SecurityGroupUpdater getSecurityGroupByName(String accountName, String name, String vpcId) {
       final credentials = getCredentialsForName(accountName)
       if (!credentials) { return null }
-      final amazonEC2 = amazonClientProvider.getAmazonEC2(credentials, region, true)
+      final amazonEC2 = amazonClientProvider.getAmazonEC2(credentials, region)
       final securityGroup = getSecurityGroups(accountName, amazonEC2).find {
         it.groupName == name && it.vpcId == vpcId
       }
@@ -81,7 +81,7 @@ class SecurityGroupLookupFactory {
 
     private List<SecurityGroup> getSecurityGroups(String accountName, AmazonEC2 amazonEC2) {
       List<SecurityGroup> securityGroupsForAccount = securityGroupsByAccount[accountName]
-      if (!securityGroupsForAccount) {
+      if (securityGroupsForAccount == null) {
         securityGroupsForAccount = amazonEC2.describeSecurityGroups().securityGroups
         securityGroupsByAccount[accountName] = securityGroupsForAccount
       }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/SecurityGroupLookupFactory.groovy
@@ -31,6 +31,10 @@ class SecurityGroupLookupFactory {
     new SecurityGroupLookup(amazonClientProvider, region, accounts)
   }
 
+  /**
+   * Allows look up for account names and security groups from a cache that lives as long as the instance.
+   * Can also be used to create a security group from a description.
+   */
   static class SecurityGroupLookup {
     private final AmazonClientProvider amazonClientProvider
     private final String region

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/SecurityGroupLookupSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/SecurityGroupLookupSpec.groovy
@@ -19,7 +19,7 @@ class SecurityGroupLookupSpec extends Specification {
 
   final amazonEC2 = Mock(AmazonEC2)
   final amazonClientProvider = Stub(AmazonClientProvider) {
-    getAmazonEC2(_, "us-east-1", true) >> amazonEC2
+    getAmazonEC2(_, "us-east-1") >> amazonEC2
   }
   final accountCredentialsRepository = Stub(AccountCredentialsRepository) {
     getAll() >> [


### PR DESCRIPTION
@cfieber 
I skipped edda just because I reused the client to modify the ingress. It appears that that was merely superstition. I think this will fix the rate limiting that we sometimes see when migrating certain ASGs in prod.
This is small and should really go to prod ASAP if it makes sense.