### PR TITLE
Travis support for clouddriver

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -219,6 +219,11 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster> {
           if (buildHost && buildInfo.containsKey("jenkins")) {
             ((Map) buildInfo.jenkins).host = buildHost
           }
+          def buildInfoUrl = image.attributes.tags?.find { it.key == "build_info_url" }?.value ?: null
+          if (buildInfoUrl) {
+            buildInfo.buildInfoUrl = buildInfoUrl
+          }
+
         }
       }
 


### PR DESCRIPTION
Part of a series of PR adding build info support for travis integration on AWS
by adding new build_info_url tag to the images in order to be able to full fill the build info correctly for travis.

This PR retrieves the build_info_url tag of the ami added by rosco as a ec2 tag.

This is the final result
![screen shot 2016-06-02 at 10 11 01](https://cloud.githubusercontent.com/assets/10425379/15742485/7e06464c-28bf-11e6-9965-1afcbb6d5078.png)

Related PRs
https://github.com/spinnaker/orca/pull/856
spinnaker/rosco#102
https://github.com/spinnaker/deck/pull/2304
