### PR TITLE
provider/cloudfoundry: Set default repository details

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -286,7 +286,9 @@ cf:
       space: ${providers.cf.defaultSpace}
       username: ${cf.account.name}
       password: ${cf.account.password}
-
+      artifactUsername: ${cf.repo.username}
+      artifactPassword: ${cf.repo.password}
+ 
 spring:
   jackson:
     mapper:


### PR DESCRIPTION
clouddriver.yml, the default settings for using CF, needs to have repository username/password fields set.