### PR TITLE
provider/kubernetes: Cache clusters for both jobs & servergroups

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
@@ -67,10 +67,11 @@ class Keys {
       case Namespace.CLUSTERS.ns:
         def names = Names.parseName(parts[4])
         result << [
-            application: parts[3],
             account: parts[2],
-            name: parts[4],
-            cluster: parts[4],
+            application: parts[3],
+            category: parts[4], // <- {`serverGroup`, `job`, `daemonSet`, etc...}
+            name: parts[5],
+            cluster: parts[5],
             stack: names.stack,
             detail: names.detail
         ]
@@ -164,8 +165,8 @@ class Keys {
     "${Namespace.provider}:${Namespace.APPLICATIONS}:${application}"
   }
 
-  static String getClusterKey(String account, String application, String clusterName) {
-    "${Namespace.provider}:${Namespace.CLUSTERS}:${account}:${application}:${clusterName}"
+  static String getClusterKey(String account, String application, String category, String clusterName) {
+    "${Namespace.provider}:${Namespace.CLUSTERS}:${account}:${application}:${category}:${clusterName}"
   }
 
   static String getServerGroupKey(String account, String namespace, String replicationControllerName) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesJobCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesJobCachingAgent.groovy
@@ -44,6 +44,7 @@ class KubernetesJobCachingAgent implements CachingAgent, OnDemandAgent, AccountA
   final KubernetesCloudProvider kubernetesCloudProvider
   final String accountName
   final String namespace
+  final String category = 'job'
   final KubernetesCredentials credentials
   final ObjectMapper objectMapper
 
@@ -51,7 +52,7 @@ class KubernetesJobCachingAgent implements CachingAgent, OnDemandAgent, AccountA
 
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
     INFORMATIVE.forType(Keys.Namespace.APPLICATIONS.ns),
-    INFORMATIVE.forType(Keys.Namespace.CLUSTERS.ns),
+    AUTHORITATIVE.forType(Keys.Namespace.CLUSTERS.ns),
     INFORMATIVE.forType(Keys.Namespace.LOAD_BALANCERS.ns),
     AUTHORITATIVE.forType(Keys.Namespace.JOBS.ns),
     INFORMATIVE.forType(Keys.Namespace.PROCESSES.ns),
@@ -272,7 +273,7 @@ class KubernetesJobCachingAgent implements CachingAgent, OnDemandAgent, AccountA
 
         def jobKey = Keys.getJobKey(accountName, namespace, jobName)
         def applicationKey = Keys.getApplicationKey(applicationName)
-        def clusterKey = Keys.getClusterKey(accountName, applicationName, clusterName)
+        def clusterKey = Keys.getClusterKey(accountName, applicationName, category, clusterName)
         def processKeys = []
         def loadBalancerKeys = KubernetesUtil.getJobLoadBalancers(job).collect({
           Keys.getLoadBalancerKey(accountName, namespace, it)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -45,6 +45,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
   final KubernetesCloudProvider kubernetesCloudProvider
   final String accountName
   final String namespace
+  final String category = 'serverGroup'
   final KubernetesCredentials credentials
   final ObjectMapper objectMapper
 
@@ -273,7 +274,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
 
         def serverGroupKey = Keys.getServerGroupKey(accountName, namespace, replicationControllerName)
         def applicationKey = Keys.getApplicationKey(applicationName)
-        def clusterKey = Keys.getClusterKey(accountName, applicationName, clusterName)
+        def clusterKey = Keys.getClusterKey(accountName, applicationName, category, clusterName)
         def instanceKeys = []
         def loadBalancerKeys = KubernetesUtil.getDescriptionLoadBalancers(replicationController).collect({
           Keys.getLoadBalancerKey(accountName, namespace, it)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -75,7 +75,7 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
 
   @Override
   KubernetesCluster getCluster(String applicationName, String account, String name) {
-    CacheData cluster = cacheView.get(Keys.Namespace.CLUSTERS.ns, Keys.getClusterKey(account, applicationName, name))
+    CacheData cluster = cacheView.get(Keys.Namespace.CLUSTERS.ns, Keys.getClusterKey(account, applicationName, "*", name))
     cluster ? translateClusters([cluster], true)[0] : null
   }
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -67,7 +67,7 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
     kubernetesCredentials = new KubernetesCredentials(apiMock, [], [], accountCredentialsRepositoryMock)
 
     applicationKey = Keys.getApplicationKey(APP)
-    clusterKey = Keys.getClusterKey(ACCOUNT_NAME, APP, CLUSTER)
+    clusterKey = Keys.getClusterKey(ACCOUNT_NAME, APP, 'serverGroup', CLUSTER)
     serverGroupKey = Keys.getServerGroupKey(ACCOUNT_NAME, NAMESPACE, REPLICATION_CONTROLLER)
     instanceKey = Keys.getInstanceKey(ACCOUNT_NAME, NAMESPACE, REPLICATION_CONTROLLER, POD)
 


### PR DESCRIPTION
Since both jobs & server groups belong to (mutually exclusive) sets of clusters, the cache needs to reflect this. By making the cluster cache key in redis aware of whether the cluster owns server groups or jobs, both the server group and job caching agents can be authoritative for clusters in the same namespace.

@ttomsu PTAL.