### PR TITLE
(google) Drop securityGroups attribute from Create/Clone description in favor of relying entirely on tags attribute.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -317,40 +317,6 @@ class GCEUtil {
     return allMIGSInRegion
   }
 
-  static Set<String> querySecurityGroupTags(Set<String> securityGroupNames,
-                                            String accountName,
-                                            GoogleSecurityGroupProvider googleSecurityGroupProvider,
-                                            Task task,
-                                            String phase) {
-    if (!securityGroupNames) {
-      return null
-    }
-
-    task.updateStatus phase, "Looking up firewall rules $securityGroupNames..."
-
-    Set<GoogleSecurityGroup> securityGroups = googleSecurityGroupProvider.getAllByAccount(false, accountName)
-
-    Set<GoogleSecurityGroup> securityGroupMatches = securityGroups.findAll { securityGroup ->
-      securityGroupNames.contains(securityGroup.name)
-    }
-
-    if (securityGroupMatches.size() == securityGroupNames.size()) {
-      return securityGroupMatches.collect { securityGroupMatch ->
-        securityGroupMatch.targetTags
-      }.flatten() - null
-    } else {
-      def securityGroupNameMatches = securityGroupMatches.collect { it.name }
-
-      updateStatusAndThrowNotFoundException("Firewall rules ${securityGroupNames - securityGroupNameMatches} not found.", task, phase)
-    }
-
-    return securityGroups.findAll { securityGroup ->
-      securityGroupNames.contains(securityGroup.name)
-    }.collect { securityGroup ->
-      securityGroup.targetTags
-    }.flatten() - null
-  }
-
   static GoogleServerGroup.View queryServerGroup(GoogleClusterProvider googleClusterProvider, String accountName, String region, String serverGroupName) {
     def serverGroup = googleClusterProvider.getServerGroup(accountName, region, serverGroupName)
 
@@ -367,10 +333,6 @@ class GCEUtil {
     }.collect {
       it.selfLink
     }
-  }
-
-  static List<String> mergeDescriptionAndSecurityGroupTags(List<String> tags, Set<String> securityGroupTags) {
-    return ((tags ?: []) + securityGroupTags).unique()
   }
 
   static boolean shouldUpdateUrlMap(UrlMap urlMap, UpsertGoogleLoadBalancerDescription description) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -36,7 +36,6 @@ import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleHttpLo
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerType
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
-import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleSecurityGroupProvider
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -64,9 +63,6 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
 
   @Autowired
   private GoogleOperationPoller googleOperationPoller
-
-  @Autowired
-  GoogleSecurityGroupProvider googleSecurityGroupProvider
 
   @Autowired
   GoogleLoadBalancerProvider googleLoadBalancerProvider
@@ -153,13 +149,6 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
         def networkLoadBalancers = foundLoadBalancers.findAll { it.loadBalancerType == GoogleLoadBalancerType.NETWORK.toString() }
         targetPools = networkLoadBalancers.collect { it.targetPool }
       }
-    }
-
-    def securityGroupTags = GCEUtil.querySecurityGroupTags(description.securityGroups, accountName,
-        googleSecurityGroupProvider, task, BASE_PHASE)
-
-    if (securityGroupTags) {
-      description.tags = GCEUtil.mergeDescriptionAndSecurityGroupTags(description.tags, securityGroupTags)
     }
 
     task.updateStatus BASE_PHASE, "Composing server group $serverGroupName..."


### PR DESCRIPTION
(google) Drop securityGroups attribute from Create/Clone description in favor of relying entirely on tags attribute.