### PR TITLE
Renames all CatsSomethingProvider -> AmazonSomethingProvider

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonApplicationProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonApplicationProvider.groovy
@@ -32,13 +32,13 @@ import org.springframework.stereotype.Component
 import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.*
 
 @Component
-class CatsApplicationProvider implements ApplicationProvider {
+class AmazonApplicationProvider implements ApplicationProvider {
   private final AmazonCloudProvider amazonCloudProvider
   private final Cache cacheView
   private final ObjectMapper objectMapper
 
   @Autowired
-  CatsApplicationProvider(AmazonCloudProvider amazonCloudProvider, Cache cacheView, ObjectMapper objectMapper) {
+  AmazonApplicationProvider(AmazonCloudProvider amazonCloudProvider, Cache cacheView, ObjectMapper objectMapper) {
     this.amazonCloudProvider = amazonCloudProvider
     this.cacheView = cacheView
     this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component
 import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.*
 
 @Component
-class CatsClusterProvider implements ClusterProvider<AmazonCluster> {
+class AmazonClusterProvider implements ClusterProvider<AmazonCluster> {
 
   private final Cache cacheView
   private final AwsProvider awsProvider
@@ -41,7 +41,7 @@ class CatsClusterProvider implements ClusterProvider<AmazonCluster> {
   String defaultBuildHost
 
   @Autowired
-  CatsClusterProvider(Cache cacheView, AwsProvider awsProvider) {
+  AmazonClusterProvider(Cache cacheView, AwsProvider awsProvider) {
     this.cacheView = cacheView
     this.awsProvider = awsProvider
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
@@ -32,12 +32,12 @@ import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.HEALTH
 import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.INSTANCES
 
 @Component
-class CatsInstanceProvider implements InstanceProvider<AmazonInstance> {
+class AmazonInstanceProvider implements InstanceProvider<AmazonInstance> {
 
   private final Cache cacheView
 
   @Autowired
-  CatsInstanceProvider(Cache cacheView) {
+  AmazonInstanceProvider(Cache cacheView) {
     this.cacheView = cacheView
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
@@ -34,13 +34,13 @@ import org.springframework.stereotype.Component
 import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.*
 
 @Component
-class CatsLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalancer> {
+class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalancer> {
 
   private final Cache cacheView
   private final AwsProvider awsProvider
 
   @Autowired
-  public CatsLoadBalancerProvider(Cache cacheView, AwsProvider awsProvider) {
+  public AmazonLoadBalancerProvider(Cache cacheView, AwsProvider awsProvider) {
     this.cacheView = cacheView
     this.awsProvider = awsProvider
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonReservationReportProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonReservationReportProvider.groovy
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component
 import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.RESERVATION_REPORTS
 
 @Component
-class CatsReservationReportProvider implements ReservationReportProvider {
+class AmazonReservationReportProvider implements ReservationReportProvider {
   @Autowired
   Cache cacheView
 


### PR DESCRIPTION
To differentiate between these and CATS infrastructure pieces like `CatsSearchProvider` and `CatsOnDemandCacheUpdater`

@cfieber @ajordens 