### PR TITLE
provider/google: Retry delete SG on timeout

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
@@ -16,16 +16,26 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.services.compute.Compute
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DestroyGoogleServerGroupDescription
+import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
+import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationTimedOutException
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
+import java.util.concurrent.TimeUnit
+
+@Slf4j
 class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
+  private static final int MAX_DELETE_RETRIES = 10
+  private static final int DELETE_RETRY_INTERVAL_SECONDS = 10
   private static final String BASE_PHASE = "DESTROY_SERVER_GROUP"
 
   private static Task getTask() {
@@ -71,6 +81,72 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
     task.updateStatus BASE_PHASE, "Checking for autoscaler..."
 
     if (serverGroup.autoscalingPolicy) {
+      destroy(destroyAutoscaler(compute, serverGroupName, project, region, zone, isRegional), "autoscaler")
+      task.updateStatus BASE_PHASE, "Deleted autoscaler"
+    }
+
+    destroy(destroyInstanceGroup(compute, serverGroupName, project, region, zone, isRegional), "instance group")
+
+    task.updateStatus BASE_PHASE, "Deleted instance group."
+
+    destroy(destroyInstanceTemplate(compute, instanceTemplateName, project), "instance template")
+
+    task.updateStatus BASE_PHASE, "Deleted instance template."
+
+    task.updateStatus BASE_PHASE, "Done destroying server group $serverGroupName in $region."
+    null
+  }
+
+  static Void destroy(Closure operation, String resource) {
+    try {
+      task.updateStatus BASE_PHASE, "Attempting destroy of $resource..."
+      operation()
+      // If the operation times out, then try
+      // 1. Deleting again ->
+      //   a. On failure (404) we treat this as a success.
+      //   b. On failure (400 meaning not ready) retry.
+      //   d. On failure (anything else) propagate error.
+      //   c. On timeout retry.
+      //   e. On success exit happily.
+    } catch (GoogleOperationTimedOutException _) {
+      log.warn "Initial delete of $resource timed out, retrying..."
+
+      int tries = 1
+      while (tries < MAX_DELETE_RETRIES) {
+        try {
+          tries++
+          sleep(TimeUnit.SECONDS.toMillis(DELETE_RETRY_INTERVAL_SECONDS))
+          log.warn "Delete $resource attempt #$tries..."
+          operation()
+          log.warn "Delete $resource attempt #$tries succeeded"
+          return
+        } catch (GoogleJsonResponseException jsonException) {
+          if (jsonException.statusCode == 404) {
+            log.warn "Retry delete of ${resource} encountered 404, treating as success..."
+            return
+          } else if (jsonException.statusCode == 400) {
+            log.warn "Retry delete of ${resource} encountered 400, trying again..."
+          } else {
+            throw jsonException
+          }
+        } catch (GoogleOperationTimedOutException __) {
+          log.warn "Retry delete timed out again, trying again..."
+        }
+      }
+
+      throw new GoogleOperationException("Failed to delete $resource after #$tries")
+    }
+  }
+
+  Closure destroyInstanceTemplate(Compute compute, String instanceTemplateName, String project) {
+    return {
+      compute.instanceTemplates().delete(project, instanceTemplateName).execute()
+      null
+    }
+  }
+
+  Closure destroyAutoscaler(Compute compute, String serverGroupName, String project, String region, String zone, Boolean isRegional) {
+    return {
       if (isRegional) {
         def autoscalerDeleteOperation = compute.regionAutoscalers().delete(project, region, serverGroupName).execute()
         def autoscalerDeleteOperationName = autoscalerDeleteOperation.getName()
@@ -79,7 +155,7 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
 
         // We must make sure the autoscaler is deleted before deleting the managed instance group.
         googleOperationPoller.waitForRegionalOperation(compute, project, region, autoscalerDeleteOperationName, null, task,
-            "regional autoscaler $serverGroupName", BASE_PHASE)
+          "regional autoscaler $serverGroupName", BASE_PHASE)
       } else {
         def autoscalerDeleteOperation = compute.autoscalers().delete(project, zone, serverGroupName).execute()
         def autoscalerDeleteOperationName = autoscalerDeleteOperation.getName()
@@ -88,34 +164,31 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
 
         // We must make sure the autoscaler is deleted before deleting the managed instance group.
         googleOperationPoller.waitForZonalOperation(compute, project, zone, autoscalerDeleteOperationName, null, task,
-            "zonal autoscaler $serverGroupName", BASE_PHASE)
+          "zonal autoscaler $serverGroupName", BASE_PHASE)
       }
+      null
     }
+  }
 
-    def instanceGroupManagerDeleteOperation =
-        isRegional
-        ? compute.regionInstanceGroupManagers().delete(project, region, serverGroupName).execute()
-        : compute.instanceGroupManagers().delete(project, zone, serverGroupName).execute()
-    def instanceGroupOperationName = instanceGroupManagerDeleteOperation.getName()
+  Closure destroyInstanceGroup(Compute compute, String serverGroupName, String project, String region, String zone, Boolean isRegional) {
+    return {
+      def instanceGroupManagerDeleteOperation = isRegional ?
+        compute.regionInstanceGroupManagers().delete(project, region, serverGroupName).execute() :
+        compute.instanceGroupManagers().delete(project, zone, serverGroupName).execute()
 
-    task.updateStatus BASE_PHASE, "Waiting on delete operation for managed instance group..."
+      def instanceGroupOperationName = instanceGroupManagerDeleteOperation.getName()
 
-    // We must make sure the managed instance group is deleted before deleting the instance template.
-    if (isRegional) {
-      googleOperationPoller.waitForRegionalOperation(compute, project, region, instanceGroupOperationName, null, task,
+      task.updateStatus BASE_PHASE, "Waiting on delete operation for managed instance group..."
+
+      // We must make sure the managed instance group is deleted before deleting the instance template.
+      if (isRegional) {
+        googleOperationPoller.waitForRegionalOperation(compute, project, region, instanceGroupOperationName, null, task,
           "regional instance group $serverGroupName", BASE_PHASE)
-    } else {
-      googleOperationPoller.waitForZonalOperation(compute, project, zone, instanceGroupOperationName, null, task,
+      } else {
+        googleOperationPoller.waitForZonalOperation(compute, project, zone, instanceGroupOperationName, null, task,
           "zonal instance group $serverGroupName", BASE_PHASE)
+      }
+      null
     }
-
-    task.updateStatus BASE_PHASE, "Deleted instance group."
-
-    compute.instanceTemplates().delete(project, instanceTemplateName).execute()
-
-    task.updateStatus BASE_PHASE, "Deleted instance template."
-
-    task.updateStatus BASE_PHASE, "Done destroying server group $serverGroupName in $region."
-    null
   }
 }


### PR DESCRIPTION
We are seeing timeouts during large numbers of MIG deletes. To avoid
inappropriate failures we retry the delete operation once. If this works at
scale we can extend this logic to other operations prone to timeouts.

@duftler, @ttomsu PTAL