### PR TITLE
Track relationships between an Azure server group and its resources

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancer.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancer.groovy
@@ -58,14 +58,14 @@ class AzureLoadBalancer implements LoadBalancer {
       return false
     }
     AzureLoadBalancer a = (AzureLoadBalancer)o;
-    a.getAccount() == this.getAccount() && a.getName() == this.getName() && a.getType() == this.getType();
+    a.getAccount() == this.getAccount() && a.getName() == this.getName() && a.getType() == this.getType() && a.region == this.region;
 
     // TODO Implement logic to compare server groups and regions(?)
   }
 
   @Override
   int hashCode() {
-    getAccount().hashCode() + getName().hashCode() + getType().hashCode();
+    getAccount().hashCode() + getName().hashCode() + getType().hashCode() + region.hashCode();
     // TODO Implement logic to add hash code for server groups and regions(?)
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
@@ -24,6 +24,8 @@ class AzureLoadBalancerDescription extends AzureResourceOpsDescription {
   String securityGroups
   String dnsName
   String cluster
+  String serverGroup
+  String appName
   List<AzureLoadBalancerProbe> probes = []
   List<AzureLoadBalancingRule> loadBalancingRules = []
   List<AzureLoadBalancerInboundNATRule> inboundNATRules = []

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.azure.resources.common.cache.Keys
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancer
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -76,7 +77,8 @@ class AzureLoadBalancerProvider implements LoadBalancerProvider<AzureLoadBalance
       account: parts.account?: "none",
       name: loadBalancerDescription.loadBalancerName,
       region: loadBalancerDescription.region,
-      vnet: loadBalancerDescription.vnet?: "none"
+      vnet: loadBalancerDescription.vnet?: "vnet-unassigned",
+      serverGroups: [new LoadBalancerServerGroup(name: loadBalancerDescription.serverGroup, isDisabled: false, detachedInstances: [], instances: [])]
     )
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
@@ -100,6 +100,7 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
       lbDescription.credentials = description.credentials
       lbDescription.appName = description.application
       lbDescription.cluster = description.clusterName
+      lbDescription.serverGroup = description.name
       lbDescription.stack = description.stack
       lbDescription.detail = description.detail
 
@@ -112,6 +113,8 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
       errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name)
 
       description.loadBalancerName = lbDescription.loadBalancerName
+      description.securityGroupName = description.securityGroup?.name
+      description.subnetId = subnetId
       task.updateStatus(BASE_PHASE, "Deploying server group")
       deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(description.credentials,
         AzureServerGroupResourceTemplate.getTemplate(description),

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureLoadBalancerResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureLoadBalancerResourceTemplate.groovy
@@ -95,7 +95,13 @@ class AzureLoadBalancerResourceTemplate {
       name = "[variables('loadBalancerName')]"
       type = "Microsoft.Network/loadBalancers"
       location = "[parameters('location')]"
-      tags = ["appName":description.appName, "stack":description.stack, "detail":description.detail]
+      tags = [:]
+      tags.appName = description.appName
+      tags.stack = description.stack
+      tags.detail = description.detail
+      if (description.cluster) tags.cluster = description.cluster
+      if (description.serverGroup) tags.serverGroup = description.serverGroup
+      if (description.vnet) tags.vnet = description.vnet
 
       properties = new LoadBalancerProperties(description)
     }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
@@ -110,17 +110,19 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "version" : "latest"
     },
     "imageReference" : "[variables('osType')]",
-    "uniqueStorageNameArray" : [ "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', variables('newStorageAccountSuffix'), '0')))]" ]
+    "uniqueStorageNameArray" : [ "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), variables('newStorageAccountSuffix'))]" ]
   },
   "resources" : [ {
     "apiVersion" : "2015-06-15",
-    "name" : "[concat(variables('uniqueStorageNameArray')[copyIndex()], variables('newStorageAccountSuffix'))]",
+    "name" : "[concat(variables('uniqueStorageNameArray')[copyIndex()])]",
     "type" : "Microsoft.Storage/storageAccounts",
     "location" : "[parameters('location')]",
     "tags" : {
       "appName" : "azureMASM",
       "stack" : "st1",
-      "detail" : "d11"
+      "detail" : "d11",
+      "cluster" : "azureMASM-st1-d11",
+      "serverGroupName" : "azureMASM-st1-d11"
     },
     "copy" : {
       "name" : "storageLoop",
@@ -138,9 +140,12 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "appName" : "azureMASM",
       "stack" : "st1",
       "detail" : "d11",
-      "cluster" : "azureMASM-st1-d11"
+      "cluster" : "azureMASM-st1-d11",
+      "loadBalancerName" : "azureMASM-st1-d11",
+      "imageIsCustom" : "false",
+      "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), variables('newStorageAccountSuffix'))]"
     },
-    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0], variables('newStorageAccountSuffix'))]" ],
+    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]" ],
     "sku" : {
       "name" : "Standard_A1",
       "tier" : "Standard",
@@ -156,7 +161,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
             "name" : "osdisk-azureMASM-st1-d11",
             "caching" : "ReadOnly",
             "createOption" : "FromImage",
-            "vhdContainers" : [ "[concat('https://', variables('uniqueStorageNameArray')[0], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]" ]
+            "vhdContainers" : [ "[concat('https://', variables('uniqueStorageNameArray')[0], '.blob.core.windows.net/', variables('vhdContainerName'))]" ]
           },
           "imageReference" : "[variables('imageReference')]"
         },
@@ -216,7 +221,9 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "appName" : "azureMASM",
       "stack" : "st1",
       "detail" : "d11",
-      "cluster" : "azureMASM-st1-d11"
+      "cluster" : "azureMASM-st1-d11",
+      "loadBalancerName" : "azureMASM-st1-d11",
+      "imageIsCustom" : "true"
     },
     "dependsOn" : [ ],
     "sku" : {

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/description/AzureServerGroupDescriptionUnitSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/description/AzureServerGroupDescriptionUnitSpec.groovy
@@ -74,12 +74,12 @@ class AzureServerGroupDescriptionUnitSpec extends Specification {
 
   private static Boolean descriptionIsValid(AzureServerGroupDescription description, VirtualMachineScaleSet scaleSet) {
     (description.name == scaleSet.name
-      && description.appName == AzureUtilities.getAppNameFromResourceId(scaleSet.id)
+      && description.appName == scaleSet.tags.appName
       && description.tags == scaleSet.tags
-      && description.stack == scaleSet.tags["stack"]
-      && description.detail == scaleSet.tags["detail"]
-      && description.application == scaleSet.tags["appName"]
-      && description.clusterName == scaleSet.tags["cluster"]
+      && description.stack == scaleSet.tags.stack
+      && description.detail == scaleSet.tags.detail
+      && description.application == scaleSet.tags.appName
+      && description.clusterName == scaleSet.tags.cluster
       && description.region == scaleSet.location
       && description.upgradePolicy == getPolicy(scaleSet.upgradePolicy.mode)
       && isValidImage(description.image, scaleSet)


### PR DESCRIPTION
Track various relationships between server group and its resources via the tag map.
Bug fix: retrieving load balancers with the same name across different locations/regions was only returning one instance.