### PR TITLE
Azure server group related bug fixes

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
@@ -82,7 +82,7 @@ class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
           description
             .credentials
             .networkClient
-            .removeAppGatewayBAPforServerGroup(resourceGroupName, description.appGatewayName, description.name)
+            .removeAppGatewayBAPforServerGroup(resourceGroupName, serverGroupDescription.appGatewayName, serverGroupDescription.name)
 
           // Delete storage accounts if any
           serverGroupDescription.storageAccountNames?.each { def storageAccountName ->

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -605,7 +605,7 @@ class AzureServerGroupResourceTemplate {
       tags.createdTime = currentTime.toString()
       if (description.clusterName) tags.cluster = description.clusterName
       if (description.name) tags.serverGroup = description.name
-      if (description.securityGroup) tags.securityGroup = description.securityGroup
+      if (description.securityGroupName) tags.securityGroupName = description.securityGroupName
 
       this.dependsOn.add("[concat('Microsoft.Network/publicIPAddresses/', variables('publicIpAddressName'))]")
 


### PR DESCRIPTION
- attaching a security group to a server group during create server group fails (typo in the load balancer settings)
- destroying server group fails to remove the app gateway BAP (typo in the destroy server group implementation)