### PR TITLE
Turn on GCE Redis-based provider impl

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -119,7 +119,7 @@ azure:
 
 google:
   enabled: false
-  providerImpl: old # or new
+  providerImpl: new # or new
   baseImageProjects:
   - centos-cloud
   - coreos-cloud


### PR DESCRIPTION
The day is finally here! This turns on the new Redis based caching implementation for GCE. 

Obviously if you're having troubles, flip this value back to "old" and file a bug report, assigning @ttomsu. 

@spinnaker/google-reviewers FYI

tag: https://github.com/spinnaker/spinnaker/issues/712