### PR TITLE
Kubernetes : Return image list back in buildInfo

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -46,6 +46,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
   DeployKubernetesAtomicOperationDescription deployDescription
   ReplicationController replicationController
   String yaml
+  Map buildInfo
 
   Boolean isDisabled() {
     this.labels ? !(this.labels.any { key, value -> KubernetesUtil.isLoadBalancerLabel(key) && value == "true" }) : false
@@ -94,6 +95,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
 
   @Override
   ServerGroup.ImagesSummary getImagesSummary() {
+    def bi = buildInfo
     return new ServerGroup.ImagesSummary() {
       @Override
       List<ServerGroup.ImageSummary> getSummaries () {
@@ -105,7 +107,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
 
             @Override
             Map<String, Object> getBuildInfo() {
-              return [:]
+              return bi
             }
 
             @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -23,17 +23,17 @@ import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.CacheFilter
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
 import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesCluster
-import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesInstance
 import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesLoadBalancer
-import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesSecurityGroup
 import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesServerGroup
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
-import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.ReplicationController
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+
+import java.util.ArrayList
 
 @Component
 class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
@@ -148,6 +148,13 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
       serverGroup.loadBalancers?.each {
         serverGroup.securityGroups.addAll(securityGroups[it])
       }
+
+      def imageList = []
+      for (def container : serverGroup.deployDescription.containers) {
+        imageList.add(KubernetesUtil.getImageId(container.imageDescription))
+      }
+      Map buildInfo = [images: imageList]
+      serverGroup.buildInfo = buildInfo
       serverGroups[Names.parseName(serverGroup.name).cluster].add(serverGroup)
     }
 


### PR DESCRIPTION
First PR for [#1047](https://github.com/spinnaker/spinnaker/issues/1047)

Sends the image information back so that it can be displayed on cluster and project page.