### PR TITLE
reworks ingress rule matching for UpsertSecurityGroupAtomicOperation

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
@@ -42,30 +42,68 @@ class SecurityGroupIngressConverter {
         ipRanges: [ingress.cidr])
     }
     description.securityGroupIngress.each { ingress ->
-      final accountName = ingress.accountName ?: description.credentialAccount
-      final accountId = ingress.accountId ?: securityGroupLookup.getAccountIdForName(accountName)
-      final vpcId = ingress.vpcId ?: description.vpcId
-      def newUserIdGroupPair = null
-      if (ingress.id) {
-        newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupId: ingress.id, vpcId: ingress.vpcId)
+      // When converting ingress we require that we can resolve the accountId for that ingress.
+      // This means it either has to be explicitly provided (in which case we prefer it, and use
+      // it to attempt to look up accountName) or it has to be an accountName that Spinnaker
+      // knows about, in which case we will use that to find the accountId.
+      //
+      // Not finding the name is ok - it means we are dealing with a cross account ingress to
+      // an account Spinnaker does not manage, but it does mean that the ingress permission also
+      // has to include all the required fields (either name for ec2 classic, or vpcId + groupId
+      // for ec2-vpc) because we can't look up the group to determine those values
+
+      String accountId = null
+      String accountName = null
+      if (ingress.accountId) {
+        accountId = ingress.accountId
+        accountName = securityGroupLookup.accountIdExists(accountId) ? securityGroupLookup.getAccountNameForId(accountId) : null
       } else {
-          final ingressSecurityGroup = securityGroupLookup.getSecurityGroupByName(accountName, ingress.name, vpcId)
-          if (ingressSecurityGroup.present) {
-            final groupId = ingressSecurityGroup.get().getSecurityGroup().groupId
-            newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupId: groupId, vpcId: ingress.vpcId)
-          } else {
-            if (description.vpcId) {
-              missing.add(ingress)
-            } else {
-              newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupName: ingress.name)
-            }
-          }
+        def creds = securityGroupLookup.getCredentialsForName(ingress.accountName ?: description.credentialAccount)
+        if (creds) {
+          accountName = creds.name
+          accountId = creds.accountId
+        }
       }
 
-      if (newUserIdGroupPair) {
-        def newIpPermission = new IpPermission(ipProtocol: ingress.ipProtocol, fromPort: ingress.startPort,
-          toPort: ingress.endPort, userIdGroupPairs: [newUserIdGroupPair])
-        ipPermissions.add(newIpPermission)
+      if (!accountId) {
+        missing.add(ingress)
+      } else {
+        final groupVpcId = description.vpcId
+        //when the ingress permission references a security group in the same vpc, the UserIdGroupPair has it as null
+        final ingressVpcId = ingress.vpcId == groupVpcId ? null : ingress.vpcId
+        def newUserIdGroupPair = null
+        if (ingress.id) {
+          newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupId: ingress.id, vpcId: ingressVpcId)
+        } else {
+          //we need name at this point to try to resolve id
+          if (!ingress.name) {
+            missing.add(ingress)
+          } else {
+            Optional<SecurityGroupLookupFactory.SecurityGroupUpdater> ingressSecurityGroup = accountName ?
+              securityGroupLookup.getSecurityGroupByName(accountName, ingress.name, ingressVpcId ?: groupVpcId) :
+              Optional.empty()
+
+            if (ingressSecurityGroup.present) {
+              final groupId = ingressSecurityGroup.get().getSecurityGroup().groupId
+              newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupId: groupId, vpcId: ingressVpcId)
+            } else {
+              //if we are in vpc, then we need to have resolved the name to id
+              if (groupVpcId) {
+                missing.add(ingress)
+              } else {
+                //in ec2 classic we can use accountId+name to grant permission. this could be valid for
+                // specifing a group in an account spinnaker doesn't manage
+                newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupName: ingress.name)
+              }
+            }
+          }
+        }
+
+        if (newUserIdGroupPair) {
+          def newIpPermission = new IpPermission(ipProtocol: ingress.ipProtocol, fromPort: ingress.startPort,
+            toPort: ingress.endPort, userIdGroupPairs: [newUserIdGroupPair])
+          ipPermissions.add(newIpPermission)
+        }
       }
     }
     new ConvertedIngress(ipPermissions, missing)
