### PR TITLE
quick stab at request times for titus API calls

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusConfiguration.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusConfiguration.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus
 
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials
 import com.netflix.spinnaker.clouddriver.titus.deploy.handlers.TitusDeployHandler
@@ -77,12 +78,12 @@ class TitusConfiguration {
 
   @Bean
   @DependsOn("netflixTitusCredentials")
-  TitusClientProvider titusClientProvider(@Value('#{netflixTitusCredentials}') List<NetflixTitusCredentials> netflixTitusCredentials) {
+  TitusClientProvider titusClientProvider(@Value('#{netflixTitusCredentials}') List<NetflixTitusCredentials> netflixTitusCredentials, Registry registry) {
     List<TitusClientProvider.TitusClientHolder> titusClientHolders = []
     netflixTitusCredentials.each { credentials ->
       credentials.regions.each { region ->
         titusClientHolders << new TitusClientProvider.TitusClientHolder(
-          credentials.name, region.name, new RegionScopedTitusClient(region)
+          credentials.name, region.name, new RegionScopedTitusClient(region, registry)
         )
       }
     }

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.client
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
 import com.netflix.spinnaker.clouddriver.titus.client.model.ResizeJobRequest
 import com.netflix.spinnaker.clouddriver.titus.client.model.SubmitJobRequest
@@ -35,7 +36,7 @@ class RegionScopedTitusClientSpec extends Specification {
     TitusRegion titusRegion = new TitusRegion(
       "us-east-1", "test", "http://titusapi.mainvpc.us-east-1.dyntest.netflix.net:7101/"
     );
-    TitusClient titusClient = new RegionScopedTitusClient(titusRegion);
+    TitusClient titusClient = new RegionScopedTitusClient(titusRegion, new NoopRegistry());
 
     // ******************************************************************************************************************
 


### PR DESCRIPTION
@tomaslin PTAL

not super happy with putting the requestName strings on all those calls but the alternatives seemed worse (mining the stack trace) or maybe not possible ( inspecting the Retrofit annotations when creating the call object)