### PR TITLE
provider/cf: Scan all load balancers when looking for a match

### DIFF
--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/cache/CacheUtils.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/cache/CacheUtils.groovy
@@ -127,7 +127,7 @@ class CacheUtils {
       loadBalancers.find { it.name == route }
     }
 
-    serverGroup.disabled = !serverGroup.nativeApplication.uris?.findResult { uri ->
+    serverGroup.disabled = !serverGroup.nativeApplication.uris?.findResults { uri ->
       def lbs = serverGroup.nativeLoadBalancers.collect { loadBalancer ->
         (loadBalancer?.nativeRoute?.name) ? loadBalancer.nativeRoute.name : ''
       }


### PR DESCRIPTION
PCF and PWS sort routes in opposite orders. When searching for a matching load balancer, it's important to search ALL routes instead of just the first, to avoid a miss.