### PR TITLE
(gce) fixed validation for autoscaler custom metrics

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
@@ -412,7 +412,12 @@ class StandardGceAttributeValidator {
 
           utilization.with {
             validateNotEmpty(metric, "${path}.metric")
-            validateInRangeExclusive(utilizationTarget, 0, 1, "${path}.utilizationTarget")
+
+            if (utilizationTarget <= 0) {
+              errors.rejectValue("${context}.${path}.utilizationTarget",
+                                 "${context}.${path}.utilizationTarget must be greater than zero.")
+            }
+
             validateNotEmpty(utilizationTargetType, "${path}.utilizationTargetType")
           }
         }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
@@ -756,9 +756,9 @@ class StandardGceAttributeValidatorSpec extends Specification {
           metric: "myMetric", utilizationTargetType: UtilizationTargetType.DELTA_PER_MINUTE) ]))
 
     then:
-      1 * errors.rejectValue("autoscalingPolicy.customMetricUtilizations[0].utilizationTarget",
-        "decorator.autoscalingPolicy.customMetricUtilizations[0].utilizationTarget " +
-          "must be between 0.0 and 1.0.")
+      1 * errors.rejectValue("decorator.autoscalingPolicy.customMetricUtilizations[0].utilizationTarget",
+                             "decorator.autoscalingPolicy.customMetricUtilizations[0].utilizationTarget " +
+                             "must be greater than zero.")
 
     when:
       validator.validateAutoscalingPolicy(new GoogleAutoscalingPolicy(


### PR DESCRIPTION
(gce) fixed validation for autoscaler custom metrics
Utilization target for custom metrics just needs to be greater than zero.
@duftler PTAL