### PR TITLE
Docker registry: prevent errors from getTags terminating polling agent

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -78,10 +78,15 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware {
     credentials.repositories.findAll { it ->
       threadCount == 1 || (it.hashCode() % threadCount).abs() == index
     }.collectEntries {
-        DockerRegistryTags tags = credentials.client.getTags(it)
-        tags ? [(tags.name): tags.tags ?: []] : [:]
+      DockerRegistryTags tags
+      try {
+        tags = credentials.client.getTags(it)
+      } catch (e) {
+        log.error("Could not load tags for ${it}")
       }
+      tags ? [(tags.name): tags.tags ?: []] : [:]
     }
+  }
 
   @Override
   String getAccountName() {


### PR DESCRIPTION
sometimes the docker registry will have incorrect indexing of repositories. Seeing that it currently terminates the poling process whereas it should just be ignored.