### PR TITLE
provider/docker: Ignore tags missing their manifest.

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -89,7 +89,6 @@ class DockerRegistryClient {
     ])
     Response get(@Path(value="path", encode=false) String path, @Header("Authorization") String token, @Header("User-Agent") String agent)
 
-
     @GET("/v2/")
     @Headers([
       "User-Agent: Spinnaker-Clouddriver",


### PR DESCRIPTION
Dockerhub sometimes leaves deleted tags around without allowing them to be pulled (the manifest is gone). To avoid crashing the caching agent when this happens, we simply avoid putting tags with missing manifests into the cache.