### PR TITLE
provider/google: Properly dedupe backend services in upsert.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleBackendService.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleBackendService.groovy
@@ -18,8 +18,9 @@ package com.netflix.spinnaker.clouddriver.google.model.loadbalancing
 
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
 import groovy.transform.Canonical
+import groovy.transform.EqualsAndHashCode
 
-@Canonical
+@EqualsAndHashCode(excludes="backends")
 class GoogleBackendService {
   String name
   GoogleHealthCheck healthCheck


### PR DESCRIPTION
@duftler please review. When a backend service has a backend associated, `unique()` equality check doesn't work properly because of the backend list. This `unique` checks everything but the backends, which aren't managed by L7 upsert.