### PR TITLE
(kubernetes) report server group events

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesEvent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesEvent.groovy
@@ -22,7 +22,7 @@ import io.fabric8.kubernetes.api.model.Event
 @Slf4j
 class KubernetesEvent {
   String message
-  Reason reason
+  String reason
   Severity type
   Integer count
   Long firstOccurrence
@@ -31,24 +31,7 @@ class KubernetesEvent {
   KubernetesEvent(Event event) {
     this.message = event.message
     this.count = event.count
-    switch (event.reason) {
-      case "FailedScheduling":
-        this.reason = Reason.Scheduling
-        break
-      case "Unhealthy":
-        this.reason = Reason.Unhealthy
-        break
-      case "Mount":
-        this.reason = Reason.Mount
-        break
-      case "Sync":
-        this.reason = Reason.Sync
-        break
-      default:
-        this.reason = Reason.Unknown
-        log.info "Unknown event reason: ${event.reason}"
-        break
-    }
+    this.reason = event.reason
 
     switch (event.type) {
       case "Warning":
@@ -66,14 +49,6 @@ class KubernetesEvent {
     this.firstOccurrence = KubernetesModelUtil.translateTime(event.firstTimestamp)
     this.lastOccurrence = KubernetesModelUtil.translateTime(event.lastTimestamp)
   }
-}
-
-enum Reason {
-  Scheduling,
-  Unhealthy,
-  Mount,
-  Sync,
-  Unknown,
 }
 
 enum Severity {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -336,6 +336,7 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
           attributes.name = serverGroupName
           attributes.replicationController = serverGroup.replicationController
           attributes.replicaSet = serverGroup.replicaSet
+          attributes.events = credentials.apiAdaptor.getEvents(namespace, serverGroup.replicationController ?: serverGroup.replicaSet)
           relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
           relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
           relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroupSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroupSpec.groovy
@@ -45,7 +45,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should return 1 up instances"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock] as Set, ACCOUNT)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock] as Set, ACCOUNT, [])
 
     then:
       serverGroup.instanceCounts.up == 1
@@ -57,7 +57,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should return 1 up, 1 down, 1 starting, 1 oos, 1 unknown instances"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock, downInstanceMock, startingInstanceMock, unknownInstanceMock, outOfServiceInstanceMock] as Set, ACCOUNT)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock, downInstanceMock, startingInstanceMock, unknownInstanceMock, outOfServiceInstanceMock] as Set, ACCOUNT, [])
 
     then:
       serverGroup.instanceCounts.up == 1
@@ -69,7 +69,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with no load balancers as disabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT, [])
       serverGroup.labels = ["hi": "there"]
 
     then:
@@ -78,7 +78,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with no enabled load balancers as disabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT, [])
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "false"]
 
     then:
@@ -87,7 +87,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with enabled load balancers as enabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT, [])
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "true"]
 
     then:
@@ -96,7 +96,7 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with mix of load balancers as enabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT)
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT, [])
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "true", (KubernetesUtil.loadBalancerKey("2")): "false"]
 
     then:


### PR DESCRIPTION
I also dropped the `Reason` enum because there were too many undocumented reasons for it to make sense to keep around, when all we were interested in was the string.

@duftler 