### PR TITLE
provider/kubernetes: Load balancer description attribute

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverter.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.loadbalan
 
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
@@ -32,8 +32,8 @@ class UpsertKubernetesLoadBalancerAtomicOperationConverter extends AbstractAtomi
     new UpsertKubernetesLoadBalancerAtomicOperation(convertDescription(input))
   }
 
-  UpsertKubernetesLoadBalancerAtomicOperationDescription convertDescription(Map input) {
-    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, UpsertKubernetesLoadBalancerAtomicOperationDescription)
+  KubernetesLoadBalancerDescription convertDescription(Map input) {
+    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, KubernetesLoadBalancerDescription)
   }
 }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/loadbalancer/KubernetesLoadBalancerDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/loadbalancer/KubernetesLoadBalancerDescription.groovy
@@ -23,8 +23,11 @@ import groovy.transform.Canonical
 
 @AutoClone
 @Canonical
-class UpsertKubernetesLoadBalancerAtomicOperationDescription extends KubernetesAtomicOperationDescription implements DeployDescription {
+class KubernetesLoadBalancerDescription extends KubernetesAtomicOperationDescription implements DeployDescription {
   String name
+  String app
+  String stack
+  String detail
   String namespace
 
   List<KubernetesNamedServicePort> ports

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperation.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesNamedServicePort
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import io.fabric8.kubernetes.api.model.ServiceBuilder
 import io.fabric8.kubernetes.api.model.ServicePort
@@ -28,9 +28,9 @@ import io.fabric8.kubernetes.api.model.ServicePort
 class UpsertKubernetesLoadBalancerAtomicOperation implements AtomicOperation<Map> {
   private static final String BASE_PHASE = "UPSERT_LOAD_BALANCER"
 
-  UpsertKubernetesLoadBalancerAtomicOperationDescription description
+  KubernetesLoadBalancerDescription description
 
-  UpsertKubernetesLoadBalancerAtomicOperation(UpsertKubernetesLoadBalancerAtomicOperationDescription description) {
+  UpsertKubernetesLoadBalancerAtomicOperation(KubernetesLoadBalancerDescription description) {
     this.description = description
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.loadbalan
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
@@ -29,12 +29,12 @@ import org.springframework.validation.Errors
 
 @KubernetesOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
 @Component
-class UpsertKubernetesLoadBalancerAtomicOperationValidator extends DescriptionValidator<UpsertKubernetesLoadBalancerAtomicOperationDescription> {
+class UpsertKubernetesLoadBalancerAtomicOperationValidator extends DescriptionValidator<KubernetesLoadBalancerDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertKubernetesLoadBalancerAtomicOperationDescription description, Errors errors) {
+  void validate(List priorDescriptions, KubernetesLoadBalancerDescription description, Errors errors) {
     def helper = new StandardKubernetesAttributeValidator("upsertKubernetesLoadBalancerAtomicOperationDescription", errors)
 
     if (!helper.validateCredentials(description.account, accountCredentialsProvider)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.model
 
+import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
@@ -37,6 +39,7 @@ class KubernetesLoadBalancer implements LoadBalancer, Serializable {
   String yaml
   // Set of server groups represented as maps of strings -> objects.
   Set<LoadBalancerServerGroup> serverGroups
+  KubernetesLoadBalancerDescription description
 
   KubernetesLoadBalancer(String name, String namespace, String accountName) {
     this.name = name
@@ -50,6 +53,7 @@ class KubernetesLoadBalancer implements LoadBalancer, Serializable {
     this.name = service.metadata.name
     this.namespace = service.metadata.namespace
     this.region = this.namespace
+    this.description = KubernetesApiAdaptor.fromService(service)
     this.account = accountName
     this.createdTime = KubernetesModelUtil.translateTime(service.metadata?.creationTimestamp)
     this.yaml = SerializationUtils.dumpWithoutRuntimeStateAsYaml(service)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationConverterSpec.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.loadbalancer
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
@@ -54,7 +54,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationConverterSpec extends Specifica
 
     then:
       1 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
-      description instanceof UpsertKubernetesLoadBalancerAtomicOperationDescription
+      description instanceof KubernetesLoadBalancerDescription
 
     when:
       def operation = converter.convertOperation(input)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesNamedServicePort
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.Service
@@ -62,7 +62,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
 
   void "should upsert a new loadbalancer"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], credentials: credentials, namespace: NAMESPACE)
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], credentials: credentials, namespace: NAMESPACE)
       def resultServiceMock = Mock(Service)
 
       @Subject def operation = new UpsertKubernetesLoadBalancerAtomicOperation(description)
@@ -90,7 +90,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
 
   void "should upsert a new loadbalancer, and overwrite port data"() {
     setup:
-    def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], credentials: credentials, namespace: NAMESPACE)
+    def description = new KubernetesLoadBalancerDescription(name: VALID_NAME1, externalIps: [VALID_IP1], ports: [namedPort1], credentials: credentials, namespace: NAMESPACE)
       def resultServiceMock = Mock(Service)
       def existingServiceMock = Mock(Service)
       def servicePortMock = Mock(ServicePort)
@@ -127,7 +127,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
 
   void "should upsert a new loadbalancer, and insert port data"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, externalIps: [VALID_IP1], credentials: credentials, namespace: NAMESPACE)
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME1, externalIps: [VALID_IP1], credentials: credentials, namespace: NAMESPACE)
       def resultServiceMock = Mock(Service)
       def existingServiceMock = Mock(Service)
       def servicePortMock = Mock(ServicePort)
@@ -163,7 +163,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
 
   void "should upsert a new loadbalancer, and insert ip data"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME1, credentials: credentials, namespace: NAMESPACE)
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME1, credentials: credentials, namespace: NAMESPACE)
       def resultServiceMock = Mock(Service)
       def existingServiceMock = Mock(Service)
       def serviceSpecMock = Mock(ServiceSpec)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.loadbalan
 
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesNamedServicePort
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.UpsertKubernetesLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
@@ -73,7 +73,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
 
   void "validation accept (all fields filled)"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME,
         externalIps: [VALID_IP],
         ports: [validPort],
         account: VALID_ACCOUNT,
@@ -89,7 +89,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
 
   void "validation accept (some fields filled)"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME,
         ports: [validPort],
         account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
@@ -102,7 +102,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
   }
   void "validation reject (bad protocol)"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME,
         ports: [invalidProtocolPort],
         account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
@@ -116,7 +116,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
 
   void "validation reject (bad port name)"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME,
         ports: [invalidNamePort],
         account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
@@ -130,7 +130,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
 
   void "validation reject (bad port value)"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME,
         ports: [invalidPortPort],
         account: VALID_ACCOUNT)
       def errorsMock = Mock(Errors)
@@ -144,7 +144,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
 
   void "validation reject (bad ip value)"() {
     setup:
-      def description = new UpsertKubernetesLoadBalancerAtomicOperationDescription(name: VALID_NAME,
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME,
         ports: [validPort],
         externalIps: [INVALID_IP],
         account: VALID_ACCOUNT)


### PR DESCRIPTION
The idea is to retrieve the operation that would have created this load balancer, making it easier to edit a load balancer in deck, and unifying the data models within the kubernetes provider. 

@ttomsu or @duftler 