### PR TITLE
Lookup owner of AMI in AllowLaunch operation.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolver.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolver.groovy
@@ -41,7 +41,7 @@ class AmiIdResolver {
     }
     Image resolvedImage = amazonEC2.describeImages(req)?.images?.getAt(0)
     if (resolvedImage) {
-      return new ResolvedAmiResult(nameOrId, region, resolvedImage.imageId, resolvedImage.virtualizationType, resolvedImage.blockDeviceMappings)
+      return new ResolvedAmiResult(nameOrId, region, resolvedImage.imageId, resolvedImage.virtualizationType, resolvedImage.ownerId, resolvedImage.blockDeviceMappings)
     }
 
     return null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ResolvedAmiResult.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ResolvedAmiResult.groovy
@@ -28,5 +28,6 @@ class ResolvedAmiResult {
   String region
   String amiId
   String virtualizationType
+  String ownerId
   List<BlockDeviceMapping> blockDeviceMappings
 }


### PR DESCRIPTION
If the AMI is baked with a different account that the one being used to
deploy, that owner account needs to be used to update the permissions on
that AMI.