### PR TITLE
Azure bug fix for disableSG and isDisable implementation

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -60,6 +60,13 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
     def start = System.currentTimeMillis()
 
     List<AzureServerGroupDescription> serverGroups = creds.computeClient.getServerGroupsAll(region)
+    serverGroups?.each {
+      try {
+        it.isDisabled = creds.networkClient.isServerGroupDisabled(AzureUtilities.getResourceGroupName(it.appName, region), it.appGatewayName, it.name)
+      } catch (Exception e) {
+        log.warn("Exception ${e.message} while computing 'isDisable' state for server group ${it.name}")
+      }
+    }
 
     Collection<String> keys = serverGroups.collect {Keys.getServerGroupKey(AzureCloudProvider.AZURE, it.name, region, accountName ) }
     def onDemandCacheResults = providerCache.getAll(AZURE_ON_DEMAND.ns, keys, RelationshipCacheFilter.none())

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -57,7 +57,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   String securityGroupName
   String subnetId
   List<String> storageAccountNames
-  Boolean isDisabled // TODO add implementation to handle when a server group has been enabled/disabled
+  Boolean isDisabled = false
   List<AzureInboundPortConfig> inboundPortConfigs = []
 
   static class AzureScaleSetSku {
@@ -99,8 +99,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
 
   @Override
   Boolean isDisabled() {
-    false
-    // TODO: (scotm) should be based on existence of LB. To be added
+    this.isDisabled
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
@@ -99,6 +99,7 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
       if (!description.appGatewayName) {
         description.appGatewayName = description.loadBalancerName
       }
+      task.updateStatus(BASE_PHASE, "Create new backend address pool in $description.appGatewayName")
       appGatewayPoolID = description.credentials
         .networkClient
         .createAppGatewayBAPforServerGroup(resourceGroupName, description.appGatewayName, description.name)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
@@ -79,6 +79,7 @@ class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
         // Clean-up the storrage account, load balancer and the subnet that where attached to the server group
         if (errList.isEmpty()) {
           // Remove association between server group and the assigned application gateway backend address pool
+          task.updateStatus(BASE_PHASE, "Remove backend address pool in $description.appGatewayName")
           description
             .credentials
             .networkClient

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DisableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DisableAzureServerGroupAtomicOperation.groovy
@@ -65,12 +65,16 @@ class DisableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
         errList.add("could not find server group ${description.name} in ${region}")
       } else {
         try {
-          description
-            .credentials
-            .networkClient
-            .disableServerGroup(resourceGroupName,serverGroupDescription.appGatewayName, serverGroupDescription.name)
+          if (description.credentials.networkClient.isServerGroupDisabled(resourceGroupName, serverGroupDescription.appGatewayName, serverGroupDescription.name)) {
+            task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already disabled."
+          } else {
+            description
+              .credentials
+              .networkClient
+              .disableServerGroup(resourceGroupName, serverGroupDescription.appGatewayName, serverGroupDescription.name)
 
-          task.updateStatus BASE_PHASE, "Done disabling Azure server group ${serverGroupDescription.name} in ${region}."
+            task.updateStatus BASE_PHASE, "Done disabling Azure server group ${serverGroupDescription.name} in ${region}."
+          }
         } catch (Exception e) {
           task.updateStatus(BASE_PHASE, "Disabling of server group ${description.name} failed: ${e.message}")
           errList.add("Failed to disable server group ${description.name}: ${e.message}")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
@@ -65,11 +65,15 @@ class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
         errList.add("could not find server group ${description.name} in ${region}")
       } else {
         try {
-          description
-            .credentials
-            .networkClient
-            .enableServerGroup(resourceGroupName,serverGroupDescription.appGatewayName, serverGroupDescription.name)
-          task.updateStatus BASE_PHASE, "Done enabling Azure server group ${serverGroupDescription.name} in ${region}."
+          if (description.credentials.networkClient.isServerGroupDisabled(resourceGroupName, serverGroupDescription.appGatewayName, serverGroupDescription.name)) {
+            description
+              .credentials
+              .networkClient
+              .enableServerGroup(resourceGroupName, serverGroupDescription.appGatewayName, serverGroupDescription.name)
+            task.updateStatus BASE_PHASE, "Done enabling Azure server group ${serverGroupDescription.name} in ${region}."
+          } else {
+            task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already enabled."
+          }
         } catch (Exception e) {
           task.updateStatus(BASE_PHASE, "Enabling of server group ${description.name} failed: ${e.message}")
           errList.add("Failed to enable server group ${description.name}: ${e.message}")


### PR DESCRIPTION
Fix for a bug in disable server group; during destroy SG we call disableop and if a different SG is active, that gets disabled as well.
Added couple more logging lines to keep track of the "orchestration" progress when creating or disabling SGs.
Implemented isDisabled for a server group; also changed enable and disable ops to take advantage of this check and fast track the op if no updates are needed.