### PR TITLE
provider/google: removed line causing error in serialize atomic operation

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/SerializeApplicationAtomicOperation/SerializeApplicationAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/SerializeApplicationAtomicOperation/SerializeApplicationAtomicOperation.groovy
@@ -233,7 +233,6 @@ class SerializeApplicationAtomicOperation implements AtomicOperation<Void> {
     if (instanceTemplate.properties.description) {
       instanceTemplateMap.instance_description = instanceTemplate.properties.description
     }
-    instanceTemplate.getProperties().getTags().ite
     if (instanceTemplate.properties.tags?.items) {
       instanceTemplateMap.tags = instanceTemplate.properties.tags.items
       applicationTags.addAll(instanceTemplate.properties.tags.items)


### PR DESCRIPTION
Removed a line that was causing an error when trying to serialize server groups. PTAL @duftler  @lwander 