### PR TITLE
provider/amazon: handle load balancer name issues in migrations to VPC

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateClusterConfigurationsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateClusterConfigurationsDescription.groovy
@@ -23,11 +23,12 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 class MigrateClusterConfigurationsDescription {
   List<ClusterConfiguration> sources = []
   Map<String, Map<String, List<String>>> regionMapping = [:]
-  Map<String, String> subnetTypeMapping = [:];
-  Map<String, String> elbSubnetTypeMapping = [:];
-  Map<String, String> accountMapping = [:];
-  Map<String, String> iamRoleMapping = [:];
-  Map<String, String> keyPairMapping = [:];
+  Map<String, String> subnetTypeMapping = [:]
+  Map<String, String> elbSubnetTypeMapping = [:]
+  Map<String, String> accountMapping = [:]
+  Map<String, String> iamRoleMapping = [:]
+  Map<String, String> keyPairMapping = [:]
+  Map<String, String> loadBalancerNameMapping = [:]
   boolean allowIngressFromClassic
   boolean dryRun
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateServerGroupDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/MigrateServerGroupDescription.groovy
@@ -31,6 +31,7 @@ class MigrateServerGroupDescription {
   String iamRole
   String keyPair
   String targetAmi
+  Map<String, String> loadBalancerNameMapping = [:]
   boolean allowIngressFromClassic
   boolean dryRun
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategy.java
@@ -45,6 +45,7 @@ public abstract class MigrateClusterConfigurationStrategy implements MigrateStra
   protected String elbSubnetType;
   protected String iamRole;
   protected String keyPair;
+  protected Map<String, String> loadBalancerNameMapping;
   protected boolean allowIngressFromClassic;
   protected boolean dryRun;
 
@@ -85,6 +86,7 @@ public abstract class MigrateClusterConfigurationStrategy implements MigrateStra
                                                                         MigrateLoadBalancerStrategy migrateLoadBalancerStrategy,
                                                                         MigrateSecurityGroupStrategy migrateSecurityGroupStrategy,
                                                                         String subnetType, String elbSubnetType, String iamRole, String keyPair,
+                                                                        Map<String, String> loadBalancerNameMapping,
                                                                         boolean allowIngressFromClassic, boolean dryRun) {
     this.sourceLookup = sourceLookup;
     this.targetLookup = targetLookup;
@@ -94,6 +96,7 @@ public abstract class MigrateClusterConfigurationStrategy implements MigrateStra
     this.elbSubnetType = elbSubnetType;
     this.iamRole = iamRole;
     this.keyPair = keyPair;
+    this.loadBalancerNameMapping = loadBalancerNameMapping;
     this.allowIngressFromClassic = allowIngressFromClassic;
     this.dryRun = dryRun;
 
@@ -201,9 +204,13 @@ public abstract class MigrateClusterConfigurationStrategy implements MigrateStra
     sourceLocation.setRegion(source.getRegion());
     sourceLocation.setVpcId(source.getVpcId());
     sourceLocation.setCredentials(source.getCredentials());
+    LoadBalancerMigrator.LoadBalancerLocation targetLocation = new LoadBalancerMigrator.LoadBalancerLocation(target);
+    if (loadBalancerNameMapping.containsKey(lbName)) {
+      targetLocation.setName(loadBalancerNameMapping.get(lbName));
+    }
     return new LoadBalancerMigrator(sourceLookup, targetLookup, getAmazonClientProvider(), getRegionScopedProviderFactory(),
       migrateSecurityGroupStrategy, getDeployDefaults(), getMigrateLoadBalancerStrategy, sourceLocation,
-      new LoadBalancerMigrator.LoadBalancerLocation(target), elbSubnetType, source.getApplication(), allowIngressFromClassic).migrate(dryRun);
+      targetLocation, elbSubnetType, source.getApplication(), allowIngressFromClassic).migrate(dryRun);
   }
 
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerResult.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerResult.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.MigrateSec
 class MigrateLoadBalancerResult {
   List<MigrateSecurityGroupResult> securityGroups = []
   boolean targetExists
+  boolean newNameRequired
   String targetName
   List<String> warnings = []
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ClusterConfigurationMigrator.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ClusterConfigurationMigrator.java
@@ -47,6 +47,7 @@ public class ClusterConfigurationMigrator {
   private String keyPair;
   private String subnetType;
   private String elbSubnetType;
+  private Map<String, String> loadBalancerNameMapping;
   private boolean allowIngressFromClassic;
 
   public ClusterConfigurationMigrator(MigrateClusterConfigurationStrategy migrationStrategy,
@@ -55,6 +56,7 @@ public class ClusterConfigurationMigrator {
                                       MigrateLoadBalancerStrategy migrateLoadBalancerStrategy,
                                       MigrateSecurityGroupStrategy migrateSecurityGroupStrategy,
                                       String iamRole, String keyPair, String subnetType, String elbSubnetType,
+                                      Map<String, String> loadBalancerNameMapping,
                                       boolean allowIngressFromClassic) {
     this.migrationStrategy = migrationStrategy;
     this.source = source;
@@ -67,13 +69,14 @@ public class ClusterConfigurationMigrator {
     this.keyPair = keyPair;
     this.subnetType = subnetType;
     this.elbSubnetType = elbSubnetType;
+    this.loadBalancerNameMapping = loadBalancerNameMapping;
     this.allowIngressFromClassic = allowIngressFromClassic;
   }
 
   public MigrateClusterConfigurationResult migrate(boolean dryRun) {
     getTask().updateStatus(BASE_PHASE, (dryRun ? "Calculating" : "Beginning") + " migration of cluster config " + source.toString());
     MigrateClusterConfigurationResult result = migrationStrategy.generateResults(source, target, sourceLookup, targetLookup, migrateLoadBalancerStrategy,
-      migrateSecurityGroupStrategy, subnetType, elbSubnetType, iamRole, keyPair, allowIngressFromClassic, dryRun);
+      migrateSecurityGroupStrategy, subnetType, elbSubnetType, iamRole, keyPair, loadBalancerNameMapping, allowIngressFromClassic, dryRun);
     getTask().updateStatus(BASE_PHASE, "Migration of cluster configuration " + source.toString() +
       (dryRun ? " calculated" : " completed") + ".");
     return result;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateClusterConfigurationsAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateClusterConfigurationsAtomicOperation.groovy
@@ -118,7 +118,7 @@ class MigrateClusterConfigurationsAtomicOperation implements AtomicOperation<Voi
         def migrator = new ClusterConfigurationMigrator(migrationStrategy.get(), source, target,
           sourceLookup, targetLookup,
           migrateLoadBalancerStrategy.get(), migrateSecurityGroupStrategy.get(), iamRole, keyPair, subnetType,
-          elbSubnetType, description.allowIngressFromClassic)
+          elbSubnetType, description.loadBalancerNameMapping, description.allowIngressFromClassic)
 
         results.add(migrator.migrate(description.dryRun))
       }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupAtomicOperation.groovy
@@ -64,7 +64,7 @@ class MigrateServerGroupAtomicOperation implements AtomicOperation<Void> {
     def migrator = new ServerGroupMigrator(migrationStrategy.get(), description.source, description.target,
       sourceLookup, targetLookup, migrateLoadBalancerStrategy.get(), migrateSecurityGroupStrategy.get(),
       description.subnetType, description.elbSubnetType, description.iamRole, description.keyPair,
-      description.targetAmi, description.allowIngressFromClassic)
+      description.targetAmi, description.loadBalancerNameMapping, description.allowIngressFromClassic)
 
     task.addResultObjects([migrator.migrate(description.dryRun)])
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ServerGroupMigrator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/ServerGroupMigrator.groovy
@@ -45,6 +45,7 @@ class ServerGroupMigrator {
   String subnetType
   String elbSubnetType
   String targetAmi
+  Map<String, String> loadBalancerNameMapping
   boolean allowIngressFromClassic
 
   ServerGroupMigrator(MigrateServerGroupStrategy migrationStrategy,
@@ -59,6 +60,7 @@ class ServerGroupMigrator {
                       String iamRole,
                       String keyPair,
                       String targetAmi,
+                      Map<String, String> loadBalancerNameMapping,
                       boolean allowIngressFromClassic) {
 
     this.migrationStrategy = migrationStrategy
@@ -73,6 +75,7 @@ class ServerGroupMigrator {
     this.subnetType = subnetType
     this.elbSubnetType = elbSubnetType
     this.targetAmi = targetAmi
+    this.loadBalancerNameMapping = loadBalancerNameMapping
     this.allowIngressFromClassic = allowIngressFromClassic
   }
 
@@ -80,7 +83,7 @@ class ServerGroupMigrator {
     task.updateStatus BASE_PHASE, (dryRun ? "Calculating" : "Beginning") + " migration of server group " + source.toString()
     MigrateServerGroupResult results = migrationStrategy.generateResults(source, target, sourceLookup, targetLookup,
       migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, subnetType, elbSubnetType, iamRole, keyPair, targetAmi,
-      allowIngressFromClassic, dryRun)
+      loadBalancerNameMapping, allowIngressFromClassic, dryRun)
     task.updateStatus BASE_PHASE, "Migration of server group " + source.toString() +
       (dryRun ? " calculated" : " completed") + ". Migrated server group name: " + results.serverGroupNames.get(0)
     results

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateClusterConfigurationStrategySpec.groovy
@@ -84,7 +84,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'external', 'external', 'newIamRole', 'newKeyPair', false, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'external', 'external', 'newIamRole', 'newKeyPair', [:], false, true)
 
     then:
     results.loadBalancerMigrations.empty
@@ -112,7 +112,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, null, false, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, null, [:], false, true)
 
     then:
     results.loadBalancerMigrations.size() == 2
@@ -152,7 +152,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, null, false, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, null, [:], false, false)
 
     then:
     results.securityGroupMigrations.size() == 3
@@ -182,7 +182,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, null, false, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, null, [:], false, false)
 
     then:
     results.cluster.securityGroups == ['sg-1a']
@@ -213,7 +213,7 @@ class MigrateClusterConfigurationStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, null, false, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, null, null, null, null, [:], false, true)
 
     then:
     results.cluster.securityGroups == ['sg-1a']

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategySpec.groovy
@@ -104,7 +104,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, false, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, [:], false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -152,7 +152,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, false, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, [:], false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -198,7 +198,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, false, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, [:], false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -236,7 +236,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, false, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, [:], false, true)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -274,7 +274,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, false, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, [:], false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -305,7 +305,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, false, false)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, [:], false, false)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling
@@ -335,7 +335,7 @@ class MigrateServerGroupStrategySpec extends Specification {
 
     when:
     def results = strategy.generateResults(source, target, sourceLookup, targetLookup,
-      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, false, true)
+      migrateLoadBalancerStrategy, migrateSecurityGroupStrategy, 'internal', 'external', null, null, null, [:], false, true)
 
     then:
     amazonClientProvider.getAutoScaling(testCredentials, 'us-east-1', true) >> amazonAutoScaling

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/MigrateClusterConfigurationsAtomicOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/MigrateClusterConfigurationsAtomicOperationSpec.groovy
@@ -167,13 +167,13 @@ class MigrateClusterConfigurationsAtomicOperationSpec extends Specification {
     then:
     1 * clusterMigrateStrategy.generateResults(source1, {
       it.region == 'us-east-1' && it.credentials == testCredentials && it.vpcId == 'vpc-test'
-    }, lookup, lookup, _, _, 'internal', 'external', 'iam', 'kp-1', false, false) >> new MigrateClusterConfigurationResult()
+    }, lookup, lookup, _, _, 'internal', 'external', 'iam', 'kp-1', [:], false, false) >> new MigrateClusterConfigurationResult()
     1 * clusterMigrateStrategy.generateResults(source2, {
       it.region == 'us-east-1' && it.credentials == prodCredentials && it.vpcId == 'vpc-prod'
-    }, lookup, lookup, _, _, 'internal', 'external', 'iam2', 'kp-2', false, false) >> new MigrateClusterConfigurationResult()
+    }, lookup, lookup, _, _, 'internal', 'external', 'iam2', 'kp-2', [:], false, false) >> new MigrateClusterConfigurationResult()
     1 * clusterMigrateStrategy.generateResults(source3, {
       it.region == 'us-east-1' && it.credentials == prodCredentials && it.vpcId == 'vpc-prod'
-    }, lookup, lookup, _, _, 'internal', 'external', 'iam3', 'kp-3', false, false) >> new MigrateClusterConfigurationResult()
+    }, lookup, lookup, _, _, 'internal', 'external', 'iam3', 'kp-3', [:], false, false) >> new MigrateClusterConfigurationResult()
     task.resultObjects.size() == 3
   }
 }


### PR DESCRIPTION
Some enhancements around migrating load balancers here:
 * if migrating to VPC and the target name already exists in non-VPC, warn the user if it's a dry run, fail the migration if it's not
 * allow users to send in a mapping of load balancer names and use that (if present) when building new load balancers

Both these changes will involve some UI work to make them really usable, but should make for a slightly better experience in migrations, especially if folks want to clean up the names of their old load balancers.