### PR TITLE
Bug fix - failed to select vnet in arbitrary resource group

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
@@ -77,13 +77,12 @@ class AzureUtilities {
 
     def parts = resourceId.split(PATH_SEPARATOR)
     def idx = parts.findIndexOf {it == "resourceGroups"}
-    def resourceGroupName = "unknown"
 
     if (idx > 0) {
-      resourceGroupName = parts[idx + 1]
+      return parts[idx + 1]
+    } else {
+      return null
     }
-
-    resourceGroupName.toLowerCase()
   }
 
   static String getAppNameFromAzureResourceName(String azureResourceName) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
@@ -26,6 +26,8 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
   String loadBalancerName
   String vnet
   String subnet
+  String subnetResourceId /* Azure resource ID */
+  String vnetResourceGroup
   Boolean hasNewSubnet // used for tracking the subnets that are automatically created and are not selected by the user
   Boolean useDefaultVnet = false // default is for the user to provide us with an existing vnet and subnet
   String securityGroup
@@ -95,9 +97,10 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
     }
 
     // We only support one subnet so we can just retrieve the first one
-    def subnetId = appGateway?.gatewayIPConfigurations?.first()?.subnet?.id
-    description.subnet = AzureUtilities.getNameFromResourceId(subnetId)
-    description.vnet = AzureUtilities.getResourceNameFromId(subnetId)
+    description.subnetResourceId = appGateway?.gatewayIPConfigurations?.first()?.subnet?.id
+    description.subnet = AzureUtilities.getNameFromResourceId(description.subnetResourceId)
+    description.vnet = AzureUtilities.getResourceNameFromId(description.subnetResourceId)
+    description.vnetResourceGroup = AzureUtilities.getResourceGroupNameFromResourceId(description.subnetResourceId)
     description.hasNewSubnet = appGateway.tags?.hasNewSubnet
 
     description.publicIpName = AzureUtilities.getNameFromResourceId(appGateway?.frontendIPConfigurations?.first()?.getPublicIPAddress()?.id)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
