### PR TITLE
provider/google: Drop .with construct since it was causing on-demand …

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -495,11 +495,8 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
     @Override
     void onSuccess(Autoscaler autoscaler, HttpHeaders responseHeaders) throws IOException {
       serverGroup.autoscalingPolicy = autoscaler.getAutoscalingPolicy()
-
-      serverGroup.autoscalingPolicy.with {
-        serverGroup.asg.minSize = minNumReplicas
-        serverGroup.asg.maxSize = maxNumReplicas
-      }
+      serverGroup.asg.minSize = serverGroup.autoscalingPolicy.minNumReplicas
+      serverGroup.asg.maxSize = serverGroup.autoscalingPolicy.maxNumReplicas
     }
   }
 
@@ -521,11 +518,8 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
 
             if (serverGroup) {
               serverGroup.autoscalingPolicy = autoscaler.getAutoscalingPolicy()
-
-              serverGroup.autoscalingPolicy.with {
-                serverGroup.asg.minSize = minNumReplicas
-                serverGroup.asg.maxSize = maxNumReplicas
-              }
+              serverGroup.asg.minSize = serverGroup.autoscalingPolicy.minNumReplicas
+              serverGroup.asg.maxSize = serverGroup.autoscalingPolicy.maxNumReplicas
             }
           }
         }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
@@ -614,11 +614,8 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
     @Override
     void onSuccess(Autoscaler autoscaler, HttpHeaders responseHeaders) throws IOException {
       serverGroup.autoscalingPolicy = autoscaler.getAutoscalingPolicy()
-
-      serverGroup.autoscalingPolicy.with {
-        serverGroup.asg.minSize = minNumReplicas
-        serverGroup.asg.maxSize = maxNumReplicas
-      }
+      serverGroup.asg.minSize = serverGroup.autoscalingPolicy.minNumReplicas
+      serverGroup.asg.maxSize = serverGroup.autoscalingPolicy.maxNumReplicas
     }
   }
 
@@ -641,11 +638,8 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
 
             if (serverGroup) {
               serverGroup.autoscalingPolicy = autoscaler.getAutoscalingPolicy()
-
-              serverGroup.autoscalingPolicy.with {
-                serverGroup.asg.minSize = minNumReplicas
-                serverGroup.asg.maxSize = maxNumReplicas
-              }
+              serverGroup.asg.minSize = serverGroup.autoscalingPolicy.minNumReplicas
+              serverGroup.asg.maxSize = serverGroup.autoscalingPolicy.maxNumReplicas
             }
           }
         }


### PR DESCRIPTION
…update to fail.