### PR TITLE
Eliminates injection of AmazonCloudProvider for cache key handling

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AmazonCloudProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AmazonCloudProvider.groovy
@@ -22,7 +22,8 @@ import java.lang.annotation.Annotation
 
 @Component
 class AmazonCloudProvider implements CloudProvider {
-  final String id = "aws"
+  static final String AWS = "aws"
+  final String id = AWS
   final String displayName = "Amazon"
   final Class<? extends Annotation> operationAnnotationType = AmazonOperation
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.cache
 
 import com.netflix.frigga.Names
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
+import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.AWS
 
 class Keys {
   static enum Namespace {
@@ -41,7 +41,7 @@ class Keys {
     }
   }
 
-  static Map<String, String> parse(AmazonCloudProvider amazonCloudProvider, String key) {
+  static Map<String, String> parse(String key) {
     def parts = key.split(':')
 
     if (parts.length < 2) {
@@ -50,7 +50,7 @@ class Keys {
 
     def result = [provider: parts[0], type: parts[1]]
 
-    if (result.provider != amazonCloudProvider.id) {
+    if (result.provider != AWS) {
       return null
     }
 
@@ -82,47 +82,41 @@ class Keys {
     result
   }
 
-  static String getSecurityGroupKey(AmazonCloudProvider amazonCloudProvider,
-                                    String securityGroupName,
+  static String getSecurityGroupKey(String securityGroupName,
                                     String securityGroupId,
                                     String region,
                                     String account,
                                     String vpcId) {
-    "$amazonCloudProvider.id:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}:${vpcId}"
+    "$AWS:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}:${vpcId}"
   }
 
-  static String getSubnetKey(AmazonCloudProvider amazonCloudProvider,
-                             String subnetId,
+  static String getSubnetKey(String subnetId,
                              String region,
                              String account) {
-    "$amazonCloudProvider.id:${Namespace.SUBNETS}:${subnetId}:${account}:${region}"
+    "$AWS:${Namespace.SUBNETS}:${subnetId}:${account}:${region}"
   }
 
-  static String getVpcKey(AmazonCloudProvider amazonCloudProvider,
-                          String vpcId,
+  static String getVpcKey(String vpcId,
                           String region,
                           String account) {
-    "$amazonCloudProvider.id:${Namespace.VPCS}:${vpcId}:${account}:${region}"
+    "$AWS:${Namespace.VPCS}:${vpcId}:${account}:${region}"
   }
 
-  static String getKeyPairKey(AmazonCloudProvider amazonCloudProvider,
-                              String keyName,
+  static String getKeyPairKey(String keyName,
                               String region,
                               String account) {
-    "$amazonCloudProvider.id:${Namespace.KEY_PAIRS}:${keyName}:${account}:${region}"
+    "$AWS:${Namespace.KEY_PAIRS}:${keyName}:${account}:${region}"
   }
 
-  static String getInstanceTypeKey(AmazonCloudProvider amazonCloudProvider,
-                                   String instanceType,
+  static String getInstanceTypeKey(String instanceType,
                                    String region,
                                    String account) {
-    "$amazonCloudProvider.id:${Namespace.INSTANCE_TYPES}:${instanceType}:${account}:${region}"
+    "$AWS:${Namespace.INSTANCE_TYPES}:${instanceType}:${account}:${region}"
   }
 
-  static String getElasticIpKey(AmazonCloudProvider amazonCloudProvider,
-                                String ipAddress,
+  static String getElasticIpKey(String ipAddress,
                                 String region,
                                 String account) {
-    "$amazonCloudProvider.id:${Namespace.ELASTIC_IPS}:${ipAddress}:${account}:${region}"
+    "$AWS:${Namespace.ELASTIC_IPS}:${ipAddress}:${account}:${region}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -19,11 +19,10 @@ package com.netflix.spinnaker.clouddriver.aws.data
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
 import groovy.transform.CompileStatic
+import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.AWS
 
 @CompileStatic
 class Keys {
-
-  public static final PROVIDER = "aws"
 
   static Map<String, String> parse(String key) {
     def parts = key.split(':')
@@ -34,7 +33,7 @@ class Keys {
 
     def result = [provider: parts[0], type: parts[1]]
 
-    if (result.provider != PROVIDER) {
+    if (result.provider != AWS) {
       return null
     }
 
@@ -79,43 +78,43 @@ class Keys {
   }
 
   static String getImageKey(String imageId, String account, String region) {
-    "${PROVIDER}:${Namespace.IMAGES}:${account}:${region}:${imageId}"
+    "${AWS}:${Namespace.IMAGES}:${account}:${region}:${imageId}"
   }
 
   static String getNamedImageKey(String account, String imageName) {
-    "${PROVIDER}:${Namespace.NAMED_IMAGES}:${account}:${imageName}"
+    "${AWS}:${Namespace.NAMED_IMAGES}:${account}:${imageName}"
   }
 
   static String getServerGroupKey(String autoScalingGroupName, String account, String region) {
     Names names = Names.parseName(autoScalingGroupName)
-    "${PROVIDER}:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}"
+    "${AWS}:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}"
   }
 
   static String getInstanceKey(String instanceId, String account, String region) {
-    "${PROVIDER}:${Namespace.INSTANCES}:${account}:${region}:${instanceId}"
+    "${AWS}:${Namespace.INSTANCES}:${account}:${region}:${instanceId}"
   }
 
   static String getLaunchConfigKey(String launchConfigName, String account, String region) {
-    "${PROVIDER}:${Namespace.LAUNCH_CONFIGS}:${account}:${region}:${launchConfigName}"
+    "${AWS}:${Namespace.LAUNCH_CONFIGS}:${account}:${region}:${launchConfigName}"
   }
 
   static String getLoadBalancerKey(String loadBalancerName, String account, String region, String vpcId) {
-    "${PROVIDER}:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}${vpcId ? ':' + vpcId : ''}"
+    "${AWS}:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}${vpcId ? ':' + vpcId : ''}"
   }
 
   static String getClusterKey(String clusterName, String application, String account) {
-    "${PROVIDER}:${Namespace.CLUSTERS}:${application.toLowerCase()}:${account}:${clusterName}"
+    "${AWS}:${Namespace.CLUSTERS}:${application.toLowerCase()}:${account}:${clusterName}"
   }
 
   static String getApplicationKey(String application) {
-    "${PROVIDER}:${Namespace.APPLICATIONS}:${application.toLowerCase()}"
+    "${AWS}:${Namespace.APPLICATIONS}:${application.toLowerCase()}"
   }
 
   static String getInstanceHealthKey(String instanceId, String account, String region, String provider) {
-    "${PROVIDER}:${Namespace.HEALTH}:${instanceId}:${account}:${region}:${provider}"
+    "${AWS}:${Namespace.HEALTH}:${instanceId}:${account}:${region}:${provider}"
   }
 
   static String getReservedInstancesKey(String reservedInstancesId, String account, String region) {
-    "${PROVIDER}:${Namespace.RESERVED_INSTANCES}:${account}:${region}:${reservedInstancesId}"
+    "${AWS}:${Namespace.RESERVED_INSTANCES}:${account}:${region}:${reservedInstancesId}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsInfrastructureProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsInfrastructureProvider.groovy
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.aws.provider
 import com.fasterxml.jackson.core.type.TypeReference
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 
@@ -30,11 +29,9 @@ class AwsInfrastructureProvider extends AgentSchedulerAware implements Searchabl
 
   public static final String PROVIDER_NAME = AwsInfrastructureProvider.name
 
-  private final AmazonCloudProvider amazonCloudProvider
   private final Collection<Agent> agents
 
-  AwsInfrastructureProvider(AmazonCloudProvider amazonCloudProvider, Collection<Agent> agents) {
-    this.amazonCloudProvider = amazonCloudProvider
+  AwsInfrastructureProvider(Collection<Agent> agents) {
     this.agents = agents
   }
 
@@ -58,6 +55,6 @@ class AwsInfrastructureProvider extends AgentSchedulerAware implements Searchabl
 
   @Override
   Map<String, String> parseKey(String key) {
-    return Keys.parse(amazonCloudProvider, key)
+    return Keys.parse(key)
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgent.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.cats.agent.DefaultCacheResult
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
@@ -39,7 +38,6 @@ import groovy.util.logging.Slf4j
 @Slf4j
 class AmazonElasticIpCachingAgent implements CachingAgent, AccountAware {
 
-  final AmazonCloudProvider amazonCloudProvider
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
   final String region
@@ -48,11 +46,9 @@ class AmazonElasticIpCachingAgent implements CachingAgent, AccountAware {
     AUTHORITATIVE.forType(ELASTIC_IPS.ns)
   ] as Set)
 
-  AmazonElasticIpCachingAgent(AmazonCloudProvider amazonCloudProvider,
-                              AmazonClientProvider amazonClientProvider,
+  AmazonElasticIpCachingAgent(AmazonClientProvider amazonClientProvider,
                               NetflixAmazonCredentials account,
                               String region) {
-    this.amazonCloudProvider = amazonCloudProvider
     this.amazonClientProvider = amazonClientProvider
     this.account = account
     this.region = region
@@ -85,7 +81,7 @@ class AmazonElasticIpCachingAgent implements CachingAgent, AccountAware {
     def eips = ec2.describeAddresses().addresses
 
     List<CacheData> data = eips.collect { Address address ->
-      new DefaultCacheData(Keys.getElasticIpKey(amazonCloudProvider, address.publicIp, region, account.name), [
+      new DefaultCacheData(Keys.getElasticIpKey(address.publicIp, region, account.name), [
         address     : address.publicIp,
         domain      : address.domain,
         attachedToId: address.instanceId,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.cats.agent.DefaultCacheResult
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
@@ -46,7 +45,6 @@ class AmazonInstanceTypeCachingAgent implements CachingAgent, CustomScheduledAge
   public static final long DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.HOURS.toMillis(2)
   public static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(15)
 
-  final AmazonCloudProvider amazonCloudProvider
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
   final String region
@@ -65,20 +63,17 @@ class AmazonInstanceTypeCachingAgent implements CachingAgent, CustomScheduledAge
     return defaultIfNonEdda
   }
 
-  AmazonInstanceTypeCachingAgent(AmazonCloudProvider amazonCloudProvider,
-                                 AmazonClientProvider amazonClientProvider,
+  AmazonInstanceTypeCachingAgent(AmazonClientProvider amazonClientProvider,
                                  NetflixAmazonCredentials account,
                                  String region) {
-    this(amazonCloudProvider, amazonClientProvider, account, region, getDefaultIfNonEdda(account, DEFAULT_POLL_INTERVAL_MILLIS), getDefaultIfNonEdda(account, DEFAULT_TIMEOUT_MILLIS))
+    this(amazonClientProvider, account, region, getDefaultIfNonEdda(account, DEFAULT_POLL_INTERVAL_MILLIS), getDefaultIfNonEdda(account, DEFAULT_TIMEOUT_MILLIS))
   }
 
-  AmazonInstanceTypeCachingAgent(AmazonCloudProvider amazonCloudProvider,
-                                 AmazonClientProvider amazonClientProvider,
+  AmazonInstanceTypeCachingAgent(AmazonClientProvider amazonClientProvider,
                                  NetflixAmazonCredentials account,
                                  String region,
                                  long pollIntervalMillis,
                                  long timeoutMillis) {
-    this.amazonCloudProvider = amazonCloudProvider
     this.amazonClientProvider = amazonClientProvider
     this.account = account
     this.region = region
@@ -116,9 +111,9 @@ class AmazonInstanceTypeCachingAgent implements CachingAgent, CustomScheduledAge
       def offerings = ec2.describeReservedInstancesOfferings(request)
       Set<String> allIdentifiers = []
       data.addAll(offerings.reservedInstancesOfferings.findResults { ReservedInstancesOffering offering ->
-        String key = Keys.getInstanceTypeKey(amazonCloudProvider, offering.instanceType, region, account.name)
+        String key = Keys.getInstanceTypeKey(offering.instanceType, region, account.name)
         if (allIdentifiers.add(key)) {
-          new DefaultCacheData(Keys.getInstanceTypeKey(amazonCloudProvider, offering.instanceType, region, account.name), [
+          new DefaultCacheData(Keys.getInstanceTypeKey(offering.instanceType, region, account.name), [
             account           : account.name,
             region            : region,
             name              : offering.instanceType,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgent.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.cats.agent.DefaultCacheResult
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
@@ -39,7 +38,6 @@ import groovy.util.logging.Slf4j
 @Slf4j
 class AmazonKeyPairCachingAgent implements CachingAgent, AccountAware {
 
-  final AmazonCloudProvider amazonCloudProvider
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
   final String region
@@ -48,11 +46,9 @@ class AmazonKeyPairCachingAgent implements CachingAgent, AccountAware {
     AUTHORITATIVE.forType(KEY_PAIRS.ns)
   ] as Set)
 
-  AmazonKeyPairCachingAgent(AmazonCloudProvider amazonCloudProvider,
-                            AmazonClientProvider amazonClientProvider,
+  AmazonKeyPairCachingAgent(AmazonClientProvider amazonClientProvider,
                             NetflixAmazonCredentials account,
                             String region) {
-    this.amazonCloudProvider = amazonCloudProvider
     this.amazonClientProvider = amazonClientProvider
     this.account = account
     this.region = region
@@ -85,7 +81,7 @@ class AmazonKeyPairCachingAgent implements CachingAgent, AccountAware {
     def keyPairs = ec2.describeKeyPairs().keyPairs
 
     List<CacheData> data = keyPairs.collect { KeyPairInfo keyPair ->
-      new DefaultCacheData(Keys.getKeyPairKey(amazonCloudProvider, keyPair.keyName, region, account.name), [
+      new DefaultCacheData(Keys.getKeyPairKey(keyPair.keyName, region, account.name), [
         keyName       : keyPair.keyName,
         keyFingerprint: keyPair.keyFingerprint
       ], [:])

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
@@ -43,7 +43,6 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.SECURIT
 @Slf4j
 class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
 
-  final AmazonCloudProvider amazonCloudProvider
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
   final String region
@@ -56,19 +55,17 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
     AUTHORITATIVE.forType(SECURITY_GROUPS.ns)
   ] as Set)
 
-  AmazonSecurityGroupCachingAgent(AmazonCloudProvider amazonCloudProvider,
-                                  AmazonClientProvider amazonClientProvider,
+  AmazonSecurityGroupCachingAgent(AmazonClientProvider amazonClientProvider,
                                   NetflixAmazonCredentials account,
                                   String region,
                                   ObjectMapper objectMapper,
                                   Registry registry) {
-    this.amazonCloudProvider = amazonCloudProvider
     this.amazonClientProvider = amazonClientProvider
     this.account = account
     this.region = region
     this.objectMapper = objectMapper
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${amazonCloudProvider.id}:${OnDemandAgent.OnDemandType.SecurityGroup}")
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${AmazonCloudProvider.AWS}:${OnDemandAgent.OnDemandType.SecurityGroup}")
   }
 
   @Override
@@ -118,7 +115,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == amazonCloudProvider.id
+    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == AmazonCloudProvider.AWS
   }
 
   @Override
@@ -140,7 +137,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
   private CacheResult buildCacheResult(ProviderCache providerCache, List<SecurityGroup> securityGroups) {
     List<CacheData> data = securityGroups.collect { SecurityGroup securityGroup ->
       Map<String, Object> attributes = objectMapper.convertValue(securityGroup, AwsInfrastructureProvider.ATTRIBUTES)
-      new DefaultCacheData(Keys.getSecurityGroupKey(amazonCloudProvider, securityGroup.groupName, securityGroup.groupId, region, account.name, securityGroup.vpcId),
+      new DefaultCacheData(Keys.getSecurityGroupKey(securityGroup.groupName, securityGroup.groupId, region, account.name, securityGroup.vpcId),
         attributes,
         [:])
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSubnetCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSubnetCachingAgent.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.aws.provider.agent
 
 import com.netflix.spinnaker.cats.agent.AccountAware
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 
@@ -40,7 +39,6 @@ import groovy.util.logging.Slf4j
 @Slf4j
 class AmazonSubnetCachingAgent implements CachingAgent, AccountAware {
 
-  final AmazonCloudProvider amazonCloudProvider
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
   final String region
@@ -50,12 +48,10 @@ class AmazonSubnetCachingAgent implements CachingAgent, AccountAware {
     AUTHORITATIVE.forType(SUBNETS.ns)
   ] as Set)
 
-  AmazonSubnetCachingAgent(AmazonCloudProvider amazonCloudProvider,
-                           AmazonClientProvider amazonClientProvider,
+  AmazonSubnetCachingAgent(AmazonClientProvider amazonClientProvider,
                            NetflixAmazonCredentials account,
                            String region,
                            AmazonObjectMapper objectMapper) {
-    this.amazonCloudProvider = amazonCloudProvider
     this.amazonClientProvider = amazonClientProvider
     this.account = account
     this.region = region
@@ -90,7 +86,7 @@ class AmazonSubnetCachingAgent implements CachingAgent, AccountAware {
 
     List<CacheData> data = subnets.collect { Subnet subnet ->
       Map<String, Object> attributes = objectMapper.convertValue(subnet, AwsInfrastructureProvider.ATTRIBUTES)
-      new DefaultCacheData(Keys.getSubnetKey(amazonCloudProvider, subnet.subnetId, region, account.name),
+      new DefaultCacheData(Keys.getSubnetKey(subnet.subnetId, region, account.name),
         attributes,
         [:])
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonVpcCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonVpcCachingAgent.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.cats.agent.DefaultCacheResult
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
@@ -40,7 +39,6 @@ import groovy.util.logging.Slf4j
 @Slf4j
 class AmazonVpcCachingAgent implements CachingAgent, AccountAware {
 
-  final AmazonCloudProvider amazonCloudProvider
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
   final String region
@@ -50,12 +48,10 @@ class AmazonVpcCachingAgent implements CachingAgent, AccountAware {
     AUTHORITATIVE.forType(VPCS.ns)
   ] as Set)
 
-  AmazonVpcCachingAgent(AmazonCloudProvider amazonCloudProvider,
-                        AmazonClientProvider amazonClientProvider,
+  AmazonVpcCachingAgent(AmazonClientProvider amazonClientProvider,
                         NetflixAmazonCredentials account,
                         String region,
                         ObjectMapper objectMapper) {
-    this.amazonCloudProvider = amazonCloudProvider
     this.amazonClientProvider = amazonClientProvider
     this.account = account
     this.region = region
@@ -90,7 +86,7 @@ class AmazonVpcCachingAgent implements CachingAgent, AccountAware {
 
     List<CacheData> data = vpcs.collect { Vpc vpc ->
       Map<String, Object> attributes = objectMapper.convertValue(vpc, AwsInfrastructureProvider.ATTRIBUTES)
-      new DefaultCacheData(Keys.getVpcKey(amazonCloudProvider, vpc.vpcId, region, account.name),
+      new DefaultCacheData(Keys.getVpcKey(vpc.vpcId, region, account.name),
         attributes,
         [:])
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsInfrastructureProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsInfrastructureProviderConfig.groovy
@@ -20,7 +20,6 @@ import com.netflix.awsobjectmapper.AmazonObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
@@ -45,16 +44,14 @@ import java.util.concurrent.ConcurrentHashMap
 class AwsInfrastructureProviderConfig {
   @Bean
   @DependsOn('netflixAmazonCredentials')
-  AwsInfrastructureProvider awsInfrastructureProvider(AmazonCloudProvider amazonCloudProvider,
-                                                      AmazonClientProvider amazonClientProvider,
+  AwsInfrastructureProvider awsInfrastructureProvider(AmazonClientProvider amazonClientProvider,
                                                       AccountCredentialsRepository accountCredentialsRepository,
                                                       AmazonObjectMapper amazonObjectMapper,
                                                       Registry registry) {
     def awsInfrastructureProvider =
-      new AwsInfrastructureProvider(amazonCloudProvider, Collections.newSetFromMap(new ConcurrentHashMap<Agent, Boolean>()))
+      new AwsInfrastructureProvider(Collections.newSetFromMap(new ConcurrentHashMap<Agent, Boolean>()))
 
     synchronizeAwsInfrastructureProvider(awsInfrastructureProvider,
-                                         amazonCloudProvider,
                                          amazonClientProvider,
                                          accountCredentialsRepository,
                                          amazonObjectMapper,
@@ -80,7 +77,6 @@ class AwsInfrastructureProviderConfig {
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @Bean
   AwsInfrastructureProviderSynchronizer synchronizeAwsInfrastructureProvider(AwsInfrastructureProvider awsInfrastructureProvider,
-                                                                             AmazonCloudProvider amazonCloudProvider,
                                                                              AmazonClientProvider amazonClientProvider,
                                                                              AccountCredentialsRepository accountCredentialsRepository,
                                                                              AmazonObjectMapper amazonObjectMapper,
@@ -93,12 +89,12 @@ class AwsInfrastructureProviderConfig {
         if (!scheduledAccounts.contains(credentials.name)) {
           def newlyAddedAgents = []
 
-          newlyAddedAgents << new AmazonElasticIpCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name)
-          newlyAddedAgents << new AmazonInstanceTypeCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name)
-          newlyAddedAgents << new AmazonKeyPairCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name)
-          newlyAddedAgents << new AmazonSecurityGroupCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, amazonObjectMapper, registry)
-          newlyAddedAgents << new AmazonSubnetCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, amazonObjectMapper)
-          newlyAddedAgents << new AmazonVpcCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, amazonObjectMapper)
+          newlyAddedAgents << new AmazonElasticIpCachingAgent(amazonClientProvider, credentials, region.name)
+          newlyAddedAgents << new AmazonInstanceTypeCachingAgent(amazonClientProvider, credentials, region.name)
+          newlyAddedAgents << new AmazonKeyPairCachingAgent(amazonClientProvider, credentials, region.name)
+          newlyAddedAgents << new AmazonSecurityGroupCachingAgent(amazonClientProvider, credentials, region.name, amazonObjectMapper, registry)
+          newlyAddedAgents << new AmazonSubnetCachingAgent(amazonClientProvider, credentials, region.name, amazonObjectMapper)
+          newlyAddedAgents << new AmazonVpcCachingAgent(amazonClientProvider, credentials, region.name, amazonObjectMapper)
 
           // If there is an agent scheduler, then this provider has been through the AgentController in the past.
           // In that case, we need to do the scheduling here (because accounts have been added to a running system).

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonElasticIpProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonElasticIpProvider.groovy
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.model.ElasticIpProvider
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonElasticIp
@@ -32,25 +31,23 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.ELASTIC
 @Component
 class AmazonElasticIpProvider implements ElasticIpProvider<AmazonElasticIp> {
 
-  private final AmazonCloudProvider amazonCloudProvider
   private final Cache cacheView
   private final ObjectMapper objectMapper
 
   @Autowired
-  AmazonElasticIpProvider(AmazonCloudProvider amazonCloudProvider, Cache cacheView, ObjectMapper objectMapper) {
-    this.amazonCloudProvider = amazonCloudProvider
+  AmazonElasticIpProvider(Cache cacheView, ObjectMapper objectMapper) {
     this.cacheView = cacheView
     this.objectMapper = objectMapper
   }
 
   @Override
   Set<AmazonElasticIp> getAllByAccount(String account) {
-    loadResults(cacheView.filterIdentifiers(ELASTIC_IPS.ns, Keys.getElasticIpKey(amazonCloudProvider, '*', '*', account)))
+    loadResults(cacheView.filterIdentifiers(ELASTIC_IPS.ns, Keys.getElasticIpKey('*', '*', account)))
   }
 
   @Override
   Set<AmazonElasticIp> getAllByAccountAndRegion(String account, String region) {
-    loadResults(cacheView.filterIdentifiers(ELASTIC_IPS.ns, Keys.getElasticIpKey(amazonCloudProvider, '*', region, account)))
+    loadResults(cacheView.filterIdentifiers(ELASTIC_IPS.ns, Keys.getElasticIpKey('*', region, account)))
   }
 
   Set<AmazonElasticIp> loadResults(Collection<String> identifiers) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonKeyPairProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonKeyPairProvider.groovy
@@ -31,19 +31,17 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.KEY_PAI
 @Component
 class AmazonKeyPairProvider implements KeyPairProvider<AmazonKeyPair> {
 
-  private final AmazonCloudProvider amazonCloudProvider
   private final Cache cacheView
 
   @Autowired
-  AmazonKeyPairProvider(AmazonCloudProvider amazonCloudProvider, Cache cacheView) {
-    this.amazonCloudProvider = amazonCloudProvider
+  AmazonKeyPairProvider(Cache cacheView) {
     this.cacheView = cacheView
   }
 
   @Override
   Set<AmazonKeyPair> getAll() {
     cacheView.getAll(KEY_PAIRS.ns, RelationshipCacheFilter.none()).collect { CacheData cacheData ->
-      Map<String, String> parts = Keys.parse(amazonCloudProvider, cacheData.id)
+      Map<String, String> parts = Keys.parse(cacheData.id)
       new AmazonKeyPair(
         parts.account,
         parts.region,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSubnetProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSubnetProvider.groovy
@@ -37,13 +37,11 @@ class AmazonSubnetProvider implements SubnetProvider<AmazonSubnet> {
   private static final String NAME_TAG_KEY = 'name'
   private static final String DEPRECATED_TAG_KEY = 'is_deprecated'
 
-  private final AmazonCloudProvider amazonCloudProvider
   private final Cache cacheView
   private final AmazonObjectMapper objectMapper
 
   @Autowired
-  AmazonSubnetProvider(AmazonCloudProvider amazonCloudProvider, Cache cacheView, AmazonObjectMapper objectMapper) {
-    this.amazonCloudProvider = amazonCloudProvider
+  AmazonSubnetProvider(Cache cacheView, AmazonObjectMapper objectMapper) {
     this.cacheView = cacheView
     this.objectMapper = objectMapper
   }
@@ -55,7 +53,7 @@ class AmazonSubnetProvider implements SubnetProvider<AmazonSubnet> {
 
   @Override
   Set<AmazonSubnet> getAll() {
-    getAllMatchingKeyPattern(Keys.getSubnetKey(amazonCloudProvider, '*', '*', '*'))
+    getAllMatchingKeyPattern(Keys.getSubnetKey('*', '*', '*'))
   }
 
   Set<AmazonSubnet> getAllMatchingKeyPattern(String pattern) {
@@ -70,7 +68,7 @@ class AmazonSubnetProvider implements SubnetProvider<AmazonSubnet> {
   }
 
   AmazonSubnet fromCacheData(CacheData cacheData) {
-    def parts = Keys.parse(amazonCloudProvider, cacheData.id)
+    def parts = Keys.parse(cacheData.id)
     def subnet = objectMapper.convertValue(cacheData.attributes, Subnet)
     def tag = subnet.tags.find { it.key == METADATA_TAG_KEY }
     def isDeprecated = subnet.tags.find { it.key == DEPRECATED_TAG_KEY }?.value
@@ -94,7 +92,7 @@ class AmazonSubnetProvider implements SubnetProvider<AmazonSubnet> {
     }
 
     new AmazonSubnet(
-      type: amazonCloudProvider.id,
+      type: AmazonCloudProvider.AWS,
       id: subnet.subnetId,
       state: subnet.state,
       vpcId: subnet.vpcId,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonVpcProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonVpcProvider.groovy
@@ -36,20 +36,18 @@ class AmazonVpcProvider implements NetworkProvider<AmazonVpc> {
   private static final String NAME_TAG_KEY = 'Name'
   private static final String DEPRECATED_TAG_KEY = 'is_deprecated'
 
-  private final AmazonCloudProvider amazonCloudProvider
   private final Cache cacheView
   private final AmazonObjectMapper objectMapper
 
   @Autowired
-  AmazonVpcProvider(AmazonCloudProvider amazonCloudProvider, Cache cacheView, AmazonObjectMapper amazonObjectMapper) {
-    this.amazonCloudProvider = amazonCloudProvider
+  AmazonVpcProvider(Cache cacheView, AmazonObjectMapper amazonObjectMapper) {
     this.cacheView = cacheView
     this.objectMapper = amazonObjectMapper
   }
 
   @Override
   String getCloudProvider() {
-    return amazonCloudProvider.id
+    return AmazonCloudProvider.AWS
   }
 
   @Override
@@ -58,13 +56,13 @@ class AmazonVpcProvider implements NetworkProvider<AmazonVpc> {
   }
 
   AmazonVpc fromCacheData(CacheData cacheData) {
-    def parts = Keys.parse(amazonCloudProvider, cacheData.id)
+    def parts = Keys.parse(cacheData.id)
     def vpc = objectMapper.convertValue(cacheData.attributes, Vpc)
     def tag = vpc.tags.find { it.key == NAME_TAG_KEY }
     def isDeprecated = vpc.tags.find { it.key == DEPRECATED_TAG_KEY }?.value
     String name = tag?.value
     new AmazonVpc(
-      cloudProvider: amazonCloudProvider.id,
+      cloudProvider: AmazonCloudProvider.AWS,
       id: vpc.vpcId,
       name: name,
       account: parts.account,

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgentSpec.groovy
@@ -40,25 +40,21 @@ class AmazonElasticIpCachingAgentSpec extends Specification {
   ProviderCache providerCache = Mock(ProviderCache)
 
   @Shared
-  AmazonCloudProvider amazonCloudProvider
-
-  @Shared
   AmazonEC2 ec2
 
   @Shared
   Address eipA = new Address().withPublicIp("10.0.0.1").withDomain(DomainType.Standard).withInstanceId("i-123456")
 
   @Shared
-  String eipAKey = Keys.getElasticIpKey(new AmazonCloudProvider(), eipA.publicIp, region, account)
+  String eipAKey = Keys.getElasticIpKey(eipA.publicIp, region, account)
 
   @Shared
   Address eipB = new Address().withPublicIp("10.0.0.2").withDomain(DomainType.Vpc)
 
   @Shared
-  String eipBKey = Keys.getElasticIpKey(new AmazonCloudProvider(), eipB.publicIp, region, account)
+  String eipBKey = Keys.getElasticIpKey(eipB.publicIp, region, account)
 
   def setup() {
-    amazonCloudProvider = new AmazonCloudProvider()
     ec2 = Mock(AmazonEC2)
     def creds = Stub(NetflixAmazonCredentials) {
       getName() >> account
@@ -66,7 +62,7 @@ class AmazonElasticIpCachingAgentSpec extends Specification {
     def acp = Stub(AmazonClientProvider) {
       getAmazonEC2(creds, region) >> ec2
     }
-    agent = new AmazonElasticIpCachingAgent(amazonCloudProvider, acp, creds, region)
+    agent = new AmazonElasticIpCachingAgent(acp, creds, region)
   }
 
   void "should add elastic ips on initial run"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgentSpec.groovy
@@ -22,7 +22,6 @@ import com.amazonaws.services.ec2.model.DescribeReservedInstancesOfferingsResult
 import com.amazonaws.services.ec2.model.ReservedInstancesOffering
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
@@ -35,7 +34,6 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
   static final String region = 'us-east-1'
 
   AmazonEC2 ec2 = Mock(AmazonEC2)
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
   AmazonClientProvider provider = Stub(AmazonClientProvider) {
     getAmazonEC2(_, _) >> ec2
   }
@@ -47,13 +45,12 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
   ProviderCache providerCache = Mock(ProviderCache)
 
   @Subject
-  AmazonInstanceTypeCachingAgent agent = new AmazonInstanceTypeCachingAgent(
-    amazonCloudProvider, provider, creds, region)
+  AmazonInstanceTypeCachingAgent agent = new AmazonInstanceTypeCachingAgent(provider, creds, region)
 
   void "should add to cache"() {
     when:
     def result = agent.loadData(providerCache)
-    def expected = Keys.getInstanceTypeKey(amazonCloudProvider, 'm1', region, account)
+    def expected = Keys.getInstanceTypeKey('m1', region, account)
 
     then:
     1 * ec2.describeReservedInstancesOfferings(new DescribeReservedInstancesOfferingsRequest()) >> new DescribeReservedInstancesOfferingsResult(
@@ -71,7 +68,7 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
   void "should dedupe instance types"() {
     when:
     def result = agent.loadData(providerCache)
-    def expected = Keys.getInstanceTypeKey(amazonCloudProvider, 'm1', region, account)
+    def expected = Keys.getInstanceTypeKey('m1', region, account)
 
     then:
     1 * ec2.describeReservedInstancesOfferings(new DescribeReservedInstancesOfferingsRequest()) >> new DescribeReservedInstancesOfferingsResult(
@@ -107,9 +104,9 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
 
     with (result.cacheResults.get(Keys.Namespace.INSTANCE_TYPES.ns)) { List<CacheData> cd ->
       cd.size() == 3
-      cd.find { it.id == Keys.getInstanceTypeKey(amazonCloudProvider, 'm1', region, account) }
-      cd.find { it.id == Keys.getInstanceTypeKey(amazonCloudProvider, 'm2', region, account) }
-      cd.find { it.id == Keys.getInstanceTypeKey(amazonCloudProvider, 'm3', region, account) }
+      cd.find { it.id == Keys.getInstanceTypeKey('m1', region, account) }
+      cd.find { it.id == Keys.getInstanceTypeKey('m2', region, account) }
+      cd.find { it.id == Keys.getInstanceTypeKey('m3', region, account) }
     }
     0 * _
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgentSpec.groovy
@@ -21,7 +21,6 @@ import com.amazonaws.services.ec2.model.DescribeKeyPairsResult
 import com.amazonaws.services.ec2.model.KeyPairInfo
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
@@ -32,7 +31,6 @@ class AmazonKeyPairCachingAgentSpec extends Specification {
   static final String account = 'test'
   static final String region = 'us-east-1'
 
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
 
   AmazonEC2 ec2 = Mock(AmazonEC2)
 
@@ -47,8 +45,7 @@ class AmazonKeyPairCachingAgentSpec extends Specification {
   }
 
   @Subject
-  AmazonKeyPairCachingAgent agent = new AmazonKeyPairCachingAgent(
-    amazonCloudProvider, amazonClientProvider, creds, region)
+  AmazonKeyPairCachingAgent agent = new AmazonKeyPairCachingAgent(amazonClientProvider, creds, region)
 
   void "should add on loadData"() {
     when:
@@ -61,10 +58,10 @@ class AmazonKeyPairCachingAgentSpec extends Specification {
     ])
     with (result.cacheResults.get(Keys.Namespace.KEY_PAIRS.ns)) { List<CacheData> cd ->
       cd.size() == 2
-      def k1 = cd.find { it.id == Keys.getKeyPairKey(amazonCloudProvider, 'key1', region, account) }
+      def k1 = cd.find { it.id == Keys.getKeyPairKey('key1', region, account) }
       k1.attributes.keyName == 'key1'
       k1.attributes.keyFingerprint == '1'
-      def k2 = cd.find { it.id == Keys.getKeyPairKey(amazonCloudProvider, 'key2', region, account) }
+      def k2 = cd.find { it.id == Keys.getKeyPairKey('key2', region, account) }
       k2.attributes.keyName == 'key2'
       k2.attributes.keyFingerprint == '2'
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgentSpec.groovy
@@ -37,18 +37,17 @@ class AmazonSecurityGroupCachingAgentSpec extends Specification {
 
   AmazonEC2 ec2 = Mock(AmazonEC2)
   NetflixAmazonCredentials creds = Stub(NetflixAmazonCredentials) { getName() >> account }
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
   AmazonClientProvider amazonClientProvider = Stub(AmazonClientProvider) { getAmazonEC2(creds, region) >> ec2 }
   ProviderCache providerCache = Mock(ProviderCache)
   AmazonObjectMapper mapper = new AmazonObjectMapper()
 
-  @Subject AmazonSecurityGroupCachingAgent agent = new AmazonSecurityGroupCachingAgent(amazonCloudProvider,
+  @Subject AmazonSecurityGroupCachingAgent agent = new AmazonSecurityGroupCachingAgent(
     amazonClientProvider, creds, region, mapper, Spectator.registry())
 
   SecurityGroup securityGroupA = new SecurityGroup(groupId: 'id-a', groupName: 'name-a', description: 'a')
   SecurityGroup securityGroupB = new SecurityGroup(groupId: 'id-b', groupName: 'name-b', description: 'b')
-  String keyGroupA = Keys.getSecurityGroupKey(amazonCloudProvider, securityGroupA.groupName, securityGroupA.groupId, region, account, null)
-  String keyGroupB = Keys.getSecurityGroupKey(amazonCloudProvider, securityGroupB.groupName, securityGroupB.groupId, region, account, null)
+  String keyGroupA = Keys.getSecurityGroupKey(securityGroupA.groupName, securityGroupA.groupId, region, account, null)
+  String keyGroupB = Keys.getSecurityGroupKey(securityGroupB.groupName, securityGroupB.groupId, region, account, null)
 
   void "should add security groups on initial run"() {
     given:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSubnetCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSubnetCachingAgentSpec.groovy
@@ -22,7 +22,6 @@ import com.amazonaws.services.ec2.model.Subnet
 import com.netflix.awsobjectmapper.AmazonObjectMapper
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
@@ -33,7 +32,6 @@ class AmazonSubnetCachingAgentSpec extends Specification {
   static final String account = 'test'
   static final String region = 'us-east-1'
 
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
 
   AmazonEC2 ec2 = Mock(AmazonEC2)
 
@@ -51,7 +49,7 @@ class AmazonSubnetCachingAgentSpec extends Specification {
 
   @Subject
   AmazonSubnetCachingAgent agent = new AmazonSubnetCachingAgent(
-      amazonCloudProvider, amazonClientProvider, creds, region, amazonObjectMapper)
+      amazonClientProvider, creds, region, amazonObjectMapper)
 
   void "should add on initial run"() {
     when:
@@ -66,8 +64,8 @@ class AmazonSubnetCachingAgentSpec extends Specification {
 
     with (result.cacheResults.get(Keys.Namespace.SUBNETS.ns)) { List<CacheData> cd ->
       cd.size() == 2
-      cd.find { it.id == Keys.getSubnetKey(amazonCloudProvider, 'subnetId1', region, account)}
-      cd.find { it.id == Keys.getSubnetKey(amazonCloudProvider, 'subnetId2', region, account)}
+      cd.find { it.id == Keys.getSubnetKey('subnetId1', region, account)}
+      cd.find { it.id == Keys.getSubnetKey('subnetId2', region, account)}
     }
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonElasticIpProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonElasticIpProviderSpec.groovy
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.mem.InMemoryCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.model.ElasticIp
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonElasticIp
@@ -37,17 +36,16 @@ class AmazonElasticIpProviderSpec extends Specification {
   @Subject
   AmazonElasticIpProvider provider
 
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
   ObjectMapper objectMapper = new ObjectMapper()
 
   def setup() {
     def cache = new InMemoryCache()
     getAllElasticIps().each {
       cache.merge(ELASTIC_IPS.ns,
-          new DefaultCacheData(makeKey(amazonCloudProvider, it), objectMapper.convertValue(it, ATTRIBUTES), [:]))
+          new DefaultCacheData(makeKey(it), objectMapper.convertValue(it, ATTRIBUTES), [:]))
     }
 
-    provider = new AmazonElasticIpProvider(amazonCloudProvider, cache, objectMapper)
+    provider = new AmazonElasticIpProvider(cache, objectMapper)
   }
 
   @Unroll
@@ -111,8 +109,8 @@ class AmazonElasticIpProviderSpec extends Specification {
     }.flatten()
   }
 
-  private static String makeKey(AmazonCloudProvider amazonCloudProvider, ElasticIp elasticIp) {
-    Keys.getElasticIpKey(amazonCloudProvider, elasticIp.address, elasticIp.region, elasticIp.accountName)
+  private static String makeKey(ElasticIp elasticIp) {
+    Keys.getElasticIpKey(elasticIp.address, elasticIp.region, elasticIp.accountName)
   }
 
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceTypeProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceTypeProviderSpec.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.CacheFilter
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonInstanceType
 import spock.lang.Specification
@@ -29,7 +28,6 @@ import spock.lang.Subject
 
 class AmazonInstanceTypeProviderSpec extends Specification {
 
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
   Cache cache = Mock(Cache)
   @Subject
   AmazonInstanceTypeProvider provider = new AmazonInstanceTypeProvider(cache, new ObjectMapper())
@@ -73,6 +71,6 @@ class AmazonInstanceTypeProviderSpec extends Specification {
     ]
 
     def attributes = defaults + params
-    new DefaultCacheData(Keys.getInstanceTypeKey(amazonCloudProvider, instanceType, attributes.region, attributes.account), attributes, [:])
+    new DefaultCacheData(Keys.getInstanceTypeKey(instanceType, attributes.region, attributes.account), attributes, [:])
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonKeyPairProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonKeyPairProviderSpec.groovy
@@ -20,8 +20,6 @@ import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.CacheFilter
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
-import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonKeyPair
 import spock.lang.Specification
@@ -29,11 +27,10 @@ import spock.lang.Subject
 
 class AmazonKeyPairProviderSpec extends Specification {
 
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
   Cache cache = Mock(Cache)
 
   @Subject
-  AmazonKeyPairProvider provider = new AmazonKeyPairProvider(amazonCloudProvider, cache)
+  AmazonKeyPairProvider provider = new AmazonKeyPairProvider(cache)
 
   void "should retrieve all key Pairs"() {
     when:
@@ -70,6 +67,6 @@ class AmazonKeyPairProviderSpec extends Specification {
       keyName       : key,
       keyFingerprint: fingerprint
     ]
-    new DefaultCacheData(Keys.getKeyPairKey(amazonCloudProvider, key, region, account), attributes, [:])
+    new DefaultCacheData(Keys.getKeyPairKey(key, region, account), attributes, [:])
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.mem.InMemoryCache
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.model.securitygroups.IpRangeRule
 import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule
@@ -43,7 +42,6 @@ class AmazonSecurityGroupProviderSpec extends Specification {
   @Subject
   AmazonSecurityGroupProvider provider
 
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
   WriteableCache cache = new InMemoryCache()
   ObjectMapper mapper = new ObjectMapper()
 
@@ -72,7 +70,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
 
 
   def setup() {
-    provider = new AmazonSecurityGroupProvider(amazonCloudProvider, accountCredentialsProvider, cache, mapper)
+    provider = new AmazonSecurityGroupProvider(accountCredentialsProvider, cache, mapper)
     cache.mergeAll(Keys.Namespace.SECURITY_GROUPS.ns, getAllGroups())
   }
 
@@ -186,7 +184,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
 
     String account = 'test'
     String region = 'us-east-1'
-    def key = Keys.getSecurityGroupKey(amazonCloudProvider, groupName, groupId, region, account, vpcId)
+    def key = Keys.getSecurityGroupKey(groupName, groupId, region, account, vpcId)
     Map<String, Object> attributes = mapper.convertValue(mixedRangedGroupA, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheData = new DefaultCacheData(key, attributes, [:])
     cache.merge(Keys.Namespace.SECURITY_GROUPS.ns, cacheData)
@@ -221,7 +219,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     ]
     String account = 'test'
     String region = 'us-east-1'
-    def key = Keys.getSecurityGroupKey(amazonCloudProvider, 'name-b', 'id-b', region, account, null)
+    def key = Keys.getSecurityGroupKey('name-b', 'id-b', region, account, null)
     Map<String, Object> attributes = mapper.convertValue(securityGroupB, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheData = new DefaultCacheData(key, attributes, [:])
     cache.merge(Keys.Namespace.SECURITY_GROUPS.ns, cacheData)
@@ -284,7 +282,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
           ipRanges: ['0.0.0.0/32', '0.0.0.1/31']
         )
       ])
-    def key = Keys.getSecurityGroupKey(amazonCloudProvider, 'name-a', 'id-a', region, account, null)
+    def key = Keys.getSecurityGroupKey('name-a', 'id-a', region, account, null)
     Map<String, Object> attributes = mapper.convertValue(group, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheData = new DefaultCacheData(key, attributes, [:])
     cache.merge(Keys.Namespace.SECURITY_GROUPS.ns, cacheData)
@@ -315,8 +313,8 @@ class AmazonSecurityGroupProviderSpec extends Specification {
             new UserIdGroupPair(userId: "accountId1", groupId: securityGroupB.groupId)
         ])
     ]
-    def keyA = Keys.getSecurityGroupKey(amazonCloudProvider, 'name-a', 'id-a', region, account, vpcId)
-    def keyB = Keys.getSecurityGroupKey(amazonCloudProvider, 'name-b', 'id-b', region, account, vpcId)
+    def keyA = Keys.getSecurityGroupKey('name-a', 'id-a', region, account, vpcId)
+    def keyB = Keys.getSecurityGroupKey('name-b', 'id-b', region, account, vpcId)
     Map<String, Object> attributesA = mapper.convertValue(securityGroupA, AwsInfrastructureProvider.ATTRIBUTES)
     Map<String, Object> attributesB = mapper.convertValue(securityGroupB, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheDataA = new DefaultCacheData(keyA, attributesA, [:])
@@ -346,8 +344,8 @@ class AmazonSecurityGroupProviderSpec extends Specification {
             new UserIdGroupPair(userId: "accountId2", groupId: securityGroupB.groupId)
         ])
     ]
-    def keyA = Keys.getSecurityGroupKey(amazonCloudProvider, 'name-a', 'id-a', region, account1, vpcId1)
-    def keyB = Keys.getSecurityGroupKey(amazonCloudProvider, 'name-b', 'id-b', region, account2, vpcId2)
+    def keyA = Keys.getSecurityGroupKey('name-a', 'id-a', region, account1, vpcId1)
+    def keyB = Keys.getSecurityGroupKey('name-b', 'id-b', region, account2, vpcId2)
     Map<String, Object> attributesA = mapper.convertValue(securityGroupA, AwsInfrastructureProvider.ATTRIBUTES)
     Map<String, Object> attributesB = mapper.convertValue(securityGroupB, AwsInfrastructureProvider.ATTRIBUTES)
     def cacheDataA = new DefaultCacheData(keyA, attributesA, [:])
@@ -393,7 +391,7 @@ class AmazonSecurityGroupProviderSpec extends Specification {
       regions.collect { String region, List<SecurityGroup> groups ->
         groups.collect { SecurityGroup group ->
           Map<String, Object> attributes = mapper.convertValue(group, AwsInfrastructureProvider.ATTRIBUTES)
-          new DefaultCacheData(Keys.getSecurityGroupKey(amazonCloudProvider, group.groupName, group.groupId, region, account, group.vpcId), attributes, [:])
+          new DefaultCacheData(Keys.getSecurityGroupKey(group.groupName, group.groupId, region, account, group.vpcId), attributes, [:])
         }
       }.flatten()
     }.flatten()

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSubnetProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSubnetProviderSpec.groovy
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.CacheFilter
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
-import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonSubnet
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
@@ -33,12 +32,11 @@ import spock.lang.Subject
 
 class AmazonSubnetProviderSpec extends Specification {
 
-  AmazonCloudProvider amazonCloudProvider = new AmazonCloudProvider()
   Cache cache = Mock(Cache)
   ObjectMapper mapper = new AmazonObjectMapper()
 
   @Subject
-  AmazonSubnetProvider provider = new AmazonSubnetProvider(amazonCloudProvider, cache, mapper)
+  AmazonSubnetProvider provider = new AmazonSubnetProvider(cache, mapper)
 
   void "should retrieve all subnets"() {
     when:
@@ -178,7 +176,7 @@ class AmazonSubnetProviderSpec extends Specification {
 
   CacheData snData(String account, String region, Subnet subnet) {
     Map<String, Object> attributes = mapper.convertValue(subnet, AwsInfrastructureProvider.ATTRIBUTES)
-    new DefaultCacheData(Keys.getSubnetKey(amazonCloudProvider, subnet.subnetId, region, account),
+    new DefaultCacheData(Keys.getSubnetKey(subnet.subnetId, region, account),
       attributes,
       [:]
     )


### PR DESCRIPTION
This introduces a constant on AmazonCloudProvider instead of injecting it as a component all over the place to reference its id attribute.

@spinnaker/netflix-reviewers PTAL