### PR TITLE
adds slowTest build flag to log slow tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,19 @@ allprojects {
     testLogging {
       exceptionFormat = 'full'
     }
+    if (project.hasProperty('slowTest')) {
+      long slow = 250
+      try {
+        slow = Long.parseLong(project.property('slowTest'))
+      } catch (Exception ex) {
+      }
+      afterTest { desc, result ->
+        long duration = result.getEndTime() - result.getStartTime()
+        if (duration > slow) {
+          logger.warn("test exceeded $slow ms: $desc.className :: $desc.name ($duration milliseconds)")
+        }
+      }
+    }
     minHeapSize = "512m"
     maxHeapSize = "512m"
   }


### PR DESCRIPTION
use with `-PslowTest` or `-PslowTest=<threshold millis>` (if unspecified the threshold is 250ms)

any test that runs for longer than the provided threshold will be logged with its execution timing

if the flag is not supplied, test timing is not logged