### PR TITLE
update spinnaker-dependencies to 0.35.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   apply plugin: 'groovy'
 
   spinnaker {
-    dependenciesVersion = "0.33.0"
+    dependenciesVersion = "0.35.0"
   }
   test {
     testLogging {


### PR DESCRIPTION
fixes NPE in aws retry/backoff handlers when generating metrics tags