### PR TITLE
provider/google: Added backend service caching agent.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -24,6 +24,7 @@ import groovy.util.logging.Slf4j
 class Keys {
   static enum Namespace {
     APPLICATIONS,
+    BACKEND_SERVICES,
     CLUSTERS,
     HTTP_HEALTH_CHECKS,
     IMAGES,
@@ -66,6 +67,12 @@ class Keys {
     switch (result.type) {
       case Namespace.APPLICATIONS.ns:
         result << [application: parts[2]]
+        break
+      case Namespace.BACKEND_SERVICES.ns:
+        result << [
+          account: parts[2],
+          name   : parts[3],
+        ]
         break
       case Namespace.CLUSTERS.ns:
         def names = Names.parseName(parts[4])
@@ -168,6 +175,11 @@ class Keys {
     "$GoogleCloudProvider.GCE:${Namespace.APPLICATIONS}:${application}"
   }
 
+  static String getBackendServiceKey(String account,
+                                     String backendServiceName) {
+    "$GoogleCloudProvider.GCE:${Namespace.BACKEND_SERVICES}:${account}:${backendServiceName}"
+  }
+
   static String getClusterKey(String account,
                               String application,
                               String clusterName) {
@@ -222,6 +234,7 @@ class Keys {
     Names names = Names.parseName(managedInstanceGroupName)
     "$GoogleCloudProvider.GCE:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}${zone ? ":$zone" : ""}"
   }
+
   static String getSslCertificateKey(String account,
                                      String sslCertificateName) {
     "$GoogleCloudProvider.GCE:${Namespace.SSL_CERTIFICATES}:${account}:${sslCertificateName}"

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
@@ -31,12 +31,14 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
 
   final Set<String> defaultCaches = [
       APPLICATIONS.ns,
+      BACKEND_SERVICES.ns,
       CLUSTERS.ns,
       HTTP_HEALTH_CHECKS.ns,
       INSTANCES.ns,
       LOAD_BALANCERS.ns,
       SECURITY_GROUPS.ns,
       SERVER_GROUPS.ns,
+      SSL_CERTIFICATES.ns,
   ].asImmutable()
 
   GoogleInfrastructureProvider(Collection<Agent> agents) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
@@ -111,6 +111,9 @@ class GoogleInfrastructureProviderConfig {
         newlyAddedAgents << new GoogleSslCertificateCachingAgent(googleConfiguration.googleApplicationName(),
                                                                  credentials,
                                                                  objectMapper)
+        newlyAddedAgents << new GoogleBackendServiceCachingAgent(googleConfiguration.googleApplicationName(),
+                                                                 credentials,
+                                                                 objectMapper)
         newlyAddedAgents << new GoogleInstanceCachingAgent(googleConfiguration.googleApplicationName(),
                                                            credentials,
                                                            objectMapper)


### PR DESCRIPTION
Also modified SSL cert agent to cache name only. This also enables both objects to be queried via `/search` now. @duftler please review. @danielpeach FYI.