### PR TITLE
Operation to terminate Openstack instance.

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackClientV3Provider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackClientV3Provider.groovy
@@ -17,19 +17,28 @@
 package com.netflix.spinnaker.clouddriver.openstack.client
 
 import org.openstack4j.api.OSClient
+import org.openstack4j.model.identity.v3.Token
+import org.openstack4j.openstack.OSFactory
 
 /**
  * Provides access to the Openstack V3 API.
  */
 class OpenstackClientV3Provider extends OpenstackClientProvider {
 
-  OpenstackClientV3Provider(OSClient client) {
-    super(client)
+  Token token
+
+  OpenstackClientV3Provider(OSClient.OSClientV3 client) {
+    this.token = client.token
+  }
+
+  @Override
+  OSClient getClient() {
+    OSFactory.clientFromToken(token)
   }
 
   @Override
   String getTokenId() {
-    ((OSClient.OSClientV3)client).token.id
+    token.id
   }
 
   //TODO v3 specific operations

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/converters/OpenstackAtomicOperationConverterHelper.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/converters/OpenstackAtomicOperationConverterHelper.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.converters
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.instance.OpenstackInstancesDescription
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+
+class OpenstackAtomicOperationConverterHelper {
+
+  static OpenstackInstancesDescription convertDescription(Map input,
+                                                          AbstractAtomicOperationsCredentialsSupport credentialsSupport,
+                                                          Class targetDescriptionType) {
+
+    String account = input.account
+
+    OpenstackInstancesDescription converted = (OpenstackInstancesDescription) credentialsSupport.objectMapper
+      .copy()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .convertValue(input, targetDescriptionType)
+
+    converted.credentials = (OpenstackCredentials) credentialsSupport.getCredentialsObject(account)?.getCredentials()
+
+    converted
+  }
+}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/converters/instance/TerminateOpenstackInstancesAtomicOperationConverter.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/converters/instance/TerminateOpenstackInstancesAtomicOperationConverter.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.converters.instance
+
+import com.netflix.spinnaker.clouddriver.openstack.OpenstackOperation
+import com.netflix.spinnaker.clouddriver.openstack.deploy.converters.OpenstackAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.instance.OpenstackInstancesDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.instance.TerminateOpenstackInstancesAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+@OpenstackOperation(AtomicOperations.TERMINATE_INSTANCES)
+@Component("terminateInstancesDescription")
+class TerminateOpenstackInstancesAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    new TerminateOpenstackInstancesAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  OpenstackInstancesDescription convertDescription(Map input) {
+    OpenstackAtomicOperationConverterHelper.convertDescription(input, this, OpenstackInstancesDescription)
+  }
+}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/OpenstackAtomicOperationDescription.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/OpenstackAtomicOperationDescription.groovy
@@ -14,33 +14,17 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.openstack.client
+package com.netflix.spinnaker.clouddriver.openstack.deploy.description
 
-import org.openstack4j.api.OSClient
-import org.openstack4j.model.identity.v2.Access
-import org.openstack4j.openstack.OSFactory
+import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
+import groovy.transform.AutoClone
+import groovy.transform.Canonical
 
-/**
- * Provides access to the Openstack V2 API.
- */
-class OpenstackClientV2Provider extends OpenstackClientProvider {
-
-  Access access
-
-  OpenstackClientV2Provider(OSClient.OSClientV2 client) {
-    this.access = client.access
-  }
-
-  @Override
-  OSClient getClient() {
-    OSFactory.clientFromAccess(access)
-  }
-
-  @Override
-  String getTokenId() {
-    access.token.id
-  }
-
-  //TODO v2 specific operations
-
+// Pair of credentials name and associated openstack account
+@AutoClone
+@Canonical
+class OpenstackAtomicOperationDescription implements DeployDescription {
+  String account
+  OpenstackCredentials credentials
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/instance/OpenstackInstancesDescription.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/instance/OpenstackInstancesDescription.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.description.instance
+
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.OpenstackAtomicOperationDescription
+
+class OpenstackInstancesDescription extends OpenstackAtomicOperationDescription {
+  List<String> instanceIds
+}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/exception/OpenstackOperationException.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/exception/OpenstackOperationException.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.exception
+
+import groovy.transform.InheritConstructors
+import org.openstack4j.model.common.ActionResponse
+
+@InheritConstructors
+class OpenstackOperationException extends RuntimeException {
+  OpenstackOperationException(String operation, Exception e) {
+    super("$operation failed: ${e.message}".toString(), e)
+  }
+
+  OpenstackOperationException(ActionResponse actionResponse, String operation) {
+    super("$operation failed: fault $actionResponse.fault with code $actionResponse.code".toString())
+  }
+
+  OpenstackOperationException(String account, String operation, Exception e) {
+    super("$operation for account $account failed: ${e.message}".toString(), e)
+  }
+}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/TerminateOpenstackInstancesAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/TerminateOpenstackInstancesAtomicOperation.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.ops.instance
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.instance.OpenstackInstancesDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import groovy.util.logging.Slf4j
+
+/**
+ * Terminates an Openstack instance.
+ */
+@Slf4j
+class TerminateOpenstackInstancesAtomicOperation implements AtomicOperation<Void> {
+
+  private final String BASE_PHASE = "TERMINATE_INSTANCES"
+  OpenstackInstancesDescription description
+
+  TerminateOpenstackInstancesAtomicOperation(OpenstackInstancesDescription description) {
+    this.description = description
+  }
+
+  protected static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  /*
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "terminateInstances": { "instanceIds": ["os-test-v000-beef"], "account": "test" }} ]' localhost:7002/openstack/ops
+   * curl -X GET -H "Accept: application/json" localhost:7002/task/1
+   */
+  @Override
+  Void operate(List priorOutputs) {
+    task.updateStatus BASE_PHASE, "Initializing terminate instances operation..."
+
+    description.instanceIds.each {
+      task.updateStatus BASE_PHASE, "Deleting $it"
+      description.credentials.provider.deleteInstance(it)
+      task.updateStatus BASE_PHASE, "Deleted $it"
+    }
+
+    task.updateStatus BASE_PHASE, "Successfully terminated provided instances."
+  }
+}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/OpenstackAttributeValidator.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/OpenstackAttributeValidator.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.validation.Errors
+
+/**
+ * TODO most of the validate methods can be moved into base class,
+ * since other drivers are doing the same thing.
+ */
+class OpenstackAttributeValidator {
+
+  String context
+  Errors errors
+
+  OpenstackAttributeValidator(String context, Errors errors) {
+    this.context = context
+    this.errors = errors  }
+
+  static final maxPort = (1 << 16) - 1
+
+  boolean validateByRegex(String value, String attribute, String regex) {
+    def result
+    if (value ==~ regex) {
+      result = true
+    } else {
+      errors.rejectValue("${context}.${attribute}", "${context}.${attribute}.invalid (Must match ${regex})")
+      result = false
+    }
+    result
+  }
+
+  boolean validateByContainment(Object value, String attribute, List<Object> list) {
+    def result
+    if (list.contains(value)) {
+      result = true
+    } else {
+      errors.rejectValue("${context}.${attribute}", "${context}.${attribute}.invalid (Must be one of $list)")
+      result = false
+    }
+    result
+  }
+
+  void reject(String attribute, String reason) {
+    errors.rejectValue("${context}.${attribute}", "${context}.${attribute}.invalid ($reason)")
+  }
+
+  def validatePort(int port, String attribute) {
+    def result = (port >= 1 && port <= maxPort)
+    if (!result) {
+      errors.rejectValue("${context}.${attribute}", "${context}.${attribute}.invalid (Must be in range [1, $maxPort])")
+    }
+    result
+  }
+
+  boolean validateNotEmpty(Object value, String attribute) {
+    def result
+    if (value != "" && value != null && value != []) {
+      result = true
+    } else {
+      errors.rejectValue("${context}.${attribute}",  "${context}.${attribute}.empty")
+      result = false
+    }
+    result
+  }
+
+  boolean validateNonNegative(int value, String attribute) {
+    def result
+    if (value >= 0) {
+      result = true
+    } else {
+      errors.rejectValue("${context}.${attribute}", "${context}.${attribute}.negative")
+      result = false
+    }
+    result
+  }
+
+  boolean validatePositive(int value, String attribute) {
+    def result
+    if (value > 0) {
+      result = true
+    } else {
+      errors.rejectValue("${context}.${attribute}", "${context}.${attribute}.notPositive")
+      result = false
+    }
+    result
+  }
+
+  /**
+   * Validate credentials.
+   * @param credentials
+   * @param accountCredentialsProvider
+   * @return
+   */
+  def validateCredentials(String account, AccountCredentialsProvider accountCredentialsProvider) {
+    def result = validateNotEmpty(account, "account")
+    if (result) {
+      def openstackCredentials = accountCredentialsProvider.getCredentials(account)
+      if (!(openstackCredentials?.credentials instanceof OpenstackCredentials)) {
+        errors.rejectValue("${context}.account",  "${context}.account.notFound")
+        result = false
+      }
+    }
+    result
+  }
+
+}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/instance/TerminateOpenstackInstancesDescriptionValidator.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/instance/TerminateOpenstackInstancesDescriptionValidator.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.validators.instance
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.instance.OpenstackInstancesDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.OpenstackAttributeValidator
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.validation.Errors
+
+/**
+ *
+ */
+class TerminateOpenstackInstancesDescriptionValidator extends DescriptionValidator<OpenstackInstancesDescription> {
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Override
+  void validate(List priorDescriptions, OpenstackInstancesDescription description, Errors errors) {
+    def validator = new OpenstackAttributeValidator("terminateOpenstackInstancesAtomicOperationDescription", errors)
+
+    //validate credentials
+    validator.validateCredentials(description.account, accountCredentialsProvider)
+
+    //validate instance ids
+    validator.validateNotEmpty(description.instanceIds, "instanceIds")
+
+  }
+
+}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackCredentials.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackCredentials.groovy
@@ -19,6 +19,9 @@ package com.netflix.spinnaker.clouddriver.openstack.security
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFactory
 
+/**
+ * TODO this layer is probably not needed. we could put the provider directly into the description.
+ */
 public class OpenstackCredentials {
 
   final OpenstackClientProvider provider

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentials.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentials.groovy
@@ -79,7 +79,17 @@ class OpenstackNamedAccountCredentials implements AccountCredentials<OpenstackCr
 
   @Override
   String getCloudProvider() {
-    return CLOUD_PROVIDER
+    CLOUD_PROVIDER
+  }
+
+  /**
+   * Note: this is needed because there is an interface method of this name that should be called
+   * in lieu of the synthetic getter for the credentials instance variable.
+   * @return
+   */
+  @Override
+  OpenstackCredentials getCredentials() {
+    credentials
   }
 
 }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackClientProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackClientProviderSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.client
+
+import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
+import org.openstack4j.api.OSClient
+import org.openstack4j.model.common.ActionResponse
+import spock.lang.Specification
+
+class OpenstackClientProviderSpec extends Specification {
+
+  private static final String OPERATION = "TestOperation"
+  private provider
+
+  def setup() {
+    provider = new OpenstackClientV2Provider(Mock(OSClient.OSClientV2))
+  }
+
+  def "handle request succeeds"() {
+    setup:
+    def success = ActionResponse.actionSuccess()
+
+    when:
+    def response = provider.handleRequest(OPERATION) { success }
+
+    then:
+    success == response
+    noExceptionThrown()
+  }
+
+  def "handle request fails with failed action request"() {
+    setup:
+    def failed = ActionResponse.actionFailed("foo", 500)
+
+    when:
+    provider.handleRequest(OPERATION) { failed }
+
+    then:
+    OpenstackOperationException ex = thrown(OpenstackOperationException)
+    ex.message.contains("foo")
+    ex.message.contains("500")
+    ex.message.contains(OPERATION)
+  }
+
+  def "handle request fails with closure throwing exception"() {
+    setup:
+    def exception = new Exception("foo")
+
+    when:
+    provider.handleRequest(OPERATION) { throw exception }
+
+    then:
+    OpenstackOperationException ex = thrown(OpenstackOperationException)
+    ex.cause == exception
+    ex.message.contains("foo")
+    ex.message.contains(OPERATION)
+  }
+}

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/TerminateOpenstackInstancesAtomicOperationUnitSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/TerminateOpenstackInstancesAtomicOperationUnitSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.ops.instance
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
+import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFactory
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.instance.OpenstackInstancesDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TerminateOpenstackInstancesAtomicOperationUnitSpec extends Specification {
+
+  private static final String ACCOUNT_NAME = 'myaccount'
+  private static final INSTANCE_IDS = ['instance1','instance2','instance3']
+
+  def credentials
+  def description
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  def setup() {
+    OpenstackClientProvider provider = Mock(OpenstackClientProvider)
+    GroovyMock(OpenstackProviderFactory, global: true)
+    OpenstackNamedAccountCredentials credz = Mock(OpenstackNamedAccountCredentials)
+    OpenstackProviderFactory.createProvider(credz) >> { provider }
+    credentials = new OpenstackCredentials(credz)
+    description = new OpenstackInstancesDescription(instanceIds: INSTANCE_IDS, account: ACCOUNT_NAME, credentials: credentials)
+  }
+
+  def "should terminate instances"() {
+    given:
+    @Subject def operation = new TerminateOpenstackInstancesAtomicOperation(description)
+
+    when:
+    operation.operate([])
+
+    then:
+    INSTANCE_IDS.each {
+      1 * credentials.provider.deleteInstance(it)
+    }
+    noExceptionThrown()
+  }
+
+  def "should throw exception"() {
+    given:
+    @Subject def operation = new TerminateOpenstackInstancesAtomicOperation(description)
+
+    when:
+    operation.operate([])
+
+    then:
+    INSTANCE_IDS.each {
+      credentials.provider.deleteInstance(it) >> { throw new OpenstackOperationException("foobar") }
+    }
+    OpenstackOperationException ex = thrown(OpenstackOperationException)
+    ex.message == "foobar"
+  }
+
+}

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/OpenstackAttributeValidatorSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/OpenstackAttributeValidatorSpec.groovy
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.validation.Errors
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ *
+ */
+@Unroll
+class OpenstackAttributeValidatorSpec extends Specification {
+
+  def validator
+  def errors
+  def accountProvider
+
+  void setup() {
+    errors = Mock(Errors)
+    validator = new OpenstackAttributeValidator('context', errors)
+    accountProvider = Mock(AccountCredentialsProvider)
+  }
+
+  def "ValidateByRegex"() {
+    when:
+    boolean actual = validator.validateByRegex(value, 'test', regex)
+
+    then:
+    actual == result
+    if (!result) {
+      1 * errors.rejectValue('context.test','context.test.invalid (Must match [A-Z]+)')
+    }
+
+    where:
+    value | regex       | result
+    'foo' | '[A-Za-z]+' | true
+    '123' | '[A-Z]+'    | false
+
+  }
+
+  def "ValidateByContainment"() {
+    when:
+    boolean actual = validator.validateByContainment(value, 'test', list)
+
+    then:
+    actual == result
+    if (!result) {
+      1 * errors.rejectValue('context.test','context.test.invalid (Must be one of [1234])')
+    }
+
+    where:
+    value | list           | result
+    'foo' | ['foo', 'bar'] | true
+    '123' | ['1234']       | false
+
+  }
+
+  def "Reject"() {
+    when:
+    validator.reject('foo','reason')
+
+    then:
+    1 * errors.rejectValue('context.foo', 'context.foo.invalid (reason)')
+  }
+
+  def "ValidatePort"() {
+    when:
+    boolean actual = validator.validatePort(port, 'foo')
+
+    then:
+    actual == result
+    if (!result) {
+      1 * errors.rejectValue('context.foo', 'context.foo.invalid (Must be in range [1, 65535])')
+    }
+
+    where:
+    port | result
+    80   | true
+    -5   | false
+  }
+
+  def "ValidateNotEmpty"() {
+    when:
+    boolean actual = validator.validateNotEmpty(value, 'test')
+
+    then:
+    actual == result
+    if (!result) {
+      1 * errors.rejectValue('context.test','context.test.empty')
+    }
+
+    where:
+    value | result
+    'foo' | true
+    ''    | false
+    null  | false
+  }
+
+  def "ValidateNonNegative"() {
+    when:
+    boolean actual = validator.validateNonNegative(value, 'test')
+
+    then:
+    actual == result
+    if (!result) {
+      1 * errors.rejectValue('context.test','context.test.negative')
+    }
+
+    where:
+    value | result
+    1     | true
+    0     | true
+    -1    | false
+  }
+
+  def "ValidatePositive"() {
+    when:
+    boolean actual = validator.validatePositive(value, 'test')
+
+    then:
+    actual == result
+    if (!result) {
+      1 * errors.rejectValue('context.test','context.test.notPositive')
+    }
+
+    where:
+    value | result
+    1     | true
+    0     | false
+    -1    | false
+  }
+
+  def "valid account and credentials"() {
+    given:
+    def named = Mock(OpenstackNamedAccountCredentials)
+    def cred = Mock(OpenstackCredentials)
+    String account = 'account'
+
+    when:
+    boolean actual = validator.validateCredentials(account, accountProvider)
+
+    then:
+    actual
+    1 * accountProvider.getCredentials(account) >> named
+    1 * named.credentials >> cred
+  }
+
+  def "empty account"() {
+    given:
+    def named = Mock(OpenstackNamedAccountCredentials)
+    def cred = Mock(OpenstackCredentials)
+    String account = ''
+
+    when:
+    boolean actual = validator.validateCredentials(account, accountProvider)
+
+    then:
+    !actual
+    0 * accountProvider.getCredentials(account) >> named
+    0 * named.credentials >> cred
+    1 * errors.rejectValue('context.account', 'context.account.empty')
+  }
+
+  def "valid account, invalid credentials"() {
+    given:
+    def named = Mock(AccountCredentials)
+    def cred = new Object()
+    String account = 'account'
+
+    when:
+    boolean actual = validator.validateCredentials(account, accountProvider)
+
+    then:
+    !actual
+    1 * accountProvider.getCredentials(account) >> named
+    1 * named.credentials >> cred
+    1 * errors.rejectValue('context.account', 'context.account.notFound')
+  }
+
+}

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/instance/TerminateOpenstackInstancesDescriptionValidatorSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/instance/TerminateOpenstackInstancesDescriptionValidatorSpec.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.validators.instance
+
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.instance.OpenstackInstancesDescription
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.validation.Errors
+import spock.lang.Specification
+
+/**
+ *
+ */
+class TerminateOpenstackInstancesDescriptionValidatorSpec extends Specification {
+
+  Errors errors
+  AccountCredentialsProvider provider
+  TerminateOpenstackInstancesDescriptionValidator validator
+  OpenstackNamedAccountCredentials credentials
+  OpenstackCredentials credz
+
+  def "Validate no exception"() {
+    given:
+    credz = Mock(OpenstackCredentials)
+    credentials = Mock(OpenstackNamedAccountCredentials) {
+      1 * getCredentials() >> credz
+    }
+    provider = Mock(AccountCredentialsProvider) {
+      1 * getCredentials(_) >> credentials
+    }
+    errors = Mock(Errors)
+    validator = new TerminateOpenstackInstancesDescriptionValidator(accountCredentialsProvider: provider)
+    OpenstackInstancesDescription description = new OpenstackInstancesDescription(account: 'foo', instanceIds: ['1','2'])
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    0 * errors.rejectValue(_,_)
+  }
+
+  def "Validate empty account exception"() {
+    given:
+    credz = Mock(OpenstackCredentials)
+    credentials = Mock(OpenstackNamedAccountCredentials) {
+      0 * getCredentials() >> credz
+    }
+    provider = Mock(AccountCredentialsProvider) {
+      0 * getCredentials(_) >> credentials
+    }
+    errors = Mock(Errors)
+    validator = new TerminateOpenstackInstancesDescriptionValidator(accountCredentialsProvider: provider)
+    OpenstackInstancesDescription description = new OpenstackInstancesDescription(account: '', instanceIds: ['1','2'])
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    1 * errors.rejectValue(_,_)
+  }
+
+  def "Validate empty instance list exception"() {
+    given:
+    credz = Mock(OpenstackCredentials)
+    credentials = Mock(OpenstackNamedAccountCredentials) {
+      1 * getCredentials() >> credz
+    }
+    provider = Mock(AccountCredentialsProvider) {
+      1 * getCredentials(_) >> credentials
+    }
+    errors = Mock(Errors)
+    validator = new TerminateOpenstackInstancesDescriptionValidator(accountCredentialsProvider: provider)
+    OpenstackInstancesDescription description = new OpenstackInstancesDescription(account: 'foo', instanceIds: [])
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    1 * errors.rejectValue(_,_)
+  }
+
+}

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentialsSpec.groovy
@@ -21,6 +21,8 @@ import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientV3Provi
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
 import org.openstack4j.api.OSClient
 import org.openstack4j.api.client.IOSClientBuilder
+import org.openstack4j.model.identity.v2.Access
+import org.openstack4j.model.identity.v3.Token
 import spock.lang.Specification
 
 class OpenstackNamedAccountCredentialsSpec extends Specification {
@@ -29,27 +31,31 @@ class OpenstackNamedAccountCredentialsSpec extends Specification {
   def "Provider factory returns v2 provider"() {
     setup:
     // Mock out the authenticate call within Openstack4J
-    IOSClientBuilder.V2.metaClass.authenticate = { Mock(OSClient.OSClientV2) }
+    OSClient.OSClientV2 mockClient = Mock(OSClient.OSClientV2)
+    IOSClientBuilder.V2.metaClass.authenticate = { mockClient }
 
     when:
     def credentials = new OpenstackNamedAccountCredentials("name", "test", "v2", "test", "user", "pw", "tenant", "domain", "endpoint", false)
 
     then:
+    1 * mockClient.access >> Mock(Access)
     credentials.credentials.provider instanceof OpenstackClientV2Provider
-    credentials.credentials.provider.client instanceof OSClient.OSClientV2
+    credentials.credentials.provider.access instanceof Access
   }
 
   def "Provider factory returns v3 provider"() {
     setup:
     // Mock out the authenticate call within Openstack4J
-    IOSClientBuilder.V3.metaClass.authenticate = { Mock(OSClient.OSClientV3) }
+    OSClient.OSClientV3 mockClient = Mock(OSClient.OSClientV3)
+    IOSClientBuilder.V3.metaClass.authenticate = { mockClient }
 
     when:
     def credentials = new OpenstackNamedAccountCredentials("name", "test", "v3", "test", "user", "pw", "tenant", "domain", "endpoint", false)
 
     then:
+    1 * mockClient.token >> Mock(Token)
     credentials.credentials.provider instanceof OpenstackClientV3Provider
-    credentials.credentials.provider.client instanceof OSClient.OSClientV3
+    credentials.credentials.provider.token instanceof Token
   }
 
 


### PR DESCRIPTION
This is just a noop with all the framework to get the operation invoked.

terminate instance changes

Successfully deleted instance

adding specs for delete operations

Tests for OpenstackClientProvider handle request.

checkpoint

undo changes to kubernetes validation, some validation logic duplicated in openstack