### PR TITLE
Move security group logic to operation instead of client

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/exception/OpenstackResourceNotFoundException.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/exception/OpenstackResourceNotFoundException.groovy
@@ -19,4 +19,4 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.exception
 import groovy.transform.InheritConstructors
 
 @InheritConstructors
-class OpenstackResourceNotFoundException extends OpenstackOperationException {}
+class OpenstackResourceNotFoundException extends OpenstackProviderException {}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/securitygroup/UpsertOpenstackSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/securitygroup/UpsertOpenstackSecurityGroupAtomicOperation.groovy
@@ -19,11 +19,22 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.ops.securitygroup
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.securitygroup.UpsertOpenstackSecurityGroupDescription
+import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
+import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
+import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import groovy.util.logging.Slf4j
+import org.apache.commons.lang.StringUtils
+import org.openstack4j.model.compute.IPProtocol
+import org.openstack4j.model.compute.SecGroupExtension
 
 /**
  * Creates or updates an Openstack security group.
+ *
+ * Note that this can only manage ingress rules for the security groups. It appears that this is a limitation of the
+ * Openstack API itself. Egress rules can be created as part of default rules for security groups, but that needs to
+ * be managed in Openstack itself, not through Spinnaker.
  */
 @Slf4j
 class UpsertOpenstackSecurityGroupAtomicOperation implements AtomicOperation<Void> {
@@ -41,18 +52,46 @@ class UpsertOpenstackSecurityGroupAtomicOperation implements AtomicOperation<Voi
 
   /*
   * Create:
-  * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertSecurityGroup": { "name": "sg-test-1", "description": "test", "account": "test", "rules": [ { "fromPort": 80, "toPort": 90, "cidr": "0.0.0.0/0"  } ] } } ]' localhost:7002/openstack/ops
+  * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertSecurityGroup": { "region": "west", "name": "sg-test-1", "description": "test", "account": "test", "rules": [ { "fromPort": 80, "toPort": 90, "cidr": "0.0.0.0/0"  } ] } } ]' localhost:7002/openstack/ops
   * Update:
-  * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertSecurityGroup": { "id": "e56fa7eb-550d-42d4-8d3f-f658fbacd496", "name": "sg-test-1", "description": "test", "account": "test", "rules": [ { "fromPort": 80, "toPort": 90, "cidr": "0.0.0.0/0"  } ] } } ]' localhost:7002/openstack/ops
+  * curl -X POST -H "Content-Type: application/json" -d '[ { "upsertSecurityGroup": { "region": "west", "id": "e56fa7eb-550d-42d4-8d3f-f658fbacd496", "name": "sg-test-1", "description": "test", "account": "test", "rules": [ { "fromPort": 80, "toPort": 90, "cidr": "0.0.0.0/0"  } ] } } ]' localhost:7002/openstack/ops
   * Task status:
   * curl -X GET -H "Accept: application/json" localhost:7002/task/1
   */
+
   @Override
   Void operate(List priorOutputs) {
-    task.updateStatus BASE_PHASE, "Upserting security group ${description.name}..."
+    task.updateStatus BASE_PHASE, "Upserting security group ${description.name} in region ${description.region}..."
 
-    description.credentials.provider.upsertSecurityGroup(description.id, description.name, description.description, description.rules)
+    OpenstackClientProvider provider = description.credentials.provider
 
-    task.updateStatus BASE_PHASE, "Finished upserting security group ${description.name}."
+    try {
+
+      // Try getting existing security group, update if needed
+      SecGroupExtension securityGroup
+      if (StringUtils.isNotEmpty(description.id)) {
+        task.updateStatus BASE_PHASE, "Looking up existing security group with id ${description.id}"
+        securityGroup = provider.getSecurityGroup(description.region, description.id)
+        task.updateStatus BASE_PHASE, "Updating security group with name ${description.name} and description '${description.description}'"
+        securityGroup = provider.updateSecurityGroup(description.region, description.id, description.name, description.description)
+      } else {
+        task.updateStatus BASE_PHASE, "Creating new security group with name ${description.name}"
+        securityGroup = provider.createSecurityGroup(description.region, description.name, description.description)
+      }
+
+      // TODO: Find the different between existing rules and only apply that instead of deleting and re-creating all the rules
+      securityGroup.rules.each { rule ->
+        task.updateStatus BASE_PHASE, "Deleting rule ${rule.id}"
+        provider.deleteSecurityGroupRule(description.region, rule.id)
+      }
+
+      description.rules.each { rule ->
+        task.updateStatus BASE_PHASE, "Creating rule for ${rule.cidr} from port ${rule.fromPort} to port ${rule.toPort}"
+        provider.createSecurityGroupRule(description.region, securityGroup.id, IPProtocol.value(rule.ruleType), rule.cidr, rule.fromPort, rule.toPort)
+      }
+      task.updateStatus BASE_PHASE, " Finished upserting security group ${description.name}."
+    } catch (OpenstackProviderException e) {
+      throw new OpenstackOperationException(AtomicOperations.UPSERT_SECURITY_GROUP, e)
+    }
   }
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/securitygroup/UpsertOpenstackSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/securitygroup/UpsertOpenstackSecurityGroupDescriptionValidator.groovy
@@ -40,17 +40,18 @@ class UpsertOpenstackSecurityGroupDescriptionValidator extends DescriptionValida
 
   @Override
   void validate(List priorDescriptions, UpsertOpenstackSecurityGroupDescription description, Errors errors) {
-    def validator = new OpenstackAttributeValidator("upsertOpenstackSecurityGroupAtomicOperationDescription", errors)
+    def validator = new OpenstackAttributeValidator('upsertOpenstackSecurityGroupAtomicOperationDescription', errors)
     validator.validateCredentials(description.account, accountCredentialsProvider)
+    validator.validateNotEmpty(description.region, "region")
     if (StringUtils.isNotEmpty(description.id)) {
-      validator.validateUUID(description.id, "id")
+      validator.validateUUID(description.id, 'id')
     }
     if (!description.rules.isEmpty()) {
       description.rules.each { r ->
-        validator.validateCIDR(r.cidr, "cidr")
-        validator.validatePort(r.fromPort, "fromPort")
-        validator.validatePort(r.toPort, "toPort")
-        validator.validateRuleType(r.ruleType, "ruleType")
+        validator.validateCIDR(r.cidr, 'cidr')
+        validator.validatePort(r.fromPort, 'fromPort')
+        validator.validatePort(r.toPort, 'toPort')
+        validator.validateRuleType(r.ruleType, 'ruleType')
       }
     }
   }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackClientProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackClientProviderSpec.groovy
@@ -16,44 +16,35 @@
 
 package com.netflix.spinnaker.clouddriver.openstack.client
 
-import com.netflix.spinnaker.clouddriver.openstack.deploy.description.securitygroup.UpsertOpenstackSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
+import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.openstack.domain.LoadBalancerPool
 import com.netflix.spinnaker.clouddriver.openstack.domain.PoolHealthMonitor
 import com.netflix.spinnaker.clouddriver.openstack.domain.VirtualIP
 import org.openstack4j.api.OSClient
+import org.openstack4j.api.compute.ComputeFloatingIPService
 import org.openstack4j.api.compute.ComputeSecurityGroupService
+import org.openstack4j.api.compute.ComputeService
 import org.openstack4j.api.compute.ServerService
+import org.openstack4j.api.exceptions.ServerResponseException
 import org.openstack4j.api.heat.HeatService
 import org.openstack4j.api.heat.StackService
 import org.openstack4j.api.heat.TemplateService
-import org.openstack4j.api.compute.ComputeFloatingIPService
-import org.openstack4j.api.compute.ComputeService
-import org.openstack4j.api.exceptions.ServerResponseException
 import org.openstack4j.api.networking.NetFloatingIPService
 import org.openstack4j.api.networking.NetworkingService
 import org.openstack4j.api.networking.PortService
 import org.openstack4j.api.networking.SubnetService
-import org.openstack4j.api.networking.ext.HealthMonitorService
-import org.openstack4j.api.networking.ext.LbPoolService
-import org.openstack4j.api.networking.ext.LoadBalancerService
-import org.openstack4j.api.networking.ext.MemberService
-import org.openstack4j.api.networking.ext.VipService
+import org.openstack4j.api.networking.ext.*
 import org.openstack4j.model.common.ActionResponse
-import org.openstack4j.model.compute.FloatingIP
+import org.openstack4j.model.compute.*
+import org.openstack4j.model.heat.Stack
 import org.openstack4j.model.network.NetFloatingIP
 import org.openstack4j.model.network.Port
 import org.openstack4j.model.network.Subnet
 import org.openstack4j.model.network.ext.HealthMonitor
-import org.openstack4j.model.network.ext.Vip
-import org.openstack4j.model.compute.Address
-import org.openstack4j.model.compute.Addresses
-import org.openstack4j.model.compute.IPProtocol
-import org.openstack4j.model.compute.SecGroupExtension
-import org.openstack4j.model.compute.Server
-import org.openstack4j.model.heat.Stack
 import org.openstack4j.model.network.ext.LbPool
 import org.openstack4j.model.network.ext.Member
+import org.openstack4j.model.network.ext.Vip
 import org.openstack4j.openstack.compute.domain.NovaSecGroupExtension
 import org.springframework.http.HttpStatus
 import spock.lang.Specification
@@ -88,56 +79,8 @@ class OpenstackClientProviderSpec extends Specification {
     mockClient.useRegion(region) >> mockClient
   }
 
-  def "create security group without rules"() {
-    setup:
-    def name = "sec-group-1"
-    def description = "A description"
-    ComputeService compute = Mock()
-    ComputeSecurityGroupService securityGroupApi = Mock()
-    SecGroupExtension securityGroup = Mock()
 
-    when:
-    provider.upsertSecurityGroup(null, name, description, [])
-
-    then:
-    1 * mockClient.compute() >> compute
-    1 * compute.securityGroups() >> securityGroupApi
-    1 * securityGroupApi.create(name, description) >> securityGroup
-    0 * securityGroupApi.createRule(_)
-    0 * securityGroupApi.deleteRule(_)
-    noExceptionThrown()
-  }
-
-  def "create security group with rules"() {
-    setup:
-    ComputeService compute = Mock()
-    ComputeSecurityGroupService securityGroupService = Mock()
-    mockClient.compute() >> compute
-    compute.securityGroups() >> securityGroupService
-
-    def name = "sec-group-1"
-    def description = "A description"
-    SecGroupExtension securityGroup = new NovaSecGroupExtension()
-    def rules = [
-      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 80, toPort: 80, cidr: "0.0.0.0/0"),
-      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 443, toPort: 443, cidr: "0.0.0.0/0")
-    ]
-
-    when:
-    provider.upsertSecurityGroup(null, name, description, rules)
-
-    then:
-    1 * securityGroupService.create(name, description) >> securityGroup
-    0 * securityGroupService.deleteRule(_)
-    rules.each { rule ->
-      1 * securityGroupService.createRule({ SecGroupExtension.Rule r ->
-        r.toPort == rule.toPort && r.fromPort == rule.fromPort && r.IPProtocol == IPProtocol.TCP
-      })
-    }
-    noExceptionThrown()
-  }
-
-  def "update security group"() {
+  def "create security group rule"() {
     setup:
     ComputeService compute = Mock()
     ComputeSecurityGroupService securityGroupService = Mock()
@@ -145,54 +88,72 @@ class OpenstackClientProviderSpec extends Specification {
     compute.securityGroups() >> securityGroupService
 
     def id = UUID.randomUUID().toString()
-    def name = "sec-group-2"
-    def description = "A description 2"
-
-    def existingRules = [
-      new NovaSecGroupExtension.SecurityGroupRule(id: '1', fromPort: 80, toPort: 8080, cidr: "192.1.68.1/24"),
-      new NovaSecGroupExtension.SecurityGroupRule(id: '2', fromPort: 443, toPort: 443, cidr: "0.0.0.0/0")
-    ]
-    def existingSecurityGroup = new NovaSecGroupExtension(id: id, name: "name", description: "desc", rules: existingRules)
-
-    def newRules = [
-      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 80, toPort: 80, cidr: "0.0.0.0/0"),
-      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 443, toPort: 443, cidr: "0.0.0.0/0")
-    ]
+    def protocol = IPProtocol.TCP
+    def cidr = '0.0.0.0/0'
+    def fromPort = 80
+    def toPort = 8080
 
     when:
-    provider.upsertSecurityGroup(id, name, description, newRules)
+    provider.createSecurityGroupRule(region, id, protocol, cidr, fromPort, toPort)
 
     then:
-    1 * securityGroupService.get(id) >> existingSecurityGroup
-    1 * securityGroupService.update(id, name, description) >> existingSecurityGroup
-    existingRules.each { rule ->
-      1 * securityGroupService.deleteRule(rule.id)
-    }
-    newRules.each { rule ->
-      1 * securityGroupService.createRule({ SecGroupExtension.Rule r ->
-        r.toPort == rule.toPort && r.fromPort == rule.fromPort && r.IPProtocol == IPProtocol.TCP
-      })
-    }
-    noExceptionThrown()
+    1 * securityGroupService.createRule({r ->
+      r.parentGroupId == id && r.ipProtocol == protocol && r.cidr == cidr && r.fromPort == fromPort && r.toPort == toPort
+    })
   }
 
