### PR TITLE
provider/kubernetes: merge server group & job cluster

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesCluster.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesCluster.groovy
@@ -29,5 +29,6 @@ class KubernetesCluster implements Cluster, Serializable {
   String accountName
   Set<KubernetesServerGroup> serverGroups = Collections.synchronizedSet(new HashSet<KubernetesServerGroup>())
   Set<KubernetesLoadBalancer> loadBalancers = Collections.synchronizedSet(new HashSet<KubernetesLoadBalancer>())
+  Set<KubernetesJob> jobs = Collections.synchronizedSet(new HashSet<KubernetesJob>())
 }
 


### PR DESCRIPTION
When returning a single cluster from the cluster endpoint, we should merge the jobs & server groups inside that cluster rather than arbitrarily return one of the two clusters.

@duftler 