### PR TITLE
Reverts changes to Amazon UpsertSecurityGroup pending regression investigation

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
@@ -42,68 +42,30 @@ class SecurityGroupIngressConverter {
         ipRanges: [ingress.cidr])
     }
     description.securityGroupIngress.each { ingress ->
-      // When converting ingress we require that we can resolve the accountId for that ingress.
-      // This means it either has to be explicitly provided (in which case we prefer it, and use
-      // it to attempt to look up accountName) or it has to be an accountName that Spinnaker
-      // knows about, in which case we will use that to find the accountId.
-      //
-      // Not finding the name is ok - it means we are dealing with a cross account ingress to
-      // an account Spinnaker does not manage, but it does mean that the ingress permission also
-      // has to include all the required fields (either name for ec2 classic, or vpcId + groupId
-      // for ec2-vpc) because we can't look up the group to determine those values
-
-      String accountId = null
-      String accountName = null
-      if (ingress.accountId) {
-        accountId = ingress.accountId
-        accountName = securityGroupLookup.accountIdExists(accountId) ? securityGroupLookup.getAccountNameForId(accountId) : null
+      final accountName = ingress.accountName ?: description.credentialAccount
+      final accountId = ingress.accountId ?: securityGroupLookup.getAccountIdForName(accountName)
+      final vpcId = ingress.vpcId ?: description.vpcId
+      def newUserIdGroupPair = null
+      if (ingress.id) {
+        newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupId: ingress.id, vpcId: ingress.vpcId)
       } else {
-        def creds = securityGroupLookup.getCredentialsForName(ingress.accountName ?: description.credentialAccount)
-        if (creds) {
-          accountName = creds.name
-          accountId = creds.accountId
-        }
-      }
-
-      if (!accountId) {
-        missing.add(ingress)
-      } else {
-        final groupVpcId = description.vpcId
-        //when the ingress permission references a security group in the same vpc, the UserIdGroupPair has it as null
-        final ingressVpcId = ingress.vpcId == groupVpcId ? null : ingress.vpcId
-        def newUserIdGroupPair = null
-        if (ingress.id) {
-          newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupId: ingress.id, vpcId: ingressVpcId)
-        } else {
-          //we need name at this point to try to resolve id
-          if (!ingress.name) {
-            missing.add(ingress)
+          final ingressSecurityGroup = securityGroupLookup.getSecurityGroupByName(accountName, ingress.name, vpcId)
+          if (ingressSecurityGroup.present) {
+            final groupId = ingressSecurityGroup.get().getSecurityGroup().groupId
+            newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupId: groupId, vpcId: ingress.vpcId)
           } else {
-            Optional<SecurityGroupLookupFactory.SecurityGroupUpdater> ingressSecurityGroup = accountName ?
-              securityGroupLookup.getSecurityGroupByName(accountName, ingress.name, ingressVpcId ?: groupVpcId) :
-              Optional.empty()
-
-            if (ingressSecurityGroup.present) {
-              final groupId = ingressSecurityGroup.get().getSecurityGroup().groupId
-              newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupId: groupId, vpcId: ingressVpcId)
+            if (description.vpcId) {
+              missing.add(ingress)
             } else {
-              //if we are in vpc, then we need to have resolved the name to id
-              if (groupVpcId) {
-                missing.add(ingress)
-              } else {
-                //in ec2 classic we can use accountId+name to grant permission. this could be valid for
-                // specifing a group in an account spinnaker doesn't manage
-                newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupName: ingress.name)
-              }
+              newUserIdGroupPair = new UserIdGroupPair(userId: accountId, groupName: ingress.name)
             }
           }
-        }
+      }
 
