### PR TITLE
prevent lookup attempts for elbv2 loadbalancers containing '--' in the name for now

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -101,7 +101,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
 
       def regionScopedProvider = regionScopedProviderFactory.forRegion(description.credentials, region)
 
-      def loadBalancers = new LoadBalancerLookupHelper().getLoadBalancersByName(regionScopedProvider, description.loadBalancers)
+      def loadBalancers = lookupHelper().getLoadBalancersByName(regionScopedProvider, description.loadBalancers)
       if (loadBalancers.unknownLoadBalancers) {
         throw new IllegalStateException("Unable to find load balancers named $loadBalancers.unknownLoadBalancers")
       }
@@ -265,6 +265,12 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
     }
 
     return deploymentResult
+  }
+
+  @VisibleForTesting
+  @PackageScope
+  LoadBalancerLookupHelper lookupHelper() {
+    return new LoadBalancerLookupHelper()
   }
 
   @VisibleForTesting

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractInstanceLoadBalancerRegistrationAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractInstanceLoadBalancerRegistrationAtomicOperation.groovy
@@ -23,13 +23,14 @@ import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLo
 import com.amazonaws.services.elasticloadbalancingv2.model.DeregisterTargetsRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
+import com.google.common.annotations.VisibleForTesting
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.InstanceLoadBalancerRegistrationDescription
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import groovy.transform.PackageScope
 import org.springframework.beans.factory.annotation.Autowired
 
 abstract class AbstractInstanceLoadBalancerRegistrationAtomicOperation implements AtomicOperation<Void> {
@@ -61,8 +62,7 @@ abstract class AbstractInstanceLoadBalancerRegistrationAtomicOperation implement
     }
 
     def instances = getInstanceIds(asg)
-    def lookupHelper = new LoadBalancerLookupHelper()
-    def loadBalancers = asg ? lookupHelper.getLoadBalancersFromAsg(asg) : lookupHelper.getLoadBalancersByName(regionScopedProvider, description.loadBalancerNames)
+    def loadBalancers = asg ? lookupHelper().getLoadBalancersFromAsg(asg) : lookupHelper().getLoadBalancersByName(regionScopedProvider, description.loadBalancerNames)
     if (loadBalancers.unknownLoadBalancers) {
       throw new IllegalStateException("loadbalancers not found: $loadBalancers.unknownLoadBalancers")
     }
@@ -123,6 +123,12 @@ abstract class AbstractInstanceLoadBalancerRegistrationAtomicOperation implement
         }
       }
     }
+  }
+
+  @PackageScope
+  @VisibleForTesting
+  LoadBalancerLookupHelper lookupHelper() {
+    return new LoadBalancerLookupHelper()
   }
 
   private Task getTask() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -39,7 +39,9 @@ import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsR
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancer
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
+import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -91,7 +93,12 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     def defaults = new AwsConfiguration.DeployDefaults(iamRole: 'IamRole')
     def credsRepo = new MapBackedAccountCredentialsRepository()
     credsRepo.save('baz', TestCredential.named('baz'))
-    this.handler = new BasicAmazonDeployHandler(rspf, credsRepo, defaults)
+    this.handler = new BasicAmazonDeployHandler(rspf, credsRepo, defaults) {
+      @Override LoadBalancerLookupHelper lookupHelper() {
+        return new LoadBalancerLookupHelper(RateLimiter.create(1000000))
+      }
+    }
+
     Task task = Stub(Task) {
       getResultObjects() >> []
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
@@ -23,6 +23,8 @@ import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRe
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
+import com.google.common.util.concurrent.RateLimiter
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
@@ -31,7 +33,11 @@ class DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec extends Instanc
   def setupSpec() {
     description.credentials = TestCredential.named('test')
     description.instanceIds = ["i-123456"]
-    op = new DeregisterInstancesFromLoadBalancerAtomicOperation(description)
+    op = new DeregisterInstancesFromLoadBalancerAtomicOperation(description) {
+      @Override LoadBalancerLookupHelper lookupHelper() {
+        return new LoadBalancerLookupHelper(RateLimiter.create(100000))
+      }
+    }
   }
 
   def setup() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
@@ -23,6 +23,8 @@ import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRe
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
 import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
+import com.google.common.util.concurrent.RateLimiter
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
@@ -31,7 +33,11 @@ class RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec extends InstanceL
   def setupSpec() {
     description.credentials = TestCredential.named('test')
     description.instanceIds = ["i-123456"]
-    op = new RegisterInstancesWithLoadBalancerAtomicOperation(description)
+    op = new RegisterInstancesWithLoadBalancerAtomicOperation(description) {
+      @Override LoadBalancerLookupHelper lookupHelper() {
+        return new LoadBalancerLookupHelper(RateLimiter.create(100000))
+      }
+    }
   }
 
   void 'should register instances with load balancers'() {


### PR DESCRIPTION
also addresses some slow tests that went in related to use of a RateLimiter on load balancer lookup
