### PR TITLE
Mutating AWS server group calls operate only on `asgs`.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeleteAsgTagsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeleteAsgTagsDescription.groovy
@@ -16,8 +16,12 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 class DeleteAsgTagsDescription extends AbstractAmazonCredentialsDescription {
-  List<AsgDescription> asgs = []
+
+  String serverGroupName
+  String region
   List<String> tagKeys
+
+  List<AsgDescription> asgs = []
 
   @Deprecated
   String asgName

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DestroyAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DestroyAsgDescription.groovy
@@ -18,6 +18,9 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 class DestroyAsgDescription extends AbstractAmazonCredentialsDescription {
 
+  String serverGroupName
+  String region
+
   List<AsgDescription> asgs = []
 
   @Deprecated

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/EnableDisableAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/EnableDisableAsgDescription.groovy
@@ -23,23 +23,15 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
  * override will also be achieved.
  */
 class EnableDisableAsgDescription extends AbstractAmazonCredentialsDescription {
-  List<AsgDescription> asgs = []
 
   String serverGroupName
+  String region
+
+  List<AsgDescription> asgs = []
 
   @Deprecated
   String asgName
 
   @Deprecated
   List<String> regions = []
-
-  List<AsgDescription> getAsgs() {
-    if (asgs) {
-      return asgs
-    }
-
-    return regions.collect {
-      new AsgDescription(serverGroupName: (serverGroupName ?: asgName), region: it)
-    }
-  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
@@ -17,14 +17,18 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
-  List<AsgDescription> asgs = []
+
+  String serverGroupName
+  String region
+  Capacity capacity = new Capacity()
+
+  List<AsgTargetDescription> asgs = []
 
   @Deprecated
   String asgName
 
   @Deprecated
   List<String> regions = []
-  Capacity capacity = new Capacity()
 
   static class Capacity {
     int min
@@ -37,14 +41,12 @@ class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
     }
   }
 
-  static class AsgDescription {
-    String region
-    String asgName
-    Capacity capacity
+  static class AsgTargetDescription extends AsgDescription {
+    Capacity capacity = new Capacity()
 
     @Override
     String toString() {
-      "region: $region, asgName: $asgName, capacity: $capacity"
+      "region: $region, serverGroupName: $serverGroupName, capacity: [$capacity]"
     }
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResumeAsgProcessesDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResumeAsgProcessesDescription.groovy
@@ -17,12 +17,15 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 class ResumeAsgProcessesDescription extends AbstractAmazonCredentialsDescription {
 
-  List<AsgDescription> asgs
+  String serverGroupName
+  String region
+
+  List<AsgDescription> asgs = []
   List<String> processes
 
   @Deprecated
   String asgName
 
   @Deprecated
-  List<String> regions
+  List<String> regions = []
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/SuspendAsgProcessesDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/SuspendAsgProcessesDescription.groovy
@@ -16,6 +16,10 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 class SuspendAsgProcessesDescription extends AbstractAmazonCredentialsDescription {
+
+  String serverGroupName
+  String region
+
   List<AsgDescription> asgs = []
   List<String> processes
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAsgTagsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAsgTagsDescription.groovy
@@ -18,6 +18,9 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 class UpsertAsgTagsDescription extends AbstractAmazonCredentialsDescription {
 
+  String serverGroupName
+  String region
+
   List<AsgDescription> asgs = []
   Map<String, String> tags
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAsgTagsAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAsgTagsAtomicOperation.groovy
@@ -18,11 +18,11 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 import com.amazonaws.services.autoscaling.model.DeleteTagsRequest
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.autoscaling.model.Tag
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAsgTagsDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAsgTagsDescription
 import org.springframework.beans.factory.annotation.Autowired
 
 class DeleteAsgTagsAtomicOperation implements AtomicOperation<Void> {
@@ -43,13 +43,10 @@ class DeleteAsgTagsAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    String descriptor = description.asgName ?: description.asgs.collect { it.toString() }
+    String descriptor = description.asgs.collect { it.toString() }
     task.updateStatus BASE_PHASE, "Initializing Delete ASG Tags operation for $descriptor..."
-    for (region in description.regions) {
-      deleteAsgTags(description.asgName, region)
-    }
     for (asg in description.asgs) {
-      deleteAsgTags(asg.asgName, asg.region)
+      deleteAsgTags(asg.serverGroupName, asg.region)
     }
     task.updateStatus BASE_PHASE, "Finished Delete ASG Tags operation for $descriptor."
     null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DestroyAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DestroyAsgAtomicOperation.groovy
@@ -22,11 +22,11 @@ import com.amazonaws.services.autoscaling.model.DeleteAutoScalingGroupRequest
 import com.amazonaws.services.autoscaling.model.DeleteLaunchConfigurationRequest
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.DestroyAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.DestroyAsgDescription
 import org.springframework.beans.factory.annotation.Autowired
 
 class DestroyAsgAtomicOperation implements AtomicOperation<Void> {
@@ -48,13 +48,10 @@ class DestroyAsgAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    String descriptor = description.asgName ?: description.asgs.collect { it.toString() }
+    String descriptor = description.asgs.collect { it.toString() }
     task.updateStatus BASE_PHASE, "Initializing ASG Destroy operation for $descriptor..."
-    for (region in description.regions) {
-      deleteAsg(description.asgName, region)
-    }
     for (asg in description.asgs) {
-      deleteAsg(asg.asgName, asg.region)
+      deleteAsg(asg.serverGroupName, asg.region)
     }
 
     task.updateStatus BASE_PHASE, "Finished Destroy ASG operation for $descriptor."

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgAtomicOperation.groovy
@@ -18,11 +18,11 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyAsgDescription
 import org.springframework.beans.factory.annotation.Autowired
 
 class ModifyAsgAtomicOperation implements AtomicOperation<Void> {
@@ -48,7 +48,7 @@ class ModifyAsgAtomicOperation implements AtomicOperation<Void> {
     String descriptor = description.asgs.collect { it.toString() }
     task.updateStatus BASE_PHASE, "Initializing Update ASG operation for $descriptor..."
     for (asg in description.asgs) {
-      hasSucceeded = modifyAsg(asg.asgName, asg.region)
+      hasSucceeded = modifyAsg(asg.serverGroupName, asg.region)
     }
 
     if (!hasSucceeded) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperation.groovy
@@ -18,11 +18,11 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
 import org.springframework.beans.factory.annotation.Autowired
 
 class ResizeAsgAtomicOperation implements AtomicOperation<Void> {
@@ -43,16 +43,11 @@ class ResizeAsgAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    String descriptor = description.asgName ?:
-        description.asgs.size() == 1 ? description.asgs[0].toString() :
-        description.asgs.collect { it.toString() }
+    String descriptor = description.asgs.collect { it.toString() }
     task.updateStatus PHASE, "Initializing Resize ASG operation for $descriptor..."
 
-    for (String region : description.regions) {
-      resizeAsg(description.asgName, region, description.capacity)
-    }
     for (asg in description.asgs) {
-      resizeAsg(asg.asgName, asg.region, asg.capacity)
+      resizeAsg(asg.serverGroupName, asg.region, asg.capacity)
     }
     task.updateStatus PHASE, "Finished Resize ASG operation for $descriptor."
     null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResumeAsgProcessesAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResumeAsgProcessesAtomicOperation.groovy
@@ -41,14 +41,11 @@ class ResumeAsgProcessesAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    String descriptor = description.asgName ?: description.asgs.collect { it.toString() }
+    String descriptor = description.asgs.collect { it.toString() }
     task.updateStatus BASE_PHASE, "Initializing Resume ASG Processes operation for $descriptor..."
 
-    for (region in description.regions) {
-      resumeProcess(description.asgName, region)
-    }
     for (asg in description.asgs) {
-      resumeProcess(asg.asgName, asg.region)
+      resumeProcess(asg.serverGroupName, asg.region)
     }
     task.updateStatus BASE_PHASE, "Finished Resume ASG Processes operation for $descriptor."
     null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/SuspendAsgProcessesAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/SuspendAsgProcessesAtomicOperation.groovy
@@ -15,12 +15,12 @@
  */
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.SuspendAsgProcessesDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
 class SuspendAsgProcessesAtomicOperation implements AtomicOperation<Void> {
@@ -41,13 +41,10 @@ class SuspendAsgProcessesAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    String descriptor = description.asgName ?: description.asgs.collect { it.toString() }
+    String descriptor = description.asgs.collect { it.toString() }
     task.updateStatus BASE_PHASE, "Initializing Suspend ASG Processes operation for $descriptor..."
-    for (region in description.regions) {
-      suspendProcesses(description.asgName, region)
-    }
     for (asg in description.asgs) {
-      suspendProcesses(asg.asgName, asg.region)
+      suspendProcesses(asg.serverGroupName, asg.region)
     }
     task.updateStatus BASE_PHASE, "Finished Suspend ASG Processes operation for $descriptor."
     null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgScheduledActionsOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgScheduledActionsOperation.groovy
@@ -21,12 +21,12 @@ import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.autoscaling.model.DescribeScheduledActionsRequest
 import com.amazonaws.services.autoscaling.model.PutScheduledUpdateGroupActionRequest
 import com.amazonaws.services.autoscaling.model.ScheduledUpdateGroupAction
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgScheduledActionsDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgScheduledActionsDescription
-import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
 import org.springframework.beans.factory.annotation.Autowired
 
 class UpsertAsgScheduledActionsOperation implements AtomicOperation<Void> {
@@ -52,11 +52,11 @@ class UpsertAsgScheduledActionsOperation implements AtomicOperation<Void> {
   Void operate(List priorOutputs) {
     boolean hasSucceeded = true
 
-    String descriptor = description.asgs.findResults { "${it.asgName} in ${it.region}" }.join(", ")
+    String descriptor = description.asgs.findResults { "${it.serverGroupName} in ${it.region}" }.join(", ")
     task.updateStatus BASE_PHASE, "Initializing Upsert ASG Scheduled Actions operation for $descriptor..."
 
     for (asg in description.asgs) {
-      hasSucceeded = upsertAsgScheduledActions(asg.asgName, asg.region)
+      hasSucceeded = upsertAsgScheduledActions(asg.serverGroupName, asg.region)
     }
 
     if (!hasSucceeded) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgTagsAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgTagsAtomicOperation.groovy
@@ -45,13 +45,10 @@ class UpsertAsgTagsAtomicOperation implements AtomicOperation<Void> {
   @Override
   Void operate(List priorOutputs) {
     boolean hasSucceeded = true
-    String descriptor = description.asgName ?: description.asgs.collect { it.toString() }
+    String descriptor = description.asgs.collect { it.toString() }
     task.updateStatus BASE_PHASE, "Initializing Upsert ASG Tags operation for $descriptor..."
-    for (region in description.regions) {
-      hasSucceeded = upsertAsgTags(description.asgName, region)
-    }
     for (asg in description.asgs) {
-      hasSucceeded = upsertAsgTags(asg.asgName, asg.region)
+      hasSucceeded = upsertAsgTags(asg.serverGroupName, asg.region)
     }
     if (!hasSucceeded) {
       task.fail()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/LegacyToAsgsDescriptionPreProcessor.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/LegacyToAsgsDescriptionPreProcessor.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.preprocessors
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAsgTagsDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.DestroyAsgDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResumeAsgProcessesDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.SuspendAsgProcessesDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgTagsDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationDescriptionPreProcessor
+import org.springframework.stereotype.Component
+
+@Component
+class LegacyToAsgsDescriptionPreProcessor implements AtomicOperationDescriptionPreProcessor {
+  @Override
+  boolean supports(Class descriptionClass) {
+    return descriptionClass in [DeleteAsgTagsDescription,
+                                DestroyAsgDescription,
+                                EnableDisableAsgDescription,
+                                ResumeAsgProcessesDescription,
+                                SuspendAsgProcessesDescription,
+                                UpsertAsgTagsDescription]
+  }
+
+  @Override
+  Map process(Map description) {
+    description.with {
+      if (!asgs) {
+        if (region) {
+          asgs = [[serverGroupName: serverGroupName ?: asgName, region: region]]
+        } else {
+          asgs = regions.collect {
+            [serverGroupName: serverGroupName ?: asgName, region: it]
+          }
+        }
+      }
+
+      // Only `asgs` should be propagated internally now.
+      description.remove("asgName")
+      description.remove("serverGroupName")
+      description.remove("regions")
+      description.remove("region")
+
+      return description
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/ResizeAsgDescriptionPreProcessor.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/ResizeAsgDescriptionPreProcessor.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.preprocessors
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationDescriptionPreProcessor
+import org.springframework.stereotype.Component
+
+@Component
+class ResizeAsgDescriptionPreProcessor implements AtomicOperationDescriptionPreProcessor {
+  @Override
+  boolean supports(Class descriptionClass) {
+    return descriptionClass == ResizeAsgDescription
+  }
+
+  @Override
+  Map process(Map description) {
+    description.with {
+      if (!asgs) {
+        if (region) {
+          asgs = [[serverGroupName: serverGroupName ?: asgName, region: region, capacity: capacity]]
+        } else {
+          asgs = regions.collect {
+            [serverGroupName: serverGroupName ?: asgName, region: it, capacity: capacity]
+          }
+        }
+      }
+
+      // Only `asgs` should be propagated internally now.
+      description.remove("asgName")
+      description.remove("serverGroupName")
+      description.remove("regions")
+      description.remove("region")
+      description.remove("capacity")
+
+      return description
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractEnableDisableAsgDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractEnableDisableAsgDescriptionValidator.groovy
@@ -21,6 +21,6 @@ import org.springframework.validation.Errors
 abstract class AbstractEnableDisableAsgDescriptionValidator extends AmazonDescriptionValidationSupport<EnableDisableAsgDescription> {
   @Override
   void validate(List priorDescriptions, EnableDisableAsgDescription description, Errors errors) {
-    validateAsgNameAndRegions description, errors
+    validateAsgs description, errors
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAsgTagsDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAsgTagsDescriptionValidator.groovy
@@ -23,7 +23,7 @@ import org.springframework.validation.Errors
 class DeleteAsgTagsDescriptionValidator extends AmazonDescriptionValidationSupport<DeleteAsgTagsDescription> {
   @Override
   void validate(List priorDescriptions, DeleteAsgTagsDescription description, Errors errors) {
-    validateAsgNameAndRegions description, errors
+    validateAsgs description, errors
     description.tagKeys.each {
       if (!it) {
         errors.rejectValue("tagKeys", "deleteAsgTagsDescription.tagKey.invalid")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DestroyAsgDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DestroyAsgDescriptionValidator.groovy
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DestroyAsgDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
@@ -27,6 +27,6 @@ import org.springframework.validation.Errors
 class DestroyAsgDescriptionValidator extends AmazonDescriptionValidationSupport<DestroyAsgDescription> {
   @Override
   void validate(List priorDescriptions, DestroyAsgDescription description, Errors errors) {
-    validateAsgNameAndRegions description, errors
+    validateAsgs description, errors
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResizeAsgDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResizeAsgDescriptionValidator.groovy
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
@@ -27,7 +27,6 @@ import org.springframework.validation.Errors
 class ResizeAsgDescriptionValidator extends AmazonDescriptionValidationSupport<ResizeAsgDescription> {
   @Override
   void validate(List priorDescriptions, ResizeAsgDescription description, Errors errors) {
-    validateAsgNameAndRegions description, errors
-    validateCapacity description, errors
+    validateAsgsWithCapacity description, errors
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResumeAsgProcessesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResumeAsgProcessesDescriptionValidator.groovy
@@ -24,7 +24,7 @@ import org.springframework.validation.Errors
 class ResumeAsgProcessesDescriptionValidator extends AmazonDescriptionValidationSupport<ResumeAsgProcessesDescription> {
   @Override
   void validate(List priorDescriptions, ResumeAsgProcessesDescription description, Errors errors) {
-    validateAsgNameAndRegions description, errors
+    validateAsgs description, errors
     def invalidProcessTypes = description.processes.findAll { !AutoScalingProcessType.parse(it) }
     if (invalidProcessTypes) {
       errors.rejectValue "processes", "createNetworkInterfaceDescription.processes.not.valid"

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/SuspendAsgProcessesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/SuspendAsgProcessesDescriptionValidator.groovy
@@ -24,7 +24,7 @@ import org.springframework.validation.Errors
 class SuspendAsgProcessesDescriptionValidator extends AmazonDescriptionValidationSupport<SuspendAsgProcessesDescription> {
   @Override
   void validate(List priorDescriptions, SuspendAsgProcessesDescription description, Errors errors) {
-    validateAsgNameAndRegions description, errors
+    validateAsgs description, errors
     def invalidProcessTypes = description.processes.findAll { !AutoScalingProcessType.parse(it) }
     if (invalidProcessTypes) {
       errors.rejectValue "processes", "suspendAsgProcessesDescription.processes.not.valid"

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgTagsDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgTagsDescriptionValidator.groovy
@@ -27,7 +27,7 @@ import org.springframework.validation.Errors
 class UpsertAsgTagsDescriptionValidator extends AmazonDescriptionValidationSupport<UpsertAsgTagsDescription> {
   @Override
   void validate(List priorDescriptions, UpsertAsgTagsDescription description, Errors errors) {
-    validateAsgNameAndRegions description, errors
+    validateAsgs description, errors
     if (!description.tags) {
       errors.rejectValue("tags", "upsertAsgTagsDescription.tags.empty")
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAsgTagsAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAsgTagsAtomicOperationUnitSpec.groovy
@@ -16,11 +16,11 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.autoscaling.model.*
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAsgTagsDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.aws.TestCredential
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAsgTagsDescription
 import spock.lang.Specification
 
 class DeleteAsgTagsAtomicOperationUnitSpec extends Specification {
@@ -33,7 +33,13 @@ class DeleteAsgTagsAtomicOperationUnitSpec extends Specification {
   }
 
   void "should delete tags on ASG by name"() {
-    def description = new DeleteAsgTagsDescription(asgName: "myasg-stack-v000", tagKeys: ["key"], regions: ["us-west-1"])
+    def description = new DeleteAsgTagsDescription(
+      asgs   : [[
+        serverGroupName: "myasg-stack-v000",
+        region         : "us-west-1"
+      ]],
+      tagKeys: ["key"]
+    )
     description.credentials = TestCredential.named('baz')
     def operation = new DeleteAsgTagsAtomicOperation(description)
     operation.amazonClientProvider = mockAmazonClientProvider

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DestroyAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DestroyAsgAtomicOperationUnitSpec.groovy
@@ -23,11 +23,11 @@ import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult
 import com.amazonaws.services.autoscaling.model.Instance
 import com.amazonaws.services.ec2.AmazonEC2
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.DestroyAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.aws.TestCredential
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.DestroyAsgDescription
 import spock.lang.Specification
 
 class DestroyAsgAtomicOperationUnitSpec extends Specification {
@@ -46,10 +46,12 @@ class DestroyAsgAtomicOperationUnitSpec extends Specification {
   void "should not fail delete when ASG does not exist"() {
     setup:
     def op = new DestroyAsgAtomicOperation(
-            new DestroyAsgDescription(
-                    asgName: "my-stack-v000",
-                    regions: ["us-east-1"],
-                    credentials: TestCredential.named('baz')))
+      new DestroyAsgDescription(
+        asgs: [[
+          serverGroupName: "my-stack-v000",
+          region         : "us-east-1"
+        ]],
+        credentials: TestCredential.named('baz')))
     op.amazonClientProvider = provider
 
     when:
@@ -63,10 +65,12 @@ class DestroyAsgAtomicOperationUnitSpec extends Specification {
   void "should delete ASG and Launch Config and terminate instances"() {
     setup:
     def op = new DestroyAsgAtomicOperation(
-            new DestroyAsgDescription(
-                    asgName: "my-stack-v000",
-                    regions: ["us-east-1"],
-                    credentials: TestCredential.named('baz')))
+      new DestroyAsgDescription(
+        asgs: [[
+          serverGroupName: "my-stack-v000",
+          region         : "us-east-1"
+        ]],
+        credentials: TestCredential.named('baz')))
     op.amazonClientProvider = provider
 
     when:
@@ -90,10 +94,12 @@ class DestroyAsgAtomicOperationUnitSpec extends Specification {
   void "should not delete launch config when not available"() {
     setup:
     def op = new DestroyAsgAtomicOperation(
-        new DestroyAsgDescription(
-            asgName: "my-stack-v000",
-            regions: ["us-east-1"],
-            credentials: TestCredential.named('baz')))
+      new DestroyAsgDescription(
+        asgs: [[
+          serverGroupName: "my-stack-v000",
+          region         : "us-east-1"
+        ]],
+        credentials: TestCredential.named('baz')))
     op.amazonClientProvider = provider
 
     when:
@@ -115,8 +121,10 @@ class DestroyAsgAtomicOperationUnitSpec extends Specification {
     setup:
     def op = new DestroyAsgAtomicOperation(
       new DestroyAsgDescription(
-        asgName: "my-stack-v000",
-        regions: ["us-east-1"],
+        asgs: [[
+          serverGroupName: "my-stack-v000",
+          region         : "us-east-1"
+        ]],
         credentials: TestCredential.named('baz')))
     op.amazonClientProvider = provider
     def instances = (100..315).collect { new Instance(instanceId: "i-123${it}") }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DisableAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DisableAsgAtomicOperationUnitSpec.groovy
@@ -19,11 +19,11 @@ import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.Instance
 import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException
-import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
-import com.netflix.spinnaker.clouddriver.data.task.TaskState
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
+import com.netflix.spinnaker.clouddriver.data.task.TaskState
 import retrofit.client.Response
 
 class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnitSpecSupport {
@@ -101,9 +101,11 @@ class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnit
   void 'should skip discovery if not enabled for account'() {
     setup:
     def noDiscovery = new EnableDisableAsgDescription([
-        asgName    : "kato-main-v000",
-        regions    : ["us-west-1"],
-        credentials: TestCredential.named('foo')
+      asgs: [[
+        serverGroupName: "kato-main-v000",
+        region         : "us-west-1"
+      ]],
+      credentials: TestCredential.named('foo')
     ])
 
     def noDiscoveryOp = new DisableAsgAtomicOperation(noDiscovery)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableAsgAtomicOperationUnitSpec.groovy
@@ -17,11 +17,11 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.Instance
 import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
-import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
-import com.netflix.spinnaker.clouddriver.data.task.TaskState
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
+import com.netflix.spinnaker.clouddriver.data.task.TaskState
 
 class EnableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnitSpecSupport {
 
@@ -75,8 +75,10 @@ class EnableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnitS
   void 'should skip discovery if not enabled for account'() {
     setup:
     def noDiscovery = new EnableDisableAsgDescription([
-      asgName    : "kato-main-v000",
-      regions    : ["us-west-1"],
+      asgs: [[
+        serverGroupName: "kato-main-v000",
+        region         : "us-west-1"
+      ]],
       credentials: TestCredential.named('foo')
     ])
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableDisableAtomicOperationUnitSpecSupport.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableDisableAtomicOperationUnitSpecSupport.groovy
@@ -18,23 +18,25 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.ec2.AmazonEC2
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.DiscoverySupport
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.Eureka
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.services.AsgService
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import spock.lang.Shared
 import spock.lang.Specification
 
 abstract class EnableDisableAtomicOperationUnitSpecSupport extends Specification {
   @Shared
   def description = new EnableDisableAsgDescription([
-      asgName    : "kato-main-v000",
-      regions    : ["us-west-1"],
+      asgs       : [[
+        serverGroupName: "kato-main-v000",
+        region         : "us-west-1"
+      ]],
       credentials: TestCredential.named('foo')
   ])
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperationUnitSpec.groovy
@@ -20,11 +20,11 @@ import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.aws.TestCredential
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -40,11 +40,18 @@ class ResizeAsgAtomicOperationUnitSpec extends Specification {
     def mockAutoScaling = Mock(AmazonAutoScaling)
     def mockAmazonClientProvider = Mock(AmazonClientProvider)
     mockAmazonClientProvider.getAutoScaling(_, _, true) >> mockAutoScaling
-    def description = new ResizeAsgDescription(asgName: "myasg-stack-v000", regions: ["us-west-1"])
-    description.credentials = TestCredential.named('baz')
-    description.capacity.min = 1
-    description.capacity.max = 2
-    description.capacity.desired = 5
+    def description = new ResizeAsgDescription(
+      asgs: [[
+        serverGroupName: "myasg-stack-v000",
+        region         : "us-west-1",
+        capacity       : new ResizeAsgDescription.Capacity(
+          min    : 1,
+          max    : 2,
+          desired: 5
+        )
+      ]],
+      credentials: TestCredential.named('baz')
+    )
     def operation = new ResizeAsgAtomicOperation(description)
     operation.amazonClientProvider = mockAmazonClientProvider
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResumeAsgProcessesAtomicOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResumeAsgProcessesAtomicOperationSpec.groovy
@@ -42,7 +42,19 @@ class ResumeAsgProcessesAtomicOperationSpec extends Specification {
   }
 
   void 'should resume ASG processes'() {
-    def description = new ResumeAsgProcessesDescription(asgName: "asg1", processes: ["Launch", "Terminate"], regions: ["us-west-1", "us-east-1"])
+    def description = new ResumeAsgProcessesDescription(
+      asgs: [
+        [
+          serverGroupName: "asg1",
+          region         : "us-west-1"
+        ],
+        [
+          serverGroupName: "asg1",
+          region         : "us-east-1"
+        ],
+      ],
+      processes: ["Launch", "Terminate"]
+    )
     @Subject operation = new ResumeAsgProcessesAtomicOperation(description)
     operation.regionScopedProviderFactory = mockRegionScopedProviderFactory
 
@@ -57,16 +69,28 @@ class ResumeAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Resume ASG Processes operation for asg1...",
+      "Initializing Resume ASG Processes operation for [[serverGroupName:asg1, region:us-west-1], [serverGroupName:asg1, region:us-east-1]]...",
       "Resuming ASG processes (Launch, Terminate) for asg1 in us-west-1...",
       "Resuming ASG processes (Launch, Terminate) for asg1 in us-east-1...",
-      "Finished Resume ASG Processes operation for asg1."
+      "Finished Resume ASG Processes operation for [[serverGroupName:asg1, region:us-west-1], [serverGroupName:asg1, region:us-east-1]]."
     ]
     0 * mockAsgService._
   }
 
   void 'should not resume ASG processes in region if ASG name is invalid'() {
-    def description = new ResumeAsgProcessesDescription(asgName: "asg1", processes: ["Launch", "Terminate"], regions: ["us-west-1", "us-east-1"])
+    def description = new ResumeAsgProcessesDescription(
+      asgs: [
+        [
+          serverGroupName: "asg1",
+          region         : "us-west-1"
+        ],
+        [
+          serverGroupName: "asg1",
+          region         : "us-east-1"
+        ],
+      ],
+      processes: ["Launch", "Terminate"]
+    )
     @Subject operation = new ResumeAsgProcessesAtomicOperation(description)
     operation.regionScopedProviderFactory = mockRegionScopedProviderFactory
 
@@ -80,16 +104,28 @@ class ResumeAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Resume ASG Processes operation for asg1...",
+      "Initializing Resume ASG Processes operation for [[serverGroupName:asg1, region:us-west-1], [serverGroupName:asg1, region:us-east-1]]...",
       "No ASG named 'asg1' found in us-west-1.",
       "Resuming ASG processes (Launch, Terminate) for asg1 in us-east-1...",
-      "Finished Resume ASG Processes operation for asg1."
+      "Finished Resume ASG Processes operation for [[serverGroupName:asg1, region:us-west-1], [serverGroupName:asg1, region:us-east-1]]."
     ]
     0 * mockAsgService._
   }
 
   void 'should not resume ASG processes in region if there is an error'() {
-    def description = new ResumeAsgProcessesDescription(asgName: "asg1", processes: ["Launch", "Terminate"], regions: ["us-west-1", "us-east-1"])
+    def description = new ResumeAsgProcessesDescription(
+      asgs: [
+        [
+          serverGroupName: "asg1",
+          region         : "us-west-1"
+        ],
+        [
+          serverGroupName: "asg1",
+          region         : "us-east-1"
+        ],
+      ],
+      processes: ["Launch", "Terminate"]
+    )
     @Subject operation = new ResumeAsgProcessesAtomicOperation(description)
     operation.regionScopedProviderFactory = mockRegionScopedProviderFactory
 
@@ -106,11 +142,11 @@ class ResumeAsgProcessesAtomicOperationSpec extends Specification {
     and:
     task.history*.status == [
       "Creating task 1",
-      "Initializing Resume ASG Processes operation for asg1...",
+      "Initializing Resume ASG Processes operation for [[serverGroupName:asg1, region:us-west-1], [serverGroupName:asg1, region:us-east-1]]...",
       "Resuming ASG processes (Launch, Terminate) for asg1 in us-west-1...",
       "Could not resume processes for ASG 'asg1' in region us-west-1! Reason: Uh oh!",
       "Resuming ASG processes (Launch, Terminate) for asg1 in us-east-1...",
-      "Finished Resume ASG Processes operation for asg1."
+      "Finished Resume ASG Processes operation for [[serverGroupName:asg1, region:us-west-1], [serverGroupName:asg1, region:us-east-1]]."
     ]
     0 * mockAsgService._
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgTagsAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgTagsAtomicOperationUnitSpec.groovy
@@ -37,7 +37,13 @@ class UpsertAsgTagsAtomicOperationUnitSpec extends Specification {
     def mockAutoScaling = Mock(AmazonAutoScaling)
     def mockAmazonClientProvider = Mock(AmazonClientProvider)
     mockAmazonClientProvider.getAutoScaling(_, _, _) >> mockAutoScaling
-    def description = new UpsertAsgTagsDescription(asgName: "myasg-stack-v000", tags: ["key": "value"], regions: ["us-west-1"])
+    def description = new UpsertAsgTagsDescription(
+      asgs: [[
+        serverGroupName: "myasg-stack-v000",
+        region         : "us-west-1"
+      ]],
+      tags: ["key": "value"]
+    )
     description.credentials = TestCredential.named('baz')
     def operation = new UpsertAsgTagsAtomicOperation(description)
     operation.amazonClientProvider = mockAmazonClientProvider
@@ -65,7 +71,13 @@ class UpsertAsgTagsAtomicOperationUnitSpec extends Specification {
     def mockAutoScaling = Mock(AmazonAutoScaling)
     def mockAmazonClientProvider = Mock(AmazonClientProvider)
     mockAmazonClientProvider.getAutoScaling(_, _, _) >> mockAutoScaling
-    def description = new UpsertAsgTagsDescription(asgName: "myasg-stack-v000", tags: ["key": "value"], regions: ["us-west-1"])
+    def description = new UpsertAsgTagsDescription(
+      asgs: [[
+        serverGroupName: "myasg-stack-v000",
+        region         : "us-west-1"
+      ]],
+      tags: ["key": "value"]
+    )
     description.credentials = TestCredential.named('baz')
     def operation = new UpsertAsgTagsAtomicOperation(description)
     operation.amazonClientProvider = mockAmazonClientProvider

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/LegacyToAsgsDescriptionPreProcessorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/LegacyToAsgsDescriptionPreProcessorSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.preprocessors
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class LegacyToAsgsDescriptionPreProcessorSpec extends Specification {
+  @Unroll
+  void "should convert legacy descriptions"() {
+    setup:
+    def preProcessor = new LegacyToAsgsDescriptionPreProcessor()
+    def legacyDescription = [
+      asgName        : asgName,
+      serverGroupName: serverGroupName,
+      region         : region,
+      regions        : regions,
+      asgs           : asgs
+    ]
+
+    when:
+    def processedDescription = preProcessor.process(legacyDescription)
+
+    then:
+    processedDescription == [
+      asgs: expectedAsgs
+    ]
+
+    where:
+    asgName  | serverGroupName | region      | regions       | asgs | expectedAsgs
+    "s-v001" | null            | "us-east-1" | null          | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    "s-v001" | null            | "us-east-1" | []            | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    "s-v001" | null            | null        | ["us-east-1"] | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    "s-v001" | ""              | "us-east-1" | null          | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    "s-v001" | ""              | "us-east-1" | []            | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    "s-v001" | ""              | null        | ["us-east-1"] | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    null     | "s-v001"        | "us-east-1" | null          | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    null     | "s-v001"        | "us-east-1" | []            | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    null     | "s-v001"        | null        | ["us-east-1"] | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    ""       | "s-v001"        | "us-east-1" | null          | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    ""       | "s-v001"        | "us-east-1" | []            | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+    ""       | "s-v001"        | null        | ["us-east-1"] | null | [[serverGroupName: "s-v001", region: "us-east-1"]]
+
+    // Multiple regions are supported.
+    "s-v001" | null            | null        | ["us-east-1", "us-west-1"] | null                                                                                                 | [[serverGroupName: "s-v001", region: "us-east-1"], [serverGroupName: "s-v001", region: "us-west-1"]]
+
+    // Passed asgs take precedence.
+    "s-v001" | null            | null        | ["us-east-1", "us-west-1"] | [[serverGroupName: "s-v002", region: "us-west-1"]]                                                   | [[serverGroupName: "s-v002", region: "us-west-1"]]
+    null     | null            | null        | null                       | [[serverGroupName: "s-v002", region: "us-east-1"], [serverGroupName: "s-v002", region: "us-west-1"]] | [[serverGroupName: "s-v002", region: "us-east-1"], [serverGroupName: "s-v002", region: "us-west-1"]]
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/ResizeAsgDescriptionPreProcessorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/ResizeAsgDescriptionPreProcessorSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.preprocessors
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ResizeAsgDescriptionPreProcessorSpec extends Specification {
+  @Unroll
+  void "should convert legacy descriptions, with capacity"() {
+    setup:
+    def preProcessor = new ResizeAsgDescriptionPreProcessor()
+    def legacyDescription = [
+      asgName        : asgName,
+      serverGroupName: serverGroupName,
+      region         : region,
+      regions        : regions,
+      capacity       : capacity,
+      asgs           : asgs
+    ]
+
+    when:
+    def processedDescription = preProcessor.process(legacyDescription)
+
+    then:
+    processedDescription == [
+      asgs: expectedAsgs
+    ]
+
+    where:
+    asgName  | serverGroupName | region      | regions       | capacity                     | asgs | expectedAsgs
+    "s-v001" | null            | "us-east-1" | null          | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    "s-v001" | null            | "us-east-1" | []            | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    "s-v001" | null            | null        | ["us-east-1"] | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    "s-v001" | ""              | "us-east-1" | null          | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    "s-v001" | ""              | "us-east-1" | []            | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    "s-v001" | ""              | null        | ["us-east-1"] | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    null     | "s-v001"        | "us-east-1" | null          | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    null     | "s-v001"        | "us-east-1" | []            | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    null     | "s-v001"        | null        | ["us-east-1"] | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    ""       | "s-v001"        | "us-east-1" | null          | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    ""       | "s-v001"        | "us-east-1" | []            | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+    ""       | "s-v001"        | null        | ["us-east-1"] | [min: 1, desired: 2, max: 3] | null | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]]]
+
+    // Multiple regions are supported.
+    "s-v001" | null            | null        | ["us-east-1", "us-west-1"] | [min: 1, desired: 2, max: 3] | null                                                                                                                                                                                 | [[serverGroupName: "s-v001", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]], [serverGroupName: "s-v001", region: "us-west-1", capacity: [min: 1, desired: 2, max: 3]]]
+
+    // Passed asgs take precedence.
+    "s-v001" | "s-v003"        | "us-west-2" | ["us-east-1", "us-west-1"] | [min: 7, desired: 8, max: 9] | [[serverGroupName: "s-v002", region: "us-west-1", capacity: [min: 1, desired: 2, max: 3]]]                                                                                           | [[serverGroupName: "s-v002", region: "us-west-1", capacity: [min: 1, desired: 2, max: 3]]]
+    null     | null            | null        | null                       | null                         | [[serverGroupName: "s-v002", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]], [serverGroupName: "s-v002", region: "us-west-1", capacity: [min: 4, desired: 5, max: 6]]] | [[serverGroupName: "s-v002", region: "us-east-1", capacity: [min: 1, desired: 2, max: 3]], [serverGroupName: "s-v002", region: "us-west-1", capacity: [min: 4, desired: 5, max: 6]]]
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractConfiguredRegionsValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractConfiguredRegionsValidatorSpec.groovy
@@ -16,9 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
-import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AsgDescription
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
@@ -42,15 +43,16 @@ abstract class AbstractConfiguredRegionsValidatorSpec extends Specification {
     validator.validate([], description, errors)
 
     then:
-    1 * errors.rejectValue("asgName", _)
-    1 * errors.rejectValue("regions", _)
+    1 * errors.rejectValue("asgs", _)
   }
 
   void "region is validated against configuration"() {
     setup:
     def description = getDescription()
     description.credentials = TestCredential.named('test')
-    description.regions = ["us-east-5"]
+    description.asgs = [new AsgDescription(
+      region: "us-east-5"
+    )]
     def errors = Mock(Errors)
 
     when:
@@ -60,7 +62,9 @@ abstract class AbstractConfiguredRegionsValidatorSpec extends Specification {
     1 * errors.rejectValue("regions", _)
 
     when:
-    description.regions = description.credentials.regions.collect { it.name }
+    description.asgs = description.credentials.regions.collect {new AsgDescription(
+      region: it.name
+    )}
     validator.validate([], description, errors)
 
     then:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResumeAsgProcessesDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResumeAsgProcessesDescriptionValidatorSpec.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResumeAsgProcessesDescription
-import com.netflix.spinnaker.clouddriver.aws.deploy.validators.ResumeAsgProcessesDescriptionValidator
 import org.springframework.validation.Errors
 import spock.lang.Specification
 
@@ -25,8 +26,16 @@ class ResumeAsgProcessesDescriptionValidatorSpec extends Specification {
 
   void "pass validation with proper description inputs"() {
     def description = new ResumeAsgProcessesDescription(
-      asgName: "asg1",
-      regions: ["us-west-1", "us-east-1"],
+      asgs: [
+        new AsgDescription(
+          serverGroupName: "asg1",
+          region: "us-west-1"
+        ),
+        new AsgDescription(
+          serverGroupName: "asg1",
+          region: "us-east-1"
+        )
+      ],
       processes: ["Launch", "Terminate"]
     )
     def errors = Mock(Errors)
@@ -40,8 +49,16 @@ class ResumeAsgProcessesDescriptionValidatorSpec extends Specification {
 
   void "invalid process names fails validation"() {
     def description = new ResumeAsgProcessesDescription(
-      asgName: "asg1",
-      regions: ["us-west-1", "us-east-1"],
+      asgs: [
+        new AsgDescription(
+          serverGroupName: "asg1",
+          region: "us-west-1"
+        ),
+        new AsgDescription(
+          serverGroupName: "asg1",
+          region: "us-east-1"
+        )
+      ],
       processes: ["Laugh", "Terminate"]
     )
     def errors = Mock(Errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/SuspendAsgProcessesDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/SuspendAsgProcessesDescriptionValidatorSpec.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.SuspendAsgProcessesDescription
-import com.netflix.spinnaker.clouddriver.aws.deploy.validators.SuspendAsgProcessesDescriptionValidator
 import org.springframework.validation.Errors
 import spock.lang.Specification
 
@@ -25,8 +26,16 @@ class SuspendAsgProcessesDescriptionValidatorSpec extends Specification {
 
   void "pass validation with proper description inputs"() {
     def description = new SuspendAsgProcessesDescription(
-      asgName: "asg1",
-      regions: ["us-west-1", "us-east-1"],
+      asgs: [
+        new AsgDescription(
+          serverGroupName: "asg1",
+          region: "us-west-1"
+        ),
+        new AsgDescription(
+          serverGroupName: "asg1",
+          region: "us-east-1"
+        )
+      ],
       processes: ["Launch", "Terminate"]
     )
     def errors = Mock(Errors)
@@ -40,8 +49,16 @@ class SuspendAsgProcessesDescriptionValidatorSpec extends Specification {
 
   void "invalid process names fails validation"() {
     def description = new SuspendAsgProcessesDescription(
-      asgName: "asg1",
-      regions: ["us-west-1", "us-east-1"],
+      asgs: [
+        new AsgDescription(
+          serverGroupName: "asg1",
+          region: "us-west-1"
+        ),
+        new AsgDescription(
+          serverGroupName: "asg1",
+          region: "us-east-1"
+        )
+      ],
       processes: ["Laugh", "Terminate"]
     )
     def errors = Mock(Errors)


### PR DESCRIPTION
All manner of asgName|serverGroupName, region|regions and asgs are supported on the requests and coerced to asgs via LegacyToAsgsDescriptionPreProcessor.
AWS resize is handled specially via its own dedicated ResizeAsgDescriptionPreProcessor due to the presence of `capacity` within `asgs`.
asgName and regions are deprecated on all the descriptions.