### PR TITLE
Azure create subnet fixes and other small tweaks

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/view/AzureInfrastructureProviderConfig.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/view/AzureInfrastructureProviderConfig.groovy
@@ -94,7 +94,7 @@ class AzureInfrastructureProviderConfig {
 //          newlyAddedAgents << new AzureLoadBalancerCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)
           newlyAddedAgents << new AzureSecurityGroupCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)
           newlyAddedAgents << new AzureNetworkCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
-          newlyAddedAgents << new AzureSubnetCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
+//          newlyAddedAgents << new AzureSubnetCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
 //          newlyAddedAgents << new AzureVMImageCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper)
           newlyAddedAgents << new AzureCustomImageCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, creds.vmCustomImages, objectMapper)
           newlyAddedAgents << new AzureServerGroupCachingAgent(azureCloudProvider, creds.accountName, creds.credentials, region.name, objectMapper, registry)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
@@ -21,11 +21,14 @@ import com.microsoft.azure.management.resources.models.DeploymentExtended
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.common.model.AzureDeploymentOperation
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.network.model.AzureVirtualNetworkDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.network.view.AzureNetworkProvider
 import com.netflix.spinnaker.clouddriver.azure.templates.AzureAppGatewayResourceTemplate
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+import org.springframework.beans.factory.annotation.Autowired
 
 class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
   private static final String BASE_PHASE = "UPSERT_APP_GATEWAY"
@@ -37,6 +40,9 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
   }
 
   private final AzureAppGatewayDescription description
