### PR TITLE
(aws) cache image creation timestamp

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupController.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupController.groovy
@@ -121,6 +121,7 @@ class AmazonNamedImageLookupController {
       Map<String, String> namedImageKeyParts = Keys.parse(data.relationships[NAMED_IMAGES.ns][0])
       NamedImage thisImage = byImageName[namedImageKeyParts.imageName]
       thisImage.attributes.virtualizationType = data.attributes.virtualizationType
+      thisImage.attributes.creationDate = data.attributes.creationDate
       thisImage.accounts.add(namedImageKeyParts.account)
       amiKeyParts.tags.each {
         thisImage.tags << [it.key, it.value]

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ImageCachingAgent.groovy
@@ -108,7 +108,8 @@ class ImageCachingAgent implements CachingAgent, AccountAware, DriftMetric {
         imageCacheData.add(new DefaultCacheData(imageId, attributes, [(NAMED_IMAGES.ns): [namedImageId]]))
         namedImageCacheData.add(new DefaultCacheData(namedImageId, [
           name              : image.name,
-          virtualizationType: image.virtualizationType
+          virtualizationType: image.virtualizationType,
+          creationDate      : image.creationDate
         ], [(IMAGES.ns): [imageId]]))
       }
     }


### PR DESCRIPTION
Considering using this when sorting images in the UI. Currently, we sort by reverse alphabetical order, which is not great.

@spinnaker/netflix-reviewers PTAL