### PR TITLE
provider/amazon: verify sequence exists in AWS and cluster provider w…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AWSServerGroupNameResolver.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AWSServerGroupNameResolver.groovy
@@ -64,7 +64,7 @@ class AWSServerGroupNameResolver extends AbstractServerGroupNameResolver {
       return []
     }
 
-    def serverGroupsInRegion = cluster.serverGroups.findAll { it.region == region }
+    def serverGroupsInRegion = cluster.serverGroups.findAll { it.region == region && asgService.getAutoScalingGroup(it.name) }
     return serverGroupsInRegion.collect {
       new AbstractServerGroupNameResolver.TakenSlot(
         serverGroupName: it.name,

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
@@ -100,6 +100,7 @@ class AutoScalingWorkerUnitSpec extends Specification {
         sG('myasg-v011', 0, 'us-east-1'), sG('myasg-v099', 1, 'us-west-1')
       ])
     }
+    1 * asgService.getAutoScalingGroup('myasg-v011') >> { new AutoScalingGroup() }
     1 * asgService.getAutoScalingGroup('myasg-v012') >> { new AutoScalingGroup() }
     1 * asgService.getAutoScalingGroup('myasg-v013') >> { null }
     0 * _


### PR DESCRIPTION
…hen generating next number

Should guard against stale cache data (at least on the clouddriver side - Edda could possibly still have stale data) when generating the next sequence number for an ASG.