### PR TITLE
provider/kubernetes: Dynamically load namespaces

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -288,6 +288,20 @@ class KubernetesApiAdaptor {
     }
   }
 
+  List<Namespace> getNamespaces() {
+    atomicWrapper("Get Namespaces", null) { KubernetesClient client ->
+      client.namespaces().list().items
+    }
+  }
+
+  List<String> getNamespacesByName() {
+    atomicWrapper("Get Namespaces", null) { KubernetesClient client ->
+      client.namespaces().list().items.collect {
+        it.metadata.name
+      }
+    }
+  }
+
   Namespace createNamespace(Namespace namespace) {
     atomicWrapper("Create Namespace $namespace", null) { KubernetesClient client ->
       client.namespaces().create(namespace)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
@@ -89,6 +89,11 @@ class KubernetesInstanceCachingAgent implements  CachingAgent, AccountAware {
         continue
       }
 
+      // Not owned by spinnaker
+      if (!pod.metadata.labels) {
+        continue
+      }
+
       def rc = pod.metadata.labels[KubernetesUtil.REPLICATION_CONTROLLER_LABEL] ?: ''
       def job = pod.metadata.labels[KubernetesUtil.JOB_LABEL] ?: ''
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
@@ -44,7 +44,6 @@ class KubernetesCredentialsInitializer implements CredentialsInitializerSynchron
   @Autowired
   ApplicationContext appContext;
 
-
   @Autowired
   KubernetesConfiguration configuration
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.groovy
@@ -66,6 +66,9 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
     this.credentials = credentials
   }
 
+  public List<String> getNamespaces() {
+    return credentials.getNamespaces()
+  }
 
   static class Builder {
     String name
@@ -150,9 +153,6 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
     private KubernetesCredentials buildCredentials() {
       Config config = KubernetesConfigParser.parse(kubeconfigFile, context, cluster, user, namespaces)
       config.setUserAgent(userAgent)
-      if (namespaces == null || namespaces.isEmpty()) {
-        namespaces = Collections.singletonList(config.getNamespace())
-      }
 
       for (LinkedDockerRegistryConfiguration registry : dockerRegistries) {
         if (registry.getNamespaces() == null || registry.getNamespaces().isEmpty()) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsSpec.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.security
+
+import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
+import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import spock.lang.Specification
+
+class KubernetesCredentialsSpec extends Specification {
+  List<String> NAMESPACES1 = ['default', 'kube-system']
+  List<String> NAMESPACES2 = ['default', 'spacename']
+
+  String ACCOUNT1 = 'account-default'
+
+  // These aren't pertinent to the test, so they can be reused for each account
+  String ADDRESS = 'gcr.io'
+  String BASIC_AUTH = 'lwander:hunter2'
+  String EMAIL = 'lwander@google.com'
+
+  List<LinkedDockerRegistryConfiguration> REGISTRIES1 = [
+    new LinkedDockerRegistryConfiguration(accountName: ACCOUNT1, namespaces: NAMESPACES1)
+  ]
+
+  List<LinkedDockerRegistryConfiguration> REGISTRIES2 = [
+    new LinkedDockerRegistryConfiguration(accountName: ACCOUNT1, namespaces: null)
+  ]
+
+  DockerRegistryNamedAccountCredentials mockCredentials(String accountName) {
+    DockerRegistryNamedAccountCredentials registryAccountMock = Mock(DockerRegistryNamedAccountCredentials)
+    registryAccountMock.getAccountName() >> ACCOUNT1
+    registryAccountMock.getAddress() >> ADDRESS
+    registryAccountMock.getBasicAuth() >> BASIC_AUTH
+    registryAccountMock.getEmail() >> EMAIL
+
+    return registryAccountMock
+  }
+
+  void "should ignore kubernetes namespaces"() {
+    setup:
+    KubernetesApiAdaptor adaptorMock = Mock(KubernetesApiAdaptor)
+    adaptorMock.getNamespacesByName() >> NAMESPACES2
+
+    AccountCredentialsRepository repositoryMock = Mock(AccountCredentialsRepository)
+    DockerRegistryNamedAccountCredentials registryAccountMock = mockCredentials(ACCOUNT1)
+    repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
+
+    when:
+    def result = new KubernetesCredentials(adaptorMock, NAMESPACES1, REGISTRIES1, repositoryMock)
+
+    then:
+    result.getNamespaces() == NAMESPACES1
+    result.dockerRegistries.get(0).namespaces == NAMESPACES1
+  }
+
+  void "should use kubernetes namespaces"() {
+    setup:
+    KubernetesApiAdaptor adaptorMock = Mock(KubernetesApiAdaptor)
+    adaptorMock.getNamespacesByName() >> NAMESPACES2
+
+    AccountCredentialsRepository repositoryMock = Mock(AccountCredentialsRepository)
+    DockerRegistryNamedAccountCredentials registryAccountMock = mockCredentials(ACCOUNT1)
+    repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
+
+    when:
+    def result = new KubernetesCredentials(adaptorMock, null, REGISTRIES2, repositoryMock)
+
+    then:
+    result.getNamespaces() == NAMESPACES2
+    result.dockerRegistries.get(0).namespaces == NAMESPACES2
+  }
+
+  void "should not use kubernetes namespaces only in registry"() {
+    setup:
+    KubernetesApiAdaptor adaptorMock = Mock(KubernetesApiAdaptor)
+    adaptorMock.getNamespacesByName() >> NAMESPACES2
+
+    AccountCredentialsRepository repositoryMock = Mock(AccountCredentialsRepository)
+    DockerRegistryNamedAccountCredentials registryAccountMock = mockCredentials(ACCOUNT1)
+    repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
+
+    when:
+    def result = new KubernetesCredentials(adaptorMock, null, REGISTRIES1, repositoryMock)
+
+    then:
+    result.getNamespaces() == NAMESPACES2
+    result.dockerRegistries.get(0).namespaces == NAMESPACES1
+  }
+}


### PR DESCRIPTION
There are two large changes here.

1. The KubernetesProvider now reconfigures its caching agents every 30 seconds
to add new agents for new namespaces
2. Every time namespaces are requested, the clouddriver checks if the namespace
is new, and if so, adds imagePullSecretes for the new namespace

@duftler PTAL