### PR TITLE
(aws) clean up old unused CloudWatch alarms

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgent.groovy
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.agent
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling
+import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest
+import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest
+import com.amazonaws.services.cloudwatch.model.MetricAlarm
+import com.amazonaws.services.cloudwatch.model.StateValue
+import com.amazonaws.services.gamelift.model.DescribeScalingPoliciesRequest
+import com.netflix.spinnaker.cats.agent.RunnableAgent
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.ProviderUtils
+import groovy.util.logging.Slf4j
+import org.joda.time.DateTime
+
+import java.util.concurrent.TimeUnit
+
+@Slf4j
+class CleanupAlarmsAgent implements RunnableAgent, CustomScheduledAgent {
+  public static final long POLL_INTERVAL_MILLIS = TimeUnit.HOURS.toMillis(24)
+  public static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(20)
+
+  final AmazonClientProvider amazonClientProvider
+  final AccountCredentialsRepository accountCredentialsRepository
+  final long pollIntervalMillis
+  final long timeoutMillis
+  final int daysToLeave
+
+
+  CleanupAlarmsAgent(AmazonClientProvider amazonClientProvider,
+                     AccountCredentialsRepository accountCredentialsRepository,
+                     int daysToLeave) {
+    this(amazonClientProvider, accountCredentialsRepository, POLL_INTERVAL_MILLIS, DEFAULT_TIMEOUT_MILLIS, daysToLeave)
+  }
+
+  CleanupAlarmsAgent(AmazonClientProvider amazonClientProvider,
+                     AccountCredentialsRepository accountCredentialsRepository,
+                     long pollIntervalMillis,
+                     long timeoutMills,
+                     int daysToLeave) {
+    this.amazonClientProvider = amazonClientProvider
+    this.accountCredentialsRepository = accountCredentialsRepository
+    this.pollIntervalMillis = pollIntervalMillis
+    this.timeoutMillis = timeoutMills
+    this.daysToLeave = daysToLeave
+  }
+
+  @Override
+  String getAgentType() {
+    "${CleanupAlarmsAgent.simpleName}"
+  }
+
+  @Override
+  String getProviderName() {
+    return AwsCleanupProvider.PROVIDER_NAME
+  }
+
+  @Override
+  void run() {
+    getAccounts().each { NetflixAmazonCredentials credentials ->
+      credentials.regions.each { AmazonCredentials.AWSRegion region ->
+        log.info("Looking for alarms to delete")
+
+        def cloudWatch = amazonClientProvider.getCloudWatch(credentials, region.name)
+        Set<String> attachedAlarms = getAttachedAlarms(amazonClientProvider.getAutoScaling(credentials, region.name))
+        def describeAlarmsRequest = new DescribeAlarmsRequest().withStateValue(StateValue.INSUFFICIENT_DATA)
+
+        while (true) {
+          def result = cloudWatch.describeAlarms(describeAlarmsRequest)
+
+          List<MetricAlarm> alarmsToDelete = result.metricAlarms.findAll {
+            it.stateUpdatedTimestamp.before(DateTime.now().minusDays(daysToLeave).toDate()) &&
+              !attachedAlarms.contains(it.alarmName)
+          }
+
+          if (alarmsToDelete) {
+            // terminate up to 20 alarms at a time (avoids any AWS limits on # of concurrent deletes)
+            alarmsToDelete.collate(20).each {
+              log.info("Deleting ${it.size()} alarms in ${credentials.name}/${region.name} " +
+                "(alarms: ${it.alarmName.join(", ")})")
+              cloudWatch.deleteAlarms(new DeleteAlarmsRequest().withAlarmNames(it.alarmName))
+              Thread.sleep(500)
+            }
+
+          }
+
+          if (result.nextToken) {
+            describeAlarmsRequest.withNextToken(result.nextToken)
+          } else {
+            break
+          }
+        }
+      }
+    }
+  }
+
+  private Set<NetflixAmazonCredentials> getAccounts() {
+    ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials)
+  }
+
+  private static Set<String> getAttachedAlarms(AmazonAutoScaling autoScaling) {
+    Set<String> alarms = []
+    def request = new DescribeScalingPoliciesRequest()
+    while (true) {
+      def result = autoScaling.describePolicies()
+      alarms.addAll(result.scalingPolicies.alarms.alarmName.flatten())
+
+      if (result.nextToken) {
+        request.withNextToken(result.nextToken)
+      } else {
+        break
+      }
+    }
+    alarms
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgentSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.agent
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling
+import com.amazonaws.services.autoscaling.model.DescribePoliciesResult
+import com.amazonaws.services.autoscaling.model.ScalingPolicy
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest
+import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult
+import com.amazonaws.services.cloudwatch.model.MetricAlarm
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import org.joda.time.DateTime
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CleanupAlarmsAgentSpec extends Specification {
+
+  @Shared
+  def test = TestCredential.named('test')
+
+  AmazonAutoScaling autoScalingUSW
+  AmazonAutoScaling autoScalingUSE
+  AmazonCloudWatch cloudWatchUSW
+  AmazonCloudWatch cloudWatchUSE
+  AmazonClientProvider amazonClientProvider
+  AccountCredentialsRepository accountCredentialsRepository
+  CleanupAlarmsAgent agent
+
+  void setup() {
+    autoScalingUSW = Mock(AmazonAutoScaling)
+    autoScalingUSE = Mock(AmazonAutoScaling)
+    cloudWatchUSW = Mock(AmazonCloudWatch)
+    cloudWatchUSE = Mock(AmazonCloudWatch)
+
+    amazonClientProvider = Mock(AmazonClientProvider) {
+      1 * getAutoScaling(test, "us-west-1") >> autoScalingUSW
+      1 * getAutoScaling(test, "us-east-1") >> autoScalingUSE
+      1 * getCloudWatch(test, "us-west-1") >> cloudWatchUSW
+      1 * getCloudWatch(test, "us-east-1") >> cloudWatchUSE
+      0 * _
+    }
+
+    accountCredentialsRepository = Mock(AccountCredentialsRepository) {
+      1 * getAll() >> [test]
+      0 * _
+    }
+
+    agent = new CleanupAlarmsAgent(amazonClientProvider, accountCredentialsRepository, 10L, 10L, 90)
+  }
+
+  void "should run across all regions/accounts and delete in each"() {
+    when:
+    agent.run()
+
+    then:
+    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
+    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult()
+    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([buildAlarm('a', 92)])
+    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([buildAlarm('b', 92)])
+    1 * cloudWatchUSE.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames == ['a']} as DeleteAlarmsRequest)
+    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames == ['b']} as DeleteAlarmsRequest)
+  }
+
+  void "should not delete alarms that are newer than threshold"() {
+    when:
+    agent.run()
+
+    then:
+    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
+    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult()
+    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([buildAlarm('a', 88)])
+    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([buildAlarm('b', 92)])
+    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames == ['b']} as DeleteAlarmsRequest)
+    0 * cloudWatchUSE.deleteAlarms(_)
+  }
+
+  void "should not delete alarms that are found in scaling policies"() {
+    given:
+    MetricAlarm alarmA = buildAlarm('a', 99)
+    MetricAlarm alarmB = buildAlarm('b', 99)
+    ScalingPolicy policyA = new ScalingPolicy(alarms: [alarmA])
+
+    when:
+    agent.run()
+
+    then:
+    1 * autoScalingUSW.describePolicies() >> new DescribePoliciesResult()
+    1 * autoScalingUSE.describePolicies() >> new DescribePoliciesResult().withScalingPolicies([policyA])
+    1 * cloudWatchUSE.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([alarmA])
+    1 * cloudWatchUSW.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms([alarmB])
+    1 * cloudWatchUSW.deleteAlarms({ DeleteAlarmsRequest r -> r.alarmNames == ['b']} as DeleteAlarmsRequest)
+    0 * cloudWatchUSE.deleteAlarms(_)
+  }
+
+
+  private static MetricAlarm buildAlarm(String name, int dataDays) {
+    new MetricAlarm(alarmName: name, stateUpdatedTimestamp: DateTime.now().minusDays(dataDays).toDate())
+  }
+
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgentSpec.groovy
@@ -27,6 +27,7 @@ import com.amazonaws.services.ec2.model.TerminateInstancesRequest
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.DetachInstancesAtomicOperation
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -45,8 +46,12 @@ class CleanupDetachedInstancesAgentSpec extends Specification {
       1 * getAmazonEC2(test, "us-east-1", true) >> { amazonEC2USE }
       0 * _
     }
-    def accounts = [test]
-    def agent = new CleanupDetachedInstancesAgent(amazonClientProvider, accounts)
+
+    def accountCredentialsRepository = Mock(AccountCredentialsRepository) {
+      1 * getAll() >> [test]
+      0 * _
+    }
+    def agent = new CleanupDetachedInstancesAgent(amazonClientProvider, accountCredentialsRepository)
 
     when:
     agent.run()


### PR DESCRIPTION
It turns out AWS doesn't let you have an infinite number of alarms. At some point (5000? 20000? it depends!), it just stops letting you create them.

When deleting an auto scaling group, AWS will delete its associated scaling policies and any alarms that are no longer part of an action. However, if a user has deleted scaling policies through the AWS console or CLI, it's possible the alarms are not deleted, and they can stack up.

@ajordens or @cfieber PTAL. Not sure about the configuration bits.