### PR TITLE
Removed time parsing workaround for old Openstack version.

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgent.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgent.groovy
@@ -40,7 +40,10 @@ import groovy.util.logging.Slf4j
 import org.openstack4j.model.heat.Stack
 import org.openstack4j.model.network.ext.LoadBalancerV2
 
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
 
@@ -202,15 +205,11 @@ class OpenstackServerGroupCachingAgent extends AbstractOpenstackCachingAgent imp
     Map<String, Object> openstackImage = buildImage(providerCache, (String) launchConfig?.image)
     Map<String, Object> advancedConfig = buildAdvancedConfig(stack.parameters)
 
-    //TODO this check will change once we have a config that indicates the openstack version, e.g. kilo, liberty, mitaka
-    //kilo stack create times have a 'Z' on the end. It was removed in liberty and mitaka.
-    ZonedDateTime zonedDateTime = DateUtils.cascadingParseDateTime(stack.creationTime)
-
     OpenstackServerGroup.builder()
       .account(accountName)
       .region(region)
       .name(stack.name)
-      .createdTime(stack.creationTime ? zonedDateTime.toInstant().toEpochMilli() : ZonedDateTime.now().toInstant().toEpochMilli())
+      .createdTime(DateUtils.parseZonedDateTime(stack.creationTime).toInstant().toEpochMilli())
       .scalingConfig(buildScalingConfig(stack))
       .launchConfig(launchConfig)
       .loadBalancers(loadbalancerIds)

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/utils/DateUtils.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/utils/DateUtils.groovy
@@ -2,7 +2,6 @@
  * Copyright 2016 Target, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
@@ -20,20 +19,26 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
 
 class DateUtils {
 
   /**
-   * Method is intended to abstract out parsing zoned date times and local date times.
-   * @param dateTime
-   * @return
-     */
-  static ZonedDateTime cascadingParseDateTime(String dateTime) {
-    try {
-      return ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-    } catch (DateTimeParseException e) {
-      return LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)?.atZone(ZoneId.systemDefault())
+   * Parses a date time string in ISO_LOCAL_DATE_TIME format.
+   *
+   * It is assumed the date time string does not include a timezone offset, as is the norm for Openstack starting with
+   * Liberty and later.
+   * @param time the date time string to parse
+   * @param defaultTime a default time to use if the given date time is null, defaults to Now
+   * @return a parsed date time object
+   */
+  static ZonedDateTime parseZonedDateTime(String time, ZonedDateTime defaultTime = null) {
+    ZonedDateTime result
+    if (time) {
+      result = LocalDateTime.parse(time, DateTimeFormatter.ISO_LOCAL_DATE_TIME).atZone(ZoneId.systemDefault())
+    } else {
+      result = defaultTime ?: ZonedDateTime.now()
     }
+    result
   }
 }
+

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgentSpec.groovy
@@ -37,12 +37,14 @@ import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccoun
 import org.openstack4j.model.common.ActionResponse
 import org.openstack4j.model.heat.Stack
 import org.openstack4j.model.network.ext.LoadBalancerV2
+import org.springframework.format.datetime.joda.DateTimeParser
 import redis.clients.jedis.exceptions.JedisException
 import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -272,7 +274,7 @@ class OpenstackServerGroupCachingAgentSpec extends Specification {
     ProviderCache providerCache = Mock(ProviderCache)
     Stack stack = Mock(Stack)
     Set<String> loadBalancerIds = Sets.newHashSet('loadBalancerId')
-    ZonedDateTime createdTime = ZonedDateTime.now()
+    LocalDateTime createdTime = LocalDateTime.now()
     String subnetId = UUID.randomUUID().toString()
 
     and:
@@ -287,7 +289,7 @@ class OpenstackServerGroupCachingAgentSpec extends Specification {
       .account(account)
       .region(region)
       .name(stack.name)
-      .createdTime(createdTime.toInstant().toEpochMilli())
+      .createdTime(createdTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
       .scalingConfig(scalingConfig)
       .launchConfig(launchConfig)
       .advancedConfig(advancedConfig)
@@ -302,7 +304,7 @@ class OpenstackServerGroupCachingAgentSpec extends Specification {
     OpenstackServerGroup result = cachingAgent.buildServerGroup(providerCache, stack, loadBalancerIds)
 
     then:
-    _ * stack.creationTime >> DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault()).format(createdTime.toInstant())
+    _ * stack.creationTime >> DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(createdTime)
     _ * stack.parameters >> [subnet_id: subnetId]
     1 * cachingAgent.buildLaunchConfig(stack.parameters) >> launchConfig
     1 * cachingAgent.buildImage(providerCache, launchConfig.image) >> openstackImage


### PR DESCRIPTION
Since Kilo isn't supported anymore, we don't need to try parsing the
time with a timezone and fallback to without the timezone anymore.