### PR TITLE
provider/google: Null guard for L7 pathRules in caching agent.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -337,7 +337,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
                   paths: pathRule.paths,
                   backendService: new GoogleBackendService(name: Utils.getLocalName(pathRule.service)),
               )
-            }
+            } ?: []
             googleLoadBalancer.hostRules << gHostRule
           }
         }


### PR DESCRIPTION
@duftler please review. GCP can return `null` for the `pathRule` in a `pathMatcher`. The frontend expects a list of some sort (even if empty), so I just added a null guard defaulting to `[]`.