### PR TITLE
provider/kubernetes: Enable specifying image w/o dropdown

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -101,7 +101,7 @@ class KubernetesUtil {
   }
 
   static String getImageId(KubernetesImageDescription image) {
-    return getImageId(image.registry, image.repository, image.tag)
+    return image.imageId ?: getImageId(image.registry, image.repository, image.tag)
   }
 
   static String getImageId(String registry, String repository, String tag) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -52,12 +52,14 @@ class KubernetesImageDescription {
   String repository
   String tag
   String registry
+  String imageId
 }
 
 @AutoClone
 @Canonical
 class KubernetesContainerDescription {
   String name
+
   KubernetesImageDescription imageDescription
 
   KubernetesResourceDescription requests


### PR DESCRIPTION
Step 1 to allow users to specify images without relying on the dropdowns.