### PR TITLE
provider/consul: Refactored discovery health

### DIFF
--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/model/ConsulHealth.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/model/ConsulHealth.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.consul.model
+
+import com.netflix.spinnaker.clouddriver.consul.api.v1.model.CheckResult
+import com.netflix.spinnaker.clouddriver.model.DiscoveryHealth
+import com.netflix.spinnaker.clouddriver.model.HealthState
+
+class ConsulHealth extends DiscoveryHealth {
+  @Override
+  public static String getDiscoveryType() {
+    return "Consul"
+  }
+
+  CheckResult result
+
+  String source
+
+  ConsulHealth(CheckResult result) {
+    this.result = result
+    this.source = result.checkId
+  }
+
+  @Override
+  HealthState getState() {
+    switch (result.status) {
+      case CheckResult.Status.passing:
+        return HealthState.Up
+      case CheckResult.Status.critical:
+      case CheckResult.Status.warning:
+        return HealthState.Down
+      default:
+        return HealthState.Unknown
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/DiscoveryHealth.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/DiscoveryHealth.groovy
@@ -14,39 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.consul.api.v1.model
+package com.netflix.spinnaker.clouddriver.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
-class CheckResult {
-  @JsonProperty("Node")
-  String node
-
-  @JsonProperty("CheckID")
-  String checkId
-
-  @JsonProperty("Name")
-  String name
-
-  @JsonProperty("Status")
-  Status status
-
-  @JsonProperty("Notes")
-  String notes
-
-  @JsonProperty("Output")
-  String output
-
-  @JsonProperty("ServiceID")
-  String serviceId
-
-  @JsonProperty("ServiceName")
-  String serviceName
-
-  enum Status {
-    passing,
-    critical,
-    warning,
-    unknown,
+abstract class DiscoveryHealth implements Health {
+  public String getType() {
+    return "Discovery"
   }
+
+  abstract public String getDiscoveryType()
 }

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/model/EurekaInstance.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/model/EurekaInstance.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.eureka.model
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.clouddriver.model.DiscoveryHealth
 import com.netflix.spinnaker.clouddriver.model.Health
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import groovy.transform.CompileStatic
@@ -27,11 +28,12 @@ import groovy.transform.Immutable
 @CompileStatic
 @Immutable
 @EqualsAndHashCode(cache = true)
-class EurekaInstance implements Health {
-  public static final String HEALTH_TYPE = 'Discovery'
-  public String getType() {
-    HEALTH_TYPE
+class EurekaInstance extends DiscoveryHealth {
+  @Override
+  public static String getDiscoveryType() {
+    return "Eureka"
   }
+
   String hostName
   String application
   String ipAddress


### PR DESCRIPTION
@duftler 

Now there is a shared `DiscoveryHealth` that `Health` objects for discovery services implement.