### PR TITLE
Kubernetes : Return only image:tag for clusters and projects

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -108,6 +108,10 @@ class KubernetesUtil {
     "$registry/$repository:$tag".toString()
   }
 
+  static getImageIdWithoutRegistry(KubernetesImageDescription image) {
+    "$image.repository:$image.tag".toString()
+  }
+
   static String validateNamespace(KubernetesCredentials credentials, String namespace) {
     def resolvedNamespace = namespace ?: "default"
     if (!credentials.isRegisteredNamespace(resolvedNamespace)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -151,7 +151,7 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
 
       def imageList = []
       for (def container : serverGroup.deployDescription.containers) {
-        imageList.add(KubernetesUtil.getImageId(container.imageDescription))
+        imageList.add(KubernetesUtil.getImageIdWithoutRegistry(container.imageDescription))
       }
       Map buildInfo = [images: imageList]
       serverGroup.buildInfo = buildInfo


### PR DESCRIPTION
Update images by removing registry based on conversation in [deck #2530](https://github.com/spinnaker/deck/pull/2530).  