### PR TITLE
add the ability to skip repositories when indexing a docker registry

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
@@ -46,6 +46,7 @@ class DockerRegistryConfigurationProperties {
     // List of all repositories to index. Can be of the form <user>/<repo>,
     // or <library> for repositories like 'ubuntu'.
     List<String> repositories
+    List<String> skip
   }
 
   List<ManagedAccount> accounts = []

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -78,6 +78,9 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware {
     credentials.repositories.findAll { it ->
       threadCount == 1 || (it.hashCode() % threadCount).abs() == index
     }.collectEntries {
+      if(credentials.skip?.contains(it)) {
+          return [:]
+      }
       DockerRegistryTags tags
       try {
         tags = credentials.client.getTags(it)

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
@@ -18,15 +18,17 @@ package com.netflix.spinnaker.clouddriver.docker.registry.security
 
 import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryClient
 
-public class DockerRegistryCredentials {
+class DockerRegistryCredentials {
   private final DockerRegistryClient client
   private List<String> repositories
   private final boolean reloadRepositories
   private final boolean trackDigests
+  private List<String> skip
 
-  public DockerRegistryCredentials(DockerRegistryClient client, List<String> repositories, boolean trackDigests) {
-    this.client = client;
+  DockerRegistryCredentials(DockerRegistryClient client, List<String> repositories, boolean trackDigests, List<String> skip) {
+    this.client = client
     this.trackDigests = trackDigests
+    this.skip = skip
     if (!repositories) {
       this.reloadRepositories = true
       // Don't load the repositories yet, as it delays application startup time.
@@ -36,15 +38,19 @@ public class DockerRegistryCredentials {
     }
   }
 
-  public DockerRegistryClient getClient() {
+  DockerRegistryClient getClient() {
     return client
   }
 
-  public boolean getTrackDigests() {
+  boolean getTrackDigests() {
     return trackDigests
   }
 
-  public List<String> getRepositories() {
+  List<String> getSkip(){
+    return skip
+  }
+
+  List<String> getRepositories() {
     if (reloadRepositories) {
       repositories = client.getCatalog()?.repositories
     }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
@@ -72,7 +72,7 @@ class DockerRegistryCredentialsInitializer implements CredentialsInitializerSync
           managedAccount.password, managedAccount.passwordFile, managedAccount.email,
           managedAccount.cacheThreads, managedAccount.clientTimeoutMillis,
           managedAccount.paginateSize, managedAccount.trackDigests,
-          managedAccount.repositories)
+          managedAccount.repositories, managedAccount.skip)
 
         accountCredentialsRepository.save(managedAccount.name, dockerRegistryAccount)
       } catch (e) {


### PR DESCRIPTION
Add ability to skip repositories

```
    - name: testregistry
      address: http://xxxyyy.com
      cacheThreads: 25
      paginateSize: 500
      clientTimeoutMillis: 360000
      trackDigests: false
      skip:
        - tonsoftags
        - smellsbad
        - org/skippy```