### PR TITLE
Bug fix: properly handle failing to create a new SG

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -301,7 +301,7 @@ class AzureNetworkClient extends AzureBaseClient {
       if (!agDescription || (agDescription.cluster && agDescription.cluster != parsedName.cluster)) {
         // The selected server group must be in the same cluster and region (see resourceGroup) with the one already
         //   assigned for the selected application gateway.
-        def errMsg = "Failed to associate ${serverGroupName} with ${appGatewayName}; expecting server group to be in ${parsedName.cluster} cluster"
+        def errMsg = "Failed to associate ${serverGroupName} with ${appGatewayName}; expecting server group to be in ${agDescription.cluster} cluster"
         log.error(errMsg)
         throw new RuntimeException(errMsg)
       }


### PR DESCRIPTION
If create server group fails there are some cases where the backend address pool entry that links the server group to an application gateway (load balancer) is not properly cleared. This leaves the application gateway in a corrupted state.