### PR TITLE
provider/kubernetes: One last health tweak...

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -133,7 +133,7 @@ class KubernetesUtil {
   static Map<String, String> getPodLoadBalancerStates(Pod pod) {
     pod.metadata?.labels?.collectEntries { key, val ->
       if (isLoadBalancerLabel(key)) {
-        return [key: val]
+        return [(key): val]
       } else {
         return [:]
       }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
@@ -93,32 +93,32 @@ class KubernetesInstanceSpec extends Specification {
 
   void "Should report state as Down"() {
     when:
-      def state = (new KubernetesHealth('', containerStatusAsTerminatedMock, new KubernetesHealth(podMock))).state
+      def state = (new KubernetesHealth('', containerStatusAsTerminatedMock)).state
 
     then:
       state == HealthState.Down
   }
 
-  void "Should report state as OOS"() {
+  void "Should report state as Starting"() {
     when:
-      def state = (new KubernetesHealth('', containerStatusAsWaitingMock, new KubernetesHealth(podMock))).state
+      def state = (new KubernetesHealth('', containerStatusAsWaitingMock)).state
 
     then:
-      state == HealthState.OutOfService
+      state == HealthState.Starting
 
     when:
-      state = (new KubernetesHealth('', containerStatusAsNoneMock, new KubernetesHealth(podMock))).state
+      state = (new KubernetesHealth('', containerStatusAsNoneMock)).state
 
     then:
-      state == HealthState.OutOfService
+      state == HealthState.Starting
   }
 
-  void "Should report state as Unknown"() {
+  void "Should report state as Up"() {
     when:
-      def state = (new KubernetesHealth('', containerStatusAsRunningMock, new KubernetesHealth(podMock))).state
+      def state = (new KubernetesHealth('', containerStatusAsRunningMock)).state
 
     then:
-      state == HealthState.Unknown
+      state == HealthState.Up
   }
 
   void "Should report pod state as Up"() {


### PR DESCRIPTION
@duftler 

I'm now labeling the health types by which kubernetes construct they come from (service, pod, container). This allows my to set `interestingHealthProviders` accordingly. For example, during disable, the only health construct that's relevant is `KubernetesService`, since pods and containers have separate notions of health.