### PR TITLE
provider/kubernetes: Allow empty apps to be deleted

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -52,7 +52,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
 
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
     INFORMATIVE.forType(Keys.Namespace.APPLICATIONS.ns),
-    INFORMATIVE.forType(Keys.Namespace.CLUSTERS.ns),
+    AUTHORITATIVE.forType(Keys.Namespace.CLUSTERS.ns),
     INFORMATIVE.forType(Keys.Namespace.LOAD_BALANCERS.ns),
     AUTHORITATIVE.forType(Keys.Namespace.SERVER_GROUPS.ns),
     INFORMATIVE.forType(Keys.Namespace.INSTANCES.ns),


### PR DESCRIPTION
When `CLUSTER` wasn't authoritative, it would persist cached relationships (for deleted server groups/load balancers), causing the application controller to return old clusters. Since this is only surfaced when summary application details are loaded, it went unnoticed until those details were used by orca to determine if an app can be deleted. This fixes that.

@duftler 