### PR TITLE
(kubernetes) fix application delete

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -53,7 +53,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
   final OnDemandMetricsSupport metricsSupport
 
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
-    INFORMATIVE.forType(Keys.Namespace.APPLICATIONS.ns),
+    AUTHORITATIVE.forType(Keys.Namespace.APPLICATIONS.ns),
     AUTHORITATIVE.forType(Keys.Namespace.CLUSTERS.ns),
     INFORMATIVE.forType(Keys.Namespace.LOAD_BALANCERS.ns),
     AUTHORITATIVE.forType(Keys.Namespace.SERVER_GROUPS.ns),


### PR DESCRIPTION
This is an artifact of having a job and servergroup caching agent adding applications at the same time. Changing the agent to authoritative now allows applications to be deleted again (since jobs are no longer cached).