### PR TITLE
Fixes server group key issue and on demand caching issue

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -125,7 +125,7 @@ class Keys {
             application: names.app.toLowerCase(),
             cluster    : parts[2],
             account    : parts[3],
-            zone       : parts[4],
+            region     : parts[4],
             serverGroup: parts[5],
             stack      : names.stack,
             detail     : names.detail,
@@ -189,9 +189,9 @@ class Keys {
 
   static String getServerGroupKey(String managedInstanceGroupName,
                                   String account,
-                                  String zone) {
+                                  String region) {
     Names names = Names.parseName(managedInstanceGroupName)
-    "$GoogleCloudProvider.GCE:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${zone}:${names.group}"
+    "$GoogleCloudProvider.GCE:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}"
   }
 
   static String getSubnetKey(String subnetName,


### PR DESCRIPTION
I goofed a few places where zone and region are used to generate the server group key in the Redis impl. This, understandably caused some issues - some nuanced and some pretty obvious.

@duftler discovered the region/zone key issue, but there was also a more nefarious issue lurking. TL;DR: don't have your On Demand handler say it's authoritative. When you do this, and your cache update only includes 1 entry, the infrastructure takes this as a sign to delete the rest of the keys in that namespace. This caused server group flapping in the UI and general instability in any stage that included `ServerGroupForceCacheRefresh`

@duftler @jtk54 PTAL