@@ -75,9 +113,6 @@ class SecurityGroupIngressConverter {
     Collection<IpPermission> ipPermissions = securityGroup.ipPermissions
     ipPermissions.collect { IpPermission ipPermission ->
       ipPermission.userIdGroupPairs.collect {
-        it.groupName = null
-        it.peeringStatus = null
-        it.vpcPeeringConnectionId = null
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
@@ -20,19 +20,16 @@ import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.ec2.model.IpPermission
 import com.amazonaws.services.ec2.model.SecurityGroup
 import com.amazonaws.services.ec2.model.UserIdGroupPair
+import com.netflix.spinnaker.clouddriver.aws.TestCredential
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription.IpIngress
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription.SecurityGroupIngress
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupUpdater
-import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.UpsertSecurityGroupAtomicOperation
-import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription.SecurityGroupIngress
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription.IpIngress
 import spock.lang.Specification
 import spock.lang.Subject
-
-import javax.swing.text.html.Option
 
 class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
   def setupSpec() {
@@ -76,8 +73,81 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     0 * _
   }
 
+  void "ingress minimally requires an accountId and security group id"() {
+    final createdSecurityGroup = Mock(SecurityGroupUpdater)
+    description.securityGroupIngress = [
+      new SecurityGroupIngress(id: "id-bar", accountName: "prod", accountId: "accountId2", name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp", vpcId: "vpc-456")
+    ]
+
+    when:
+    op.operate([])
+
+    then:
+    1 * securityGroupLookup.accountIdExists("accountId2") >> false
+
+    then:
+    1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.empty()
+    1 * securityGroupLookup.createSecurityGroup(description) >> createdSecurityGroup
+    1 * createdSecurityGroup.getSecurityGroup()
+
+    then:
+    1 * createdSecurityGroup.addIngress([
+      new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
+        new UserIdGroupPair(userId: "accountId2", groupId: "id-bar", vpcId: "vpc-456")
+      ])
+    ])
+    0 * _
+  }
+
+  void "ingress by group name requires a known account id"() {
+    final createdSecurityGroup = Mock(SecurityGroupUpdater)
+    description.securityGroupIngress = [
+      new SecurityGroupIngress(accountName: "prod", accountId: "accountId2", name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp", vpcId: "vpc-456")
+    ]
+
+    when:
+    op.operate([])
+
+    then:
+    1 * securityGroupLookup.accountIdExists("accountId2") >> true
+    1 * securityGroupLookup.getAccountNameForId("accountId2") >> "prod"
+    1 * securityGroupLookup.getSecurityGroupByName("prod", "bar", "vpc-456") >> Optional.of(new SecurityGroupUpdater(
+      new SecurityGroup(groupId: "id-bar"),
+      null
+    ))
+
+    then:
+    1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.empty()
+    1 * securityGroupLookup.createSecurityGroup(description) >> createdSecurityGroup
+    1 * createdSecurityGroup.getSecurityGroup()
+
+    then:
+    1 * createdSecurityGroup.addIngress([
+      new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
+        new UserIdGroupPair(userId: "accountId2", groupId: "id-bar", vpcId: "vpc-456")
+      ])
+    ])
+    0 * _
+
+  }
+
+  void "ingress by group name fails with unknown account id"() {
+    description.securityGroupIngress = [
+      new SecurityGroupIngress(accountName: "prod", accountId: "accountId2", name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp", vpcId: "vpc-456")
+    ]
+
+    when:
+    op.operate([])
+
+    then:
+    1 * securityGroupLookup.accountIdExists("accountId2") >> false
+    thrown(IllegalStateException)
+  }
+
+
   void "non-existent security group should be created with ingress"() {
     final createdSecurityGroup = Mock(SecurityGroupUpdater)
+    final testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -86,7 +156,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(new SecurityGroupUpdater(
       new SecurityGroup(groupId: "id-bar"),
       null
@@ -102,7 +172,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * createdSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
       ])
     ])
     0 * _
@@ -110,6 +180,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "non-existent security group that is found on create should be updated"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
+    def testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp"),
       new SecurityGroupIngress(name: "bar", startPort: 211, endPort: 212, ipProtocol: "tcp")
@@ -119,7 +190,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    2 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    2 * securityGroupLookup.getCredentialsForName("test") >> testCred
     2 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(new SecurityGroupUpdater(
       new SecurityGroup(groupId: "id-bar"),
       null
@@ -137,15 +208,15 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     }
     1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.of(existingSecurityGroup)
     1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(ipPermissions: [
-            new IpPermission(fromPort: 211, toPort: 212, ipProtocol: "tcp", userIdGroupPairs: [
-                    new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
-            ])
+      new IpPermission(fromPort: 211, toPort: 212, ipProtocol: "tcp", userIdGroupPairs: [
+        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+      ])
     ])
 
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
       ])
     ])
     0 * _
