### PR TITLE
provider/google: Remove backendService and healthCheck prefixes.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -392,8 +392,7 @@ class GCEUtil {
     if (!urlMap) {
       return false
     }
-    def defaultServiceName = "${description.loadBalancerName}-${UpsertGoogleHttpLoadBalancerAtomicOperation.BACKEND_SERVICE_NAME_PREFIX}-${description.defaultService.name}"
-    if (getLocalName(urlMap.getDefaultService()) != defaultServiceName) {
+    if (getLocalName(urlMap.getDefaultService()) != description.defaultService.name) {
       return true
     }
 
@@ -417,9 +416,8 @@ class GCEUtil {
       def hostPatterns = googleHostRule.hostPatterns.sort()
       googleHostRule?.pathMatcher?.pathRules?.each { GooglePathRule googlePathRule ->
         def urlPatterns = googlePathRule?.paths?.sort()
-        def serviceName = "${description.loadBalancerName}-${UpsertGoogleHttpLoadBalancerAtomicOperation.BACKEND_SERVICE_NAME_PREFIX}-${getLocalName(googlePathRule.backendService.name)}"
         Map urlPatternMap = existingHostRuleMap.get(hostPatterns)
-        if (!urlPatternMap || !urlPatternMap.containsKey(urlPatterns) || urlPatternMap.get(urlPatterns) != serviceName) {
+        if (!urlPatternMap || !urlPatternMap.containsKey(urlPatterns) || urlPatternMap.get(urlPatterns) != getLocalName(googlePathRule.backendService.name)) {
           mapServicesDiffer = true // Groovy, baby.
           return
         }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtilSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtilSpec.groovy
@@ -553,10 +553,8 @@ class GCEUtilSpec extends Specification {
           )
         ]
       )
-      def oldDefaultName = "${LOAD_BALANCER_NAME}-${UpsertGoogleHttpLoadBalancerAtomicOperation.BACKEND_SERVICE_NAME_PREFIX}-${oldDefault}"
-      def oldServiceName = "${LOAD_BALANCER_NAME}-${UpsertGoogleHttpLoadBalancerAtomicOperation.BACKEND_SERVICE_NAME_PREFIX}-${oldService}"
       def urlMap = new UrlMap(
-        defaultService: oldDefaultName,
+        defaultService: oldDefault,
         hostRules: [
             new HostRule(
               pathMatcher: "pmName",
@@ -569,7 +567,7 @@ class GCEUtilSpec extends Specification {
             pathRules: [
                 new PathRule(
                   paths: oldPaths,
-                  service: oldServiceName,
+                  service: oldService,
                 )
             ]
           )

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -455,11 +455,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
-      def hcName = "$LOAD_BALANCER_NAME-${UpsertGoogleHttpLoadBalancerAtomicOperation.HEALTH_CHECK_NAME_PREFIX}-${hc.name}"
-      def healthCheckListReal = new HttpHealthCheckList(items: [new HttpHealthCheck(name: hcName)])
+      def healthCheckListReal = new HttpHealthCheckList(items: [new HttpHealthCheck(name: hc.name)])
       def httpHealthChecksUpdate = Mock(Compute.HttpHealthChecks.Update)
       def httpHealthChecksUpdateOp = new Operation(
-        targetLink: hcName,
+        targetLink: hc.name,
         name: HEALTH_CHECK_OP_NAME,
         status: DONE)
 
@@ -543,7 +542,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.httpHealthChecks() >> httpHealthChecks
       1 * httpHealthChecks.list(PROJECT_NAME) >> httpHealthChecksList
       1 * httpHealthChecksList.execute() >> healthCheckListReal
-      1 * httpHealthChecks.update(PROJECT_NAME, hcName, _) >> httpHealthChecksUpdate
+      1 * httpHealthChecks.update(PROJECT_NAME, hc.name, _) >> httpHealthChecksUpdate
       1 * httpHealthChecksUpdate.execute() >> httpHealthChecksUpdateOp
 
       4 * computeMock.backendServices() >> backendServices
@@ -600,18 +599,16 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
-      def hcName = "$LOAD_BALANCER_NAME-${UpsertGoogleHttpLoadBalancerAtomicOperation.HEALTH_CHECK_NAME_PREFIX}-${hc.name}"
-      def healthCheckListReal = new HttpHealthCheckList(items: [new HttpHealthCheck(name: hcName)])
+      def healthCheckListReal = new HttpHealthCheckList(items: [new HttpHealthCheck(name: hc.name)])
       def httpHealthChecksUpdate = Mock(Compute.HttpHealthChecks.Update)
       def httpHealthChecksUpdateOp = new Operation(
-        targetLink: hcName,
+        targetLink: hc.name,
         name: HEALTH_CHECK_OP_NAME,
         status: DONE)
 
       def backendServices = Mock(Compute.BackendServices)
       def backendServicesList = Mock(Compute.BackendServices.List)
-      def bsName = "$LOAD_BALANCER_NAME-${UpsertGoogleHttpLoadBalancerAtomicOperation.BACKEND_SERVICE_NAME_PREFIX}-$PM_SERVICE"
-      def bsListReal = new BackendServiceList(items: [new BackendService(name: bsName)])
+      def bsListReal = new BackendServiceList(items: [new BackendService(name: PM_SERVICE)])
       def backendServicesInsert = Mock(Compute.BackendServices.Insert)
       def backendServicesInsertOp = new Operation(
         targetLink: "backend-service",
@@ -694,7 +691,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.httpHealthChecks() >> httpHealthChecks
       1 * httpHealthChecks.list(PROJECT_NAME) >> httpHealthChecksList
       1 * httpHealthChecksList.execute() >> healthCheckListReal
-      1 * httpHealthChecks.update(PROJECT_NAME, hcName, _) >> httpHealthChecksUpdate
+      1 * httpHealthChecks.update(PROJECT_NAME, hc.name, _) >> httpHealthChecksUpdate
       1 * httpHealthChecksUpdate.execute() >> httpHealthChecksUpdateOp
 
       4 * computeMock.backendServices() >> backendServices
@@ -702,7 +699,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * backendServicesList.execute() >> bsListReal
       2 * backendServices.insert(PROJECT_NAME, _) >> backendServicesInsert
       2 * backendServicesInsert.execute() >> backendServicesInsertOp
-      1 * backendServices.update(PROJECT_NAME, bsName, _) >> backendServicesUpdate
+      1 * backendServices.update(PROJECT_NAME, PM_SERVICE, _) >> backendServicesUpdate
       1 * backendServicesUpdate.execute() >> backendServicesUpdateOp
 
       2 * computeMock.urlMaps() >> urlMaps
@@ -755,18 +752,16 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
-      def hcName = "$LOAD_BALANCER_NAME-${UpsertGoogleHttpLoadBalancerAtomicOperation.HEALTH_CHECK_NAME_PREFIX}-${hc.name}"
-      def healthCheckListReal = new HttpHealthCheckList(items: [new HttpHealthCheck(name: hcName)])
+      def healthCheckListReal = new HttpHealthCheckList(items: [new HttpHealthCheck(name: hc.name)])
       def httpHealthChecksUpdate = Mock(Compute.HttpHealthChecks.Update)
       def httpHealthChecksUpdateOp = new Operation(
-        targetLink: hcName,
+        targetLink: hc.name,
         name: HEALTH_CHECK_OP_NAME,
         status: DONE)
 
       def backendServices = Mock(Compute.BackendServices)
       def backendServicesList = Mock(Compute.BackendServices.List)
-      def bsName = "$LOAD_BALANCER_NAME-${UpsertGoogleHttpLoadBalancerAtomicOperation.BACKEND_SERVICE_NAME_PREFIX}-$PM_SERVICE"
-      def bsListReal = new BackendServiceList(items: [new BackendService(name: bsName)])
+      def bsListReal = new BackendServiceList(items: [new BackendService(name: PM_SERVICE)])
       def backendServicesInsert = Mock(Compute.BackendServices.Insert)
       def backendServicesInsertOp = new Operation(
         targetLink: "backend-service",
@@ -850,7 +845,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.httpHealthChecks() >> httpHealthChecks
       1 * httpHealthChecks.list(PROJECT_NAME) >> httpHealthChecksList
       1 * httpHealthChecksList.execute() >> healthCheckListReal
-      1 * httpHealthChecks.update(PROJECT_NAME, hcName, _) >> httpHealthChecksUpdate
+      1 * httpHealthChecks.update(PROJECT_NAME, hc.name, _) >> httpHealthChecksUpdate
       1 * httpHealthChecksUpdate.execute() >> httpHealthChecksUpdateOp
 
       4 * computeMock.backendServices() >> backendServices
@@ -858,7 +853,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * backendServicesList.execute() >> bsListReal
       2 * backendServices.insert(PROJECT_NAME, _) >> backendServicesInsert
       2 * backendServicesInsert.execute() >> backendServicesInsertOp
-      1 * backendServices.update(PROJECT_NAME, bsName, _) >> backendServicesUpdate
+      1 * backendServices.update(PROJECT_NAME, PM_SERVICE, _) >> backendServicesUpdate
       1 * backendServicesUpdate.execute() >> backendServicesUpdateOp
 
       2 * computeMock.urlMaps() >> urlMaps
@@ -911,18 +906,16 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
-      def hcName = "$LOAD_BALANCER_NAME-${UpsertGoogleHttpLoadBalancerAtomicOperation.HEALTH_CHECK_NAME_PREFIX}-${hc.name}"
-      def healthCheckListReal = new HttpHealthCheckList(items: [new HttpHealthCheck(name: hcName)])
+      def healthCheckListReal = new HttpHealthCheckList(items: [new HttpHealthCheck(name: hc.name)])
       def httpHealthChecksUpdate = Mock(Compute.HttpHealthChecks.Update)
       def httpHealthChecksUpdateOp = new Operation(
-        targetLink: hcName,
+        targetLink: hc.name,
         name: HEALTH_CHECK_OP_NAME,
         status: DONE)
 
       def backendServices = Mock(Compute.BackendServices)
       def backendServicesList = Mock(Compute.BackendServices.List)
-      def bsName = "$LOAD_BALANCER_NAME-${UpsertGoogleHttpLoadBalancerAtomicOperation.BACKEND_SERVICE_NAME_PREFIX}-$PM_SERVICE"
-      def bsListReal = new BackendServiceList(items: [new BackendService(name: bsName)])
+      def bsListReal = new BackendServiceList(items: [new BackendService(name: PM_SERVICE)])
       def backendServicesInsert = Mock(Compute.BackendServices.Insert)
       def backendServicesInsertOp = new Operation(
         targetLink: "backend-service",
@@ -1019,7 +1012,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.httpHealthChecks() >> httpHealthChecks
       1 * httpHealthChecks.list(PROJECT_NAME) >> httpHealthChecksList
       1 * httpHealthChecksList.execute() >> healthCheckListReal
-      1 * httpHealthChecks.update(PROJECT_NAME, hcName, _) >> httpHealthChecksUpdate
+      1 * httpHealthChecks.update(PROJECT_NAME, hc.name, _) >> httpHealthChecksUpdate
       1 * httpHealthChecksUpdate.execute() >> httpHealthChecksUpdateOp
 
       4 * computeMock.backendServices() >> backendServices
@@ -1027,7 +1020,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * backendServicesList.execute() >> bsListReal
       2 * backendServices.insert(PROJECT_NAME, _) >> backendServicesInsert
       2 * backendServicesInsert.execute() >> backendServicesInsertOp
-      1 * backendServices.update(PROJECT_NAME, bsName, _) >> backendServicesUpdate
+      1 * backendServices.update(PROJECT_NAME, PM_SERVICE, _) >> backendServicesUpdate
       1 * backendServicesUpdate.execute() >> backendServicesUpdateOp
 
       2 * computeMock.urlMaps() >> urlMaps


### PR DESCRIPTION
@duftler @danielpeach please review. I used a prefix to keep health checks and backend services unique for L7 so that no accidental updates happen. This causes the presentation to the user to be inconsistent though, since what they were seeing in the UI doesn't match the Cloud Console. Instead, I'll remove the prefixes and we'll warn users in the UI when they are updating health checks and backend services during upsert.