### PR TITLE
provider/google: Refactor safeRetry and handle socket timeout.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GoogleOperationPoller.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GoogleOperationPoller.groovy
@@ -92,7 +92,7 @@ class GoogleOperationPoller {
     The timeoutSeconds parameter is really treated as a lower-bound. We will poll until the operation reaches a DONE
     state or until <em>at least</em> that many seconds have passed.
    */
-  private Operation waitForOperation(Closure getOperation, long timeoutSeconds) {
+  private Operation waitForOperation(Closure<Operation> getOperation, long timeoutSeconds) {
     int totalTimePollingSeconds = 0
     boolean timeoutExceeded = false
 
@@ -105,7 +105,8 @@ class GoogleOperationPoller {
 
       totalTimePollingSeconds += pollInterval
 
-      Operation operation = getOperation()
+      def retry = new SafeRetry<Operation>()
+      Operation operation = retry.doRetry(getOperation, "wait", "operation", null, null, [], [])
 
       if (operation.getStatus() == "DONE") {
         return operation

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/SafeRetry.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/SafeRetry.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.deploy
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.common.annotations.VisibleForTesting
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
+import groovy.util.logging.Slf4j
+
+import java.util.concurrent.TimeUnit
+
+@Slf4j
+class SafeRetry<T> {
+
+  @VisibleForTesting
+  static long SAFE_RETRY_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(10)
+
+  /**
+   * Retry a GCP operation if it fails. Treat any error codes in successfulErrorCodes as success.
+   *
+   * @param operation - The GCP operation.
+   * @param action - String describing the GCP operation.
+   * @param resource - Resource we are operating on.
+   * @param task - Spinnaker task. Can be null.
+   * @param phase
+   * @param retryCodes - GoogleJsonResponseException codes we retry on.
+   * @param successfulErrorCodes - GoogleJsonException codes we treat as success.
+   *
+   * @return Object of type T returned from the operation.
+   */
+  public T doRetry(Closure<T> operation,
+                   String action,
+                   String resource,
+                   Task task,
+                   String phase,
+                   List<Integer> retryCodes,
+                   List<Integer> successfulErrorCodes) {
+    try {
+      task?.updateStatus phase, "Attempting $action of $resource..."
+      return operation()
+    } catch (GoogleJsonResponseException | SocketTimeoutException _) {
+      log.warn "Initial $action of $resource failed, retrying..."
+
+      int tries = 1
+      Exception lastSeenException = null
+      while (tries < 10) { // Retry 10 times.
+        try {
+          tries++
+          sleep(SAFE_RETRY_INTERVAL_MILLIS) // Sleep for some interval between attempts.
+          log.warn "$action $resource attempt #$tries..."
+          return operation()
+        } catch (GoogleJsonResponseException jsonException) {
+          if (jsonException.statusCode in successfulErrorCodes) {
+            log.warn "Retry $action of $resource encountered ${jsonException.statusCode}, treating as success..."
+            return
+          } else if (jsonException.statusCode in retryCodes) {
+            log.warn "Retry $action of $resource encountered ${jsonException.statusCode} with error message: ${jsonException.message}. Trying again..."
+          } else {
+            throw jsonException
+          }
+          lastSeenException = jsonException
+        } catch (SocketTimeoutException toEx) {
+          log.warn "Retry $action timed out again, trying again..."
+          lastSeenException = toEx
+        }
+      }
+
+      if (lastSeenException && lastSeenException instanceof GoogleJsonResponseException) {
+        def lastSeenError = lastSeenException?.getDetails()?.getErrors()[0] ?: null
+        if (lastSeenError) {
+          throw new GoogleOperationException("Failed to $action $resource after #$tries."
+            + " Last seen exception has status code ${lastSeenException.getStatusCode()} with error message ${lastSeenError.getMessage()}"
+            + " and reason ${lastSeenError.getReason()}.")
+        } else {
+          throw new GoogleOperationException("Failed to $action $resource after #$tries."
+            + " Last seen exception has status code ${lastSeenException.getStatusCode()} with message ${lastSeenException.getMessage()}.")
+        }
+      } else if (lastSeenException && lastSeenException instanceof SocketTimeoutException) {
+        throw new GoogleOperationException("Failed to $action $resource after #$tries."
+          + " Last operation timed out.")
+      } else {
+        throw new IllegalStateException("Caught exception is neither a JsonResponseException nor a OperationTimedOutException."
+          + " Caught exception: ${lastSeenException}")
+      }
+    }
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DestroyGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
@@ -102,7 +103,8 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   static void destroy(Closure operation, String resource) {
-    GCEUtil.safeRetry(operation, "destroy", resource, task, BASE_PHASE, RETRY_ERROR_CODES, SUCCESSFUL_ERROR_CODES)
+    def retry = new SafeRetry<Void>()
+    retry.doRetry(operation, "destroy", resource, task, BASE_PHASE, RETRY_ERROR_CODES, SUCCESSFUL_ERROR_CODES)
   }
 
   Closure destroyInstanceTemplate(Compute compute, String instanceTemplateName, String project) {

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DestroyGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleHttpLoadBalancer
@@ -58,7 +59,7 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
     TaskRepository.threadLocalTask.set(Mock(Task))
 
     // Yes this can affect other tests; but only in a good way.
-    GCEUtil.SAFE_RETRY_INTERVAL_MILLIS = 1
+    SafeRetry.SAFE_RETRY_INTERVAL_MILLIS = 1
   }
 
   void "should delete managed instance group"() {
@@ -281,8 +282,8 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
   }
 
   @Unroll
-  void "should retry http backend deletion on 400, 412, sock timeout, succeed on 404"() {
-    // Note: Implicitly tests GCEUtil.safeRetry
+  void "should retry http backend deletion on 400, 412, socket timeout, succeed on 404"() {
+    // Note: Implicitly tests SafeRetry.doRetry
     setup:
       def computeMock = Mock(Compute)
       def backendServicesMock = Mock(Compute.BackendServices)


### PR DESCRIPTION
@duftler @lwander please review. Refactored `safeRetry` into a generic, type-safe class since `getOperation` actually returns something instead of `void`. Added socket timeout handling instead of `GoogleOperationTimedOutException` since the latter is not something the platform throws.