### PR TITLE
provider/kubernetes: Fix image pull secret address

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
@@ -101,7 +101,6 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
       replicationControllerBuilder = replicationControllerBuilder.addNewImagePullSecret(imagePullSecret)
     }
 
-
     if (description.volumeSources) {
       task.updateStatus BASE_PHASE, "Adding pod volume sources... "
       def volumeSources = description.volumeSources.findResults { volumeSource ->

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -76,7 +76,7 @@ public class KubernetesCredentials {
         secretBuilder = secretBuilder.withNewMetadata().withName(secretName).endMetadata();
 
         HashMap<String, String> secretData = new HashMap<>(1);
-        String dockerCfg = String.format("{ \"%s\": { \"auth\": \"%s\", \"email\": \"%s\" } }", account.getV2Endpoint(), account.getBasicAuth(), account.getEmail());
+        String dockerCfg = String.format("{ \"%s\": { \"auth\": \"%s\", \"email\": \"%s\" } }", account.getAddress(), account.getBasicAuth(), account.getEmail());
         try {
           dockerCfg = new String(Base64.getEncoder().encode(dockerCfg.getBytes("UTF-8")), "UTF-8");
         } catch (UnsupportedEncodingException uee) {


### PR DESCRIPTION
Using the full v2 endpoint was preventing Kubernetes from correctly authenticating with some private registries

@duftler 