-        if (newUserIdGroupPair) {
-          def newIpPermission = new IpPermission(ipProtocol: ingress.ipProtocol, fromPort: ingress.startPort,
-            toPort: ingress.endPort, userIdGroupPairs: [newUserIdGroupPair])
-          ipPermissions.add(newIpPermission)
-        }
+      if (newUserIdGroupPair) {
+        def newIpPermission = new IpPermission(ipProtocol: ingress.ipProtocol, fromPort: ingress.startPort,
+          toPort: ingress.endPort, userIdGroupPairs: [newUserIdGroupPair])
+        ipPermissions.add(newIpPermission)
       }
     }
     new ConvertedIngress(ipPermissions, missing)
@@ -113,6 +75,9 @@ class SecurityGroupIngressConverter {
     Collection<IpPermission> ipPermissions = securityGroup.ipPermissions
     ipPermissions.collect { IpPermission ipPermission ->
       ipPermission.userIdGroupPairs.collect {
+        it.groupName = null
+        it.peeringStatus = null
+        it.vpcPeeringConnectionId = null
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -24,7 +24,6 @@ import com.amazonaws.services.ec2.model.Filter
 import com.amazonaws.services.ec2.model.IpPermission
 import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest
 import com.amazonaws.services.ec2.model.SecurityGroup
-import com.amazonaws.services.ec2.model.UserIdGroupPair
 import com.google.common.collect.ImmutableSet
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -211,7 +210,7 @@ class SecurityGroupLookupFactory {
         groupId: securityGroup.groupId,
         ipPermissions: ipPermissionsToAdd
       ))
-      securityGroup.ipPermissions.addAll(ipPermissionsToAdd.findResults(SecurityGroupLookupFactory.&cleanPermissionForApi))
+      securityGroup.ipPermissions.addAll(ipPermissionsToAdd)
     }
 
     void removeIngress(List<IpPermission> ipPermissionsToRemove) {
@@ -219,30 +218,9 @@ class SecurityGroupLookupFactory {
         groupId: securityGroup.groupId,
         ipPermissions: ipPermissionsToRemove
       ))
-      securityGroup.ipPermissions.removeAll(ipPermissionsToRemove.findResults(SecurityGroupLookupFactory.&cleanPermissionForApi))
+      securityGroup.ipPermissions.removeAll(ipPermissionsToRemove)
     }
 
   }
 
-  static IpPermission cleanPermissionForApi(IpPermission perm) {
-    if (perm == null) {
-      return null
-    }
-    return new IpPermission(
-      fromPort: perm.fromPort,
-      toPort: perm.toPort,
-      ipProtocol: perm.ipProtocol,
-      ipRanges: perm.ipRanges ? new ArrayList<String>(perm.ipRanges) : null,
-      userIdGroupPairs: perm.userIdGroupPairs?.collect {
-        def pair = new UserIdGroupPair(userId: it.userId, vpcId: it.vpcId)
-        if (it.groupId) {
-          pair.setGroupId(it.groupId)
-        } else if (it.groupName) {
-          pair.setGroupName(it.groupName)
-        } else {
-          throw new IllegalStateException("one of groupName or groupId is required")
-        }
-        return pair
-      } ?: null)
-  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperation.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup
 
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.ec2.model.IpPermission
-import com.amazonaws.services.ec2.model.UserIdGroupPair
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
@@ -89,8 +88,8 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
       }
     }
 
-    List<IpPermission> ipPermissionsToAdd = findMissing(ipPermissionsFromDescription.converted, existingIpPermissions)
-    List<IpPermission> ipPermissionsToRemove = findMissing(existingIpPermissions, ipPermissionsFromDescription.converted)
+    List<IpPermission> ipPermissionsToAdd = ipPermissionsFromDescription.converted - existingIpPermissions
+    List<IpPermission> ipPermissionsToRemove = existingIpPermissions - ipPermissionsFromDescription.converted
 
     if (ipPermissionsToAdd) {
       try {
@@ -111,73 +110,6 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
       }
     }
     null
