### PR TITLE
Use Azure Application Gateway as a Load Balancer

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -177,10 +177,16 @@ public class AzureComputeClient extends AzureBaseClient {
     null
   }
 
+  /**
+   * It deletes a given server group 
+   * @param resourceGroupName - name of the resource group
+   * @param serverGroupName - name of the server group
+   * @return a ServiceResponse object
+   */
   ServiceResponse<Void> destroyServerGroup(String resourceGroupName, String serverGroupName) {
 
     deleteAzureResource(
-      getScaleSetOps().&delete,
+      scaleSetOps.&delete,
       resourceGroupName,
       serverGroupName,
       null,
@@ -189,7 +195,7 @@ public class AzureComputeClient extends AzureBaseClient {
     )
   }
 
-  ServiceResponse<Void> disableServerGroup(String resourceGroupName, String serverGroupName) {
+  ServiceResponse<Void> powerOffServerGroup(String resourceGroupName, String serverGroupName) {
 
     List<String> instanceIds = this.getServerGroupInstances(resourceGroupName,serverGroupName)?.collect {it.resourceId}
 
@@ -199,7 +205,7 @@ public class AzureComputeClient extends AzureBaseClient {
     //ops.deallocate(resourceGroupName, serverGroupName, instanceIds)
   }
 
-  ServiceResponse<Void> enableServerGroup(String resourceGroupName, String serverGroupName) {
+  ServiceResponse<Void> powerOnServerGroup(String resourceGroupName, String serverGroupName) {
 
     List<String> instanceIds = this.getServerGroupInstances(resourceGroupName,serverGroupName)?.collect {it.resourceId}
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -178,7 +178,7 @@ public class AzureComputeClient extends AzureBaseClient {
   }
 
   /**
-   * It deletes a given server group 
+   * It deletes a given server group
    * @param resourceGroupName - name of the resource group
    * @param serverGroupName - name of the server group
    * @return a ServiceResponse object
@@ -193,23 +193,6 @@ public class AzureComputeClient extends AzureBaseClient {
       "Delete Server Group ${serverGroupName}",
       "Failed to delete Server Group ${serverGroupName} in ${resourceGroupName}"
     )
-  }
-
-  ServiceResponse<Void> powerOffServerGroup(String resourceGroupName, String serverGroupName) {
-
-    List<String> instanceIds = this.getServerGroupInstances(resourceGroupName,serverGroupName)?.collect {it.resourceId}
-
-    scaleSetOps.powerOff(resourceGroupName, serverGroupName, instanceIds)
-
-    // TODO: investigate if we can deallocate the VMs
-    //ops.deallocate(resourceGroupName, serverGroupName, instanceIds)
-  }
-
-  ServiceResponse<Void> powerOnServerGroup(String resourceGroupName, String serverGroupName) {
-
-    List<String> instanceIds = this.getServerGroupInstances(resourceGroupName,serverGroupName)?.collect {it.resourceId}
-
-    scaleSetOps.start(resourceGroupName, serverGroupName, instanceIds)
   }
 
   /**

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/DeleteAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/DeleteAzureAppGatewayAtomicOperation.groovy
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
 
 class DeleteAzureAppGatewayAtomicOperation implements AtomicOperation<Void> {
   private static final String BASE_PHASE = "DELETE_APP_GATEWAY"
-  // TODO: change this later to the real thing, DELETE_LOAD_BALANCER
+  // TODO: we change this later to be the Spinnaker load balancer
   // private static final String BASE_PHASE = "DELETE_LOAD_BALANCER"
 
   private static Task getTask() {
@@ -39,9 +39,6 @@ class DeleteAzureAppGatewayAtomicOperation implements AtomicOperation<Void> {
   }
 
   /**
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "deleteAppGateway": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "credentials" : "azure-cred1", "region" : "westus", "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
-   *
-   * TODO: change ops task name to deleteLoadBalancer:
    * curl -X POST -H "Content-Type: application/json" -d '[ { "deleteLoadBalancer": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "credentials" : "azure-cred1", "region" : "westus", "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
    *
    * @param priorOutputs

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
@@ -29,7 +29,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
 
 class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
   private static final String BASE_PHASE = "UPSERT_APP_GATEWAY"
-  // TODO: change this later to the real thing, UPSERT_LOAD_BALANCER
+  // TODO: we change this later to be the Spinnaker load balancer
   // private static final String BASE_PHASE = "UPSERT_LOAD_BALANCER"
 
   private static Task getTask() {
@@ -43,10 +43,7 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
   }
 
   /**
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertAppGateway": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "stack" : "st1", "detail" : "d1", "credentials" : "azure-cred1", "region" : "westus", "probes" : [ { "name" : "healthcheck1", "protocol" : "HTTP", "path" : "/healthcheck", "interval" : 120, "unhealthyThreshold" : 8, "timeout" : 30 } ], "rules" : [ { "name" : "lbRule1", "protocol" : "HTTP", "externalPort" : "80", "backendPort" : "8080" }, { "name" : "lbRule2", "protocol" : "HTTP", "externalPort" : "8080", "backendPort" : "8080" } ], "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
-   *
-   * TODO: change ops task name to upserLoadBalancer:
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertLoadBalancer": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "stack" : "st1", "detail" : "d1", "credentials" : "azure-cred1", "region" : "westus", "probes" : [ { "name" : "healthcheck1", "protocol" : "HTTP", "path" : "/healthcheck", "interval" : 120, "unhealthyThreshold" : 8, "timeout" : 30 } ], "rules" : [ { "name" : "lbRule1", "protocol" : "HTTP", "externalPort" : "80", "backendPort" : "8080" }, { "name" : "lbRule2", "protocol" : "HTTP", "externalPort" : "8080", "backendPort" : "8080" } ], "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertLoadBalancer": { "cloudProvider" : "azure", "appName" : "tappgw1", "loadBalancerName" : "tappgw1-st1-d1", "stack" : "st1", "detail" : "d1", "credentials" : "azure-cred1", "region" : "westus", "probes" : [ { "probeName" : "healthcheck1", "probeProtocol" : "HTTP", "probePort" : "www.bing.com", "probePath" : "/", "probeInterval" : 120, "unhealthyThreshold" : 8, "timeout" : 30 } ], "rules" : [ { "ruleName" : "lbRule1", "protocol" : "HTTP", "externalPort" : "80", "backendPort" : "8080" }, { "ruleName" : "lbRule2", "protocol" : "HTTP", "externalPort" : "8080", "backendPort" : "8080" } ], "name" : "tappgw1-st1-d1", "user" : "[anonymous]" }} ]' localhost:7002/azure/ops
    *
    * @param priorOutputs
    * @return
@@ -69,40 +66,20 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
       resourceGroupName = AzureUtilities.getResourceGroupName(description.appName, description.region)
       virtualNetworkName = AzureUtilities.getVirtualNetworkName(resourceGroupName)
 
-      description.credentials.resourceManagerClient.initializeResourceGroupAndVNet(description.credentials, resourceGroupName, virtualNetworkName, description.region)
+      // Check if we are executing an edit operation on an existing application gateway (it returns null if it does not exist)
+      // def appGatewayDescription = description.credentials.networkClient.editAppGateway(description)
+      def appGatewayDescription = description.credentials.networkClient.getAppGateway(resourceGroupName, description.name)
 
-      // TODO We just try to grab the next subnet, which fails if the largest possible subnet is already taken.
-      // TODO We also just assume that a vnet can only have one address range.
-      task.updateStatus(BASE_PHASE, "Creating subnet for application gateway")
-      def vnet = description.credentials.networkClient.getVirtualNetwork(resourceGroupName, virtualNetworkName)
-      if (vnet.addressSpace.addressPrefixes.size() != 1) {
-        throw new RuntimeException(
-          "Virtual Network found with ${vnet.addressSpace.addressPrefixes.size()} address spaces; expected: 1")
-      }
+      if (appGatewayDescription) {
+        // We are executing an edit operation on an existing application gateway; update application gateway using a template deployment
+        task.updateStatus(BASE_PHASE, "Update existing application gateway ${appGatewayDescription.loadBalancerName} in ${appGatewayDescription.region}...")
 
-      String vnetPrefix = vnet.addressSpace.addressPrefixes[0]
-      String subnetPrefix = null
-      if (vnet.subnets.size() > 0) {
-        subnetPrefix = vnet.subnets.max({ a, b -> AzureUtilities.compareIpv4AddrPrefixes(a.addressPrefix, b.addressPrefix) }).addressPrefix
-      }
+        // We need to retain some of the settings from the current application gateway
+        description.publicIpId = appGatewayDescription.publicIpId
+        description.subnet = appGatewayDescription.subnet
+        description.serverGroups = appGatewayDescription.serverGroups
+        description.trafficEnabledSG = appGatewayDescription.trafficEnabledSG
 
-      String nextSubnet = AzureUtilities.getNextSubnet(vnetPrefix, subnetPrefix)
-      subnetName = AzureUtilities.getSubnetName(virtualNetworkName, nextSubnet)
-
-      task.updateStatus(BASE_PHASE, "Creating new subnet ${subnetName} for ${description.loadBalancerName}")
-      String subnetId = description.credentials.networkClient.createSubnet(resourceGroupName,
-        virtualNetworkName,
-        subnetName,
-        nextSubnet,
-        description.securityGroup)
-
-      if(!subnetId) {
-        task.updateStatus(BASE_PHASE, "Failed to create subnet for Application Gateway ${description.name}")
-      } else {
-        description.vnet = virtualNetworkName
-        description.subnet = AzureUtilities.getNameFromResourceId(subnetId)
-
-        task.updateStatus(BASE_PHASE, "Create new application gateway ${description.loadBalancerName} in ${description.region}...")
         DeploymentExtended deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(description.credentials,
           AzureAppGatewayResourceTemplate.getTemplate(description),
           resourceGroupName,
@@ -111,7 +88,52 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
           "appGateway")
 
         errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name)
-        loadBalancerName = description.name
+      } else {
+        // We are attempting to create a new application gateway
+        description.credentials.resourceManagerClient.initializeResourceGroupAndVNet(description.credentials, resourceGroupName, virtualNetworkName, description.region)
+
+        // TODO We just try to grab the next subnet, which fails if the largest possible subnet is already taken.
+        // TODO We also just assume that a vnet can only have one address range.
+        task.updateStatus(BASE_PHASE, "Creating subnet for application gateway")
+        def vnet = description.credentials.networkClient.getVirtualNetwork(resourceGroupName, virtualNetworkName)
+        if (vnet.addressSpace.addressPrefixes.size() != 1) {
+          throw new RuntimeException(
+            "Virtual Network found with ${vnet.addressSpace.addressPrefixes.size()} address spaces; expected: 1")
+        }
+
+        String vnetPrefix = vnet.addressSpace.addressPrefixes[0]
+        String subnetPrefix = null
+        if (vnet.subnets.size() > 0) {
+          subnetPrefix = vnet.subnets.max({ a, b -> AzureUtilities.compareIpv4AddrPrefixes(a.addressPrefix, b.addressPrefix) }).addressPrefix
+        }
+
+        String nextSubnet = AzureUtilities.getNextSubnet(vnetPrefix, subnetPrefix)
+        subnetName = AzureUtilities.getSubnetName(virtualNetworkName, nextSubnet)
+
+        task.updateStatus(BASE_PHASE, "Creating new subnet ${subnetName} for ${description.loadBalancerName}")
+        def subnetId = description.credentials.networkClient.createSubnet(resourceGroupName,
+          virtualNetworkName,
+          subnetName,
+          nextSubnet,
+          description.securityGroup)
+
+        if (!subnetId) {
+          task.updateStatus(BASE_PHASE, "Failed to create subnet for Application Gateway ${description.name}")
+        } else {
+          description.vnet = virtualNetworkName
+          description.subnet = AzureUtilities.getNameFromResourceId(subnetId)
+
+          task.updateStatus(BASE_PHASE, "Create new application gateway ${description.loadBalancerName} in ${description.region}...")
+          DeploymentExtended deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(description.credentials,
+            AzureAppGatewayResourceTemplate.getTemplate(description),
+            resourceGroupName,
+            description.region,
+            description.loadBalancerName,
+            "appGateway")
+
+          errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name)
+          loadBalancerName = description.name
+        }
       }
     } catch (CloudException ce) {
       task.updateStatus(BASE_PHASE, "One or more deployment operations have failed. Please see Azure portal for more information. Resource Group: ${resourceGroupName} Application Gateway: ${description.loadBalancerName}")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/converters/DeleteAzureAppGatewayAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/converters/DeleteAzureAppGatewayAtomicOperationConverter.groovy
@@ -21,14 +21,13 @@ import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConver
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.DeleteAzureAppGatewayAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 @Slf4j
-@AzureOperation("deleteAppGateway")
-// TODO: change operation type to AtomicOperations.DELETE_LOAD_BALANCER after we retire AzureLoadBalancer
-//@AzureOperation(AtomicOperations.DELETE_LOAD_BALANCER)
+@AzureOperation(AtomicOperations.DELETE_LOAD_BALANCER)
 @Component("deleteAzureAppGatewayDescription")
 class DeleteAzureAppGatewayAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   DeleteAzureAppGatewayAtomicOperationConverter() {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/converters/UpsertAzureAppGatewayAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/converters/UpsertAzureAppGatewayAtomicOperationConverter.groovy
@@ -21,14 +21,13 @@ import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConver
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.UpsertAzureAppGatewayAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 @Slf4j
-@AzureOperation("upsertAppGateway")
-// TODO: change operation type to AtomicOperations.UPSERT_LOAD_BALANCER after we retire AzureLoadBalancer
-//@AzureOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
+@AzureOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
 @Component("upsertAzureAppGatewayDescription")
 class UpsertAzureAppGatewayAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   UpsertAzureAppGatewayAtomicOperationConverter() {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/DeleteAzureAppGatewayAtomicOperationValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/DeleteAzureAppGatewayAtomicOperationValidator.groovy
@@ -39,13 +39,12 @@ class DeleteAzureAppGatewayAtomicOperationValidator extends
     helper.validateRegion(description.region)
     helper.validateName(description.loadBalancerName, "loadBalancerName")
     helper.validateName(description.appName, "appName")
-    if (!ValidateNoServerGroupsAttached(description.appName, description.loadBalancerName)) {
+    if (!ValidateNoServerGroupsAttached(description)) {
       errors.rejectValue "serverGroups", "deleteAzureAppGatewayDescriptionValidator.serverGroupsList.not_empty"
     }
   }
 
-  static Boolean ValidateNoServerGroupsAttached(String appName, String appGateway) {
-    // TODO: Implement real check
-    return true
+  static Boolean ValidateNoServerGroupsAttached(AzureAppGatewayDescription appGatewayDescription) {
+    !appGatewayDescription?.cluster && !appGatewayDescription?.serverGroups
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/UpsertAzureAppGatewayAtomicOperationValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/UpsertAzureAppGatewayAtomicOperationValidator.groovy
@@ -42,13 +42,13 @@ class UpsertAzureAppGatewayAtomicOperationValidator extends
     helper.validateRegion(description.region)
     helper.validateName(description.loadBalancerName, "loadBalancerName")
     helper.validateName(description.appName, "appName")
-    description.rules?.each { rule ->
+    description.loadBalancingRules?.each { rule ->
       if(!SUPPORTED_IP_PROTOCOLS.contains(rule.protocol.toString().toUpperCase())) {
         errors.rejectValue "protocolType", "upsertAzureAppGatewayDescriptionValidator.rule.protocolType.not_supported"
       }
     }
     description.probes?.each { probe ->
-      if(!SUPPORTED_PROBE_PROTOCOLS.contains(probe.protocol.toString().toUpperCase())) {
+      if(!SUPPORTED_PROBE_PROTOCOLS.contains(probe.probeProtocol.toString().toUpperCase())) {
         errors.rejectValue "protocolType", "upsertAzureAppGatewayDescriptionValidator.probe.protocolType.not_supported"
       }
     }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayController.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayController.groovy
@@ -19,8 +19,6 @@ package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.view
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
-import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
-import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.view.AzureLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.PathVariable
@@ -29,7 +27,7 @@ import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/azure/appGateways")
+@RequestMapping("/azure/loadBalancers")
 class AzureAppGatewayController {
 
   @Autowired
@@ -81,7 +79,7 @@ class AzureAppGatewayController {
       lbDetail.dnsName = description.dnsName ?: "dnsname-unassigned"
 
       lbDetail.probes = description.probes
-      lbDetail.loadBalancingRules = description.rules
+      lbDetail.loadBalancingRules = description.loadBalancingRules
       lbDetail.tags = description.tags
 
       lbDetail.sku = description.sku

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/cluster/view/AzureClusterProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/cluster/view/AzureClusterProvider.groovy
@@ -122,7 +122,7 @@ class AzureClusterProvider implements ClusterProvider<AzureCluster> {
     Map<String, AzureServerGroupDescription> serverGroups
 
     if (includeDetails) {
-      Collection<CacheData> allLoadBalancers = resolveRelationshipDataForCollection(clusterData, AZURE_LOAD_BALANCERS.ns)
+      Collection<CacheData> allLoadBalancers = resolveRelationshipDataForCollection(clusterData, AZURE_APP_GATEWAYS.ns)
       Collection<CacheData> allServerGroups = resolveRelationshipDataForCollection(clusterData, AZURE_SERVER_GROUPS.ns, RelationshipCacheFilter.include(AZURE_INSTANCES.ns))
 
       loadBalancers = translateLoadBalancers(allLoadBalancers)
@@ -136,14 +136,14 @@ class AzureClusterProvider implements ClusterProvider<AzureCluster> {
       cluster.accountName = clusterKey.account
       cluster.name = clusterKey.name
       if (includeDetails) {
-        cluster.loadBalancers = clusterDataEntry.relationships[AZURE_LOAD_BALANCERS.ns]?.findResults {
+        cluster.loadBalancers = clusterDataEntry.relationships[AZURE_APP_GATEWAYS.ns]?.findResults {
           loadBalancers.get(it)
         }
         cluster.serverGroups = clusterDataEntry.relationships[AZURE_SERVER_GROUPS.ns]?.findResults {
           serverGroups.get(it)
         }
       } else {
-        cluster.loadBalancers = clusterDataEntry.relationships[AZURE_LOAD_BALANCERS.ns]?.collect { loadBalancerKey ->
+        cluster.loadBalancers = clusterDataEntry.relationships[AZURE_APP_GATEWAYS.ns]?.collect { loadBalancerKey ->
           Map parts = Keys.parse(azureCloudProvider, loadBalancerKey)
           new AzureLoadBalancer(name: parts.name, region: parts.region, account: parts.account)
         }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
@@ -82,12 +82,12 @@ class Keys {
         result << [application: names.app, name: parts[2], id: parts[3], cluster: parts[4], appname: parts[5], region: parts[6], account: parts[7]]
         break
       case Namespace.AZURE_APP_GATEWAYS.ns:
-        def names = Names.parseName(parts[2])
+        def names = Names.parseName(parts[3])
         result << [
           appname: names.app,
-          name:    parts[2],
-          region:  parts[3],
-          account: parts[4]
+          name:    parts[3],
+          region:  parts[4],
+          account: parts[5]
         ]
         break
       case Namespace.AZURE_APPLICATIONS.ns:

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
@@ -89,39 +89,39 @@ class AzureLoadBalancerDescription extends AzureResourceOpsDescription {
     description.region = azureLoadBalancer.location
 
     for (def rule : azureLoadBalancer.loadBalancingRules) {
-      def r = new AzureLoadBalancerDescription.AzureLoadBalancingRule(ruleName: rule.name)
+      def r = new AzureLoadBalancingRule(ruleName: rule.name)
       r.externalPort = rule.frontendPort
       r.backendPort = rule.backendPort
-      r.probeName = AzureUtilities.getNameFromResourceId(rule.probe.id)
+      r.probeName = AzureUtilities.getNameFromResourceId(rule?.probe?.id) ?: "not-assigned"
       r.persistence = rule.loadDistribution;
       r.idleTimeout = rule.idleTimeoutInMinutes;
 
       if (rule.protocol.toLowerCase() == "udp") {
-        r.protocol = AzureLoadBalancerDescription.AzureLoadBalancingRule.AzureLoadBalancingRulesType.UDP
+        r.protocol = AzureLoadBalancingRule.AzureLoadBalancingRulesType.UDP
       } else {
-        r.protocol = AzureLoadBalancerDescription.AzureLoadBalancingRule.AzureLoadBalancingRulesType.TCP
+        r.protocol = AzureLoadBalancingRule.AzureLoadBalancingRulesType.TCP
       }
       description.loadBalancingRules.add(r)
     }
 
     // Add the probes
     for (def probe : azureLoadBalancer.probes) {
-      def p = new AzureLoadBalancerDescription.AzureLoadBalancerProbe()
+      def p = new AzureLoadBalancerProbe()
       p.probeName = probe.name
       p.probeInterval = probe.intervalInSeconds
       p.probePath = probe.requestPath
       p.probePort = probe.port
       p.unhealthyThreshold = probe.numberOfProbes
       if (probe.protocol.toLowerCase() == "tcp") {
-        p.probeProtocol = AzureLoadBalancerDescription.AzureLoadBalancerProbe.AzureLoadBalancerProbesType.TCP
+        p.probeProtocol = AzureLoadBalancerProbe.AzureLoadBalancerProbesType.TCP
       } else {
-        p.probeProtocol = AzureLoadBalancerDescription.AzureLoadBalancerProbe.AzureLoadBalancerProbesType.HTTP
+        p.probeProtocol = AzureLoadBalancerProbe.AzureLoadBalancerProbesType.HTTP
       }
       description.probes.add(p)
     }
 
     for (def natRule : azureLoadBalancer.inboundNatRules) {
-      def n = new AzureLoadBalancerDescription.AzureLoadBalancerInboundNATRule(ruleName: natRule.name)
+      def n = new AzureLoadBalancerInboundNATRule(ruleName: natRule.name)
       description.inboundNATRules.add(n)
     }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/DeleteAzureLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/DeleteAzureLoadBalancerAtomicOperationConverter.groovy
@@ -27,7 +27,8 @@ import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 @Slf4j
-@AzureOperation(AtomicOperations.DELETE_LOAD_BALANCER)
+@AzureOperation("deleteLoadBalancerL4")
+//@AzureOperation(AtomicOperations.DELETE_LOAD_BALANCER)
 @Component("deleteAzureLoadBalancerDescription")
 class DeleteAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   public DeleteAzureLoadBalancerAtomicOperationConverter() {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/UpsertAzureLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/converters/UpsertAzureLoadBalancerAtomicOperationConverter.groovy
@@ -27,7 +27,8 @@ import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 @Slf4j
-@AzureOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
+@AzureOperation("upsertLoadBalancerL4")
+//@AzureOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
 @Component("upsertAzureLoadBalancerDescription")
 class UpsertAzureLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   UpsertAzureLoadBalancerAtomicOperationConverter() {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerController.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerController.groovy
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/azure/loadBalancers")
+@RequestMapping("/azure/loadBalancersL4")
 class AzureLoadBalancerController {
 
   @Autowired

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
@@ -24,13 +24,17 @@ import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.azure.resources.common.cache.Keys
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancer
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
-import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
 
+@RestController
 @Component
-class AzureLoadBalancerProvider implements LoadBalancerProvider<AzureLoadBalancer> {
+class AzureLoadBalancerProvider /*implements LoadBalancerProvider<AzureLoadBalancer> */ {
 
   private final AzureCloudProvider azureCloudProvider
   private final Cache cacheView
@@ -52,8 +56,9 @@ class AzureLoadBalancerProvider implements LoadBalancerProvider<AzureLoadBalance
    *         for each server group: its name, region, and *only* the instances attached to the load balancers described above.
    *         The instances will have a minimal amount of data, as well: name, zone, and health related to any load balancers
    */
-  @Override
-  Set<AzureLoadBalancer> getApplicationLoadBalancers(String application) {
+//  @Override
+  @RequestMapping(value = "/applications/{application}/loadBalancersL4", method = RequestMethod.GET)
+  Set<AzureLoadBalancer> getApplicationLoadBalancers(@PathVariable String application) {
     getAllMatchingKeyPattern(Keys.getLoadBalancerKey(azureCloudProvider, '*', '*', application, '*', '*', '*'))
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
@@ -242,7 +242,7 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
       }
     }
 
-    return new DefaultCacheResult([(Keys.Namespace.AZURE_LOAD_BALANCERS.ns): []])
+    return new DefaultCacheResult([(Keys.Namespace.AZURE_APP_GATEWAYS.ns): []])
   }
 
   // Update current cache only if the current entry is a new OnDemand request or if the current entry is more recent

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -215,7 +215,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
             attributes.name = serverGroup.appName
             relationships[AZURE_CLUSTERS.ns].add(clusterKey)
             relationships[AZURE_SERVER_GROUPS.ns].add(serverGroupKey)
-            relationships[AZURE_LOAD_BALANCERS.ns].add(loadBalancerKey)
+            relationships[AZURE_APP_GATEWAYS.ns].add(loadBalancerKey)
           }
 
           cachedClusters[clusterKey].with {
@@ -223,14 +223,14 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
             attributes.accountName = accountName
             relationships[AZURE_APPLICATIONS.ns].add(appKey)
             relationships[AZURE_SERVER_GROUPS.ns].add(serverGroupKey)
-            relationships[AZURE_LOAD_BALANCERS.ns].add(loadBalancerKey)
+            relationships[AZURE_APP_GATEWAYS.ns].add(loadBalancerKey)
           }
 
           cachedServerGroups[serverGroupKey].with {
             attributes.serverGroup = serverGroup
             relationships[AZURE_APPLICATIONS.ns].add(appKey)
             relationships[AZURE_CLUSTERS.ns].add(clusterKey)
-            relationships[AZURE_LOAD_BALANCERS.ns].add(loadBalancerKey)
+            relationships[AZURE_APP_GATEWAYS.ns].add(loadBalancerKey)
           }
 
           creds.computeClient.getServerGroupInstances(AzureUtilities.getResourceGroupName(serverGroup), serverGroup.name)?.each { instance ->

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -45,6 +45,8 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
 
   UpgradePolicy upgradePolicy
   String loadBalancerName
+  String appGatewayName
+  String appGatewayBapId
   AzureSecurityGroup securityGroup
   AzureNamedImage image
   AzureScaleSetSku sku
@@ -137,6 +139,9 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
     azureSG.clusterName = scaleSet.tags?.cluster ?: parsedName.cluster
     azureSG.securityGroupName = scaleSet.tags?.securityGroupName
     azureSG.loadBalancerName = scaleSet.tags?.loadBalancerName
+    azureSG.appGatewayName = scaleSet.tags?.appGatewayName
+    azureSG.appGatewayBapId = scaleSet.tags?.appGatewayBapId
+    // TODO: appGatewayBapId can be retrieved via scaleSet->networkProfile->networkInterfaceConfigurations->ipConfigurations->ApplicationGatewayBackendAddressPools
     azureSG.subnetId = scaleSet.tags?.subnetId
     azureSG.createdTime = scaleSet.tags?.createdTime?.toLong()
     azureSG.image = new AzureNamedImage( isCustom:  scaleSet.tags?.customImage, imageName: scaleSet.tags?.imageName)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
@@ -39,7 +39,7 @@ class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   /**
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "destroyServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/ops
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "destroyServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/azure/ops
    */
   @Override
   Void operate(List priorOutputs) {
@@ -78,6 +78,11 @@ class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
 
         // Clean-up the storrage account, load balancer and the subnet that where attached to the server group
         if (errList.isEmpty()) {
+          // Remove association between server group and the assigned application gateway backend address pool
+          description
+            .credentials
+            .networkClient
+            .removeAppGatewayBAPforServerGroup(resourceGroupName, description.appGatewayName, description.name)
 
           // Delete storage accounts if any
           serverGroupDescription.storageAccountNames?.each { def storageAccountName ->

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DisableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DisableAzureServerGroupAtomicOperation.groovy
@@ -39,7 +39,7 @@ class DisableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   /**
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "disableServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/ops
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "disableServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/azure/ops
    */
   @Override
   Void operate(List priorOutputs) {
@@ -67,10 +67,10 @@ class DisableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
         try {
           description
             .credentials
-            .computeClient
-            .disableServerGroup(resourceGroupName, description.name)
+            .networkClient
+            .disableServerGroup(resourceGroupName,serverGroupDescription.appGatewayName, serverGroupDescription.name)
 
-          task.updateStatus BASE_PHASE, "Done disabling Azure server group ${description.name} in ${region}."
+          task.updateStatus BASE_PHASE, "Done disabling Azure server group ${serverGroupDescription.name} in ${region}."
         } catch (Exception e) {
           task.updateStatus(BASE_PHASE, "Disabling of server group ${description.name} failed: ${e.message}")
           errList.add("Failed to disable server group ${description.name}: ${e.message}")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.Enabl
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
 
 class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
-  private static final String BASE_PHASE = "DISABLE_SERVER_GROUP"
+  private static final String BASE_PHASE = "ENABLE_SERVER_GROUP"
 
   private static Task getTask() {
     TaskRepository.threadLocalTask.get()
@@ -39,7 +39,7 @@ class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   /**
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "enableServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/ops
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "enableServerGroup": { "serverGroupName": "taz-web1-d1-v000", "name": "taz-web1-d1-v000", "account" : "azure-cred1", "cloudProvider" : "azure", "appName" : "taz", "regions": ["westus"], "credentials": "azure-cred1" }} ]' localhost:7002/azure/ops
    */
   @Override
   Void operate(List priorOutputs) {
@@ -67,10 +67,9 @@ class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
         try {
           description
             .credentials
-            .computeClient
-            .enableServerGroup(resourceGroupName, description.name)
-
-          task.updateStatus BASE_PHASE, "Done enabling Azure server group ${description.name} in ${region}."
+            .networkClient
+            .enableServerGroup(resourceGroupName,serverGroupDescription.appGatewayName, serverGroupDescription.name)
+          task.updateStatus BASE_PHASE, "Done enabling Azure server group ${serverGroupDescription.name} in ${region}."
         } catch (Exception e) {
           task.updateStatus(BASE_PHASE, "Enabling of server group ${description.name} failed: ${e.message}")
           errList.add("Failed to enable server group ${description.name}: ${e.message}")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -290,6 +290,11 @@ class AzureServerGroupResourceTemplate {
       tags.cluster = description.clusterName
       tags.createdTime = currentTime.toString()
       tags.loadBalancerName = LB_NAME
+
+      // debug only; can be removed as part of the tags cleanup
+      if (description.appGatewayName) tags.appGatewayName = description.appGatewayName
+      if (description.appGatewayBapId) tags.appGatewayBapId = description.appGatewayBapId
+
       if (description.securityGroupName) tags.securityGroupName = description.securityGroupName
       if (description.subnetId) tags.subnetId = description.subnetId
       tags.imageIsCustom = description.image.isCustom.toString()

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
@@ -55,23 +55,23 @@ class UpsertAzureAppGatewayAtomicOperationConverterSpec extends  Specification{
       detail: "d1",
       probes: [
         [
-          name: "healthcheck1",
-          protocol: "HTTP",
-          path: "/healthcheck",
-          interval: 120,
+          probeName: "healthcheck1",
+          probeProtocol: "HTTP",
+          probePath: "/healthcheck",
+          probeInterval: 120,
           timeout: 30,
           unhealthyThreshold: 8
         ]
       ],
-      rules: [
+      loadBalancingRules: [
         [
-          name: "lbRule1",
+          ruleName: "lbRule1",
           protocol: "HTTP",
           externalPort: 80,
           backendPort: 8080,
         ],
         [
-          name: "lbRule2",
+          ruleName: "lbRule2",
           protocol: "HTTP",
           externalPort: 8080,
           backendPort: 8080,
@@ -107,23 +107,25 @@ class UpsertAzureAppGatewayAtomicOperationConverterSpec extends  Specification{
   "dnsName" : null,
   "cluster" : null,
   "serverGroups" : null,
+  "trafficEnabledSG" : null,
+  "publicIpId" : null,
   "probes" : [ {
-    "name" : "healthcheck1",
-    "protocol" : "HTTP",
-    "host" : "localhost",
-    "path" : "/healthcheck",
-    "interval" : 120,
+    "probeName" : "healthcheck1",
+    "probeProtocol" : "HTTP",
+    "probePort" : "localhost",
+    "probePath" : "/healthcheck",
+    "probeInterval" : 120,
     "timeout" : 30,
     "unhealthyThreshold" : 8
   } ],
-  "rules" : [ {
-    "name" : "lbRule1",
+  "loadBalancingRules" : [ {
+    "ruleName" : "lbRule1",
     "protocol" : "HTTP",
     "externalPort" : 80,
     "backendPort" : 8080,
     "sslCertificate" : null
   }, {
-    "name" : "lbRule2",
+    "ruleName" : "lbRule2",
     "protocol" : "HTTP",
     "externalPort" : 8080,
     "backendPort" : 8080,

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/DeleteAzureAppGatewayAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/DeleteAzureAppGatewayAtomicOperationSpec.groovy
@@ -76,8 +76,10 @@ class DeleteAzureAppGatewayAtomicOperationSpec extends Specification{
   "dnsName" : null,
   "cluster" : null,
   "serverGroups" : null,
+  "trafficEnabledSG" : null,
+  "publicIpId" : null,
   "probes" : [ ],
-  "rules" : [ ],
+  "loadBalancingRules" : [ ],
   "sku" : "Standard_Small",
   "tier" : "Standard",
   "capacity" : 2

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/UpsertAzureAppGatewayAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/UpsertAzureAppGatewayAtomicOperationSpec.groovy
@@ -44,7 +44,7 @@ class UpsertAzureAppGatewayAtomicOperationSpec extends Specification{
     setup:
     mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
     mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-    def input = '''{ "cloudProvider" : "azure", "appName" : "testappgw", "loadBalancerName" : "testappgw-lb1-d1", "stack" : "lb1", "detail" : "d1", "credentials" : "myazure-account", "region" : "westus", "probes" : [ { "name" : "healthcheck1", "protocol" : "HTTP", "path" : "/healthcheck", "interval" : 120, "unhealthyThreshold" : 8, "timeout" : 30 } ], "rules" : [ { "name" : "lbRule1", "protocol" : "HTTP", "externalPort" : "80", "backendPort" : "8080" } ], "name" : "testappgw-lb1-d1", "user" : "[anonymous]" }'''
+    def input = '''{ "cloudProvider" : "azure", "appName" : "testappgw", "loadBalancerName" : "testappgw-lb1-d1", "stack" : "lb1", "detail" : "d1", "credentials" : "myazure-account", "region" : "westus", "probes" : [ { "probeName" : "healthcheck1", "probeProtocol" : "HTTP", "probePath" : "/healthcheck", "probeInterval" : 120, "unhealthyThreshold" : 8, "timeout" : 30 } ], "loadBalancingRules" : [ { "ruleName" : "lbRule1", "protocol" : "HTTP", "externalPort" : "80", "backendPort" : "8080" } ], "name" : "testappgw-lb1-d1", "user" : "[anonymous]" }'''
 
     when:
     UpsertAzureAppGatewayAtomicOperation operation = converter.convertOperation(mapper.readValue(input, Map))
@@ -75,17 +75,19 @@ class UpsertAzureAppGatewayAtomicOperationSpec extends Specification{
   "dnsName" : null,
   "cluster" : null,
   "serverGroups" : null,
+  "trafficEnabledSG" : null,
+  "publicIpId" : null,
   "probes" : [ {
-    "name" : "healthcheck1",
-    "protocol" : "HTTP",
-    "host" : "localhost",
-    "path" : "/healthcheck",
-    "interval" : 120,
+    "probeName" : "healthcheck1",
+    "probeProtocol" : "HTTP",
+    "probePort" : "localhost",
+    "probePath" : "/healthcheck",
+    "probeInterval" : 120,
     "timeout" : 30,
     "unhealthyThreshold" : 8
   } ],
-  "rules" : [ {
-    "name" : "lbRule1",
+  "loadBalancingRules" : [ {
+    "ruleName" : "lbRule1",
     "protocol" : "HTTP",
     "externalPort" : 80,
     "backendPort" : 8080,

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/template/AzureAppGatewayResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/template/AzureAppGatewayResourceTemplateSpec.groovy
@@ -75,7 +75,7 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
     description.name = 'testappgw-lb1-d1'
     description.vnet = 'vnet-testappgw-westus'
 
-    String template = AzureAppGatewayResourceTemplate.getTemplate(description)
+    AzureAppGatewayResourceTemplate.getTemplate(description)
 
     then:
     // The subnet is required; it must be created prior to calling the getTemplate() and should be set in the description object
@@ -100,23 +100,23 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
 
     description.probes.add(new AzureAppGatewayDescription.
       AzureAppGatewayHealthcheckProbe(
-        name: 'probe1',
-        path: '/healthcheck',
-        interval: 300,
+        probeName: 'probe1',
+        probePath: '/healthcheck',
+        probeInterval: 300,
         timeout: 60,
         unhealthyThreshold: 10
     ))
 
-    description.rules.add(new AzureAppGatewayDescription.
+    description.loadBalancingRules.add(new AzureAppGatewayDescription.
       AzureAppGatewayRule(
-        name: 'rule1',
+        ruleName: 'rule1',
         protocol: 'HTTP',
         externalPort: 80,
         backendPort: 8080
     ))
-    description.rules.add(new AzureAppGatewayDescription.
+    description.loadBalancingRules.add(new AzureAppGatewayDescription.
       AzureAppGatewayRule(
-      name: 'rule2',
+      ruleName: 'rule2',
       protocol: 'HTTP',
       externalPort: 8080,
       backendPort: 8080
@@ -148,7 +148,7 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
     "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
     "appGwID" : "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]",
     "appGwSubnetID" : "[concat(variables('virtualNetworkID'),'/subnets/',variables('appGwSubnetName'))]",
-    "appGwBeAddrPoolName" : "beaddrpool-default"
+    "appGwBeAddrPoolName" : "default_BAP0"
   },
   "resources" : [ {
     "apiVersion" : "[variables('apiVersion')]",
@@ -211,7 +211,11 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
         }
       } ],
       "backendAddressPools" : [ {
-        "name" : "[variables('appGwBeAddrPoolName')]"
+        "name" : "default_BAP0"
+      }, {
+        "name" : "testappgw-sg1-d1-v000"
+      }, {
+        "name" : "testappgw-sg1-d1-v001"
       } ],
       "backendHttpSettingsCollection" : [ {
         "name" : "appGwBackendHttpSettings-rule1",
@@ -320,7 +324,7 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
     "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
     "appGwID" : "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]",
     "appGwSubnetID" : "[concat(variables('virtualNetworkID'),'/subnets/',variables('appGwSubnetName'))]",
-    "appGwBeAddrPoolName" : "beaddrpool-default"
+    "appGwBeAddrPoolName" : "default_BAP0"
   },
   "resources" : [ {
     "apiVersion" : "[variables('apiVersion')]",
@@ -366,7 +370,7 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
       } ],
       "frontendPorts" : [ ],
       "backendAddressPools" : [ {
-        "name" : "[variables('appGwBeAddrPoolName')]"
+        "name" : "default_BAP0"
       } ],
       "backendHttpSettingsCollection" : [ ],
       "httpListeners" : [ ],

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
@@ -51,7 +51,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     description.clusterName = description.getClusterName()
     description.region = 'westus'
     description.user = '[anonymous]'
-    //description.loadBalancerName = 'lb-azureMASM-st1-d11'
 
     description.upgradePolicy = AzureServerGroupDescription.UpgradePolicy.Manual
 


### PR DESCRIPTION
This enables Azure Application Gateway as the default Spinnaker Load Balancer when targeting Azure. Only HTTP protocol is supported at the moment (HTTPS support will be added later).

Also part of this change:
- add clouddriver support for enable/disable server groups
- associate server group with a given application gateway
- implement proper application gateway edit op
- update application gateway to match the deck JSON content when creating/editing an application gateway
- make the proper association between server groups and application gateway while storing or retrieving cache info
- various bug fixes