### PR TITLE
Drop `region` from EnableDisableDestroyAzureServerGroupDescription si…

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/EnableDisableDestroyAzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/EnableDisableDestroyAzureServerGroupDescription.groovy
@@ -16,9 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model
 
-class EnableDisableDestroyAzureServerGroupDescription extends AzureServerGroupDescription{
+class EnableDisableDestroyAzureServerGroupDescription extends AzureServerGroupDescription {
   String serverGroupName
-  String region
 
   @Deprecated
   List<String> regions


### PR DESCRIPTION
…nce it is already defined on the superclass.