-  }
-
-  static List<IpPermission> findMissing(List<IpPermission> src, List<IpPermission> expected) {
-    src.findResults { toCheck ->
-      expected.find {
-        it.fromPort == toCheck.fromPort &&
-          it.toPort == toCheck.toPort &&
-          it.ipProtocol == toCheck.ipProtocol &&
-          pairsEqual(it.userIdGroupPairs, toCheck.userIdGroupPairs) &&
-          rangesEqual(it.ipRanges, toCheck.ipRanges)
-      } ? null : toCheck
-    }
-  }
-
-  static boolean pairsEqual(Collection<UserIdGroupPair> pairsA, Collection<UserIdGroupPair> pairsB) {
-    if (pairsA) {
-      if (pairsA.size() != pairsB?.size()) {
-        false
-      } else {
-        Map matched = new IdentityHashMap()
-        pairsA.every { a ->
-          def match = pairsB.find { b ->
-            if (matched.containsKey(b)) {
-              return false
-            }
-
-            //Pairs are equal if
-            // - userIds and vpcIds match
-            // - both have a groupId and those match
-            //   or
-            //   both have a groupName and those match
-            //
-            // we support the case of one pair having a
-            // groupId present and the other not and falling
-            // back to matching on name because we may be
-            // dealing with cross-account permissions from
-            // an account that Spinnaker does not manage so
-            // can not go resolve the groupId from the name
-            if (a.userId != b.userId) {
-              return false
-            }
-            if (a.vpcId != b.vpcId) {
-              return false
-            }
-            if (a.groupId && b.groupId) {
-              return a.groupId == b.groupId
-            }
-            if (a.groupName && b.groupName) {
-              return a.groupName == b.groupName
-            }
-            return false
-          }
-          match && matched.put(match, Boolean.TRUE) == null
-        }
-        matched.keySet().size() == pairsB.size()
-      }
-    } else {
-      !pairsB
-    }
-  }
-
-  static boolean rangesEqual(Collection<String> rangesA, Collection<String> rangesB) {
-    if (rangesA) {
-      rangesA.sort() == rangesB?.sort()
-    } else {
-      !rangesB
-    }
   }
 
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
@@ -20,16 +20,19 @@ import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.ec2.model.IpPermission
 import com.amazonaws.services.ec2.model.SecurityGroup
 import com.amazonaws.services.ec2.model.UserIdGroupPair
-import com.netflix.spinnaker.clouddriver.aws.TestCredential
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription.IpIngress
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription.SecurityGroupIngress
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupUpdater
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.UpsertSecurityGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription.SecurityGroupIngress
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription.IpIngress
 import spock.lang.Specification
 import spock.lang.Subject
+
+import javax.swing.text.html.Option
 
 class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
   def setupSpec() {
@@ -73,81 +76,8 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     0 * _
   }
 
