### PR TITLE
(aws) change serverGroupName to serverGroupNames on migrate result

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateSecurityGroupStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateSecurityGroupStrategy.java
@@ -85,7 +85,7 @@ public abstract class MigrateSecurityGroupStrategy {
       targetReferences = getTargetReferences(sourceUpdater.get());
 
       // convert names before determining if rules are important
-      targetReferences.stream().forEach(reference -> reference.setTargetName(getTargetName(reference.getSourceName())));
+      targetReferences.forEach(reference -> reference.setTargetName(getTargetName(reference.getSourceName())));
 
       result.setErrors(shouldError(target, targetReferences));
       if (!result.getErrors().isEmpty()) {
@@ -133,8 +133,7 @@ public abstract class MigrateSecurityGroupStrategy {
     if (!results.targetExists()) {
       targetGroups.add(results.getTarget());
     }
-    results.getCreated().stream()
-      .forEach(r -> r.setTargetId(
+    results.getCreated().forEach(r -> r.setTargetId(
         createDependentSecurityGroup(r, source, target).getSecurityGroup().getGroupId()));
 
     Optional<SecurityGroupUpdater> targetGroup = targetLookup.getSecurityGroupByName(
@@ -316,7 +315,7 @@ public abstract class MigrateSecurityGroupStrategy {
 
     String targetName = AmazonVpcProvider.getVpcName(targetVpc);
 
-    accounts.stream().forEach(account -> {
+    accounts.forEach(account -> {
       List<Vpc> vpcs = getAmazonClientProvider().getAmazonEC2(account, target.getRegion()).describeVpcs().getVpcs();
       Vpc match = vpcs.stream()
         .filter(vpc -> AmazonVpcProvider.getVpcName(vpc).equals(targetName))

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategy.java
@@ -39,7 +39,6 @@ import com.netflix.spinnaker.clouddriver.aws.services.AsgService;
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory;
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidationErrors;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.validation.Errors;
 
 import java.util.*;
@@ -164,7 +163,7 @@ public abstract class MigrateServerGroupStrategy {
 
       result.setServerGroupNames(Collections.singletonList(targetName));
     }
-    migrateResult.setServerGroupName(result.getServerGroupNames().get(0));
+    migrateResult.setServerGroupNames(result.getServerGroupNames());
     migrateResult.setLoadBalancers(targetLoadBalancers);
     migrateResult.setSecurityGroups(targetSecurityGroups);
     return migrateResult;
@@ -188,7 +187,7 @@ public abstract class MigrateServerGroupStrategy {
 
     if (errors.hasErrors()) {
       throw new IllegalStateException("Invalid deployment configuration. Errors: "
-        + errors.getAllErrors().stream().flatMap(s -> Arrays.asList(s.getCodes()).stream()).collect(Collectors.toList()));
+        + errors.getAllErrors().stream().flatMap(s -> Arrays.stream(s.getCodes())).collect(Collectors.toList()));
     }
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupResult.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupResult.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.MigrateLoad
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.MigrateSecurityGroupResult
 
 class MigrateServerGroupResult {
-  String serverGroupName
+  List<String> serverGroupNames
   List<String> warnings
   List<MigrateLoadBalancerResult> loadBalancers
   List<MigrateSecurityGroupResult> securityGroups

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategySpec.groovy
@@ -268,7 +268,7 @@ class MigrateServerGroupStrategySpec extends Specification {
     1 * basicAmazonDeployHandler.copySourceAttributes(regionScopedProvider, 'asg-v001', false, _) >> { a, b, c, d -> d }
     1 * basicAmazonDeployHandler.handle(_, []) >> new DeploymentResult(serverGroupNames: ['asg-v003'])
     0 * _
-    results.serverGroupName == 'asg-v003'
+    results.serverGroupNames == ['asg-v003']
   }
 
   void 'sets name on dryRun'() {
@@ -297,7 +297,7 @@ class MigrateServerGroupStrategySpec extends Specification {
     1 * deployDefaults.getAddAppGroupToServerGroup() >> false
     1 * nameResolver.resolveNextServerGroupName('asg', null, null, false) >> 'asg-v002'
     0 * _
-    results.serverGroupName == 'asg-v002'
+    results.serverGroupNames == ['asg-v002']
   }
 
 }


### PR DESCRIPTION
For `forceCacheRefresh`ing to work, we need to send back an array of `serverGroupNames`.

Also removing some unnecessary `stream()` calls that IntelliJ is now shaming me for originally including.