### PR TITLE
provider/amazon: apply correct vpcId to ingress rules

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProvider.groovy
@@ -201,7 +201,7 @@ class AmazonSecurityGroupProvider implements SecurityGroupProvider<AmazonSecurit
               accountId: sg.userId,
               accountName: ingressAccount?.name,
               region: region,
-              vpcId: ingressGroupSummary.vpcId
+              vpcId: sg.vpcId ?: ingressGroupSummary.vpcId
             ),
           portRanges   : [] as SortedSet
         ])


### PR DESCRIPTION
@cfieber we're caching an invalid value for ingress rules in accounts not managed by spinnaker