### PR TITLE
Add flag to build uber jar

### DIFF
--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -3,6 +3,7 @@ apply plugin: 'nebula.ospackage'
 
 ext {
   springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
+  repackage = System.getProperty('springBoot.repackage', "false")
 }
 
 tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
@@ -39,7 +40,7 @@ dependencies {
   runtime 'org.eclipse.jetty:jetty-servlets:9.2.11.v20150529'
 }
 
-tasks.bootRepackage.enabled = false
+tasks.bootRepackage.enabled = project.repackage
 
 applicationName = 'clouddriver'
 applicationDefaultJvmArgs = ["-Djava.security.egd=file:/dev/./urandom"]


### PR DESCRIPTION
Deploying clouddriver to Cloud Foundry requires an uber jar. This adds a flag "springBoot.repackage" that can be used on the command line to build an uber jar.