### PR TITLE
core: Add process & job providers & models

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Job.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Job.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+/**
+ * A Job is a collection of Processes. The Job defines how many processes may run, and the failure/success conditions
+ * leading to a terminal status.
+ *
+ * See Process.groovy for an overview of Processes.
+ */
+interface Job {
+  String getName()
+
+  String getAccount()
+
+  String getId()
+
+  String getLocation()
+
+  JobState getJobState()
+
+  Set<Process> getProcesses()
+
+  Long getLaunchTime()
+
+  Long getFinishTime()
+
+  Set<String> getLoadBalancers()
+
+  Set<String> getSecurityGroups()
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/JobProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/JobProvider.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+public interface JobProvider<T extends Job> {
+  String getPlatform()
+
+  T getJob(String account, String location, String id)
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/JobState.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/JobState.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+enum JobState {
+  Starting, Running, Failed, Succeeded, Unknown
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Process.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Process.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+/**
+ * A Process is a terminating task, which on termination reports either "Success", or "Failure". It is run and managed
+ * by a Cloud Provider, inside that Cloud Provider's deployment context. For example, in the case of the Kubernetes
+ * Provider, a Process is a single container running to completion inside the Kubernetes Cluster.
+ */
+interface Process {
+  String getName()
+
+  String getId()
+
+  String getLocation()
+
+  String getJobId()
+
+  HealthState getHealthState()
+
+  List<String> getLoadBalancers()
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ProcessProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ProcessProvider.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model
+
+public interface ProcessProvider<T extends Process> {
+  String getPlatform()
+
+  T getProcess(String account, String location, String id)
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
@@ -24,6 +24,7 @@ class Keys {
     CLUSTERS,
     SERVER_GROUPS,
     INSTANCES,
+    PROCESSES,
     LOAD_BALANCERS,
     SECURITY_GROUPS,
     JOBS,
@@ -128,6 +129,18 @@ class Keys {
             region: parts[3]
         ]
         break
+      case Namespace.PROCESSES.ns:
+        def names = Names.parseName(parts[4])
+        result << [
+            application: names.app,
+            account: parts[2],
+            serverGroup: parts[4],
+            namespace: parts[3],
+            name: parts[5],
+            processId: parts[5],
+            region: parts[3]
+        ]
+        break
       case Namespace.SECURITY_GROUPS.ns:
         def names = Names.parseName(parts[4])
         result << [
@@ -169,6 +182,10 @@ class Keys {
 
   static String getInstanceKey(String account, String namespace, String replicationControllerName, String name) {
     "${Namespace.provider}:${Namespace.INSTANCES}:${account}:${namespace}:${replicationControllerName}:${name}"
+  }
+
+  static String getProcessKey(String account, String namespace, String jobName, String name) {
+    "${Namespace.provider}:${Namespace.PROCESSES}:${account}:${namespace}:${jobName}:${name}"
   }
 
   static String getSecurityGroupKey(String account, String namespace, String ingressName) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJob.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJob.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import com.netflix.spinnaker.clouddriver.model.Job
+import com.netflix.spinnaker.clouddriver.model.JobState
+import com.netflix.spinnaker.clouddriver.model.Process
+
+class KubernetesJob implements Job, Serializable {
+  String name
+  String account
+  String id
+  String location
+  Set<Process> processes
+  Long launchTime
+  Set<String> loadBalancers
+  Set<String> securityGroups
+  io.fabric8.kubernetes.api.model.extensions.Job job
+
+  KubernetesJob(io.fabric8.kubernetes.api.model.extensions.Job job, Set<KubernetesProcess> processes, String account) {
+    this.name = job.metadata.name
+    this.location = job.metadata.namespace
+    this.job = job
+    this.account = account
+    this.processes = processes
+    this.launchTime = KubernetesModelUtil.translateTime(job.metadata.creationTimestamp)
+  }
+
+  @Override
+  Long getFinishTime() {
+    if (jobState == JobState.Running || jobState == JobState.Starting || jobState == JobState.Unknown) {
+      return 0;
+    } else {
+      return KubernetesModelUtil.translateTime(job.status.completionTime)
+    }
+  }
+
+
+  @Override
+  JobState getJobState() {
+    job.status.succeeded == job.spec.completions ? JobState.Succeeded :
+      job.status.active > 0 ? JobState.Running : JobState.Unknown  // TODO(lwander) figure out how to extract failure state
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesModelUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesModelUtil.groovy
@@ -16,10 +16,37 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.model
 
+import com.netflix.spinnaker.clouddriver.model.HealthState
+
 import java.text.SimpleDateFormat
 
 class KubernetesModelUtil {
   static long translateTime(String time) {
     time ? (new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse(time)).getTime() : 0
+  }
+
+  static HealthState getHealthState(health) {
+    someUpRemainingUnknown(health) ? HealthState.Up :
+        anyStarting(health) ? HealthState.Starting :
+            anyDown(health) ? HealthState.Down :
+                anyOutOfService(health) ? HealthState.OutOfService :
+                    HealthState.Unknown
+  }
+
+  private static boolean anyDown(List<Map<String, String>> healthsList) {
+    healthsList.any { it.state == HealthState.Down.name() }
+  }
+
+  private static boolean someUpRemainingUnknown(List<Map<String, String>> healthsList) {
+    List<Map<String, String>> knownHealthList = healthsList.findAll { it.state != HealthState.Unknown.name() }
+    knownHealthList ? knownHealthList.every { it.state == HealthState.Up.name() } : false
+  }
+
+  private static boolean anyStarting(List<Map<String, String>> healthsList) {
+    healthsList.any { it.state == HealthState.Starting.name() }
+  }
+
+  private static boolean anyOutOfService(List<Map<String, String>> healthsList) {
+    healthsList.any { it.state == HealthState.OutOfService.name() }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesJob
+import com.netflix.spinnaker.clouddriver.model.JobProvider
+import io.fabric8.kubernetes.api.model.extensions.Job
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class KubernetesJobProvider implements JobProvider<KubernetesJob> {
+  String platform = "kubernetes"
+  private final Cache cacheView
+  private final ObjectMapper objectMapper
+
+  @Autowired
+  KubernetesJobProvider(Cache cacheView, ObjectMapper objectMapper) {
+    this.cacheView = cacheView
+    this.objectMapper = objectMapper
+  }
+
+  @Override
+  KubernetesJob getJob(String account, String location, String id) {
+    String jobKey = Keys.getJobKey(account, location, id)
+    CacheData jobData = cacheView.get(Keys.Namespace.SERVER_GROUPS.ns, jobKey)
+    if (!jobData) {
+      return null
+    }
+
+    Collection<CacheData> allLoadBalancers = KubernetesClusterProvider.resolveRelationshipDataForCollection(cacheView, [jobData], Keys.Namespace.LOAD_BALANCERS.ns, RelationshipCacheFilter.include(Keys.Namespace.SECURITY_GROUPS.ns))
+
+    def securityGroups = KubernetesClusterProvider.loadBalancerToSecurityGroupMap(cacheView, allLoadBalancers)
+
+    Set<CacheData> instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.PROCESSES.ns, Keys.getInstanceKey(account, location, id, "*"))
+
+    def job = objectMapper.convertValue(jobData.attributes.job, Job)
+    def res = new KubernetesJob(job, KubernetesProviderUtils.jobToProcessMap(objectMapper, instances)[id], account)
+    res.loadBalancers?.each {
+      res.securityGroups.addAll(securityGroups[it])
+    }
+
+    return res
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesProcessProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesProcessProvider.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesProcess
+import com.netflix.spinnaker.clouddriver.model.ProcessProvider
+import io.fabric8.kubernetes.api.model.Pod
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class KubernetesProcessProvider implements ProcessProvider<KubernetesProcess> {
+  private final Cache cacheView
+  private final ObjectMapper objectMapper
+  String platform = "kubernetes"
+
+  @Autowired
+  KubernetesProcessProvider(Cache cacheView, ObjectMapper objectMapper) {
+    this.cacheView = cacheView
+    this.objectMapper = objectMapper
+  }
+
+  @Override
+  KubernetesProcess getProcess(String account, String location, String id) {
+    Set<CacheData> processs = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.PROCESSES.ns, Keys.getProcessKey(account, location, "*", id))
+    if (!processs || processs.size() == 0) {
+      return null
+    }
+
+    if (processs.size() > 1) {
+      throw new IllegalStateException("Multiple kubernetes pods with name $id in namespace $location exist.")
+    }
+
+    CacheData processData = (CacheData) processs.toArray()[0]
+
+    def pod = objectMapper.convertValue(processData.attributes.pod, Pod)
+
+    return new KubernetesProcess(pod, account)
+  }
+}

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -36,6 +36,8 @@ swagger:
     - .*instances.*
     - .*reports.*
     - .*docker.*
+    - .*job.*
+    - .*process.*
 
 default:
   # legacyServerPort is a non-ssl listener, if ssl is enabled. -1 to disable

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/JobController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/JobController.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers
+
+import com.netflix.spinnaker.clouddriver.model.Job
+import com.netflix.spinnaker.clouddriver.model.JobProvider
+import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiParam
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.MessageSource
+import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/jobs")
+class JobController {
+
+  @Autowired
+  List<JobProvider> jobProviders
+
+  @Autowired
+  MessageSource messageSource
+
+  @ApiOperation(value = "Get a Job", notes = "Composed of many running `Process` objects")
+  @RequestMapping(value = "/{account}/{location}/{id:.+}", method = RequestMethod.GET)
+  Job getJob(@ApiParam(value = "Account job was created by", required = true) @PathVariable String account,
+             @ApiParam(value = "Namespace, region, or zone job is running in", required = true) @PathVariable String location,
+             @ApiParam(value = "Unique identifier of job being looked up", required = true) @PathVariable String id) {
+    Collection<Job> jobMatches = jobProviders.findResults {
+      it.getJob(account, location, id)
+    }
+    if (!jobMatches) {
+      throw new JobNotFoundException(name: id)
+    }
+    jobMatches.first()
+  }
+
+  static class JobNotFoundException extends RuntimeException {
+    String name
+  }
+
+  @ExceptionHandler
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  Map jobNotFoundException(JobNotFoundException ex) {
+    def message = messageSource.getMessage("job.not.found", [ex.name] as String[], "Job not found", LocaleContextHolder.locale)
+    [error: "job.not.found", message: message, status: HttpStatus.NOT_FOUND]
+  }
+
+  @ExceptionHandler
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map badRequestException(IllegalArgumentException ex) {
+    [error: 'invalid.request', message: ex.message, status: HttpStatus.BAD_REQUEST]
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProcessController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProcessController.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers
+
+import com.netflix.spinnaker.clouddriver.model.Process
+import com.netflix.spinnaker.clouddriver.model.ProcessProvider
+import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiParam
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.MessageSource
+import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/processs")
+class ProcessController {
+
+  @Autowired
+  List<ProcessProvider> processProviders
+
+  @Autowired
+  MessageSource messageSource
+
+  @ApiOperation(value = "Get a Process", notes = "Usually associated with a `Job` object")
+  @RequestMapping(value = "/{account}/{location}/{id:.+}", method = RequestMethod.GET)
+  Process getProcess(@ApiParam(value = "Account process was created by", required = true) @PathVariable String account,
+                     @ApiParam(value = "Namespace, region, or zone process is running in", required = true) @PathVariable String location,
+                     @ApiParam(value = "Unique identifier of process being looked up", required = true) @PathVariable String id) {
+    Collection<Process> processMatches = processProviders.findResults {
+      it.getProcess(account, location, id)
+    }
+    if (!processMatches) {
+      throw new ProcessNotFoundException(name: id)
+    }
+    processMatches.first()
+  }
+
+  static class ProcessNotFoundException extends RuntimeException {
+    String name
+  }
+
+  @ExceptionHandler
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  Map processNotFoundException(ProcessNotFoundException ex) {
+    def message = messageSource.getMessage("process.not.found", [ex.name] as String[], "Process not found", LocaleContextHolder.locale)
+    [error: "process.not.found", message: message, status: HttpStatus.NOT_FOUND]
+  }
+
+  @ExceptionHandler
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  Map badRequestException(IllegalArgumentException ex) {
+    [error: 'invalid.request', message: ex.message, status: HttpStatus.BAD_REQUEST]
+  }
+}


### PR DESCRIPTION
This complements https://github.com/spinnaker/clouddriver/pull/513, allowing jobs to be queried. I'm representing jobs as composed of "processes", borrowing language from https://github.com/spinnaker/spinnaker/issues/818. Since "processes" are effectively containers, they share the same `HealthState` enum with VMs and containers running in server groups. Jobs have a separate notion of success/failure depending on the state of the processes they manage. 

I'll likely be adding to this as in separate PRs as I decide what needs to be forwarded to Deck to visualize Jobs and Processes. 

@tomaslin @duftler could you PTAL?