@@ -163,6 +234,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "existing security group should be updated with ingress by name"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
+    def testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -171,7 +243,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >>
       Optional.of(new SecurityGroupUpdater(new SecurityGroup(groupId: "id-bar"), null))
 
@@ -182,7 +254,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
       ])
     ])
     0 * _
@@ -190,6 +262,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "existing security group should be updated with ingress by id"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
+    def testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(id: "id-bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -198,7 +271,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
 
     then:
     1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.of(existingSecurityGroup)
@@ -207,7 +280,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
       ])
     ])
     0 * _
@@ -215,6 +288,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "existing security group should be updated with ingress from another account"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
+    def prodCred = TestCredential.named("prod")
     description.securityGroupIngress = [
       new SecurityGroupIngress(accountName: "prod", name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -223,7 +297,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getAccountIdForName("prod") >> "accountId2"
+    1 * securityGroupLookup.getCredentialsForName("prod") >> prodCred
     1 * securityGroupLookup.getSecurityGroupByName("prod", "bar", "vpc-123") >>
       Optional.of(new SecurityGroupUpdater(new SecurityGroup(groupId: "id-bar"), null))
 
@@ -234,7 +308,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId2", groupId: "id-bar")
+        new UserIdGroupPair(userId: prodCred.accountId, groupId: "id-bar")
       ])
     ])
     0 * _
@@ -242,6 +316,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "existing permissions should not be re-created when a security group is modified"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
+    def testCred = TestCredential.named("test")
 
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp"),
@@ -256,7 +331,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    3 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    3 * securityGroupLookup.getCredentialsForName("test") >> testCred
     3 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(new SecurityGroupUpdater(
       new SecurityGroup(groupId: "id-bar"),
       null
@@ -265,26 +340,26 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.of(existingSecurityGroup)
     1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", ipPermissions: [
-        new IpPermission(fromPort: 80, toPort: 81,
-          userIdGroupPairs: [
-            new UserIdGroupPair(userId: "accountId1", groupId: "grp"),
-            new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
-          ],
-          ipRanges: ["10.0.0.1/32"], ipProtocol: "tcp"
-        ),
-        new IpPermission(fromPort: 25, toPort: 25,
-          userIdGroupPairs: [new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")], ipProtocol: "tcp"),
-      ])
+      new IpPermission(fromPort: 80, toPort: 81,
+        userIdGroupPairs: [
+          new UserIdGroupPair(userId: testCred.accountId, groupId: "grp"),
+          new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+        ],
+        ipRanges: ["10.0.0.1/32"], ipProtocol: "tcp"
+      ),
+      new IpPermission(fromPort: 25, toPort: 25,
+        userIdGroupPairs: [new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")], ipProtocol: "tcp"),
+    ])
 
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
       ])
     ])
     1 * existingSecurityGroup.removeIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 80, toPort: 81, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupId: "grp")
+        new UserIdGroupPair(userId: testCred.accountId, groupId: "grp")
       ])
     ])
     0 * _
@@ -292,6 +367,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "should only append security group ingress"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
+    def testCred = TestCredential.named("test")
 
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp"),
@@ -304,7 +380,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    3 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    3 * securityGroupLookup.getCredentialsForName("test") >> testCred
     3 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(new SecurityGroupUpdater(
       new SecurityGroup(groupId: "id-bar"),
       null
@@ -315,25 +391,26 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", ipPermissions: [
       new IpPermission(fromPort: 80, toPort: 81,
         userIdGroupPairs: [
-          new UserIdGroupPair(userId: "accountId1", groupId: "grp"),
-          new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+          new UserIdGroupPair(userId: testCred.accountId, groupId: "grp"),
+          new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
         ],
         ipRanges: ["10.0.0.1/32"], ipProtocol: "tcp"
       ),
       new IpPermission(fromPort: 25, toPort: 25,
-        userIdGroupPairs: [new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")], ipProtocol: "tcp"),
+        userIdGroupPairs: [new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")], ipProtocol: "tcp"),
     ])
 
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
       ])
     ])
     0 * _
   }
 
   void "should fail for missing ingress security group in vpc"() {
+    def testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -342,7 +419,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.empty()
     0 * _
 
@@ -352,6 +429,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
   }
 
   void "should add ingress by name for missing ingress security group in EC2 classic"() {
+    def testCred = TestCredential.named("test")
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
@@ -362,7 +440,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", null) >> Optional.empty()
 
     then:
@@ -373,36 +451,92 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupName: "bar")
+        new UserIdGroupPair(userId: testCred.accountId, groupName: "bar")
       ])
     ])
