### PR TITLE
(aws) relax app security group lookup

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -143,6 +143,7 @@ class AwsConfiguration {
     boolean addAppGroupsToClassicLink = false
     int maxClassicLinkSecurityGroups = 5
     boolean addAppGroupToServerGroup = false
+    int maxSecurityGroups = 5
   }
 
   @Bean

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/SecurityGroupService.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/SecurityGroupService.groovy
@@ -100,4 +100,19 @@ class SecurityGroupService {
     result.groupId
   }
 
+  Map<String, String> getSecurityGroupNamesFromIds(Collection<String> securityGroupIds) {
+    if (!securityGroupIds) {
+      return [:]
+    }
+    def groupIds = new HashSet<>(securityGroupIds)
+    def groups = amazonEC2.describeSecurityGroups(new DescribeSecurityGroupsRequest().withGroupIds(groupIds)).securityGroups
+    if (groups.size() != groupIds.size()) {
+      def missing = groupIds.findAll { id -> !groups.find { it.groupId == id }}
+      throw new SecurityGroupNotFoundException("Failed to find groups ${missing}")
+    }
+    return groups.collectEntries {
+      [(it.groupName): it.groupId]
+    } ?: [:]
+  }
+
 }


### PR DESCRIPTION
if any specified group name contains the application name, consider that acceptable for addAppGroupToServerGroup
if adding an app group is necessary, but doing so would exceed the maximum number of groups, fail the request

@spinnaker/netflix-reviewers PTAL