### PR TITLE
provider/aws: disregard all but groupId and userId when comparing sec…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/SecurityGroupIngressConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/SecurityGroupIngressConverter.groovy
@@ -56,6 +56,9 @@ class SecurityGroupIngressConverter {
     ipPermissions.collect { IpPermission ipPermission ->
       ipPermission.userIdGroupPairs.collect {
         it.groupName = null
+        it.vpcId = null
+        it.peeringStatus = null
+        it.vpcPeeringConnectionId = null
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)


### PR DESCRIPTION
…urity group ingress rules

We never send these values to the UI (well, we send `vpcId`, and it's sent back, but it's a mess to ensure it's the desired VPC and we have the `groupId` and `accountId` so we're safe), so we won't have them in place when we try to do our fancy `-` operation in the UpsertSecurityGroupAtomicOperation to figure out if we need to add or remove these rules, which means we always think we need to add the rules, even if they're unchanged, and Amazon throws an exception.

For @ajordens , I spun up Gate, Clouddriver, Deck, and Orca locally, and tested this in every scenario I could come up with to make sure it actually works beyond unit tests.

@ajordens or @cfieber PTAL