-  void "ingress minimally requires an accountId and security group id"() {
-    final createdSecurityGroup = Mock(SecurityGroupUpdater)
-    description.securityGroupIngress = [
-      new SecurityGroupIngress(id: "id-bar", accountName: "prod", accountId: "accountId2", name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp", vpcId: "vpc-456")
-    ]
-
-    when:
-    op.operate([])
-
-    then:
-    1 * securityGroupLookup.accountIdExists("accountId2") >> false
-
-    then:
-    1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.empty()
-    1 * securityGroupLookup.createSecurityGroup(description) >> createdSecurityGroup
-    1 * createdSecurityGroup.getSecurityGroup()
-
-    then:
-    1 * createdSecurityGroup.addIngress([
-      new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId2", groupId: "id-bar", vpcId: "vpc-456")
-      ])
-    ])
-    0 * _
-  }
-
-  void "ingress by group name requires a known account id"() {
-    final createdSecurityGroup = Mock(SecurityGroupUpdater)
-    description.securityGroupIngress = [
-      new SecurityGroupIngress(accountName: "prod", accountId: "accountId2", name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp", vpcId: "vpc-456")
-    ]
-
-    when:
-    op.operate([])
-
-    then:
-    1 * securityGroupLookup.accountIdExists("accountId2") >> true
-    1 * securityGroupLookup.getAccountNameForId("accountId2") >> "prod"
-    1 * securityGroupLookup.getSecurityGroupByName("prod", "bar", "vpc-456") >> Optional.of(new SecurityGroupUpdater(
-      new SecurityGroup(groupId: "id-bar"),
-      null
-    ))
-
-    then:
-    1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.empty()
-    1 * securityGroupLookup.createSecurityGroup(description) >> createdSecurityGroup
-    1 * createdSecurityGroup.getSecurityGroup()
-
-    then:
-    1 * createdSecurityGroup.addIngress([
-      new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: "accountId2", groupId: "id-bar", vpcId: "vpc-456")
-      ])
-    ])
-    0 * _
-
-  }
-
-  void "ingress by group name fails with unknown account id"() {
-    description.securityGroupIngress = [
-      new SecurityGroupIngress(accountName: "prod", accountId: "accountId2", name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp", vpcId: "vpc-456")
-    ]
-
-    when:
-    op.operate([])
-
-    then:
-    1 * securityGroupLookup.accountIdExists("accountId2") >> false
-    thrown(IllegalStateException)
-  }
-
-
   void "non-existent security group should be created with ingress"() {
     final createdSecurityGroup = Mock(SecurityGroupUpdater)
-    final testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -156,7 +86,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(new SecurityGroupUpdater(
       new SecurityGroup(groupId: "id-bar"),
       null
@@ -172,7 +102,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * createdSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
     0 * _
@@ -180,7 +110,6 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "non-existent security group that is found on create should be updated"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
-    def testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp"),
       new SecurityGroupIngress(name: "bar", startPort: 211, endPort: 212, ipProtocol: "tcp")
@@ -190,7 +119,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    2 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    2 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
     2 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(new SecurityGroupUpdater(
       new SecurityGroup(groupId: "id-bar"),
       null
@@ -208,15 +137,15 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     }
     1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.of(existingSecurityGroup)
     1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(ipPermissions: [
-      new IpPermission(fromPort: 211, toPort: 212, ipProtocol: "tcp", userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
-      ])
+            new IpPermission(fromPort: 211, toPort: 212, ipProtocol: "tcp", userIdGroupPairs: [
+                    new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+            ])
     ])
 
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
     0 * _
@@ -234,7 +163,6 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "existing security group should be updated with ingress by name"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
-    def testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -243,7 +171,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >>
       Optional.of(new SecurityGroupUpdater(new SecurityGroup(groupId: "id-bar"), null))
 
@@ -254,7 +182,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
     0 * _
@@ -262,7 +190,6 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "existing security group should be updated with ingress by id"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
-    def testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(id: "id-bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -271,7 +198,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
 
     then:
     1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.of(existingSecurityGroup)
@@ -280,7 +207,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
     0 * _
@@ -288,7 +215,6 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "existing security group should be updated with ingress from another account"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
-    def prodCred = TestCredential.named("prod")
     description.securityGroupIngress = [
       new SecurityGroupIngress(accountName: "prod", name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -297,7 +223,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getCredentialsForName("prod") >> prodCred
+    1 * securityGroupLookup.getAccountIdForName("prod") >> "accountId2"
     1 * securityGroupLookup.getSecurityGroupByName("prod", "bar", "vpc-123") >>
       Optional.of(new SecurityGroupUpdater(new SecurityGroup(groupId: "id-bar"), null))
 
@@ -308,7 +234,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: prodCred.accountId, groupId: "id-bar")
+        new UserIdGroupPair(userId: "accountId2", groupId: "id-bar")
       ])
     ])
     0 * _
@@ -316,7 +242,6 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "existing permissions should not be re-created when a security group is modified"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
-    def testCred = TestCredential.named("test")
 
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp"),
@@ -331,7 +256,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    3 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    3 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
     3 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(new SecurityGroupUpdater(
       new SecurityGroup(groupId: "id-bar"),
       null
@@ -340,26 +265,26 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-123") >> Optional.of(existingSecurityGroup)
     1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", ipPermissions: [
-      new IpPermission(fromPort: 80, toPort: 81,
-        userIdGroupPairs: [
-          new UserIdGroupPair(userId: testCred.accountId, groupId: "grp"),
-          new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
-        ],
-        ipRanges: ["10.0.0.1/32"], ipProtocol: "tcp"
-      ),
-      new IpPermission(fromPort: 25, toPort: 25,
-        userIdGroupPairs: [new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")], ipProtocol: "tcp"),
-    ])
+        new IpPermission(fromPort: 80, toPort: 81,
+          userIdGroupPairs: [
+            new UserIdGroupPair(userId: "accountId1", groupId: "grp"),
+            new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
+          ],
+          ipRanges: ["10.0.0.1/32"], ipProtocol: "tcp"
+        ),
+        new IpPermission(fromPort: 25, toPort: 25,
+          userIdGroupPairs: [new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")], ipProtocol: "tcp"),
+      ])
 
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
     1 * existingSecurityGroup.removeIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 80, toPort: 81, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupId: "grp")
+        new UserIdGroupPair(userId: "accountId1", groupId: "grp")
       ])
     ])
     0 * _
