### PR TITLE
provider/consul: Config options

### DIFF
--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/config/ConsulConfig.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/config/ConsulConfig.groovy
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.consul.api.v1.model
+package com.netflix.spinnaker.clouddriver.consul.config
 
-class CheckResult {
-  String Node
-  String CheckID
-  String Name
-  Status Status
-  String Notes
-  String Output
-  String ServiceID
-  String ServiceName
-
-  enum Status {
-    passing,
-    critical,
-    warning,
-    unknown,
-  }
+class ConsulConfig {
+  boolean enabled
+  // required: reachable Consul server endpoints (IP address or DNS name)
+  List<String> servers
+  // optional: datacenters to cache/keep updated
+  List<String> datacenters
 }

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -1,5 +1,6 @@
 dependencies {
   compile project(":clouddriver-core")
+  compile project(":clouddriver-consul")
   spinnaker.group('google')
   compile spinnaker.dependency('frigga')
   compile spinnaker.dependency('bootActuator')

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/config/GoogleConfigurationProperties.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/config/GoogleConfigurationProperties.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.config
 
+import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import groovy.transform.ToString
 
 class GoogleConfigurationProperties {
@@ -32,6 +33,7 @@ class GoogleConfigurationProperties {
     String jsonPath
     List<String> imageProjects
     List<String> requiredGroupMembership
+    ConsulConfig consul
 
     public InputStream getInputStream() {
       if (jsonPath) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleCredentialsInitializer.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleCredentialsInitializer.groovy
@@ -44,7 +44,7 @@ class GoogleCredentialsInitializer implements CredentialsInitializerSynchronizab
   AccountCredentialsRepository accountCredentialsRepository
 
   @Autowired
-  ApplicationContext appContext;
+  ApplicationContext appContext
 
   @Autowired
   List<ProviderSynchronizerTypeWrapper> providerSynchronizerTypeWrappers
@@ -81,6 +81,7 @@ class GoogleCredentialsInitializer implements CredentialsInitializerSynchronizab
             .imageProjects(managedAccount.imageProjects)
             .requiredGroupMembership(managedAccount.requiredGroupMembership)
             .applicationName(googleApplicationName)
+            .consulConfig(managedAccount.consul)
             .build()
 
         if (!managedAccount.project) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.groovy
@@ -20,6 +20,7 @@ import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Region
 import com.google.api.services.compute.model.RegionList
 import com.google.common.annotations.VisibleForTesting
+import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import com.netflix.spinnaker.clouddriver.google.ComputeVersion
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
@@ -42,6 +43,7 @@ class GoogleNamedAccountCredentials implements AccountCredentials<GoogleCredenti
   final ComputeVersion computeVersion
   final Map<String, List<String>> regionToZonesMap
   final Compute compute
+  final ConsulConfig consulConfig
 
   static class Builder {
     String name
@@ -56,6 +58,7 @@ class GoogleNamedAccountCredentials implements AccountCredentials<GoogleCredenti
     String jsonKey
     GoogleCredentials credentials
     Compute compute
+    ConsulConfig consulConfig
 
     /**
      * If true, overwrites any value in regionToZoneMap with values from the platform.
@@ -114,6 +117,11 @@ class GoogleNamedAccountCredentials implements AccountCredentials<GoogleCredenti
 
     Builder regionLookupEnabled(boolean enabled) {
       this.regionLookupEnabled = enabled
+      return this
+    }
+
+    Builder consulConfig(ConsulConfig consulConfig) {
+      this.consulConfig = consulConfig
       return this
     }
 


### PR DESCRIPTION
I've made a different choice here w.r.t. configuring consul for a specific provider when compared to the eureka support. The idea here is that consul is added/configured once per account per provider, because it's easy to imagine a multi-cloud situation where either 
  1. each cloud is running a separate consul installation
  2. the cloud's consul installations are connected into one consul installation (multi [datacenter](https://www.consul.io/docs/guides/datacenters.html)).

If we make the ability to configure consul a top level option like it is for eureka, we can't have separate consul installations for each clouddriver account. This is an issue for consul, since it's intended to be cloud-agnostic. 

Ultimately, the `clouddriver-consul` package will provide all the utility for caching, reporting health, etc... but the actual cache and health results will need to be surfaced per-provider for this reason. 

PTAL @duftler @ttomsu @jtk54 