### PR TITLE
Kubernetes : Return images for project clusters

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectController.groovy
@@ -198,7 +198,8 @@ class ProjectController {
               host: host,
               job: job,
               buildNumber: buildNumber,
-              deployed: serverGroup.createdTime)
+              deployed: serverGroup.createdTime,
+              images: serverGroup.imageSummary?.buildInfo?.images)
         } else {
           existingBuild.deployed = Math.max(existingBuild.deployed, serverGroup.createdTime)
         }
@@ -222,6 +223,7 @@ class ProjectController {
     String job
     String buildNumber
     Long deployed
+    List images
   }
 
 


### PR DESCRIPTION
This is to return images for the project clusters call so that the projects cluster directive can be updated with images from Kubernetes.  Please see [#1047](https://github.com/spinnaker/spinnaker/issues/1047).