### PR TITLE
(kubernetes) Job pod container names can be empty

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -73,6 +73,7 @@ class RunKubernetesJobAtomicOperation implements AtomicOperation<DeploymentResul
       podBuilder = podBuilder.withVolumes(volumeSources)
     }
 
+    description.container.name = description.container.name ?: "job"
     def container = KubernetesApiConverter.toContainer(description.container)
 
     podBuilder = podBuilder.withContainers(container)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/job/RunKubernetesJobAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/job/RunKubernetesJobAtomicOperationValidator.groovy
@@ -55,6 +55,7 @@ class RunKubernetesJobAtomicOperationValidator extends DescriptionValidator<RunK
     }
 
     helper.validateNotEmpty(description.container, "containers")
+    description.container.name = description.container.name ?: "job"
     KubernetesContainerValidator.validate(description.container, helper, "container")
   }
 }


### PR DESCRIPTION
@danielpeach FYI (in fact, they shouldn't ever need to be specified from the UI).