### PR TITLE
dependency cleanup

### DIFF
--- a/cats/cats-core/cats-core.gradle
+++ b/cats/cats-core/cats-core.gradle
@@ -1,14 +1,3 @@
 dependencies {
-  compile spinnaker.dependency("frigga")
-
   testCompile project(":cats:cats-test")
-
-  // Seems there is a bug in the findbugs module - no idea why this won't go away.
-  // There is no "new String()" constructor anywhere in that file...
-  //
-  // com.netflix.spinnaker.cats.mem.InMemoryCache$Glob.handleDelim(String) invokes inefficient new String(String) constructor
-  // In class com.netflix.spinnaker.cats.mem.InMemoryCache$Glob
-  // In method com.netflix.spinnaker.cats.mem.InMemoryCache$Glob.handleDelim(String)
-  // At InMemoryCache.java:[line 335]
-  tasks.findbugsMain.enabled = false
 }

--- a/cats/cats.gradle
+++ b/cats/cats.gradle
@@ -16,6 +16,6 @@ subprojects {
   tasks.pmdTest.enabled = false
 
   findbugs {
-    toolVersion = '3.0.0'
+    toolVersion = '3.0.1'
   }
 }

--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile spinnaker.dependency('korkWeb')
   compile spinnaker.dependency('eurekaClient')
   compile spinnaker.dependency("jedis")
+  compile spinnaker.dependency("frigga")
 
   compile project(':cats:cats-core')
   compile project(':cats:cats-redis')


### PR DESCRIPTION
for some reason frigga was added in cats-core but never used and not added in clouddriver-core...

turns findbugs back on with newer toolVersion