### PR TITLE
Made 'type' a proper Enum in OnDemandAgent/CacheUpdater interfaces

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
@@ -43,11 +43,6 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.SECURIT
 @Slf4j
 class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
 
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'AmazonSecurityGroup'
-
-  private static final String ON_DEMAND_TYPE = 'SecurityGroup'
-
   final AmazonCloudProvider amazonCloudProvider
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
@@ -73,7 +68,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
     this.region = region
     this.objectMapper = objectMapper
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, amazonCloudProvider.id + ":" + ON_DEMAND_TYPE)
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${amazonCloudProvider.id}:${OnDemandAgent.OnDemandType.SecurityGroup}")
   }
 
   @Override
@@ -122,13 +117,8 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    type == ON_DEMAND_TYPE && cloudProvider == amazonCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == amazonCloudProvider.id
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -61,10 +61,6 @@ import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
 
 class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, DriftMetric {
   final Logger log = LoggerFactory.getLogger(getClass())
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'AmazonServerGroup'
-
-  private static final String ON_DEMAND_TYPE = 'ServerGroup'
 
   private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
 
@@ -98,7 +94,7 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
     this.region = region
     this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, amazonCloudProvider.id + ":" + ON_DEMAND_TYPE)
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${amazonCloudProvider.id}:${OnDemandAgent.OnDemandType.ServerGroup}")
   }
 
   @Override
@@ -159,13 +155,8 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    type == ON_DEMAND_TYPE && cloudProvider == amazonCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == amazonCloudProvider.id
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/LoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/LoadBalancerCachingAgent.groovy
@@ -40,7 +40,6 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
-import groovy.util.logging.Slf4j
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -52,10 +51,6 @@ import static com.netflix.spinnaker.clouddriver.aws.data.Keys.Namespace.ON_DEMAN
 
 class LoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, DriftMetric {
   final Logger log = LoggerFactory.getLogger(getClass())
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'AmazonLoadBalancer'
-
-  private static final String ON_DEMAND_TYPE = 'LoadBalancer'
 
   private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
 
@@ -109,7 +104,7 @@ class LoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, AccountAw
     this.region = region
     this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, amazonCloudProvider.id + ":" + ON_DEMAND_TYPE)
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, amazonCloudProvider.id + ":" + "${amazonCloudProvider.id}:${OnDemandAgent.OnDemandType.LoadBalancer}")
   }
 
   static class MutableCacheData implements CacheData {
@@ -132,13 +127,8 @@ class LoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, AccountAw
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    type == ON_DEMAND_TYPE && cloudProvider == amazonCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == amazonCloudProvider.id
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/cache/AzureCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/cache/AzureCachingAgent.groovy
@@ -84,12 +84,7 @@ abstract class AzureCachingAgent implements CachingAgent, OnDemandAgent, Account
   }
 
   @Override
-  boolean handles(String type) {
-    type == getLegacyType()
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
     type == getOnDemandType() && cloudProvider == azureCloudProvider.id
   }
 
@@ -106,9 +101,7 @@ abstract class AzureCachingAgent implements CachingAgent, OnDemandAgent, Account
 
   abstract Boolean validKeys(Map<String, ? extends Object> data)
 
-  abstract protected String getLegacyType()
-
-  abstract protected String getOnDemandType()
+  abstract protected OnDemandAgent.OnDemandType getOnDemandType()
 
   def static parseOnDemandCache(Collection<CacheData> results, long lastReadTime) {
     List<String> evictions = new ArrayList<String>()

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/cache/AzureLoadBalancerCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/cache/AzureLoadBalancerCachingAgent.groovy
@@ -43,10 +43,6 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 
 @Slf4j
 class AzureLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'AzureLoadBalancer'
-
-  private static final String ON_DEMAND_TYPE = 'LoadBalancer'
 
   final AzureCloudProvider azureCloudProvider
   final String accountName
@@ -72,7 +68,7 @@ class AzureLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, Acco
     this.region = region
     this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, azureCloudProvider.id + ":" + ON_DEMAND_TYPE)
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${azureCloudProvider.id}:${OnDemandAgent.OnDemandType.LoadBalancer}")
   }
 
   @Override
