### PR TITLE
provider/amazon: send attributes when migrating load balancers

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateLoadBalancerStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateLoadBalancerStrategy.java
@@ -187,8 +187,10 @@ public abstract class MigrateLoadBalancerStrategy implements MigrateStrategySupp
       .getAmazonElasticLoadBalancing(target.getCredentials(), target.getRegion(), true);
     if (targetLoadBalancer == null) {
       boolean isInternal = subnetType == null || subnetType.contains("internal");
+      LoadBalancerAttributes sourceAttributes = sourceClient.describeLoadBalancerAttributes(
+        new DescribeLoadBalancerAttributesRequest().withLoadBalancerName(source.getName())).getLoadBalancerAttributes();
       LoadBalancerUpsertHandler.createLoadBalancer(
-        targetClient, targetName, isInternal, target.getAvailabilityZones(), subnetIds, listeners, securityGroups);
+        targetClient, targetName, isInternal, target.getAvailabilityZones(), subnetIds, listeners, securityGroups, sourceAttributes);
       configureHealthCheck(targetClient, sourceLoadBalancer, targetName);
     } else {
       LoadBalancerUpsertHandler.updateLoadBalancer(targetClient, targetLoadBalancer, listeners, securityGroups);

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerStrategySpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/MigrateLoadBalancerStrategySpec.groovy
@@ -25,6 +25,7 @@ import com.amazonaws.services.ec2.model.Tag
 import com.amazonaws.services.ec2.model.Vpc
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
 import com.amazonaws.services.elasticloadbalancing.model.CreateLoadBalancerResult
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancerAttributesResult
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancerPoliciesResult
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
 import com.amazonaws.services.elasticloadbalancing.model.HealthCheck
@@ -265,6 +266,7 @@ class MigrateLoadBalancerStrategySpec extends Specification {
     amazonClientProvider.getAmazonElasticLoadBalancing(prodCredentials, 'eu-west-1', true) >> targetLoadBalancing
     regionScopedProviderFactory.forRegion(prodCredentials, 'eu-west-1') >> regionProvider
     1 * loadBalancing.describeLoadBalancers(_) >> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(sourceDescription)
+    1 * loadBalancing.describeLoadBalancerAttributes(_) >> new DescribeLoadBalancerAttributesResult()
     1 * targetLoadBalancing.describeLoadBalancers(_) >> null
     1 * loadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
     1 * targetLoadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
@@ -329,6 +331,7 @@ class MigrateLoadBalancerStrategySpec extends Specification {
     amazonClientProvider.getAmazonElasticLoadBalancing(prodCredentials, 'eu-west-1', true) >> targetLoadBalancing
 
     1 * targetLoadBalancing.createLoadBalancer({it.securityGroups == ['sg-1b', 'sg-elb']}) >> new CreateLoadBalancerResult().withDNSName('new-elb-dns')
+    1 * loadBalancing.describeLoadBalancerAttributes(_) >> new DescribeLoadBalancerAttributesResult()
     1 * loadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
     1 * targetLoadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
   }
@@ -370,6 +373,7 @@ class MigrateLoadBalancerStrategySpec extends Specification {
     1 * loadBalancing.describeLoadBalancers(_) >> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(sourceDescription)
     1 * targetLoadBalancing.createLoadBalancer(_) >> new CreateLoadBalancerResult().withDNSName('new-elb-dns')
     1 * targetLoadBalancing.configureHealthCheck(_)
+    1 * loadBalancing.describeLoadBalancerAttributes(_) >> new DescribeLoadBalancerAttributesResult()
     1 * loadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
     1 * targetLoadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
     2 * targetLookup.getSecurityGroupByName(prodCredentials.name, 'classic-link', 'vpc-2') >> Optional.of(new SecurityGroupUpdater(classicGroup, amazonEC2))
@@ -450,6 +454,7 @@ class MigrateLoadBalancerStrategySpec extends Specification {
     1 * loadBalancing.describeLoadBalancers({ it.loadBalancerNames == ['newapp-elb']}) >> new DescribeLoadBalancersResult()
     1 * loadBalancing.createLoadBalancer({ it.loadBalancerName == 'newapp-elb'}) >> new CreateLoadBalancerResult().withDNSName('new-elb-dns')
     1 * loadBalancing.configureHealthCheck(_)
+    1 * loadBalancing.describeLoadBalancerAttributes(_) >> new DescribeLoadBalancerAttributesResult()
     2 * loadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
     0 * amazonEC2.authorizeSecurityGroupIngress(_)
   }
@@ -478,6 +483,7 @@ class MigrateLoadBalancerStrategySpec extends Specification {
     1 * loadBalancing.describeLoadBalancers({ it.loadBalancerNames == ['app-elb']}) >> new DescribeLoadBalancersResult()
     1 * loadBalancing.createLoadBalancer({ it.loadBalancerName == 'app-elb'}) >> new CreateLoadBalancerResult().withDNSName('new-elb-dns')
     1 * loadBalancing.configureHealthCheck(_)
+    1 * loadBalancing.describeLoadBalancerAttributes(_) >> new DescribeLoadBalancerAttributesResult()
     2 * loadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
     0 * amazonEC2.authorizeSecurityGroupIngress(_)
   }
@@ -514,6 +520,7 @@ class MigrateLoadBalancerStrategySpec extends Specification {
       it.healthCheck.unhealthyThreshold == 4 &&
       it.healthCheck.timeout == 5
     })
+    1 * loadBalancing.describeLoadBalancerAttributes(_) >> new DescribeLoadBalancerAttributesResult()
     1 * loadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
     1 * targetLoadBalancing.describeLoadBalancerPolicies(_) >> new DescribeLoadBalancerPoliciesResult()
   }


### PR DESCRIPTION
Connection draining, idle timeout, access logs, and other fancy configuration settings that need to come along for the ride on a migration.

@cfieber PTAL