### PR TITLE
provider/amazon: update status with dependent group creation info

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerMigrator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerMigrator.groovy
@@ -31,7 +31,7 @@ import static com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.Sec
 
 class LoadBalancerMigrator {
 
-  private static final String BASE_PHASE = "MIGRATE_LOAD_BALANCER"
+  public static final String BASE_PHASE = "MIGRATE_LOAD_BALANCER"
 
   private static Task getTask() {
     TaskRepository.threadLocalTask.get()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupMigrator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupMigrator.groovy
@@ -28,7 +28,7 @@ import static com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.Sec
 
 class SecurityGroupMigrator {
 
-  private static final String BASE_PHASE = "MIGRATE_SECURITY_GROUP"
+  public static final String BASE_PHASE = "MIGRATE_SECURITY_GROUP"
 
   private static Task getTask() {
     TaskRepository.threadLocalTask.get()

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateSecurityGroupStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateSecurityGroupStrategySpec.groovy
@@ -30,6 +30,8 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGr
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupMigrator.SecurityGroupLocation
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -51,11 +53,17 @@ class MigrateSecurityGroupStrategySpec extends Specification {
 
   AmazonClientProvider amazonClientProvider = Mock(AmazonClientProvider)
 
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
   def setup() {
     strategy = new DefaultMigrateSecurityGroupStrategy(amazonClientProvider, ['infra'])
 
     sourceLookup.getCredentialsForId(testCredentials.accountId) >> testCredentials
     targetLookup.getCredentialsForId(testCredentials.accountId) >> testCredentials
+    sourceLookup.getCredentialsForName(testCredentials.name) >> testCredentials
+    targetLookup.getCredentialsForName(testCredentials.name) >> testCredentials
 
     sourceLookup.getAccountNameForId(testCredentials.accountId) >> 'test'
     targetLookup.getAccountNameForId(testCredentials.accountId) >> 'test'
@@ -64,6 +72,8 @@ class MigrateSecurityGroupStrategySpec extends Specification {
 
     sourceLookup.getCredentialsForId(prodCredentials.accountId) >> prodCredentials
     targetLookup.getCredentialsForId(prodCredentials.accountId) >> prodCredentials
+    sourceLookup.getCredentialsForName(prodCredentials.name) >> prodCredentials
+    targetLookup.getCredentialsForName(prodCredentials.name) >> prodCredentials
 
     sourceLookup.getAccountNameForId(prodCredentials.accountId) >> 'prod'
     targetLookup.getAccountNameForId(prodCredentials.accountId) >> 'prod'


### PR DESCRIPTION
Tracking down an issue where the migration is failing because it is trying to create a security group in a VPC that somehow does not exist, but we don't have visibility into what it's trying to create. Hopefully this provides that visibility.