### PR TITLE
Adding back the ability to override environment and accounttype.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.groovy
@@ -72,8 +72,10 @@ class AmazonCredentialsInitializer implements CredentialsInitializerSynchronizab
   List<? extends NetflixAmazonCredentials> netflixAmazonCredentials(CredentialsLoader<? extends NetflixAmazonCredentials> credentialsLoader,
                                                                     CredentialsConfig credentialsConfig,
                                                                     AccountCredentialsRepository accountCredentialsRepository,
-                                                                    @Value('${default.account.env:default}') String defaultAccountName) {
-    synchronizeAmazonAccounts(credentialsLoader, credentialsConfig, accountCredentialsRepository, defaultAccountName, null)
+                                                                    @Value('${default.account.env:default}') String defaultAccountName,
+                                                                    @Value('${default.account.environment:#{default.account.env}}') String defaultEnvironment,
+                                                                    @Value('${default.account.accountType:#{default.account.env}}') String defaultAccountType) {
+    synchronizeAmazonAccounts(credentialsLoader, credentialsConfig, accountCredentialsRepository, defaultAccountName, defaultEnvironment, defaultAccountType, null)
   }
 
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -82,9 +84,11 @@ class AmazonCredentialsInitializer implements CredentialsInitializerSynchronizab
                                     CredentialsConfig credentialsConfig,
                                     AccountCredentialsRepository accountCredentialsRepository,
                                     @Value('${default.account.env:default}') String defaultAccountName,
+                                    @Value('${default.account.environment:#{default.account.env}}') String defaultEnvironment,
+                                    @Value('${default.account.accountType:#{default.account.env}}') String defaultAccountType,
                                     CatsModule catsModule) {
     if (!credentialsConfig.accounts && !credentialsConfig.defaultAssumeRole) {
-      credentialsConfig.accounts = [new CredentialsConfig.Account(name: defaultAccountName)]
+      credentialsConfig.accounts = [new CredentialsConfig.Account(name: defaultAccountName, environment: defaultEnvironment, accountType: defaultAccountType)]
       if (!credentialsConfig.defaultRegions) {
         credentialsConfig.defaultRegions = [US_EAST_1, US_WEST_1, US_WEST_2, EU_WEST_1].collect { new CredentialsConfig.Region(name: it.name) }
       }


### PR DESCRIPTION
Putting back because the wrong NETFILX_ENVIRONMENT is being written to userdata for the SEG account.

NETFILX_ENVIRONMENT is getting set to 'seg' and should be set to 'prod'


@robfletcher you put this in and rolled it back b/c @anotherchrisberry said that it has some OSS implications.  Please review and add concerns. 
