### PR TITLE
provider/aws: allow multiple credentials to be validated for an opera…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateClusterConfigurationsAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateClusterConfigurationsAtomicOperationConverter.groovy
@@ -45,7 +45,9 @@ class MigrateClusterConfigurationsAtomicOperationConverter extends AbstractAtomi
     def converted = objectMapper.convertValue(input, MigrateClusterConfigurationsDescription)
     converted.sources.each {
       it.credentials = getCredentialsObject(it.cluster.account as String)
+      converted.credentials.add(it.credentials)
     }
+    converted.accountMapping.values().each { converted.credentials.add(getCredentialsObject(it)) }
     converted
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateLoadBalancerAtomicOperationConverter.groovy
@@ -38,6 +38,8 @@ class MigrateLoadBalancerAtomicOperationConverter extends AbstractAtomicOperatio
     def converted = objectMapper.convertValue(input, MigrateLoadBalancerDescription)
     converted.source.credentials = getCredentialsObject(input.source.credentials as String)
     converted.target.credentials = getCredentialsObject(input.target.credentials as String)
+    converted.credentials.add(converted.source.credentials)
+    converted.credentials.add(converted.target.credentials)
     converted
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateSecurityGroupAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateSecurityGroupAtomicOperationConverter.groovy
@@ -38,6 +38,8 @@ class MigrateSecurityGroupAtomicOperationConverter extends AbstractAtomicOperati
     def converted = objectMapper.convertValue(input, MigrateSecurityGroupDescription)
     converted.source.credentials = getCredentialsObject(input.source.credentials as String)
     converted.target.credentials = getCredentialsObject(input.target.credentials as String)
+    converted.credentials.add(converted.source.credentials)
+    converted.credentials.add(converted.target.credentials)
     converted
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/MigrateServerGroupAtomicOperationConverter.groovy
@@ -38,6 +38,8 @@ class MigrateServerGroupAtomicOperationConverter extends AbstractAtomicOperation
     def converted = objectMapper.convertValue(input, MigrateServerGroupDescription)
     converted.source.credentials = getCredentialsObject(input.source.credentials as String)
     converted.target.credentials = getCredentialsObject(input.target.credentials as String)
+    converted.credentials.add(converted.source.credentials)
+    converted.credentials.add(converted.target.credentials)
     converted
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateClusterConfigurationsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateClusterConfigurationsDescription.groovy
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ClusterConfigurationMigrator.ClusterConfiguration
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 
 class MigrateClusterConfigurationsDescription {
   List<ClusterConfiguration> sources = []
@@ -26,4 +28,8 @@ class MigrateClusterConfigurationsDescription {
   Map<String, String> iamRoleMapping = [:];
   Map<String, String> keyPairMapping = [:];
   boolean dryRun
+
+  @JsonIgnore
+  Set<AccountCredentials> credentials = [];
+
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateLoadBalancerDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateLoadBalancerDescription.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 
 import static com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerMigrator.LoadBalancerLocation
 
@@ -30,8 +30,6 @@ class MigrateLoadBalancerDescription {
   boolean dryRun
 
   @JsonIgnore
-  NetflixAmazonCredentials getCredentials() {
-    return target.getCredentials();
-  }
+  Set<AccountCredentials> credentials = [];
 
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateSecurityGroupDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateSecurityGroupDescription.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupMigrator.SecurityGroupLocation
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 
 class MigrateSecurityGroupDescription {
   SecurityGroupLocation source
@@ -26,7 +26,5 @@ class MigrateSecurityGroupDescription {
   boolean dryRun
 
   @JsonIgnore
-  NetflixAmazonCredentials getCredentials() {
-    return target.getCredentials();
-  }
+  Set<AccountCredentials> credentials = [];
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateServerGroupDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateServerGroupDescription.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 
 import static com.netflix.spinnaker.clouddriver.aws.deploy.ops.servergroup.ServerGroupMigrator.ServerGroupLocation
 
@@ -32,7 +33,6 @@ class MigrateServerGroupDescription {
   boolean dryRun
 
   @JsonIgnore
-  NetflixAmazonCredentials getCredentials() {
-    return target.getCredentials();
-  }
+  Set<AccountCredentials> credentials = [];
+
 }


### PR DESCRIPTION
…tion

@ajordens looks like you were the original author of the account validation stuff... does this make sense to you?

Also, should there be a check to ensure either `credentials` or `credentialsList` is declared on the description? Otherwise, a developer could create a pipeline stage that avoids validation altogether (not the case currently but definitely the case with this PR).