### PR TITLE
enhancements to scaling policy upsert operations

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/DeleteScalingPolicyDescriptionAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/DeleteScalingPolicyDescriptionAtomicOperationConverter.groovy
@@ -18,15 +18,18 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.converters
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteScalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertScalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.DeleteScalingPolicyAtomicOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.UpsertScalingPolicyAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component('deleteScalingPolicyDescription')
+@AmazonOperation(AtomicOperations.DELETE_SCALING_POLICY)
 class DeleteScalingPolicyDescriptionAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
 
   @Autowired
@@ -39,7 +42,9 @@ class DeleteScalingPolicyDescriptionAtomicOperationConverter extends AbstractAto
 
   @Override
   DeleteScalingPolicyDescription convertDescription(Map input) {
-    def converted = objectMapper.copy().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).convertValue(input, DeleteScalingPolicyDescription)
+    def converted = objectMapper.copy()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .convertValue(input, DeleteScalingPolicyDescription)
     converted.credentials = getCredentialsObject(input.credentials as String)
     converted
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/UpsertScalingPolicyDescriptionAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/UpsertScalingPolicyDescriptionAtomicOperationConverter.groovy
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.converters
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertScalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.UpsertScalingPolicyAtomicOperation
@@ -25,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component('upsertScalingPolicyDescription')
+@AmazonOperation(AtomicOperations.UPSERT_SCALING_POLICY)
 class UpsertScalingPolicyDescriptionAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
 
   @Autowired
