### PR TITLE
provider/cloudfoundry: Add version specific route for canary testing

### DIFF
--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/handlers/CloudFoundryDeployHandler.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/handlers/CloudFoundryDeployHandler.groovy
@@ -15,7 +15,6 @@
  */
 
 package com.netflix.spinnaker.clouddriver.cf.deploy.handlers
-
 import com.netflix.frigga.NameBuilder
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.cf.config.CloudFoundryConstants
@@ -45,7 +44,6 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.*
 import org.springframework.util.StreamUtils
 import org.springframework.web.client.HttpServerErrorException
-
 /**
  * A deployment handler for Cloud Foundry.
  */
@@ -152,8 +150,10 @@ class CloudFoundryDeployHandler implements DeployHandler<CloudFoundryDeployDescr
     try {
       Staging staging = (description?.buildpackUrl) ? new Staging(null, description.buildpackUrl) : new Staging()
       if (application == null) {
-        def domain = client.defaultDomain
-        def loadBalancers = description.loadBalancers?.split(',').collect { (domain != null) ? it + "." + domain.name : it }
+        def defaultDomain = client.defaultDomain
+        def domain = (defaultDomain != null) ? '.' + defaultDomain.name : ''
+        def loadBalancers = description.loadBalancers?.split(',').collect { it + domain }
+        loadBalancers += description.serverGroupName + domain
 
         task.updateStatus BASE_PHASE, "Memory set to ${description.memory}"
         if (description?.buildpackUrl) {

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -93,6 +93,7 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
     def loadBalancerHosts = loadBalancers.collect { loadBalancer ->
       description.nativeLoadBalancers?.find { it?.name == loadBalancer }?.nativeRoute?.name
     }
+    loadBalancerHosts += description.serverGroupName + "." + client.defaultDomain.name
 
     if (disable) {
       task.updateStatus phaseName, "Deregistering instances from load balancers..."

--- a/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/handlers/CloudFoundryDeployHandlerSpec.groovy
+++ b/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/handlers/CloudFoundryDeployHandlerSpec.groovy
@@ -120,7 +120,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -185,7 +185,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -228,7 +228,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -287,7 +287,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -324,7 +324,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.deleteApplication(serverGroupName)
     0 * client._
 
@@ -366,7 +366,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v003.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -412,7 +412,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [new CloudApplication(null, description.application + '-v999')] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -508,7 +508,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.deleteApplication(serverGroupName)
     0 * client._
 
@@ -558,7 +558,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { null }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, "example.com", null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -606,7 +606,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _) >> { throw new IOException("Simulated CF failure") }
     1 * client.deleteApplication(serverGroupName)
     0 * client._
@@ -673,7 +673,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { throw new CloudFoundryException(HttpStatus.NOT_FOUND, "Not Found", "Application not found") }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -748,7 +748,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { throw new HttpServerErrorException(HttpStatus.SERVICE_UNAVAILABLE) }
     1 * client.getDefaultDomain() >> { null }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}", "${description.application}-v000"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -791,7 +791,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR) }
     1 * client.getDefaultDomain() >> { null }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}", "${description.application}-v000"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -834,7 +834,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { null }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}", "${description.application}-v000"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -876,7 +876,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null) >> {
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null) >> {
       throw new CloudFoundryException(HttpStatus.INTERNAL_SERVER_ERROR, 'Simulated failure', 'Unable to create application')
     }
     1 * client.deleteApplication(serverGroupName)
@@ -916,7 +916,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -963,7 +963,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { new CloudDomain(null, 'example.com', null) }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}.example.com", "${description.application}-v000.example.com"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -1015,7 +1015,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { null }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}", "${description.application}-v000"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [
@@ -1064,7 +1064,7 @@ class CloudFoundryDeployHandlerSpec extends Specification {
     1 * client.getApplications() >> { [] }
     1 * client.getApplication(serverGroupName) >> { null }
     1 * client.getDefaultDomain() >> { null }
-    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}"], null)
+    1 * client.createApplication(serverGroupName, _, 1024, ["${description.loadBalancers}", "${description.application}-v000"], null)
     1 * client.uploadApplication(serverGroupName, _, _)
     1 * client.updateApplicationEnv(serverGroupName,
         [

--- a/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/ops/DisableCloudFoundryServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/ops/DisableCloudFoundryServerGroupAtomicOperationSpec.groovy
@@ -189,6 +189,7 @@ class DisableCloudFoundryServerGroupAtomicOperationSpec extends Specification {
       app.state = CloudApplication.AppState.STOPPED
       app
     }
+    1 * client.getDefaultDomain() >> { new CloudDomain(null, 'cfapps.io', null) }
     1 * client.updateApplicationUris(serverGroupName, ['other.cfapps.io'])
     1 * client.stopApplication(serverGroupName)
     1 * client.getApplicationInstances(_) >> { new InstancesInfo([]) }

--- a/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/ops/EnableCloudFoundryServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/deploy/ops/EnableCloudFoundryServerGroupAtomicOperationSpec.groovy
@@ -183,7 +183,8 @@ class EnableCloudFoundryServerGroupAtomicOperationSpec extends Specification {
       app.uris = ['other.cfapps.io']
       app
     }
-    1 * client.updateApplicationUris(serverGroupName, ['other.cfapps.io', 'production.cfapps.io', 'staging.cfapps.io'])
+    1 * client.getDefaultDomain() >> { new CloudDomain(null, 'cfapps.io', null) }
+    1 * client.updateApplicationUris(serverGroupName, ['other.cfapps.io', 'production.cfapps.io', 'staging.cfapps.io', "${serverGroupName}.cfapps.io"])
     1 * client.startApplication(serverGroupName)
     2 * client.getApplicationInstances(_) >> { instancesInfo }
 


### PR DESCRIPTION
To support canary testing, Cloud Foundry-based server groups need a version-specific route ALSO mapped during deployment. This is also handled during enable/disable server group operations.