### PR TITLE
Fix an issue while editing an existing load balancer

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/view/AzureInfrastructureProviderConfig.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/view/AzureInfrastructureProviderConfig.groovy
@@ -91,11 +91,11 @@ class AzureInfrastructureProviderConfig {
         if (!scheduledAccounts.contains(creds.accountName)) {
           def newlyAddedAgents = []
 
-          newlyAddedAgents << new AzureLoadBalancerCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)
+//          newlyAddedAgents << new AzureLoadBalancerCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)
           newlyAddedAgents << new AzureSecurityGroupCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)
           newlyAddedAgents << new AzureNetworkCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
           newlyAddedAgents << new AzureSubnetCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
-          newlyAddedAgents << new AzureVMImageCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
+//          newlyAddedAgents << new AzureVMImageCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
           newlyAddedAgents << new AzureCustomImageCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, creds.vmCustomImages, objectMapper)
           newlyAddedAgents << new AzureServerGroupCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)
           newlyAddedAgents << new AzureAppGatewayCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
@@ -31,7 +31,7 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
   String cluster
   List<String> serverGroups
   String trafficEnabledSG
-  String publicIpId
+  String publicIpName
   List<AzureAppGatewayHealthcheckProbe> probes = []
   List<AzureAppGatewayRule> loadBalancingRules = []
   // TODO: remove hardcoded sku, tier and capacity
@@ -92,13 +92,11 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
       if (bap.name != AzureAppGatewayResourceTemplate.defaultAppGatewayBeAddrPoolName) description.serverGroups << bap.name
     }
 
-    description.publicIpId = appGateway.frontendIPConfigurations
-
     // We only support one subnet so we can just retrieve the first one
     def subnetId = appGateway?.gatewayIPConfigurations?.first()?.subnet?.id
     description.subnet = appGateway.tags?.subnet ?: AzureUtilities.getNameFromResourceId(subnetId)
 
-    description.publicIpId = appGateway?.frontendIPConfigurations?.first()?.getPublicIPAddress()?.id
+    description.publicIpName = AzureUtilities.getResourceNameFromID(appGateway?.frontendIPConfigurations?.first()?.getPublicIPAddress()?.id)
     description.vnet = appGateway.tags?.vnet
     description.createdTime = appGateway.tags?.createdTime?.toLong()
     description.tags = appGateway.tags ?: [:]

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
@@ -75,7 +75,7 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
         task.updateStatus(BASE_PHASE, "Update existing application gateway ${appGatewayDescription.loadBalancerName} in ${appGatewayDescription.region}...")
 
         // We need to retain some of the settings from the current application gateway
-        description.publicIpId = appGatewayDescription.publicIpId
+        description.publicIpName = appGatewayDescription.publicIpName
         description.subnet = appGatewayDescription.subnet
         description.serverGroups = appGatewayDescription.serverGroups
         description.trafficEnabledSG = appGatewayDescription.trafficEnabledSG

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
@@ -58,7 +58,7 @@ class AzureAppGatewayResourceTemplate {
     AppGatewayTemplate(AzureAppGatewayDescription description) {
       parameters = new AppGatewayTemplateParameters()
       variables = new AppGatewayTemplateVariables(description)
-      if (!description.publicIpId) {
+      if (!description.publicIpName) {
         // this is not an edit operation of an existing application gateway; we must create a PublicIp resource in this case
         resources.add(new PublicIpResource())
       }
@@ -95,9 +95,9 @@ class AzureAppGatewayResourceTemplate {
     AppGatewayTemplateVariables(AzureAppGatewayDescription description) {
       appGwName = description.name
       virtualNetworkName = description.vnet.toLowerCase()
-      if (description.publicIpId) {
+      if (description.publicIpName) {
         // reuse the existing public IP (this is an edit operation)
-        publicIPAddressName = description.publicIpId
+        publicIPAddressName = description.publicIpName
       } else {
         publicIPAddressName = AzureUtilities.PUBLICIP_NAME_PREFIX + description.name.toLowerCase()
       }
@@ -132,7 +132,9 @@ class AzureAppGatewayResourceTemplate {
       if (description.securityGroup) tags.securityGroup = description.securityGroup
       if (description.vnet) tags.vnet = description.vnet
       if (description.subnet) tags.subnet = description.subnet
-      this.dependsOn.add("[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]")
+      if (!description.publicIpName) {
+        this.dependsOn.add("[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]")
+      }
       properties = new ApplicationGatewayResourceProperties(description)
     }
   }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
@@ -108,7 +108,7 @@ class UpsertAzureAppGatewayAtomicOperationConverterSpec extends  Specification{
   "cluster" : null,
   "serverGroups" : null,
   "trafficEnabledSG" : null,
-  "publicIpId" : null,
+  "publicIpName" : null,
   "probes" : [ {
     "probeName" : "healthcheck1",
     "probeProtocol" : "HTTP",

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/DeleteAzureAppGatewayAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/DeleteAzureAppGatewayAtomicOperationSpec.groovy
@@ -77,7 +77,7 @@ class DeleteAzureAppGatewayAtomicOperationSpec extends Specification{
   "cluster" : null,
   "serverGroups" : null,
   "trafficEnabledSG" : null,
-  "publicIpId" : null,
+  "publicIpName" : null,
   "probes" : [ ],
   "loadBalancingRules" : [ ],
   "sku" : "Standard_Small",

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/UpsertAzureAppGatewayAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/UpsertAzureAppGatewayAtomicOperationSpec.groovy
@@ -76,7 +76,7 @@ class UpsertAzureAppGatewayAtomicOperationSpec extends Specification{
   "cluster" : null,
   "serverGroups" : null,
   "trafficEnabledSG" : null,
-  "publicIpId" : null,
+  "publicIpName" : null,
   "probes" : [ {
     "probeName" : "healthcheck1",
     "probeProtocol" : "HTTP",


### PR DESCRIPTION
Fix an issue while editing an existing load balancer (aka Azure Application Gateway); the public Ip resources was not handled properly in the deployment template.

Also part of this change I've disabled the caching for Azure Market Store VM images and Azure L4 Load Balancers (it reduces the redis cache footprint too); none of these resources are not exposed to the "deck" at the moment.