### PR TITLE
provider/kubernetes: Prepare for deploying spinnaker with spinnaker

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -265,6 +265,9 @@ class KubernetesApiAdaptor {
       new KubernetesVolumeMount(name: volumeMount.name, readOnly: volumeMount.readOnly, mountPath: volumeMount.mountPath)
     }
 
+    containerDescription.args = container?.args ?: []
+    containerDescription.command = container?.command ?: []
+
     return containerDescription
   }
 
@@ -302,6 +305,9 @@ class KubernetesApiAdaptor {
         res.type = KubernetesVolumeSourceType.PERSISTENTVOLUMECLAIM
         res.persistentVolumeClaim = new KubernetesPersistentVolumeClaim(claimName: volume.persistentVolumeClaim.claimName,
                                                                         readOnly: volume.persistentVolumeClaim.readOnly)
+      } else if (volume.secret) {
+        res.type = KubernetesVolumeSourceType.SECRET
+        res.secret = new KubernetesSecretVolumeSource(secretName: volume.secret.secretName)
       } else {
         res.type = KubernetesVolumeSourceType.UNSUPPORTED
       }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -59,13 +59,20 @@ class KubernetesImageDescription {
 class KubernetesContainerDescription {
   String name
   KubernetesImageDescription imageDescription
+
   KubernetesResourceDescription requests
   KubernetesResourceDescription limits
+
   List<KubernetesContainerPort> ports
+
   KubernetesProbe livenessProbe
   KubernetesProbe readinessProbe
+
   List<KubernetesVolumeMount> volumeMounts
   List<KubernetesEnvVar> envVars
+
+  List<String> command
+  List<String> args
 }
 
 @AutoClone
@@ -85,7 +92,7 @@ class KubernetesVolumeMount {
 }
 
 enum KubernetesVolumeSourceType {
-  HOSTPATH, EMPTYDIR, PERSISTENTVOLUMECLAIM, UNSUPPORTED
+  HOSTPATH, EMPTYDIR, PERSISTENTVOLUMECLAIM, SECRET, UNSUPPORTED
 }
 
 enum KubernetesStorageMediumType {
@@ -100,6 +107,13 @@ class KubernetesVolumeSource {
   KubernetesHostPath hostPath
   KubernetesEmptyDir emptyDir
   KubernetesPersistentVolumeClaim persistentVolumeClaim
+  KubernetesSecretVolumeSource secret
+}
+
+@AutoClone
+@Canonical
+class KubernetesSecretVolumeSource {
+  String secretName
 }
 
 @AutoClone

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
@@ -135,6 +135,12 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
             volume.persistentVolumeClaim = res.build()
             break
 
+          case KubernetesVolumeSourceType.SECRET:
+            def res = new SecretVolumeSourceBuilder()
+                .withSecretName(volumeSource.secret.secretName)
+            volume.secret = res.build()
+            break
+
           default:
             return null
         }
@@ -313,6 +319,18 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
         }
 
         replicationControllerBuilder = replicationControllerBuilder.withEnv(envVars)
+      }
+
+      if (container.command) {
+        task.updateStatus BASE_PHASE, "Setting container command..."
+
+        replicationControllerBuilder = replicationControllerBuilder.withCommand(container.command)
+      }
+
+      if (container.args) {
+        task.updateStatus BASE_PHASE, "Setting container args..."
+
+        replicationControllerBuilder = replicationControllerBuilder.withArgs(container.args)
       }
 
       replicationControllerBuilder = replicationControllerBuilder.endContainer()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidator.groovy
@@ -68,10 +68,18 @@ class DeployKubernetesAtomicOperationValidator extends DescriptionValidator<Depl
           break
 
         case KubernetesVolumeSourceType.PERSISTENTVOLUMECLAIM:
-          if (!helper.validateNotEmpty(source.persistentVolumeClaim, "volumueSources[$idx].persistentVolumeClaim")) {
+          if (!helper.validateNotEmpty(source.persistentVolumeClaim, "volumeSources[$idx].persistentVolumeClaim")) {
             break
           }
           helper.validateName(source.persistentVolumeClaim.claimName, "volumeSources[$idx].persistentVolumeClaim.claimName")
+
+          break
+
+        case KubernetesVolumeSourceType.SECRET:
+          if (!helper.validateNotEmpty(source.secret, "volumeSources[$idx].secret")) {
+            break
+          }
+          helper.validateName(source.secret.secretName, "volumeSources[$idx].secret.secretName")
 
           break
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/KubernetesContainerValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/KubernetesContainerValidator.groovy
@@ -71,6 +71,14 @@ class KubernetesContainerValidator {
     if (description.readinessProbe) {
       validateProbe(description.readinessProbe, helper, "${prefix}.readinessProbe")
     }
+
+    description.command?.eachWithIndex { command, i ->
+      helper.validateNotEmpty(command, "${prefix}.command[$i]")
+    }
+
+    description.args?.eachWithIndex { arg, i ->
+      helper.validateNotEmpty(arg, "${prefix}.args[$i]")
+    }
   }
 
   static void validateProbe(KubernetesProbe probe, StandardKubernetesAttributeValidator helper, String prefix) {


### PR DESCRIPTION
These additions allow Spinnaker to be deployed on Kubernetes using Spinnaker 

Most important was the addition of secrets as volume sources, which is how we will be deploying configuration.

@duftler or @ttomsu 