### PR TITLE
Reduce aws image caching

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgentSpec.groovy
@@ -24,10 +24,8 @@ import com.amazonaws.services.ec2.model.InstanceState
 import com.amazonaws.services.ec2.model.Reservation
 import com.amazonaws.services.ec2.model.Tag
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest
-import com.netflix.spinnaker.clouddriver.aws.agent.CleanupDetachedInstancesAgent
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.DetachInstancesAtomicOperation
 import spock.lang.Shared
 import spock.lang.Specification
@@ -35,9 +33,7 @@ import spock.lang.Unroll
 
 class CleanupDetachedInstancesAgentSpec extends Specification {
   @Shared
-  def test = new NetflixAmazonCredentials("test", "test", "test", '1', null, [
-    new AmazonCredentials.AWSRegion('us-west-1', []), new AmazonCredentials.AWSRegion('us-east-1', [])
-  ], null, null, false, null, false, null, false, null, false)
+  def test = TestCredential.named('test')
 
   void "should run across all regions/accounts and terminate in each"() {
     given:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -53,9 +53,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
   BasicAmazonDeployHandler handler
 
   @Shared
-  NetflixAmazonCredentials testCredentials = new NetflixAmazonCredentials(
-    "test", "test", "test", "test", null, null, null, null, null, null, null, null, null, null, null
-  )
+  NetflixAmazonCredentials testCredentials = TestCredential.named('test')
 
   @Shared
   Task task = Mock(Task)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonLoadBalancerDescriptionValidatorSpec.groovy
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
-import com.netflix.spinnaker.clouddriver.aws.deploy.validators.CreateAmazonLoadBalancerDescriptionValidator
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerDescription
 import org.springframework.validation.Errors
 import spock.lang.Shared
@@ -36,8 +34,7 @@ class UpsertAmazonLoadBalancerDescriptionValidatorSpec extends Specification {
   }
 
   void setup() {
-    description = new UpsertAmazonLoadBalancerDescription(credentials:
-            new NetflixAmazonCredentials('test', 'test', 'test', '12345', 'kp', [new AmazonCredentials.AWSRegion("us-west-1", ["us-west-1a"])], null, null, null, null, null, null, null, null, null))
+    description = new UpsertAmazonLoadBalancerDescription(credentials: TestCredential.named('test'))
   }
 
   void "empty parameters fails validation"() {
@@ -67,7 +64,7 @@ class UpsertAmazonLoadBalancerDescriptionValidatorSpec extends Specification {
 
   void "availability zone not configured for account is rejected"() {
     setup:
-    description.availabilityZones = ["us-west-1": ["us-west-1b"]]
+    description.availabilityZones = ["us-west-1": ["us-west-1c"]]
     def errors = Mock(Errors)
 
     when:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicatorSpec.groovy
@@ -19,9 +19,8 @@ package com.netflix.spinnaker.clouddriver.aws.health
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.ec2.AmazonEC2
 import com.amazonaws.services.ec2.model.DescribeAccountAttributesResult
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.boot.actuate.health.Status
 import spock.lang.Specification
@@ -30,7 +29,7 @@ class AmazonHealthIndicatorSpec extends Specification {
 
   def "health fails when amazon appears unreachable"() {
     setup:
-    def creds = [credential('foo')]
+    def creds = [TestCredential.named('foo')]
     def holder = Stub(AccountCredentialsProvider) {
       getAll() >> creds
       getCredentials("foo") >> creds[0]
@@ -53,7 +52,7 @@ class AmazonHealthIndicatorSpec extends Specification {
 
   def "health succeeds when amazon is reachable"() {
     setup:
-    def creds = [credential('foo')]
+    def creds = [TestCredential.named('foo')]
     def holder = Stub(AccountCredentialsProvider) {
       getAll() >> creds
       getCredentials("foo") >> creds[0]
@@ -72,9 +71,5 @@ class AmazonHealthIndicatorSpec extends Specification {
 
     then:
     health.status == Status.UP
-  }
-
-  NetflixAmazonCredentials credential(String name = 'foo') {
-    new NetflixAmazonCredentials(name, name, name, '12345', 'key', [new AmazonCredentials.AWSRegion('us-east-1', ['us-east-1c', 'us-east-1d'])], null, null, false, null, false, null, false, null, false)
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonAllowedAccountsValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonAllowedAccountsValidatorSpec.groovy
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.clouddriver.aws.security
 
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonAllowedAccountsValidator
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
 import org.springframework.validation.Errors
@@ -9,9 +8,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class AmazonAllowedAccountsValidatorSpec extends Specification {
-  NetflixAmazonCredentials credentialsWithRequiredGroup = new NetflixAmazonCredentials(
-    "TestAccount", "test", "test", "1", null, null, ["targetAccount1"], null, null, null, null, null, null, null, null
-  )
+  NetflixAmazonCredentials credentialsWithRequiredGroup = TestCredential.named('TestAccount', [requiredGroupMembership: ['targetAccount1']])
 
   @Unroll
   void "should reject if allowed accounts does not intersect with required group memberships"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProviderSpec.groovy
@@ -21,6 +21,7 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.ec2.AmazonEC2
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import org.apache.http.Header
 import org.apache.http.HttpEntity
 import org.apache.http.HttpResponse
@@ -28,7 +29,6 @@ import org.apache.http.StatusLine
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.entity.ContentType
-import org.apache.http.message.BasicHeader
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -38,8 +38,8 @@ class AmazonClientProviderSpec extends Specification {
       getCredentials() >> new BasicAWSCredentials('foo', 'bar')
   }
 
-  @Shared NetflixAmazonCredentials credentialsWithEdda = new NetflixAmazonCredentials("test", "test", "test", "1", null, [new AmazonCredentials.AWSRegion('us-east-1', ['us-east-1e'])], null, credentialsProvider, 'foo', true, null, null, null, null, null, null)
-  @Shared NetflixAmazonCredentials credentialsNoEdda = new NetflixAmazonCredentials("test", "test", "test", "1", null, [new AmazonCredentials.AWSRegion('us-east-1', ['us-east-1e'])], null, credentialsProvider, null, null, null, null, null, null, null, null)
+  @Shared NetflixAmazonCredentials credentialsWithEdda = TestCredential.named('test', [edda: 'foo'])
+  @Shared NetflixAmazonCredentials credentialsNoEdda = TestCredential.named('test')
 
   void "client proxies to edda when available"() {
     setup:

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtils.groovy
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtils.groovy
@@ -46,10 +46,9 @@ public class ProviderUtils {
    * Build a thread-safe set containing each account in the accountCredentialsRepository that is of type
    * credentialsType.
    */
-  public static Set buildThreadSafeSetOfAccounts(AccountCredentialsRepository accountCredentialsRepository, def credentialsType) {
-    def allAccounts = Collections.newSetFromMap(new ConcurrentHashMap<Object, Boolean>())
-
-    allAccounts.addAll(accountCredentialsRepository.all.findAll { credentialsType.isInstance(it) })
+  public static <T extends AccountCredentials> Set<T> buildThreadSafeSetOfAccounts(AccountCredentialsRepository accountCredentialsRepository, Class<T> credentialsType) {
+    def allAccounts = Collections.newSetFromMap(new ConcurrentHashMap<T, Boolean>())
+    allAccounts.addAll(accountCredentialsRepository.all.findResults { credentialsType.isInstance(it) ? credentialsType.cast(it) : null })
 
     allAccounts
   }


### PR DESCRIPTION
Right now we index the same public images in every account clouddriver manages.

This change updates it to only index them once per region - they will still show up in the search dropdown but in our case this eliminates on the order of 1.5 million keys in redis.

This is a step towards image caching cleanup that will only index the images actually owned by an account, in each account, but that is a bit more invasive as the Key structure for IMAGES and NAMED_IMAGES has to change to remove the account name component.

The three commits in this change all stand alone so I wasn't intending to squash this except to address any feedback towards the last commit into that commit

@spinnaker/netflix-reviewers PTAL