### PR TITLE
provider/kubernetes: Probe HTTP headers

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -240,6 +240,15 @@ class KubernetesApiConverter {
               containerBuilder = containerBuilder.withScheme(get.uriScheme)
             }
 
+            if (get.httpHeaders) {
+              def headers = get.httpHeaders.collect() {
+                def builder = new HTTPHeaderBuilder()
+                return builder.withName(it.name).withValue(it.value).build()
+              }
+
+              containerBuilder.withHttpHeaders(headers)
+            }
+
             containerBuilder = containerBuilder.endHttpGet()
             break
         }
@@ -515,6 +524,9 @@ class KubernetesApiConverter {
     kubernetesHttpGetAction.path = httpGet.path
     kubernetesHttpGetAction.port = httpGet.port?.intVal
     kubernetesHttpGetAction.uriScheme = httpGet.scheme
+    kubernetesHttpGetAction.httpHeaders = httpGet.httpHeaders?.collect() {
+      new KeyValuePair(name: it.name, value: it.value)
+    }
     return kubernetesHttpGetAction
   }
 }


### PR DESCRIPTION
@danielpeach FYI

@duftler PTAL

This was missing from the fabric8 API when I first added probes (so it's in the deploy description, but previously couldn't be used). Now it'll actually create probes with HTTP headers attached.