+
+  @Autowired
+  AzureNetworkProvider networkProvider
 
   UpsertAzureAppGatewayAtomicOperation(AzureAppGatewayDescription description) {
     this.description = description
@@ -92,29 +98,30 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
         // We are attempting to create a new application gateway
         description.credentials.resourceManagerClient.initializeResourceGroupAndVNet(description.credentials, resourceGroupName, virtualNetworkName, description.region)
 
-        // TODO We just try to grab the next subnet, which fails if the largest possible subnet is already taken.
-        // TODO We also just assume that a vnet can only have one address range.
         task.updateStatus(BASE_PHASE, "Creating subnet for application gateway")
+
+        // Compute the next subnet address prefix using the cached vnet and a random generated seed
+        def vnetDescription = networkProvider.get(description.accountName, description.region, virtualNetworkName)
+        Random rand = new Random()
+        def nextSubnetAddressPrefix = AzureVirtualNetworkDescription.getNextSubnetAddressPrefix(vnetDescription, rand.nextInt(vnetDescription?.maxSubnets ?: 1))
+        subnetName = AzureUtilities.getSubnetName(virtualNetworkName, nextSubnetAddressPrefix)
+
+        // we'll do a final check to make sure that the subnet can be created before we pass it in the deployment template
         def vnet = description.credentials.networkClient.getVirtualNetwork(resourceGroupName, virtualNetworkName)
-        if (vnet.addressSpace.addressPrefixes.size() != 1) {
-          throw new RuntimeException(
-            "Virtual Network found with ${vnet.addressSpace.addressPrefixes.size()} address spaces; expected: 1")
-        }
 
-        String vnetPrefix = vnet.addressSpace.addressPrefixes[0]
-        String subnetPrefix = null
-        if (vnet.subnets.size() > 0) {
-          subnetPrefix = vnet.subnets.max({ a, b -> AzureUtilities.compareIpv4AddrPrefixes(a.addressPrefix, b.addressPrefix) }).addressPrefix
+        if (!subnetName || vnet?.subnets?.find {it.name == subnetName}) {
+          // virtualNetworkName is not yet in the cache or the subnet we try to create already exists; we'll use the current vnet
+          //   we just got to re-compute the next subnet
+          vnetDescription = AzureVirtualNetworkDescription.getDescriptionForVirtualNetwork(vnet)
+          nextSubnetAddressPrefix = AzureVirtualNetworkDescription.getNextSubnetAddressPrefix(vnetDescription, rand.nextInt(vnetDescription?.maxSubnets ?: 1))
+          subnetName = AzureUtilities.getSubnetName(virtualNetworkName, nextSubnetAddressPrefix)
         }
-
-        String nextSubnet = AzureUtilities.getNextSubnet(vnetPrefix, subnetPrefix)
-        subnetName = AzureUtilities.getSubnetName(virtualNetworkName, nextSubnet)
 
         task.updateStatus(BASE_PHASE, "Creating new subnet ${subnetName} for ${description.loadBalancerName}")
         def subnetId = description.credentials.networkClient.createSubnet(resourceGroupName,
           virtualNetworkName,
           subnetName,
-          nextSubnet,
+          nextSubnetAddressPrefix,
           description.securityGroup)
 
         if (!subnetId) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/view/AzureNetworkProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/view/AzureNetworkProvider.groovy
@@ -27,7 +27,12 @@ import com.netflix.spinnaker.clouddriver.azure.resources.network.model.AzureVirt
 import com.netflix.spinnaker.clouddriver.model.NetworkProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
 
+@RestController
 @Component
 class AzureNetworkProvider implements NetworkProvider<AzureNetwork> {
 
@@ -50,6 +55,16 @@ class AzureNetworkProvider implements NetworkProvider<AzureNetwork> {
   @Override
   Set<AzureNetwork> getAll() {
     cacheView.getAll(Keys.Namespace.AZURE_NETWORKS.ns, RelationshipCacheFilter.none()).collect(this.&fromCacheData)
+  }
+
+  AzureVirtualNetworkDescription get(String account, String region, String name) {
+    AzureVirtualNetworkDescription vnet = null
+    def cacheData = cacheView.get(Keys.Namespace.AZURE_NETWORKS.ns, Keys.getNetworkKey(azureCloudProvider, name, region, account))
+    if (cacheData) {
+      vnet = objectMapper.convertValue(cacheData.attributes['network'], AzureVirtualNetworkDescription)
+    }
+
+    vnet
   }
 
   AzureNetwork fromCacheData(CacheData cacheData) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/subnet/model/AzureSubnetDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/subnet/model/AzureSubnetDescription.groovy
@@ -16,15 +16,42 @@
 
 package com.netflix.spinnaker.clouddriver.azure.resources.subnet.model
 
+import com.microsoft.azure.management.network.models.Subnet
+import com.microsoft.azure.management.network.models.VirtualNetwork
+import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.common.AzureResourceOpsDescription
 
 class AzureSubnetDescription extends AzureResourceOpsDescription {
   String id = "unknown"
   String addressPrefix = "unknown"
   String resourceId /*Azure resource ID*/
-  String etag
   List<String> ipConfigurations = []
   String networkSecurityGroup
-  String routeTable
   String vnet = "unknown"
+  int ipv4
+  int addressPrefixLength
+
+  static AzureSubnetDescription getDescriptionForAzureSubnet(VirtualNetwork vnet, Subnet subnet) {
+    AzureSubnetDescription description = new AzureSubnetDescription(name: subnet.name)
+    description.name = subnet.name
+    description.region = vnet.location
+    description.cloudProvider = "azure"
+    description.vnet = vnet.name
+    description.resourceId = subnet.id
+    description.id = subnet.name
+    description.addressPrefix = subnet.addressPrefix
+    description.ipv4 = AzureUtilities.convertIpv4PrefixToInt(subnet.addressPrefix)
+    description.addressPrefixLength = AzureUtilities.getAddressPrefixLength(subnet.addressPrefix)
+    subnet.ipConfigurations?.each {resourceId -> description.ipConfigurations += resourceId.id}
+    description.networkSecurityGroup = subnet.networkSecurityGroup?.id
+
+    description
+  }
+
+  static Collection<AzureSubnetDescription> getSubnetsForVirtualNetwork(VirtualNetwork vnet, long currentTime = 0) {
+    // sort the list of subnet based on their ivp4 vals in order to speed the search when computing the next subnet
+    vnet.subnets?.collect {
+      getDescriptionForAzureSubnet(vnet, it)
+    }?.sort { a,b -> a.ipv4 <=> b.ipv4}
+  }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -244,7 +244,9 @@ class AzureServerGroupResourceTemplate {
      * @param description
      */
     StorageAccountProperties() {
-      accountType = "Standard_LRS" // TODO get this from the description
+      // Hardcoded value to use premium storage for better perf per Azure recommendation;
+      // TODO: we will revisit this later given that premium storage is a bit more expensive than standard
+      accountType = "Premium_LRS"
     }
   }
 

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilitiesSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilitiesSpec.groovy
@@ -118,4 +118,52 @@ class AzureUtilitiesSpec extends Specification {
     '254.255.255.0/24'    | '254.255.255.0/24'
   }
 
+  def "getSubnetRangeMax"() {
+    expect:
+    AzureUtilities.getSubnetRangeMax(vnet, 24) == rangeMax
+
+    where:
+    vnet                  | rangeMax
+    null                  | 0
+    ''                    | 0
+    '10.0.0.0/25'         | 0
+    '10.0.0.0/8'          | 0x10000
+    '10.0.0.0/16'         | 0x100
+    '10.0.0.0/23'         | 2
+    '255.0.0.0/8'         | 0x10000
+    '254.255.255.0/24'    | 0
+  }
+
+  def "convertIpv4PrefixToInt"() {
+    expect:
+    AzureUtilities.convertIpv4PrefixToInt(addrPrefix) == val
+
+    where:
+    addrPrefix            | val
+    null                  | -1
+    ''                    | -1
+    '10.0.0.0/24'         | 0x0A000000
+    '10.0.10.0/24'        | 0x0A000A00
+    '10.0.0.0/8'          | 0x0A000000
+    '10.0.0.0/16'         | 0x0A000000
+    '255.0.0.0/8'         | -16777216
+    '255.255.0.0/16'      | -65536
+  }
+
+  def "getAddressPrefixLength"() {
+    expect:
+    AzureUtilities.getAddressPrefixLength(addrPrefix) == val
+
+    where:
+    addrPrefix            | val
+    null                  | 0
+    ''                    | 0
+    '10.0.0.0/24'         | 24
+    '10.0.10.0/24'        | 24
+    '10.0.0.0/8'          | 8
+    '10.0.0.0/16'         | 16
+    '255.0.0.0/8'         | 8
+    '255.255.0.0/16'      | 16
+  }
+
 }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/model/AzureVirtualNetworkDescriptionSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/model/AzureVirtualNetworkDescriptionSpec.groovy
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2016 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.network.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.microsoft.azure.management.network.models.VirtualNetwork
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AzureVirtualNetworkDescriptionSpec extends Specification {
+
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  VirtualNetwork vnet
+
+  void "Create a simple AzureVirtualNetworkDescription from a given input"() {
+    setup:
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+
+    def input = [
+      name: "vnet-test-westus",
+      location: "westus",
+      id: "vnet-test-westus-id",
+    ]
+    def vnet = mapper.convertValue(input, VirtualNetwork) as VirtualNetwork
+
+    when:
+    def vnetDescription = AzureVirtualNetworkDescription.getDescriptionForVirtualNetwork(vnet)
+
+    then:
+    vnetDescription instanceof AzureVirtualNetworkDescription
+    mapper.writeValueAsString(vnetDescription) == expectedSimpleDescription
+  }
+
+  void "Create a full AzureVirtualNetworkDescription from a given input and calculate next subnet address prefix"() {
+    setup:
+    mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+
+    def input = [
+      name: "vnet-test-westus",
+      location: "westus",
+      id: "vnet-test-westus-id",
+      "properties.addressSpace": [
+        addressPrefixes: ["10.0.0.0/8"]
+      ],
+      "properties.subnets": [
+        [
+          name: "vnet-test-westus-subnet-10_0_1_0_24",
+          "properties.addressPrefix": "10.0.1.0/24"
+        ],
+        [
+          name: "vnet-test-westus-subnet-10_0_2_0_24",
+          "properties.addressPrefix": "10.0.2.0/24"
+        ],
+        [
+          name: "vnet-test-westus-subnet-10_0_30_0_24",
+          "properties.addressPrefix": "10.0.30.0/24"
+        ]
+      ],
+    ]
+    def vnet = mapper.convertValue(input, VirtualNetwork) as VirtualNetwork
+
+    when:
+    def vnetDescription = AzureVirtualNetworkDescription.getDescriptionForVirtualNetwork(vnet)
+    def nextSubnetAddressPrefix1 = AzureVirtualNetworkDescription.getNextSubnetAddressPrefix(vnetDescription, 1)
+    def nextSubnetAddressPrefix2 = AzureVirtualNetworkDescription.getNextSubnetAddressPrefix(vnetDescription, 30)
+    def nextSubnetAddressPrefix3 = AzureVirtualNetworkDescription.getNextSubnetAddressPrefix(vnetDescription, 10)
+
+    then:
+    vnetDescription instanceof AzureVirtualNetworkDescription
+    mapper.writeValueAsString(vnetDescription) == expectedFullDescription
+    nextSubnetAddressPrefix1 == "10.0.3.0/24"
+    nextSubnetAddressPrefix2 == "10.0.31.0/24"
+    nextSubnetAddressPrefix3 == "10.0.10.0/24"
+  }
+
+  private static String expectedSimpleDescription = '''{
+  "name" : "vnet-test-westus",
+  "cloudProvider" : null,
+  "accountName" : null,
+  "appName" : null,
+  "stack" : null,
+  "detail" : null,
+  "credentials" : null,
+  "region" : "westus",
+  "user" : null,
+  "createdTime" : null,
+  "lastReadTime" : 0,
+  "tags" : null,
+  "id" : "vnet-test-westus",
+  "type" : null,
+  "addressSpace" : null,
+  "resourceId" : "vnet-test-westus-id",
+  "subnets" : null,
+  "maxSubnets" : 0,
+  "subnetAddressPrefixLength" : 24
+}'''
+
+  private static String expectedFullDescription = '''{
+  "name" : "vnet-test-westus",
+  "cloudProvider" : null,
+  "accountName" : null,
+  "appName" : null,
+  "stack" : null,
+  "detail" : null,
+  "credentials" : null,
+  "region" : "westus",
+  "user" : null,
+  "createdTime" : null,
+  "lastReadTime" : 0,
+  "tags" : null,
+  "id" : "vnet-test-westus",
+  "type" : null,
+  "addressSpace" : [ "10.0.0.0/8" ],
+  "resourceId" : "vnet-test-westus-id",
+  "subnets" : [ {
+    "name" : "vnet-test-westus-subnet-10_0_1_0_24",
+    "cloudProvider" : "azure",
+    "accountName" : null,
+    "appName" : null,
+    "stack" : null,
+    "detail" : null,
+    "credentials" : null,
+    "region" : "westus",
+    "user" : null,
+    "createdTime" : null,
+    "lastReadTime" : 0,
+    "tags" : { },
+    "id" : "vnet-test-westus-subnet-10_0_1_0_24",
+    "addressPrefix" : "10.0.1.0/24",
+    "resourceId" : null,
+    "ipConfigurations" : [ ],
+    "networkSecurityGroup" : null,
+    "vnet" : "vnet-test-westus",
+    "ipv4" : 167772416,
+    "addressPrefixLength" : 24
+  }, {
+    "name" : "vnet-test-westus-subnet-10_0_2_0_24",
+    "cloudProvider" : "azure",
+    "accountName" : null,
+    "appName" : null,
+    "stack" : null,
+    "detail" : null,
+    "credentials" : null,
+    "region" : "westus",
+    "user" : null,
+    "createdTime" : null,
+    "lastReadTime" : 0,
+    "tags" : { },
+    "id" : "vnet-test-westus-subnet-10_0_2_0_24",
+    "addressPrefix" : "10.0.2.0/24",
+    "resourceId" : null,
+    "ipConfigurations" : [ ],
+    "networkSecurityGroup" : null,
+    "vnet" : "vnet-test-westus",
+    "ipv4" : 167772672,
+    "addressPrefixLength" : 24
+  }, {
+    "name" : "vnet-test-westus-subnet-10_0_30_0_24",
+    "cloudProvider" : "azure",
+    "accountName" : null,
+    "appName" : null,
+    "stack" : null,
+    "detail" : null,
+    "credentials" : null,
+    "region" : "westus",
+    "user" : null,
+    "createdTime" : null,
+    "lastReadTime" : 0,
+    "tags" : { },
+    "id" : "vnet-test-westus-subnet-10_0_30_0_24",
+    "addressPrefix" : "10.0.30.0/24",
+    "resourceId" : null,
+    "ipConfigurations" : [ ],
+    "networkSecurityGroup" : null,
+    "vnet" : "vnet-test-westus",
+    "ipv4" : 167779840,
+    "addressPrefixLength" : 24
+  } ],
+  "maxSubnets" : 65536,
+  "subnetAddressPrefixLength" : 24
+}'''
+
+}

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
@@ -147,7 +147,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "count" : 1
     },
     "properties" : {
-      "accountType" : "Standard_LRS"
+      "accountType" : "Premium_LRS"
     }
   }, {
     "apiVersion" : "2015-06-15",


### PR DESCRIPTION
Moved Azure Subnet and VirtualNetwork description creation from AzureNetworkClient into the respective description classes and disabled the Azure Subnet caching agent for now; we already get the subnets through the Azure network caching agents.
Default to premium storage.
Added ipv4 representation for the subnet address prefix which will be used to calculate next subnet address prefix using a randomly selected seed.
Compute and select the next subnet using the cached virtual network and using a randomly generated seed.
Added test cases for AzureVirtualNetworkDescription class and methods and the new methods in the AzureUtilities.
