### PR TITLE
provider/aws: Replace one missed amazonCloudProvider.id with AmazonCl…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSubnetProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSubnetProvider.groovy
@@ -48,7 +48,7 @@ class AmazonSubnetProvider implements SubnetProvider<AmazonSubnet> {
 
   @Override
   String getType() {
-    return amazonCloudProvider.id
+    return AmazonCloudProvider.AWS
   }
 
   @Override


### PR DESCRIPTION
…oudProvider.AWS. Without this fix, no provider-specific subnets can be retrieved.