@@ -367,7 +292,6 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "should only append security group ingress"() {
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
-    def testCred = TestCredential.named("test")
 
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp"),
@@ -380,7 +304,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    3 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    3 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
     3 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(new SecurityGroupUpdater(
       new SecurityGroup(groupId: "id-bar"),
       null
@@ -391,26 +315,25 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", ipPermissions: [
       new IpPermission(fromPort: 80, toPort: 81,
         userIdGroupPairs: [
-          new UserIdGroupPair(userId: testCred.accountId, groupId: "grp"),
-          new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+          new UserIdGroupPair(userId: "accountId1", groupId: "grp"),
+          new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
         ],
         ipRanges: ["10.0.0.1/32"], ipProtocol: "tcp"
       ),
       new IpPermission(fromPort: 25, toPort: 25,
-        userIdGroupPairs: [new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")], ipProtocol: "tcp"),
+        userIdGroupPairs: [new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")], ipProtocol: "tcp"),
     ])
 
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupId: "id-bar")
+        new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
     0 * _
   }
 
   void "should fail for missing ingress security group in vpc"() {
-    def testCred = TestCredential.named("test")
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
     ]
@@ -419,7 +342,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.empty()
     0 * _
 
@@ -429,7 +352,6 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
   }
 
   void "should add ingress by name for missing ingress security group in EC2 classic"() {
-    def testCred = TestCredential.named("test")
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, ipProtocol: "tcp")
@@ -440,7 +362,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", null) >> Optional.empty()
 
     then:
@@ -451,92 +373,36 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * existingSecurityGroup.addIngress([
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupName: "bar")
+        new UserIdGroupPair(userId: "accountId1", groupName: "bar")
       ])
     ])
+
   }
 
   void "should ignore name, peering status, vpcPeeringConnectionId when comparing ingress rules"() {
-    def testCred = TestCredential.named("test")
     final existingSecurityGroup = Mock(SecurityGroupUpdater)
     final ingressSecurityGroup = Mock(SecurityGroupUpdater)
     description.securityGroupIngress = [
       new SecurityGroupIngress(name: "bar", startPort: 111, endPort: 112, vpcId: "vpc-123", ipProtocol: "tcp", accountName: "test")
     ]
-    description.vpcId = "vpc-456"
+    description.vpcId = null
 
     when:
     op.operate([])
 
     then:
-    1 * securityGroupLookup.getCredentialsForName("test") >> testCred
+    1 * securityGroupLookup.getAccountIdForName("test") >> "accountId1"
     1 * securityGroupLookup.getSecurityGroupByName("test", "bar", "vpc-123") >> Optional.of(ingressSecurityGroup)
 
     then:
-    1 * securityGroupLookup.getSecurityGroupByName("test", "foo", "vpc-456") >> Optional.of(existingSecurityGroup)
+    1 * securityGroupLookup.getSecurityGroupByName("test", "foo", null) >> Optional.of(existingSecurityGroup)
     1 * ingressSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "bar", groupId: "124", vpcId: "vpc-123")
