### PR TITLE
(aws) derive migration operation credentials from target

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateLoadBalancerDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateLoadBalancerDescription.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+
 import static com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerMigrator.LoadBalancerLocation
 
 class MigrateLoadBalancerDescription {
@@ -25,5 +28,10 @@ class MigrateLoadBalancerDescription {
   String subnetType
   String application
   boolean dryRun
+
+  @JsonIgnore
+  NetflixAmazonCredentials getCredentials() {
+    return target.getCredentials();
+  }
 
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateSecurityGroupDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateSecurityGroupDescription.groovy
@@ -16,10 +16,17 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupMigrator
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupMigrator.SecurityGroupLocation
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 
 class MigrateSecurityGroupDescription {
-  SecurityGroupMigrator.SecurityGroupLocation source
-  SecurityGroupMigrator.SecurityGroupLocation target
+  SecurityGroupLocation source
+  SecurityGroupLocation target
   boolean dryRun
+
+  @JsonIgnore
+  NetflixAmazonCredentials getCredentials() {
+    return target.getCredentials();
+  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateServerGroupDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateServerGroupDescription.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+
 import static com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ServerGroupMigrator.ServerGroupLocation
 
 class MigrateServerGroupDescription {
@@ -28,4 +31,8 @@ class MigrateServerGroupDescription {
   String targetAmi
   boolean dryRun
 
+  @JsonIgnore
+  NetflixAmazonCredentials getCredentials() {
+    return target.getCredentials();
+  }
 }


### PR DESCRIPTION
Turns out the credentials are needed when authentication is enabled.

@cfieber or @ajordens PTAL