### PR TITLE
(aws) report app security group at proper level of nesting

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategy.java
@@ -229,7 +229,11 @@ public abstract class MigrateServerGroupStrategy {
     ).collect(Collectors.toList());
 
     if (getDeployDefaults().getAddAppGroupToServerGroup()) {
-      targetSecurityGroups.add(generateAppSecurityGroup(source, target, sourceLookup, targetLookup, dryRun));
+      Names names = Names.parseName(source.getName());
+      // if the app security group is already present, don't include it twice
+      if (targetSecurityGroups.stream().noneMatch(r -> names.getApp().equals(r.getTarget().getTargetName()))) {
+        targetSecurityGroups.add(generateAppSecurityGroup(source, target, sourceLookup, targetLookup, dryRun));
+      }
     }
 
     return targetSecurityGroups;

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerStrategySpec.groovy
@@ -189,7 +189,8 @@ class MigrateLoadBalancerStrategySpec extends Specification {
     def results = strategy.generateResults(sourceLookup, targetLookup, securityGroupStrategy, source, target, 'internal', 'app', false)
 
     then:
-    results.securityGroups.created.targetName.flatten().sort() == ['app', 'app-elb']
+    results.securityGroups[0].created.targetName.sort() == ['app', 'app-elb']
+    results.securityGroups[0].target.targetName == 'app-elb'
     amazonClientProvider.getAmazonEC2(prodCredentials, 'eu-west-1', true) >> amazonEC2
     amazonClientProvider.getAmazonEC2(prodCredentials, 'eu-west-1') >> amazonEC2
     amazonClientProvider.getAmazonElasticLoadBalancing(testCredentials, 'us-east-1', true) >> loadBalancing


### PR DESCRIPTION
Now that I'm working on the UI, I am seeing a few things that are incorrect:

1. When creating a load balancer, the application security group should be listed as a dependency of the ELB security group, since it is not going to be applied directly to the load balancer.
2. We need to include the ELB security group's id once we create it
3. We should include the app security group reference, even if we don't create it
4. We should not include the app security group twice in the application if it's already present in the source