### PR TITLE
provider/amazon: omit skipped security groups when migrating items

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategy.java
@@ -115,7 +115,9 @@ public abstract class MigrateClusterConfigurationStrategy implements MigrateStra
     cluster.put("availabilityZones", zones);
 
     cluster.put("loadBalancers", targetLoadBalancers.stream().map(MigrateLoadBalancerResult::getTargetName).collect(Collectors.toList()));
-    cluster.put("securityGroups", targetSecurityGroups.stream().map(s -> s.getTarget().getTargetId()).collect(Collectors.toList()));
+    cluster.put("securityGroups", targetSecurityGroups.stream()
+      .filter(g -> !g.getSkipped().contains(g.getTarget()))
+      .map(s -> s.getTarget().getTargetId()).collect(Collectors.toList()));
     cluster.put("account", target.getCredentialAccount());
     if (MigrateClusterConfigurationsAtomicOperation.CLASSIC_SUBNET_KEY.equals(subnetType)) {
       cluster.remove("subnetType");

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateLoadBalancerStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateLoadBalancerStrategy.java
@@ -99,10 +99,13 @@ public abstract class MigrateLoadBalancerStrategy implements MigrateStrategySupp
 
     List<MigrateSecurityGroupResult> targetGroups = getTargetSecurityGroups(sourceLoadBalancer, result);
 
-    List<String> securityGroups = targetGroups.stream().map(g -> g.getTarget().getTargetId()).distinct().collect(Collectors.toList());
+    List<String> securityGroups = targetGroups.stream()
+      .filter(g -> !g.getSkipped().contains(g.getTarget()))
+      .map(g -> g.getTarget().getTargetId()).distinct().collect(Collectors.toList());
     securityGroups.addAll(buildExtraSecurityGroups(sourceLoadBalancer, result));
 
     result.getSecurityGroups().addAll(targetGroups);
+
     result.setTargetName(targetName);
     result.setTargetExists(targetLoadBalancer != null);
     if (!dryRun) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategy.java
@@ -161,6 +161,7 @@ public abstract class MigrateServerGroupStrategy implements MigrateStrategySuppo
       deployDescription.setLoadBalancers(targetLoadBalancers.stream()
         .map(MigrateLoadBalancerResult::getTargetName).collect(Collectors.toList()));
       deployDescription.setSecurityGroups(targetSecurityGroups.stream()
+        .filter(sg -> !sg.getSkipped().contains(sg.getTarget()))
         .map(sg -> sg.getTarget().getTargetName()).collect(Collectors.toList()));
       deployDescription.setAvailabilityZones(zones);
       deployDescription.setStartDisabled(true);


### PR DESCRIPTION
We still want to report them - we just don't want to include them in the output load balancer/cluster/server group