### PR TITLE
provider/kubernetes: Fix loading of LBs

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesLoadBalancerProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesLoadBalancerProvider.groovy
@@ -88,8 +88,12 @@ class KubernetesLoadBalancerProvider implements LoadBalancerProvider<KubernetesL
     Service service = objectMapper.convertValue(loadBalancerEntry.attributes.service, Service)
     List<KubernetesServerGroup> serverGroups = []
     List<String> securityGroups
-    loadBalancerEntry.relationships[Keys.Namespace.SERVER_GROUPS.ns]?.forEach {
-      serverGroups << serverGroupMap[it]
+    loadBalancerEntry.relationships[Keys.Namespace.SERVER_GROUPS.ns]?.forEach { String serverGroupKey ->
+      KubernetesServerGroup serverGroup = serverGroupMap[serverGroupKey]
+      if (serverGroup) {
+        serverGroups << serverGroup
+      }
+      return
     }
 
     securityGroups = KubernetesProviderUtils.resolveRelationshipData(cacheView, loadBalancerEntry, Keys.Namespace.SECURITY_GROUPS.ns).findResults { cacheData ->


### PR DESCRIPTION
The cause was that when load balancers were cached and loaded before the
first server group cache cycle, we would pass `null` server group objects into
the load balancer view. These would then be sent to Deck, causing the unrolling
of server groups to fail.

@duftler 