### PR TITLE
provider/google: Allow empty loadBalancerType in upsert/delete.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleLoadBalancerDescriptionValidator.groovy
@@ -67,13 +67,13 @@ class UpsertGoogleLoadBalancerDescriptionValidator extends
 
         // Each backend service must have a health check.
         def googleHttpLoadBalancer = new GoogleHttpLoadBalancer(
-          name: description.loadBalancerName,
-          defaultService: description.defaultService,
-          hostRules: description.hostRules,
-          certificate: description.certificate,
-          ipAddress: description.ipAddress,
-          ipProtocol: description.ipProtocol,
-          portRange: description.portRange
+            name: description.loadBalancerName,
+            defaultService: description.defaultService,
+            hostRules: description.hostRules,
+            certificate: description.certificate,
+            ipAddress: description.ipAddress,
+            ipProtocol: description.ipProtocol,
+            portRange: description.portRange
         )
         List<GoogleBackendService> services = Utils.getBackendServicesFromHttpLoadBalancerView(googleHttpLoadBalancer.view)
         services?.each { GoogleBackendService service ->
@@ -84,7 +84,7 @@ class UpsertGoogleLoadBalancerDescriptionValidator extends
         }
         break
       default:
-        errors.rejectValue("description.loadBalancerType", "upsertGoogleLoadBalancerDescription.loadBalancerType.illegalType")
+        // TODO(jacobkiefer): Fail here once frontend calls are modified.
         break
     }
   }


### PR DESCRIPTION
@duftler @danielpeach  @ewiseblatt  FYI. Addressing integration test failures. Currently the upsert/delete L4 calls don't have the `loadBalancerType` enum.