### PR TITLE
Removed version from URIs to support Spring Cloud Eureka. Fixed #956

### DIFF
--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/Eureka.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/Eureka.groovy
@@ -25,10 +25,10 @@ import retrofit.http.Query
 
 interface Eureka {
   @Headers('Accept: application/json')
-  @GET('/v2/instances/{instanceId}')
+  @GET('/instances/{instanceId}')
   Map getInstanceInfo(@Path('instanceId') String instanceId)
 
   @Headers('Accept: application/json')
-  @PUT('/v2/apps/{application}/{instanceId}/status')
+  @PUT('/apps/{application}/{instanceId}/status')
   Response updateInstanceStatus(@Path('application') String application, @Path('instanceId') String instanceId, @Query('value') String status)
 }

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApi.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApi.groovy
@@ -22,7 +22,7 @@ import retrofit.http.Headers
 
 interface EurekaApi {
 
-  @GET('/v2/apps')
+  @GET('/apps')
   @Headers(['Accept: application/json'])
   EurekaApplications loadEurekaApplications()
 }


### PR DESCRIPTION
As discussed with @cfieber via Slack, this change removes the Eureka API version from the URI and let that be configured as part of the DiscoveryURL in the clouddriver.yml instead so we can support Spring Cloud Eureka.