### PR TITLE
Add destroy server group ops and other minor bug fixes

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -20,7 +20,9 @@ import com.microsoft.azure.CloudException
 import com.microsoft.azure.credentials.ApplicationTokenCredentials
 import com.microsoft.azure.management.compute.ComputeManagementClient
 import com.microsoft.azure.management.compute.ComputeManagementClientImpl
+import com.microsoft.azure.management.compute.VirtualMachineScaleSetsOperations
 import com.microsoft.azure.management.compute.models.VirtualMachineScaleSet
+import com.microsoft.rest.ServiceResponse
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureInstance
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureVMImage
@@ -152,6 +154,20 @@ public class AzureComputeClient extends AzureBaseClient {
       log.warn("ServerGroup: ${e.message} (${serverGroupName} was not found)")
     }
     null
+  }
+
+  ServiceResponse<Void> destroyServerGroup(String resourceGroupName, String serverGroupName) {
+    VirtualMachineScaleSetsOperations ops = getAzureOps(
+      client.&getVirtualMachineScaleSetsOperations, "Get operations object", "Failed to get operation object") as VirtualMachineScaleSetsOperations
+
+    deleteAzureResource(
+      ops.&delete,
+      resourceGroupName,
+      serverGroupName,
+      null,
+      "Delete Server Group ${serverGroupName}",
+      "Failed to delete Server Group ${serverGroupName} in ${resourceGroupName}"
+    )
   }
 
   Collection<AzureInstance> getServerGroupInstances(String resourceGroupName, String serverGroupName) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
