### PR TITLE
provider/google: Remove google-containers image source

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -128,7 +128,6 @@ google:
   - centos-cloud
   - coreos-cloud
   - debian-cloud
-  - google-containers
   - opensuse-cloud
   - rhel-cloud
   - suse-cloud


### PR DESCRIPTION
`google-containers` is no longer included in the list of images `gcloud images list` returns, so we stop supplying it in the default list of images.

@duftler 