### PR TITLE
Bug fix; don't overwrite the user's selection for vnet/subnet

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
@@ -156,11 +156,11 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
             throw new RuntimeException("Could not create subnet $subnetName in virtual network $virtualNetworkName")
           }
 
+          description.vnet = virtualNetworkName
+          description.subnet = subnetName
+
           description.hasNewSubnet = true
         }
-
-        description.vnet = virtualNetworkName
-        description.subnet = AzureUtilities.getNameFromResourceId(subnetId)
 
         task.updateStatus(BASE_PHASE, "Create new application gateway ${description.loadBalancerName} in ${description.region}...")
         DeploymentExtended deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(description.credentials,

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -61,7 +61,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   List<AzureInboundPortConfig> inboundPortConfigs = []
   String vnet
   String subnet
-  Boolean hasNewSubnet
+  Boolean hasNewSubnet = false
   Boolean createNewSubnet = false
 
   static class AzureScaleSetSku {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
@@ -134,6 +134,9 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
           throw new RuntimeException("Could not create subnet $subnetName in virtual network $virtualNetworkName")
         }
 
+        description.vnet = virtualNetworkName
+        description.subnet = subnetName
+
         description.hasNewSubnet = true
       }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/subnet/model/AzureSubnetDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/subnet/model/AzureSubnetDescription.groovy
@@ -79,16 +79,14 @@ class AzureSubnetDescription extends AzureResourceOpsDescription {
     if (vnet.subnets && appGateways) {
       appGateways.each { appGateway ->
         // Iterate through the gatewayIPConfigurations and extract the subnet id which will be compared with the subnets within the vnet
-        appGateways?.gatewayIPConfigurations?.each { gatewayConfigs ->
-          gatewayConfigs.each { gatewayConfig ->
-            def subnetDescription = vnet.subnets.find { it.resourceId == gatewayConfig?.subnet?.id }
-            if (subnetDescription) {
-              subnetDescription.connectedDevices += new SubnetConnectedDevices(
-                name: appGateway.name,
-                resourceId: gatewayConfig.id,
-                type: "applicationGateways",
-              )
-            }
+        appGateway?.gatewayIPConfigurations?.each { gatewayConfig ->
+          def subnetDescription = vnet.subnets.find { it.resourceId == gatewayConfig?.subnet?.id }
+          if (subnetDescription) {
+            subnetDescription.connectedDevices += new SubnetConnectedDevices(
+              name: appGateway.name,
+              resourceId: gatewayConfig?.id,
+              type: "applicationGateways",
+            )
           }
         }
       }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -292,7 +292,7 @@ class AzureServerGroupResourceTemplate {
       tags.cluster = description.clusterName
       tags.createdTime = currentTime.toString()
       tags.loadBalancerName = LB_NAME
-      tags.hasNewSubnet = description.hasNewSubnet
+      tags.hasNewSubnet = description.hasNewSubnet.toString()
 
       // debug only; can be removed as part of the tags cleanup
       if (description.appGatewayName) tags.appGatewayName = description.appGatewayName

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
@@ -212,7 +212,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "cluster" : "azureMASM-st1-d11",
       "createdTime" : "1234567890",
       "loadBalancerName" : "lb-azureMASM-st1-d11",
-      "hasNewSubnet" : null,
+      "hasNewSubnet" : "false",
       "imageIsCustom" : "false",
       "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]"
     },
@@ -369,7 +369,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "cluster" : "azureMASM-st1-d11",
       "createdTime" : "1234567890",
       "loadBalancerName" : "lb-azureMASM-st1-d11",
-      "hasNewSubnet" : null,
+      "hasNewSubnet" : "false",
       "imageIsCustom" : "true"
     },
     "dependsOn" : [ "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]" ],


### PR DESCRIPTION
Bug fix; we end-up overwriting the user's selection for vnet/subnet with default values after the validation check. This causes the deployment to fail later on if the resources corresponding to those default values do not exist.