### PR TITLE
Consolidate version of Jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,12 @@ subprojects { project ->
           if (it.requested.group == 'org.apache.xbean') {
             it.useVersion '4.3'
           }
+          if (it.requested.group == 'com.fasterxml.jackson.core'
+                  || it.requested.group == 'com.fasterxml.jackson.datatype'
+                  || it.requested.group == 'com.fasterxml.jackson.dataformat'
+                  || it.requested.group == 'com.fasterxml.jackson.module') {
+            it.useVersion '2.5.4'
+          }
         }
       }
     }


### PR DESCRIPTION
Running clouddriver in uber JAR mode generated quirky errors in Jackson that didn't happen in my IDE. Spotted that different modules were using different versions of Jackson, k8 being on 2.7 and all the others on 2.5. This patch tweaks the build system to use one version of Jackson.