-    1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", vpcId: "vpc-456", ipPermissions: [
+    1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", vpcId: "vpc-123", ipPermissions: [
       new IpPermission(ipProtocol: "tcp", fromPort: 111, toPort: 112, userIdGroupPairs: [
-        new UserIdGroupPair(userId: testCred.accountId, groupName: "baz", groupId: "124", vpcId: "vpc-123", vpcPeeringConnectionId: "pca", peeringStatus: "active")])
+        new UserIdGroupPair(userId: "accountId1", groupName: "baz", groupId: "124", vpcId: "vpc-123", vpcPeeringConnectionId: "pca", peeringStatus: "active")])
     ])
     0 * _
-  }
 
-  void "userIdGroupPair comparison"() {
-    expect:
-
-    UpsertSecurityGroupAtomicOperation.pairsEqual(pairsA, pairsB) == expected
-
-    where:
-    accountA | accountB | vpcIdA    | vpcIdB | idA   | idB   | nameA       | nameB       | expected
-    "1"      | "1"      | null      | null   | "sg1" | "sg1" | null        | null        | true
-    "1"      | null     | null      | null   | "sg1" | "sg1" | null        | null        | false
-    "1"      | "1"      | "vpc-foo" | null   | "sg1" | "sg1" | null        | null        | false
-    "1"      | "1"      | null      | null   | "sg1" | "sg1" | "dontCareA" | "dontCareB" | true
-    "1"      | "1"      | null      | null   | null  | "sg1" | null        | null        | false
-    "1"      | "1"      | null      | null   | null  | "sg1" | "foo"       | "foo"       | true
-
-    pairsA = [pair(idA, nameA, vpcIdA, accountA)]
-    pairsB = [pair(idB, nameB, vpcIdB, accountB)]
-  }
-
-  void "userIdGroupPair comparison collection size fails fast"() {
-    expect:
-
-    UpsertSecurityGroupAtomicOperation.pairsEqual(pairsA, pairsB) == expected
-
-    where:
-    pairsA           | pairsB                 | expected
-    [pair()]         | [pair()]               | true
-    [pair()]         | null                   | false
-    null             | null                   | true
-    []               | null                   | true
-    null             | []                     | true
-    []               | []                     | true
-    null             | [pair()]               | false
-    [pair(), pair()] | [pair(), pair()]       | true
-    [pair(), pair()] | [pair(), pair("asdf")] | false
-  }
-
-  UserIdGroupPair pair(String groupId = "sg-foo", String groupName = "foo", String vpcId = "vpc-foo", String userId = "account-foo") {
-    new UserIdGroupPair(groupId: groupId, groupName: groupName, vpcId: vpcId, userId: userId)
-  }
-
-  void "ranges comparison"() {
-    expect:
-    UpsertSecurityGroupAtomicOperation.rangesEqual(rangesA, rangesB) == expected
-
-    where:
-    rangesA      | rangesB      | expected
-    null         | null         | true
-    []           | []           | true
-    ["r1"]       | ["r1"]       | true
-    ["r1", "r2"] | ["r2", "r1"] | true
-    []           | null         | true
-    null         | []           | true
-    []           | ["r1"]       | false
-    ["r1"]       | []           | false
-    ["r1"]       | ["r2"]       | false
   }
 
 }


### PR DESCRIPTION

Revert "when calling the authorize or revoke ingress API, the IpPermission UserIdGroupPair can only have one of a groupId or groupName"
This reverts commit 37dee7a1ae8c04e897d9bf1257b3ebb6199579ab.
Revert "reworks ingress rule matching for UpsertSecurityGroupAtomicOperation"
This reverts commit 7e800cb49e44fff1c5e6b37a300f30b47554683e.

@spinnaker/netflix-reviewers FYI