### PR TITLE
(aws) remove vpcId insertion code on security group ingress conversion

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateSecurityGroupStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateSecurityGroupStrategy.java
@@ -371,7 +371,9 @@ public abstract class MigrateSecurityGroupStrategy {
         ).findFirst().get();
         pair.setGroupId(targetReference.getTargetId());
         pair.setGroupName(null);
-        pair.setVpcId(targetReference.getVpcId());
+        if (!targetGroup.getSecurityGroup().getOwnerId().equals(targetReference.getAccountId())) {
+          pair.setVpcId(targetReference.getVpcId());
+        }
       })
     );
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
@@ -78,10 +78,6 @@ class SecurityGroupIngressConverter {
         it.groupName = null
         it.peeringStatus = null
         it.vpcPeeringConnectionId = null
-        // AWS does not populate the vpcId unless the rule is cross-account
-        if (it.userId == securityGroup.ownerId) {
-          it.vpcId = securityGroup.vpcId
-        }
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)


### PR DESCRIPTION
Need to verify the migration changes still work as expected.

Partially addresses https://github.com/spinnaker/spinnaker/issues/1020

PR for UI changes: https://github.com/spinnaker/deck/pull/2480