### PR TITLE
(aws) do not require description on security group update

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidator.groovy
@@ -36,7 +36,7 @@ class UpsertSecurityGroupDescriptionValidator extends AmazonDescriptionValidatio
     if (!description.name) {
       errors.rejectValue("name", "upsertSecurityGroupDescription.name.not.nullable")
     }
-    if (!description.description) {
+    if (!description.description && !description.ingressAppendOnly) {
       errors.rejectValue("description", "upsertSecurityGroupDescription.description.not.nullable")
     }
 


### PR DESCRIPTION
We don't try to update the description so it's kind of silly to require users to send one in.

@spinnaker/netflix-reviewers fyi