### PR TITLE
provider/amazon: refactor migrators; include classic ingress flag

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateClusterConfigurationsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateClusterConfigurationsDescription.groovy
@@ -27,6 +27,7 @@ class MigrateClusterConfigurationsDescription {
   Map<String, String> accountMapping = [:];
   Map<String, String> iamRoleMapping = [:];
   Map<String, String> keyPairMapping = [:];
+  boolean allowIngressFromClassic
   boolean dryRun
 
   @JsonIgnore

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateLoadBalancerDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateLoadBalancerDescription.groovy
@@ -27,6 +27,7 @@ class MigrateLoadBalancerDescription {
   LoadBalancerLocation target
   String subnetType
   String application
+  boolean allowIngressFromClassic
   boolean dryRun
 
   @JsonIgnore

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateServerGroupDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateServerGroupDescription.groovy
@@ -30,6 +30,7 @@ class MigrateServerGroupDescription {
   String iamRole
   String keyPair
   String targetAmi
+  boolean allowIngressFromClassic
   boolean dryRun
 
   @JsonIgnore

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateStrategySupport.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateStrategySupport.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.handlers;
+
+import com.amazonaws.services.ec2.model.IpPermission;
+import com.amazonaws.services.ec2.model.SecurityGroup;
+import com.amazonaws.services.ec2.model.UserIdGroupPair;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupLookup;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+
+import java.util.Collections;
+
+public interface MigrateStrategySupport {
+
+  default void addClassicLinkIngress(SecurityGroupLookup lookup, String classicLinkGroupName, String groupId, NetflixAmazonCredentials credentials, String vpcId) {
+    if (classicLinkGroupName == null) {
+      return;
+    }
+    lookup.getSecurityGroupById(credentials.getName(), groupId, vpcId).ifPresent(targetGroupUpdater -> {
+      SecurityGroup targetGroup = targetGroupUpdater.getSecurityGroup();
+      lookup.getSecurityGroupByName(credentials.getName(), classicLinkGroupName, vpcId)
+        .map(updater -> updater.getSecurityGroup().getGroupId())
+        .ifPresent(classicLinkGroupId -> {
+          // don't attach if there's already some rule already configured
+          if (targetGroup.getIpPermissions().stream()
+            .anyMatch(p -> p.getUserIdGroupPairs().stream()
+              .anyMatch(p2 -> p2.getGroupId().equals(classicLinkGroupId)))) {
+            return;
+          }
+          targetGroupUpdater.addIngress(Collections.singletonList(
+            new IpPermission()
+              .withIpProtocol("tcp").withFromPort(80).withToPort(65535)
+              .withUserIdGroupPairs(
+                new UserIdGroupPair()
+                  .withUserId(credentials.getAccountId())
+                  .withGroupId(classicLinkGroupId)
+                  .withVpcId(vpcId)
+              )
+          ));
+        });
+    });
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerMigrator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerMigrator.groovy
@@ -49,6 +49,7 @@ class LoadBalancerMigrator {
   SecurityGroupLookup targetLookup
   String applicationName
   String subnetType
+  boolean allowIngressFromClassic
 
   LoadBalancerMigrator(SecurityGroupLookup sourceLookup,
                        SecurityGroupLookup targetLookup,
@@ -60,7 +61,8 @@ class LoadBalancerMigrator {
                        LoadBalancerLocation source,
                        LoadBalancerLocation target,
                        String subnetType,
-                       String applicationName) {
+                       String applicationName,
+                       boolean allowIngressFromClassic) {
 
     this.sourceLookup = sourceLookup
     this.targetLookup = targetLookup
@@ -73,12 +75,13 @@ class LoadBalancerMigrator {
     this.target = target
     this.subnetType = subnetType
     this.applicationName = applicationName
+    this.allowIngressFromClassic = allowIngressFromClassic
   }
 
   public MigrateLoadBalancerResult migrate(boolean dryRun) {
     task.updateStatus BASE_PHASE, (dryRun ? "Calculating" : "Beginning") + " migration of load balancer " + source.toString()
     def results = migrationStrategy.generateResults(sourceLookup, targetLookup, migrateSecurityGroupStrategy,
-      source, target, subnetType, applicationName, dryRun)
+      source, target, subnetType, applicationName, allowIngressFromClassic, dryRun)
     task.updateStatus BASE_PHASE, "Migration of load balancer " + source.toString() +
       (dryRun ? " calculated" : " completed") + ". Migrated load balancer name: " + results.targetName +
       (results.targetExists ? " (already exists)": "")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerAtomicOperation.groovy
@@ -70,7 +70,8 @@ class MigrateLoadBalancerAtomicOperation implements AtomicOperation<Void> {
 
     def migrator = new LoadBalancerMigrator(sourceLookup, targetLookup, amazonClientProvider,
       regionScopedProviderFactory, migrateSecurityGroupStrategy.get(), deployDefaults, migrationStrategy.get(),
-      description.source, description.target, description.subnetType, description.application)
+      description.source, description.target, description.subnetType, description.application,
+      description.allowIngressFromClassic)
 
     task.addResultObjects([migrator.migrate(description.dryRun)])
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -209,6 +209,7 @@ class SecurityGroupLookupFactory {
         groupId: securityGroup.groupId,
         ipPermissions: ipPermissionsToAdd
       ))
+      securityGroup.ipPermissions.addAll(ipPermissionsToAdd)
     }
 
     void removeIngress(List<IpPermission> ipPermissionsToRemove) {
@@ -216,6 +217,7 @@ class SecurityGroupLookupFactory {
         groupId: securityGroup.groupId,
         ipPermissions: ipPermissionsToRemove
       ))
+      securityGroup.ipPermissions.removeAll(ipPermissionsToRemove)
     }
 
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ClusterConfigurationMigrator.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ClusterConfigurationMigrator.java
@@ -46,13 +46,14 @@ public class ClusterConfigurationMigrator {
   private String iamRole;
   private String keyPair;
   private String subnetType;
+  private boolean allowIngressFromClassic;
 
   public ClusterConfigurationMigrator(MigrateClusterConfigurationStrategy migrationStrategy,
                                       ClusterConfiguration source, ClusterConfigurationTarget target,
                                       SecurityGroupLookup sourceLookup, SecurityGroupLookup targetLookup,
                                       MigrateLoadBalancerStrategy migrateLoadBalancerStrategy,
                                       MigrateSecurityGroupStrategy migrateSecurityGroupStrategy,
-                                      String iamRole, String keyPair, String subnetType) {
+                                      String iamRole, String keyPair, String subnetType, boolean allowIngressFromClassic) {
     this.migrationStrategy = migrationStrategy;
     this.source = source;
     this.target = target;
@@ -63,12 +64,13 @@ public class ClusterConfigurationMigrator {
     this.iamRole = iamRole;
     this.keyPair = keyPair;
     this.subnetType = subnetType;
+    this.allowIngressFromClassic = allowIngressFromClassic;
   }
 
   public MigrateClusterConfigurationResult migrate(boolean dryRun) {
     getTask().updateStatus(BASE_PHASE, (dryRun ? "Calculating" : "Beginning") + " migration of cluster config " + source.toString());
     MigrateClusterConfigurationResult result = migrationStrategy.generateResults(source, target, sourceLookup, targetLookup, migrateLoadBalancerStrategy,
-      migrateSecurityGroupStrategy, subnetType, iamRole, keyPair, dryRun);
+      migrateSecurityGroupStrategy, subnetType, iamRole, keyPair, allowIngressFromClassic, dryRun);
     getTask().updateStatus(BASE_PHASE, "Migration of cluster configuration " + source.toString() +
       (dryRun ? " calculated" : " completed") + ".");
     return result;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateClusterConfigurationsAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateClusterConfigurationsAtomicOperation.groovy
@@ -116,7 +116,8 @@ class MigrateClusterConfigurationsAtomicOperation implements AtomicOperation<Voi
 
         def migrator = new ClusterConfigurationMigrator(migrationStrategy.get(), source, target,
           sourceLookup, targetLookup,
-          migrateLoadBalancerStrategy.get(), migrateSecurityGroupStrategy.get(), iamRole, keyPair, subnetType)
+          migrateLoadBalancerStrategy.get(), migrateSecurityGroupStrategy.get(), iamRole, keyPair, subnetType,
+          description.allowIngressFromClassic)
 
         results.add(migrator.migrate(description.dryRun))
       }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupAtomicOperation.groovy
@@ -63,7 +63,7 @@ class MigrateServerGroupAtomicOperation implements AtomicOperation<Void> {
 
     def migrator = new ServerGroupMigrator(migrationStrategy.get(), description.source, description.target,
       sourceLookup, targetLookup, migrateLoadBalancerStrategy.get(), migrateSecurityGroupStrategy.get(),
-      description.subnetType, description.iamRole, description.keyPair, description.targetAmi)
+      description.subnetType, description.iamRole, description.keyPair, description.targetAmi, description.allowIngressFromClassic)
 
     task.addResultObjects([migrator.migrate(description.dryRun)])
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ServerGroupMigrator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ServerGroupMigrator.groovy
@@ -44,6 +44,7 @@ class ServerGroupMigrator {
   String keyPair
   String subnetType
   String targetAmi
+  boolean allowIngressFromClassic
 
   ServerGroupMigrator(MigrateServerGroupStrategy migrationStrategy,
                       ServerGroupLocation source,
@@ -55,7 +56,8 @@ class ServerGroupMigrator {
                       String subnetType,
                       String iamRole,
                       String keyPair,
-                      String targetAmi) {
+                      String targetAmi,
+                      boolean allowIngressFromClassic) {
 
     this.migrationStrategy = migrationStrategy
     this.migrateLoadBalancerStrategy = migrateLoadBalancerStrategy
@@ -68,12 +70,14 @@ class ServerGroupMigrator {
     this.keyPair = keyPair
     this.subnetType = subnetType
     this.targetAmi = targetAmi
+    this.allowIngressFromClassic = allowIngressFromClassic
   }
 
   public MigrateServerGroupResult migrate(boolean dryRun) {
     task.updateStatus BASE_PHASE, (dryRun ? "Calculating" : "Beginning") + " migration of server group " + source.toString()
     MigrateServerGroupResult results = migrationStrategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, subnetType, iamRole, keyPair, targetAmi, dryRun)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, subnetType, iamRole, keyPair, targetAmi,
+      allowIngressFromClassic, dryRun)
     task.updateStatus BASE_PHASE, "Migration of server group " + source.toString() +
       (dryRun ? " calculated" : " completed") + ". Migrated server group name: " + results.serverGroupNames.get(0)
     results

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategySpec.groovy
@@ -84,7 +84,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'external', 'newIamRole', 'newKeyPair', true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'external', 'newIamRole', 'newKeyPair', false, true)
 
     then:
     results.loadBalancerMigrations.empty
@@ -112,15 +112,15 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, false, true)
 
     then:
     results.loadBalancerMigrations.size() == 2
     results.cluster.loadBalancers == ['lb-a2', 'lb-b2']
     1 * migrateLoadBalancerStrategy.generateResults(sourceLookup, targetLookup, migrateSecurityGroupStrategy,
-      { it.name == 'lb-a' && it.region == 'us-east-1'}, { it.credentials == prodCredentials && it.region == 'eu-west-1'}, null, null, true) >> new MigrateLoadBalancerResult(targetName: 'lb-a2')
+      { it.name == 'lb-a' && it.region == 'us-east-1'}, { it.credentials == prodCredentials && it.region == 'eu-west-1'}, null, null, false, true) >> new MigrateLoadBalancerResult(targetName: 'lb-a2')
     1 * migrateLoadBalancerStrategy.generateResults(sourceLookup, targetLookup, migrateSecurityGroupStrategy,
-      { it.name == 'lb-b' && it.region == 'us-east-1'}, { it.credentials == prodCredentials && it.region == 'eu-west-1'}, null, null, true) >> new MigrateLoadBalancerResult(targetName: 'lb-b2')
+      { it.name == 'lb-b' && it.region == 'us-east-1'}, { it.credentials == prodCredentials && it.region == 'eu-west-1'}, null, null, false, true) >> new MigrateLoadBalancerResult(targetName: 'lb-b2')
     1 * deployDefaults.getAddAppGroupToServerGroup() >> false
     0 * _
   }
@@ -147,7 +147,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, false, false)
 
     then:
     results.securityGroupMigrations.size() == 2
@@ -175,7 +175,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, false, false)
 
     then:
     results.cluster.securityGroups == ['sg-1a']
