### PR TITLE
(consul & google) report if server group is disabled

### DIFF
--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/model/ConsulNode.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/model/ConsulNode.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.consul.model
+
+class ConsulNode {
+  boolean enabled
+  List<ConsulHealth> healths
+}

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/provider/ConsulProviderUtils.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/provider/ConsulProviderUtils.groovy
@@ -20,17 +20,36 @@ import com.netflix.spinnaker.clouddriver.consul.api.v1.ConsulAgent
 import com.netflix.spinnaker.clouddriver.consul.api.v1.model.CheckResult
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulHealth
+import com.netflix.spinnaker.clouddriver.consul.model.ConsulNode
 import com.netflix.spinnaker.clouddriver.model.DiscoveryHealth
+import com.netflix.spinnaker.clouddriver.model.HealthState
 import retrofit.RetrofitError
 
 class ConsulProviderUtils {
-  static List<ConsulHealth> getHealths(ConsulConfig config, String agent) {
+  static ConsulNode getHealths(ConsulConfig config, String agent) {
+    def healths = []
+    def enabled = false
     try {
-      new ConsulAgent(config, agent).api.checks()?.collect { String name, CheckResult result ->
+      healths = new ConsulAgent(config, agent).api.checks()?.collect { String name, CheckResult result ->
         return new ConsulHealth(result: result, source: result.checkID)
       } ?: []
+      enabled = true
     } catch (RetrofitError e) {
-      return []
+    }
+    return new ConsulNode(healths: healths, enabled: enabled)
+  }
+
+  // Returns true i.f.f. this "server group" of nodes is running consul.
+  static boolean consulServerGroup(List<ConsulNode> nodes) {
+    nodes?.any { it?.enabled } ?: false // If any nodes have consul running, we assume they all do since they have the same machine image.
+  }
+
+  // The return value of this function is non-sensical when `!consulServerGroup(nodes)` holds. (It will also possibly NPE).
+  static boolean serverGroupDisabled(List<ConsulNode> nodes) {
+    nodes.every { node -> // If every node isn't discoverable through consul, we say it's disabled.
+      node.healths.any { health -> // If any health isn't "up", the node is removed from consul service discovery.
+        health.state != HealthState.Up
+      }
     }
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance.groovy
@@ -25,12 +25,12 @@ import com.google.api.services.compute.model.NetworkInterface
 import com.google.api.services.compute.model.ServiceAccount
 import com.google.api.services.compute.model.Tags
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulHealth
+import com.netflix.spinnaker.clouddriver.consul.model.ConsulNode
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.model.health.GoogleHealth
 import com.netflix.spinnaker.clouddriver.google.model.health.GoogleInstanceHealth
 import com.netflix.spinnaker.clouddriver.google.model.health.GoogleLoadBalancerHealth
-import com.netflix.spinnaker.clouddriver.model.DiscoveryHealth
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
 import groovy.transform.Canonical
@@ -46,7 +46,7 @@ class GoogleInstance {
   String region
   GoogleInstanceHealth instanceHealth
   List<GoogleLoadBalancerHealth> loadBalancerHealths = []
-  List<ConsulHealth> consulHealths = []
+  ConsulNode consulNode
   List<NetworkInterface> networkInterfaces
   Metadata metadata
   List<Disk> disks
@@ -89,7 +89,7 @@ class GoogleInstance {
     String selfLink = GoogleInstance.this.selfLink
     String serverGroup = GoogleInstance.this.serverGroup
     Tags tags = GoogleInstance.this.tags
-    List<ConsulHealth> consulHealths = GoogleInstance.this.consulHealths
+    ConsulNode consulNode = GoogleInstance.this.consulNode
 
     List<Map<String, String>> getSecurityGroups() {
       GoogleInstance.this.securityGroups.collect {
@@ -104,7 +104,7 @@ class GoogleInstance {
       loadBalancerHealths.each { GoogleLoadBalancerHealth h ->
         healths << mapper.convertValue(h.view, new TypeReference<Map<String, Object>>() {})
       }
-      consulHealths?.each { ConsulHealth h ->
+      consulNode?.healths?.each { ConsulHealth h ->
         healths << mapper.convertValue(h, new TypeReference<Map<String, Object>>() {})
       }
       healths << mapper.convertValue(instanceHealth?.view, new TypeReference<Map<String, Object>>() {})
@@ -119,6 +119,9 @@ class GoogleInstance {
       }
       if (instanceHealth) {
         allHealths << instanceHealth.view
+      }
+      consulNode?.healths?.each {
+        allHealths << it
       }
       allHealths
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
@@ -23,8 +23,6 @@ import com.google.api.services.compute.model.AutoscalingPolicy
 import com.google.api.services.compute.model.InstanceGroupManagerActionsSummary
 import com.google.api.services.compute.model.InstanceGroupManagerAutoHealingPolicy
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
-import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
-import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
@@ -47,6 +45,7 @@ class GoogleServerGroup {
   Set<String> securityGroups = []
   Map buildInfo
   Boolean disabled = false
+  Boolean discovery = false
   String networkName
   Set<String> instanceTemplateTags = []
   String selfLink
@@ -91,6 +90,7 @@ class GoogleServerGroup {
     String networkName = GoogleServerGroup.this.networkName
     Set<String> instanceTemplateTags = GoogleServerGroup.this.instanceTemplateTags
     String selfLink = GoogleServerGroup.this.selfLink
+    Boolean discovery = GoogleServerGroup.this.discovery
     InstanceGroupManagerActionsSummary currentActions = GoogleServerGroup.this.currentActions
     AutoscalingPolicy autoscalingPolicy = GoogleServerGroup.this.autoscalingPolicy
     InstanceGroupManagerAutoHealingPolicy autoHealingPolicy = GoogleServerGroup.this.autoHealingPolicy

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInstanceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInstanceCachingAgent.groovy
@@ -93,9 +93,9 @@ class GoogleInstanceCachingAgent extends AbstractGoogleCachingAgent {
     instanceAggregatedList?.items?.each { String zone, InstancesScopedList instancesScopedList ->
       def localZoneName = Utils.getLocalName(zone)
       instancesScopedList?.instances?.each { Instance instance ->
-        List<ConsulHealth> consulHealths = credentials.consulConfig?.enabled ?
+        def consulNode = credentials.consulConfig?.enabled ?
           ConsulProviderUtils.getHealths(credentials.consulConfig, instance.getName())
-          : []
+          : null
         long instanceTimestamp = instance.creationTimestamp ?
             Utils.getTimeFromTimestamp(instance.creationTimestamp) :
             Long.MAX_VALUE
@@ -112,7 +112,7 @@ class GoogleInstanceCachingAgent extends AbstractGoogleCachingAgent {
             serviceAccounts: instance.serviceAccounts,
             selfLink: instance.selfLink,
             tags: instance.tags,
-            consulHealths: consulHealths,
+            consulNode: consulNode,
             instanceHealth: new GoogleInstanceHealth(
                 status: GoogleInstanceHealth.Status.valueOf(instance.getStatus())
             ))


### PR DESCRIPTION
Whenever consul is running for any instance in a server group, we start taking consul health into account.

![ycafp5aqzvc](https://cloud.githubusercontent.com/assets/4874941/18206724/e7ba0b86-70f5-11e6-9c4d-453c4560578d.png)