-  def "upsert security group handles exceptions"() {
+  def "create security group rule throws exception"() {
     setup:
     ComputeService compute = Mock()
     ComputeSecurityGroupService securityGroupService = Mock()
     mockClient.compute() >> compute
     compute.securityGroups() >> securityGroupService
 
-    def name = "name"
-    def description = "desc"
+    def id = UUID.randomUUID().toString()
+    def protocol = IPProtocol.TCP
+    def cidr = '0.0.0.0/0'
+    def fromPort = 80
+    def toPort = 8080
 
     when:
-    provider.upsertSecurityGroup(null, name, description, [])
+    provider.createSecurityGroupRule(region, id, protocol, cidr, fromPort, toPort)
 
     then:
-    1 * securityGroupService.create(name, description) >> { throw new RuntimeException("foo") }
-    Exception ex = thrown(OpenstackProviderException)
-    ex.cause.message.contains("foo")
+    1 * securityGroupService.createRule(_) >> { throw new RuntimeException('foo') }
+    thrown(OpenstackProviderException)
+  }
+
+  def "delete security group rule"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def id = UUID.randomUUID().toString()
+
+    when:
+    provider.deleteSecurityGroupRule(region, id)
+
+    then:
+    1 * securityGroupService.deleteRule(id)
+  }
+
+  def "delete security group rule throws exception"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def id = UUID.randomUUID().toString()
+
+    when:
+    provider.deleteSecurityGroupRule(region, id)
+
+    then:
+    1 * securityGroupService.deleteRule(id) >> { throw new RuntimeException('foo')}
+    thrown(OpenstackProviderException)
   }
 
   def "delete security group"() {
@@ -218,16 +179,138 @@ class OpenstackClientProviderSpec extends Specification {
     mockClient.compute() >> compute
     compute.securityGroups() >> securityGroupService
     def id = UUID.randomUUID().toString()
-    def failure = ActionResponse.actionFailed("foo", 500)
+    def failure = ActionResponse.actionFailed('foo', 500)
 
     when:
     provider.deleteSecurityGroup(region, id)
 
     then:
     1 * securityGroupService.delete(id) >> failure
-    Exception ex = thrown(OpenstackProviderException)
-    ex.message.contains("foo")
-    ex.message.contains("500")
+    thrown(OpenstackProviderException)
+  }
+
+  def "create security group"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def name = 'security-group'
+    def description = 'description 1'
+
+    when:
+    provider.createSecurityGroup(region, name, description)
+
+    then:
+    1 * securityGroupService.create(name, description)
+  }
+
+  def "create security group throws exception"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def name = 'security-group'
+    def description = 'description 1'
+
+    when:
+    provider.createSecurityGroup(region, name, description)
+
+    then:
+    1 * securityGroupService.create(name, description) >> { throw new RuntimeException('foo')}
+    thrown(OpenstackProviderException)
+  }
+
+  def "update security group"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def id = UUID.randomUUID().toString()
+    def name = 'security-group'
+    def description = 'description 1'
+
+    when:
+    provider.updateSecurityGroup(region, id, name, description)
+
+    then:
+    1 * securityGroupService.update(id, name, description)
+  }
+
+  def "update security group throws exception"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def id = UUID.randomUUID().toString()
+    def name = 'security-group'
+    def description = 'description 1'
+
+    when:
+    provider.updateSecurityGroup(region, id, name, description)
+
+    then:
+    1 * securityGroupService.update(id, name, description) >> { throw new RuntimeException('foo')}
+    thrown(OpenstackProviderException)
+  }
+
+  def "get security group"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def id = UUID.randomUUID().toString()
+    SecGroupExtension securityGroup = new NovaSecGroupExtension()
+
+    when:
+    def actual = provider.getSecurityGroup(region, id)
+
+    then:
+    actual == securityGroup
+    1 * securityGroupService.get(id) >> securityGroup
+  }
+
+  def "get security group throws exception when not found"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def id = UUID.randomUUID().toString()
+
+    when:
+    def actual = provider.getSecurityGroup(region, id)
+
+    then:
+    1 * securityGroupService.get(id)
+    thrown(OpenstackResourceNotFoundException)
+  }
+
+  def "get security group throws exception"() {
+    setup:
+    ComputeService compute = Mock()
+    ComputeSecurityGroupService securityGroupService = Mock()
+    mockClient.compute() >> compute
+    compute.securityGroups() >> securityGroupService
+
+    def id = UUID.randomUUID().toString()
+
+    when:
+    provider.getSecurityGroup(region, id)
+
+    then:
+    1 * securityGroupService.get(id) >> { throw new RuntimeException('foo')}
+    thrown(OpenstackProviderException)
   }
 
   def "get vip success"() {
@@ -1784,6 +1867,23 @@ class OpenstackClientProviderSpec extends Specification {
     actual == mockStack
   }
 
+  def "get stack does not find stack"() {
+    given:
+    HeatService heat = Mock()
+    StackService stackApi = Mock()
+    mockClient.heat() >> heat
+    heat.stacks() >> stackApi
+    def name = 'mystack'
+
+    when:
+    provider.getStack(region, name)
+
+    then:
+    1 * stackApi.getStackByName(name) >> null
+    def ex = thrown(OpenstackResourceNotFoundException)
+    ex.message.contains(name)
+  }
+
   def "get stack fails - exception"() {
     setup:
     String stackName = 'stackofpancakesyumyum'
@@ -1863,5 +1963,4 @@ class OpenstackClientProviderSpec extends Specification {
     Exception e = thrown(OpenstackProviderException)
     e.message == "Action request failed with fault foo and code 400"
   }
-
 }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/securitygroup/UpsertOpenstackSecurityGroupAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/securitygroup/UpsertOpenstackSecurityGroupAtomicOperationSpec.groovy
@@ -22,20 +22,25 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFactory
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.securitygroup.UpsertOpenstackSecurityGroupDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
+import org.openstack4j.model.compute.IPProtocol
+import org.openstack4j.model.compute.SecGroupExtension
+import org.openstack4j.openstack.compute.domain.NovaSecGroupExtension
 import spock.lang.Specification
 
 class UpsertOpenstackSecurityGroupAtomicOperationSpec extends Specification {
 
   private static final String ACCOUNT_NAME = 'account'
-  def credentials
-  def provider
+  private static final String REGION = 'west'
+  OpenstackCredentials credentials
+  OpenstackClientProvider provider
+
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
   }
-
   def setup() {
     provider = Mock(OpenstackClientProvider)
     GroovyMock(OpenstackProviderFactory, global: true)
@@ -44,20 +49,103 @@ class UpsertOpenstackSecurityGroupAtomicOperationSpec extends Specification {
     credentials = new OpenstackCredentials(namedAccountCredentials)
   }
 
-  def "upsert a security group"() {
+  def "create security group without rules"() {
     setup:
     def id = UUID.randomUUID().toString()
-    def name = "name"
-    def desc = "description"
-    def description = new UpsertOpenstackSecurityGroupDescription(account: ACCOUNT_NAME, credentials: credentials, id: id, name: name, description: desc, rules: [])
+    def name = 'name'
+    def desc = 'description'
+    SecGroupExtension securityGroup = new NovaSecGroupExtension(id: id, name: name, description: desc)
+    def description = new UpsertOpenstackSecurityGroupDescription(account: ACCOUNT_NAME, region: REGION, credentials: credentials, name: name, description: desc, rules: [])
     def operation = new UpsertOpenstackSecurityGroupAtomicOperation(description)
 
     when:
     operation.operate([])
 
     then:
-    1 * provider.upsertSecurityGroup(id, name, desc, [])
+    1 * provider.createSecurityGroup(REGION, name, desc) >> securityGroup
+    0 * provider.getSecurityGroup(_, _)
+    0 * provider.updateSecurityGroup(_, _, _, _)
+    0 * provider.deleteSecurityGroupRule(_, _)
+    0 * provider.createSecurityGroupRule(_, _, _, _, _, _)
+    noExceptionThrown()
   }
 
+  def "create security group with rules"() {
+    setup:
+    def id = UUID.randomUUID().toString()
+    def name = 'sec-group-1'
+    def desc = 'A description'
+    SecGroupExtension securityGroup = new NovaSecGroupExtension(id: id, name: name, description: desc)
+    def rules = [
+      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 80, toPort: 80, cidr: '0.0.0.0/0'),
+      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 443, toPort: 443, cidr: '0.0.0.0/0')
+    ]
 
+    def description = new UpsertOpenstackSecurityGroupDescription(account: ACCOUNT_NAME, region: REGION, credentials: credentials, name: name, description: desc, rules: rules)
+    def operation = new UpsertOpenstackSecurityGroupAtomicOperation(description)
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * provider.createSecurityGroup(REGION, name, desc) >> securityGroup
+    0 * provider.getSecurityGroup(_, _)
+    0 * provider.updateSecurityGroup(_, _, _, _)
+    0 * provider.deleteSecurityGroupRule(_, _)
+    rules.each { rule ->
+      1 * provider.createSecurityGroupRule(REGION, id, IPProtocol.TCP, rule.cidr, rule.fromPort, rule.toPort)
+    }
+    noExceptionThrown()
+  }
+
+  def "update security group"() {
+    setup:
+    def id = UUID.randomUUID().toString()
+    def name = 'sec-group-2'
+    def desc= 'A description 2'
+
+    def existingRules = [
+      new NovaSecGroupExtension.SecurityGroupRule(id: '1', fromPort: 80, toPort: 8080, cidr: '192.1.68.1/24'),
+      new NovaSecGroupExtension.SecurityGroupRule(id: '2', fromPort: 443, toPort: 443, cidr: '0.0.0.0/0')
+    ]
+    def existingSecurityGroup = new NovaSecGroupExtension(id: id, name: name, description: desc, rules: existingRules)
+
+    def newRules = [
+      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 80, toPort: 80, cidr: '0.0.0.0/0'),
+      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 443, toPort: 443, cidr: '0.0.0.0/0')
+    ]
+
+    def description = new UpsertOpenstackSecurityGroupDescription(account: ACCOUNT_NAME, region: REGION, id: id, credentials: credentials, name: name, description: desc, rules: newRules)
+    def operation = new UpsertOpenstackSecurityGroupAtomicOperation(description)
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * provider.getSecurityGroup(REGION, id) >> existingSecurityGroup
+    1 * provider.updateSecurityGroup(REGION, id, name, desc) >> existingSecurityGroup
+    existingRules.each { rule ->
+      1 * provider.deleteSecurityGroupRule(REGION, rule.id)
+    }
+    newRules.each { rule ->
+      1 * provider.createSecurityGroupRule(REGION, id, IPProtocol.TCP, rule.cidr, rule.fromPort, rule.toPort)
+    }
+    0 * provider.createSecurityGroup(_, _, _)
+    noExceptionThrown()
+  }
+
+  def "upsert security group handles exceptions"() {
+    setup:
+    def name = 'name'
+    def desc = 'desc'
+    def description = new UpsertOpenstackSecurityGroupDescription(account: ACCOUNT_NAME, region: REGION, credentials: credentials, name: name, description: desc, rules: [])
+    def operation = new UpsertOpenstackSecurityGroupAtomicOperation(description)
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * provider.createSecurityGroup(REGION, name, desc) >> { throw new OpenstackOperationException('foo') }
+    thrown(OpenstackOperationException)
+  }
 }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/CloneOpenstackAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/CloneOpenstackAtomicOperationSpec.groovy
