### PR TITLE
provider/kubernetes: Unscheduled pods are "Down"

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesHealth.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesHealth.groovy
@@ -26,15 +26,28 @@ class KubernetesHealth implements Health {
   final String source
   final String type
   final String healthClass = "platform"
+  String description = ""
 
   KubernetesHealth(Pod pod) {
     source = "Pod"
     type = "KubernetesPod"
     def phase = pod.status.phase
-    state = phase == "Pending" ? HealthState.OutOfService :
-      phase == "Running" ? HealthState.Up :
-        phase == "Succeeded" ? HealthState.Succeeded :
-          phase == "Failed" ? HealthState.Failed : HealthState.Unknown
+
+    state = HealthState.Unknown
+    if (phase == "Pending") {
+      if (!pod.status.containerStatuses) {
+        description = pod.status?.conditions?.get(0)?.reason ?: "No containers scheduled"
+        state = HealthState.Down
+      } else {
+        state = HealthState.Unknown
+      }
+    } else if (phase == "Running") {
+      state = HealthState.Up
+    } else if (phase == "Succeeded") {
+      state = HealthState.Succeeded
+    } else if (phase == "Failed") {
+      state = HealthState.Failed
+    }
   }
 
   KubernetesHealth(String service, String enabled) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
@@ -127,13 +127,13 @@ class KubernetesInstanceSpec extends Specification {
       instance.healthState == HealthState.Up
   }
 
-  void "Should report pod state as OOS"() {
+  void "Should report pod state as Unscheduled"() {
     when:
       podStatusMock.getPhase() >> "Pending"
       def instance = new KubernetesInstance(podMock, [])
 
     then:
-      instance.healthState == HealthState.OutOfService
+      instance.healthState == HealthState.Down
   }
 
   void "Should report pod state as Unknown"() {


### PR DESCRIPTION
Written to address https://github.com/spinnaker/spinnaker/issues/1049

Unscheduled pods are now considered down, causing pipelines/stages depending on the deployment to hang until the pods are scheduled. Unfortunately the API doesn't seem to list the reason why a container couldn't be scheduled, but at least this behavior is now more correct.

@duftler 

![gjp4bsnbwtd](https://cloud.githubusercontent.com/assets/4874941/17866192/996ddd20-6873-11e6-8097-b4123480e6e0.png)
