### PR TITLE
provider/google: Created atomic operation for restoring snapshot, implemented job executor to run terraform, added logic for importing terraform state files

### DIFF
--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -3,6 +3,8 @@ dependencies {
 
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootDataRest')
+  compile spinnaker.dependency("commonsExec")
+  compile spinnaker.dependency('rxJava')
   compile spinnaker.dependency('kork')
   compile spinnaker.dependency('korkWeb')
   compile spinnaker.dependency('eurekaClient')

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobExecutor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobExecutor.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jobs
+
+interface JobExecutor {
+  String startJob(JobRequest jobRequest)
+  JobStatus updateJob(String jobId)
+  void cancelJob(String jobId)
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobRequest.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobRequest.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jobs
+
+import groovy.transform.CompileStatic
+import groovy.transform.Immutable
+
+@Immutable(copyWith = true)
+@CompileStatic
+class JobRequest {
+  List<String> tokenizedCommand
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobStatus.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobStatus.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jobs
+
+class JobStatus {
+
+  String id
+  State state
+  Result result
+  String logsContent
+
+  static enum State {
+    RUNNING, COMPLETED
+  }
+
+  static enum Result {
+    SUCCESS, FAILURE
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/config/LocalJobConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/config/LocalJobConfig.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jobs.config
+
+import com.netflix.spinnaker.clouddriver.jobs.JobExecutor
+import com.netflix.spinnaker.clouddriver.jobs.local.JobExecutorLocal
+import groovy.util.logging.Slf4j
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Slf4j
+@Configuration
+class LocalJobConfig {
+
+  @Bean
+  @ConditionalOnMissingBean(JobExecutor)
+  JobExecutor jobExecutorLocal() {
+    new JobExecutorLocal()
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.groovy
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jobs.local
+
+import com.netflix.spinnaker.clouddriver.jobs.JobExecutor
+import com.netflix.spinnaker.clouddriver.jobs.JobRequest
+import com.netflix.spinnaker.clouddriver.jobs.JobStatus
+import groovy.util.logging.Slf4j
+import org.apache.commons.exec.*
+import org.springframework.beans.factory.annotation.Value
+import rx.Scheduler
+import rx.functions.Action0
+import rx.schedulers.Schedulers
+
+import java.util.concurrent.ConcurrentHashMap
+
+@Slf4j
+class JobExecutorLocal implements JobExecutor {
+
+  @Value('${jobs.local.timeoutMinutes:10}')
+  long timeoutMinutes
+
+  Scheduler scheduler = Schedulers.computation()
+  Map<String, Map> jobIdToHandlerMap = new ConcurrentHashMap<String, Map>()
+
+  @Override
+  String startJob(JobRequest jobRequest) {
+    log.info("Starting job: $jobRequest.tokenizedCommand...")
+
+    String jobId = UUID.randomUUID().toString()
+
+    scheduler.createWorker().schedule(
+      new Action0() {
+        @Override
+        public void call() {
+          ByteArrayOutputStream stdOutAndErr = new ByteArrayOutputStream()
+          PumpStreamHandler pumpStreamHandler = new PumpStreamHandler(stdOutAndErr)
+          CommandLine commandLine
+
+          if (jobRequest.tokenizedCommand) {
+            log.info("Executing $jobId with tokenized command: $jobRequest.tokenizedCommand")
+
+            // Grab the first element as the command.
+            commandLine = new CommandLine(jobRequest.tokenizedCommand[0])
+
+            // Treat the rest as arguments.
+            String[] arguments = Arrays.copyOfRange(jobRequest.tokenizedCommand.toArray(), 1, jobRequest.tokenizedCommand.size())
+
+            commandLine.addArguments(arguments, false)
+          } else {
+            throw new IllegalArgumentException("No tokenizedCommand specified for $jobId.")
+          }
+
+          DefaultExecuteResultHandler resultHandler = new DefaultExecuteResultHandler()
+          ExecuteWatchdog watchdog = new ExecuteWatchdog(timeoutMinutes * 60 * 1000){
+            @Override
+            void timeoutOccured(Watchdog w) {
+              // If a watchdog is passed in, this was an actual time-out. Otherwise, it is likely
+              // the result of calling watchdog.destroyProcess().
+              if (w) {
+                log.warn("Job $jobId timed-out (after $timeoutMinutes minutes).")
+
+                cancelJob(jobId)
+              }
+
+              super.timeoutOccured(w)
+            }
+          }
+          Executor executor = new DefaultExecutor()
+          executor.setStreamHandler(pumpStreamHandler)
+          executor.setWatchdog(watchdog)
+          executor.execute(commandLine, resultHandler)
+
+          // Give the job some time to spin up.
+          sleep(500)
+
+          jobIdToHandlerMap.put(jobId, [
+            handler: resultHandler,
+            watchdog: watchdog,
+            stdOutAndErr: stdOutAndErr
+          ])
+        }
+      }
+    )
+
+    return jobId
+  }
+
+  @Override
+  JobStatus updateJob(String jobId) {
+    try {
+      log.info("Polling state for $jobId...")
+
+      if (jobIdToHandlerMap[jobId]) {
+        JobStatus jobStatus = new JobStatus(id: jobId)
+
+        DefaultExecuteResultHandler resultHandler
+        ByteArrayOutputStream stdOutAndErr
+
+        jobIdToHandlerMap[jobId].with {
+          resultHandler = it.handler
+          stdOutAndErr = it.stdOutAndErr
+        }
+
+        String logsContent = new String(stdOutAndErr.toByteArray())
+
+        if (resultHandler.hasResult()) {
+          log.info("State for $jobId changed with exit code $resultHandler.exitValue.")
+
+          if (!logsContent) {
+            logsContent = resultHandler.exception ? resultHandler.exception.message : "No output from command."
+          }
+
+          if (resultHandler.exitValue == 0) {
+            jobStatus.state = JobStatus.State.COMPLETED
+            jobStatus.result = JobStatus.Result.SUCCESS
+          } else {
+            jobStatus.state = JobStatus.State.COMPLETED
+            jobStatus.result = JobStatus.Result.FAILURE
+          }
+
+          jobIdToHandlerMap.remove(jobId)
+        } else {
+          jobStatus.state = JobStatus.State.RUNNING
+        }
+
+        if (logsContent) {
+          jobStatus.logsContent = logsContent
+        }
+
+        return jobStatus
+      } else {
+        // This instance is not managing the job
+        return null
+      }
+    } catch (Exception e) {
+      log.error("Failed to update $jobId", e)
+
+      return null
+    }
+
+  }
+
+  @Override
+  void cancelJob(String jobId) {
+    log.info("Canceling job $jobId...")
+
+    // Remove the job from this rosco instance's handler map.
+    def canceledJob = jobIdToHandlerMap.remove(jobId)
+
+    // Terminate the process.
+    canceledJob?.watchdog?.destroyProcess()
+
+    // The next polling interval will be unable to retrieve the job status and will mark it as canceled.
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
@@ -67,4 +67,5 @@ final class AtomicOperations {
 
   // Serialize operations
   public static final String SERIALIZE_APPLICATION = "serializeApplication"
+  public static final String RESTORE_SNAPSHOT = "restoreSnapshot"
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/SerializeApplicationAtomicOperationConverter/RestoreSnapshotAtomicOperationConverter.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/SerializeApplicationAtomicOperationConverter/RestoreSnapshotAtomicOperationConverter.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.deploy.converters.SerializeApplicationAtomicOperationConverter
+
+import com.netflix.spinnaker.clouddriver.google.deploy.converters.GoogleAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.google.deploy.description.SerializeApplicationDescription.RestoreSnapshotDescription
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.SerializeApplicationAtomicOperation.RestoreSnapshotAtomicOperation
+import com.netflix.spinnaker.clouddriver.google.GoogleOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+@GoogleOperation(AtomicOperations.RESTORE_SNAPSHOT)
+@Component("restoreSnapshotDescription")
+class RestoreSnapshotAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    new RestoreSnapshotAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  RestoreSnapshotDescription convertDescription(Map input) {
+    GoogleAtomicOperationConverterHelper.convertDescription(input, this, RestoreSnapshotDescription)
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/SerializeApplicationDescription/RestoreSnapshotDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/SerializeApplicationDescription/RestoreSnapshotDescription.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.deploy.description.SerializeApplicationDescription
+
+import com.netflix.spinnaker.clouddriver.google.deploy.description.AbstractGoogleCredentialsDescription
+
+class RestoreSnapshotDescription extends AbstractGoogleCredentialsDescription {
+  String applicationName
+  String accountName
+  Long snapshotTimestamp
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/SerializeApplicationAtomicOperation/RestoreSnapshotAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/SerializeApplicationAtomicOperation/RestoreSnapshotAtomicOperation.groovy
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.deploy.ops.SerializeApplicationAtomicOperation
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.deploy.description.SerializeApplicationDescription.RestoreSnapshotDescription
+import com.netflix.spinnaker.clouddriver.google.model.GoogleCluster
+import com.netflix.spinnaker.clouddriver.google.model.GoogleSecurityGroup
+import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerView
+import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
+import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
+import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleSecurityGroupProvider
+import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.jobs.JobExecutor
+import com.netflix.spinnaker.clouddriver.jobs.JobRequest
+import com.netflix.spinnaker.clouddriver.jobs.JobStatus
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import org.springframework.beans.factory.annotation.Autowired
+
+class RestoreSnapshotAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "RESTORE_SNAPSHOT"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  private final RestoreSnapshotDescription description
+  private final String applicationName
+  private final String accountName
+  private final Long snapshotTimestamp
+  private String project
+  private List applicationTags
+
+  @Autowired
+  GoogleClusterProvider googleClusterProvider
+
+  @Autowired
+  GoogleLoadBalancerProvider googleLoadBalancerProvider
+
+  @Autowired
+  GoogleSecurityGroupProvider googleSecurityGroupProvider
+
+  @Autowired
+  AccountCredentialsRepository accountCredentialsRepository
+
+  @Autowired
+  JobExecutor jobExecutor
+
+  RestoreSnapshotAtomicOperation(RestoreSnapshotDescription description) {
+    this.description = description
+    this.applicationName = description.applicationName
+    this.accountName = description.accountName
+    this.snapshotTimestamp = description.snapshotTimestamp
+    this.applicationTags = []
+  }
+
+  /* curl -X POST -H "Content-Type: application/json" -d '[ { "restoreSnapshot": { "applicationName": "example", "credentials": "my-google-account" "snapshotTimestamp": "123456789"}} ]' localhost:7002/gce/ops */
+  @Override
+  Void operate(List priorOutputs) {
+    def credentials = accountCredentialsRepository.getOne(this.accountName) as GoogleNamedAccountCredentials
+    this.project = credentials.project
+
+    // Make directory for terraform files
+    File dir = new File("$applicationName-$accountName");
+    if (!dir.mkdir()) {
+      throw new IllegalStateException("Error creating directory $applicationName-$accountName")
+    }
+
+    task.updateStatus BASE_PHASE, "Importing state of server groups for the application ${this.applicationName} in account ${this.accountName}"
+    googleClusterProvider.getClusters(applicationName, accountName).each { GoogleCluster.View cluster ->
+      cluster.serverGroups.each { GoogleServerGroup.View serverGroup ->
+        importServerGroupState(serverGroup)
+      }
+    }
+
+    task.updateStatus BASE_PHASE, "Importing state of load balancers for the application ${this.applicationName} in account ${this.accountName}"
+    googleLoadBalancerProvider.getApplicationLoadBalancers(applicationName).each { GoogleLoadBalancerView loadBalancer ->
+      if (loadBalancer.account == this.accountName) {
+        importLoadBalancerState(loadBalancer)
+      }
+    }
+
+    task.updateStatus BASE_PHASE, "Importing state of security groups for application ${this.applicationName} in account ${this.accountName}"
+    googleSecurityGroupProvider.getAll(true).each { GoogleSecurityGroup securityGroup ->
+      if (securityGroup.accountName == this.accountName && securityGroup.targetTags && !Collections.disjoint(securityGroup.targetTags, applicationTags)) {
+        importSecurityGroupState(securityGroup)
+      }
+    }
+
+    cleanUpDirectory()
+    return null
+  }
+
+  private Void importServerGroupState(GoogleServerGroup.View serverGroup) {
+    importResource("google_compute_instance_group_manager", serverGroup.name)
+    def instanceTemplate = serverGroup.imageSummary.image
+    if (instanceTemplate) {
+      importResource("google_compute_instance_template", serverGroup.imageSummary.image.name)
+      if (instanceTemplate.properties.tags?.items) {
+        applicationTags.addAll(instanceTemplate.properties.tags.items)
+      }
+    }
+    if (serverGroup.autoscalingPolicy) {
+      importResource("google_compute_autoscaler", serverGroup.name)
+    }
+    return null
+  }
+
+  private Void importLoadBalancerState(GoogleLoadBalancerView loadBalancer) {
+    def targetPoolName = loadBalancer.targetPool.split("/").last()
+    importResource("google_compute_target_pool", targetPoolName)
+    importResource("google_compute_forwarding_rule", loadBalancer.name)
+    if (loadBalancer.healthCheck) {
+      importResource("google_compute_http_health_check", loadBalancer.healthCheck.name)
+    }
+    return null
+  }
+
+  private Void importSecurityGroupState(GoogleSecurityGroup securityGroup) {
+    importResource("google_compute_firewall", securityGroup.name)
+    return null
+  }
+
+  private void importResource(String resource, String name) {
+    ArrayList<String> command = ["terraform", "import", "-state=$applicationName-$accountName/terraform.tfstate", "$resource.$name", name]
+    String jobId = jobExecutor.startJob(new JobRequest(tokenizedCommand: command))
+    waitForJobCompletion(jobId)
+  }
+
+  private void waitForJobCompletion(String jobId) {
+    sleep(1000)
+    JobStatus jobStatus = jobExecutor.updateJob(jobId)
+    while (jobStatus.state == JobStatus.State.RUNNING) {
+      sleep(1000)
+      jobStatus = jobExecutor.updateJob(jobId)
+    }
+
+    if (jobStatus.result == JobStatus.Result.FAILURE && jobStatus.logsContent) {
+      cleanUpDirectory()
+      throw new IllegalArgumentException(jobStatus.logsContent)
+    }
+  }
+
+  private void cleanUpDirectory() {
+    List<File> files = new ArrayList<>()
+    files << new File("$applicationName-$accountName/terraform.tfstate")
+    files << new File("$applicationName-$accountName/terraform.tfstate.backup")
+    for (File file: files) {
+      if (file.exists()) {
+        if (!file.delete()) {
+          throw new IllegalStateException("Error deleting file $file.name")
+        }
+      }
+    }
+    def dir = new File("$applicationName-$accountName")
+    if (!dir.delete()) {
+      throw new IllegalStateException("Error deleting directory $dir.name")
+    }
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.deploy.config.DeployConfiguration
 import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryConfiguration
 import com.netflix.spinnaker.clouddriver.eureka.EurekaProviderConfiguration
 import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
+import com.netflix.spinnaker.clouddriver.jobs.config.LocalJobConfig
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesConfiguration
 import com.netflix.spinnaker.clouddriver.openstack.OpenstackConfiguration
 import com.netflix.spinnaker.clouddriver.security.config.SecurityConfig
@@ -59,7 +60,8 @@ import java.security.Security
   CloudFoundryConfig,
   AzureConfiguration,
   SecurityConfig,
-  EurekaProviderConfiguration
+  EurekaProviderConfiguration,
+  LocalJobConfig
 ])
 @ComponentScan([
   'com.netflix.spinnaker.config',


### PR DESCRIPTION
Added a job executor mostly copied from the one @duftler [wrote for rosco](https://github.com/spinnaker/rosco/tree/f165221be7bece9492af99f8501b154bc168cfff/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/jobs). This required me to add two dependencies to clouddriver (commonsExec and rxJava). I also created an atomic operation for restoring snapshots. Right now the operation successfully imports the state of existing resources into a terraform state file, but only works locally if terraform v7.1 or greater is found in PATH. Also environment variables must be set for terraform to [properly find google credentials](https://www.terraform.io/docs/providers/google/). PTAL @lwander 