@@ -62,12 +62,13 @@ class AzureResourceManagerClient extends AzureBaseClient {
                                                 String resourceGroupName,
                                                 String region,
                                                 String resourceName,
+                                                String resourceType,
                                                 Map<String, String> templateParams = [:]) {
 
     // TODO validate that all callers invoke this themselves, then remove this call
     initializeResourceGroupAndVNet(credentials, resourceGroupName, null, region)
 
-    String deploymentName = resourceName + AzureUtilities.NAME_SEPARATOR +"deployment"
+    String deploymentName = [resourceName, resourceType, "deployment"].join(AzureUtilities.NAME_SEPARATOR)
     if (!templateParams['location']) {
       templateParams['location'] = region
     }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureStorageClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureStorageClient.groovy
@@ -16,20 +16,66 @@
 
 package com.netflix.spinnaker.clouddriver.azure.client
 
+import com.microsoft.azure.credentials.ApplicationTokenCredentials
+import com.microsoft.azure.management.storage.StorageAccountsOperations
+import com.microsoft.azure.management.storage.StorageManagementClient
+import com.microsoft.azure.management.storage.StorageManagementClientImpl
 import com.microsoft.azure.storage.blob.CloudBlobClient
 import com.microsoft.azure.storage.blob.CloudBlobContainer
 import com.microsoft.azure.storage.blob.CloudBlobDirectory
 import com.microsoft.azure.storage.blob.ListBlobItem
 import com.microsoft.azure.storage.CloudStorageAccount
+import com.microsoft.rest.ServiceResponse
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureCustomImageStorage
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureCustomVMImage
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import okhttp3.logging.HttpLoggingInterceptor
 
 @Slf4j
 @CompileStatic
-class AzureStorageClient {
+class AzureStorageClient extends AzureBaseClient {
   static final String AZURE_IMAGE_FILE_EXT = ".vhd"
+
+  private final StorageManagementClient client
+
+  AzureStorageClient(String subscriptionId, ApplicationTokenCredentials credentials) {
+    super(subscriptionId)
+    this.client = this.initialize(credentials)
+  }
+
+  /**
+   * get the StorageManagementClient which will be used for all interaction related to compute resources in Azure
+   * @param creds the credentials to use when communicating to the Azure subscription(s)
+   * @return an instance of the Azure StorageManagementClient
+   */
+  private StorageManagementClient initialize(ApplicationTokenCredentials tokenCredentials) {
+    StorageManagementClient storageClient = new StorageManagementClientImpl(tokenCredentials)
+    storageClient.setSubscriptionId(this.subscriptionId)
+    storageClient.setLogLevel(HttpLoggingInterceptor.Level.NONE)
+    storageClient
+  }
+
+  /**
+   * Delete a storage account in the resource group specified
+   * @param resourceGroupName Resource Group in Azure where the storage account will exist
+   * @param storageName Name of the storage account to delete
+   * @throws RuntimeException Throws RuntimeException if operation response indicates failure
+   * @return a ServiceResponse object
+   */
+  ServiceResponse<Void> deleteStorageAccount(String resourceGroupName, String storageName) {
+    StorageAccountsOperations ops = getAzureOps(
+      client.&getStorageAccountsOperations, "Get operations object", "Failed to get operation object") as StorageAccountsOperations
+
+    deleteAzureResource(
+      ops.&delete,
+      resourceGroupName,
+      storageName,
+      null,
+      "Delete Storage Account ${storageName}",
+      "Failed to delete Storage Account ${storageName} in ${resourceGroupName}"
+    )
+  }
 
   /**
    * Return list of available .VHD files from a list of connection strings

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/application/view/AzureApplicationProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/application/view/AzureApplicationProvider.groovy
@@ -52,7 +52,7 @@ class AzureApplicationProvider implements ApplicationProvider {
 
   @Override
   AzureApplication getApplication(String name) {
-    translate(cacheView.get(Keys.Namespace.AZURE_APPLICATIONS.ns, Keys.getApplicationKey(azureCloudProvider, name)))
+    translate(cacheView.get(Keys.Namespace.AZURE_APPLICATIONS.ns, Keys.getApplicationKey(azureCloudProvider, name))) ?: new AzureApplication(name, [:], [:])
   }
 
   AzureApplication translate(CacheData cacheData) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/DeleteAzureLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/DeleteAzureLoadBalancerAtomicOperation.groovy
@@ -57,6 +57,7 @@ class DeleteAzureLoadBalancerAtomicOperation implements AtomicOperation<Void> {
           .networkClient
           .deleteLoadBalancer(resourceGroupName, description.loadBalancerName)
 
+        // TODO: check response to ensure operation succeeded
         task.updateStatus(BASE_PHASE, "Deletion of Azure load balancer ${description.loadBalancerName} in ${region} has succeeded.")
       } catch (Exception e) {
         task.updateStatus(BASE_PHASE, "Deletion of load balancer ${description.loadBalancerName} failed: e.message")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/UpsertAzureLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/UpsertAzureLoadBalancerAtomicOperation.groovy
@@ -62,7 +62,8 @@ class UpsertAzureLoadBalancerAtomicOperation implements AtomicOperation<Map> {
         AzureLoadBalancerResourceTemplate.getTemplate(description),
         resourceGroupName,
         description.region,
-        description.loadBalancerName)
+        description.loadBalancerName,
+        "loadBalancer")
 
       errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name)
     } catch (CloudException ce) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/DeleteAzureSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/DeleteAzureSecurityGroupAtomicOperation.groovy
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.model.Del
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
 
 class DeleteAzureSecurityGroupAtomicOperation implements AtomicOperation<Void> {
-  private static final String BASE_PHASE = "DELETE_LOAD_BALANCER"
+  private static final String BASE_PHASE = "DELETE_SECURITY_GROUP"
 
   private static Task getTask() {
     TaskRepository.threadLocalTask.get()
@@ -52,20 +52,13 @@ class DeleteAzureSecurityGroupAtomicOperation implements AtomicOperation<Void> {
       try {
         String resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, region)
 
-        def response = description
+        description
           .credentials
           .networkClient
           .deleteSecurityGroup(resourceGroupName, description.securityGroupName)
 
-        // Check to see if the operation succeeded
-        if (response.response.success) {
-          task.updateStatus BASE_PHASE, "Done deleting Azure network security group ${description.securityGroupName} in ${region}."
-        }
-        else {
-          task.updateStatus(BASE_PHASE,
-            String.format("Delete operation failed for security group ${description.securityGroupName}: %s", response.response.message()))
-          task.fail()
-        }
+        // TODO: check response to ensure operation succeeded
+        task.updateStatus BASE_PHASE, "Done deleting Azure network security group ${description.securityGroupName} in ${region}."
       } catch (Exception e) {
         task.updateStatus BASE_PHASE, String.format("Deletion of Azure network security group ${description.securityGroupName} failed: %s", e.message)
         throw new AtomicOperationException(

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/UpsertAzureSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/UpsertAzureSecurityGroupAtomicOperation.groovy
@@ -61,7 +61,8 @@ class UpsertAzureSecurityGroupAtomicOperation implements AtomicOperation<Map> {
         AzureSecurityGroupResourceTemplate.getTemplate(description),
         resourceGroupName,
         description.region,
-        description.securityGroupName)
+        description.securityGroupName,
+        "securityGroup")
 
       errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task,BASE_PHASE, description.credentials, resourceGroupName, deployment.name)
     } catch (Exception e) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
@@ -22,6 +22,8 @@ class AzureInstance implements Instance, Serializable {
         case "ProvisioningState":
           if (codes[1].toLowerCase() == AzureUtilities.ProvisioningState.SUCCEEDED.toLowerCase()) {
             instance.launchTime = status.time?.millis
+          } else {
+            instance.healthState = HealthState.Failed
           }
           break
         case "PowerState":

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/DestroyAzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/DestroyAzureServerGroupDescription.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The original authors.
+ * Copyright 2016 The original authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.azure.resources.common
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model
 
-import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
-
-class AzureResourceOpsDescription {
-  String name
-  String cloudProvider
-  String accountName
-  String appName
-  String stack
-  String detail
-  AzureCredentials credentials
-  String region
-  String user
-  Long createdTime
-  long lastReadTime
-  Map<String,String> tags = [:]
-
-  Long getCreatedTime() {
-    this.lastReadTime
-  }
+class DestroyAzureServerGroupDescription extends AzureServerGroupDescription{
+  String serverGroupName
+  List<String> regions
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+
+class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "DESTROY_SERVER_GROUP"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  private final DestroyAzureServerGroupDescription description
+
+  DestroyAzureServerGroupAtomicOperation(DestroyAzureServerGroupDescription description) {
+    this.description = description
+  }
+
+  /**
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "destroyServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/ops
+   */
+  @Override
+  Void operate(List priorOutputs) {
+    task.updateStatus BASE_PHASE, "Initializing Destroy Azure Server Group Operation..."
+    for (region in description.regions) {
+      if (description.serverGroupName) description.name = description.serverGroupName
+      if (!description.application) description.application = description.appName ?: Names.parseName(description.name).app
+      task.updateStatus BASE_PHASE, "Destroying server group ${description.name} " + "in ${region}..."
+
+      if (!description.credentials) {
+        throw new IllegalArgumentException("Unable to resolve credentials for the selected Azure account.")
+      }
+
+      def errList = new ArrayList<String>()
+
+      try {
+        String resourceGroupName = AzureUtilities.getResourceGroupName(description.application, region)
+        AzureServerGroupDescription serverGroupDescription = description.credentials.computeClient.getServerGroup(resourceGroupName, description.name)
+
+        if (!serverGroupDescription) {
+          task.updateStatus(BASE_PHASE, "Destroy Server Group Operation failed: could not find server group ${description.name} in ${region}")
+          errList.add("could not find server group ${description.name} in ${region}")
+        } else {
+          try {
+            description
+              .credentials
+              .computeClient
+              .destroyServerGroup(resourceGroupName, description.name)
+
+            task.updateStatus BASE_PHASE, "Done destroying Azure server group ${description.name} in ${region}."
+          } catch (Exception e) {
+            task.updateStatus(BASE_PHASE, "Deletion of server group ${description.name} failed: ${e.message}")
+            errList.add("Failed to delete server group ${description.name}: ${e.message}")
+          }
+
+          // Clean-up the storrage account, load balancer and the subnet that where attached to the server group
+          if (errList.isEmpty()) {
+
+            // Delete storage accounts if any
+            serverGroupDescription.storageAccountNames?.each { def storageAccountName ->
+              task.updateStatus(BASE_PHASE, "Deleting storage account ${storageAccountName} " + "in ${region}...")
+              try {
+                description
+                  .credentials
+                  .storageClient
+                  .deleteStorageAccount(resourceGroupName, storageAccountName)
+
+                task.updateStatus(BASE_PHASE, "Deletion of Azure storage account ${storageAccountName} in ${region} has succeeded.")
+              } catch (Exception e) {
+                task.updateStatus(BASE_PHASE, "Deletion of Azure storage account ${storageAccountName} failed: ${e.message}")
+                errList.add("Failed to delete storage account ${storageAccountName}: ${e.message}")
+              }
+            }
+
+            // Delete load balancer attached to server group
+            if (serverGroupDescription.loadBalancerName) {
+              task.updateStatus(BASE_PHASE, "Deleting load balancer ${serverGroupDescription.loadBalancerName} " + "in ${region}...")
+              try {
+                description
+                  .credentials
+                  .networkClient
+                  .deleteLoadBalancer(resourceGroupName, serverGroupDescription.loadBalancerName)
+
+                task.updateStatus(BASE_PHASE, "Deletion of Azure load balancer ${serverGroupDescription.loadBalancerName} in ${region} has succeeded.")
+              } catch (Exception e) {
+                task.updateStatus(BASE_PHASE, "Deletion of Azure load balancer ${serverGroupDescription.loadBalancerName} failed: ${e.message}")
+                errList.add("Failed to delete ${serverGroupDescription.loadBalancerName}: ${e.message}")
+              }
+            }
+
+            // Delete subnet attached to server group
+            if (serverGroupDescription.subnetId) {
+              String subnetName = AzureUtilities.getNameFromResourceId(serverGroupDescription.subnetId)
+              String virtualNetworkName = AzureUtilities.getVirtualNetworkName(resourceGroupName)
+              task.updateStatus(BASE_PHASE, "Deleting subnet ${subnetName} " + "in ${region}...")
+              try {
+                description
+                  .credentials
+                  .networkClient
+                  .deleteSubnet(resourceGroupName, virtualNetworkName, subnetName)
+
+                task.updateStatus(BASE_PHASE, "Deletion of subnet ${subnetName} in ${region} has succeeded.")
+              } catch (Exception e) {
+                task.updateStatus(BASE_PHASE, "Deletion of subnet ${subnetName} in ${virtualNetworkName} failed: ${e.message}")
+                errList.add("Failed to delete subnet ${subnetName} in ${virtualNetworkName}: ${e.message}")
+              }
+            }
+          }
+        }
+      } catch (Exception e) {
+        task.updateStatus(BASE_PHASE, "Destroying server group ${description.name} failed: ${e.message}")
+        errList.add("Failed to destroy server group ${description.name}: ${e.message}")
+      }
+
+      if (errList.isEmpty()) {
+        task.updateStatus BASE_PHASE, "Destroy Azure Server Group Operation for ${description.name} succeeded."
+      }
+      else {
+        errList.add(" Go to Azure Portal for more info")
+        throw new AtomicOperationException(
+          error: "Failed to destroy ${description.name}",
+          errors: errList)
+      }
+    }
+
+    null
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.converters
+
+import com.netflix.spinnaker.clouddriver.azure.AzureOperation
+import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+
+@Slf4j
+@AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
+@Component("destroyAzureServerGroupDescription")
+class DestroyAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  DestroyAzureServerGroupAtomicOperationConverter() {
+    log.info("Constructor....DeleteAzureSecurityGroupAtomicOperationConverter")
+  }
+
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    new DestroyAzureServerGroupAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  DestroyAzureServerGroupDescription convertDescription(Map input) {
+    AzureAtomicOperationConverterHelper.
+      convertDescription(input, this, DestroyAzureServerGroupDescription) as DestroyAzureServerGroupDescription
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DestroyAzureServerGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DestroyAzureServerGroupDescriptionValidator.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.validators
+
+import com.netflix.spinnaker.clouddriver.azure.AzureOperation
+import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.validation.Errors
+
+@AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
+@Component("DestroyAzureServerGroupDescriptionValidator")
+class DestroyAzureServerGroupDescriptionValidator extends
+  DescriptionValidator<DestroyAzureServerGroupDescription> {
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Override
+  void validate(List priorDescriptions, DestroyAzureServerGroupDescription description, Errors errors) {
+    def helper = new StandardAzureAttributeValidator("DestroyAzureServerGroupDescription", errors)
+
+    helper.validateCredentials(description.credentials, accountCredentialsProvider)
+    helper.validateRegionList(description.regions)
+    helper.validateName(description.serverGroupName, "serverGroupName")
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentials.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentials.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.azure.client.AzureBaseClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureComputeClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureNetworkClient
 import com.netflix.spinnaker.clouddriver.azure.client.AzureResourceManagerClient
+import com.netflix.spinnaker.clouddriver.azure.client.AzureStorageClient
 
 class AzureCredentials {
 
@@ -32,6 +33,7 @@ class AzureCredentials {
   final AzureResourceManagerClient resourceManagerClient
   final AzureNetworkClient networkClient
   final AzureComputeClient computeClient
+  final AzureStorageClient storageClient
 
   AzureCredentials(String tenantId, String clientId, String appKey, String subscriptionId) {
     this.tenantId = tenantId
@@ -40,13 +42,14 @@ class AzureCredentials {
     this.subscriptionId = subscriptionId
     this.project = "AzureProject"
 
-    resourceManagerClient = new AzureResourceManagerClient(this.subscriptionId,
-      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
+    def token = AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey)
 
-    networkClient = new AzureNetworkClient(this.subscriptionId,
-      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
+    resourceManagerClient = new AzureResourceManagerClient(this.subscriptionId, token)
 
-    computeClient = new AzureComputeClient(this.subscriptionId,
-      AzureBaseClient.getTokenCredentials(this.clientId, this.tenantId, this.appKey))
+    networkClient = new AzureNetworkClient(this.subscriptionId, token)
+
+    computeClient = new AzureComputeClient(this.subscriptionId, token)
+
+    storageClient = new AzureStorageClient(this.subscriptionId, token)
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -84,10 +84,8 @@ class AzureServerGroupResourceTemplate {
     // These *Var variables are meant to help keep that reference from breaking IF the name of the actual variable
     // changes
     static transient String uniqueStorageNamesArrayVar = 'uniqueStorageNameArray'
-    static transient String newStorageAccountsSuffixVar = 'newStorageAccountSuffix'
     static transient String vhdContainerNameVar = 'vhdContainerName'
 
-    String newStorageAccountSuffix
     String vhdContainerName
     OsType osType
     String imageReference
@@ -99,7 +97,6 @@ class AzureServerGroupResourceTemplate {
      */
     ServerGroupTemplateVariables(AzureServerGroupDescription description) {
 
-      newStorageAccountSuffix = STORAGE_ACCOUNT_SUFFIX
       vhdContainerName = description.name.toLowerCase()
       osType = new OsType(description)
       imageReference = "[variables('osType')]"
@@ -112,7 +109,7 @@ class AzureServerGroupResourceTemplate {
 
   static String getUniqueStorageName(String name, long idx) {
     String noDashName = name.replaceAll("-", "").toLowerCase()
-    "[concat(uniqueString(concat(resourceGroup().id, subscription().id, '$noDashName', '$idx')), variables('$ServerGroupTemplateVariables.newStorageAccountsSuffixVar'))]"
+    "[concat(uniqueString(concat(resourceGroup().id, subscription().id, '$noDashName', '$idx')), '$STORAGE_ACCOUNT_SUFFIX')]"
   }
 
   /**

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroups.deploy.ops
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
+import com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.converters.DestroyAzureServerGroupAtomicOperationConverter
+import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
+import org.mockito.Mock
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DestroyAzureServerGroupAtomicOperationSpec extends Specification {
+  static final ACCOUNT_NAME = "my-azure-account"
+  private static final CLOUD_PROVIDER = "azure"
+  private static final ACCOUNT_CLIENTID = "azureclientid"
+  private static final ACCOUNT_TENANTID = "azuretenantid1"
+  private static final ACCOUNT_APPKEY = "azureappkey1"
+  private static final SUBSCRIPTION_ID = "azuresubscriptionid1"
+
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared
+  DestroyAzureServerGroupAtomicOperationConverter converter
+
+  @Shared
+  AzureCredentials azureCredentials
+
+  @Shared
+  AzureNamedAccountCredentials credentials
+
+  @Shared
+  AccountCredentialsProvider accountCredentialsProvider
+
+  def setupSpec() {
+    converter = new DestroyAzureServerGroupAtomicOperationConverter(objectMapper: mapper)
+    azureCredentials = new AzureCredentials(ACCOUNT_CLIENTID, ACCOUNT_TENANTID, ACCOUNT_APPKEY, SUBSCRIPTION_ID)
+
+    def credentialsRepo = new MapBackedAccountCredentialsRepository()
+    credentials = Mock(AzureNamedAccountCredentials)
+    credentials.getAccountName() >> ACCOUNT_NAME
+    credentials.getName() >> ACCOUNT_NAME
+    credentials.getCredentials() >> azureCredentials
+    credentialsRepo.save(ACCOUNT_NAME, credentials)
+    accountCredentialsProvider = new DefaultAccountCredentialsProvider(credentialsRepo)
+    accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    accountCredentialsProvider.getCredentials(_) >> credentials
+    converter.accountCredentialsProvider = accountCredentialsProvider
+  }
+
+  void "Create DestroyAzureServerGroupAtomicOperation object simple test"() {
+    setup:
+    def input = '''{ "serverGroupName": "testazure-web1-d1-v000", "name": "testazure-web1-d1-v000", "account" : "my-azure-account", "cloudProvider" : "azure", "appName" : "testazure", "regions": ["westus"], "credentials": "my-azure-account" }'''
+
+    when:
+    DestroyAzureServerGroupAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
+    DestroyAzureServerGroupDescription description = converter.convertDescription(mapper.readValue(input, Map))
+
+    then:
+    operation
+    description.name == "testazure-web1-d1-v000"
+    description.accountName == "my-azure-account"
+    description.regions[0] == "westus"
+  }
+
+  void "Create DestroyAzureServerGroupAtomicOperation object with no name and acccountName"() {
+    setup:
+    def input = '''{ "serverGroupName": "testazure-web1-d1-v000", "cloudProvider" : "azure", "appName" : "testazure", "regions": ["westus", "eastus"], "credentials": "my-azure-account" }'''
+
+    when:
+    DestroyAzureServerGroupAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
+    DestroyAzureServerGroupDescription description = converter.convertDescription(mapper.readValue(input, Map))
+
+    then:
+    operation
+    description.serverGroupName == "testazure-web1-d1-v000"
+    description.accountName == "my-azure-account"
+    description.regions[1] == "eastus"
+  }
+}

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
@@ -101,7 +101,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "newStorageAccountSuffix" : "sa",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -110,7 +109,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "version" : "latest"
     },
     "imageReference" : "[variables('osType')]",
-    "uniqueStorageNameArray" : [ "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), variables('newStorageAccountSuffix'))]" ]
+    "uniqueStorageNameArray" : [ "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]" ]
   },
   "resources" : [ {
     "apiVersion" : "2015-06-15",
@@ -143,7 +142,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "cluster" : "azureMASM-st1-d11",
       "loadBalancerName" : "azureMASM-st1-d11",
       "imageIsCustom" : "false",
-      "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), variables('newStorageAccountSuffix'))]"
+      "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]"
     },
     "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]" ],
     "sku" : {


### PR DESCRIPTION
Add destroy server group ops. 
Cleanup resources that are created as part of the create server group in case of a failure during the creation.
Add retries support when deleting a resource in Azure (work around for random timeouts when accessing Azure resources in the Azure Cloud).
Fix an exception in clouddriver console when the application has no clusters.
Add type as part of the deployment name. 
