### PR TITLE
Fix for AWS instance search where a partial key was matched

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProvider.groovy
@@ -87,6 +87,9 @@ class AwsProvider extends AgentSchedulerAware implements SearchableProvider, Eur
     @Override
     Map<String, String> hydrateResult(Cache cacheView, Map<String, String> result, String id) {
       def item = cacheView.get(INSTANCES.ns, id)
+      if (!item) {
+        return null
+      }
       if (!item?.relationships["serverGroups"]) {
         return result
       }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -84,7 +84,8 @@ class CatsSearchProvider implements SearchProvider {
   }
 
   private SearchResultSet generateResultSet(String query, List<String> matches, Integer pageNumber, Integer pageSize) {
-    List<Map<String, String>> results = paginateResults(matches, pageSize, pageNumber).findResults { String key ->
+    List<String> resultPage = paginateResults(matches, pageSize, pageNumber)
+    List<Map<String, String>> results = resultPage.findResults { String key ->
       Map<String, String> result = providers.findResult { it.parseKey(key) }
       if (result) {
         return searchResultHydrators.containsKey(result.type) ? searchResultHydrators[result.type].hydrateResult(cacheView, result, key) : result
@@ -92,8 +93,10 @@ class CatsSearchProvider implements SearchProvider {
       return null
     }
 
+    int filteredItems = resultPage.size() - results.size()
+
     SearchResultSet resultSet = new SearchResultSet(
-      totalMatches: matches.size(),
+      totalMatches: matches.size() - filteredItems,
       platform: getPlatform(),
       query: query,
       pageNumber: pageNumber,

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/LoggingExceptionHandler.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/LoggingExceptionHandler.groovy
@@ -30,5 +30,6 @@ class LoggingExceptionHandler {
   @ExceptionHandler(value = Exception.class)
   def defaultErrorHandler(HttpServletRequest request, Exception e) {
     log.error("Error occurred handling request for ${request.requestURL}: ${ExceptionUtils.getFullStackTrace(e)}")
+    throw e
   }
 }


### PR DESCRIPTION
This highlighted a few items which are all addressed in separate commits.

The root cause of this is that the id set for an AWS instance still contains an entry where the actual item has been deleted. The hydrator would load the underlying item and NPE. The LoggingExceptionHandler would swallow the exception.

@anotherchrisberry PTAL