@@ -206,7 +206,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, false, true)
 
     then:
     results.cluster.securityGroups == ['sg-1a']

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateSecurityGroupStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateSecurityGroupStrategySpec.groovy
@@ -517,8 +517,7 @@ class MigrateSecurityGroupStrategySpec extends Specification {
     }
 
     @Override
-    Set<MigrateSecurityGroupReference> shouldError(SecurityGroupLocation target,
-                                                   Set<MigrateSecurityGroupReference> references) {
+    Set<MigrateSecurityGroupReference> shouldError(Set<MigrateSecurityGroupReference> references) {
       return references;
     }
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategySpec.groovy
@@ -104,7 +104,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -118,7 +118,7 @@ class MigrateServerGroupStrategySpec extends Specification {
       migrateSecurityGroupStrategy,
       {s -> s.name == 'lb-1' && s.region == 'us-east-1' && s.credentials == testCredentials && s.vpcId == 'vpc-1'},
       {s -> !s.name && s.region == 'eu-west-1' && s.credentials == prodCredentials && s.vpcId == 'vpc-2' && s.availabilityZones == ['eu-west-1b']},
-      'internal', _, false) >> new MigrateLoadBalancerResult()
+      'internal', _, false, false) >> new MigrateLoadBalancerResult()
     1 * basicAmazonDeployHandler.copySourceAttributes(regionScopedProvider, 'asg-v001', false, _) >> { a, b, c, d -> d }
     1 * basicAmazonDeployHandler.handle(_, []) >> new DeploymentResult(serverGroupNames: ['asg-v003'])
     0 * _
