### PR TITLE
Don't print stacktrace when no application is found.

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ApplicationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ApplicationsController.groovy
@@ -64,7 +64,7 @@ class ApplicationsController {
         return transform(apps)
       }
     } catch (e) {
-      log.error("Unable to fetch application (${name})", e)
+      log.error("Unable to fetch application (${name})")
       throw new ApplicationNotFoundException(name: name)
     }
   }


### PR DESCRIPTION
When a new application is created via Deck (to Gate -> Orca -> Front50), a GET
request for the application is made to Clouddriver and it fails because
clouddriver doesn't know about this application yet. Clouddriver only
learns about applications through having a server group in that
application. So, keeping the logging, not the stacktrace.