### PR TITLE
Support for specifying an explicit ASG sequence number

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -53,6 +53,7 @@ class AutoScalingWorker {
   private String iamRole
   private String keyPair
   private String base64UserData
+  private Integer sequence
   private Boolean ignoreSequence
   private Boolean startDisabled
   private Boolean associatePublicIpAddress
@@ -106,7 +107,12 @@ class AutoScalingWorker {
     task.updateStatus AWS_PHASE, "Beginning ASG deployment."
 
     AWSServerGroupNameResolver awsServerGroupNameResolver = regionScopedProvider.AWSServerGroupNameResolver
-    String asgName = awsServerGroupNameResolver.resolveNextServerGroupName(application, stack, freeFormDetails, ignoreSequence)
+    String asgName
+    if (sequence != null) {
+      asgName = awsServerGroupNameResolver.generateServerGroupName(application, stack, freeFormDetails, sequence, false)
+    }  else {
+      asgName = awsServerGroupNameResolver.resolveNextServerGroupName(application, stack, freeFormDetails, ignoreSequence)
+    }
 
     def settings = new LaunchConfigurationBuilder.LaunchConfigurationSettings(
       account: credentials.name,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -48,6 +48,13 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   String classicLinkVpcId
   List<String> classicLinkVpcSecurityGroups
 
+  /**
+   * If specified, this sequence number will be used when generating the server group name.
+   *
+   * Expectation is on the caller to ensure that an explicitly provided sequence number is not already in use.
+   */
+  Integer sequence
+
   boolean ignoreSequence
   boolean startDisabled
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -221,6 +221,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         securityGroups: description.securityGroups,
         iamRole: description.iamRole ?: deployDefaults.iamRole,
         keyPair: description.keyPair ?: account?.defaultKeyPair,
+        sequence: description.sequence,
         ignoreSequence: description.ignoreSequence,
         startDisabled: description.startDisabled,
         associatePublicIpAddress: description.associatePublicIpAddress,

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolver.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolver.groovy
@@ -95,6 +95,10 @@ abstract class AbstractServerGroupNameResolver extends NameBuilder {
   }
 
   static String generateServerGroupName(String application, String stack, String details, Integer sequence, Boolean ignoreSequence) {
+    if (sequence < 0 || sequence >= 1000) {
+      throw new IllegalArgumentException("Sequence '${sequence}' is invalid")
+    }
+
     def builder = new AutoScalingGroupNameBuilder(appName: application, stack: stack, detail: details)
     def groupName = builder.buildGroupName(true)
     if (ignoreSequence) {

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolverSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolverSpec.groovy
@@ -105,6 +105,27 @@ class AbstractServerGroupNameResolverSpec extends Specification {
     exc.message == "All server group names for cluster app-dev in test-region are taken."
   }
 
+  @Unroll
+  void "generateServerGroupName should throw exception if sequence is invalid"() {
+    setup:
+    def serverGroupNameResolver = new TestServerGroupNameResolver([])
+
+    expect:
+    try {
+      serverGroupNameResolver.generateServerGroupName("application", "stack", "details", sequence, false)
+      assert !expectedException
+    } catch (IllegalArgumentException ignored) {
+      assert expectedException
+    }
+
+    where:
+    sequence || expectedException
+    -1       || true
+    1000     || true
+    0        || false
+    999      || false
+  }
+
   void "resolveNextServerGroupName should yield v001 when most recent server group does not define sequence number"() {
     setup:
     def takenSlots = [


### PR DESCRIPTION
This handles the scenario where an API user would like to bulk create (or clone) multiple ASGs