### PR TITLE
Adds option to attach application security group to server group on deploy.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -142,6 +142,7 @@ class AwsConfiguration {
     String classicLinkSecurityGroupName
     boolean addAppGroupsToClassicLink = false
     int maxClassicLinkSecurityGroups = 5
+    boolean addAppGroupToServerGroup = false
   }
 
   @Bean


### PR DESCRIPTION
To enable (disabled by default):
````yaml
aws:
  defaults:
    addAppGroupToServerGroup: true
````

This will add an existing security group or create a new empty security group matching the application name during a deploy operation to AWS.