### PR TITLE
(kubernetes) handle kubernetes-level errors when running jobs

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJobStatus.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesJobStatus.groovy
@@ -66,6 +66,12 @@ class KubernetesJobStatus implements JobStatus, Serializable {
     if (state?.getRunning()) {
       return JobState.Running
     } else if (state?.getWaiting()) {
+      def waiting = state.getWaiting()
+      if (waiting.reason in ["ImagePullBackoff", "RegistryUnavailable"] || waiting.reason.contains("Err")) {
+        message = waiting.getMessage()
+        reason = waiting.getReason()
+        return JobState.Failed
+      }
       return JobState.Starting
     } else if (state?.getTerminated()) {
       def terminated = state.getTerminated()


### PR DESCRIPTION
There are error conditions surfaced when a container is set to "waiting" that will cause a pipeline to hang indefinitely that depends on a job. These surface those errors: https://github.com/kubernetes/kubernetes/blob/de92db35206c986c8313400910e87773df3144a2/pkg/kubelet/images/types.go