@@ -147,7 +147,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -186,7 +186,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -224,7 +224,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false, true)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -262,7 +262,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -293,7 +293,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -323,7 +323,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', null, null, null, false, true)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateStrategySupportSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateStrategySupportSpec.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.handlers
+
+import com.amazonaws.services.ec2.model.IpPermission
+import com.amazonaws.services.ec2.model.SecurityGroup
+import com.amazonaws.services.ec2.model.UserIdGroupPair
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupLookup
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupUpdater
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class MigrateStrategySupportSpec extends Specification {
+
+  @Subject
+  MigrateStrategySupport strategy = new TestMigrateStrategy()
+
+  @Shared
+  NetflixAmazonCredentials testCredentials = TestCredential.named('test')
+
+  SecurityGroupLookup lookup
+
+  void setup() {
+    lookup = Mock()
+  }
+
+  void 'returns immediately when classicLinkGroupName is null'() {
+    when:
+    strategy.addClassicLinkIngress(lookup, null, 'sg-1', testCredentials, 'vpc-1')
+
+    then:
+    0 * _
+  }
+
+  void 'returns without adding an ingress or looking up classic link group if target not found'() {
+    when:
+    strategy.addClassicLinkIngress(lookup, 'nf-classic-link', 'sg-1', testCredentials, 'vpc-1')
+
+    then:
+    1 * lookup.getSecurityGroupById('test', 'sg-1', 'vpc-1') >> Optional.empty()
+    0 * _
+  }
+
+  void 'returns without adding an ingress when classic link group not found'() {
+    given:
+    SecurityGroup securityGroup = new SecurityGroup()
+    SecurityGroupUpdater updater = Stub() {
+      getSecurityGroup() >> securityGroup
+    }
+
+    when:
+    strategy.addClassicLinkIngress(lookup, 'nf-classic-link', 'sg-1', testCredentials, 'vpc-1')
+
+    then:
+    1 * lookup.getSecurityGroupById('test', 'sg-1', 'vpc-1') >> Optional.of(updater)
+    1 * lookup.getSecurityGroupByName('test', 'nf-classic-link', 'vpc-1') >> Optional.empty()
+    0 * _
+  }
+
+  void 'returns without adding an ingress when classic link group already has ingress'() {
+    given:
+    SecurityGroup securityGroup = new SecurityGroup()
+    SecurityGroup classicLinkGroup = new SecurityGroup(groupId: 'sg-c1')
+    securityGroup.ipPermissions = [
+      new IpPermission().withUserIdGroupPairs(new UserIdGroupPair().withGroupId('sg-c'))
+    ]
+    SecurityGroupUpdater updater = Stub() {
+      getSecurityGroup() >> securityGroup
+    }
+    SecurityGroupUpdater classicLinkUpdater = Stub() {
+      getSecurityGroup() >> classicLinkGroup
+    }
+
+    when:
+    strategy.addClassicLinkIngress(lookup, 'nf-classic-link', 'sg-1', testCredentials, 'vpc-1')
+
+    then:
+    1 * lookup.getSecurityGroupById('test', 'sg-1', 'vpc-1') >> Optional.of(updater)
+    1 * lookup.getSecurityGroupByName('test', 'nf-classic-link', 'vpc-1') >> Optional.of(classicLinkUpdater)
+    0 * _
+  }
+
+  @Unroll
+  void 'adds an ingress when one not already present for classic link group'() {
+    given:
+    SecurityGroup securityGroup = new SecurityGroup()
+    SecurityGroup classicLinkGroup = new SecurityGroup(groupId: 'sg-c1')
+    securityGroup.ipPermissions = [
+      new IpPermission().withUserIdGroupPairs(userIdGroupPairs)
+    ]
+    SecurityGroupUpdater updater = Mock()
+    SecurityGroupUpdater classicLinkUpdater = Stub() {
+      getSecurityGroup() >> classicLinkGroup
+    }
+
+    when:
+    strategy.addClassicLinkIngress(lookup, 'nf-classic-link', 'sg-1', testCredentials, 'vpc-1')
+
+    then:
+    1 * lookup.getSecurityGroupById('test', 'sg-1', 'vpc-1') >> Optional.of(updater)
+    1 * lookup.getSecurityGroupByName('test', 'nf-classic-link', 'vpc-1') >> Optional.of(classicLinkUpdater)
+    1 * updater.getSecurityGroup() >> securityGroup
+    1 * updater.addIngress({ rules ->
+      def rule = rules[0]
+      def pair = rule.userIdGroupPairs[0]
+      rule.ipProtocol == 'tcp' && rule.fromPort == 80 && rule.toPort == 65535 &&
+        pair.groupId == 'sg-c1' && pair.vpcId == 'vpc-1' && pair.userId == testCredentials.accountId
+    })
+    0 * _
+
+    where:
+    userIdGroupPairs << [
+      [],
+      [new UserIdGroupPair().withGroupId('sg-d')],
+      [new UserIdGroupPair().withGroupId('sg-d'), new UserIdGroupPair().withGroupId('sg-e')]
+    ]
+  }
+
+
+  static class TestMigrateStrategy implements MigrateStrategySupport {}
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/MigrateClusterConfigurationsAtomicOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/MigrateClusterConfigurationsAtomicOperationSpec.groovy
@@ -166,13 +166,13 @@ class MigrateClusterConfigurationsAtomicOperationSpec extends Specification {
     then:
     1 * clusterMigrateStrategy.generateResults(source1, {
       it.region == 'us-east-1' && it.credentials == testCredentials && it.vpcId == 'vpc-test'
-    }, lookup, lookup, _, _, 'internal', 'iam', 'kp-1', false) >> new MigrateClusterConfigurationResult()
+    }, lookup, lookup, _, _, 'internal', 'iam', 'kp-1', false, false) >> new MigrateClusterConfigurationResult()
     1 * clusterMigrateStrategy.generateResults(source2, {
       it.region == 'us-east-1' && it.credentials == prodCredentials && it.vpcId == 'vpc-prod'
-    }, lookup, lookup, _, _, 'internal', 'iam2', 'kp-2', false) >> new MigrateClusterConfigurationResult()
+    }, lookup, lookup, _, _, 'internal', 'iam2', 'kp-2', false, false) >> new MigrateClusterConfigurationResult()
     1 * clusterMigrateStrategy.generateResults(source3, {
       it.region == 'us-east-1' && it.credentials == prodCredentials && it.vpcId == 'vpc-prod'
-    }, lookup, lookup, _, _, 'internal', 'iam3', 'kp-3', false) >> new MigrateClusterConfigurationResult()
+    }, lookup, lookup, _, _, 'internal', 'iam3', 'kp-3', false, false) >> new MigrateClusterConfigurationResult()
     task.resultObjects.size() == 3
   }
 }


### PR DESCRIPTION
Two things happening:
  1. Letting producers declare whether the application security group should allow ingress from EC2-Classic
  2. Refactoring the migrator method signatures to not require a bunch of common fields, which can just become protected fields on the migrator. They weren't originally because I'm not a good programmer.