@@ -37,7 +40,9 @@ class UpsertScalingPolicyDescriptionAtomicOperationConverter extends AbstractAto
 
   @Override
   UpsertScalingPolicyDescription convertDescription(Map input) {
-    def converted = objectMapper.copy().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).convertValue(input, UpsertScalingPolicyDescription)
+    def converted = objectMapper.copy()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .convertValue(input, UpsertScalingPolicyDescription)
     converted.credentials = getCredentialsObject(input.credentials as String)
     converted
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeleteScalingPolicyDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeleteScalingPolicyDescription.groovy
@@ -16,13 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import com.amazonaws.services.cloudwatch.model.ComparisonOperator
-import com.amazonaws.services.cloudwatch.model.Dimension
-import com.amazonaws.services.cloudwatch.model.StandardUnit
-import com.amazonaws.services.cloudwatch.model.Statistic
-
 class DeleteScalingPolicyDescription extends AbstractAmazonCredentialsDescription {
-  String name
-  String asgName
+  String policyName
+  String serverGroupName
   String region
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAlarmDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAlarmDescription.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 import com.amazonaws.services.cloudwatch.model.ComparisonOperator
 import com.amazonaws.services.cloudwatch.model.Dimension
+import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import com.amazonaws.services.cloudwatch.model.Statistic
 
@@ -47,4 +48,24 @@ class UpsertAlarmDescription extends AbstractAmazonCredentialsDescription {
   Collection<String> alarmActionArns
   Collection<String> insufficientDataActionArns
   Collection<String> okActionArns
+
+  PutMetricAlarmRequest buildRequest() {
+    new PutMetricAlarmRequest(
+        alarmName: name,
+        actionsEnabled: actionsEnabled,
+        alarmDescription: alarmDescription,
+        comparisonOperator: comparisonOperator,
+        evaluationPeriods: evaluationPeriods,
+        period: period,
+        threshold: threshold,
+        namespace: namespace,
+        metricName: metricName,
+        statistic: statistic,
+        unit: unit,
+        dimensions: dimensions,
+        alarmActions: alarmActionArns,
+        insufficientDataActions: insufficientDataActionArns,
+        oKActions: okActionArns
+    )
+  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertScalingPolicyDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertScalingPolicyDescription.groovy
@@ -20,17 +20,25 @@ import com.amazonaws.services.autoscaling.model.StepAdjustment
 
 class UpsertScalingPolicyDescription extends AbstractAmazonCredentialsDescription {
 
-  // required
+  @Deprecated
+  /**
+   * Use serverGroupName instead
+   */
   String asgName
+
+  // required
   String region
   AdjustmentType adjustmentType = AdjustmentType.ChangeInCapacity
 
   // optional
+  String serverGroupName
   String name
   Integer minAdjustmentMagnitude
 
   Simple simple
   Step step
+
+  UpsertAlarmDescription alarm
 
   static class Simple {
     Integer cooldown = 600

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAlarmAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAlarmAtomicOperation.groovy
@@ -40,7 +40,7 @@ class UpsertAlarmAtomicOperation implements AtomicOperation<Map<String, String>>
   @Override
   Map<String, String> operate(List priorOutputs) {
 
-    final alarmName = description.name ?: "${description.asgName ?: ""}${description.asgName ? "-" : ""}alarm-${idGenerator.nextId()}"
+    description.name = description.name ?: "${description.asgName ?: ""}${description.asgName ? "-" : ""}alarm-${idGenerator.nextId()}"
 
     if (description.asgName) {
       description.dimensions = description.dimensions ?: []
@@ -55,28 +55,11 @@ class UpsertAlarmAtomicOperation implements AtomicOperation<Map<String, String>>
       description.alarmActionArns.add(previousUpsertScalingPolicyResult.policyArn)
     }
 
-    def request = new PutMetricAlarmRequest(
-      alarmName: alarmName,
-      actionsEnabled: description.actionsEnabled,
-      alarmDescription: description.alarmDescription,
-      comparisonOperator: description.comparisonOperator,
-      evaluationPeriods: description.evaluationPeriods,
-      period: description.period,
-      threshold: description.threshold,
-      namespace: description.namespace,
-      metricName: description.metricName,
-      statistic: description.statistic,
-      unit: description.unit,
-      dimensions: description.dimensions,
-      alarmActions: description.alarmActionArns,
-      insufficientDataActions: description.insufficientDataActionArns,
-      oKActions: description.okActionArns
-    )
-
+    def request = description.buildRequest()
     def cloudWatch = amazonClientProvider.getCloudWatch(description.credentials, description.region, true)
     cloudWatch.putMetricAlarm(request)
 
-    [alarmName: alarmName.toString()]
+    [alarmName: description.name.toString()]
   }
 
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertScalingPolicyResult.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertScalingPolicyResult.groovy
@@ -22,4 +22,5 @@ import groovy.transform.Immutable
 class UpsertScalingPolicyResult {
   String policyName
   String policyArn
+  String alarmName
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteScalingPolicyDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteScalingPolicyDescriptionValidator.groovy
@@ -26,11 +26,11 @@ class DeleteScalingPolicyDescriptionValidator extends AmazonDescriptionValidatio
   void validate(List priorDescriptions, DeleteScalingPolicyDescription description, Errors errors) {
     validateRegions(description, [description.region], "deleteScalingPolicyDescription", errors)
 
-    if (!description.asgName) {
-      rejectNull "asgName", errors
+    if (!description.serverGroupName && !description.asgName) {
+      rejectNull "serverGroupName", errors
     }
 
-    if (!description.name) {
+    if (!description.policyName) {
       rejectNull "policyName", errors
     }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertScalingPolicyDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertScalingPolicyDescriptionValidator.groovy
@@ -27,8 +27,8 @@ class UpsertScalingPolicyDescriptionValidator extends AmazonDescriptionValidatio
   void validate(List priorDescriptions, UpsertScalingPolicyDescription description, Errors errors) {
     validateRegions(description, [description.region], "upsertScalingPolicyDescription", errors)
 
-    if (!description.asgName) {
-      rejectNull "asgName", errors
+    if (!description.serverGroupName && !description.asgName) {
+      rejectNull "serverGroupName", errors
     }
 
     if (description.minAdjustmentMagnitude && !(description.adjustmentType == AdjustmentType.PercentChangeInCapacity)) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
@@ -31,6 +31,8 @@ final class AtomicOperations {
   public static final String RESIZE_SERVER_GROUP = "resizeServerGroup"
   public static final String UPSERT_SERVER_GROUP_TAGS = "upsertServerGroupTags"
   public static final String UPDATE_LAUNCH_CONFIG = "updateLaunchConfig"
+  public static final String UPSERT_SCALING_POLICY = "upsertScalingPolicy"
+  public static final String DELETE_SCALING_POLICY = "deleteScalingPolicy"
 
   // Instance operations
   public static final String REBOOT_INSTANCES = "rebootInstances"


### PR DESCRIPTION
Basically three types of changes mashed together in one PR:
 1. Including support for the `AtomicOperations` so the changes via https://github.com/spinnaker/orca/pull/772 will be passthrough, and future providers will only need to touch Clouddriver (fine, and Deck) to get the same functionality in place
 2. tweaking the names of some of the `*name` fields: `asgName` is deprecated in favor of `serverGroupName` (more closely aligned with recent changes elsewhere), changed `name` to `policyName` in the `DeleteScalingPolicyAtomicOperation` (it's closer to the AWS API)
 3. Adding alarm support to the upsert and delete operations: when deleting a scaling policy, if there are no other policies using the alarm, we'll delete it; when upserting a policy, the client can include an `alarm` field, which we'll also upsert.

@claymccoy PTAL