### PR TITLE
(k8s) prevent container hostPort from defaulting to zero

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -40,10 +40,10 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesAtomicOperati
 @Canonical
 class KubernetesContainerPort {
   String name
-  int containerPort
+  Integer containerPort
   String protocol
   String hostIp
-  int hostPort
+  Integer hostPort
 }
 
 @AutoClone


### PR DESCRIPTION
(k8s) prevent container hostPort from defaulting to zero (instead of null)
@lwander PTAL