### PR TITLE
provider/google: FailureLogger is producing too much noise

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/FailureLogger.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/FailureLogger.groovy
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory
 trait FailureLogger {
 
   void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
-    def errorJson = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(e)
-    LoggerFactory.getLogger(this.class).error errorJson
+    LoggerFactory.getLogger(this.class).error e.getMessage()
   }
 }


### PR DESCRIPTION
Logging the whole error JSON body is overkill, since 90% of the body is noise. For example, every instance that doesn't have a health check produces about 3600+ bytes of useless info.

```
2016-07-07 12:13:37.897 ERROR 51313 --- [  AgentWorker-4] ngAgent$TargetPoolInstanceHealthCallback : {
  "code" : 404,
  "errors" : [ {
    "domain" : "global",
    "message" : "The resource 'projects/nits-1132/zones/us-central1-f/instances/gke-cafe-5-c1c9c9b6-node-ct2b' was not found",
    "reason" : "notFound",
    "debugInfo" : "com.google.api.server.core.Fault: ImmutableErrorDefinition{base=NOT_FOUND, category=USER_ERROR, cause=null, debugInfo=null, domain=global, extendedHelp=null, httpHeaders={}, httpStatus=notFound, internalReason=Reason{arguments={}, cause=null, code=bigcluster.BigClusterErrorDomain.RESOURCE_NOT_FOUND, createdByBackend=true, debugMessage=null, errorProtoCode=RESOURCE_NOT_FOUND, errorProtoDomain=bigcluster.BigClusterErrorDomain, filteredMessage=null, location=null, message=The resource 'projects/nits-1132/zones/us-central1-f/instances/gke-cafe-5-c1c9c9b6-node-ct2b' was not found, unnamedArguments=[projects/nits-1132/zones/us-central1-f/instances/gke-cafe-5-c1c9c9b6-node-ct2b]}, location=null, message=The resource 'projects/nits-1132/zones/us-central1-f/instances/gke-cafe-5-c1c9c9b6-node-ct2b' was not found, reason=notFound, rpcCode=404} The resource 'projects/nits-1132/zones/us-central1-f/instances/gke-cafe-5-c1c9c9b6-node-ct2b' was not found\n\tat com.google.api.server.core.ErrorCollector.toFault(ErrorCollector.java:43)\n\tat com.google.api.server.rest.adapter.rosy.RosyErrorConverter.toFault(RosyErrorConverter.java:62)\n\tat com.google.api.server.rest.adapter.rosy.RosyHandler$2.call(RosyHandler.java:256)\n\tat com.google.api.server.rest.adapter.rosy.RosyHandler$2.call(RosyHandler.java:237)\n\tat com.google.api.server.core.util.CallableFuture.run(CallableFuture.java:62)\n\tat com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:441)\n\tat com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:840)\n\tat com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:770)\n\tat com.google.common.util.concurrent                                  .AbstractFuture.set(AbstractFuture.java:626)\n\tat com.google.api.server.core.util.CallableFuture.run(CallableFuture.java:62)\n\tat com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:441)\n\tat com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:840)\n\tat com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:770)\n\tat com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:626)\n\tat com.google.api.server.core.util.CallableFuture.run(CallableFuture.java:62)\n\tat com.google.api.server.thread.ThreadTrackers$ThreadTrackingRunnable.run(ThreadTrackers.java:126)\n\tat com.google.tracing.TraceContext$TraceContextRunnable.runInContext(TraceContext.java:447)\n\tat com.google.api.server.server.CommonModule$ContextCarryingExecutorService$1.runInContext(CommonModule.java:805)\n\tat com.google.tracing.TraceContext$TraceContextRunnable$1.run(TraceContext.java:454)\n\tat com.google.tracing.CurrentContext.runInContext(CurrentContext.java:256)\n\tat com.google.tracing.TraceContext$AbstractTraceContextCallback.runInInheritedContextNoUnref(TraceContext.java:313)\n\tat com.google.tracing.TraceContext$AbstractTraceContextCallback.runInInheritedContext(TraceContext.java:305)\n\tat com.google.tracing.TraceContext$TraceContextRunnable.run(TraceContext.java:451)\n\tat com.google.gse.internal.DispatchQueueImpl$WorkerThread.run(DispatchQueueImpl.java:387)\n"
  } ],
  "message" : "The resource 'projects/nits-1132/zones/us-central1-f/instances/gke-cafe-5-c1c9c9b6-node-ct2b' was not found"
}
```

(notice how long the debug line is) 

@ttomsu 