### PR TITLE
(aws) support migration of pipeline cluster configurations

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -29,9 +29,11 @@ import com.netflix.spinnaker.clouddriver.aws.agent.CleanupDetachedInstancesAgent
 import com.netflix.spinnaker.clouddriver.aws.agent.ReconcileClassicLinkSecurityGroupsAgent
 import com.netflix.spinnaker.clouddriver.aws.bastion.BastionConfig
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.BasicAmazonDeployHandler
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.DefaultMigrateClusterConfigurationStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.DefaultMigrateLoadBalancerStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.DefaultMigrateSecurityGroupStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.DefaultMigrateServerGroupStrategy
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateClusterConfigurationStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateLoadBalancerStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateSecurityGroupStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateServerGroupStrategy
@@ -177,6 +179,15 @@ class AwsConfiguration {
                                                         DeployDefaults deployDefaults) {
     new DefaultMigrateServerGroupStrategy(amazonClientProvider, basicAmazonDeployHandler,
       regionScopedProviderFactory, basicAmazonDeployDescriptionValidator, deployDefaults)
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  MigrateClusterConfigurationStrategy migrateClusterConfigurationStrategy(AmazonClientProvider amazonClientProvider,
+                                                                          RegionScopedProviderFactory regionScopedProviderFactory,
+                                                                          DeployDefaults deployDefaults) {
+    new DefaultMigrateClusterConfigurationStrategy(amazonClientProvider, regionScopedProviderFactory, deployDefaults)
   }
 
   @Bean

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateClusterConfigurationsAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateClusterConfigurationsAtomicOperationConverter.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.converters
+
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.MigrateClusterConfigurationsDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.MigrateClusterConfigurationsAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+@AmazonOperation(AtomicOperations.MIGRATE_CLUSTER_CONFIGURATIONS)
+@Component("migrateClusterConfigurationsDescription")
+class MigrateClusterConfigurationsAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    new MigrateClusterConfigurationsAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  MigrateClusterConfigurationsDescription convertDescription(Map input) {
+    if (input.regionMapping) {
+      ((Map<String, Object>) input.regionMapping).keySet().each { i ->
+        if (input.regionMapping[i] instanceof String) {
+          input.regionMapping[i] = [ (input.regionMapping[i]) : []]
+        }
+      };
+    }
+    def converted = objectMapper.convertValue(input, MigrateClusterConfigurationsDescription)
+    converted.sources.each {
+      it.credentials = getCredentialsObject(it.cluster.account as String)
+    }
+    converted
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateClusterConfigurationsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateClusterConfigurationsDescription.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.description
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfiguration
+
+class MigrateClusterConfigurationsDescription {
+  List<ClusterConfiguration> sources = []
+  Map<String, Map<String, List<String>>> regionMapping = [:]
+  Map<String, String> subnetTypeMapping = [:];
+  Map<String, String> accountMapping = [:];
+  Map<String, String> iamRoleMapping = [:];
+  Map<String, String> keyPairMapping = [:];
+  boolean dryRun
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/DefaultMigrateClusterConfigurationStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/DefaultMigrateClusterConfigurationStrategy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.handlers;
+
+import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory;
+
+public class DefaultMigrateClusterConfigurationStrategy extends MigrateClusterConfigurationStrategy {
+
+  private AmazonClientProvider amazonClientProvider;
+  private RegionScopedProviderFactory regionScopedProviderFactory;
+  private AwsConfiguration.DeployDefaults deployDefaults;
+
+  public DefaultMigrateClusterConfigurationStrategy(AmazonClientProvider amazonClientProvider,
+                                                    RegionScopedProviderFactory regionScopedProviderFactory,
+                                                    AwsConfiguration.DeployDefaults deployDefaults) {
+    this.amazonClientProvider = amazonClientProvider;
+    this.regionScopedProviderFactory = regionScopedProviderFactory;
+    this.deployDefaults = deployDefaults;
+  }
+
+  @Override
+  public AmazonClientProvider getAmazonClientProvider() {
+    return amazonClientProvider;
+  }
+
+  @Override
+  public RegionScopedProviderFactory getRegionScopedProviderFactory() {
+    return regionScopedProviderFactory;
+  }
+
+  @Override
+  public AwsConfiguration.DeployDefaults getDeployDefaults() {
+    return deployDefaults;
+  }
+
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategy.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.handlers;
+
+import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerMigrator;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.MigrateLoadBalancerResult;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.MigrateSecurityGroupResult;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupLookup;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupMigrator;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupMigrator.SecurityGroupLocation;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfigurationTarget;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfiguration;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.MigrateClusterConfigurationResult;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.MigrateClusterConfigurationsAtomicOperation;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class MigrateClusterConfigurationStrategy {
+
+  protected SecurityGroupLookup sourceLookup;
+  protected SecurityGroupLookup targetLookup;
+  protected MigrateSecurityGroupStrategy migrateSecurityGroupStrategy;
+  protected MigrateLoadBalancerStrategy getMigrateLoadBalancerStrategy;
+
+  abstract AmazonClientProvider getAmazonClientProvider();
+
+  abstract RegionScopedProviderFactory getRegionScopedProviderFactory();
+
+  abstract AwsConfiguration.DeployDefaults getDeployDefaults();
+
+  /**
+   * Migrates load balancers and security groups in a cluster configuration, returning the mutations and the cluster
+   * configuration, with load balancers and security group collections updated, as well as subnetType, iamRole,
+   * and keyPair
+   *
+   * @param source                       the source configuration
+   * @param target                       the target location
+   * @param sourceLookup                 a security group lookup cache for the source region
+   * @param targetLookup                 a security group lookup cache for the target region (may be the same object as
+   *                                     the sourceLookup)
+   * @param migrateLoadBalancerStrategy  the load balancer migration strategy
+   * @param migrateSecurityGroupStrategy the security group migration strategy
+   * @param subnetType                   the subnetType in which to migrate the dependencies (should be null for EC
+   *                                     Classic migrations)
+   * @param iamRole                      the iamRole to apply when migrating (optional)
+   * @param keyPair                      the keyPair to apply when migrating (optional)
+   * @param dryRun                       whether to perform the migration or simply calculate the migration
+   * @return a result set with the new cluster configuration and a collection of load balancers and security groups
+   * required to perform the migration
+   */
+  public synchronized MigrateClusterConfigurationResult generateResults(ClusterConfiguration source, ClusterConfigurationTarget target,
+                                                                        SecurityGroupLookup sourceLookup, SecurityGroupLookup targetLookup,
+                                                                        MigrateLoadBalancerStrategy migrateLoadBalancerStrategy,
+                                                                        MigrateSecurityGroupStrategy migrateSecurityGroupStrategy,
+                                                                        String subnetType, String iamRole, String keyPair, boolean dryRun) {
+    this.sourceLookup = sourceLookup;
+    this.targetLookup = targetLookup;
+    this.migrateSecurityGroupStrategy = migrateSecurityGroupStrategy;
+    this.getMigrateLoadBalancerStrategy = migrateLoadBalancerStrategy;
+
+    MigrateClusterConfigurationResult result = new MigrateClusterConfigurationResult();
+
+    List<MigrateLoadBalancerResult> targetLoadBalancers = generateTargetLoadBalancers(source, target, subnetType, dryRun);
+    List<MigrateSecurityGroupResult> targetSecurityGroups = generateTargetSecurityGroups(source, target, result, dryRun);
+
+    result.setLoadBalancerMigrations(targetLoadBalancers);
+    result.setSecurityGroupMigrations(targetSecurityGroups);
+
+    Map<String, Object> cluster = source.getCluster();
+
+    Map<String, List<String>> zones = new HashMap<>();
+    zones.put(target.getRegion(), target.getAvailabilityZones());
+    cluster.put("availabilityZones", zones);
+
+    cluster.put("loadBalancers", targetLoadBalancers.stream().map(MigrateLoadBalancerResult::getTargetName).collect(Collectors.toList()));
+    cluster.put("securityGroups", targetSecurityGroups.stream().map(s -> s.getTarget().getTargetId()).collect(Collectors.toList()));
+    cluster.put("account", target.getCredentialAccount());
+    if (MigrateClusterConfigurationsAtomicOperation.CLASSIC_SUBNET_KEY.equals(subnetType)) {
+      cluster.remove("subnetType");
+    } else {
+      cluster.put("subnetType", subnetType);
+    }
+    if (iamRole != null) {
+      cluster.put("iamRole", iamRole);
+    }
+    if (keyPair != null) {
+      cluster.put("keyPair", keyPair);
+    }
+    result.setCluster(cluster);
+
+    return result;
+  }
+
+  protected List<MigrateSecurityGroupResult> generateTargetSecurityGroups(ClusterConfiguration source,
+                                                                          ClusterConfigurationTarget target,
+                                                                          MigrateClusterConfigurationResult result,
+                                                                          boolean dryRun) {
+
+    source.getSecurityGroupIds().stream()
+      .filter(g -> !sourceLookup.getSecurityGroupById(source.getCredentialAccount(), g, source.getVpcId()).isPresent())
+      .forEach(m -> result.getWarnings().add("Skipping creation of security group: " + m
+        + " (could not be found in source location)"));
+
+    List<String> securityGroupNames = source.getSecurityGroupIds().stream()
+      .filter(g -> sourceLookup.getSecurityGroupById(source.getCredentialAccount(), g, source.getVpcId()).isPresent())
+      .map(g -> sourceLookup.getSecurityGroupById(source.getCredentialAccount(), g, source.getVpcId()).get())
+      .map(g -> g.getSecurityGroup().getGroupName())
+      .collect(Collectors.toList());
+
+    List<MigrateSecurityGroupResult> targetSecurityGroups = securityGroupNames.stream().map(group ->
+      getMigrateSecurityGroupResult(source, target, sourceLookup, targetLookup, dryRun, group)
+    ).collect(Collectors.toList());
+
+    if (getDeployDefaults().getAddAppGroupToServerGroup()) {
+      // if the app security group is already present, don't include it twice
+      if (targetSecurityGroups.stream().noneMatch(r -> source.getApplication().equals(r.getTarget().getTargetName()))) {
+        targetSecurityGroups.add(generateAppSecurityGroup(source, target, sourceLookup, targetLookup, dryRun));
+      }
+    }
+
+    return targetSecurityGroups;
+  }
+
+  protected List<MigrateLoadBalancerResult> generateTargetLoadBalancers(ClusterConfiguration source,
+                                                                        ClusterConfigurationTarget target,
+                                                                        String subnetType,
+                                                                        boolean dryRun) {
+    return source.getLoadBalancerNames().stream().map(lbName ->
+      getMigrateLoadBalancerResult(source, target, sourceLookup, targetLookup, subnetType, dryRun, lbName)
+    ).collect(Collectors.toList());
+  }
+
+  protected MigrateSecurityGroupResult generateAppSecurityGroup(ClusterConfiguration source,
+                                                                ClusterConfigurationTarget target,
+                                                                SecurityGroupLookup sourceLookup,
+                                                                SecurityGroupLookup targetLookup, boolean dryRun) {
+    SecurityGroupMigrator.SecurityGroupLocation appGroupLocation = new SecurityGroupMigrator.SecurityGroupLocation();
+    appGroupLocation.setName(source.getApplication());
+    appGroupLocation.setRegion(source.getRegion());
+    appGroupLocation.setCredentials(source.getCredentials());
+    appGroupLocation.setVpcId(source.getVpcId());
+    SecurityGroupMigrator migrator = new SecurityGroupMigrator(sourceLookup, targetLookup, migrateSecurityGroupStrategy,
+      appGroupLocation, new SecurityGroupLocation(target));
+    migrator.setCreateIfSourceMissing(true);
+    return migrator.migrate(dryRun);
+  }
+
+  private MigrateSecurityGroupResult getMigrateSecurityGroupResult(ClusterConfiguration source,
+                                                                   ClusterConfigurationTarget target,
+                                                                   SecurityGroupLookup sourceLookup,
+                                                                   SecurityGroupLookup targetLookup,
+                                                                   boolean dryRun, String group) {
+    SecurityGroupMigrator.SecurityGroupLocation sourceLocation = new SecurityGroupMigrator.SecurityGroupLocation();
+    sourceLocation.setName(group);
+    sourceLocation.setRegion(source.getRegion());
+    sourceLocation.setCredentials(source.getCredentials());
+    sourceLocation.setVpcId(source.getVpcId());
+    return new SecurityGroupMigrator(sourceLookup, targetLookup, migrateSecurityGroupStrategy,
+      sourceLocation, new SecurityGroupMigrator.SecurityGroupLocation(target)).migrate(dryRun);
+  }
+
+  private MigrateLoadBalancerResult getMigrateLoadBalancerResult(ClusterConfiguration source, ClusterConfigurationTarget target,
+                                                                 SecurityGroupLookup sourceLookup,
+                                                                 SecurityGroupLookup targetLookup, String subnetType,
+                                                                 boolean dryRun, String lbName) {
+    LoadBalancerMigrator.LoadBalancerLocation sourceLocation = new LoadBalancerMigrator.LoadBalancerLocation();
+    sourceLocation.setName(lbName);
+    sourceLocation.setRegion(source.getRegion());
+    sourceLocation.setVpcId(source.getVpcId());
+    sourceLocation.setCredentials(source.getCredentials());
+    return new LoadBalancerMigrator(sourceLookup, targetLookup, getAmazonClientProvider(), getRegionScopedProviderFactory(),
+      migrateSecurityGroupStrategy, getDeployDefaults(), getMigrateLoadBalancerStrategy, sourceLocation,
+      new LoadBalancerMigrator.LoadBalancerLocation(target), subnetType, source.getApplication()).migrate(dryRun);
+  }
+
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerMigrator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerMigrator.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration.DeployDefaults
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateLoadBalancerStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateSecurityGroupStrategy
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfigurationTarget
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ServerGroupMigrator.ServerGroupLocation
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
@@ -97,6 +98,13 @@ class LoadBalancerMigrator {
       this.availabilityZones = serverGroupLocation.availabilityZones
       this.region = serverGroupLocation.region
       this.vpcId = serverGroupLocation.vpcId
+    }
+
+    LoadBalancerLocation(ClusterConfigurationTarget clusterConfigurationTarget) {
+      this.credentials = clusterConfigurationTarget.credentials
+      this.availabilityZones = clusterConfigurationTarget.availabilityZones
+      this.region = clusterConfigurationTarget.region
+      this.vpcId = clusterConfigurationTarget.vpcId
     }
 
     @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupMigrator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupMigrator.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateSecurityGroupStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerMigrator.LoadBalancerLocation
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfigurationTarget
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ServerGroupMigrator.ServerGroupLocation
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -72,6 +73,12 @@ class SecurityGroupMigrator {
       "${name ?: '(no name)'} in $credentialAccount/$region" + (vpcId ? "/$vpcId" : "")
     }
     SecurityGroupLocation() {}
+
+    SecurityGroupLocation(ClusterConfigurationTarget clusterConfigurationTarget) {
+      this.credentials = clusterConfigurationTarget.credentials
+      this.region = clusterConfigurationTarget.region
+      this.vpcId = clusterConfigurationTarget.vpcId
+    }
 
     SecurityGroupLocation(LoadBalancerLocation loadBalancerLocation) {
       this.credentials = loadBalancerLocation.credentials

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ClusterConfigurationMigrator.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ClusterConfigurationMigrator.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup;
+
+import com.netflix.frigga.autoscaling.AutoScalingGroupNameBuilder;
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateClusterConfigurationStrategy;
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateLoadBalancerStrategy;
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateSecurityGroupStrategy;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupLookup;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+
+import java.util.List;
+import java.util.Map;
+
+public class ClusterConfigurationMigrator {
+
+  private static final String BASE_PHASE = "MIGRATE_CLUSTER_CONFIG";
+
+  private static Task getTask() {
+    return TaskRepository.threadLocalTask.get();
+  }
+
+  private ClusterConfiguration source;
+  private ClusterConfigurationTarget target;
+  private MigrateClusterConfigurationStrategy migrationStrategy;
+  private MigrateLoadBalancerStrategy migrateLoadBalancerStrategy;
+  private MigrateSecurityGroupStrategy migrateSecurityGroupStrategy;
+  private SecurityGroupLookup sourceLookup;
+  private SecurityGroupLookup targetLookup;
+  private String iamRole;
+  private String keyPair;
+  private String subnetType;
+
+  public ClusterConfigurationMigrator(MigrateClusterConfigurationStrategy migrationStrategy,
+                                      ClusterConfiguration source, ClusterConfigurationTarget target,
+                                      SecurityGroupLookup sourceLookup, SecurityGroupLookup targetLookup,
+                                      MigrateLoadBalancerStrategy migrateLoadBalancerStrategy,
+                                      MigrateSecurityGroupStrategy migrateSecurityGroupStrategy,
+                                      String iamRole, String keyPair, String subnetType) {
+    this.migrationStrategy = migrationStrategy;
+    this.source = source;
+    this.target = target;
+    this.sourceLookup = sourceLookup;
+    this.targetLookup = targetLookup;
+    this.migrateLoadBalancerStrategy = migrateLoadBalancerStrategy;
+    this.migrateSecurityGroupStrategy = migrateSecurityGroupStrategy;
+    this.iamRole = iamRole;
+    this.keyPair = keyPair;
+    this.subnetType = subnetType;
+  }
+
+  public MigrateClusterConfigurationResult migrate(boolean dryRun) {
+    getTask().updateStatus(BASE_PHASE, (dryRun ? "Calculating" : "Beginning") + " migration of cluster config " + source.toString());
+    MigrateClusterConfigurationResult result = migrationStrategy.generateResults(source, target, sourceLookup, targetLookup, migrateLoadBalancerStrategy,
+      migrateSecurityGroupStrategy, subnetType, iamRole, keyPair, dryRun);
+    getTask().updateStatus(BASE_PHASE, "Migration of cluster configuration " + source.toString() +
+      (dryRun ? " calculated" : " completed") + ".");
+    return result;
+  }
+
+  public static class ClusterConfiguration extends AbstractAmazonCredentialsDescription {
+    private Map<String, Object> cluster;
+
+    public Map<String, Object> getCluster() {
+      return cluster;
+    }
+
+    public void setCluster(Map<String, Object> cluster) {
+      this.cluster = cluster;
+    }
+
+    public List<String> getSecurityGroupIds() {
+      return (List<String>) cluster.get("securityGroups");
+    }
+
+    public String getVpcId() {
+      return (String) cluster.get("vpcId");
+    }
+
+    public String getApplication() {
+      return (String) cluster.get("application");
+    }
+
+    public List<String> getLoadBalancerNames() {
+      return (List<String>) cluster.get("loadBalancers");
+    }
+
+    public String getRegion() {
+      return ((Map<String, List<String>>) cluster.get("availabilityZones")).keySet().iterator().next();
+    }
+
+    @Override
+    public String toString() {
+      AutoScalingGroupNameBuilder nameBuilder = new AutoScalingGroupNameBuilder();
+      nameBuilder.setAppName(getApplication());
+      nameBuilder.setStack((String) cluster.get("stack"));
+      nameBuilder.setDetail((String) cluster.get("freeFormDetails"));
+      return nameBuilder.buildGroupName() + " in " + cluster.get("account") + "/" + getRegion() +
+        (getVpcId() != null ? "/" + getVpcId() : "");
+    }
+  }
+
+  public static class ClusterConfigurationTarget extends AbstractAmazonCredentialsDescription {
+    private String region;
+    private String vpcId;
+    private List<String> availabilityZones;
+
+    public String getRegion() {
+      return region;
+    }
+
+    public void setRegion(String region) {
+      this.region = region;
+    }
+
+    public String getVpcId() {
+      return vpcId;
+    }
+
+    public void setVpcId(String vpcId) {
+      this.vpcId = vpcId;
+    }
+
+    public List<String> getAvailabilityZones() {
+      return availabilityZones;
+    }
+
+    public void setAvailabilityZones(List<String> availabilityZones) {
+      this.availabilityZones = availabilityZones;
+    }
+
+    @Override
+    public String toString() {
+      return getCredentialAccount() + "/" + region + (vpcId != null ? "/" + vpcId : "");
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateClusterConfigurationResult.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateClusterConfigurationResult.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.MigrateLoadBalancerResult;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.MigrateSecurityGroupResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MigrateClusterConfigurationResult {
+
+  private Map<String, Object> cluster;
+  private List<MigrateSecurityGroupResult> securityGroupMigrations;
+  private List<MigrateLoadBalancerResult> loadBalancerMigrations;
+  private List<String> warnings = new ArrayList<>();
+
+  public Map<String, Object> getCluster() {
+    return cluster;
+  }
+
+  public void setCluster(Map<String, Object> cluster) {
+    this.cluster = cluster;
+  }
+
+  public List<MigrateSecurityGroupResult> getSecurityGroupMigrations() {
+    return securityGroupMigrations;
+  }
+
+  public void setSecurityGroupMigrations(List<MigrateSecurityGroupResult> securityGroupMigrations) {
+    this.securityGroupMigrations = securityGroupMigrations;
+  }
+
+  public List<MigrateLoadBalancerResult> getLoadBalancerMigrations() {
+    return loadBalancerMigrations;
+  }
+
+  public void setLoadBalancerMigrations(List<MigrateLoadBalancerResult> loadBalancerMigrations) {
+    this.loadBalancerMigrations = loadBalancerMigrations;
+  }
+
+  public List<String> getWarnings() {
+    return warnings;
+  }
+
+
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateClusterConfigurationsAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateClusterConfigurationsAtomicOperation.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.MigrateClusterConfigurationsDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateClusterConfigurationStrategy
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateLoadBalancerStrategy
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateSecurityGroupStrategy
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupLookup
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfigurationTarget
+import com.netflix.spinnaker.clouddriver.aws.model.SubnetAnalyzer
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
+
+import javax.inject.Provider
+
+class MigrateClusterConfigurationsAtomicOperation implements AtomicOperation<Void> {
+
+  final MigrateClusterConfigurationsDescription description
+
+  // When migrating from EC2-Classic to VPC, this is the key that should be passed in with the subnetTypeMappings
+  public final static String CLASSIC_SUBNET_KEY = 'EC2-CLASSIC'
+
+  MigrateClusterConfigurationsAtomicOperation(MigrateClusterConfigurationsDescription description) {
+    this.description = description
+  }
+
+  @Autowired
+  Provider<MigrateClusterConfigurationStrategy> migrationStrategy
+
+  @Autowired
+  SecurityGroupLookupFactory securityGroupLookupFactory
+
+  @Autowired
+  Provider<MigrateSecurityGroupStrategy> migrateSecurityGroupStrategy
+
+  @Autowired
+  Provider<MigrateLoadBalancerStrategy> migrateLoadBalancerStrategy
+
+  @Autowired
+  RegionScopedProviderFactory regionScopedProviderFactory
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  @Override
+  Void operate(List priorOutputs) {
+    Map<String, SecurityGroupLookup> lookups = [:]
+    Map<String, SubnetAnalyzer> subnetAnalyzers = [:]
+    List<MigrateClusterConfigurationResult> results = []
+
+    description.sources.each { source ->
+      String targetRegion = source.region
+      List<String> targetZones = ((Map) source.cluster.availabilityZones).get(source.region) as List<String>
+      if (description.regionMapping.containsKey(source.region)) {
+        def targetRegionZone = description.regionMapping.get(source.region)
+        targetRegion = targetRegionZone.keySet().first()
+        targetZones = targetRegionZone.values().first()
+      }
+      String sourceAccount = (String) source.cluster.account
+      String sourceIamRole = (String) source.cluster.iamRole
+      String sourceSubnetType = (String) source.cluster.subnetType ?: CLASSIC_SUBNET_KEY
+      String sourceKeyPair = (String) source.cluster.keyPair
+      String account = description.accountMapping.getOrDefault(sourceAccount, sourceAccount)
+      String iamRole = description.iamRoleMapping.getOrDefault(sourceIamRole, sourceIamRole)
+      String subnetType = description.subnetTypeMapping.getOrDefault(sourceSubnetType, sourceSubnetType)
+      String keyPair = description.keyPairMapping.getOrDefault(sourceKeyPair, sourceKeyPair)
+
+      // nothing changed? don't calculate anything for this cluster
+      if (sourceAccount == account && source.region == targetRegion && sourceSubnetType == subnetType) {
+        MigrateClusterConfigurationResult result = new MigrateClusterConfigurationResult(cluster: source.cluster)
+        results.add(result)
+      } else {
+        SecurityGroupLookup sourceLookup = lookups.get(source.region)
+        if (!sourceLookup) {
+          sourceLookup = securityGroupLookupFactory.getInstance(source.region, false)
+          lookups.put(source.region, sourceLookup)
+        }
+        SecurityGroupLookup targetLookup = lookups.get(targetRegion)
+        if (!targetLookup) {
+          targetLookup = securityGroupLookupFactory.getInstance(targetRegion, false)
+          lookups.put(targetRegion, targetLookup)
+        }
+        def credentials = targetLookup.getCredentialsForName(account)
+
+        if (targetZones.empty) {
+          targetZones = credentials.getRegions().find { it.name == targetRegion }.preferredZones
+        }
+        SubnetAnalyzer subnetAnalyzer = subnetAnalyzers.get(targetRegion + ':' + credentials.name)
+        if (!subnetAnalyzer) {
+          subnetAnalyzer = regionScopedProviderFactory.forRegion(credentials, targetRegion).subnetAnalyzer
+          subnetAnalyzers.put(targetRegion + ':' + credentials.name, subnetAnalyzer)
+        }
+
+        ClusterConfigurationTarget target = new ClusterConfigurationTarget(region: targetRegion, credentials: credentials,
+          availabilityZones: targetZones, vpcId: subnetAnalyzer.getVpcIdForSubnetPurpose(subnetType))
+
+        def migrator = new ClusterConfigurationMigrator(migrationStrategy.get(), source, target,
+          sourceLookup, targetLookup,
+          migrateLoadBalancerStrategy.get(), migrateSecurityGroupStrategy.get(), iamRole, keyPair, subnetType)
+
+        results.add(migrator.migrate(description.dryRun))
+      }
+    }
+    task.addResultObjects(results)
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateClusterConfigurationsAtomicOperationConverterSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateClusterConfigurationsAtomicOperationConverterSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.converters
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MigrateClusterConfigurationsAtomicOperationConverterSpec extends Specification {
+
+  @Shared
+  MigrateClusterConfigurationsAtomicOperationConverter converter
+
+  def setupSpec() {
+    converter = new MigrateClusterConfigurationsAtomicOperationConverter(objectMapper: new ObjectMapper())
+  }
+
+  void 'converts regionMappings to maps if input as string:string'() {
+    setup:
+    def input = [
+      regionMapping: [
+        'us-east-1': 'us-west-1',
+        'us-west-2': ['eu-west-1': ['eu-west-1a']]
+      ]
+    ]
+
+    when:
+    def description = converter.convertDescription(input)
+
+    then:
+    description.regionMapping['us-east-1'] == ['us-west-1': []]
+    description.regionMapping['us-west-2'] == ['eu-west-1': ['eu-west-1a']]
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategySpec.groovy
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.handlers
+
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.model.SecurityGroup
+import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration.DeployDefaults
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.MigrateLoadBalancerResult
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.MigrateSecurityGroupReference
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.MigrateSecurityGroupResult
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupLookup
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupUpdater
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfiguration
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfigurationTarget
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ServerGroupMigrator.ServerGroupLocation
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class MigrateClusterConfigurationStrategySpec extends Specification {
+
+  @Subject
+  MigrateClusterConfigurationStrategy strategy
+
+  @Shared
+  NetflixAmazonCredentials testCredentials = TestCredential.named('test')
+
+  @Shared
+  NetflixAmazonCredentials prodCredentials = TestCredential.named('prod')
+
+  AmazonClientProvider amazonClientProvider = Mock(AmazonClientProvider)
+
+  RegionScopedProviderFactory regionScopedProviderFactory = Mock(RegionScopedProviderFactory)
+
+  DeployDefaults deployDefaults = Mock(DeployDefaults)
+
+  MigrateSecurityGroupStrategy migrateSecurityGroupStrategy = Mock(MigrateSecurityGroupStrategy)
+
+  MigrateLoadBalancerStrategy migrateLoadBalancerStrategy = Mock(MigrateLoadBalancerStrategy)
+
+  SecurityGroupLookup sourceLookup = Mock(SecurityGroupLookup)
+
+  SecurityGroupLookup targetLookup = Mock(SecurityGroupLookup)
+
+  AmazonEC2 amazonEC2 = Mock(AmazonEC2)
+
+  void setup() {
+    TaskRepository.threadLocalTask.set(Stub(Task))
+    strategy = new DefaultMigrateClusterConfigurationStrategy(amazonClientProvider,
+      regionScopedProviderFactory,
+      deployDefaults)
+  }
+
+  void 'sets availability zones, subnetType, iamRole, keyPair on target'() {
+    given:
+    ClusterConfigurationTarget target = new ClusterConfigurationTarget(credentials: prodCredentials, vpcId: 'vpc-2', region: 'eu-west-1', availabilityZones: ['eu-west-1b'])
+    Map cluster = [
+      loadBalancers : [],
+      securityGroups: [],
+      region: 'us-east-1',
+      availabilityZones: [ 'us-east-1': ['us-east-1c']]
+    ]
+    ClusterConfiguration source = new ClusterConfiguration(credentials: testCredentials, cluster: cluster)
+
+    when:
+    def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'external', 'newIamRole', 'newKeyPair', true)
+
+    then:
+    results.loadBalancerMigrations.empty
+    results.securityGroupMigrations.empty
+    results.cluster.subnetType == 'external'
+    results.cluster.iamRole == 'newIamRole'
+    results.cluster.keyPair == 'newKeyPair'
+    results.cluster.loadBalancers == []
+    results.cluster.securityGroups == []
+    results.cluster.availabilityZones == [ 'eu-west-1': ['eu-west-1b']]
+    1 * deployDefaults.getAddAppGroupToServerGroup() >> false
+    0 * _
+  }
+
+  void 'generates load balancers from config'() {
+    given:
+    ClusterConfigurationTarget target = new ClusterConfigurationTarget(credentials: prodCredentials, vpcId: 'vpc-2', region: 'eu-west-1', availabilityZones: ['eu-west-1b'])
+    Map cluster = [
+      loadBalancers : ['lb-a', 'lb-b'],
+      securityGroups: [],
+      region: 'us-east-1',
+      availabilityZones: [ 'us-east-1': ['us-east-1c']]
+    ]
+    ClusterConfiguration source = new ClusterConfiguration(credentials: testCredentials, cluster: cluster)
+
+    when:
+    def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, true)
+
+    then:
+    results.loadBalancerMigrations.size() == 2
+    results.cluster.loadBalancers == ['lb-a2', 'lb-b2']
+    1 * migrateLoadBalancerStrategy.generateResults(sourceLookup, targetLookup, migrateSecurityGroupStrategy,
+      { it.name == 'lb-a' && it.region == 'us-east-1'}, { it.credentials == prodCredentials && it.region == 'eu-west-1'}, null, null, true) >> new MigrateLoadBalancerResult(targetName: 'lb-a2')
+    1 * migrateLoadBalancerStrategy.generateResults(sourceLookup, targetLookup, migrateSecurityGroupStrategy,
+      { it.name == 'lb-b' && it.region == 'us-east-1'}, { it.credentials == prodCredentials && it.region == 'eu-west-1'}, null, null, true) >> new MigrateLoadBalancerResult(targetName: 'lb-b2')
+    1 * deployDefaults.getAddAppGroupToServerGroup() >> false
+    0 * _
+  }
+
+  void 'generates security groups from config'() {
+    given:
+    ClusterConfigurationTarget target = new ClusterConfigurationTarget(credentials: prodCredentials, vpcId: 'vpc-2', region: 'eu-west-1', availabilityZones: ['eu-west-1b'])
+    Map cluster = [
+      loadBalancers : [],
+      securityGroups: ['sg-1', 'sg-2'],
+      region: 'us-east-1',
+      availabilityZones: [ 'us-east-1': ['us-east-1c']]
+    ]
+    ClusterConfiguration source = new ClusterConfiguration(credentials: testCredentials, cluster: cluster)
+
+    SecurityGroup group1 = new SecurityGroup(groupId: 'sg-1a', groupName: 'group1', vpcId: 'vpc-1')
+    SecurityGroup group2 = new SecurityGroup(groupId: 'sg-2a', groupName: 'group2', vpcId: 'vpc-1')
+    SecurityGroupUpdater updater1 = Stub(SecurityGroupUpdater) {
+      getSecurityGroup() >> group1
+    }
+    SecurityGroupUpdater updater2 = Stub(SecurityGroupUpdater) {
+      getSecurityGroup() >> group2
+    }
+
+    when:
+    def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, false)
+
+    then:
+    results.securityGroupMigrations.size() == 2
+    results.cluster.securityGroups == ['sg-1a', 'sg-2a']
+
+    3 * sourceLookup.getSecurityGroupById('test', 'sg-1', null) >> Optional.of(updater1)
+    3 * sourceLookup.getSecurityGroupById('test', 'sg-2', null) >> Optional.of(updater2)
+    1 * migrateSecurityGroupStrategy.generateResults({it.name == 'group1'}, { it.region == 'eu-west-1' }, sourceLookup, targetLookup, false, false) >> new MigrateSecurityGroupResult(target: new MigrateSecurityGroupReference(targetId: 'sg-1a'))
+    1 * migrateSecurityGroupStrategy.generateResults({it.name == 'group2'}, { it.region == 'eu-west-1' }, sourceLookup, targetLookup, false, false) >> new MigrateSecurityGroupResult(target: new MigrateSecurityGroupReference(targetId: 'sg-2a'))
+    1 * deployDefaults.getAddAppGroupToServerGroup() >> false
+    0 * _
+  }
+
+  void 'adds app security group if configured in deployDefaults'() {
+    given:
+    ClusterConfigurationTarget target = new ClusterConfigurationTarget(credentials: prodCredentials, vpcId: 'vpc-2', region: 'eu-west-1')
+    Map cluster = [
+      application: 'theapp',
+      loadBalancers : [],
+      securityGroups: [],
+      region: 'us-east-1',
+      availabilityZones: [ 'us-east-1': ['us-east-1c']]
+    ]
+    ClusterConfiguration source = new ClusterConfiguration(credentials: testCredentials, cluster: cluster)
+
+    when:
+    def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, false)
+
+    then:
+    results.cluster.securityGroups == ['sg-1a']
+    1 * deployDefaults.getAddAppGroupToServerGroup() >> true
+    1 * migrateSecurityGroupStrategy.generateResults(
+      {s -> s.name == 'theapp' && s.region == 'us-east-1' && s.credentials == testCredentials},
+      {s -> s.region == 'eu-west-1' && s.credentials == prodCredentials},
+      sourceLookup, targetLookup, true, false) >> new MigrateSecurityGroupResult(target: new MigrateSecurityGroupReference(targetId: 'sg-1a'))
+    0 * _
+  }
+
+  void 'replaces app security group if it is already there'() {
+    given:
+    ClusterConfigurationTarget target = new ClusterConfigurationTarget(credentials: prodCredentials, vpcId: 'vpc-2', region: 'eu-west-1')
+    Map cluster = [
+      application: 'theapp',
+      loadBalancers : [],
+      securityGroups: ['sg-1'],
+      region: 'us-east-1',
+      availabilityZones: [ 'us-east-1': ['us-east-1c']]
+    ]
+    ClusterConfiguration source = new ClusterConfiguration(credentials: testCredentials, cluster: cluster)
+
+    SecurityGroup appGroup = new SecurityGroup(groupId: 'sg-1', groupName: 'theapp', vpcId: 'vpc-1')
+    SecurityGroupUpdater updater = Stub(SecurityGroupUpdater) {
+      getSecurityGroup() >> appGroup
+    }
+
+    when:
+    def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, true)
+
+    then:
+    results.cluster.securityGroups == ['sg-1a']
+    3 * sourceLookup.getSecurityGroupById('test', 'sg-1', null) >> Optional.of(updater)
+    1 * deployDefaults.getAddAppGroupToServerGroup() >> true
+    1 * migrateSecurityGroupStrategy.generateResults(
+      {s -> s.name == 'theapp' && s.region == 'us-east-1' && s.credentials == testCredentials},
+      {s -> s.region == 'eu-west-1' && s.credentials == prodCredentials},
+      sourceLookup, targetLookup, false, true) >> new MigrateSecurityGroupResult(target: new MigrateSecurityGroupReference(targetId: 'sg-1a', targetName: 'theapp'))
+    0 * _
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategySpec.groovy
@@ -88,6 +88,7 @@ class MigrateServerGroupStrategySpec extends Specification {
   }
 
   void 'generates load balancers from launch config'() {
+    given:
     ServerGroupLocation source = new ServerGroupLocation(name: 'asg-v001', credentials: testCredentials, vpcId: 'vpc-1', region: 'us-east-1')
     ServerGroupLocation target = new ServerGroupLocation(credentials: prodCredentials, vpcId: 'vpc-2', region: 'eu-west-1', availabilityZones: ['eu-west-1b'])
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/MigrateClusterConfigurationsAtomicOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/MigrateClusterConfigurationsAtomicOperationSpec.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.MigrateClusterConfigurationsDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.MigrateClusterConfigurationStrategy
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupLookup
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfiguration
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.MigrateClusterConfigurationResult
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.MigrateClusterConfigurationsAtomicOperation
+import com.netflix.spinnaker.clouddriver.aws.model.SubnetAnalyzer
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory.RegionScopedProvider
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTask
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.inject.Provider
+
+class MigrateClusterConfigurationsAtomicOperationSpec extends Specification {
+
+  Task task
+
+  @Shared
+  NetflixAmazonCredentials testCredentials = TestCredential.named('test')
+
+  @Shared
+  NetflixAmazonCredentials prodCredentials = TestCredential.named('prod')
+
+  def setup() {
+    task = new DefaultTask("taskId")
+    TaskRepository.threadLocalTask.set(task)
+  }
+
+  void 'performs no migrations when clusters are not matched on account, region, or subnet mappings'() {
+    given:
+    def clusters = [
+      [ application: 'theapp',
+        availabilityZones: ['us-east-1': ['us-east-1c']],
+        region: 'us-east-1',
+        account: 'test',
+        iamRole: 'iam',
+        keyPair: 'kp-1',
+        credentials: testCredentials
+      ],
+      [ application: 'theapp',
+        availabilityZones: ['us-east-1': ['us-east-1c']],
+        region: 'us-east-1',
+        account: 'prod',
+        iamRole: 'iam2',
+        keyPair: 'kp-2',
+        credentials: prodCredentials
+      ]
+    ]
+    def description = new MigrateClusterConfigurationsDescription(
+      sources: clusters.collect { new ClusterConfiguration(cluster: it)},
+      subnetTypeMapping: [ 'old-internal': 'internal'],
+      accountMapping: [ 'other': 'someOther'],
+      regionMapping: ['us-west-1':['us-east-1':['us-east-1c']]],
+      iamRoleMapping: ['iam': 'iam3', 'iam2': 'iam4']
+    )
+    def operation = new MigrateClusterConfigurationsAtomicOperation(description)
+
+    when:
+    operation.operate([])
+
+    then:
+    task.resultObjects.size() == 2
+    task.resultObjects.cluster == clusters
+    0 * _
+  }
+
+  void 'migrates matched clusters, reusing security group lookups and subnet analyzers when possible'() {
+    given:
+    def clusters = [
+      [ application: 'theapp',
+        availabilityZones: ['us-east-1': ['us-east-1c']],
+        region: 'us-east-1',
+        account: 'test',
+        iamRole: 'iam',
+        keyPair: 'kp-1',
+        credentials: testCredentials
+      ],
+      [ application: 'theapp',
+        stack: 'a',
+        availabilityZones: ['us-east-1': ['us-east-1c']],
+        region: 'us-east-1',
+        account: 'prod',
+        iamRole: 'iam2',
+        keyPair: 'kp-2',
+        credentials: prodCredentials
+      ],
+      [ application: 'theapp',
+        stack: 'b',
+        availabilityZones: ['us-east-1': ['us-east-1c']],
+        region: 'us-east-1',
+        account: 'prod',
+        iamRole: 'iam3',
+        keyPair: 'kp-3',
+        credentials: prodCredentials
+      ]
+    ]
+    def source1 = new ClusterConfiguration(cluster: clusters[0])
+    def source2 = new ClusterConfiguration(cluster: clusters[1])
+    def source3 = new ClusterConfiguration(cluster: clusters[2])
+    def description = new MigrateClusterConfigurationsDescription(
+      sources: [source1, source2, source3],
+    subnetTypeMapping: [ (MigrateClusterConfigurationsAtomicOperation.CLASSIC_SUBNET_KEY): 'internal'])
+    def operation = new MigrateClusterConfigurationsAtomicOperation(description)
+
+    SecurityGroupLookup lookup = Mock(SecurityGroupLookup) {
+      1 * getCredentialsForName('test') >> testCredentials
+      2 * getCredentialsForName('prod') >> prodCredentials
+    }
+    SecurityGroupLookupFactory securityGroupLookupFactory = Mock(SecurityGroupLookupFactory) {
+      1 * getInstance('us-east-1', false) >> lookup
+    }
+    SubnetAnalyzer testSubnetAnalyzer = Mock(SubnetAnalyzer) {
+      1 * getVpcIdForSubnetPurpose('internal') >> 'vpc-test'
+    }
+    SubnetAnalyzer prodSubnetAnalyzer = Mock(SubnetAnalyzer) {
+      2 * getVpcIdForSubnetPurpose('internal') >> 'vpc-prod'
+    }
+    RegionScopedProvider testScopedProvider = Mock(RegionScopedProvider) {
+      1 * getSubnetAnalyzer() >> testSubnetAnalyzer
+    }
+    RegionScopedProvider prodScopedProvider = Mock(RegionScopedProvider) {
+      1 * getSubnetAnalyzer() >> prodSubnetAnalyzer
+    }
+    RegionScopedProviderFactory regionScopedProviderFactory = Mock(RegionScopedProviderFactory) {
+      1 * forRegion(testCredentials, 'us-east-1') >> testScopedProvider
+      1 * forRegion(prodCredentials, 'us-east-1') >> prodScopedProvider
+    }
+    MigrateClusterConfigurationStrategy clusterMigrateStrategy = Mock(MigrateClusterConfigurationStrategy)
+
+    operation.regionScopedProviderFactory = regionScopedProviderFactory;
+    operation.securityGroupLookupFactory = securityGroupLookupFactory;
+    operation.migrationStrategy = Stub(Provider) {
+      get() >> clusterMigrateStrategy
+    }
+    operation.migrateLoadBalancerStrategy = Mock(Provider)
+    operation.migrateSecurityGroupStrategy = Mock(Provider)
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * clusterMigrateStrategy.generateResults(source1, {
+      it.region == 'us-east-1' && it.credentials == testCredentials && it.vpcId == 'vpc-test'
+    }, lookup, lookup, _, _, 'internal', 'iam', 'kp-1', false) >> new MigrateClusterConfigurationResult()
+    1 * clusterMigrateStrategy.generateResults(source2, {
+      it.region == 'us-east-1' && it.credentials == prodCredentials && it.vpcId == 'vpc-prod'
+    }, lookup, lookup, _, _, 'internal', 'iam2', 'kp-2', false) >> new MigrateClusterConfigurationResult()
+    1 * clusterMigrateStrategy.generateResults(source3, {
+      it.region == 'us-east-1' && it.credentials == prodCredentials && it.vpcId == 'vpc-prod'
+    }, lookup, lookup, _, _, 'internal', 'iam3', 'kp-3', false) >> new MigrateClusterConfigurationResult()
+    task.resultObjects.size() == 3
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
@@ -34,6 +34,7 @@ final class AtomicOperations {
   public static final String UPSERT_SCALING_POLICY = "upsertScalingPolicy"
   public static final String DELETE_SCALING_POLICY = "deleteScalingPolicy"
   public static final String MIGRATE_SERVER_GROUP = "migrateServerGroup"
+  public static final String MIGRATE_CLUSTER_CONFIGURATIONS = "migrateClusterConfigurations"
 
   // Instance operations
   public static final String REBOOT_INSTANCES = "rebootInstances"


### PR DESCRIPTION
The idea here is for Orca to send in the cluster as a big dumb map and let Clouddriver send back an updated version.

This may change a little as I work on the Orca implementation but would like to get this in place so I don't have to run it locally while testing.

@cfieber Sorry again, PTAL