### PR TITLE
provider/docker: Make tracking digests optional

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
@@ -39,8 +39,10 @@ class DockerRegistryConfigurationProperties {
     int cacheThreads
     // Timeout time in milliseconds for this repository. Default is 60,000 (1 minute).
     long clientTimeoutMillis
-    // Paginate size for the docker repository /_catalog endpoint. Default is 100
+    // Paginate size for the docker repository /_catalog endpoint. Default is 100.
     int paginateSize
+    // Track digest changes. This is _not_ recommended as it consumes a high QPM, and most registries are flaky.
+    boolean trackDigests
     // List of all repositories to index. Can be of the form <user>/<repo>,
     // or <library> for repositories like 'ubuntu'.
     List<String> repositories

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
@@ -19,12 +19,14 @@ package com.netflix.spinnaker.clouddriver.docker.registry.security
 import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryClient
 
 public class DockerRegistryCredentials {
-  private final DockerRegistryClient client;
-  private List<String> repositories;
-  private final boolean reloadRepositories;
+  private final DockerRegistryClient client
+  private List<String> repositories
+  private final boolean reloadRepositories
+  private final boolean trackDigests
 
-  public DockerRegistryCredentials(DockerRegistryClient client, List<String> repositories) {
+  public DockerRegistryCredentials(DockerRegistryClient client, List<String> repositories, boolean trackDigests) {
     this.client = client;
+    this.trackDigests = trackDigests
     if (!repositories) {
       this.reloadRepositories = true
       // Don't load the repositories yet, as it delays application startup time.
@@ -35,12 +37,16 @@ public class DockerRegistryCredentials {
   }
 
   public DockerRegistryClient getClient() {
-    return client;
+    return client
+  }
+
+  public boolean getTrackDigests() {
+    return trackDigests
   }
 
   public List<String> getRepositories() {
     if (reloadRepositories) {
-      repositories = client.getCatalog()?.repositories;
+      repositories = client.getCatalog()?.repositories
     }
     return repositories
   }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
@@ -71,7 +71,8 @@ class DockerRegistryCredentialsInitializer implements CredentialsInitializerSync
           managedAccount.address, managedAccount.username,
           managedAccount.password, managedAccount.passwordFile, managedAccount.email,
           managedAccount.cacheThreads, managedAccount.clientTimeoutMillis,
-          managedAccount.paginateSize, managedAccount.repositories)
+          managedAccount.paginateSize, managedAccount.trackDigests,
+          managedAccount.repositories)
 
         accountCredentialsRepository.save(managedAccount.name, dockerRegistryAccount)
       } catch (e) {

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
@@ -29,14 +29,15 @@ import java.util.concurrent.TimeUnit
 public class DockerRegistryNamedAccountCredentials implements AccountCredentials<DockerRegistryCredentials> {
   public DockerRegistryNamedAccountCredentials(String accountName, String environment, String accountType,
                                                String address, String username, String password, String passwordFile, String email,
-                                               int cacheThreads, long clientTimeoutMillis, int paginateSize, List<String> repositories) {
-    this(accountName, environment, accountType, address, username, password, passwordFile, email, repositories, cacheThreads, clientTimeoutMillis, paginateSize, null)
+                                               int cacheThreads, long clientTimeoutMillis, int paginateSize, boolean trackDigests,
+                                               List<String> repositories) {
+    this(accountName, environment, accountType, address, username, password, passwordFile, email, repositories, cacheThreads, clientTimeoutMillis, paginateSize, trackDigests, null)
   }
 
   public DockerRegistryNamedAccountCredentials(String accountName, String environment, String accountType,
                                                String address, String username, String password, String passwordFile, String email,
                                                List<String> repositories, int cacheThreads, long clientTimeoutMillis,
-                                               int paginateSize, List<String> requiredGroupMembership) {
+                                               int paginateSize, boolean trackDigests, List<String> requiredGroupMembership) {
     if (!accountName) {
       throw new IllegalArgumentException("Docker Registry account must be provided with a name.")
     }
@@ -76,6 +77,7 @@ public class DockerRegistryNamedAccountCredentials implements AccountCredentials
     }
     this.password = password
     this.email = email
+    this.trackDigests = trackDigests
     this.requiredGroupMembership = requiredGroupMembership == null ? Collections.emptyList() : Collections.unmodifiableList(requiredGroupMembership)
     this.credentials = buildCredentials(repositories)
   }
@@ -111,7 +113,7 @@ public class DockerRegistryNamedAccountCredentials implements AccountCredentials
   private DockerRegistryCredentials buildCredentials(List<String> repositories) {
     try {
       DockerRegistryClient client = new DockerRegistryClient(address, email, username, password, clientTimeoutMillis, paginateSize)
-      return new DockerRegistryCredentials(client, repositories)
+      return new DockerRegistryCredentials(client, repositories, trackDigests)
     } catch (RetrofitError e) {
       if (e.response?.status == 404) {
         throw new DockerRegistryConfigException("No repositories specified for ${name}, and the provided endpoint ${address} does not support /_catalog.")
@@ -130,6 +132,7 @@ public class DockerRegistryNamedAccountCredentials implements AccountCredentials
   final String username
   final String password
   final String email
+  final boolean trackDigests
   final int cacheThreads
   final long clientTimeoutMillis
   final int paginateSize


### PR DESCRIPTION
@duftler 
@tomaslin FYI

By default tracking digest changes is now disabled. The end goal is to trigger pipelines only from tags being added to a specific repository. Once this is finished (changes to igor inbound), this will be the only place this behavior needs to be configured.

When enabled, there is a slight change. If the registry responds with a 404 during the digest lookup the tag is removed from the cache as before. If any other error is encountered, the tag is left in the cache but without a digest. This will be handled gracefully in igor (digests flipping between null & some value won't trigger pipelines).