### PR TITLE
provider/cloudfoundry: Fix createdTime for out of order instances

### DIFF
--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryServerGroup.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryServerGroup.groovy
@@ -50,13 +50,13 @@ class CloudFoundryServerGroup implements ServerGroup, Serializable {
   }
 
   /**
-   * Return an instance's "since" attribute if it exists. Otherwise, fallback to "updated"
+   * Return an instance's "since" attribute if it exists, fetching the oldest one available. Otherwise, fallback to "updated"
    * @return
    */
   @Override
   Long getCreatedTime() {
     if (this.instances.size() > 0) {
-      this.instances.first().launchTime
+      this.instances.collect { it.launchTime }.min()
     } else {
       nativeApplication?.meta?.updated?.time
     }


### PR DESCRIPTION
When cloudfoundry fetches createdTime for a server group running multiple instances, it simply grabs the first one. It should actually look at all instances and grab the oldest.