### PR TITLE
add an option to attach app, stack, and cluster scoped vpc security groups to the classic link interface if they exist during deployment

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -121,6 +121,8 @@ class AwsConfiguration {
   static class DeployDefaults {
     String iamRole
     String classicLinkSecurityGroupName
+    boolean addAppGroupsToClassicLink = false
+    int maxClassicLinkSecurityGroups = 5
   }
 
   @Bean

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/SecurityGroupService.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/SecurityGroupService.groovy
@@ -52,13 +52,13 @@ class SecurityGroupService {
    * @param securityGroupNames
    * @return Map of security group ids keyed by corresponding security group name
    */
-  Map<String, String> getSecurityGroupIds(Collection<String> securityGroupNames, String vpcId = null) {
+  Map<String, String> getSecurityGroupIds(Collection<String> securityGroupNames, String vpcId = null, boolean failIfNotAllResolved = true) {
     if (!securityGroupNames) { return [:] }
     DescribeSecurityGroupsResult result = amazonEC2.describeSecurityGroups()
     Map<String, String> securityGroups = result.securityGroups.findAll { securityGroupNames.contains(it.groupName) && it.vpcId == vpcId }.collectEntries {
       [(it.groupName): it.groupId]
     }
-    if (!securityGroups.keySet().containsAll(securityGroupNames)) {
+    if (failIfNotAllResolved && !securityGroups.keySet().containsAll(securityGroupNames)) {
       def missingGroups = securityGroupNames - securityGroups.keySet()
       def ex = new SecurityGroupNotFoundException("Missing security groups: ${missingGroups.join(',')}")
       ex.missingSecurityGroups = missingGroups


### PR DESCRIPTION
also fixes a clone across regions or accounts (resolves groupIds to names, then re-looks up those names in the destination account's classic link vpc)

@ajordens PTAL