### PR TITLE
Surface a view of image tags that exist across all AMIs

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/UpsertAmiTagsAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/UpsertAmiTagsAtomicOperationConverter.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.converters
+
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmiTagsDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.UpsertAmiTagsAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+@AmazonOperation(AtomicOperations.UPSERT_MACHINE_IMAGE_TAGS)
+@Component("upsertAmiTagsDescription")
+class UpsertAmiTagsAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  AtomicOperation convertOperation(Map input) {
+    new UpsertAmiTagsAtomicOperation(convertDescription(input))
+  }
+
+  UpsertAmiTagsDescription convertDescription(Map input) {
+    def converted = objectMapper.convertValue(input, UpsertAmiTagsDescription)
+    converted.credentials = getCredentialsObject(input.credentials as String)
+    converted
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmiTagsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmiTagsDescription.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.description
+
+class UpsertAmiTagsDescription extends AbstractAmazonCredentialsDescription {
+  String amiName
+  Collection<String> regions
+  Map<String, String> tags
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAmiTagsAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAmiTagsAtomicOperation.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops
+
+import com.amazonaws.services.ec2.model.CreateTagsRequest
+import com.amazonaws.services.ec2.model.DescribeImagesRequest
+import com.amazonaws.services.ec2.model.Filter
+import com.amazonaws.services.ec2.model.Tag
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmiTagsDescription
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
+
+class UpsertAmiTagsAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "UPSERT_AMI_TAGS"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  @Autowired
+  AmazonClientProvider amazonClientProvider
+
+  private final UpsertAmiTagsDescription description
+
+  UpsertAmiTagsAtomicOperation(UpsertAmiTagsDescription description) {
+    this.description = description
+  }
+
+  @Override
+  Void operate(List priorOutputs) {
+    def descriptor = "${description.credentials.name}/${description.amiName}"
+    task.updateStatus BASE_PHASE, "Initializing Upsert ASG Tags operation for ${descriptor}..."
+
+    description.regions.each { String region ->
+      def amazonEC2 = amazonClientProvider.getAmazonEC2(description.credentials, region, true)
+      def describeImagesRequest = new DescribeImagesRequest().withFilters(
+        new Filter("name", [description.amiName])
+      )
+      def images = amazonEC2.describeImages(describeImagesRequest).images
+      if (!images) {
+        task.updateStatus BASE_PHASE, "No AMI found for ${descriptor} in ${region}."
+        task.fail()
+        return
+      }
+
+      def amiId = images?.get(0)?.imageId
+      if (upsertAmiTags(region, amiId, buildTags(description))) {
+        task.updateStatus BASE_PHASE, "Finished Upsert AMI Tags operation for ${descriptor} in ${region}."
+      } else {
+        task.fail()
+      }
+    }
+
+    null
+  }
+
+  private boolean upsertAmiTags(String region, String amiId, Collection<Tag> tags) {
+    try {
+      def amazonEC2 = amazonClientProvider.getAmazonEC2(description.credentials, region)
+      def createTagsRequest = new CreateTagsRequest()
+        .withResources(amiId)
+        .withTags(tags)
+
+      task.updateStatus BASE_PHASE, "Updating tags for ${amiId} in ${region}..."
+      amazonEC2.createTags(createTagsRequest)
+      task.updateStatus BASE_PHASE, "Tags updated for ${amiId} in ${region}..."
+      return true
+    } catch (e) {
+      task.updateStatus BASE_PHASE, "Could not upsert AMI tags for ${amiId} in ${region}! Reason: $e.message"
+    }
+    return false
+  }
+
+  private static Collection<Tag> buildTags(UpsertAmiTagsDescription upsertAmiTagsDescription) {
+    return upsertAmiTagsDescription.tags.collect {
+      new Tag(it.key, it.value)
+    }
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupControllerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupControllerSpec.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.aws.controllers
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletRequest
+
+class AmazonNamedImageLookupControllerSpec extends Specification {
+  @Unroll
+  void "should extract tags from query parameters"() {
+    given:
+    def httpServletRequest = httpServletRequest(["tag:tag1": "value1", "tag:Tag2": "value2"])
+
+    expect:
+    AmazonNamedImageLookupController.extractTagFilters(httpServletRequest) == ["tag1": "value1", "tag2": "value2"]
+  }
+
+  void "should support filtering on 1..* tags"() {
+    given:
+    def namedImage1 = new AmazonNamedImageLookupController.NamedImage(
+      amis: ["us-east-1": ["ami-123"]],
+      tagsByImageId: ["ami-123": ["state": "released"]]
+    )
+    def namedImage2 = new AmazonNamedImageLookupController.NamedImage(
+      amis: ["us-east-1": ["ami-456"]],
+      tagsByImageId: ["ami-456": ["state": "released", "engine": "spinnaker"]]
+    )
+
+    and:
+    def controller = new AmazonNamedImageLookupController(null)
+
+    expect:
+    // single tag ... matches all
+    controller.filter([namedImage1, namedImage2], ["state": "released"]) == [namedImage1, namedImage2]
+
+    // multiple tags ... matches one (case-insensitive)
+    controller.filter([namedImage1, namedImage2], ["STATE": "released", "engine": "SpinnakeR"]) == [namedImage2]
+
+    // single tag ... matches none
+    controller.filter([namedImage1, namedImage2], ["xxx": "released"]) == []
+
+    // no tags ... matches all
+    controller.filter([namedImage1, namedImage2], [:]) == [namedImage1, namedImage2]
+  }
+
+  private HttpServletRequest httpServletRequest(Map<String, String> tagFilters) {
+    return Mock(HttpServletRequest) {
+      getParameterNames() >> {
+        new Vector(["param1"] + tagFilters.keySet()).elements()
+      }
+      getParameter(_) >> { String key -> tagFilters.get(key) }
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
@@ -59,4 +59,7 @@ final class AtomicOperations {
   public static final String RUN_JOB = "runJob"
   public static final String DESTROY_JOB = "destroyJob"
   public static final String CLONE_JOB = "cloneJob"
+
+  // Machine Image operations
+  public static final String UPSERT_MACHINE_IMAGE_TAGS = "upsertMachineImageTags"
 }


### PR DESCRIPTION
This PR introduces the ability to both tag images and search for images by 1..* tags.

The current implementation is AWS-specific, but it is an AtomicOperation and open to implementation by other cloud providers.

Relates to https://github.com/spinnaker/gate/pull/255.

There will be `orca` changes forthcoming that provide an UpsertMachineImageTagsStage.