### PR TITLE
provider/aws: The list() entrypoint in AmazonLoadBalancerController s…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonLoadBalancerController.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonLoadBalancerController.groovy
@@ -42,8 +42,9 @@ class AmazonLoadBalancerController {
 
   @RequestMapping(method = RequestMethod.GET)
   List<AmazonLoadBalancerSummary> list() {
-    Collection<String> loadBalancers = cacheView.getIdentifiers(LOAD_BALANCERS.ns)
-    getSummaryForLoadBalancers(loadBalancers).values() as List
+    def searchKey = Keys.getLoadBalancerKey('*', '*', '*', null) + '*'
+    Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey)
+    getSummaryForLoadBalancers(identifiers).values() as List
   }
 
   @RequestMapping(value = "/{name:.+}", method = RequestMethod.GET)

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/controllers/CloudFoundryLoadBalancerController.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/controllers/CloudFoundryLoadBalancerController.groovy
@@ -42,8 +42,9 @@ class CloudFoundryLoadBalancerController {
 
   @RequestMapping(method = RequestMethod.GET)
   List<CloudFoundryLoadBalancerAccount> list() {
-    Collection<String> loadBalancers = cacheView.getIdentifiers(LOAD_BALANCERS.ns)
-    getSummaryForLoadBalancers(loadBalancers).values() as List
+    def searchKey = Keys.getLoadBalancerKey('*', '*', '*')
+    Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey)
+    getSummaryForLoadBalancers(identifiers).values() as List
   }
 
   @RequestMapping(value = "/{name:.+}", method = RequestMethod.GET)


### PR DESCRIPTION
…hould not query for all load balancer identifiers. When other providers are caching in the same redis instance, NPEs are thrown.

provider/cf: The list() entrypoint in CloudFoundryLoadBalancerController should not query for all load balancer identifiers.