### PR TITLE
cats & kubernetes: on-demand locking

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/AgentLock.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/AgentLock.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.agent;
+
+public class AgentLock {
+  private final Agent agent;
+
+  public AgentLock(Agent agent) {
+    this.agent = agent;
+  }
+
+  public Agent getAgent() {
+    return agent;
+  }
+}

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/AgentScheduler.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/AgentScheduler.java
@@ -19,7 +19,27 @@ package com.netflix.spinnaker.cats.agent;
 /**
  * An AgentScheduler manages the execution of a CachingAgent.
  */
-public interface AgentScheduler {
+public interface AgentScheduler<T extends AgentLock> {
     void schedule(Agent agent, AgentExecution agentExecution, ExecutionInstrumentation executionInstrumentation);
     default void unschedule(Agent agent) {};
+
+    /**
+     * @return True iff this scheduler supports synchronization between LoadData & OnDemand cache updates.
+     */
+    default boolean isAtomic() { return false; };
+
+    /**
+     * @return A "Lock" that will allow exclusive access to updating this agent's cache data. null iff isAtomic == false.
+     */
+    default T tryLock(Agent agent) { return null; };
+
+    /**
+     * @return True iff the lock was still in our possession when the release call was made.
+     */
+    default boolean tryRelease(T lock) { return false; };
+
+    /**
+     * @return True iff the lock is still in our possession.
+     */
+    default boolean lockValid(T lock) { return false; };
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultAgentScheduler.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultAgentScheduler.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * An exception thrown while reporting executionFailure will abort the schedule for
  * the CachingAgent.
  */
-public class DefaultAgentScheduler extends CatsModuleAware implements AgentScheduler {
+public class DefaultAgentScheduler extends CatsModuleAware implements AgentScheduler<AgentLock> {
     private static final long DEFAULT_INTERVAL = 60000;
 
     private final ScheduledExecutorService scheduledExecutorService;
@@ -73,6 +73,21 @@ public class DefaultAgentScheduler extends CatsModuleAware implements AgentSched
     public void unschedule(Agent agent) {
         agentFutures.get(agent).cancel(false);
         agentFutures.remove(agent);
+    }
+
+    @Override
+    public AgentLock tryLock(Agent agent) {
+        return null;
+    }
+
+    @Override
+    public boolean tryRelease(AgentLock lock) {
+        return false;
+    }
+
+    @Override
+    public boolean isAtomic() {
+        return false;
     }
 
     private static class AgentExecutionRunnable implements Runnable {

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.concurrent.*;
 
 @SuppressFBWarnings
-public class ClusteredAgentScheduler extends CatsModuleAware implements AgentScheduler, Runnable {
+public class ClusteredAgentScheduler extends CatsModuleAware implements AgentScheduler<AgentLock>, Runnable {
     private final JedisSource jedisSource;
     private final NodeIdentity nodeIdentity;
     private final AgentIntervalProvider intervalProvider;

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentLock.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentLock.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.redis.cluster;
+
+import com.netflix.spinnaker.cats.agent.Agent;
+import com.netflix.spinnaker.cats.agent.AgentLock;
+
+public class ClusteredSortAgentLock extends AgentLock {
+  // The score the agent was acquired with (Used to ensure we own this agent on release).
+  private final String acquireScore;
+  // The score the agent was release from the WAITING set with (Used to ensure it is readded to the WAITING set with the right score).
+  private final String releaseScore;
+
+  ClusteredSortAgentLock(Agent agent, String acquireScore, String releaseScore) {
+    super(agent);
+    this.acquireScore = acquireScore;
+    this.releaseScore = releaseScore;
+  }
+
+  public String getAcquireScore() {
+    return acquireScore;
+  }
+
+  public String getReleaseScore() {
+    return releaseScore;
+  }
+}

--- a/cats/cats-test/src/main/groovy/com/netflix/spinnaker/cats/test/TestScheduler.groovy
+++ b/cats/cats-test/src/main/groovy/com/netflix/spinnaker/cats/test/TestScheduler.groovy
@@ -18,11 +18,12 @@ package com.netflix.spinnaker.cats.test
 
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentExecution
+import com.netflix.spinnaker.cats.agent.AgentLock
 import com.netflix.spinnaker.cats.agent.AgentScheduler
 import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation
 import com.netflix.spinnaker.cats.module.CatsModuleAware
 
-class TestScheduler extends CatsModuleAware implements AgentScheduler {
+class TestScheduler extends CatsModuleAware implements AgentScheduler<AgentLock> {
     Collection<Scheduled> scheduled = []
 
     @Override

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CacheConfig.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.cache
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentExecution
+import com.netflix.spinnaker.cats.agent.AgentLock
 import com.netflix.spinnaker.cats.agent.AgentScheduler
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.agent.DefaultAgentScheduler


### PR DESCRIPTION
@cfieber @duftler 

OnDemand cache updates (for agents that implement AgentSchedulerAware) using the new Sort scheduler no longer need the OnDemand namespace. This make these force cache refreshes much faster: 

![fast-scheduler](https://cloud.githubusercontent.com/assets/4874941/14648318/b6f438ea-062f-11e6-96ce-567ee732c4c3.png)

To make sure that the Kubernetes provider keeps working regardles of the scheduler, I left the OnDemand namespace code in for now.
