### PR TITLE
(kubernetes) slight improvments to health widget contents

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesHealth.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesHealth.groovy
@@ -66,10 +66,12 @@ class KubernetesHealth implements Health {
       if (containerStatus.ready) {
         state = HealthState.Up
       } else {
+        description = "Readiness probe hasn't passed"
         state = HealthState.Down
       }
     } else if (containerStatus.state.terminated) {
       if (containerStatus.state.terminated.reason == "Completed") {
+        description = "Container terminated with code $containerStatus.state.terminated.exitCode"
         if (containerStatus.state.terminated.exitCode == 0) {
           state = HealthState.Succeeded
         } else {


### PR DESCRIPTION
@duftler. The goal is to better explain why certain kubernetes-level events fail (scheduling decisions, probe failures, etc...) but it looks like this information isn't exposed at the resource level, so I will have to dig a little deeper.