### PR TITLE
(docker) Improve lookup semantics

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/cache/Keys.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/cache/Keys.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.docker.registry.cache
 class Keys {
   static enum Namespace {
     TAGGED_IMAGE,
+    IMAGE_ID,
 
     static String provider = "dockerRegistry"
 
@@ -52,6 +53,9 @@ class Keys {
       case Namespace.TAGGED_IMAGE.ns:
         result << [account: parts[2], repository: parts[3], tag: parts[4]]
         break
+      case Namespace.IMAGE_ID.ns:
+        result << [imageId: parts[2]]
+        break
       default:
         return null
         break
@@ -62,5 +66,9 @@ class Keys {
 
   static String getTaggedImageKey(String account, String repository, String tag) {
     "${Namespace.provider}:${Namespace.TAGGED_IMAGE}:${account}:${repository}:${tag}"
+  }
+
+  static String getImageIdKey(String imageId) {
+    "${Namespace.provider}:${Namespace.IMAGE_ID}:${imageId}"
   }
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/DockerRegistryProviderUtils.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/DockerRegistryProviderUtils.groovy
@@ -25,7 +25,11 @@ class DockerRegistryProviderUtils {
     loadResults(cacheView, namespace, cacheView.filterIdentifiers(namespace, pattern))
   }
 
-  private static Set<CacheData> loadResults(Cache cacheView, String namespace, Collection<String> identifiers) {
+  static Set<CacheData> loadResults(Cache cacheView, String namespace, Collection<String> identifiers) {
     cacheView.getAll(namespace, identifiers, RelationshipCacheFilter.none())
+  }
+
+  static imageId(String registry, String repository, String tag) {
+    "$registry/$repository:$tag"
   }
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/config/DockerRegistryProviderConfig.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/config/DockerRegistryProviderConfig.groovy
@@ -78,7 +78,7 @@ class DockerRegistryProviderConfig {
         def newlyAddedAgents = []
 
         credentials.cacheThreads.times { i ->
-          newlyAddedAgents << new DockerRegistryImageCachingAgent(dockerRegistryCloudProvider, credentials.accountName, credentials.credentials, i, credentials.cacheThreads)
+          newlyAddedAgents << new DockerRegistryImageCachingAgent(dockerRegistryCloudProvider, credentials.accountName, credentials.credentials, i, credentials.cacheThreads, credentials.registry)
         }
 
         // If there is an agent scheduler, then this provider has been through the AgentController in the past.

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentials.groovy
@@ -42,6 +42,10 @@ class DockerRegistryCredentials {
     return client
   }
 
+  String getRegistry() {
+    return client
+  }
+
   boolean getTrackDigests() {
     return trackDigests
   }


### PR DESCRIPTION
@danielpeach @duftler PTAL

Since large lists of images slow down the UI, we added a `count` parameter to shrink the returned list of images. This meant that the `q` parameter needed to be used to find images that weren't immediately returned in the first `count` results; however, since the `q` parameter only searched by image and tag it was confusing to use. This fixes that by make `q` search for the full image ID.