### PR TITLE
provider/google: Targeted cluster load

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -89,8 +89,13 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
   }
 
   @Override
-  GoogleCluster.View getCluster(String application, String account, String name) {
-    getClusters(application, account).find { it.name == name }
+  GoogleCluster.View getCluster(String applicationName, String accountName, String clusterName) {
+    CacheData clusterData = cacheView.get(
+      CLUSTERS.ns,
+      Keys.getClusterKey(accountName, applicationName, clusterName),
+      RelationshipCacheFilter.include(SERVER_GROUPS.ns))
+
+    return clusterData ? clusterFromCacheData(clusterData, true /* Include instance details */ ) : null
   }
 
   @Override


### PR DESCRIPTION
@ttomsu PTAL
@duftler FYI

This change prevents loading every cluster from Redis on a single-cluster lookup.