### PR TITLE
Add flag to build uber jar

### DIFF
--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/converters/CloudFoundryDeployAtomicOperationConverter.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/converters/CloudFoundryDeployAtomicOperationConverter.groovy
@@ -60,6 +60,10 @@ class CloudFoundryDeployAtomicOperationConverter extends AbstractAtomicOperation
       def artifactAccount = (CloudFoundryAccountCredentials) repository.getOne(parts[2])
       converted.username = artifactAccount.artifactUsername
       converted.password = artifactAccount.artifactPassword
+    } else if (input.containsKey('credentials')) {
+      def artifactAccount = (CloudFoundryAccountCredentials) repository.getOne(input.credentials)
+      converted.username = artifactAccount.artifactUsername
+      converted.password = artifactAccount.artifactPassword
     }
 
     /**

--- a/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/converters/CloudFoundryDeployAtomicOperationConverterSpec.groovy
+++ b/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/converters/CloudFoundryDeployAtomicOperationConverterSpec.groovy
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 package com.netflix.spinnaker.clouddriver.cf.deploy.converters
-
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.cf.TestCredential
+import com.netflix.spinnaker.clouddriver.cf.deploy.description.CloudFoundryDeployDescription
 import com.netflix.spinnaker.clouddriver.cf.security.CloudFoundryAccountCredentials
 import com.netflix.spinnaker.clouddriver.deploy.DeployAtomicOperation
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.netflix.spinnaker.clouddriver.cf.deploy.description.CloudFoundryDeployDescription
+import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import spock.lang.Shared
 import spock.lang.Specification
-
 /**
  * Test cases for {@link CloudFoundryDeployAtomicOperationConverter}
  *
@@ -33,15 +33,22 @@ class CloudFoundryDeployAtomicOperationConverterSpec extends Specification {
   @Shared
   ObjectMapper mapper = new ObjectMapper()
 
+  private static final ACCOUNT_NAME = "test"
+
   @Shared
   CloudFoundryDeployAtomicOperationConverter converter
 
   def setupSpec() {
+    def credentialsRepo = new MapBackedAccountCredentialsRepository()
+
+    credentialsRepo.save(ACCOUNT_NAME, TestCredential.named(ACCOUNT_NAME))
+
     def accountCredentialsProvider = Stub(AccountCredentialsProvider) {
-      getCredentials('test') >> Stub(CloudFoundryAccountCredentials)
+      getCredentials(ACCOUNT_NAME) >> Stub(CloudFoundryAccountCredentials)
     }
     this.converter = new CloudFoundryDeployAtomicOperationConverter(objectMapper: mapper,
-        accountCredentialsProvider: accountCredentialsProvider
+        accountCredentialsProvider: accountCredentialsProvider,
+        repository: credentialsRepo
     )
   }
 

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -3,6 +3,7 @@ apply plugin: 'nebula.ospackage'
 
 ext {
   springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
+  repackage = System.getProperty('springBoot.repackage', "false")
 }
 
 tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
@@ -39,7 +40,7 @@ dependencies {
   runtime 'org.eclipse.jetty:jetty-servlets:9.2.11.v20150529'
 }
 
-tasks.bootRepackage.enabled = false
+tasks.bootRepackage.enabled = project.repackage
 
 applicationName = 'clouddriver'
 applicationDefaultJvmArgs = ["-Djava.security.egd=file:/dev/./urandom"]


### PR DESCRIPTION
Deploying clouddriver to Cloud Foundry requires an uber jar. This adds a flag "springBoot.repackage" that can be used on the command line to build an uber jar.

Cherry-picks #465.