### PR TITLE
Add in desired capacity to server group operations

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationProvider.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.openstack.client
 
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import org.openstack4j.model.heat.Stack
 
 interface OpenstackOrchestrationProvider {

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationV1Provider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationV1Provider.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.openstack.client
 
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import org.openstack4j.api.Builders
 import org.openstack4j.model.heat.Resource
 import org.openstack4j.model.heat.Stack

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/DeployOpenstackAtomicOperationDescription.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/DeployOpenstackAtomicOperationDescription.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergro
 
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.OpenstackAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/ResizeOpenstackAtomicOperationDescription.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/ResizeOpenstackAtomicOperationDescription.groovy
@@ -28,6 +28,7 @@ class ResizeOpenstackAtomicOperationDescription extends OpenstackAtomicOperation
   static class Capacity {
     int min
     int max
+    int desired
   }
 
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/ServerGroupParameters.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/ServerGroupParameters.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.openstack.domain
+package com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup
 
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
@@ -32,6 +32,7 @@ class ServerGroupParameters {
   Integer internalPort
   Integer maxSize
   Integer minSize
+  Integer desiredSize
   String networkId
   String subnetId
   String poolId
@@ -43,7 +44,8 @@ class ServerGroupParameters {
       'image':image,
       'internal_port':internalPort ? internalPort.toString() : null,
       'max_size':maxSize ? maxSize.toString() : null,
-      'min_size':minSize? minSize.toString() : null,
+      'min_size':minSize ? minSize.toString() : null,
+      'desired_size':desiredSize ? desiredSize.toString() : null,
       'network_id':networkId,
       'subnet_id':subnetId,
       'pool_id':poolId,
@@ -58,6 +60,7 @@ class ServerGroupParameters {
       internalPort: params.get('internal_port')?.toInteger(),
       maxSize: params.get('max_size')?.toInteger(),
       minSize: params.get('min_size')?.toInteger(),
+      desiredSize: params.get('desired_size')?.toInteger(),
       networkId: params.get('network_id'),
       subnetId: params.get('subnet_id'),
       poolId: params.get('pool_id'),

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/CloneOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/CloneOpenstackAtomicOperation.groovy
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.CloneOpenstackAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.DeployOpenstackAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.openstack4j.model.heat.Stack
@@ -88,6 +88,7 @@ class CloneOpenstackAtomicOperation implements AtomicOperation<DeploymentResult>
       instanceType = description.serverGroupParameters?.instanceType ?: ancestorParams.instanceType
       maxSize = description.serverGroupParameters?.maxSize ?: ancestorParams.maxSize
       minSize = description.serverGroupParameters?.minSize ?: ancestorParams.minSize
+      desiredSize = description.serverGroupParameters?.desiredSize ?: ancestorParams.desiredSize
       subnetId = description.serverGroupParameters?.subnetId ?: ancestorParams.subnetId
       poolId = description.serverGroupParameters?.poolId ?: ancestorParams.poolId
       securityGroups = description.serverGroupParameters?.securityGroups ?: ancestorParams.securityGroups

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperation.groovy
@@ -65,7 +65,7 @@ class DeployOpenstackAtomicOperation implements AtomicOperation<DeploymentResult
   }
 
   /*
-  * curl -X POST -H "Content-Type: application/json" -d '[{"createServerGroup":{"stack":"teststack","application":"myapp","serverGroupParameters":{"instanceType":"m1.medium","image":"4e0d0b4b-8089-4703-af99-b6a0c90fbbc7","maxSize":5,"minSize":3,"subnetId":"77bb3aeb-c1e2-4ce5-8d8f-b8e9128af651","poolId":"87077f97-83e7-4ea1-9ca9-40dc691846db","securityGroups":["sg-heat-test-1"]},"region":"REGION1","disableRollback":false,"timeoutMins":5,"account":"test"}}]' localhost:7002/openstack/ops
+  * curl -X POST -H "Content-Type: application/json" -d '[{"createServerGroup":{"stack":"teststack","application":"myapp","serverGroupParameters":{"instanceType":"m1.medium","image":"4e0d0b4b-8089-4703-af99-b6a0c90fbbc7","maxSize":5,"minSize":3, "desiredSize":4, "subnetId":"77bb3aeb-c1e2-4ce5-8d8f-b8e9128af651","poolId":"87077f97-83e7-4ea1-9ca9-40dc691846db","securityGroups":["sg-heat-test-1"]},"region":"REGION1","disableRollback":false,"timeoutMins":5,"account":"test"}}]' localhost:7002/openstack/ops
   * curl -X GET -H "Accept: application/json" localhost:7002/task/1
   */
   @Override

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/ResizeOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/ResizeOpenstackAtomicOperation.groovy
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ResizeOpenstackAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.openstack4j.model.heat.Stack
@@ -47,7 +47,7 @@ class ResizeOpenstackAtomicOperation implements AtomicOperation<Void> {
   }
 
   /*
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "resizeServerGroup": { "serverGroupName": "myapp-teststack-v000", "capacity": { "min": 1, "max": 2 }, "account": "test", "region": "REGION1" }} ]' localhost:7002/openstack/ops
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "resizeServerGroup": { "serverGroupName": "myapp-teststack-v000", "capacity": { "min": 1, "desired": 2, "max": 3 }, "account": "test", "region": "REGION1" }} ]' localhost:7002/openstack/ops
    * curl -X GET -H "Accept: application/json" localhost:7002/task/1
    */
   @Override
@@ -70,6 +70,7 @@ class ResizeOpenstackAtomicOperation implements AtomicOperation<Void> {
       newParams.identity {
         minSize = description.capacity.min
         maxSize = description.capacity.max
+        desiredSize = description.capacity.desired
       }
 
       //get the current template from the stack

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/AbstractServergroupOpenstackAtomicOperationValidator.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/AbstractServergroupOpenstackAtomicOperationValidator.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.validators.servergrou
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.OpenstackAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.AbstractOpenstackDescriptionValidator
 import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.OpenstackAttributeValidator
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 
 /**
  * This class adds validation for creating and cloning server groups.
@@ -40,6 +40,8 @@ abstract class AbstractServergroupOpenstackAtomicOperationValidator<T extends Op
       validator.validatePositive(maxSize, "${prefix}.maxSize")
       validator.validatePositive(minSize, "${prefix}.minSize")
       validator.validateGreaterThan(maxSize, minSize, "${prefix}.maxSize")
+      validator.validatePositive(desiredSize, "${prefix}.desiredSize")
+      validator.validateGreaterThanEqual(desiredSize, minSize, "${prefix}.desiredSize")
       validator.validateNotEmpty(subnetId, "${prefix}.subnetId")
       validator.validateNotEmpty(poolId, "${prefix}.poolId")
       validator.validateNotEmpty(securityGroups, "${prefix}.securityGroups")

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/ResizeOpenstackAtomicOperationValidator.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/ResizeOpenstackAtomicOperationValidator.groovy
@@ -36,6 +36,7 @@ class ResizeOpenstackAtomicOperationValidator extends AbstractOpenstackDescripti
     validator.validateNotNull(description.capacity, "capacity")
     validator.validatePositive(description.capacity.min, "capacity.min")
     validator.validateGreaterThanEqual(description.capacity.max, description.capacity.min, "capacity.max")
+    validator.validateGreaterThanEqual(description.capacity.desired, description.capacity.min, "capacity.desired")
   }
 
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgent.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgent.groovy
@@ -291,6 +291,7 @@ class OpenstackServerGroupCachingAgent extends AbstractOpenstackCachingAgent imp
     if (stack) {
       result.put('minSize', stack.parameters?.get('min_size') ?: 0)
       result.put('maxSize', stack.parameters?.get('max_size') ?: 0)
+      result.put('desiredSize', stack.parameters?.get('desired_size') ?: 0)
     }
 
     result

--- a/clouddriver-openstack/src/main/resources/asg.yaml
+++ b/clouddriver-openstack/src/main/resources/asg.yaml
@@ -16,6 +16,9 @@ parameters:
   min_size:
     type: number
     description: minimum cluster size
+  desired_size:
+    type: number
+    description: desired cluster size
   network_id:
     type: string
     description: Network used by the servers
@@ -34,6 +37,7 @@ resources:
     properties:
       min_size: {get_param: min_size}
       max_size: {get_param: max_size}
+      desired_capacity: {get_param: desired_size}
       resource:
         type: asg_resource.yaml
         properties:

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationV1ClientProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationV1ClientProviderSpec.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.openstack.client
 
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import org.openstack4j.api.Builders
 import org.openstack4j.api.exceptions.ServerResponseException
 import org.openstack4j.api.heat.HeatService

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/CloneOpenstackAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/CloneOpenstackAtomicOperationSpec.groovy
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergrou
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.DeployOpenstackAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperationSpec.groovy
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFactory
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.DeployOpenstackAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
 import org.openstack4j.model.heat.Stack

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/ResizeOpenstackAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/ResizeOpenstackAtomicOperationSpec.groovy
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFacto
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ResizeOpenstackAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
 import org.openstack4j.model.heat.Stack
@@ -37,6 +37,7 @@ class ResizeOpenstackAtomicOperationSpec extends Specification {
   String region = "r1"
   int maxSize = 5
   int minSize = 3
+  int desiredSize = 4
   String createdStackName = 'app-stack-details-v000'
   String stackId = UUID.randomUUID().toString()
 
@@ -56,8 +57,8 @@ class ResizeOpenstackAtomicOperationSpec extends Specification {
     OpenstackNamedAccountCredentials creds = Mock(OpenstackNamedAccountCredentials)
     OpenstackProviderFactory.createProvider(creds) >> { provider }
     credentials = new OpenstackCredentials(creds)
-    serverGroupParams = new ServerGroupParameters(maxSize: maxSize, minSize: minSize)
-    description = new ResizeOpenstackAtomicOperationDescription(region: region, account: accountName, credentials: credentials, serverGroupName: createdStackName, capacity: new ResizeOpenstackAtomicOperationDescription.Capacity(min: 3, max: 5))
+    serverGroupParams = new ServerGroupParameters(maxSize: maxSize, minSize: minSize, desiredSize: desiredSize)
+    description = new ResizeOpenstackAtomicOperationDescription(region: region, account: accountName, credentials: credentials, serverGroupName: createdStackName, capacity: new ResizeOpenstackAtomicOperationDescription.Capacity(min: 3, desired: 4, max: 5))
   }
 
   def "should resize a heat stack"() {

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/CloneOpenstackAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/CloneOpenstackAtomicOperationValidatorSpec.groovy
@@ -59,7 +59,7 @@ class CloneOpenstackAtomicOperationValidatorSpec extends Specification {
 
   def "Validate - no error"() {
     given:
-    ResizeOpenstackAtomicOperationDescription description = new ResizeOpenstackAtomicOperationDescription(serverGroupName: 'from', region: 'r1', credentials: credz, account: account, capacity: new ResizeOpenstackAtomicOperationDescription.Capacity(max: 5, min: 3))
+    ResizeOpenstackAtomicOperationDescription description = new ResizeOpenstackAtomicOperationDescription(serverGroupName: 'from', region: 'r1', credentials: credz, account: account, capacity: new ResizeOpenstackAtomicOperationDescription.Capacity(max: 5, desired: 4, min: 3))
 
     when:
     validator.validate([], description, errors)
@@ -70,7 +70,7 @@ class CloneOpenstackAtomicOperationValidatorSpec extends Specification {
 
   def "Validate invalid sizing"() {
     given:
-    ResizeOpenstackAtomicOperationDescription description = new ResizeOpenstackAtomicOperationDescription(serverGroupName: 'from', region: 'r1', credentials: credz, account: account, capacity: new ResizeOpenstackAtomicOperationDescription.Capacity(max: 3, min: 4))
+    ResizeOpenstackAtomicOperationDescription description = new ResizeOpenstackAtomicOperationDescription(serverGroupName: 'from', region: 'r1', credentials: credz, account: account, capacity: new ResizeOpenstackAtomicOperationDescription.Capacity(max: 3, min: 4, desired: 5))
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/ResizeOpenstackAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/ResizeOpenstackAtomicOperationValidatorSpec.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.validators.servergrou
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFactory
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.DeployOpenstackAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.openstack.domain.ServerGroupParameters
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
@@ -47,6 +47,7 @@ class ResizeOpenstackAtomicOperationValidatorSpec extends Specification {
   String image = 'ubuntu-latest'
   int maxSize = 5
   int minSize = 3
+  int desiredSize = 4
   String subnetId = '1234'
   String poolId = '5678'
   List<String> securityGroups = ['sg1']
@@ -70,7 +71,7 @@ class ResizeOpenstackAtomicOperationValidatorSpec extends Specification {
 
   def "Validate no error"() {
     given:
-    ServerGroupParameters params = new ServerGroupParameters(instanceType: instanceType, image:image, maxSize: maxSize, minSize: minSize, subnetId: subnetId, poolId: poolId, securityGroups: securityGroups)
+    ServerGroupParameters params = new ServerGroupParameters(instanceType: instanceType, image:image, maxSize: maxSize, minSize: minSize, desiredSize: desiredSize, subnetId: subnetId, poolId: poolId, securityGroups: securityGroups)
     DeployOpenstackAtomicOperationDescription description = new DeployOpenstackAtomicOperationDescription(account: account, application: application, region: region, stack: stack, freeFormDetails: freeFormDetails, disableRollback: disableRollback, timeoutMins: timeoutMins, serverGroupParameters: params, credentials: credz)
 
     when:
@@ -84,7 +85,7 @@ class ResizeOpenstackAtomicOperationValidatorSpec extends Specification {
   @Unroll
   def "Validate create missing required core field - #attribute"() {
     given:
-    ServerGroupParameters params = new ServerGroupParameters(instanceType: instanceType, image:image, maxSize: maxSize, minSize: minSize, subnetId: subnetId, poolId: poolId, securityGroups: securityGroups)
+    ServerGroupParameters params = new ServerGroupParameters(instanceType: instanceType, image:image, maxSize: maxSize, minSize: minSize, desiredSize: desiredSize, subnetId: subnetId, poolId: poolId, securityGroups: securityGroups)
     DeployOpenstackAtomicOperationDescription description = new DeployOpenstackAtomicOperationDescription(account: account, application: application, region: region, stack: stack, freeFormDetails: freeFormDetails, disableRollback: disableRollback, timeoutMins: timeoutMins, serverGroupParameters: params, credentials: credz)
     description."$attribute" = value
 
@@ -104,7 +105,7 @@ class ResizeOpenstackAtomicOperationValidatorSpec extends Specification {
   @Unroll
   def "Validate create missing required template field - #attribute"() {
     given:
-    ServerGroupParameters params = new ServerGroupParameters(instanceType: instanceType, image:image, maxSize: maxSize, minSize: minSize, subnetId: subnetId, poolId: poolId, securityGroups: securityGroups)
+    ServerGroupParameters params = new ServerGroupParameters(instanceType: instanceType, image:image, maxSize: maxSize, minSize: minSize, desiredSize: desiredSize, subnetId: subnetId, poolId: poolId, securityGroups: securityGroups)
     DeployOpenstackAtomicOperationDescription description = new DeployOpenstackAtomicOperationDescription(account: account, application: application, region: region, stack: stack, freeFormDetails: freeFormDetails, disableRollback: disableRollback, timeoutMins: timeoutMins, serverGroupParameters: params, credentials: credz)
     description.serverGroupParameters."$attribute" = null
 
@@ -119,22 +120,23 @@ class ResizeOpenstackAtomicOperationValidatorSpec extends Specification {
     'instanceType'   | 1
     'image'          | 1
     'maxSize'        | 2
-    'minSize'        | 2
-    'subnetId'      | 1
+    'minSize'        | 3
+    'desiredSize'    | 2
+    'subnetId'       | 1
     'poolId'         | 1
     'securityGroups' | 1
   }
 
   def "Validate sizing - error"() {
     given:
-    ServerGroupParameters params = new ServerGroupParameters(instanceType: instanceType, image:image, maxSize: -2, minSize: -1, subnetId: subnetId, poolId: poolId, securityGroups: securityGroups)
+    ServerGroupParameters params = new ServerGroupParameters(instanceType: instanceType, image:image, maxSize: -2, minSize: -1, desiredSize: -3, subnetId: subnetId, poolId: poolId, securityGroups: securityGroups)
     DeployOpenstackAtomicOperationDescription description = new DeployOpenstackAtomicOperationDescription(account: account, application: application, region: region, stack: stack, freeFormDetails: freeFormDetails, disableRollback: disableRollback, timeoutMins: timeoutMins, serverGroupParameters: params, credentials: credz)
 
     when:
     validator.validate([], description, errors)
 
     then:
-    3 * errors.rejectValue(_,_)
+    5 * errors.rejectValue(_,_)
   }
 
 }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgentSpec.groovy
@@ -389,10 +389,10 @@ class OpenstackServerGroupCachingAgentSpec extends Specification {
     noExceptionThrown()
 
     where:
-    testCase  | stack            | expected
-    'empty'   | null             | [:]
-    'normal'  | buildStack(1, 5) | [minSize: 1, maxSize: 5]
-    'missing' | buildStack()     | [minSize: 0, maxSize: 0]
+    testCase  | stack               | expected
+    'empty'   | null                | [:]
+    'normal'  | buildStack(1, 5, 3) | [minSize: 1, maxSize: 5, desiredSize: 3]
+    'missing' | buildStack()        | [minSize: 0, maxSize: 0, desiredSize: 0]
   }
 
   void "test build info config - #testCase"() {
@@ -598,9 +598,9 @@ class OpenstackServerGroupCachingAgentSpec extends Specification {
     cacheResultBuilder.namespace('test').keep(serverGroupKey).relationships == cacheData['test'].first().relationships
   }
 
-  protected Stack buildStack(Integer minSize = null, Integer maxSize = null) {
+  protected Stack buildStack(Integer minSize = null, Integer maxSize = null, Integer desiredSize = null) {
     Stub(Stack) {
-      getParameters() >> { (minSize && maxSize) ? ['min_size': minSize, 'max_size': maxSize] : [:] }
+      getParameters() >> { (minSize && maxSize && desiredSize) ? ['min_size': minSize, 'max_size': maxSize, 'desired_size':desiredSize] : [:] }
     }
   }
 }


### PR DESCRIPTION
Added desiredSize attribute to payload. 

Create server group example:
```
curl -X POST -H "Content-Type: application/json" -d '[{"createServerGroup":{"stack":"teststack","application":"myapp","serverGroupParameters":{"instanceType":"m1.medium","image":"4e0d0b4b-8089-4703-af99-b6a0c90fbbc7","maxSize":5,"minSize":3, "desiredSize":4, "subnetId":"77bb3aeb-c1e2-4ce5-8d8f-b8e9128af651","poolId":"87077f97-83e7-4ea1-9ca9-40dc691846db","securityGroups":["sg-heat-test-1"]},"region":"REGION1","disableRollback":false,"timeoutMins":5,"account":"test"}}]' localhost:7002/openstack/ops
```

Resize example:
```
curl -X POST -H "Content-Type: application/json" -d '[ { "resizeServerGroup": { "serverGroupName": "myapp-teststack-v000", "capacity": { "min": 1, "desired": 2, "max": 3 }, "account": "test", "region": "REGION1" }} ]' localhost:7002/openstack/ops
```

Clone example:
```
curl -X POST -H "Content-Type: application/json" -d '[{"cloneServerGroup": {"source": {"serverGroupName": "myapp-teststack-v000", "region": "RegionOne"}, "serverGroupParameters":{"instanceType":"m1.medium","image":"4e0d0b4b-8089-4703-af99-b6a0c90fbbc7","maxSize":5,"minSize":3, "desiredSize":4, "subnetId":"77bb3aeb-c1e2-4ce5-8d8f-b8e9128af651","poolId":"87077f97-83e7-4ea1-9ca9-40dc691846db","securityGroups":["sg-heat-test-1"]}, "region": "RegionTwo", "account": "test"}}]' localhost:7002/openstack/ops
```