### PR TITLE
(aws) prefer edda when looking up security groups for migrations

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerAtomicOperation.groovy
@@ -63,10 +63,10 @@ class MigrateLoadBalancerAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    SecurityGroupLookup sourceLookup = securityGroupLookupFactory.getInstance(description.source.region)
+    SecurityGroupLookup sourceLookup = securityGroupLookupFactory.getInstance(description.source.region, false)
     SecurityGroupLookup targetLookup = description.source.region == description.target.region ?
       sourceLookup :
-      securityGroupLookupFactory.getInstance(description.target.region)
+      securityGroupLookupFactory.getInstance(description.target.region, false)
 
     def migrator = new LoadBalancerMigrator(sourceLookup, targetLookup, amazonClientProvider,
       regionScopedProviderFactory, migrateSecurityGroupStrategy.get(), deployDefaults, migrationStrategy.get(),

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/MigrateSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/MigrateSecurityGroupAtomicOperation.groovy
@@ -48,10 +48,10 @@ class MigrateSecurityGroupAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    SecurityGroupLookup sourceLookup = securityGroupLookupFactory.getInstance(description.source.region)
+    SecurityGroupLookup sourceLookup = securityGroupLookupFactory.getInstance(description.source.region, false)
     SecurityGroupLookup targetLookup = description.source.region == description.target.region ?
       sourceLookup :
-      securityGroupLookupFactory.getInstance(description.target.region)
+      securityGroupLookupFactory.getInstance(description.target.region, false)
 
     task.addResultObjects( [new SecurityGroupMigrator(sourceLookup, targetLookup, migrationStrategy.get(), description.source, description.target)
       .migrate(description.dryRun)])

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupAtomicOperation.groovy
@@ -56,10 +56,10 @@ class MigrateServerGroupAtomicOperation implements AtomicOperation<Void> {
 
   @Override
   Void operate(List priorOutputs) {
-    SecurityGroupLookup sourceLookup = securityGroupLookupFactory.getInstance(description.source.region)
+    SecurityGroupLookup sourceLookup = securityGroupLookupFactory.getInstance(description.source.region, false)
     SecurityGroupLookup targetLookup = description.source.region == description.target.region ?
       sourceLookup :
-      securityGroupLookupFactory.getInstance(description.target.region)
+      securityGroupLookupFactory.getInstance(description.target.region, false)
 
     def migrator = new ServerGroupMigrator(migrationStrategy.get(), description.source, description.target,
       sourceLookup, targetLookup, migrateLoadBalancerStrategy.get(), migrateSecurityGroupStrategy.get(),

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerStrategySpec.groovy
@@ -200,8 +200,9 @@ class MigrateLoadBalancerStrategySpec extends Specification {
     1 * loadBalancing.describeLoadBalancers(_) >> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(sourceDescription)
     1 * targetLoadBalancing.createLoadBalancer(_) >> new CreateLoadBalancerResult().withDNSName('new-elb-dns')
     1 * targetLoadBalancing.configureHealthCheck(_)
-    amazonEC2.createSecurityGroup(_) >>> [new CreateSecurityGroupResult().withGroupId('sg-4'), new CreateSecurityGroupResult().withGroupId('sg-3')]
     1 * targetLookup.getSecurityGroupByName(prodCredentials.name, 'classic-link', 'vpc-2') >> Optional.of(new SecurityGroupUpdater(elbGroup, amazonEC2))
+    1 * targetLookup.createSecurityGroup({ it.name == 'app' && it.vpcId == 'vpc-2' && it.credentials == prodCredentials}) >> new SecurityGroupUpdater(appGroup, amazonEC2)
+    1 * targetLookup.createSecurityGroup({ it.name == 'app-elb' && it.vpcId == 'vpc-2' && it.credentials == prodCredentials}) >> new SecurityGroupUpdater(elbGroup, amazonEC2)
     1 * amazonEC2.describeSecurityGroups({r -> r.groupIds == ['sg-3']}) >> new DescribeSecurityGroupsResult().withSecurityGroups([appGroup])
     1 * amazonEC2.describeSecurityGroups({r -> r.filters[0].values == ['app', 'app-elb']}) >> new DescribeSecurityGroupsResult().withSecurityGroups([])
     1 * amazonEC2.describeVpcs(_) >> new DescribeVpcsResult().withVpcs(new Vpc())


### PR DESCRIPTION
Migrations can get slow with all the one-off AWS calls. I feel pretty confident that things being migrated are probably up-to-date in Edda's cache, so let's take advantage of that and cache the list of security groups for the lifespan of the SecurityGroupLookup.

Running locally, this cuts the average time to perform a dry run from ~18s to ~10s, and an actual migration from ~41s to ~30s. It also should avoid rate limiting issues if several migrations are going at once.

@cfieber PTAL