@@ -72,7 +72,11 @@ class Keys {
         result << [application: names.app, name: parts[2], id: parts[3], region: parts[4], account: parts[5]]
         break
       case Namespace.AZURE_NETWORKS.ns:
-        result << [id: parts[2], account: parts[3], region: parts[4]]
+        result << [
+          id:            parts[2],
+          account:       parts[3],
+          resourceGroup: parts[4],
+          region:        parts[5]]
         break
       case Namespace.AZURE_SUBNETS.ns:
         result << [id: parts[2], account: parts[3], region: parts[4]]
@@ -176,17 +180,19 @@ class Keys {
 
   static String getNetworkKey(AzureCloudProvider azureCloudProvider,
                               String networkId,
+                              String resourceGroup,
                               String region,
                               String account) {
-    //"$azureCloudProvider.id:${Namespace.AZURE_NETWORKS}:${networkId}:${account}:${region}"
-    getNetworkKey(azureCloudProvider.id, networkId, region, account)
+    //"$azureCloudProvider.id:${Namespace.AZURE_NETWORKS}:${networkId}:${account}:${resourceGroup}:${region}"
+    getNetworkKey(azureCloudProvider.id, networkId, resourceGroup, region, account)
   }
 
   static String getNetworkKey(String azureCloudProviderId,
                               String networkId,
+                              String resourceGroup,
                               String region,
                               String account) {
-    "${azureCloudProviderId}:${Namespace.AZURE_NETWORKS}:${networkId}:${account}:${region}"
+    "${azureCloudProviderId}:${Namespace.AZURE_NETWORKS}:${networkId}:${account}:${resourceGroup}:${region}"
   }
 
   static String getVMImageKey(AzureCloudProvider azureCloudProvider,

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/cache/AzureNetworkCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/cache/AzureNetworkCachingAgent.groovy
@@ -89,7 +89,7 @@ class AzureNetworkCachingAgent implements CachingAgent, AccountAware {
 
     List<CacheData> data = networks.collect() { AzureVirtualNetworkDescription network ->
       Map<String, Object> attributes = [network: network]
-      new DefaultCacheData(Keys.getNetworkKey(azureCloudProvider, network.id, region, accountName),
+      new DefaultCacheData(Keys.getNetworkKey(azureCloudProvider, network.id, network.resourceGroup, region, accountName),
         attributes,
         [:])
     }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/model/AzureNetwork.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/model/AzureNetwork.groovy
@@ -25,5 +25,6 @@ class AzureNetwork implements Network {
   String name
   String account
   String region
+  String resourceGroup
   List<AzureSubnet> subnets = []
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/model/AzureVirtualNetworkDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/model/AzureVirtualNetworkDescription.groovy
@@ -25,7 +25,8 @@ class AzureVirtualNetworkDescription extends AzureResourceOpsDescription {
   String id
   String type
   List<String> addressSpace /* see addressPrefix */
-  String resourceId /*Azure resource ID*/
+  String resourceId /* Azure resource ID */
+  String resourceGroup /* the Azure resource group where virtual network was created */
   Map<String, String> tags
   List<AzureSubnetDescription> subnets
   int maxSubnets
@@ -43,6 +44,7 @@ class AzureVirtualNetworkDescription extends AzureResourceOpsDescription {
     description.addressSpace = vnet.addressSpace?.addressPrefixes
     description.subnets = AzureSubnetDescription.getSubnetsForVirtualNetwork(vnet)
     description.resourceId = vnet.id
+    description.resourceGroup = AzureUtilities.getResourceGroupNameFromResourceId(vnet.id)
     description.id = vnet.name
     description.tags = vnet.tags
     description.subnetAddressPrefixLength = description.subnets?.min {it.addressPrefixLength}?.addressPrefixLength ?: AzureUtilities.SUBNET_DEFAULT_ADDRESS_PREFIX_LENGTH

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/view/AzureNetworkProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/view/AzureNetworkProvider.groovy
@@ -58,9 +58,9 @@ class AzureNetworkProvider implements NetworkProvider<AzureNetwork> {
     cacheView.getAll(Keys.Namespace.AZURE_NETWORKS.ns, RelationshipCacheFilter.none()).collect(this.&fromCacheData)
   }
 
-  AzureVirtualNetworkDescription get(String account, String region, String name) {
+  AzureVirtualNetworkDescription get(String account, String region, String resourceGroup, String name) {
     AzureVirtualNetworkDescription vnet = null
-    def cacheData = cacheView.get(Keys.Namespace.AZURE_NETWORKS.ns, Keys.getNetworkKey(azureCloudProvider, name, region, account))
+    def cacheData = cacheView.get(Keys.Namespace.AZURE_NETWORKS.ns, Keys.getNetworkKey(azureCloudProvider, name, resourceGroup, region, account))
     if (cacheData) {
       vnet = objectMapper.convertValue(cacheData.attributes['network'], AzureVirtualNetworkDescription)
     }
@@ -94,6 +94,7 @@ class AzureNetworkProvider implements NetworkProvider<AzureNetwork> {
       name: vnet.name,
       account: parts.account?: "none",
       region: vnet.region,
+      resourceGroup: vnet.resourceGroup,
       subnets: subnets
     )
   }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -61,6 +61,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   List<AzureInboundPortConfig> inboundPortConfigs = []
   String vnet
   String subnet
+  String vnetResourceGroup
   Boolean hasNewSubnet = false
   Boolean createNewSubnet = false
 
@@ -158,6 +159,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
     azureSG.subnetId = scaleSet.tags?.subnetId
     azureSG.subnet = AzureUtilities.getNameFromResourceId(azureSG.subnetId)
     azureSG.vnet = azureSG.subnetId? AzureUtilities.getNameFromResourceId(azureSG.subnetId) : scaleSet.tags?.vnet
+    azureSG.vnetResourceGroup = azureSG.subnetId? AzureUtilities.getResourceGroupNameFromResourceId(azureSG.subnetId) : scaleSet.tags?.vnetResourceGroup
     azureSG.hasNewSubnet = scaleSet.tags?.hasNewSubnet
 
     azureSG.createdTime = scaleSet.tags?.createdTime?.toLong()

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
@@ -85,7 +85,7 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
         throw new RuntimeException("Invalid load balancer was selected; $description.appGatewayName does not exist")
       }
 
-      def vnetDescription = networkProvider.get(description.accountName, description.region, virtualNetworkName)
+      def vnetDescription = networkProvider.get(description.accountName, description.region, appGatewayDescription.vnetResourceGroup, virtualNetworkName)
 
       if (!vnetDescription) {
         throw new RuntimeException("Selected virtual network $virtualNetworkName does not exist")
@@ -134,9 +134,6 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
           throw new RuntimeException("Could not create subnet $subnetName in virtual network $virtualNetworkName")
         }
 
-        description.vnet = virtualNetworkName
-        description.subnet = subnetName
-
         description.hasNewSubnet = true
       }
 
@@ -144,6 +141,9 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
       description.name = nameResolver.resolveNextServerGroupName(description.application, description.stack, description.detail, false)
       description.clusterName = description.getClusterName()
       description.appName = description.application
+      description.vnet = virtualNetworkName
+      description.subnet = subnetName
+      description.vnetResourceGroup = appGatewayDescription.vnetResourceGroup
 
       // Verify that it can be used for this server group/cluster. create a backend address pool entry if it doesn't already exist
       task.updateStatus(BASE_PHASE, "Create new backend address pool in $description.appGatewayName")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureAppGatewayResourceTemplate.groovy
@@ -80,21 +80,17 @@ class AzureAppGatewayResourceTemplate {
   static class AppGatewayTemplateVariables {
     final String apiVersion = "2015-06-15"
     String appGwName
-    String virtualNetworkName
     String publicIPAddressName
     String dnsNameForLBIP
-    String appGwSubnetName
+    String appGwSubnetID
 
-    final String virtualNetworkID = "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]"
     final String publicIPAddressType = "Dynamic"
     final String publicIPAddressID = "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
     final String appGwID = "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]"
-    final String appGwSubnetID = "[concat(variables('virtualNetworkID'),'/subnets/',variables('appGwSubnetName'))]"
     String appGwBeAddrPoolName = defaultAppGatewayBeAddrPoolName
 
     AppGatewayTemplateVariables(AzureAppGatewayDescription description) {
       appGwName = description.name
-      virtualNetworkName = description.vnet.toLowerCase()
       if (description.publicIpName) {
         // reuse the existing public IP (this is an edit operation)
         publicIPAddressName = description.publicIpName
@@ -102,7 +98,7 @@ class AzureAppGatewayResourceTemplate {
         publicIPAddressName = AzureUtilities.PUBLICIP_NAME_PREFIX + description.name.toLowerCase()
       }
       dnsNameForLBIP = DnsSettings.getUniqueDNSName(description.name)
-      appGwSubnetName = description.subnet.toLowerCase()
+      appGwSubnetID = description.subnetResourceId
       if (description.trafficEnabledSG) {
         // This is an edit operation; preserve the current backend address pool as the active rule
         appGwBeAddrPoolName = description.trafficEnabledSG
@@ -132,6 +128,7 @@ class AzureAppGatewayResourceTemplate {
       if (description.securityGroup) tags.securityGroup = description.securityGroup
       if (description.vnet) tags.vnet = description.vnet
       if (description.subnet) tags.subnet = description.subnet
+      if (description.vnet) tags.vnetResourceGroup = description.vnetResourceGroup
       if (!description.publicIpName) {
         this.dependsOn.add("[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]")
       }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/converters/UpsertAzureAppGatewayAtomicOperationConverterSpec.groovy
@@ -103,6 +103,8 @@ class UpsertAzureAppGatewayAtomicOperationConverterSpec extends  Specification{
   "loadBalancerName" : "testappgw-lb1-d1",
   "vnet" : null,
   "subnet" : null,
+  "subnetResourceId" : null,
+  "vnetResourceGroup" : null,
   "hasNewSubnet" : null,
   "useDefaultVnet" : false,
   "securityGroup" : null,

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/DeleteAzureAppGatewayAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/DeleteAzureAppGatewayAtomicOperationSpec.groovy
@@ -72,6 +72,8 @@ class DeleteAzureAppGatewayAtomicOperationSpec extends Specification{
   "loadBalancerName" : "testappgw-lb1-d1",
   "vnet" : null,
   "subnet" : null,
+  "subnetResourceId" : null,
+  "vnetResourceGroup" : null,
   "hasNewSubnet" : null,
   "useDefaultVnet" : false,
   "securityGroup" : null,

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/UpsertAzureAppGatewayAtomicOperationSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/ops/UpsertAzureAppGatewayAtomicOperationSpec.groovy
@@ -71,6 +71,8 @@ class UpsertAzureAppGatewayAtomicOperationSpec extends Specification{
   "loadBalancerName" : "testappgw-lb1-d1",
   "vnet" : null,
   "subnet" : null,
+  "subnetResourceId" : null,
+  "vnetResourceGroup" : null,
   "hasNewSubnet" : null,
   "useDefaultVnet" : false,
   "securityGroup" : null,

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/template/AzureAppGatewayResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/deploy/template/AzureAppGatewayResourceTemplateSpec.groovy
@@ -94,6 +94,7 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
     description.loadBalancerName = description.name
     description.vnet = 'vnet-testappgw-westus'
     description.subnet = 'subnet-testappgw-lb1-d1'
+    description.subnetResourceId = 'subnet-testappgw-lb1-d1'
     description.cluster = 'testappgw-sg1-d1'
     description.serverGroups = ['testappgw-sg1-d1-v000', 'testappgw-sg1-d1-v001']
     description.tags = ["key1":"val1", "key2":"val2"]
@@ -139,15 +140,12 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
   "variables" : {
     "apiVersion" : "2015-06-15",
     "appGwName" : "testappgw-lb1-d1",
-    "virtualNetworkName" : "vnet-testappgw-westus",
     "publicIPAddressName" : "pip-testappgw-lb1-d1",
     "dnsNameForLBIP" : "[concat('dns-', uniqueString(concat(resourceGroup().id, subscription().id, 'testappgwlb1d1')))]",
-    "appGwSubnetName" : "subnet-testappgw-lb1-d1",
-    "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "appGwSubnetID" : "subnet-testappgw-lb1-d1",
     "publicIPAddressType" : "Dynamic",
     "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
     "appGwID" : "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]",
-    "appGwSubnetID" : "[concat(variables('virtualNetworkID'),'/subnets/',variables('appGwSubnetName'))]",
     "appGwBeAddrPoolName" : "default_BAP0"
   },
   "resources" : [ {
@@ -174,7 +172,8 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
       "cluster" : "testappgw-sg1-d1",
       "serverGroups" : "testappgw-sg1-d1-v000 testappgw-sg1-d1-v001",
       "vnet" : "vnet-testappgw-westus",
-      "subnet" : "subnet-testappgw-lb1-d1"
+      "subnet" : "subnet-testappgw-lb1-d1",
+      "vnetResourceGroup" : null
     },
     "dependsOn" : [ "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]" ],
     "properties" : {
@@ -315,15 +314,12 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
   "variables" : {
     "apiVersion" : "2015-06-15",
     "appGwName" : "testappgw-lb1-d1",
-    "virtualNetworkName" : "vnet-testappgw-westus",
     "publicIPAddressName" : "pip-testappgw-lb1-d1",
     "dnsNameForLBIP" : "[concat('dns-', uniqueString(concat(resourceGroup().id, subscription().id, 'testappgwlb1d1')))]",
-    "appGwSubnetName" : "subnet-testappgw-lb1-d1",
-    "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "appGwSubnetID" : null,
     "publicIPAddressType" : "Dynamic",
     "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
     "appGwID" : "[resourceId('Microsoft.Network/applicationGateways',variables('appGwName'))]",
-    "appGwSubnetID" : "[concat(variables('virtualNetworkID'),'/subnets/',variables('appGwSubnetName'))]",
     "appGwBeAddrPoolName" : "default_BAP0"
   },
   "resources" : [ {
@@ -343,7 +339,8 @@ class AzureAppGatewayResourceTemplateSpec extends Specification {
     "tags" : {
       "createdTime" : "1234567890",
       "vnet" : "vnet-testappgw-westus",
-      "subnet" : "subnet-testappgw-lb1-d1"
+      "subnet" : "subnet-testappgw-lb1-d1",
+      "vnetResourceGroup" : null
     },
     "dependsOn" : [ "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]" ],
     "properties" : {

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/model/AzureVirtualNetworkDescriptionSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/network/model/AzureVirtualNetworkDescriptionSpec.groovy
@@ -109,6 +109,7 @@ class AzureVirtualNetworkDescriptionSpec extends Specification {
   "type" : null,
   "addressSpace" : null,
   "resourceId" : "vnet-test-westus-id",
+  "resourceGroup" : null,
   "subnets" : null,
   "maxSubnets" : 0,
   "subnetAddressPrefixLength" : 24
@@ -131,6 +132,7 @@ class AzureVirtualNetworkDescriptionSpec extends Specification {
   "type" : null,
   "addressSpace" : [ "10.0.0.0/8" ],
   "resourceId" : "vnet-test-westus-id",
+  "resourceGroup" : null,
   "subnets" : [ {
     "name" : "vnet-test-westus-subnet-10_0_1_0_24",
     "cloudProvider" : "azure",


### PR DESCRIPTION
When creating an azure load balancer and server group, the selected virtual network can be from a different resource group then the one corresponding to the application.