@@ -22,100 +22,27 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFactory
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.CloneOpenstackAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.DeployOpenstackAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
+import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.openstack4j.openstack.heat.domain.HeatStack
 import spock.lang.Specification
 import spock.lang.Subject
 
 class CloneOpenstackAtomicOperationSpec extends Specification {
   private static final String ACCOUNT_NAME = 'myaccount'
-  private static final APPLICATION = "app"
-  private static final STACK = "stack"
-  private static final DETAILS = "details"
-  private static final REGION = "region"
+  private static final REGION = 'region'
   private static final String HEAT_TEMPLATE = '{"heat_template_version":"2013-05-23",' +
     '"description":"Simple template to test heat commands",' +
     '"parameters":{"flavor":{"default":"m1.nano","type":"string"}},' +
     '"resources":{"hello_world":{"type":"OS::Nova::Server",' +
     'properties":{"flavor":{"get_param":"flavor"},' +
     '"image":"cirros-0.3.4-x86_64-uec","user_data":""}}}}'
-  private static final Integer TIMEOUT_MINS = 5
-  private static final Map<String,String> PARAMS_MAP = Collections.emptyMap()
-  private static final Boolean DISABLE_ROLLBACK = false
-
-  private static final SEQUENCE = "v000"
-  private static final ANCESTOR_STACK_NAME = "$APPLICATION-$STACK-$DETAILS-$SEQUENCE"
-  private static final ANCESTOR_STACK_ID = "978f378f-0b98-469d-90dd-f61a73f8703a"
-
-  // Changed Parameters
-  private static final STACK_N = "stackn"
-  private static final APPLICATION_N = "appn"
-  private static final DETAILS_N = "detailn"
-  private static final REGION_N = "regionn"
-  private static final String HEAT_TEMPLATE_N = '{"heat_template_version":"2013-06-10",' +
-    '"description":"Simple template to test heat commands",' +
-    '"parameters":{"flavor":{"default":"m1.nano","type":"string"}},' +
-    '"resources":{"hello_world":{"type":"OS::Nova::Server",' +
-    'properties":{"flavor":{"get_param":"flavor"},' +
-    '"image":"cirros-0.3.4-x86_64-uec","user_data":""}}}}'
-  private static final Integer TIMEOUT_MINS_N = 6
-  private static final Boolean DISABLE_ROLLBACK_N = true
 
   def credentials
   def provider
-
-  HeatStack createHeatStack() {
-    return new HeatStack(
-      id: ANCESTOR_STACK_ID,
-      name: ANCESTOR_STACK_NAME,
-      status: "CREATE_COMPLETE",
-      timeoutMins: 5
-    )
-  }
-
-  DeployOpenstackAtomicOperation createDeployOpenstackAO() {
-    return new DeployOpenstackAtomicOperation(createAncestorDeployAtomicOperationDescription())
-  }
-  DeployOpenstackAtomicOperationDescription createAncestorDeployAtomicOperationDescription() {
-    return new DeployOpenstackAtomicOperationDescription(
-      stack: STACK,
-      application: APPLICATION,
-      freeFormDetails: DETAILS,
-      region: REGION,
-      heatTemplate: HEAT_TEMPLATE,
-      timeoutMins: TIMEOUT_MINS,
-      parameters: PARAMS_MAP,
-      disableRollback: DISABLE_ROLLBACK,
-      account: ACCOUNT_NAME,
-      credentials: credentials
-    )
-  }
-
-  DeployOpenstackAtomicOperationDescription createNewDeployAtomicOperationDescription() {
-    return new DeployOpenstackAtomicOperationDescription(
-      stack: STACK_N,
-      application: APPLICATION_N,
-      freeFormDetails: DETAILS_N,
-      region: REGION_N,
-      heatTemplate: HEAT_TEMPLATE_N,
-      timeoutMins: TIMEOUT_MINS_N,
-      parameters: PARAMS_MAP,
-      disableRollback: DISABLE_ROLLBACK_N,
-      account: ACCOUNT_NAME,
-      credentials: credentials
-    )
-  }
-
-  def ancestorNames = [
-  "app": APPLICATION,
-  "stack": STACK,
-  "detail": DETAILS
-  ]
-
-  def ancestorDeployAtomicOperationDescription = createAncestorDeployAtomicOperationDescription()
-  def newDeployAtomicOperationDescription = createNewDeployAtomicOperationDescription()
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -123,7 +50,7 @@ class CloneOpenstackAtomicOperationSpec extends Specification {
 
   def setup() {
     provider = Mock(OpenstackClientProvider)
-    GroovyMock(OpenstackProviderFactory, global : true)
+    GroovyMock(OpenstackProviderFactory, global: true)
     OpenstackNamedAccountCredentials creds = Mock(OpenstackNamedAccountCredentials)
     OpenstackProviderFactory.createProvider(creds) >> { provider }
     credentials = new OpenstackCredentials(creds)
@@ -132,8 +59,19 @@ class CloneOpenstackAtomicOperationSpec extends Specification {
 
   def "builds a description based on ancestor server group, overrides nothing"() {
     given:
+    def ancestorApp = 'app'
+    def ancestorStack = 'stack'
+    def ancestorDetails = 'details'
+    def ancestor = new HeatStack(
+      id: '978f378f-0b98-469d-90dd-f61a73f8703a',
+      name: "$ancestorApp-$ancestorStack-$ancestorDetails-v000",
+      status: 'CREATE_COMPLETE',
+      timeoutMins: 5,
+      parameters: [key: 'value']
+    )
+
     def inputDescription = new CloneOpenstackAtomicOperationDescription(
-      source: [stackName: ANCESTOR_STACK_NAME, region: REGION],
+      source: [stackName: ancestor.name, region: REGION],
       account: ACCOUNT_NAME,
       credentials: credentials
     )
@@ -144,34 +82,44 @@ class CloneOpenstackAtomicOperationSpec extends Specification {
     def resultDescription = operation.cloneAndOverrideDescription()
 
     then:
-    1 * inputDescription.credentials.provider.getStack(REGION, ANCESTOR_STACK_NAME) >> createHeatStack()
-    1 * inputDescription.credentials.provider.getHeatTemplate(REGION, ANCESTOR_STACK_NAME, ANCESTOR_STACK_ID) >> HEAT_TEMPLATE
+    1 * inputDescription.credentials.provider.getStack(REGION, ancestor.name) >> ancestor
+    1 * inputDescription.credentials.provider.getHeatTemplate(REGION, ancestor.name, ancestor.id) >> HEAT_TEMPLATE
 
-    resultDescription.application == ancestorDeployAtomicOperationDescription.application
-    resultDescription.stack == ancestorDeployAtomicOperationDescription.stack
-    resultDescription.timeoutMins == ancestorDeployAtomicOperationDescription.timeoutMins
-    resultDescription.heatTemplate == ancestorDeployAtomicOperationDescription.heatTemplate
-    resultDescription.freeFormDetails == ancestorDeployAtomicOperationDescription.freeFormDetails
-    resultDescription.parameters == ancestorDeployAtomicOperationDescription.parameters
-    resultDescription.disableRollback == ancestorDeployAtomicOperationDescription.disableRollback
-    resultDescription.account == ancestorDeployAtomicOperationDescription.account
-    resultDescription.region == ancestorDeployAtomicOperationDescription.region
+    resultDescription.application == ancestorApp
+    resultDescription.stack == ancestorStack
+    resultDescription.timeoutMins == (int) ancestor.timeoutMins
+    resultDescription.heatTemplate == HEAT_TEMPLATE
+    resultDescription.freeFormDetails == ancestorDetails
+    resultDescription.parameters == ancestor.parameters
+    resultDescription.account == ACCOUNT_NAME
+    resultDescription.region == REGION
+    !resultDescription.disableRollback // False is the default
   }
 
   def "builds a description based on ancestor server group, overrides everything"() {
     given:
+    def app = 'app'
+    def stack = 'stack'
+    def details = 'details'
+    def stackName = "$app-$stack-$details-v000"
     def inputDescription = new CloneOpenstackAtomicOperationDescription(
-      stack: STACK_N,
-      application: APPLICATION_N,
-      freeFormDetails: DETAILS_N,
-      region: REGION_N,
-      heatTemplate: HEAT_TEMPLATE_N,
-      timeoutMins: TIMEOUT_MINS_N,
-      parameters: PARAMS_MAP,
-      disableRollback: DISABLE_ROLLBACK_N,
-      source: [stackName: ANCESTOR_STACK_NAME, region: REGION],
+      stack: stack,
+      application: app,
+      freeFormDetails: details,
+      region: REGION,
+      heatTemplate: HEAT_TEMPLATE,
+      timeoutMins: 5,
+      parameters: [key: 'value'],
+      disableRollback: true,
+      source: [stackName: stackName, region: REGION],
       credentials: credentials,
       account: ACCOUNT_NAME
+    )
+    def ancestor = new HeatStack(
+      id: '978f378f-0b98-469d-90dd-f61a73f8703a',
+      name: stackName,
+      status: 'CREATE_COMPLETE',
+      timeoutMins: 5
     )
 
     @Subject def operation = new CloneOpenstackAtomicOperation(inputDescription)
@@ -180,16 +128,38 @@ class CloneOpenstackAtomicOperationSpec extends Specification {
     def resultDescription = operation.cloneAndOverrideDescription()
 
     then:
-    1 * inputDescription.credentials.provider.getStack(REGION, ANCESTOR_STACK_NAME) >> createHeatStack()
+    1 * inputDescription.credentials.provider.getStack(REGION, stackName) >> ancestor
 
-    resultDescription.application == newDeployAtomicOperationDescription.application
-    resultDescription.stack == newDeployAtomicOperationDescription.stack
-    resultDescription.heatTemplate == newDeployAtomicOperationDescription.heatTemplate
-    resultDescription.timeoutMins == newDeployAtomicOperationDescription.timeoutMins
-    resultDescription.freeFormDetails == newDeployAtomicOperationDescription.freeFormDetails
-    resultDescription.parameters == newDeployAtomicOperationDescription.parameters
-    resultDescription.disableRollback == newDeployAtomicOperationDescription.disableRollback
-    resultDescription.account == newDeployAtomicOperationDescription.account
-    resultDescription.region == newDeployAtomicOperationDescription.region
+    resultDescription.application == inputDescription.application
+    resultDescription.stack == inputDescription.stack
+    resultDescription.heatTemplate == inputDescription.heatTemplate
+    resultDescription.timeoutMins == inputDescription.timeoutMins
+    resultDescription.freeFormDetails == inputDescription.freeFormDetails
+    resultDescription.parameters == inputDescription.parameters
+    resultDescription.disableRollback == inputDescription.disableRollback
+    resultDescription.account == inputDescription.account
+    resultDescription.region == inputDescription.region
+  }
+
+  def "ancestor stack not found throws operation exception"() {
+    given:
+    def stackName = 'app-stack-details-v000'
+    def notFound = new OpenstackResourceNotFoundException("foo")
+    def inputDescription = new CloneOpenstackAtomicOperationDescription(
+      source: [stackName: stackName, region: REGION],
+      account: ACCOUNT_NAME,
+      credentials: credentials
+    )
+
+    @Subject def operation = new CloneOpenstackAtomicOperation(inputDescription)
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * inputDescription.credentials.provider.getStack(REGION, stackName) >> { throw notFound }
+    def ex = thrown(OpenstackOperationException)
+    ex.message.contains(AtomicOperations.CLONE_SERVER_GROUP)
+    ex.cause == notFound
   }
 }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/securitygroup/UpsertOpenstackSecurityGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/securitygroup/UpsertOpenstackSecurityGroupDescriptionValidatorSpec.groovy
@@ -47,9 +47,9 @@ class UpsertOpenstackSecurityGroupDescriptionValidatorSpec extends Specification
   def "validate no rules"() {
     setup:
     def id = UUID.randomUUID().toString()
-    def name = "name"
-    def desc = "description"
-    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', id: id, name: name, description: desc, rules: [])
+    def name = 'name'
+    def desc = 'description'
+    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', 'region': 'west', id: id, name: name, description: desc, rules: [])
 
     when:
     validator.validate([], description, errors)
@@ -61,13 +61,13 @@ class UpsertOpenstackSecurityGroupDescriptionValidatorSpec extends Specification
   def "validate with rules"() {
     setup:
     def id = UUID.randomUUID().toString()
-    def name = "name"
-    def desc = "description"
+    def name = 'name'
+    def desc = 'description'
     def rules = [
-      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 80, toPort: 80, cidr: "0.0.0.0/0"),
-      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 443, toPort: 443, cidr: "0.0.0.0/0")
+      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 80, toPort: 80, cidr: '0.0.0.0/0'),
+      new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: 443, toPort: 443, cidr: '0.0.0.0/0')
     ]
-    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', id: id, name: name, description: desc, rules: rules)
+    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', 'region': 'west', id: id, name: name, description: desc, rules: rules)
 
     when:
     validator.validate([], description, errors)
@@ -78,10 +78,10 @@ class UpsertOpenstackSecurityGroupDescriptionValidatorSpec extends Specification
 
   def "validate with invalid id"() {
     setup:
-    def id = "not a uuid"
-    def name = "name"
-    def desc = "description"
-    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', id: id, name: name, description: desc, rules: [])
+    def id = 'not a uuid'
+    def name = 'name'
+    def desc = 'description'
+    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', 'region': 'west', id: id, name: name, description: desc, rules: [])
 
     when:
     validator.validate([], description, errors)
@@ -90,11 +90,11 @@ class UpsertOpenstackSecurityGroupDescriptionValidatorSpec extends Specification
     1 * errors.rejectValue('upsertOpenstackSecurityGroupAtomicOperationDescription.id', 'upsertOpenstackSecurityGroupAtomicOperationDescription.id.notUUID')
   }
 
-  def "validate with without id is valid"() {
+  def "validate without id is valid"() {
     setup:
-    def name = "name"
-    def desc = "description"
-    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', id: null, name: name, description: desc, rules: [])
+    def name = 'name'
+    def desc = 'description'
+    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', 'region': 'west', id: null, name: name, description: desc, rules: [])
 
     when:
     validator.validate([], description, errors)
@@ -103,15 +103,28 @@ class UpsertOpenstackSecurityGroupDescriptionValidatorSpec extends Specification
     0 * errors.rejectValue(_, _)
   }
 
+  def "missing region is invalid"() {
+    setup:
+    def name = 'name'
+    def desc = 'description'
+    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', id: null, name: name, description: desc, rules: [])
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    1 * errors.rejectValue(_, 'upsertOpenstackSecurityGroupAtomicOperationDescription.region.empty')
+  }
+
   def "validate with invalid rule"() {
     setup:
     def id = UUID.randomUUID().toString()
-    def name = "name"
-    def desc = "description"
+    def name = 'name'
+    def desc = 'description'
     def rules = [
       new UpsertOpenstackSecurityGroupDescription.Rule(fromPort: fromPort, toPort: toPort, cidr: cidr)
     ]
-    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', id: id, name: name, description: desc, rules: rules)
+    def description = new UpsertOpenstackSecurityGroupDescription(account: 'foo', 'region': 'west', id: id, name: name, description: desc, rules: rules)
 
     when:
     validator.validate([], description, errors)
@@ -120,9 +133,9 @@ class UpsertOpenstackSecurityGroupDescriptionValidatorSpec extends Specification
     1 * errors.rejectValue(_, rejectValue)
 
     where:
-    fromPort | toPort | cidr      | rejectValue
-    80       | 80     | '0.0.0.0' | 'upsertOpenstackSecurityGroupAtomicOperationDescription.cidr.invalidCIDR'
-    80       | 80     | null      | 'upsertOpenstackSecurityGroupAtomicOperationDescription.cidr.empty'
+    fromPort | toPort | cidr        | rejectValue
+    80       | 80     | '0.0.0.0'   | 'upsertOpenstackSecurityGroupAtomicOperationDescription.cidr.invalidCIDR'
+    80       | 80     | null        | 'upsertOpenstackSecurityGroupAtomicOperationDescription.cidr.empty'
     0        | 80     | '0.0.0.0/0' | 'upsertOpenstackSecurityGroupAtomicOperationDescription.fromPort.invalid (Must be in range [1, 65535])'
     80       | 0      | '0.0.0.0/0' | 'upsertOpenstackSecurityGroupAtomicOperationDescription.toPort.invalid (Must be in range [1, 65535])'
   }


### PR DESCRIPTION
Making the client more of a pass through to the Openstack4j API and letting the operations figure out the business logic. This gives better logging at the operation level.