### PR TITLE
provider/kubernetes: Looser coupling of labels

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -172,6 +172,12 @@ class KubernetesApiAdaptor {
     }
   }
 
+  List<Pod> getPods(String namespace, Map<String, String> labels) {
+    atomicWrapper("Get Pods matching $labels", namespace) { KubernetesClient client ->
+      client.pods().inNamespace(namespace).withLabels(labels).list().items
+    }
+  }
+
   boolean deletePod(String namespace, String name) {
     atomicWrapper("Delete Pod $name", namespace) { KubernetesClient client ->
       client.pods().inNamespace(namespace).withName(name).delete()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
@@ -73,7 +73,7 @@ class Keys {
             name: parts[5],
             cluster: parts[5],
             stack: names.stack,
-            detail: names.detail
+            detail: names.detail,
         ]
         break
       case Namespace.JOBS.ns:
@@ -81,39 +81,39 @@ class Keys {
         result << [
             application: names.app,
             account: parts[2],
-            name: parts[4],
             namespace: parts[3],
+            region: parts[3],
+            name: parts[4],
+            job: parts[4],
             stack: names.stack,
             cluster: names.cluster,
             detail: names.detail,
             sequence: names.sequence?.toString(),
-            job: parts[4],
-            region: parts[3]
         ]
         break
       case Namespace.SERVER_GROUPS.ns:
         def names = Names.parseName(parts[4])
         result << [
-            application: names.app,
             account: parts[2],
             name: parts[4],
             namespace: parts[3],
+            region: parts[3],
+            serverGroup: parts[4],
+            application: names.app,
             stack: names.stack,
             cluster: names.cluster,
             detail: names.detail,
             sequence: names.sequence?.toString(),
-            serverGroup: parts[4],
-            region: parts[3]
         ]
         break
       case Namespace.LOAD_BALANCERS.ns:
         def names = Names.parseName(parts[4])
         result << [
-            application: names.app,
             account: parts[2],
+            namespace: parts[3],
             name: parts[4],
             loadBalancer: parts[4],
-            namespace: parts[3],
+            application: names.app,
             stack: names.stack,
             detail: names.detail
         ]
@@ -121,36 +121,35 @@ class Keys {
       case Namespace.INSTANCES.ns:
         def names = Names.parseName(parts[4])
         result << [
-            application: names.app,
             account: parts[2],
-            serverGroup: parts[4],
             namespace: parts[3],
-            name: parts[5],
-            instanceId: parts[5],
-            region: parts[3]
+            region: parts[3],
+            name: parts[4],
+            instanceId: parts[4],
+            application: names.app,
         ]
         break
       case Namespace.PROCESSES.ns:
         def names = Names.parseName(parts[4])
         result << [
-            application: names.app,
             account: parts[2],
             serverGroup: parts[4],
             namespace: parts[3],
             name: parts[5],
             processId: parts[5],
-            region: parts[3]
+            region: parts[3],
+            application: names.app,
         ]
         break
       case Namespace.SECURITY_GROUPS.ns:
         def names = Names.parseName(parts[4])
         result << [
-            application: names.app,
             account: parts[2],
             namespace: parts[3],
             region: parts[3],
             name: parts[4],
-            id: parts[4]
+            id: parts[4],
+            application: names.app,
         ]
         break
       default:
@@ -181,12 +180,12 @@ class Keys {
     "${Namespace.provider}:${Namespace.LOAD_BALANCERS}:${account}:${namespace}:${serviceName}"
   }
 
-  static String getInstanceKey(String account, String namespace, String replicationControllerName, String name) {
-    "${Namespace.provider}:${Namespace.INSTANCES}:${account}:${namespace}:${replicationControllerName}:${name}"
+  static String getInstanceKey(String account, String namespace, String name) {
+    "${Namespace.provider}:${Namespace.INSTANCES}:${account}:${namespace}:${name}"
   }
 
-  static String getProcessKey(String account, String namespace, String jobName, String name) {
-    "${Namespace.provider}:${Namespace.PROCESSES}:${account}:${namespace}:${jobName}:${name}"
+  static String getProcessKey(String account, String namespace, String name) {
+    "${Namespace.provider}:${Namespace.PROCESSES}:${account}:${namespace}:${name}"
   }
 
   static String getSecurityGroupKey(String account, String namespace, String ingressName) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
@@ -89,23 +89,11 @@ class KubernetesInstanceCachingAgent implements  CachingAgent, AccountAware {
         continue
       }
 
-      // Not owned by spinnaker
-      if (!pod.metadata.labels) {
-        continue
-      }
-
-      def rc = pod.metadata.labels[KubernetesUtil.REPLICATION_CONTROLLER_LABEL] ?: ''
-      def job = pod.metadata.labels[KubernetesUtil.JOB_LABEL] ?: ''
-
-
-      if (job) {
-        def key = Keys.getProcessKey(accountName, namespace, job, pod.metadata.name)
-        cachedProcesses[key].with {
-          attributes.name = pod.metadata.name
-          attributes.pod = pod
-        }
-      } else {
-        def key = Keys.getInstanceKey(accountName, namespace, rc, pod.metadata.name)
+      def key = Keys.getProcessKey(accountName, namespace, pod.metadata.name)
+      cachedProcesses[key].with {
+        attributes.name = pod.metadata.name
+        attributes.pod = pod
+        key = Keys.getInstanceKey(accountName, namespace, pod.metadata.name)
         cachedInstances[key].with {
           attributes.name = pod.metadata.name
           attributes.pod = pod

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesJobCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesJobCachingAgent.groovy
@@ -294,7 +294,7 @@ class KubernetesJobCachingAgent implements CachingAgent, OnDemandAgent, AccountA
         }
 
         pods.forEach { pod ->
-          def key = Keys.getProcessKey(accountName, namespace, jobName, pod.metadata.name)
+          def key = Keys.getProcessKey(accountName, namespace, pod.metadata.name)
           processKeys << key
           cachedProcesses[key].with {
             relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -195,8 +195,8 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
     credentials.apiAdaptor.getReplicationController(namespace, name)
   }
 
-  List<Pod> loadPods(String replicationControllerName) {
-    credentials.apiAdaptor.getReplicationControllerPods(namespace, replicationControllerName)
+  List<Pod> loadPods(ReplicationController replicationController) {
+    credentials.apiAdaptor.getPods(namespace, replicationController.spec.selector)
   }
 
   @Override
@@ -267,7 +267,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
         cache(cacheResults, Keys.Namespace.INSTANCES.ns, cachedInstances)
       } else {
         def replicationControllerName = replicationController.metadata.name
-        def pods = loadPods(replicationControllerName)
+        def pods = loadPods(replicationController)
         def names = Names.parseName(replicationControllerName)
         def applicationName = names.app
         def clusterName = names.cluster
@@ -295,7 +295,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
         }
 
         pods.forEach { pod ->
-          def key = Keys.getInstanceKey(accountName, namespace, replicationControllerName, pod.metadata.name)
+          def key = Keys.getInstanceKey(accountName, namespace, pod.metadata.name)
           instanceKeys << key
           cachedInstances[key].with {
             relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
@@ -41,9 +41,9 @@ class KubernetesInstanceProvider implements InstanceProvider<KubernetesInstance>
 
   @Override
   KubernetesInstance getInstance(String account, String namespace, String name) {
-    Set<CacheData> instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.INSTANCES.ns, Keys.getInstanceKey(account, namespace, "*", name))
+    Set<CacheData> instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.INSTANCES.ns, Keys.getInstanceKey(account, namespace, name))
     if (!instances || instances.size() == 0) {
-      instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.PROCESSES.ns, Keys.getProcessKey(account, namespace, "*", name))
+      instances = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.PROCESSES.ns, Keys.getProcessKey(account, namespace, name))
       if (!instances || instances.size() == 0) {
         return null
       }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesJobProvider.groovy
@@ -56,8 +56,9 @@ class KubernetesJobProvider implements JobProvider<KubernetesJob> {
 
     def securityGroups = KubernetesClusterProvider.loadBalancerToSecurityGroupMap(securityGroupProvider, cacheView, allLoadBalancers)
 
-    Set<CacheData> processes = KubernetesProviderUtils.getAllMatchingKeyPattern(cacheView, Keys.Namespace.PROCESSES.ns,
-                                                                                Keys.getProcessKey(account, location, (String)jobData.attributes.name, "*"))
+    Set<CacheData> processes = KubernetesClusterProvider.resolveRelationshipDataForCollection(cacheView, [jobData],
+                                                                                              Keys.Namespace.INSTANCES.ns,
+                                                                                              RelationshipCacheFilter.none())
 
     def job = objectMapper.convertValue(jobData.attributes.job, Job)
     def res = new KubernetesJob(job, KubernetesProviderUtils.controllerToInstanceMap(objectMapper, processes)[(String)jobData.attributes.name], account)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta
 import io.fabric8.kubernetes.api.model.PodList
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.ReplicationControllerList
+import io.fabric8.kubernetes.api.model.ReplicationControllerSpec
 import spock.lang.Specification
 
 class KubernetesServerGroupCachingAgentSpec extends Specification {
@@ -69,7 +70,7 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
     applicationKey = Keys.getApplicationKey(APP)
     clusterKey = Keys.getClusterKey(ACCOUNT_NAME, APP, 'serverGroup', CLUSTER)
     serverGroupKey = Keys.getServerGroupKey(ACCOUNT_NAME, NAMESPACE, REPLICATION_CONTROLLER)
-    instanceKey = Keys.getInstanceKey(ACCOUNT_NAME, NAMESPACE, REPLICATION_CONTROLLER, POD)
+    instanceKey = Keys.getInstanceKey(ACCOUNT_NAME, NAMESPACE, POD)
 
     cachingAgent = new KubernetesServerGroupCachingAgent(new KubernetesCloudProvider(), ACCOUNT_NAME, kubernetesCredentials, NAMESPACE, new ObjectMapper(), registryMock)
   }
@@ -78,8 +79,12 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
     setup:
       def replicationControllerMock = Mock(ReplicationController)
       def replicationControllerMetadataMock = Mock(ObjectMeta)
+      def replicationControllerSpecMock = Mock(ReplicationControllerSpec)
+      def selector = ['replicationController': REPLICATION_CONTROLLER.toString()]
+      replicationControllerSpecMock.getSelector() >> selector
       replicationControllerMetadataMock.getName() >> REPLICATION_CONTROLLER
       replicationControllerMock.getMetadata() >> replicationControllerMetadataMock
+      replicationControllerMock.getSpec() >> replicationControllerSpecMock
 
       def podMock = Mock(ReplicationController)
       def podMetadataMock = Mock(ObjectMeta)
@@ -87,7 +92,7 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
       podMock.getMetadata() >> podMetadataMock
 
       apiMock.getReplicationControllers(NAMESPACE) >> [replicationControllerMock]
-      apiMock.getReplicationControllerPods(NAMESPACE, _) >> [podMock]
+      apiMock.getPods(NAMESPACE, selector) >> [podMock]
 
       def providerCacheMock = Mock(ProviderCache)
       providerCacheMock.getAll(_, _) >> []


### PR DESCRIPTION
The idea is to allow custom user-defined RC -> Pod labels to render correctly in spinnaker. This loosens my arbitrary naming-convention requirements to get infrastructure to show up correctly in Deck. For example, `kube-system` components now have their pods rendered correctly: 

![kubdns](https://cloud.githubusercontent.com/assets/4874941/16529222/a77d8242-3f8f-11e6-8125-d6d2c4c8dcef.png)

@duftler PTAL