### PR TITLE
Initial support for AWS Application Load Balancers

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -69,7 +69,8 @@ class AutoScalingWorker {
   private String ramdiskId
   private Boolean instanceMonitoring
   private Boolean ebsOptimized
-  private List<String> loadBalancers
+  private Collection<String> classicLoadBalancers
+  private Collection<String> targetGroupArns
   private List<String> securityGroups
   private List<String> availabilityZones
   private List<AmazonBlockDevice> blockDevices
@@ -185,7 +186,8 @@ class AutoScalingWorker {
       .withMinSize(0)
       .withMaxSize(0)
       .withDesiredCapacity(0)
-      .withLoadBalancerNames(loadBalancers)
+      .withLoadBalancerNames(classicLoadBalancers)
+      .withTargetGroupARNs(targetGroupArns)
       .withDefaultCooldown(cooldown)
       .withHealthCheckGracePeriod(healthCheckGracePeriod)
       .withHealthCheckType(healthCheckType)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerLookupHelper.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerLookupHelper.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer
+
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeLoadBalancersRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
+import com.google.common.util.concurrent.RateLimiter
+import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+
+/**
+ * LoadBalancerLookupHelper.
+ */
+class LoadBalancerLookupHelper {
+
+  static class LoadBalancerLookupResult {
+    Set<String> classicLoadBalancers = []
+    Set<String> targetGroupArns = []
+    Set<String> unknownLoadBalancers = []
+  }
+
+  LoadBalancerLookupResult getLoadBalancersFromAsg(AutoScalingGroup asg) {
+    def result = new LoadBalancerLookupResult()
+    result.classicLoadBalancers.addAll(asg.loadBalancerNames ?: [])
+    result.targetGroupArns.addAll(asg.targetGroupARNs ?: [])
+    return result
+  }
+
+  LoadBalancerLookupResult getLoadBalancersByName(RegionScopedProviderFactory.RegionScopedProvider rsp, Collection<String> loadBalancerNames) {
+    def result = new LoadBalancerLookupResult()
+    Set<String> allLoadBalancers = new HashSet<>(loadBalancerNames ?: [])
+    if (!allLoadBalancers) {
+      return result
+    }
+    def lbv2 = rsp.getAmazonElasticLoadBalancingV2()
+    def lbv1 = rsp.getAmazonElasticLoadBalancing()
+    def limiter = RateLimiter.create(1);
+    Set<String> v2LoadBalancers = []
+    for (String lbName : allLoadBalancers) {
+      try {
+        limiter.acquire()
+        def lb = lbv2.describeLoadBalancers(new DescribeLoadBalancersRequest().withNames(lbName)).loadBalancers.first()
+        v2LoadBalancers.add(lbName)
+        limiter.acquire()
+        result.targetGroupArns.addAll(lbv2.describeTargetGroups(new DescribeTargetGroupsRequest().withLoadBalancerArn(lb.loadBalancerArn)).targetGroups*.targetGroupArn)
+      } catch (LoadBalancerNotFoundException lbnfe) {
+        //ignore
+      }
+
+      try {
+        limiter.acquire()
+        lbv1.describeLoadBalancers(new com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest().withLoadBalancerNames(lbName))
+        result.classicLoadBalancers.add(lbName)
+      } catch (com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException lbnfe) {
+        //ignore
+      }
+    }
+    allLoadBalancers.removeAll(result.classicLoadBalancers)
+    allLoadBalancers.removeAll(v2LoadBalancers)
+
+    result.unknownLoadBalancers.addAll(allLoadBalancers)
+
+    return result
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -284,6 +284,18 @@ public class AmazonClientProvider {
     return getClient(AmazonElasticLoadBalancingClient.class, awsCredentialsProvider, region);
   }
 
+  public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2(NetflixAmazonCredentials amazonCredentials, String region) {
+    return getAmazonElasticLoadBalancingV2(amazonCredentials, region, false);
+  }
+
+  public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
+    return getProxyHandler(com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing.class, com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClient.class, amazonCredentials, region, skipEdda);
+  }
+
+  public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2(AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return getClient(com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClient.class, awsCredentialsProvider, region);
+  }
+
   public AmazonSimpleWorkflow getAmazonSimpleWorkflow(NetflixAmazonCredentials amazonCredentials, String region) {
     return getAmazonSimpleWorkflow(amazonCredentials, region, false);
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/RegionScopedProviderFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/RegionScopedProviderFactory.groovy
@@ -79,6 +79,14 @@ class RegionScopedProviderFactory {
       amazonClientProvider.getAutoScaling(amazonCredentials, region, true)
     }
 
+    com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2() {
+      amazonClientProvider.getAmazonElasticLoadBalancingV2(amazonCredentials, region, true)
+    }
+
+    com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing getAmazonElasticLoadBalancing() {
+      amazonClientProvider.getAmazonElasticLoadBalancing(amazonCredentials, region, true)
+    }
+
     SubnetAnalyzer getSubnetAnalyzer() {
       SubnetAnalyzer.from(amazonEC2.describeSubnets().subnets)
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -28,6 +28,17 @@ import com.amazonaws.services.ec2.model.DescribeImagesResult
 import com.amazonaws.services.ec2.model.DescribeVpcClassicLinkResult
 import com.amazonaws.services.ec2.model.Image
 import com.amazonaws.services.ec2.model.VpcClassicLink
+import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing as AmazonELBV1
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
+import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
+import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException as LBNFEV1
+import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeLoadBalancersResult as DescribeLBV2
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsResult
+import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancer
+import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -60,18 +71,21 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
   @Shared
   Task task = Mock(Task)
 
-  AmazonEC2 amazonEC2
+  AmazonEC2 amazonEC2 = Mock(AmazonEC2)
+  AmazonElasticLoadBalancing elbV2 = Mock(AmazonElasticLoadBalancing)
+  AmazonELBV1 elbV1 = Mock(AmazonELBV1)
 
   List<AmazonBlockDevice> blockDevices
 
   def setup() {
-    amazonEC2 = Mock(AmazonEC2)
     amazonEC2.describeImages(_) >> new DescribeImagesResult().withImages(new Image().withImageId("ami-12345"))
     this.blockDevices = [new AmazonBlockDevice(deviceName: "/dev/sdb", virtualName: "ephemeral0")]
     def rspf = Stub(RegionScopedProviderFactory) {
       forRegion(_, _) >> Stub(RegionScopedProviderFactory.RegionScopedProvider) {
         getAutoScaling() >> Stub(AmazonAutoScaling)
         getAmazonEC2() >> amazonEC2
+        getAmazonElasticLoadBalancingV2() >> elbV2
+        getAmazonElasticLoadBalancing() >> elbV1
       }
     }
     def defaults = new AwsConfiguration.DeployDefaults(iamRole: 'IamRole')
@@ -117,7 +131,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     setup:
     def setlbCalls = 0
     AutoScalingWorker.metaClass.deploy = {}
-    AutoScalingWorker.metaClass.setLoadBalancers = { setlbCalls++ }
+    AutoScalingWorker.metaClass.setClassicLoadBalancers = { setlbCalls++ }
     def description = new BasicAmazonDeployDescription(amiName: "ami-12345")
     description.availabilityZones = ["us-east-1": []]
     description.credentials = TestCredential.named('baz')
@@ -127,7 +141,48 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
 
     then:
     setlbCalls
+    1 * elbV1.describeLoadBalancers(_) >> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(new LoadBalancerDescription().withLoadBalancerName("lb"))
+    1 * elbV2.describeLoadBalancers(_) >> { throw new LoadBalancerNotFoundException("not found") }
     1 * amazonEC2.describeVpcClassicLink() >> new DescribeVpcClassicLinkResult()
+  }
+
+  void "handles classic and application load balancers"() {
+
+    def classicLbs = []
+    def targetGroupARNs = []
+    AutoScalingWorker.metaClass.setClassicLoadBalancers = { Collection<String> lbs -> classicLbs.addAll(lbs) }
+    AutoScalingWorker.metaClass.setTargetGroupArns = { Collection<String> arns -> targetGroupARNs.addAll(arns) }
+    def description = new BasicAmazonDeployDescription(amiName: "ami-12345", loadBalancers: ["lb"])
+    description.availabilityZones = ["us-east-1": []]
+    description.credentials = TestCredential.named('baz')
+
+    when:
+    handler.handle(description, [])
+
+    then:
+    1 * elbV1.describeLoadBalancers(_) >> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(new LoadBalancerDescription().withLoadBalancerName("lb"))
+    1 * elbV2.describeLoadBalancers(_) >> new DescribeLBV2().withLoadBalancers(new LoadBalancer().withLoadBalancerName("lb").withLoadBalancerArn("arn:lb"))
+    1 * elbV2.describeTargetGroups(new DescribeTargetGroupsRequest().withLoadBalancerArn("arn:lb")) >> new DescribeTargetGroupsResult().withTargetGroups(new TargetGroup().withTargetGroupArn("arn:lb:targetGroup1"))
+    1 * amazonEC2.describeVpcClassicLink() >> new DescribeVpcClassicLinkResult()
+
+    classicLbs == ['lb']
+    targetGroupARNs == ['arn:lb:targetGroup1']
+  }
+
+  void "fails if load balancer name is not in classic or application load balancer"() {
+    def description = new BasicAmazonDeployDescription(amiName: "ami-12345", loadBalancers: ["lb"])
+    description.availabilityZones = ["us-east-1": []]
+    description.credentials = TestCredential.named('baz')
+
+    when:
+    handler.handle(description, [])
+
+    then:
+    1 * elbV1.describeLoadBalancers(_) >> { throw new LBNFEV1("not found") }
+    1 * elbV2.describeLoadBalancers(_) >> { throw new LoadBalancerNotFoundException("not found") }
+
+    thrown(IllegalStateException)
+
   }
 
   void "should populate classic link VPC Id when classic link is enabled"() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
@@ -19,6 +19,10 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.Instance
 import com.amazonaws.services.elasticloadbalancing.model.DeregisterInstancesFromLoadBalancerRequest
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
+import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
+import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
@@ -40,6 +44,7 @@ class DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec extends Instanc
     setup:
     def asg = Mock(AutoScalingGroup) {
       1 * getLoadBalancerNames() >> ["lb1"]
+      1 * getTargetGroupARNs() >> []
       1 * getInstances() >> [new Instance().withInstanceId("i-123456")]
       0 * _._
     }
@@ -59,6 +64,7 @@ class DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec extends Instanc
     setup:
     def asg = Mock(AutoScalingGroup) {
       1 * getLoadBalancerNames() >> []
+      1 * getTargetGroupARNs() >> []
       1 * getInstances() >> description.instanceIds.collect { new Instance().withInstanceId(it) }
       0 * _._
     }
@@ -82,6 +88,8 @@ class DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec extends Instanc
 
     then:
     0 * asgService.getAutoScalingGroup(_)
+    2 * loadBalancing.describeLoadBalancers(_) >> { DescribeLoadBalancersRequest req -> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(new LoadBalancerDescription().withLoadBalancerName(req.loadBalancerNames[0]))}
+    2 * loadBalancingV2.describeLoadBalancers(_) >> { throw new LoadBalancerNotFoundException("nope") }
     2 * loadBalancing.deregisterInstancesFromLoadBalancer(_) >> { DeregisterInstancesFromLoadBalancerRequest req ->
       assert req.instances*.instanceId == description.instanceIds
       assert description.loadBalancerNames.contains(req.loadBalancerName)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/InstanceLoadBalancerRegistrationUnitSpecSupport.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/InstanceLoadBalancerRegistrationUnitSpecSupport.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing as AmazonElasticLoadBalancingV2
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.InstanceLoadBalancerRegistrationDescription
 import com.netflix.spinnaker.clouddriver.aws.services.AsgService
@@ -42,23 +42,24 @@ class InstanceLoadBalancerRegistrationUnitSpecSupport extends Specification {
   @Shared
   AmazonElasticLoadBalancing loadBalancing
 
+  @Shared
+  AmazonElasticLoadBalancingV2 loadBalancingV2
+
   def setup() {
     asgService = Mock(AsgService)
     loadBalancing = Mock(AmazonElasticLoadBalancing)
+    loadBalancingV2 = Mock(AmazonElasticLoadBalancingV2)
     wireOpMocks(op)
   }
 
   def wireOpMocks(AbstractInstanceLoadBalancerRegistrationAtomicOperation op) {
-    def rsp = Mock(RegionScopedProviderFactory.RegionScopedProvider)
+    def rsp = Stub(RegionScopedProviderFactory.RegionScopedProvider)
     rsp.getAsgService() >> asgService
+    rsp.getAmazonElasticLoadBalancingV2() >> loadBalancingV2
+    rsp.getAmazonElasticLoadBalancing() >> loadBalancing
 
     def rspf = Mock(RegionScopedProviderFactory)
     rspf.forRegion(_, _) >> rsp
     op.regionScopedProviderFactory = rspf
-
-    def provider = Mock(AmazonClientProvider) {
-      getAmazonElasticLoadBalancing(_, _, true) >> loadBalancing
-    }
-    op.amazonClientProvider = provider
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
@@ -18,7 +18,11 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.Instance
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
+import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
 import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
@@ -38,6 +42,7 @@ class RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec extends InstanceL
 
     def asg = Mock(AutoScalingGroup) {
       1 * getLoadBalancerNames() >> ["lb1"]
+      1 * getTargetGroupARNs() >> []
       1 * getInstances() >> [new Instance().withInstanceId("i-123456")]
       0 * _._
     }
@@ -62,6 +67,7 @@ class RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec extends InstanceL
 
     def asg = Mock(AutoScalingGroup) {
       1 * getLoadBalancerNames() >> []
+      1 * getTargetGroupARNs() >> []
       1 * getInstances() >> description.instanceIds.collect { new Instance().withInstanceId(it) }
       0 * _._
     }
@@ -85,6 +91,8 @@ class RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec extends InstanceL
 
     then:
     0 * asgService.getAutoScalingGroup(_)
+    2 * loadBalancing.describeLoadBalancers(_) >> { DescribeLoadBalancersRequest r -> new DescribeLoadBalancersResult().withLoadBalancerDescriptions(new LoadBalancerDescription().withLoadBalancerName(r.loadBalancerNames[0]))}
+    2 * loadBalancingV2.describeLoadBalancers(_) >> { throw new LoadBalancerNotFoundException("not found") }
     2 * loadBalancing.registerInstancesWithLoadBalancer(_) >> { RegisterInstancesWithLoadBalancerRequest req ->
       assert req.instances*.instanceId == description.instanceIds
       assert description.loadBalancerNames.contains(req.loadBalancerName)


### PR DESCRIPTION
Right now it is treating the ALB the same as we treat an ELB - you request it by the name of the load balancer, and your server group is attached to all the target groups for that load balancer.

LoadBalancer names are not unique across classic and application load balancers, so currently this will attach both the classic and the application load balancer that match the requested name - not really sure that is the best strategy. We could fail the deploy if this was the case, we could just use the classic LB if it matches on name (I guess more backwards compatible?)

I could also see us having to evolve the deploy description if we want to support fancier ALB use cases (only attach my server group to a specific target group, not to every target group in the ALB). I'm sure at some point that will be a request...

@spinnaker/netflix-reviewers PTAL