### PR TITLE
Disable/enable ops initial implementation

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -174,6 +174,27 @@ public class AzureComputeClient extends AzureBaseClient {
     )
   }
 
+  ServiceResponse<Void> disableServerGroup(String resourceGroupName, String serverGroupName) {
+    VirtualMachineScaleSetsOperations ops = getAzureOps(
+      client.&getVirtualMachineScaleSetsOperations, "Get operations object", "Failed to get operation object") as VirtualMachineScaleSetsOperations
+
+    List<String> instanceIds = this.getServerGroupInstances(resourceGroupName,serverGroupName)?.collect {it.resourceId}
+
+    ops.powerOff(resourceGroupName, serverGroupName, instanceIds)
+
+    // TODO: investigate if we can deallocate the VMs
+    //ops.deallocate(resourceGroupName, serverGroupName, instanceIds)
+  }
+
+  ServiceResponse<Void> enableServerGroup(String resourceGroupName, String serverGroupName) {
+    VirtualMachineScaleSetsOperations ops = getAzureOps(
+      client.&getVirtualMachineScaleSetsOperations, "Get operations object", "Failed to get operation object") as VirtualMachineScaleSetsOperations
+
+    List<String> instanceIds = this.getServerGroupInstances(resourceGroupName,serverGroupName)?.collect {it.resourceId}
+
+    ops.start(resourceGroupName, serverGroupName, instanceIds)
+  }
+
   Collection<AzureInstance> getServerGroupInstances(String resourceGroupName, String serverGroupName) {
     def vmOps = this.client.virtualMachineScaleSetVMsOperations
     def instances = new ArrayList<AzureInstance>()

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -136,6 +136,8 @@ class AzureNetworkClient extends AzureBaseClient {
     description.cluster = azureLoadBalancer.tags?.cluster
     description.serverGroup = azureLoadBalancer.tags?.serverGroup
     description.vnet = azureLoadBalancer.tags?.vnet
+    description.createdTime = azureLoadBalancer.tags?.createdTime?.toLong()
+    description.tags = azureLoadBalancer.tags
     description.region = azureLoadBalancer.location
 
     for (def rule : azureLoadBalancer.loadBalancingRules) {
@@ -408,9 +410,13 @@ class AzureNetworkClient extends AzureBaseClient {
     sgItem.cloudProvider = "azure"
     sgItem.provisioningState = item.provisioningState
     sgItem.resourceGuid = item.resourceGuid
-    sgItem.etag = item.etag
     sgItem.resourceId = item.id
     sgItem.tags = item.tags
+    def parsedName = Names.parseName(item.name)
+    sgItem.stack = item.tags?.stack ?: parsedName.stack
+    sgItem.detail = item.tags?.detail ?: parsedName.detail
+    sgItem.appName = item.tags?.appName ?: parsedName.app
+    sgItem.createdTime = item.tags?.createdTime?.toLong()
     sgItem.type = item.type
     sgItem.securityRules = new ArrayList<AzureSecurityGroupDescription.AzureSGRule>()
     item.securityRules?.each {rule -> sgItem.securityRules += new AzureSecurityGroupDescription.AzureSGRule(

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/AzureResourceOpsDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/AzureResourceOpsDescription.groovy
@@ -31,8 +31,4 @@ class AzureResourceOpsDescription {
   Long createdTime
   long lastReadTime
   Map<String,String> tags = [:]
-
-  Long getCreatedTime() {
-    this.lastReadTime
-  }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.azure.resources.common.AzureResourceOps
 class AzureLoadBalancerDescription extends AzureResourceOpsDescription {
   String loadBalancerName
   String vnet
-  String securityGroups
+  String securityGroup
   String dnsName
   String cluster
   String serverGroup

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerController.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerController.groovy
@@ -70,13 +70,14 @@ class AzureLoadBalancerController {
         name: azureLoadBalancerDescription.loadBalancerName
       ]
 
-      // return constant values in order to test the "deck" details view for a given load balancer
-      lbDetail.createdTime = azureLoadBalancerDescription.createdTime ?: 1448944139570
+      lbDetail.createdTime = azureLoadBalancerDescription.createdTime
+      lbDetail.serverGroup = azureLoadBalancerDescription.serverGroup
       lbDetail.vnet = azureLoadBalancerDescription.vnet ?: "vnet-unassigned"
+      lbDetail.vnet = azureLoadBalancerDescription.subnet ?: "subnet-unassigned"
       lbDetail.dnsName = azureLoadBalancerDescription.dnsName ?: "dnsname-unassigned"
 
       lbDetail.probes = azureLoadBalancerDescription.probes
-      lbDetail.securityGroups = azureLoadBalancerDescription.securityGroups
+      lbDetail.securityGroup = azureLoadBalancerDescription.securityGroup
       lbDetail.loadBalancingRules = azureLoadBalancerDescription.loadBalancingRules
       lbDetail.inboundNATRules = azureLoadBalancerDescription.inboundNATRules
       lbDetail.tags = azureLoadBalancerDescription.tags

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/model/AzureSecurityGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/model/AzureSecurityGroupDescription.groovy
@@ -22,7 +22,6 @@ class AzureSecurityGroupDescription extends AzureResourceOpsDescription {
   String securityGroupName
   String resourceId
   String id
-  String etag
   String location
   String type
   Map<String, String> tags = [:]

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
@@ -8,6 +8,8 @@ import com.netflix.spinnaker.clouddriver.model.Instance
 
 class AzureInstance implements Instance, Serializable {
   String name
+  String resourceId
+  String vhd
   HealthState healthState
   Long launchTime
   String zone
@@ -16,6 +18,8 @@ class AzureInstance implements Instance, Serializable {
   static AzureInstance build(VirtualMachineScaleSetVM vm) {
     AzureInstance instance = new AzureInstance()
     instance.name = vm.name
+    instance.resourceId = vm.instanceId
+    instance.vhd = vm.storageProfile?.osDisk?.vhd?.uri
     vm.instanceView.statuses.each { status ->
       def codes = status.code.split('/')
       switch (codes[0]) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/EnableDisableDestroyAzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/EnableDisableDestroyAzureServerGroupDescription.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model
 
-class DestroyAzureServerGroupDescription extends AzureServerGroupDescription{
+class EnableDisableDestroyAzureServerGroupDescription extends AzureServerGroupDescription{
   String serverGroupName
   List<String> regions
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
@@ -108,6 +108,8 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
       lbDescription.serverGroup = description.name
       lbDescription.stack = description.stack
       lbDescription.detail = description.detail
+      lbDescription.securityGroup = description.securityGroup?.name
+      lbDescription.vnet = virtualNetworkName
 
       task.updateStatus(BASE_PHASE, "Create new load balancer ${description.loadBalancerName} in ${description.region}...")
       DeploymentExtended deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(description.credentials,

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.Azure
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
 
 class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
@@ -32,9 +32,9 @@ class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
     TaskRepository.threadLocalTask.get()
   }
 
-  private final DestroyAzureServerGroupDescription description
+  private final EnableDisableDestroyAzureServerGroupDescription description
 
-  DestroyAzureServerGroupAtomicOperation(DestroyAzureServerGroupDescription description) {
+  DestroyAzureServerGroupAtomicOperation(EnableDisableDestroyAzureServerGroupDescription description) {
     this.description = description
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DisableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DisableAzureServerGroupAtomicOperation.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+
+class DisableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "DISABLE_SERVER_GROUP"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  private final EnableDisableDestroyAzureServerGroupDescription description
+
+  DisableAzureServerGroupAtomicOperation(EnableDisableDestroyAzureServerGroupDescription description) {
+    this.description = description
+  }
+
+  /**
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "disableServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/ops
+   */
+  @Override
+  Void operate(List priorOutputs) {
+    task.updateStatus BASE_PHASE, "Initializing Disable Azure Server Group Operation..."
+    for (region in description.regions) {
+      if (description.serverGroupName) description.name = description.serverGroupName
+      if (!description.application) description.application = description.appName ?: Names.parseName(description.name).app
+      task.updateStatus BASE_PHASE, "Disablinging server group ${description.name} " + "in ${region}..."
+
+      if (!description.credentials) {
+        throw new IllegalArgumentException("Unable to resolve credentials for the selected Azure account.")
+      }
+
+      def errList = new ArrayList<String>()
+
+      try {
+        String resourceGroupName = AzureUtilities.getResourceGroupName(description.application, region)
+        AzureServerGroupDescription serverGroupDescription = description.credentials.computeClient.getServerGroup(resourceGroupName, description.name)
+
+        if (!serverGroupDescription) {
+          task.updateStatus(BASE_PHASE, "Disable Server Group Operation failed: could not find server group ${description.name} in ${region}")
+          errList.add("could not find server group ${description.name} in ${region}")
+        } else {
+          try {
+            description
+              .credentials
+              .computeClient
+              .disableServerGroup(resourceGroupName, description.name)
+
+            task.updateStatus BASE_PHASE, "Done disabling Azure server group ${description.name} in ${region}."
+          } catch (Exception e) {
+            task.updateStatus(BASE_PHASE, "Disabling of server group ${description.name} failed: ${e.message}")
+            errList.add("Failed to disable server group ${description.name}: ${e.message}")
+          }
+        }
+      } catch (Exception e) {
+        task.updateStatus(BASE_PHASE, "Disabling server group ${description.name} failed: ${e.message}")
+        errList.add("Failed to disable server group ${description.name}: ${e.message}")
+      }
+
+      if (errList.isEmpty()) {
+        task.updateStatus BASE_PHASE, "Disable Azure Server Group Operation for ${description.name} succeeded."
+      }
+      else {
+        errList.add(" Go to Azure Portal for more info")
+        throw new AtomicOperationException(
+          error: "Failed to disable ${description.name}",
+          errors: errList)
+      }
+    }
+
+    null
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+
+class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "DISABLE_SERVER_GROUP"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  private final EnableDisableDestroyAzureServerGroupDescription description
+
+  EnableAzureServerGroupAtomicOperation(EnableDisableDestroyAzureServerGroupDescription description) {
+    this.description = description
+  }
+
+  /**
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "enableServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/ops
+   */
+  @Override
+  Void operate(List priorOutputs) {
+    task.updateStatus BASE_PHASE, "Initializing Enable Azure Server Group Operation..."
+    for (region in description.regions) {
+      if (description.serverGroupName) description.name = description.serverGroupName
+      if (!description.application) description.application = description.appName ?: Names.parseName(description.name).app
+      task.updateStatus BASE_PHASE, "Enabling server group ${description.name} " + "in ${region}..."
+
+      if (!description.credentials) {
+        throw new IllegalArgumentException("Unable to resolve credentials for the selected Azure account.")
+      }
+
+      def errList = new ArrayList<String>()
+
+      try {
+        String resourceGroupName = AzureUtilities.getResourceGroupName(description.application, region)
+        AzureServerGroupDescription serverGroupDescription = description.credentials.computeClient.getServerGroup(resourceGroupName, description.name)
+
+        if (!serverGroupDescription) {
+          task.updateStatus(BASE_PHASE, "Enable Server Group Operation failed: could not find server group ${description.name} in ${region}")
+          errList.add("could not find server group ${description.name} in ${region}")
+        } else {
+          try {
+            description
+              .credentials
+              .computeClient
+              .enableServerGroup(resourceGroupName, description.name)
+
+            task.updateStatus BASE_PHASE, "Done enabling Azure server group ${description.name} in ${region}."
+          } catch (Exception e) {
+            task.updateStatus(BASE_PHASE, "Enabling of server group ${description.name} failed: ${e.message}")
+            errList.add("Failed to enable server group ${description.name}: ${e.message}")
+          }
+        }
+      } catch (Exception e) {
+        task.updateStatus(BASE_PHASE, "Enabling server group ${description.name} failed: ${e.message}")
+        errList.add("Failed to enable server group ${description.name}: ${e.message}")
+      }
+
+      if (errList.isEmpty()) {
+        task.updateStatus BASE_PHASE, "Enable Azure Server Group Operation for ${description.name} succeeded."
+      }
+      else {
+        errList.add(" Go to Azure Portal for more info")
+        throw new AtomicOperationException(
+          error: "Failed to enable ${description.name}",
+          errors: errList)
+      }
+    }
+
+    null
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DisableAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DisableAzureServerGroupAtomicOperationConverter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The original authors.
+ * Copyright 2016 The original authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.conver
 import com.netflix.spinnaker.clouddriver.azure.AzureOperation
 import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConverterHelper
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
-import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DisableAzureServerGroupAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
@@ -27,16 +27,16 @@ import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 @Slf4j
-@AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
-@Component("destroyAzureServerGroupDescription")
-class DestroyAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
-  DestroyAzureServerGroupAtomicOperationConverter() {
+@AzureOperation(AtomicOperations.DISABLE_SERVER_GROUP)
+@Component("disableAzureServerGroupDescription")
+class DisableAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  DisableAzureServerGroupAtomicOperationConverter() {
     log.info("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
   }
 
   @Override
   AtomicOperation convertOperation(Map input) {
-    new DestroyAzureServerGroupAtomicOperation(convertDescription(input))
+    new DisableAzureServerGroupAtomicOperation(convertDescription(input))
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/EnableAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/EnableAzureServerGroupAtomicOperationConverter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The original authors.
+ * Copyright 2016 The original authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.conver
 import com.netflix.spinnaker.clouddriver.azure.AzureOperation
 import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConverterHelper
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
-import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.EnableAzureServerGroupAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
@@ -27,16 +27,16 @@ import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 @Slf4j
-@AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
-@Component("destroyAzureServerGroupDescription")
-class DestroyAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
-  DestroyAzureServerGroupAtomicOperationConverter() {
-    log.info("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
+@AzureOperation(AtomicOperations.ENABLE_SERVER_GROUP)
+@Component("enableAzureServerGroupDescription")
+class EnableAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport{
+  EnableAzureServerGroupAtomicOperationConverter() {
+    log.info("Constructor....EnableAzureServerGroupAtomicOperationConverter")
   }
 
   @Override
   AtomicOperation convertOperation(Map input) {
-    new DestroyAzureServerGroupAtomicOperation(convertDescription(input))
+    new EnableAzureServerGroupAtomicOperation(convertDescription(input))
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DisableAzureServerGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DisableAzureServerGroupDescriptionValidator.groovy
@@ -26,9 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
-@AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
-@Component("DestroyAzureServerGroupDescriptionValidator")
-class DestroyAzureServerGroupDescriptionValidator extends
+@AzureOperation(AtomicOperations.DISABLE_SERVER_GROUP)
+@Component("disableAzureServerGroupDescriptionValidator")
+class DisableAzureServerGroupDescriptionValidator extends
   DescriptionValidator<EnableDisableDestroyAzureServerGroupDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/EnableAzureServerGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/EnableAzureServerGroupDescriptionValidator.groovy
@@ -26,9 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
-@AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
-@Component("DestroyAzureServerGroupDescriptionValidator")
-class DestroyAzureServerGroupDescriptionValidator extends
+@AzureOperation(AtomicOperations.ENABLE_SERVER_GROUP)
+@Component("enableAzureServerGroupDescriptionValidator")
+class EnableAzureServerGroupDescriptionValidator extends
   DescriptionValidator<EnableDisableDestroyAzureServerGroupDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureLoadBalancerResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureLoadBalancerResourceTemplate.groovy
@@ -95,12 +95,15 @@ class AzureLoadBalancerResourceTemplate {
       name = "[variables('loadBalancerName')]"
       type = "Microsoft.Network/loadBalancers"
       location = "[parameters('location')]"
+      def currentTime = System.currentTimeMillis()
       tags = [:]
       tags.appName = description.appName
       tags.stack = description.stack
       tags.detail = description.detail
+      tags.createdTime = currentTime.toString()
       if (description.cluster) tags.cluster = description.cluster
       if (description.serverGroup) tags.serverGroup = description.serverGroup
+      if (description.securityGroup) tags.securityGroup = description.securityGroup
       if (description.vnet) tags.vnet = description.vnet
 
       properties = new LoadBalancerProperties(description)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureSecurityGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureSecurityGroupResourceTemplate.groovy
@@ -74,7 +74,12 @@ class AzureSecurityGroupResourceTemplate {
       name = "[variables('securityGroupName')]"
       type = "Microsoft.Network/networkSecurityGroups"
       location = "[parameters('location')]"
-      tags = ["appName":description.appName, "detail":description.detail?:"none"]
+      def currentTime = System.currentTimeMillis()
+      tags = [:]
+      tags.appName = description.appName
+      tags.stack = description.stack ?: "none"
+      tags.detail = description.detail ?: "none"
+      tags.createdTime = currentTime.toString()
 
       properties = new SecurityGroupProperties(description)
     }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -170,6 +170,7 @@ class AzureServerGroupResourceTemplate {
       name = String.format("[concat(variables('%s')[copyIndex()])]", ServerGroupTemplateVariables.uniqueStorageNamesArrayVar)
       type = "Microsoft.Storage/storageAccounts"
       location = "[parameters('location')]"
+      def currentTime = System.currentTimeMillis()
 
       copy = new CopyOperation("storageLoop", description.getStorageAccountCount())
       tags = [:]
@@ -178,6 +179,7 @@ class AzureServerGroupResourceTemplate {
       tags.detail = description.detail
       tags.cluster = description.clusterName
       tags.serverGroupName = description.name
+      tags.createdTime = currentTime.toString()
 
       properties = new StorageAccountProperties()
     }
@@ -232,11 +234,13 @@ class AzureServerGroupResourceTemplate {
       name = description.name
       type = "Microsoft.Compute/virtualMachineScaleSets"
       location = "[parameters('location')]"
+      def currentTime = System.currentTimeMillis()
       tags = [:]
       tags.appName = description.application
       tags.stack = description.stack
       tags.detail = description.detail
       tags.cluster = description.clusterName
+      tags.createdTime = currentTime.toString()
       if (description.loadBalancerName) tags.loadBalancerName = description.loadBalancerName
       if (description.securityGroupName) tags.securityGroupName = description.securityGroupName
       if (description.subnetId) tags.subnetId = description.subnetId

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/deploy/templates/AzureLoadBalancerResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/deploy/templates/AzureLoadBalancerResourceTemplateSpec.groovy
@@ -29,14 +29,14 @@ class AzureLoadBalancerResourceTemplateSpec extends Specification {
   def 'should generate correct LoadBalancer create template'(){
     String template = AzureLoadBalancerResourceTemplate.getTemplate(description)
 
-    expect: template == expectedFullTemplate
+    expect: template.replaceAll('"createdTime" : "\\d+"', '"createdTime" : "1234567890"') == expectedFullTemplate
   }
 
   AzureLoadBalancerDescription createDescription(){
     AzureLoadBalancerDescription description = new AzureLoadBalancerDescription()
     description.cloudProvider = 'azure'
-    description.appName = 'azureMASM'
-    description.loadBalancerName = 'azureMASM-st1-d11'
+    description.appName = 'azuremasm'
+    description.loadBalancerName = 'azuremasm-st1-d11'
     description.stack = 'st1'
     description.detail = 'd11'
     description.region = 'westus'
@@ -52,7 +52,8 @@ class AzureLoadBalancerResourceTemplateSpec extends Specification {
     probe.unhealthyThreshold = 2
 
     description.probes.add(probe)
-    description.securityGroups = null
+    description.securityGroup = "azuremasm-sg1"
+    description.vnet = "azuremasm-vnet-westus"
     description.loadBalancingRules = new ArrayList<AzureLoadBalancerDescription.AzureLoadBalancingRule>()
 
     AzureLoadBalancerDescription.AzureLoadBalancingRule rule = new AzureLoadBalancerDescription.AzureLoadBalancingRule()
@@ -74,7 +75,7 @@ class AzureLoadBalancerResourceTemplateSpec extends Specification {
     natRule.port = 80
 
     description.inboundNATRules.add(natRule)
-    description.name = 'azureMASM-st1-d11'
+    description.name = 'azuremasm-st1-d11'
     description.user = '[anonymous]'
 
     return description
@@ -123,9 +124,12 @@ class AzureLoadBalancerResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Network/loadBalancers",
     "location" : "[parameters('location')]",
     "tags" : {
-      "appName" : "azureMASM",
+      "appName" : "azuremasm",
       "stack" : "st1",
-      "detail" : "d11"
+      "detail" : "d11",
+      "createdTime" : "1234567890",
+      "securityGroup" : "azuremasm-sg1",
+      "vnet" : "azuremasm-vnet-westus"
     },
     "dependsOn" : [ "[concat('Microsoft.Network/publicIPAddresses/',variables('publicIPAddressName'))]" ],
     "properties" : {

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/deploy/templates/AzureSecurityGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/deploy/templates/AzureSecurityGroupResourceTemplateSpec.groovy
@@ -32,7 +32,7 @@ class AzureSecurityGroupResourceTemplateSpec extends Specification {
   def 'should generate a correct Azure Security Group create template'(){
     String template = AzureSecurityGroupResourceTemplate.getTemplate(description)
 
-    expect: template == expectedFullTemplate
+    expect: template.replaceAll('"createdTime" : "\\d+"', '"createdTime" : "1234567890"') == expectedFullTemplate
   }
 
   UpsertAzureSecurityGroupDescription createNoRulesDescription(){
@@ -100,7 +100,9 @@ class AzureSecurityGroupResourceTemplateSpec extends Specification {
     "location" : "[parameters('location')]",
     "tags" : {
       "appName" : "azureMASM",
-      "detail" : "d11"
+      "stack" : "none",
+      "detail" : "d11",
+      "createdTime" : "1234567890"
     },
     "dependsOn" : [ ],
     "properties" : {

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationSpec.groovy
@@ -20,12 +20,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
 import com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.DestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.converters.DestroyAzureServerGroupAtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.mockito.Mock
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -74,7 +73,7 @@ class DestroyAzureServerGroupAtomicOperationSpec extends Specification {
 
     when:
     DestroyAzureServerGroupAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
-    DestroyAzureServerGroupDescription description = converter.convertDescription(mapper.readValue(input, Map))
+    EnableDisableDestroyAzureServerGroupDescription description = converter.convertDescription(mapper.readValue(input, Map))
 
     then:
     operation
@@ -89,7 +88,7 @@ class DestroyAzureServerGroupAtomicOperationSpec extends Specification {
 
     when:
     DestroyAzureServerGroupAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
-    DestroyAzureServerGroupDescription description = converter.convertDescription(mapper.readValue(input, Map))
+    EnableDisableDestroyAzureServerGroupDescription description = converter.convertDescription(mapper.readValue(input, Map))
 
     then:
     operation

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
@@ -31,14 +31,14 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   def 'should generate correct ServerGroup resource template'() {
     String template = AzureServerGroupResourceTemplate.getTemplate(description)
 
-    expect:    template == expectedFullTemplate
+    expect: template.replaceAll('"createdTime" : "\\d+"', '"createdTime" : "1234567890"') == expectedFullTemplate
   }
 
   def 'should generate correct ServerGroup resource template with custom image'() {
     description = createDescription(true)
     String template = AzureServerGroupResourceTemplate.getTemplate(description)
 
-    expect:    template == expectedFullTemplateWithCustomImage
+    expect: template.replaceAll('"createdTime" : "\\d+"', '"createdTime" : "1234567890"') == expectedFullTemplateWithCustomImage
   }
 
   private static AzureServerGroupDescription createDescription(boolean withCustomImage) {
@@ -121,7 +121,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "stack" : "st1",
       "detail" : "d11",
       "cluster" : "azureMASM-st1-d11",
-      "serverGroupName" : "azureMASM-st1-d11"
+      "serverGroupName" : "azureMASM-st1-d11",
+      "createdTime" : "1234567890"
     },
     "copy" : {
       "name" : "storageLoop",
@@ -140,6 +141,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "stack" : "st1",
       "detail" : "d11",
       "cluster" : "azureMASM-st1-d11",
+      "createdTime" : "1234567890",
       "loadBalancerName" : "azureMASM-st1-d11",
       "imageIsCustom" : "false",
       "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]"
@@ -221,6 +223,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "stack" : "st1",
       "detail" : "d11",
       "cluster" : "azureMASM-st1-d11",
+      "createdTime" : "1234567890",
       "loadBalancerName" : "azureMASM-st1-d11",
       "imageIsCustom" : "true"
     },


### PR DESCRIPTION
Return proper create time and image name when querying server group details.
Add initial implementation for disable/enable ops; we will revisit these when moving to use AppGateway; for the time being we will power down/restart the instances only.
Other minor fixes.

@JargoonPard @scotmoor  PTAL