### PR TITLE
Adds previousJedisPool to allow a rolling redis update.

### DIFF
--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskSpec.groovy
@@ -19,8 +19,6 @@ package com.netflix.spinnaker.clouddriver.data.task.jedis
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
 import com.netflix.spinnaker.clouddriver.data.task.Status
 import com.netflix.spinnaker.clouddriver.data.task.TaskState
-import redis.clients.jedis.Jedis
-import redis.clients.jedis.JedisPool
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -38,11 +36,7 @@ class JedisTaskSpec extends Specification {
 
   void setup() {
     repository = Mock(JedisTaskRepository)
-
-    repository.jedisPool = Stub(JedisPool) {
-      getResource() >> Stub(Jedis)
-    }
-    task = new JedisTask('666', System.currentTimeMillis(), repository)
+    task = new JedisTask('666', System.currentTimeMillis(), repository, false)
   }
 
   void 'updating task status adds a history entry'() {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/TaskController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/TaskController.groovy
@@ -19,10 +19,15 @@ package com.netflix.spinnaker.clouddriver.controllers
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+
+import javax.servlet.http.HttpServletRequest
 
 @RequestMapping("/task")
 @RestController
@@ -32,11 +37,31 @@ class TaskController {
 
   @RequestMapping(value = "/{id}", method = RequestMethod.GET)
   Task get(@PathVariable("id") String id) {
-    taskRepository.get id
+    Task t = taskRepository.get(id)
+    if (!t) {
+      throw new TaskNotFoundException(id)
+    }
+    return t
   }
 
   @RequestMapping(method = RequestMethod.GET)
   List<Task> list() {
     taskRepository.list()
+  }
+
+  @ExceptionHandler(TaskNotFoundException)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  Map handleTaskNotFoundException(HttpServletRequest req, TaskNotFoundException e) {
+    [id: e.id, resourceUri: "/task/$e.id".toString(), status: HttpStatus.NOT_FOUND.value(), reason: HttpStatus.NOT_FOUND.reasonPhrase]
+  }
+
+
+  static class TaskNotFoundException extends Exception {
+    final String id
+
+    public TaskNotFoundException(String id) {
+      super("Task $id not found")
+      this.id = id
+    }
   }
 }


### PR DESCRIPTION
To enable a redis update without clouddriver downtime, this adds the ability to read task data from a previous redis instance. An update looks like:

* deploy a new redis
* deploy a new clouddriver to populate the cache data in the redis
  * the redis.connection.previous points at the original redis
* swap traffic to the new clouddriver
* let any tasks in the old clouddriver complete (they will be pollable via the /task endpoint)
* destroy old clouddriver
* destroy old redis

`redis.connection.previous` is optional, and only used in `JedisTaskRepository`

also fixes the `/task/:id` endpoint which would previously return an empty http 200 if an unknown
task was requested (now returns 404)

@spinnaker/netflix-reviewers PTAL