@@ -101,13 +97,8 @@ class AzureLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, Acco
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    type == ON_DEMAND_TYPE && cloudProvider == azureCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == azureCloudProvider.id
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
@@ -43,10 +43,6 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 
 @Slf4j
 class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'AzureSecurityGroup'
-
-  private static final String ON_DEMAND_TYPE = 'SecurityGroup'
 
   final AzureCloudProvider azureCloudProvider
   final String accountName
@@ -72,7 +68,7 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
     this.region = region
     this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, azureCloudProvider.id + ":" + ON_DEMAND_TYPE)
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${azureCloudProvider.id}:${OnDemandAgent.OnDemandType.SecurityGroup}")
   }
 
   @Override
@@ -101,13 +97,8 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    type == ON_DEMAND_TYPE && cloudProvider == azureCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == azureCloudProvider.id
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -50,7 +50,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
     super(azureCloudProvider, accountName, creds, region, objectMapper)
 
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, azureCloudProvider.id + ":" + getOnDemandType())
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${azureCloudProvider.id}:${onDemandType}")
 
   }
 
@@ -294,13 +294,8 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
   }
 
   @Override
-  String getLegacyType() {
-    "AzureServerGroup"
-  }
-
-  @Override
-  String getOnDemandType() {
-    "ServerGroup"
+  OnDemandAgent.OnDemandType getOnDemandType() {
+    OnDemandAgent.OnDemandType.ServerGroup
   }
 
   private String getServerGroupKey(AzureServerGroupDescription serverGroup) {

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/agent/ClusterCachingAgent.groovy
@@ -53,11 +53,6 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
 
   final static Logger log = LoggerFactory.getLogger(ClusterCachingAgent)
 
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'CloudFoundry' // not relevant for CF
-
-  private static final String ON_DEMAND_TYPE = 'ServerGroup'
-
   private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
 
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
@@ -86,7 +81,7 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
     this.cloudFoundryClientFactory = cloudFoundryClientFactory
     this.cloudFoundryCloudProvider = cloudFoundryCloudProvider
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, cloudFoundryCloudProvider.id + ":" + ON_DEMAND_TYPE)
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${cloudFoundryCloudProvider.id}:${OnDemandAgent.OnDemandType.ServerGroup}")
   }
 
   @Override
@@ -136,13 +131,8 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    type == ON_DEMAND_TYPE && cloudProvider == cloudFoundryCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == cloudFoundryCloudProvider.id
   }
 
   @Override

--- a/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/provider/agent/ClusterCachingAgentSpec.groovy
+++ b/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/provider/agent/ClusterCachingAgentSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.cats.mem.InMemoryCache
 import com.netflix.spinnaker.cats.provider.DefaultProviderCache
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.cf.CloudFoundryCloudProvider
 import com.netflix.spinnaker.clouddriver.cf.TestCredential
 import com.netflix.spinnaker.clouddriver.cf.cache.Keys
