### PR TITLE
Azure server group caching bug fixes

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -98,6 +98,16 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   }
 
   @Override
+  Set<String> getLoadBalancers() {
+    return [this.appGatewayName]
+  }
+
+  @Override
+  Set<String> getSecurityGroups() {
+    return [this.securityGroupName]
+  }
+
+  @Override
   Boolean isDisabled() {
     this.isDisabled
   }


### PR DESCRIPTION
When the user deletes the server group through the Azure Portal web site, it causes the Redis entries to be in a corrupted state. One side effect of it is Spinnaker continues to render "ghost" server groups that can become confusing.
Also fixed an issue with how deck is expecting load balancers and security groups associated with a server group to be passed (some core functionality is expecting a list rather than a string).