### PR TITLE
provider/consul: cleanup API usage

### DIFF
--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/Consul.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/Consul.groovy
@@ -16,16 +16,33 @@
 
 package com.netflix.spinnaker.clouddriver.consul.api.v1
 
-import com.netflix.spinnaker.clouddriver.consul.api.v1.services.AgentApi
+import com.netflix.spinnaker.clouddriver.consul.api.v1.services.ConsulApi
+import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
 import com.squareup.okhttp.OkHttpClient
 import retrofit.RestAdapter
 import retrofit.client.OkClient
 
-import java.util.concurrent.TimeUnit
+class Consul<T extends ConsulApi> {
+  T api
+  String endpoint
+  Long timeout
 
-class ConsulAgent extends Consul<AgentApi> {
-  ConsulAgent(String agentBaseUrl) {
-    super(agentBaseUrl, ConsulProperties.DEFAULT_TIMEOUT_MILLIS)
+  Consul(ConsulConfig config) {
+    if (!config.enabled) {
+      throw new IllegalArgumentException("Consul not enabled, cannot create Consul API")
+    }
+    Consul(config.servers[0], ConsulProperties.DEFAULT_TIMEOUT_MILLIS)
+  }
+
+  Consul(String endpoint, Long timeout) {
+    this.endpoint = endpoint
+    this.timeout = timeout
+    this.api = new RestAdapter.Builder()
+      .setEndpoint(endpoint)
+      .setClient(new OkClient(new OkHttpClient()))
+      .setLogLevel(RestAdapter.LogLevel.NONE)
+      .build()
+      .create(T)
   }
 }

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulCatalog.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulCatalog.groovy
@@ -17,23 +17,16 @@
 package com.netflix.spinnaker.clouddriver.consul.api.v1
 
 import com.netflix.spinnaker.clouddriver.consul.api.v1.services.CatalogApi
+import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
+import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
 import com.squareup.okhttp.OkHttpClient
 import retrofit.RestAdapter
 import retrofit.client.OkClient
 
 import java.util.concurrent.TimeUnit
 
-class ConsulCatalog {
-  public CatalogApi api
-
-  ConsulCatalog(String serverBaseUrl, Long timeout) {
-    OkHttpClient client = new OkHttpClient()
-    client.setReadTimeout(timeout, TimeUnit.MILLISECONDS)
-    this.api = new RestAdapter.Builder()
-      .setEndpoint(serverBaseUrl)
-      .setClient(new OkClient(client))
-      .setLogLevel(RestAdapter.LogLevel.NONE)
-      .build()
-      .create(CatalogApi)
+class ConsulCatalog extends Consul<CatalogApi> {
+  ConsulCatalog(ConsulConfig config) {
+    super(config)
   }
 }

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulKeyValueStore.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/ConsulKeyValueStore.groovy
@@ -17,23 +17,16 @@
 package com.netflix.spinnaker.clouddriver.consul.api.v1
 
 import com.netflix.spinnaker.clouddriver.consul.api.v1.services.KeyValueApi
+import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
+import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
 import com.squareup.okhttp.OkHttpClient
 import retrofit.RestAdapter
 import retrofit.client.OkClient
 
 import java.util.concurrent.TimeUnit
 
-class ConsulKeyValueStore {
-  public KeyValueApi api
-
-  ConsulKeyValueStore(String agentBaseUrl, Long timeout) {
-    OkHttpClient client = new OkHttpClient()
-    client.setReadTimeout(timeout, TimeUnit.MILLISECONDS)
-    this.api = new RestAdapter.Builder()
-      .setEndpoint(agentBaseUrl)
-      .setClient(new OkClient(client))
-      .setLogLevel(RestAdapter.LogLevel.NONE)
-      .build()
-      .create(KeyValueApi)
+class ConsulKeyValueStore extends Consul<KeyValueApi> {
+  ConsulKeyValueStore(ConsulConfig config) {
+    super(config)
   }
 }

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/services/AgentApi.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/services/AgentApi.groovy
@@ -16,15 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.consul.api.v1.services
 
-import com.netflix.spinnaker.clouddriver.consul.api.v1.model.AgentDefinition
-import com.netflix.spinnaker.clouddriver.consul.api.v1.model.CheckDefinition
-import com.netflix.spinnaker.clouddriver.consul.api.v1.model.CheckResult
-import com.netflix.spinnaker.clouddriver.consul.api.v1.model.ServiceDefinition
-import com.netflix.spinnaker.clouddriver.consul.api.v1.model.ServiceResult
+import com.netflix.spinnaker.clouddriver.consul.api.v1.model.*
 import com.squareup.okhttp.Response
 import retrofit.http.*
 
-interface AgentApi {
+interface AgentApi extends ConsulApi {
   @GET("/v1/agent/checks")
   Map<String, CheckResult> checks()
 

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/services/CatalogApi.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/services/CatalogApi.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.consul.api.v1.model.NodeDefinition
 import retrofit.http.GET
 import retrofit.http.Query
 
-interface CatalogApi {
+interface CatalogApi extends ConsulApi {
   @GET("/v1/catalog/datacenters")
   List<String> datacenters()
 

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/services/ConsulApi.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/services/ConsulApi.groovy
@@ -14,18 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.consul.api.v1
+package com.netflix.spinnaker.clouddriver.consul.api.v1.services
 
-import com.netflix.spinnaker.clouddriver.consul.api.v1.services.AgentApi
-import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
-import com.squareup.okhttp.OkHttpClient
-import retrofit.RestAdapter
-import retrofit.client.OkClient
-
-import java.util.concurrent.TimeUnit
-
-class ConsulAgent extends Consul<AgentApi> {
-  ConsulAgent(String agentBaseUrl) {
-    super(agentBaseUrl, ConsulProperties.DEFAULT_TIMEOUT_MILLIS)
-  }
+interface ConsulApi {
 }

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/services/KeyValueApi.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/services/KeyValueApi.groovy
@@ -25,7 +25,7 @@ import retrofit.http.PUT
 import retrofit.http.Path
 import retrofit.http.Query
 
-interface KeyValueApi {
+interface KeyValueApi extends ConsulApi {
   @GET("/v1/kv/{key}")
   List<KeyValuePair> getKey(@Path("key") String key, @Query("dc") String dc, @Query("recurse") Boolean recurse)
 

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/config/ConsulConfig.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/config/ConsulConfig.groovy
@@ -46,7 +46,7 @@ class ConsulConfig {
     }
 
     if (!datacenters) {
-      datacenters = (new ConsulCatalog(servers[0], ConsulProperties.DEFAULT_TIMEOUT_MILLIS)).api.datacenters()
+      datacenters = (new ConsulCatalog(this)).api.datacenters()
     }
   }
 }

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/deploy/ops/UpsertConsulLoadBalancer.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/deploy/ops/UpsertConsulLoadBalancer.groovy
@@ -34,7 +34,7 @@ class UpsertConsulLoadBalancer {
     def jsonSlurper = new JsonSlurper()
     def objectMapper = new ObjectMapper()
 
-    def kvApi = new ConsulKeyValueStore(config.servers[0], ConsulProperties.DEFAULT_TIMEOUT_MILLIS).api
+    def kvApi = new ConsulKeyValueStore(config).api
     List<KeyValuePair> services = kvApi.getKey(description.name, description.datacenter, false)
 
     ConsulLoadBalancerDescription oldDescription = new ConsulLoadBalancerDescription()


### PR DESCRIPTION
This allows us to instantiate each consul API with the `config` object stored in the provider credentials.