### PR TITLE
provider/google: added name field to GoogleHealthCheck

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleHealthCheck.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleHealthCheck.groovy
@@ -21,6 +21,8 @@ import groovy.transform.Canonical
 
 @Canonical
 class GoogleHealthCheck {
+
+  String name
   String requestPath
   int port
 
@@ -37,6 +39,7 @@ class GoogleHealthCheck {
 
   @Canonical
   class View implements Serializable {
+    String name = GoogleHealthCheck.this.name
     int interval = GoogleHealthCheck.this.checkIntervalSec
     int timeout = GoogleHealthCheck.this.timeoutSec
     int unhealthyThreshold = GoogleHealthCheck.this.unhealthyThreshold

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -241,6 +241,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
     void onSuccess(HttpHealthCheck httpHealthCheck, HttpHeaders responseHeaders) throws IOException {
       if (httpHealthCheck) {
         googleLoadBalancer.healthCheck = new GoogleHealthCheck(
+            name: httpHealthCheck.name,
             port: httpHealthCheck.port,
             requestPath: httpHealthCheck.requestPath,
             checkIntervalSec: httpHealthCheck.checkIntervalSec,


### PR DESCRIPTION
@lwander @duftler 

Added a name field to the GoogleHealthCheck class and updated the agent to provide this field. I need the name of the health check in order to properly serialize it. Terraform uses the name to determine if it needs to create a new resource or edit an existing one. The name of a health check is determined in part by the time it was created, so it is not possible to reconstruct this name from the current fields in the model. Adding the name field fixes this issue.