### PR TITLE
Updates CopyLastAsgAtomicOperation to pull more from the source field.

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperationUnitSpec.groovy
@@ -26,6 +26,7 @@ import com.amazonaws.services.autoscaling.model.LaunchConfiguration
 import com.amazonaws.services.autoscaling.model.TagDescription
 import com.amazonaws.services.ec2.AmazonEC2
 import com.netflix.spinnaker.clouddriver.aws.deploy.AWSServerGroupNameResolver
+import com.netflix.spinnaker.clouddriver.aws.deploy.validators.BasicAmazonDeployDescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.services.AsgService
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -71,6 +72,7 @@ class CopyLastAsgAtomicOperationUnitSpec extends Specification {
         getAWSServerGroupNameResolver() >> serverGroupNameResolver
       }
     }
+    op.basicAmazonDeployDescriptionValidator = Stub(BasicAmazonDeployDescriptionValidator)
     def expectedDeployDescription = { region ->
       new BasicAmazonDeployDescription(application: 'asgard', stack: 'stack', keyPair: 'key-pair-name',
         securityGroups: ['someGroupName', 'sg-12345a'], availabilityZones: [(region): null],

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidationException.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidationException.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.deploy
+
+import groovy.transform.Canonical
+import org.springframework.validation.Errors
+
+@Canonical
+class DescriptionValidationException extends RuntimeException {
+  Errors errors
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.controllers
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidationErrors
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidationException
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationConverter
@@ -101,9 +102,9 @@ class OperationsController {
    * ----------------------------------------------------------------------------------------------------------------------------
    */
 
-  @ExceptionHandler(ValidationException)
+  @ExceptionHandler(DescriptionValidationException)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  Map handleValidationException(HttpServletRequest req, ValidationException ex) {
+  Map handleValidationException(HttpServletRequest req, DescriptionValidationException ex) {
     Locale locale = LocaleContextHolder.locale
     def errorStrings = []
     ex.errors.each { Errors errors ->
@@ -134,7 +135,7 @@ class OperationsController {
     def atomicOperations = []
     for (bindingResult in results) {
       if (bindingResult.errors.hasErrors()) {
-        throw new ValidationException(bindingResult.errors)
+        throw new DescriptionValidationException(bindingResult.errors)
       } else {
         atomicOperations.addAll(bindingResult.atomicOperations)
       }
@@ -199,11 +200,6 @@ class OperationsController {
   @Canonical
   static class AtomicOperationBindingResult {
     AtomicOperation atomicOperations
-    Errors errors
-  }
-
-  @Canonical
-  static class ValidationException extends RuntimeException {
     Errors errors
   }
 }


### PR DESCRIPTION
The minimum requred payload becomes `credentials` + `source` to make a copy of an existing server group, and then any additional fields to make changes from the `source`'s configuration. `credentials` is required because asserting that exists is baked pretty far up the operation handling stack (could theoretically have pulled that from `source.account`)
Normalizes security groups to names when filling defaults that cross an account or zone
Resets keypair to the defaultKeyPair when crossing account or region and the keyPair wasn't explicitly passed

Also runs the validation after the final `BasicAmazonDeployDescription` has been constructed.

It is possible to issue a cloneServerGroup and the source not be found - so long as it is a fully formed deploy it will succeed, otherwise it will fail validation. Previously it would just fail with an NPE when the source could not be located