### PR TITLE
provider/kubernetes: Allow envvars to come from k8s sources

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -80,7 +80,28 @@ class KubernetesContainerDescription {
 class KubernetesEnvVar {
   String name
   String value
-  // TODO(lwander) Q2 2016 add EnvVarSource for selecting secrets.
+  KubernetesEnvVarSource envSource
+}
+
+@AutoClone
+@Canonical
+class KubernetesEnvVarSource {
+  KubernetesSecretSource secretSource
+  KubernetesConfigMapSource configMapSource
+}
+
+@AutoClone
+@Canonical
+class KubernetesSecretSource {
+  String secretName
+  String key
+}
+
+@AutoClone
+@Canonical
+class KubernetesConfigMapSource {
+  String configMapName
+  String key
 }
 
 @AutoClone


### PR DESCRIPTION
Now env vars can come from both secrets and config maps (which will be configurable in the "properties" stage) @duftler 