-
   }
 
   void "should ignore name, peering status, vpcPeeringConnectionId when comparing ingress rules"() {
+    def testCred = TestCredential.named("test")
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
     final ingressSecurityGroup = Mock(SecurityGroupUpdater)
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, vpcId: "vpc-123", ipProtocol: "tcp", accountName: "test")
     ]
-    description.vpcId = null
+    description.vpcId = "vpc-456"
 
     when:
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
+    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(ingressSecurityGroup)
 
     then:
-    1 * securityGroupLookup.getSecurityGroupByName("test", "foo", null) >> Optional.of(existingSecurityGroup)
+    1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-456") >> Optional.of(existingSecurityGroup)
     1 * ingressSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "bar", groupId: "124", vpcId: "vpc-123")
-    1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", vpcId: "vpc-123", ipPermissions: [
+    1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", vpcId: "vpc-456", ipPermissions: [
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId1", groupName: "baz", groupId: "124", vpcId: "vpc-123", vpcPeeringConnectionId: "pca", peeringStatus: "active")])
+        new UserIdGroupPair(userId: testCred.accountId, groupName: "baz", groupId: "124", vpcId: "vpc-123", vpcPeeringConnectionId: "pca", peeringStatus: "active")])
     ])
     0 * _
+  }
 
+  void "userIdGroupPair comparison"() {
+    expect:
+
+    UpsertSecurityGroupAtomicOperation.pairsEqual(pairsA, pairsB) == expected
+
+    where:
+    accountA | accountB | vpcIdA    | vpcIdB | idA   | idB   | nameA       | nameB       | expected
+    "1"      | "1"      | null      | null   | "sg1" | "sg1" | null        | null        | true
+    "1"      | null     | null      | null   | "sg1" | "sg1" | null        | null        | false
+    "1"      | "1"      | "vpc-foo" | null   | "sg1" | "sg1" | null        | null        | false
+    "1"      | "1"      | null      | null   | "sg1" | "sg1" | "dontCareA" | "dontCareB" | true
+    "1"      | "1"      | null      | null   | null  | "sg1" | null        | null        | false
+    "1"      | "1"      | null      | null   | null  | "sg1" | "foo"       | "foo"       | true
+
+    pairsA = [pair(idA, nameA, vpcIdA, accountA)]
+    pairsB = [pair(idB, nameB, vpcIdB, accountB)]
+  }
+
+  void "userIdGroupPair comparison collection size fails fast"() {
+    expect:
+
+    UpsertSecurityGroupAtomicOperation.pairsEqual(pairsA, pairsB) == expected
+
+    where:
+    pairsA           | pairsB                 | expected
+    [pair()]         | [pair()]               | true
+    [pair()]         | null                   | false
+    null             | null                   | true
+    []               | null                   | true
+    null             | []                     | true
+    []               | []                     | true
+    null             | [pair()]               | false
+    [pair(), pair()] | [pair(), pair()]       | true
+    [pair(), pair()] | [pair(), pair("asdf")] | false
+  }
+
+  UserIdGroupPair pair(String groupId = "sg-foo", String groupName = "foo", String vpcId = "vpc-foo", String userId = "account-foo") {
+    new UserIdGroupPair(groupId: groupId, groupName: groupName, vpcId: vpcId, userId: userId)
+  }
+
+  void "ranges comparison"() {
+    expect:
+    UpsertSecurityGroupAtomicOperation.rangesEqual(rangesA, rangesB) == expected
+
+    where:
+    rangesA      | rangesB      | expected
+    null         | null         | true
+    []           | []           | true
+    ["r1"]       | ["r1"]       | true
+    ["r1", "r2"] | ["r2", "r1"] | true
+    []           | null         | true
+    null         | []           | true
+    []           | ["r1"]       | false
+    ["r1"]       | []           | false
+    ["r1"]       | ["r2"]       | false
   }
 
 }


### PR DESCRIPTION
handles some potential edge cases in how an API request can come in, particularly around dealing with ingress from an unknown
account. reworks equality comparison on IpPermission to not depend on object level equality

@spinnaker/netflix-reviewers PTAL