### PR TITLE
provider/google: handle null backend list in L7 caching agent.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -384,7 +384,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
               serverGroupUrl: backend.group,
               policy: GCEUtil.loadBalancingPolicyFromBackend(backend)
           )
-        }
+        } ?: []
       }
 
       backendService.backends?.each { Backend backend ->


### PR DESCRIPTION
@lwander PTAL, @duftler FYI.