### PR TITLE
(kubernetes) Translate objects before loading them into the cache

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesEvent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesEvent.groovy
@@ -28,6 +28,8 @@ class KubernetesEvent {
   Long firstOccurrence
   Long lastOccurrence
 
+  KubernetesEvent() { }
+
   KubernetesEvent(Event event) {
     this.message = event.message
     this.count = event.count

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstance.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstance.groovy
@@ -43,11 +43,13 @@ class KubernetesInstance implements Instance, Serializable {
     KubernetesUtil.getPodLoadBalancerStates(pod)?.get(KubernetesUtil.loadBalancerKey(serviceName)) == "true"
   }
 
-  KubernetesInstance(Pod pod, List<String> loadBalancers) {
-    this(pod, loadBalancers, [])
+  KubernetesInstance() { }
+
+  KubernetesInstance(Pod pod) {
+    this(pod, [])
   }
 
-  KubernetesInstance(Pod pod, List<String> loadBalancers, List<Event> events) {
+  KubernetesInstance(Pod pod, List<Event> events) {
     this.name = pod.metadata?.name
     this.location = pod.metadata?.namespace
     this.instanceId = this.name
@@ -55,7 +57,6 @@ class KubernetesInstance implements Instance, Serializable {
     this.zone = pod.metadata?.namespace
     this.pod = pod
     this.yaml = SerializationUtils.dumpWithoutRuntimeStateAsYaml(pod)
-    this.loadBalancers = loadBalancers
     this.events = events?.collect { event ->
       new KubernetesEvent(event)
     } - null

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -55,20 +55,21 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
     this.labels ? !(this.labels.any { key, value -> KubernetesUtil.isLoadBalancerLabel(key) && value == "true" }) : false
   }
 
+  KubernetesServerGroup() { }
+
   KubernetesServerGroup(String name, String namespace) {
     this.name = name
     this.region = namespace
     this.namespace = namespace
   }
 
-  KubernetesServerGroup(ReplicaSet replicaSet, Set<KubernetesInstance> instances, String account, List<Event> events) {
+  KubernetesServerGroup(ReplicaSet replicaSet, String account, List<Event> events) {
     this.name = replicaSet.metadata?.name
     this.account = account
     this.region = replicaSet.metadata?.namespace
     this.namespace = this.region
     this.createdTime = KubernetesModelUtil.translateTime(replicaSet.metadata?.creationTimestamp)
     this.zones = [this.region] as Set
-    this.instances = instances
     this.securityGroups = []
     this.replicas = replicaSet.spec?.replicas ?: 0
     this.loadBalancers = KubernetesUtil.getLoadBalancers(replicaSet) as Set
@@ -82,14 +83,13 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
     }
   }
 
-  KubernetesServerGroup(ReplicationController replicationController, Set<KubernetesInstance> instances, String account, List<Event> events) {
+  KubernetesServerGroup(ReplicationController replicationController, String account, List<Event> events) {
     this.name = replicationController.metadata?.name
     this.account = account
     this.region = replicationController.metadata?.namespace
     this.namespace = this.region
     this.createdTime = KubernetesModelUtil.translateTime(replicationController.metadata?.creationTimestamp)
     this.zones = [this.region] as Set
-    this.instances = instances
     this.securityGroups = []
     this.replicas = replicationController.spec?.replicas ?: 0
     this.loadBalancers = KubernetesUtil.getLoadBalancers(replicationController) as Set

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.cats.agent.*
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesInstance
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.view.MutableCacheData
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
@@ -99,8 +100,7 @@ class KubernetesInstanceCachingAgent implements CachingAgent, AccountAware {
       def key = Keys.getInstanceKey(accountName, namespace, pod.metadata.name)
       cachedInstances[key].with {
         attributes.name = pod.metadata.name
-        attributes.pod = pod
-        attributes.events = events
+        attributes.instance = new KubernetesInstance(pod, events)
       }
     }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesServerGroup
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.view.MutableCacheData
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
@@ -342,10 +343,9 @@ class KubernetesServerGroupCachingAgent implements CachingAgent, OnDemandAgent, 
         }
 
         cachedServerGroups[serverGroupKey].with {
+          def events = serverGroup.replicationController ? rcEvents[serverGroupName] : rsEvents[serverGroupName]
           attributes.name = serverGroupName
-          attributes.replicationController = serverGroup.replicationController
-          attributes.replicaSet = serverGroup.replicaSet
-          attributes.events = serverGroup.replicationController ? rcEvents[serverGroupName] : rsEvents[serverGroupName]
+          attributes.serverGroup = new KubernetesServerGroup(serverGroup.replicaSet ?: serverGroup.replicationController, accountName, events)
           relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
           relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
           relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
@@ -51,20 +51,20 @@ class KubernetesInstanceProvider implements InstanceProvider<KubernetesInstance>
       throw new IllegalStateException("Multiple kubernetes pods with name $name in namespace $namespace exist.")
     }
 
-    CacheData instanceData = instances.toArray()[0]
+    CacheData instanceData = (CacheData) instances.toArray()[0]
+
+    if (!instanceData) {
+      return null
+    }
 
     def loadBalancers = instanceData.relationships[Keys.Namespace.LOAD_BALANCERS.ns].collect {
       Keys.parse(it).name
     }
 
-    def pod = objectMapper.convertValue(instanceData.attributes.pod, Pod)
-    def events = objectMapper.convertValue(instanceData.attributes.events, List)
+    KubernetesInstance instance = objectMapper.convertValue(instanceData.attributes.instance, KubernetesInstance)
+    instance.loadBalancers = loadBalancers
 
-    events = events.collect { event ->
-      objectMapper.convertValue(event, Event)
-    }
-
-    return new KubernetesInstance(pod, loadBalancers, events)
+    return instance
   }
 
   @Override

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroupSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroupSpec.groovy
@@ -45,7 +45,8 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should return 1 up instances"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock] as Set, ACCOUNT, [])
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), ACCOUNT, [])
+      serverGroup.instances = [upInstanceMock] as Set
 
     then:
       serverGroup.instanceCounts.up == 1
@@ -57,7 +58,8 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should return 1 up, 1 down, 1 starting, 1 oos, 1 unknown instances"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [upInstanceMock, downInstanceMock, startingInstanceMock, unknownInstanceMock, outOfServiceInstanceMock] as Set, ACCOUNT, [])
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), ACCOUNT, [])
+      serverGroup.instances = [upInstanceMock, downInstanceMock, startingInstanceMock, unknownInstanceMock, outOfServiceInstanceMock] as Set
 
     then:
       serverGroup.instanceCounts.up == 1
@@ -69,7 +71,8 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with no load balancers as disabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT, [])
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), ACCOUNT, [])
+      serverGroup.instances = [] as Set
       serverGroup.labels = ["hi": "there"]
 
     then:
@@ -78,7 +81,8 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with no enabled load balancers as disabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT, [])
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), ACCOUNT, [])
+      serverGroup.instances = [] as Set
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "false"]
 
     then:
@@ -87,7 +91,8 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with enabled load balancers as enabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT, [])
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), ACCOUNT, [])
+      serverGroup.instances = [] as Set
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "true"]
 
     then:
@@ -96,7 +101,8 @@ class KubernetesServerGroupSpec extends Specification {
 
   void "Should list servergroup with mix of load balancers as enabled"() {
     when:
-      def serverGroup = new KubernetesServerGroup(new ReplicationController(), [] as Set, ACCOUNT, [])
+      def serverGroup = new KubernetesServerGroup(new ReplicationController(), ACCOUNT, [])
+      serverGroup.instances = [] as Set
       serverGroup.labels = [(KubernetesUtil.loadBalancerKey("1")): "true", (KubernetesUtil.loadBalancerKey("2")): "false"]
 
     then:


### PR DESCRIPTION
In an effort to make the clusters tab more responsive I do the translation of kubernetes resource -> spinnaker resource before the instance and server group object enters the cache. This is at the expense of more overall CPU usage.