### PR TITLE
Azure Application Gateway related ops and others

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -210,7 +210,7 @@ public class AzureComputeClient extends AzureBaseClient {
   Collection<AzureInstance> getServerGroupInstances(String resourceGroupName, String serverGroupName) {
     def instances = new ArrayList<AzureInstance>()
 
-    executeOp({scaleSetVMOps.list(resourceGroupName, serverGroupName, null, null, "instanceView")}).body.each {
+    executeOp({scaleSetVMOps.list(resourceGroupName, serverGroupName, null, null, "instanceView")})?.body?.each {
       instances.add(AzureInstance.build(it))
     }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/view/AzureInfrastructureProviderConfig.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/view/AzureInfrastructureProviderConfig.groovy
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.cache.AzureAppGatewayCachingAgent
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.cache.AzureLoadBalancerCachingAgent
 import com.netflix.spinnaker.clouddriver.azure.resources.network.cache.AzureNetworkCachingAgent
 import com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.cache.AzureSecurityGroupCachingAgent
@@ -97,6 +98,7 @@ class AzureInfrastructureProviderConfig {
           newlyAddedAgents << new AzureVMImageCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
           newlyAddedAgents << new AzureCustomImageCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, creds.vmCustomImages, objectMapper)
           newlyAddedAgents << new AzureServerGroupCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)
+          newlyAddedAgents << new AzureAppGatewayCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)
 
           // If there is an agent scheduler, then this provider has been through the AgentController in the past.
           // In that case, we need to do the scheduling here (because accounts have been added to a running system).

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/cache/AzureAppGatewayCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/cache/AzureAppGatewayCachingAgent.groovy
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.cache
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.AccountAware
+import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.CacheResult
+import com.netflix.spinnaker.cats.agent.CachingAgent
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.common.cache.AzureCachingAgent
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.common.cache.Keys
+import com.netflix.spinnaker.clouddriver.azure.resources.common.cache.provider.AzureInfrastructureProvider
+import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
+import groovy.transform.WithWriteLock
+import groovy.util.logging.Slf4j
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+
+@Slf4j
+class AzureAppGatewayCachingAgent extends AzureCachingAgent {
+  final Registry registry
+  final OnDemandMetricsSupport metricsSupport
+
+  static final Set<AgentDataType> types = Collections.unmodifiableSet([
+    AUTHORITATIVE.forType(Keys.Namespace.AZURE_APP_GATEWAYS.ns)
+  ] as Set)
+
+  AzureAppGatewayCachingAgent(AzureCloudProvider azureCloudProvider,
+                              String accountName,
+                              AzureCredentials creds,
+                              String region,
+                              ObjectMapper objectMapper,
+                              Registry registry) {
+    super(azureCloudProvider, accountName, creds, region, objectMapper)
+    this.registry = registry
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${azureCloudProvider.id}:${OnDemandAgent.OnDemandType.LoadBalancer}")
+  }
+
+  @Override
+  Set<AgentDataType> initializeTypes() {
+    Collections.unmodifiableSet([
+      AUTHORITATIVE.forType(Keys.Namespace.AZURE_APP_GATEWAYS.ns)
+    ] as Set)
+  }
+
+  @Override
+  Boolean validKeys(Map<String, ? extends Object> data) {
+    data.containsKey("loadBalancerName") &&
+      data.containsKey("account") &&
+      data.containsKey("region") &&
+      accountName == data.account &&
+      region == data.region
+  }
+
+  @Override
+  OnDemandAgent.OnDemandType getOnDemandType() {
+    OnDemandAgent.OnDemandType.LoadBalancer
+  }
+
+  @Override
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == azureCloudProvider.id
+  }
+
+  @Override
+  OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data) {
+    if (validKeys(data)) {
+      return null
+    }
+
+    AzureAppGatewayDescription updatedAppGateway = null
+    AzureAppGatewayDescription evictedAppGateway = null
+    String appGatewayName = data.loadBalancerName as String
+    String resourceGroupName = AzureUtilities.getResourceGroupName(AzureUtilities.getAppNameFromAzureResourceName(appGatewayName), region)
+    if (resourceGroupName == null) {
+      log.info("handle->Unexpected error retrieving resource group name: null")
+      return []
+    }
+
+    try {
+      updatedAppGateway = metricsSupport.readData {
+        creds.networkClient.getAppGateway(resourceGroupName, appGatewayName)
+      }
+    } catch (Exception e ) {
+      log.error("handle->Unexpected exception", e)
+      return null
+    }
+
+    def cacheResult = metricsSupport.transformData {
+      if (updatedAppGateway) {
+        return buildCacheResult(providerCache, null, 0, updatedAppGateway, null)
+      } else {
+        evictedAppGateway = new AzureAppGatewayDescription(
+          loadBalancerName: appGatewayName,
+          name: appGatewayName,
+          region: region,
+          appName: AzureUtilities.getAppNameFromAzureResourceName(appGatewayName),
+          cloudProvider: "azure",
+          cluster: "none",
+          lastReadTime: System.currentTimeMillis()
+        )
+        return buildCacheResult(providerCache, null, 0, null, evictedAppGateway)
+      }
+    }
+    Map<String, Collection<String>> evictions = evictedAppGateway ? [(Keys.Namespace.AZURE_APP_GATEWAYS.ns): [getAppGatewayKey(evictedAppGateway)]] : [:]
+
+    log.info("onDemand cache refresh (data: ${data}, evictions: ${evictions})")
+    return new OnDemandAgent.OnDemandResult(
+      sourceAgentType: getAgentType(), cacheResult: cacheResult, evictions: evictions
+    )
+  }
+
+  @Override
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    return []
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    log.info("Describing items in ${agentType}")
+    def currentTime = System.currentTimeMillis()
+    buildCacheResult(providerCache, creds.networkClient.getAppGatewaysAll(region), currentTime, null, null)
+  }
+
+  @WithWriteLock
+  // Allow only one thread at a given time to go through the AppGateway specific cache entries and modify them
+  private CacheResult buildCacheResult(ProviderCache providerCache,
+                                       Collection<AzureAppGatewayDescription> appGateways,
+                                       long lastReadTime,
+                                       AzureAppGatewayDescription updatedAppGateway,
+                                       AzureAppGatewayDescription evictedAppGateway) {
+    if (appGateways) {
+      List<CacheData> data = new ArrayList<CacheData>()
+      Collection<String> identifiers = providerCache.filterIdentifiers(
+        Keys.Namespace.AZURE_ON_DEMAND.ns,
+        Keys.getAppGatewayKey(azureCloudProvider, "*", "*", region, accountName)
+      )
+      def onDemandCacheResults = providerCache.getAll(
+        Keys.Namespace.AZURE_ON_DEMAND.ns,
+        identifiers,
+        RelationshipCacheFilter.none()
+      )
+
+      // Add any outdated OnDemand cache entries to the evicted list
+      List<String> evictions = new ArrayList<String>()
+      Map<String, CacheData> usableOnDemandCacheDatas = [:]
+      onDemandCacheResults.each {
+        if(it.attributes.cachedTime < lastReadTime){
+          evictions.add(it.id)
+        } else {
+          usableOnDemandCacheDatas[it.id] = it
+        }
+      }
+
+      appGateways.each { AzureAppGatewayDescription item ->
+        AzureAppGatewayDescription appGateway = item
+        String agKey = getAppGatewayKey(appGateway)
+
+        // Search the current OnDemand update map entries and look for an application gateway match
+        def onDemandAG = usableOnDemandCacheDatas[agKey]
+        if (onDemandAG) {
+          if (onDemandAG.attributes.cachedTime > appGateway.lastReadTime) {
+            if (onDemandAG.attributes.onDemandCacheType == "OnDemandUpdated") {
+              // Found an application gateway that has been updated since last time was read from Azure cloud
+              appGateway = objectMapper.readValue(onDemandAG.attributes.azureResourceDescription as String, AzureAppGatewayDescription)
+            } else {
+              // Found an application gateway that has been deleted since last time was read from Azure cloud
+              appGateway = null
+            }
+          }
+        }
+
+        if (appGateway) {
+          data.add(buildCacheData(appGateway))
+        }
+      }
+
+      log.info("Caching ${data.size()} items in ${agentType}")
+
+      return new DefaultCacheResult(
+        [(Keys.Namespace.AZURE_APP_GATEWAYS.ns): data],
+        [(Keys.Namespace.AZURE_ON_DEMAND.ns): evictions])
+
+    } else {
+      if (updatedAppGateway) {
+        // This is an OnDemand update/edit request for a given application gateway resource
+        // Attempt to add entry into the OnDemand respective cache
+        if (updateCache(providerCache, updatedAppGateway, "OnDemandUpdated")) {
+          CacheData data = buildCacheData(updatedAppGateway)
+
+          log.info("Caching 1 OnDemand updated item in ${agentType}")
+          return new DefaultCacheResult([(Keys.Namespace.AZURE_APP_GATEWAYS.ns): [data]])
+        } else {
+          return null
+        }
+      }
+
+      if (evictedAppGateway) {
+        // This is an OnDemand delete request for a given application gateway resource
+        // Attempt to add entry into the OnDemand respective cache
+        if (updateCache(providerCache, evictedAppGateway, "OnDemandEvicted")) {
+          log.info("Caching 1 OnDemand evicted item in ${agentType}")
+          return new DefaultCacheResult([(Keys.Namespace.AZURE_APP_GATEWAYS.ns): []])
+        } else {
+          return null
+        }
+      }
+    }
+
+    return new DefaultCacheResult([(Keys.Namespace.AZURE_APP_GATEWAYS.ns): []])
+  }
+
+  // Update current cache only if the current entry is a new OnDemand request or if the current entry is more recent
+  //  than the cache entry
+  private Boolean updateCache(ProviderCache providerCache, AzureAppGatewayDescription appGateway, String onDemandCacheType) {
+    Boolean foundUpdatedOnDemandLB = false
+
+    if (appGateway) {
+      // Get the current list of all OnDemand requests from the cache
+      def cacheResults = providerCache.getAll(Keys.Namespace.AZURE_ON_DEMAND.ns, [getAppGatewayKey(appGateway)])
+
+      if (cacheResults && !cacheResults.isEmpty()) {
+        cacheResults.each {
+          // cacheResults.each should only return one item which is matching the given application gateway details object
+          if (it.attributes.cachedTime > appGateway.lastReadTime) {
+            // Found a newer matching entry in the cache when compared with the current OnDemand request
+            foundUpdatedOnDemandLB = true
+          }
+        }
+      }
+
+      if (!foundUpdatedOnDemandLB) {
+        // Add entry to the OnDemand respective cache
+        def cacheData = new DefaultCacheData(
+          getAppGatewayKey(appGateway),
+          [
+            azureResourceDescription: objectMapper.writeValueAsString(appGateway),
+            cachedTime: appGateway.lastReadTime,
+            onDemandCacheType : onDemandCacheType
+          ],
+          [:]
+        )
+        providerCache.putCacheData(Keys.Namespace.AZURE_ON_DEMAND.ns, cacheData)
+
+        return true
+      }
+    }
+
+    false
+  }
+
+  private CacheData buildCacheData(AzureAppGatewayDescription appGateway) {
+    Map<String, Object> attributes = [appgateway: appGateway]
+
+    new DefaultCacheData(getAppGatewayKey(appGateway), attributes, [:])
+  }
+
+  // return a key corresponding to a specific application gateway resource to be used for map indexing
+  private String getAppGatewayKey(AzureAppGatewayDescription appGateway) {
+    Keys.getAppGatewayKey(
+      azureCloudProvider,
+      appGateway.appName ?: "none",
+      appGateway.name,
+      region,
+      accountName)
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/DeleteAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/DeleteAzureAppGatewayAtomicOperation.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops
+
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+
+class DeleteAzureAppGatewayAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "DELETE_APP_GATEWAY"
+  // TODO: change this later to the real thing, DELETE_LOAD_BALANCER
+  // private static final String BASE_PHASE = "DELETE_LOAD_BALANCER"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  private final AzureAppGatewayDescription description
+
+  DeleteAzureAppGatewayAtomicOperation(AzureAppGatewayDescription description) {
+    this.description = description
+  }
+
+  /**
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "deleteAppGateway": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "credentials" : "azure-cred1", "region" : "westus", "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
+   *
+   * TODO: change ops task name to deleteLoadBalancer:
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "deleteLoadBalancer": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "credentials" : "azure-cred1", "region" : "westus", "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
+   *
+   * @param priorOutputs
+   * @return
+   */
+  @Override
+  Void operate(List priorOutputs) {
+    task.updateStatus(BASE_PHASE, "Initializing deletion of load balancer ${description.loadBalancerName} " +
+      "in ${description.region}...")
+
+    if (!description.credentials) {
+      throw new IllegalArgumentException("Unable to resolve credentials for the given Azure account.")
+    }
+
+    try {
+      task.updateStatus(BASE_PHASE, "Deleting Azure Application Gateway ${description.loadBalancerName} " + "in ${description.region}...")
+      String resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, description.region)
+
+      description
+        .credentials
+        .networkClient
+        .deleteAppGateway(resourceGroupName, description.loadBalancerName)
+
+      // TODO: check response to ensure operation succeeded
+      task.updateStatus(BASE_PHASE, "Deletion of load balancer ${description.loadBalancerName} in ${description.region} has succeeded.")
+    } catch (Exception e) {
+      task.updateStatus(BASE_PHASE, "Deletion of load balancer ${description.loadBalancerName} failed: e.message")
+      throw new AtomicOperationException(
+        error: "Failed to delete ${description.name}",
+        errors: [e.message])
+    }
+
+    null
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops
+
+import com.microsoft.azure.CloudException
+import com.microsoft.azure.management.resources.models.DeploymentExtended
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.resources.common.model.AzureDeploymentOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.templates.AzureAppGatewayResourceTemplate
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+
+class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
+  private static final String BASE_PHASE = "UPSERT_APP_GATEWAY"
+  // TODO: change this later to the real thing, UPSERT_LOAD_BALANCER
+  // private static final String BASE_PHASE = "UPSERT_LOAD_BALANCER"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  private final AzureAppGatewayDescription description
+
+  UpsertAzureAppGatewayAtomicOperation(AzureAppGatewayDescription description) {
+    this.description = description
+  }
+
+  /**
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertAppGateway": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "stack" : "st1", "detail" : "d1", "credentials" : "azure-cred1", "region" : "westus", "probes" : [ { "name" : "healthcheck1", "protocol" : "HTTP", "path" : "/healthcheck", "interval" : 120, "unhealthyThreshold" : 8, "timeout" : 30 } ], "rules" : [ { "name" : "lbRule1", "protocol" : "HTTP", "externalPort" : "80", "backendPort" : "8080" }, { "name" : "lbRule2", "protocol" : "HTTP", "externalPort" : "8080", "backendPort" : "8080" } ], "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
+   *
+   * TODO: change ops task name to upserLoadBalancer:
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertLoadBalancer": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "stack" : "st1", "detail" : "d1", "credentials" : "azure-cred1", "region" : "westus", "probes" : [ { "name" : "healthcheck1", "protocol" : "HTTP", "path" : "/healthcheck", "interval" : 120, "unhealthyThreshold" : 8, "timeout" : 30 } ], "rules" : [ { "name" : "lbRule1", "protocol" : "HTTP", "externalPort" : "80", "backendPort" : "8080" }, { "name" : "lbRule2", "protocol" : "HTTP", "externalPort" : "8080", "backendPort" : "8080" } ], "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
+   *
+   * @param priorOutputs
+   * @return
+   */
+  @Override
+  Map operate(List priorOutputs) {
+    task.updateStatus(BASE_PHASE, "Initializing upsert of load balancer ${description.loadBalancerName} " +
+      "in ${description.region}...")
+
+    def errList = new ArrayList<String>()
+    String resourceGroupName = null
+    String virtualNetworkName = null
+    String subnetName = null
+    String loadBalancerName = null
+
+    try {
+      task.updateStatus(BASE_PHASE, "Beginning load balancer deployment")
+
+      description.name = description.loadBalancerName
+      resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, description.region)
+      virtualNetworkName = AzureUtilities.getVirtualNetworkName(resourceGroupName)
+
+      description.credentials.resourceManagerClient.initializeResourceGroupAndVNet(description.credentials, resourceGroupName, virtualNetworkName, description.region)
+
+      // TODO We just try to grab the next subnet, which fails if the largest possible subnet is already taken.
+      // TODO We also just assume that a vnet can only have one address range.
+      task.updateStatus(BASE_PHASE, "Creating subnet for application gateway")
+      def vnet = description.credentials.networkClient.getVirtualNetwork(resourceGroupName, virtualNetworkName)
+      if (vnet.addressSpace.addressPrefixes.size() != 1) {
+        throw new RuntimeException(
+          "Virtual Network found with ${vnet.addressSpace.addressPrefixes.size()} address spaces; expected: 1")
+      }
+
+      String vnetPrefix = vnet.addressSpace.addressPrefixes[0]
+      String subnetPrefix = null
+      if (vnet.subnets.size() > 0) {
+        subnetPrefix = vnet.subnets.max({ a, b -> AzureUtilities.compareIpv4AddrPrefixes(a.addressPrefix, b.addressPrefix) }).addressPrefix
+      }
+
+      String nextSubnet = AzureUtilities.getNextSubnet(vnetPrefix, subnetPrefix)
+      subnetName = AzureUtilities.getSubnetName(virtualNetworkName, nextSubnet)
+
+      task.updateStatus(BASE_PHASE, "Creating new subnet ${subnetName} for ${description.loadBalancerName}")
+      String subnetId = description.credentials.networkClient.createSubnet(resourceGroupName,
+        virtualNetworkName,
+        subnetName,
+        nextSubnet,
+        description.securityGroup)
+
+      if(!subnetId) {
+        task.updateStatus(BASE_PHASE, "Failed to create subnet for Application Gateway ${description.name}")
+      } else {
+        description.vnet = virtualNetworkName
+        description.subnet = AzureUtilities.getNameFromResourceId(subnetId)
+
+        task.updateStatus(BASE_PHASE, "Create new application gateway ${description.loadBalancerName} in ${description.region}...")
+        DeploymentExtended deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(description.credentials,
+          AzureAppGatewayResourceTemplate.getTemplate(description),
+          resourceGroupName,
+          description.region,
+          description.loadBalancerName,
+          "appGateway")
+
+        errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name)
+        loadBalancerName = description.name
+      }
+    } catch (CloudException ce) {
+      task.updateStatus(BASE_PHASE, "One or more deployment operations have failed. Please see Azure portal for more information. Resource Group: ${resourceGroupName} Application Gateway: ${description.loadBalancerName}")
+      errList.add(ce.message)
+    } catch (Exception e) {
+      task.updateStatus(BASE_PHASE, "Deployment of application gateway ${description.loadBalancerName} failed: ${e.message}")
+      errList.add(e.message)
+    }
+
+    if (errList.isEmpty()) {
+      task.updateStatus(BASE_PHASE, "Deployment for load balancer ${description.loadBalancerName} in ${description.region} has succeeded.")
+    }
+    else {
+      // cleanup any resources that might have been created prior to server group failing to deploy
+      task.updateStatus(BASE_PHASE, "Cleanup any resources created as part of server group upsert")
+      try {
+        if (loadBalancerName) description.credentials.networkClient.deleteAppGateway(resourceGroupName, loadBalancerName)
+        if (subnetName) description.credentials.networkClient.deleteSubnet(resourceGroupName, virtualNetworkName, subnetName)
+      } catch (Exception e) {
+        def errMessage = "Unexpected exception: ${e.message}; please log in into the Azure Portal and manually remove the following resources: ${subnetName} ${loadBalancerName} ${AzureUtilities.PUBLICIP_NAME_PREFIX + loadBalancerName}"
+        task.updateStatus(BASE_PHASE, errMessage)
+        errList.add(errMessage)
+      }
+
+      throw new AtomicOperationException(
+        error: "${description.loadBalancerName} deployment failed",
+        errors: errList)
+    }
+
+    [loadBalancers: [(description.region): [name: description.loadBalancerName]]]
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/converters/DeleteAzureAppGatewayAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/converters/DeleteAzureAppGatewayAtomicOperationConverter.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.converters
+
+import com.netflix.spinnaker.clouddriver.azure.AzureOperation
+import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.DeleteAzureAppGatewayAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+
+@Slf4j
+@AzureOperation("deleteAppGateway")
+// TODO: change operation type to AtomicOperations.DELETE_LOAD_BALANCER after we retire AzureLoadBalancer
+//@AzureOperation(AtomicOperations.DELETE_LOAD_BALANCER)
+@Component("deleteAzureAppGatewayDescription")
+class DeleteAzureAppGatewayAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  DeleteAzureAppGatewayAtomicOperationConverter() {
+    log.info("Constructor....UpsertAzureAppGatewayAtomicOperationConverter")
+  }
+
+  AtomicOperation convertOperation(Map input) {
+    new DeleteAzureAppGatewayAtomicOperation(convertDescription(input))
+  }
+
+  AzureAppGatewayDescription convertDescription(Map input) {
+    AzureAtomicOperationConverterHelper.
+      convertDescription(input, this, AzureAppGatewayDescription) as AzureAppGatewayDescription
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/converters/UpsertAzureAppGatewayAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/converters/UpsertAzureAppGatewayAtomicOperationConverter.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.converters
+
+import com.netflix.spinnaker.clouddriver.azure.AzureOperation
+import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.UpsertAzureAppGatewayAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+
+@Slf4j
+@AzureOperation("upsertAppGateway")
+// TODO: change operation type to AtomicOperations.UPSERT_LOAD_BALANCER after we retire AzureLoadBalancer
+//@AzureOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
+@Component("upsertAzureAppGatewayDescription")
+class UpsertAzureAppGatewayAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  UpsertAzureAppGatewayAtomicOperationConverter() {
+    log.info("Constructor....UpsertAzureAppGatewayAtomicOperationConverter")
+  }
+
+  AtomicOperation convertOperation(Map input) {
+    new UpsertAzureAppGatewayAtomicOperation(convertDescription(input))
+  }
+
+  AzureAppGatewayDescription convertDescription(Map input) {
+    AzureAtomicOperationConverterHelper.
+      convertDescription(input, this, AzureAppGatewayDescription) as AzureAppGatewayDescription
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/DeleteAzureAppGatewayAtomicOperationValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/DeleteAzureAppGatewayAtomicOperationValidator.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.validators
+
+import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.validation.Errors
+
+@Component("deleteAzureAppGatewayDescriptionValidator")
+class DeleteAzureAppGatewayAtomicOperationValidator extends
+  DescriptionValidator<AzureAppGatewayDescription> {
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Override
+  void validate(List priorDescriptions, AzureAppGatewayDescription description, Errors errors) {
+    def helper = new StandardAzureAttributeValidator("deletetAzureAppGatewayDescriptionValidator", errors)
+
+    helper.validateCredentials(description.credentials, accountCredentialsProvider)
+    helper.validateRegion(description.region)
+    helper.validateName(description.loadBalancerName, "loadBalancerName")
+    helper.validateName(description.appName, "appName")
+    if (!ValidateNoServerGroupsAttached(description.appName, description.loadBalancerName)) {
+      errors.rejectValue "serverGroups", "deleteAzureAppGatewayDescriptionValidator.serverGroupsList.not_empty"
+    }
+  }
+
+  static Boolean ValidateNoServerGroupsAttached(String appName, String appGateway) {
+    // TODO: Implement real check
+    return true
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/UpsertAzureAppGatewayAtomicOperationValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/UpsertAzureAppGatewayAtomicOperationValidator.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.validators
+
+import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.validation.Errors
+
+@Component("upsertAzureAppGatewayDescriptionValidator")
+class UpsertAzureAppGatewayAtomicOperationValidator extends
+  DescriptionValidator<AzureAppGatewayDescription> {
+  private static final List<String> SUPPORTED_IP_PROTOCOLS = ["HTTP"]
+  private static final List<String> SUPPORTED_PROBE_PROTOCOLS = ["HTTP"]
+  // TODO: add support for the remaining protocols: HTTPS, TCP, UDP
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Override
+  void validate(List priorDescriptions, AzureAppGatewayDescription description, Errors errors) {
+    def helper = new StandardAzureAttributeValidator("upsertAzureAppGatewayDescriptionValidator", errors)
+
+    helper.validateCredentials(description.credentials, accountCredentialsProvider)
+    helper.validateRegion(description.region)
+    helper.validateName(description.loadBalancerName, "loadBalancerName")
+    helper.validateName(description.appName, "appName")
+    description.rules?.each { rule ->
+      if(!SUPPORTED_IP_PROTOCOLS.contains(rule.protocol.toString().toUpperCase())) {
+        errors.rejectValue "protocolType", "upsertAzureAppGatewayDescriptionValidator.rule.protocolType.not_supported"
+      }
+    }
+    description.probes?.each { probe ->
+      if(!SUPPORTED_PROBE_PROTOCOLS.contains(probe.protocol.toString().toUpperCase())) {
+        errors.rejectValue "protocolType", "upsertAzureAppGatewayDescriptionValidator.probe.protocolType.not_supported"
+      }
+    }
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayController.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayController.groovy
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.view
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.view.AzureLoadBalancerProvider
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/azure/appGateways")
+class AzureAppGatewayController {
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Autowired
+  AzureAppGatewayProvider azureAppGatewayProvider
+
+  @RequestMapping(method = RequestMethod.GET)
+  List<AzureAppGatewaySummary> list() {
+    getSummaryForAppGateways().values() as List
+  }
+
+  private Map<String, AzureAppGatewaySummary> getSummaryForAppGateways() {
+    Map<String, AzureAppGatewaySummary> map = [:]
+    def loadBalancers = azureAppGatewayProvider.getApplicationLoadBalancers('*')
+
+    loadBalancers?.each() { lb ->
+      def summary = map.get(lb.name)
+
+      if (!summary) {
+        summary = new AzureAppGatewaySummary(name: lb.name)
+        map.put lb.name, summary
+      }
+
+      def loadBalancerDetail = new AzureAppGatewayAccountRegionDetail(account: lb.account, name: lb.name, region: lb.region)
+
+      summary.getOrCreateAccount(lb.account).getOrCreateRegion(lb.region).loadBalancers << loadBalancerDetail
+    }
+    map
+  }
+
+  @RequestMapping(value = "/{account}/{region}/{name:.+}", method = RequestMethod.GET)
+  List<Map> getDetailsInAccountAndRegionByName(@PathVariable String account, @PathVariable String region, @PathVariable String name) {
+    String appName = AzureUtilities.getAppNameFromAzureResourceName(name)
+    AzureAppGatewayDescription description = azureAppGatewayProvider.getAppGatewayDescription(account, appName, region, name)
+
+    if (description) {
+      def lbDetail = [
+        name: description.loadBalancerName
+      ]
+
+      lbDetail.createdTime = description.createdTime
+      lbDetail.cluster = description.cluster ?: "unassigned"
+      lbDetail.serverGroups = description.serverGroups?.join(" ") ?: "unassigned"
+      lbDetail.securityGroup = description.securityGroup ?: "unassigned"
+      lbDetail.vnet = description.vnet ?: "vnet-unassigned"
+      lbDetail.subnet = description.subnet ?: "subnet-unassigned"
+      lbDetail.dnsName = description.dnsName ?: "dnsname-unassigned"
+
+      lbDetail.probes = description.probes
+      lbDetail.loadBalancingRules = description.rules
+      lbDetail.tags = description.tags
+
+      lbDetail.sku = description.sku
+      lbDetail.tier = description.tier
+      lbDetail.capacity = description.capacity
+
+      return [lbDetail]
+    }
+
+    return []
+  }
+
+  static class AzureAppGatewaySummary {
+    private Map<String, AzureAppGatewayAccount> mappedAccounts = [:]
+    String name
+
+    AzureAppGatewayAccount getOrCreateAccount(String name) {
+      if (!mappedAccounts[name]) {
+        mappedAccounts[name] = new AzureAppGatewayAccount(name:name)
+      }
+
+      mappedAccounts[name]
+    }
+  }
+
+  static class AzureAppGatewayAccount {
+    private Map<String, AzureAppGatewayAccountRegion> mappedRegions = [:]
+    String name
+
+    AzureAppGatewayAccountRegion getOrCreateRegion(String name) {
+      if (!mappedRegions[name]) {
+        mappedRegions[name] =  new AzureAppGatewayAccountRegion(name: name, loadBalancers: [])
+      }
+
+      mappedRegions[name];
+    }
+
+    @JsonProperty("regions")
+    List<AzureAppGatewayAccountRegion> getRegions() {
+      mappedRegions.values() as List
+    }
+
+  }
+
+  static class AzureAppGatewayAccountRegion {
+    String name
+    List<AzureAppGatewayAccountRegionDetail> loadBalancers = []
+  }
+
+  static class AzureAppGatewayAccountRegionDetail {
+    String type="azure"
+    String account
+    String region
+    String name
+  }
+}

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
@@ -25,6 +25,7 @@ class Keys {
     AZURE_SUBNETS,
     AZURE_NETWORKS,
     AZURE_LOAD_BALANCERS,
+    AZURE_APP_GATEWAYS,
     AZURE_APPLICATIONS,
     AZURE_CLUSTERS,
     AZURE_SERVER_GROUPS,
@@ -79,6 +80,15 @@ class Keys {
       case Namespace.AZURE_LOAD_BALANCERS.ns:
         def names = Names.parseName(parts[2])
         result << [application: names.app, name: parts[2], id: parts[3], cluster: parts[4], appname: parts[5], region: parts[6], account: parts[7]]
+        break
+      case Namespace.AZURE_APP_GATEWAYS.ns:
+        def names = Names.parseName(parts[2])
+        result << [
+          appname: names.app,
+          name:    parts[2],
+          region:  parts[3],
+          account: parts[4]
+        ]
         break
       case Namespace.AZURE_APPLICATIONS.ns:
         result << [application: parts[2].toLowerCase()]
@@ -230,6 +240,22 @@ class Keys {
                                    String region,
                                    String account) {
     "${azureCloudProviderId}:${Namespace.AZURE_LOAD_BALANCERS}:${loadBalancerName}:${loadBalancerId}:${cluster}:${application}:${region}:${account}"
+  }
+
+  static String getAppGatewayKey(AzureCloudProvider azureCloudProvider,
+                                 String appName,
+                                 String name,
+                                 String region,
+                                 String account) {
+    getAppGatewayKey(azureCloudProvider.id, appName, name, region, account)
+  }
+
+  static String getAppGatewayKey(String azureCloudProviderId,
+                                 String appName,
+                                 String name,
+                                 String region,
+                                 String account) {
+    "${azureCloudProviderId}:${Namespace.AZURE_APP_GATEWAYS}:${appName}:${name}:${region}:${account}"
   }
 
   static String getApplicationKey(AzureCloudProvider azureCloudProvider,

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancer.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancer.groovy
@@ -30,6 +30,7 @@ class AzureLoadBalancer implements LoadBalancer {
   String subnet
   String type = AZURE_LOAD_BALANCER_TYPE
   Set<LoadBalancerServerGroup> serverGroups = new HashSet<>()
+  String cluster
 
   private static final AZURE_LOAD_BALANCER_TYPE = "azure"
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -233,7 +233,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
             relationships[AZURE_LOAD_BALANCERS.ns].add(loadBalancerKey)
           }
 
-          creds.computeClient.getServerGroupInstances(AzureUtilities.getResourceGroupName(serverGroup), serverGroup.name).each { instance ->
+          creds.computeClient.getServerGroupInstances(AzureUtilities.getResourceGroupName(serverGroup), serverGroup.name)?.each { instance ->
             def instanceKey = Keys.getInstanceKey(azureCloudProvider, serverGroup.name, instance.name, region, accountName)
             cachedInstances[instanceKey].with {
               attributes.instance = instance

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
@@ -236,7 +236,7 @@ class AzureAppGatewayResourceTemplate {
     AppGatewayRequestRoutingRuleProperties properties
 
     AppGatewayRequestRoutingRule(String ruleName) {
-      name = "appGwRouting-" + ruleName
+      name = ruleName
       properties = new AppGatewayRequestRoutingRuleProperties(ruleName)
     }
 

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.deploy.converters
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.converters.UpsertAzureAppGatewayAtomicOperationConverter
+import com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Shared
+import spock.lang.Specification
+
+class UpsertAzureAppGatewayAtomicOperationConverterSpec extends  Specification{
+
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared UpsertAzureAppGatewayAtomicOperationConverter converter
+
+  def setupSpec() {
+    this.converter = new UpsertAzureAppGatewayAtomicOperationConverter(objectMapper: mapper)
+    def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    def mockCredentials = Mock(AzureNamedAccountCredentials)
+    accountCredentialsProvider.getCredentials(_) >> mockCredentials
+    converter.accountCredentialsProvider = accountCredentialsProvider
+  }
+
+  void "Create an AzureAppGatewayDescription from a given input"() {
+    setup:
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+    def input = [
+      name: "testappgw-lb1-d1",
+      loadBalancerName: "testappgw-lb1-d1",
+      region: "westus",
+      accountName: "myazure-account",
+      cloudProvider: "azure",
+      appName: "testappgw",
+      stack: "lb1",
+      detail: "d1",
+      probes: [
+        [
+          name: "healthcheck1",
+          protocol: "HTTP",
+          path: "/healthcheck",
+          interval: 120,
+          timeout: 30,
+          unhealthyThreshold: 8
+        ]
+      ],
+      rules: [
+        [
+          name: "lbRule1",
+          protocol: "HTTP",
+          externalPort: 80,
+          backendPort: 8080,
+        ],
+        [
+          name: "lbRule2",
+          protocol: "HTTP",
+          externalPort: 8080,
+          backendPort: 8080,
+        ]
+      ]
+    ]
+
+    when:
+    def description = converter.convertDescription(input)
+
+    then:
+    description instanceof AzureAppGatewayDescription
+    mapper.writeValueAsString(description) == expectedFullDescription
+  }
+
+  private static String expectedFullDescription = '''{
+  "name" : "testappgw-lb1-d1",
+  "cloudProvider" : "azure",
+  "accountName" : "myazure-account",
+  "appName" : "testappgw",
+  "stack" : "lb1",
+  "detail" : "d1",
+  "credentials" : null,
+  "region" : "westus",
+  "user" : null,
+  "createdTime" : null,
+  "lastReadTime" : 0,
+  "tags" : { },
+  "loadBalancerName" : "testappgw-lb1-d1",
+  "vnet" : null,
+  "subnet" : null,
+  "securityGroup" : null,
+  "dnsName" : null,
+  "cluster" : null,
+  "serverGroups" : null,
+  "probes" : [ {
+    "name" : "healthcheck1",
+    "protocol" : "HTTP",
+    "host" : "localhost",
+    "path" : "/healthcheck",
+    "interval" : 120,
+    "timeout" : 30,
+    "unhealthyThreshold" : 8
+  } ],
+  "rules" : [ {
+    "name" : "lbRule1",
+    "protocol" : "HTTP",
+    "externalPort" : 80,
+    "backendPort" : 8080,
+    "sslCertificate" : null
+  }, {
+    "name" : "lbRule2",
+    "protocol" : "HTTP",
+    "externalPort" : 8080,
+    "backendPort" : 8080,
+    "sslCertificate" : null
+  } ],
+  "sku" : "Standard_Small",
+  "tier" : "Standard",
+  "capacity" : 2
+}'''
+}

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/DeleteAzureAppGatewayAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/DeleteAzureAppGatewayAtomicOperationSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.deploy.ops
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.converters.DeleteAzureAppGatewayAtomicOperationConverter
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.DeleteAzureAppGatewayAtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DeleteAzureAppGatewayAtomicOperationSpec extends Specification{
+
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared DeleteAzureAppGatewayAtomicOperationConverter converter
+
+  def setupSpec() {
+    this.converter = new DeleteAzureAppGatewayAtomicOperationConverter(objectMapper: mapper)
+    def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    def mockCredentials = Mock(AzureNamedAccountCredentials)
+    accountCredentialsProvider.getCredentials(_) >> mockCredentials
+    converter.accountCredentialsProvider = accountCredentialsProvider
+  }
+
+  void "Create deleteAzureAppGatewayAtomicOperation object - simple test"() {
+    setup:
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+    def input = '''{ "cloudProvider" : "azure", "appName" : "testappgw", "loadBalancerName" : "testappgw-lb1-d1", "credentials" : "myazure-account", "region" : "westus", "name" : "testappgw-lb1-d1", "user" : "[anonymous]" }'''
+
+    when:
+    DeleteAzureAppGatewayAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
+    AzureAppGatewayDescription description = converter.convertDescription(mapper.readValue(input, Map))
+
+    then:
+    operation
+    mapper.writeValueAsString(description) == expectedFullDescription
+  }
+
+  private static String expectedFullDescription = '''{
+  "name" : "testappgw-lb1-d1",
+  "cloudProvider" : "azure",
+  "accountName" : "myazure-account",
+  "appName" : "testappgw",
+  "stack" : null,
+  "detail" : null,
+  "credentials" : null,
+  "region" : "westus",
+  "user" : "[anonymous]",
+  "createdTime" : null,
+  "lastReadTime" : 0,
+  "tags" : { },
+  "loadBalancerName" : "testappgw-lb1-d1",
+  "vnet" : null,
+  "subnet" : null,
+  "securityGroup" : null,
+  "dnsName" : null,
+  "cluster" : null,
+  "serverGroups" : null,
+  "probes" : [ ],
+  "rules" : [ ],
+  "sku" : "Standard_Small",
+  "tier" : "Standard",
+  "capacity" : 2
+}'''
+}

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/UpsertAzureAppGatewayAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/UpsertAzureAppGatewayAtomicOperationSpec.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.deploy.ops
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.converters.UpsertAzureAppGatewayAtomicOperationConverter
+import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.UpsertAzureAppGatewayAtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Shared
+import spock.lang.Specification
+
+class UpsertAzureAppGatewayAtomicOperationSpec extends Specification{
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared UpsertAzureAppGatewayAtomicOperationConverter converter
+
+  def setupSpec() {
+    this.converter = new UpsertAzureAppGatewayAtomicOperationConverter(objectMapper: mapper)
+    def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    def mockCredentials = Mock(AzureNamedAccountCredentials)
+    accountCredentialsProvider.getCredentials(_) >> mockCredentials
+    converter.accountCredentialsProvider = accountCredentialsProvider
+  }
+
+  void "Create UpsertAzureAppGatewayAtomicOperation object - simple test"() {
+    setup:
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+    def input = '''{ "cloudProvider" : "azure", "appName" : "testappgw", "loadBalancerName" : "testappgw-lb1-d1", "stack" : "lb1", "detail" : "d1", "credentials" : "myazure-account", "region" : "westus", "probes" : [ { "name" : "healthcheck1", "protocol" : "HTTP", "path" : "/healthcheck", "interval" : 120, "unhealthyThreshold" : 8, "timeout" : 30 } ], "rules" : [ { "name" : "lbRule1", "protocol" : "HTTP", "externalPort" : "80", "backendPort" : "8080" } ], "name" : "testappgw-lb1-d1", "user" : "[anonymous]" }'''
+
+    when:
+    UpsertAzureAppGatewayAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
+    AzureAppGatewayDescription description = converter.convertDescription(mapper.readValue(input, Map))
+
+    then:
+    operation
+    mapper.writeValueAsString(description) == expectedFullDescription
+  }
+
+  private static String expectedFullDescription = '''{
+  "name" : "testappgw-lb1-d1",
+  "cloudProvider" : "azure",
+  "accountName" : "myazure-account",
+  "appName" : "testappgw",
+  "stack" : "lb1",
+  "detail" : "d1",
+  "credentials" : null,
+  "region" : "westus",
+  "user" : "[anonymous]",
+  "createdTime" : null,
+  "lastReadTime" : 0,
+  "tags" : { },
+  "loadBalancerName" : "testappgw-lb1-d1",
+  "vnet" : null,
+  "subnet" : null,
+  "securityGroup" : null,
+  "dnsName" : null,
+  "cluster" : null,
+  "serverGroups" : null,
+  "probes" : [ {
+    "name" : "healthcheck1",
+    "protocol" : "HTTP",
+    "host" : "localhost",
+    "path" : "/healthcheck",
+    "interval" : 120,
+    "timeout" : 30,
+    "unhealthyThreshold" : 8
+  } ],
+  "rules" : [ {
+    "name" : "lbRule1",
+    "protocol" : "HTTP",
+    "externalPort" : 80,
+    "backendPort" : 8080,
+    "sslCertificate" : null
+  } ],
+  "sku" : "Standard_Small",
+  "tier" : "Standard",
+  "capacity" : 2
+}'''
+  }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/template/AzureAppGatewayResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/template/AzureAppGatewayResourceTemplateSpec.groovy
@@ -254,7 +254,7 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
         }
       } ],
       "requestRoutingRules" : [ {
-        "name" : "appGwRouting-rule1",
+        "name" : "rule1",
         "properties" : {
           "ruleType" : "Basic",
           "httpListener" : {
@@ -268,7 +268,7 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
           }
         }
       }, {
-        "name" : "appGwRouting-rule2",
+        "name" : "rule2",
         "properties" : {
           "ruleType" : "Basic",
           "httpListener" : {


### PR DESCRIPTION
Add Application Gateway ops (create, delete).
Add Application Gateway caching.
Add Application gateway viewing via new HTTP request mapping (see localhost:7002/azure/appgateways). Expect this to change once we have all the pieces in place to switch over to using application gateways instead of load balancers.
Fix regression: we were failing to create the vnet associated with a new resource group (app).
Various minor bug fixes: some operations can be expected to return null rather then an object that has a valid "body".