### PR TITLE
provider/kubernetes: Job instance health reporting

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesModelUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesModelUtil.groovy
@@ -27,10 +27,12 @@ class KubernetesModelUtil {
 
   static HealthState getHealthState(health) {
     someUpRemainingUnknown(health) ? HealthState.Up :
-        anyStarting(health) ? HealthState.Starting :
-            anyDown(health) ? HealthState.Down :
-                anyOutOfService(health) ? HealthState.OutOfService :
-                    HealthState.Unknown
+        someSucceededRemainingUnknown(health) ? HealthState.Succeeded :
+            anyStarting(health) ? HealthState.Starting :
+                anyDown(health) ? HealthState.Down :
+                    anyFailed(health) ? HealthState.Failed :
+                        anyOutOfService(health) ? HealthState.OutOfService :
+                            HealthState.Unknown
   }
 
   private static boolean anyDown(List<Map<String, String>> healthsList) {
@@ -42,8 +44,17 @@ class KubernetesModelUtil {
     knownHealthList ? knownHealthList.every { it.state == HealthState.Up.name() } : false
   }
 
+  private static boolean someSucceededRemainingUnknown(List<Map<String, String>> healthsList) {
+    List<Map<String, String>> knownHealthList = healthsList.findAll { it.state != HealthState.Unknown.name() }
+    knownHealthList ? knownHealthList.every { it.state == HealthState.Succeeded.name() } : false
+  }
+
   private static boolean anyStarting(List<Map<String, String>> healthsList) {
     healthsList.any { it.state == HealthState.Starting.name() }
+  }
+
+  private static boolean anyFailed(List<Map<String, String>> healthsList) {
+    healthsList.any { it.state == HealthState.Failed.name() }
   }
 
   private static boolean anyOutOfService(List<Map<String, String>> healthsList) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
@@ -43,7 +43,10 @@ class KubernetesInstanceProvider implements InstanceProvider<KubernetesInstance>
   KubernetesInstance getInstance(String account, String namespace, String name) {
     Set<CacheData> instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.INSTANCES.ns, Keys.getInstanceKey(account, namespace, "*", name))
     if (!instances || instances.size() == 0) {
-      return null
+      instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.PROCESSES.ns, Keys.getProcessKey(account, namespace, "*", name))
+      if (!instances || instances.size() == 0) {
+        return null
+      }
     }
 
     if (instances.size() > 1) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
@@ -18,14 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.model
 
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.model.HealthState
-import io.fabric8.kubernetes.api.model.ContainerState
-import io.fabric8.kubernetes.api.model.ContainerStateRunning
-import io.fabric8.kubernetes.api.model.ContainerStateTerminated
-import io.fabric8.kubernetes.api.model.ContainerStateWaiting
-import io.fabric8.kubernetes.api.model.ContainerStatus
-import io.fabric8.kubernetes.api.model.ObjectMeta
-import io.fabric8.kubernetes.api.model.Pod
-import io.fabric8.kubernetes.api.model.PodStatus
+import io.fabric8.kubernetes.api.model.*
 import spock.lang.Specification
 
 class KubernetesInstanceSpec extends Specification {
@@ -105,12 +98,6 @@ class KubernetesInstanceSpec extends Specification {
 
     then:
       state == HealthState.Starting
-
-    when:
-      state = (new KubernetesHealth('', containerStatusAsNoneMock)).state
-
-    then:
-      state == HealthState.Starting
   }
 
   void "Should report state as Up"() {
@@ -119,6 +106,14 @@ class KubernetesInstanceSpec extends Specification {
 
     then:
       state == HealthState.Up
+  }
+
+  void "Should report state as Unknown"() {
+    when:
+      def state = (new KubernetesHealth('', containerStatusAsNoneMock)).state
+
+    then:
+      state == HealthState.Unknown
   }
 
   void "Should report pod state as Up"() {


### PR DESCRIPTION
Correctly report `KubernetesContainer` type health checks for jobs (including succeeding & failing instances).

@duftler 