@@ -72,8 +73,7 @@ class ClusterCachingAgentSpec extends Specification {
 
   def "handles CF caching"() {
     expect:
-    cachingAgent.handles('CloudFoundry')
-    cachingAgent.handles('ServerGroup', 'cf')
+    cachingAgent.handles(OnDemandAgent.OnDemandType.ServerGroup, 'cf')
   }
 
   def "should report standard info"() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.groovy
@@ -44,28 +44,17 @@ class CatsOnDemandCacheUpdater implements OnDemandCacheUpdater {
   }
 
   @Override
-  boolean handles(String type) {
-    onDemandAgents.any { it.handles(type) }
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
     onDemandAgents.any { it.handles(type, cloudProvider) }
   }
 
   @Override
-  OnDemandCacheUpdater.OnDemandCacheStatus handle(String type, Map<String, ? extends Object> data) {
-    Collection<OnDemandAgent> onDemandAgents = onDemandAgents.findAll { it.handles(type) }
-    return handle(type, onDemandAgents, data)
-  }
-
-  @Override
-  OnDemandCacheUpdater.OnDemandCacheStatus handle(String type, String cloudProvider, Map<String, ? extends Object> data) {
+  OnDemandCacheUpdater.OnDemandCacheStatus handle(OnDemandAgent.OnDemandType type, String cloudProvider, Map<String, ? extends Object> data) {
     Collection<OnDemandAgent> onDemandAgents = onDemandAgents.findAll { it.handles(type, cloudProvider) }
     return handle(type, onDemandAgents, data)
   }
 
-  OnDemandCacheUpdater.OnDemandCacheStatus handle(String type, Collection<OnDemandAgent> onDemandAgents, Map<String, ? extends Object> data) {
+  OnDemandCacheUpdater.OnDemandCacheStatus handle(OnDemandAgent.OnDemandType type, Collection<OnDemandAgent> onDemandAgents, Map<String, ? extends Object> data) {
     boolean hasOnDemandResults = false
     for (OnDemandAgent agent : onDemandAgents) {
       try {
@@ -100,7 +89,7 @@ class CatsOnDemandCacheUpdater implements OnDemandCacheUpdater {
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(String type, String cloudProvider) {
+  Collection<Map> pendingOnDemandRequests(OnDemandAgent.OnDemandType type, String cloudProvider) {
     Collection<OnDemandAgent> onDemandAgents = onDemandAgents.findAll { it.handles(type, cloudProvider) }
     return onDemandAgents.collect {
       def providerCache = catsModule.getProviderRegistry().getProviderCache(it.providerName)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/NoopOnDemandCacheUpdater.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/NoopOnDemandCacheUpdater.groovy
@@ -23,28 +23,19 @@ import org.springframework.stereotype.Component
  */
 @Component
 class NoopOnDemandCacheUpdater implements OnDemandCacheUpdater {
+
   @Override
-  boolean handles(String type) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
     false
   }
 
   @Override
-  OnDemandCacheUpdater.OnDemandCacheStatus handle(String type, Map<String, ? extends Object> data) {
+  OnDemandCacheUpdater.OnDemandCacheStatus handle(OnDemandAgent.OnDemandType type, String cloudProvider, Map<String, ? extends Object> data) {
     return OnDemandCacheUpdater.OnDemandCacheStatus.SUCCESSFUL
   }
 
   @Override
-  boolean handles(String type, String cloudProvider) {
-    false
-  }
-
-  @Override
-  OnDemandCacheUpdater.OnDemandCacheStatus handle(String type, String cloudProvider, Map<String, ? extends Object> data) {
-    return OnDemandCacheUpdater.OnDemandCacheStatus.SUCCESSFUL
-  }
-
-  @Override
-  Collection<Map> pendingOnDemandRequests(String type, String cloudProvider) {
+  Collection<Map> pendingOnDemandRequests(OnDemandAgent.OnDemandType type, String cloudProvider) {
     return []
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.groovy
@@ -34,10 +34,26 @@ interface OnDemandAgent {
     Map<String, Collection<String>> evictions = [:]
   }
 
-  @Deprecated
-  boolean handles(String type)
+  enum OnDemandType {
+    ServerGroup,
+    SecurityGroup,
+    LoadBalancer,
 
-  boolean handles(String type, String cloudProvider)
+    static OnDemandType fromString(String s) {
+      if (s) {
+        String mod = s.toLowerCase().trim()
+        for (OnDemandType type : values()) {
+          String typeMod = type.toString().toLowerCase()
+          if (typeMod == mod) {
+            return type
+          }
+        }
+      }
+      throw new IllegalArgumentException("Cannot create OnDemandType from String '${s}'")
+    }
+  }
+
+  boolean handles(OnDemandType type, String cloudProvider)
 
   OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data)
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.groovy
@@ -40,16 +40,11 @@ interface OnDemandAgent {
     LoadBalancer,
 
     static OnDemandType fromString(String s) {
-      if (s) {
-        String mod = s.toLowerCase().trim()
-        for (OnDemandType type : values()) {
-          String typeMod = type.toString().toLowerCase()
-          if (typeMod == mod) {
-            return type
-          }
-        }
+      OnDemandType t = values().find { it.toString().equalsIgnoreCase(s) }
+      if (!t) {
+        throw new IllegalArgumentException("Cannot create OnDemandType from String '${s}'")
       }
-      throw new IllegalArgumentException("Cannot create OnDemandType from String '${s}'")
+      return t
     }
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandCacheUpdater.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandCacheUpdater.groovy
@@ -29,27 +29,12 @@ interface OnDemandCacheUpdater {
   }
 
   /**
-   * Indicates if the updater is able to handle this on-demand request.
-   * @param type
-   * @return
-   */
-  @Deprecated
-  boolean handles(String type)
-
-  /**
-   * The input for the updater to process this request.
-   * @param data
-   */
-  @Deprecated
-  OnDemandCacheStatus handle(String type, Map<String, ? extends Object> data)
-
-  /**
    * Indicates if the updater is able to handle this on-demand request given the type and cloudProvider
    * @param type
    * @param cloudProvider
    * @return
    */
-  boolean handles(String type, String cloudProvider)
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider)
 
   /**
    * Handles the update request
@@ -57,7 +42,7 @@ interface OnDemandCacheUpdater {
    * @param cloudProvider
    * @param data
    */
-  OnDemandCacheStatus handle(String type, String cloudProvider, Map<String, ? extends Object> data)
+  OnDemandCacheStatus handle(OnDemandAgent.OnDemandType type, String cloudProvider, Map<String, ? extends Object> data)
 
-  Collection<Map> pendingOnDemandRequests(String type, String cloudProvider)
+  Collection<Map> pendingOnDemandRequests(OnDemandAgent.OnDemandType type, String cloudProvider)
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.docker.registry.provider.agent
 
-import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.cats.agent.*
+import com.netflix.spinnaker.cats.agent.AccountAware
+import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.CacheResult
+import com.netflix.spinnaker.cats.agent.CachingAgent
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
-import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider
 import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryTags
 import com.netflix.spinnaker.clouddriver.docker.registry.cache.DefaultCacheDataBuilder

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleOnDemandCacheUpdater.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleOnDemandCacheUpdater.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.model
 
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
@@ -24,15 +25,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
+@Deprecated
 @ConditionalOnProperty(value = "google.providerImpl", havingValue = "old", matchIfMissing = true)
 @Component
 class GoogleOnDemandCacheUpdater implements OnDemandCacheUpdater {
   protected final Logger log = Logger.getLogger(GoogleOnDemandCacheUpdater.class)
-
-  @Deprecated
-  private static final String LEGACY_TYPE = "GoogleServerGroup"
-
-  private static final String TYPE = "ServerGroup"
 
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
@@ -44,29 +41,18 @@ class GoogleOnDemandCacheUpdater implements OnDemandCacheUpdater {
   GoogleCloudProvider googleCloudProvider
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_TYPE
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == googleCloudProvider.id
   }
 
   @Override
-  OnDemandCacheUpdater.OnDemandCacheStatus handle(String type, Map<String, ? extends Object> data) {
+  OnDemandCacheUpdater.OnDemandCacheStatus handle(OnDemandAgent.OnDemandType type, String cloudProvider, Map<String, ? extends Object> data) {
     googleResourceRetriever.handleCacheUpdate(data)
     return OnDemandCacheUpdater.OnDemandCacheStatus.SUCCESSFUL
   }
 
   @Override
-  boolean handles(String type, String cloudProvider) {
-    type == TYPE && cloudProvider == googleCloudProvider.id
-  }
-
-  @Override
-  OnDemandCacheUpdater.OnDemandCacheStatus handle(String type, String cloudProvider, Map<String, ? extends Object> data) {
-    handle(type, data)
-    return OnDemandCacheUpdater.OnDemandCacheStatus.SUCCESSFUL
-  }
-
-  @Override
-  Collection<Map> pendingOnDemandRequests(String type, String cloudProvider) {
+  Collection<Map> pendingOnDemandRequests(OnDemandAgent.OnDemandType type, String cloudProvider) {
     return []
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -36,11 +36,6 @@ import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.SECU
 @Slf4j
 class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent implements OnDemandAgent {
 
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'GoogleSecurityGroup'
-
-  private static final String ON_DEMAND_TYPE = 'SecurityGroup'
-
   final OnDemandMetricsSupport metricsSupport
 
   final Set<AgentDataType> providedDataTypes = [
@@ -56,7 +51,7 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
     super(googleApplicationName,
           credentials,
           objectMapper)
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${GoogleCloudProvider.GCE}:${ON_DEMAND_TYPE}")
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.SecurityGroup}")
   }
 
   @Override
@@ -95,13 +90,8 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    type == ON_DEMAND_TYPE && cloudProvider == GoogleCloudProvider.GCE
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == GoogleCloudProvider.GCE
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
@@ -39,11 +39,6 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATI
 @Slf4j
 class KubernetesLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
 
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'KubernetesLoadBalancer'
-
-  private static final String ON_DEMAND_TYPE = 'LoadBalancer'
-
   final KubernetesCloudProvider kubernetesCloudProvider
   final String accountName
   final String namespace
@@ -68,7 +63,7 @@ class KubernetesLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent,
     this.credentials = credentials
     this.objectMapper = objectMapper
     this.namespace = namespace
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "$kubernetesCloudProvider.id:$ON_DEMAND_TYPE")
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "$kubernetesCloudProvider.id:$OnDemandAgent.OnDemandType.LoadBalancer")
   }
 
   @Override
@@ -182,13 +177,8 @@ class KubernetesLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent,
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    ON_DEMAND_TYPE == type && cloudProvider == kubernetesCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    OnDemandAgent.OnDemandType.LoadBalancer == type && cloudProvider == kubernetesCloudProvider.id
   }
 
   List<Service> loadServices() {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -42,11 +42,6 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATI
 @Slf4j
 class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
 
-  @Deprecated
-  private static final String LEGACY_ON_DEMAND_TYPE = 'KubernetesServerGroup'
-
-  private static final String ON_DEMAND_TYPE = 'ServerGroup'
-
   final KubernetesCloudProvider kubernetesCloudProvider
   final String accountName
   final String namespace
@@ -74,7 +69,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
     this.credentials = credentials
     this.objectMapper = objectMapper
     this.namespace = namespace
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "$kubernetesCloudProvider.id:$ON_DEMAND_TYPE")
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "$kubernetesCloudProvider.id:$OnDemandAgent.OnDemandType.ServerGroup")
   }
 
   @Override
@@ -187,13 +182,8 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
   }
 
   @Override
-  boolean handles(String type) {
-    type == LEGACY_ON_DEMAND_TYPE
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    ON_DEMAND_TYPE == type && cloudProvider == kubernetesCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    OnDemandAgent.OnDemandType.ServerGroup == type && cloudProvider == kubernetesCloudProvider.id
   }
 
   List<ReplicationController> loadReplicationControllers() {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusClusterCachingAgent.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusClusterCachingAgent.groovy
@@ -49,8 +49,6 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATI
 
 class TitusClusterCachingAgent implements CachingAgent, OnDemandAgent {
 
-  private static final String ON_DEMAND_TYPE = 'ServerGroup'
-
   private static final Logger log = LoggerFactory.getLogger(TitusClusterCachingAgent)
 
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
@@ -80,7 +78,7 @@ class TitusClusterCachingAgent implements CachingAgent, OnDemandAgent {
     this.objectMapper = objectMapper
     this.titusClient = titusClientProvider.getTitusClient(account, region)
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, titusCloudProvider.id + ":" + ON_DEMAND_TYPE)
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${titusCloudProvider.id}:${OnDemandAgent.OnDemandType.ServerGroup}")
   }
 
   @Override
@@ -109,13 +107,8 @@ class TitusClusterCachingAgent implements CachingAgent, OnDemandAgent {
   }
 
   @Override
-  boolean handles(String type) {
-    return false
-  }
-
-  @Override
-  boolean handles(String type, String cloudProvider) {
-    return type == ON_DEMAND_TYPE && cloudProvider == titusCloudProvider.id
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    return type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == titusCloudProvider.id
   }
 
   @Override

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.controllers
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -49,5 +50,11 @@ class CacheController {
     }.collect {
       it.pendingOnDemandRequests(onDemandType, cloudProvider)
     }.flatten()
+  }
+
+  @ExceptionHandler
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  Map handleOnDemandTypeNotFound(IllegalArgumentException ex) {
+    [error: "cache.type.not.found", message: "Cache update type not found. Exception: ${ex.getMessage()}", status: HttpStatus.NOT_FOUND]
   }
 }


### PR DESCRIPTION
Considering the `type` of each OnDemandAgent is limited in scope to either ServerGroups, SecurityGroups, or LoadBalancers, having a free form String felt extraneous, so I made it a proper Enum.

Based on the OortService/MortService interfaces in Orca, the deprecated/legacy stuff is just dead code and has been dropped in this PR. 

@duftler @lwander @cfieber @ajordens @JargoonPard @gregturn - This change touches all providers. PTAL.

tag:  https://github.com/spinnaker/spinnaker/issues/712