### PR TITLE
(kubernetes) batch & frontload event lookup

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -122,6 +122,17 @@ class KubernetesApiAdaptor {
     }
   }
 
+  Map<String, List<Event>> getEvents(String namespace, String type) {
+    atomicWrapper("Get Events", namespace) { KubernetesClient client ->
+      def events = client.events().inNamespace(namespace).withField("involvedObject.kind", type).list().items
+      def eventMap = [:].withDefault { _ -> [] }
+      events.each { Event event ->
+        eventMap[event.involvedObject.name] += [event]
+      }
+      return eventMap
+    }
+  }
+
   Ingress createIngress(String namespace, Ingress ingress) {
     atomicWrapper("Create Ingress ${ingress?.metadata?.name}", namespace) { KubernetesClient client ->
       client.extensions().ingresses().inNamespace(namespace).create(ingress)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -92,6 +92,7 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
       podMock.getMetadata() >> podMetadataMock
 
       apiMock.getReplicationControllers(NAMESPACE) >> [replicationControllerMock]
+      apiMock.getEvents(NAMESPACE, "ReplicationController") >> [:].withDefault { _ -> [] }
       apiMock.getPods(NAMESPACE, selector) >> [podMock]
 
       def providerCacheMock = Mock(ProviderCache)


### PR DESCRIPTION
@duftler I saw the servergroup & pod refresh cycles taking abnormally long (1 minute +), and realized it was due to the events being loaded for each resource individually. This approach loads the events all at once, greatly speeding up the refresh cycles.