### PR TITLE
provider/kubernetes: Fix error message for k8s on AWS toggle pods operation

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -196,7 +196,6 @@ class KubernetesApiAdaptor {
 
       edit.endMetadata().done()
     } catch (KubernetesClientException e) {
-      log.error("$e.stackTrace")
       throw new KubernetesOperationException("Toggle Pod Labels", e)
     }
   }
@@ -212,7 +211,6 @@ class KubernetesApiAdaptor {
 
       edit.endMetadata().endTemplate().endSpec().done()
     } catch (KubernetesClientException e) {
-      log.error("$e.stackTrace")
       throw new KubernetesOperationException("Toggle Replication Controller Labels", e)
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesConfigParser.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesConfigParser.groovy
@@ -52,7 +52,7 @@ class KubernetesConfigParser {
       config.setCaCertData(currentCluster.getCertificateAuthorityData())
 
       AuthInfo currentAuthInfo = KubeConfigUtils.getUserAuthInfo(kubeConfig, currentContext)
-        if (currentAuthInfo != null) {
+      if (currentAuthInfo != null) {
         config.setClientCertFile(currentAuthInfo.getClientCertificate())
         config.setClientCertData(currentAuthInfo.getClientCertificateData())
         config.setClientKeyFile(currentAuthInfo.getClientKey())
@@ -62,7 +62,7 @@ class KubernetesConfigParser {
         config.setPassword(currentAuthInfo.getPassword())
 
         config.getErrorMessages().put(401, "Unauthorized! Token may have expired! Please log-in again.")
-        config.getErrorMessages().put(403, "Forbidden! User ${config.getUsername()} doesn't have permission.")
+        config.getErrorMessages().put(403, "Forbidden! User ${currentContext.user} doesn't have permission.".toString())
       }
     }
 


### PR DESCRIPTION
This only fixes the error message "Cannot cast gstring to string" when toggling pod labels on for Kubernetes installations on AWS. The root cause is that the default credentials provided in kube/config don't seem to allow you to edit pods with the REST API, or there is a bug with the client library (since kubectl with the provided credentials work fine). I'm filing a bug with the client library to see where to go next. 