### PR TITLE
(kubernetes) remove synch around api access

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -6,5 +6,5 @@ dependencies {
   compile spinnaker.dependency('bootWeb')
 
   // TODO (move to https://github.com/spinnaker/spinnaker-dependencies/blob/master/src/spinnaker-dependencies.yml)
-  compile 'io.fabric8:kubernetes-api:2.2.136'
+  compile 'io.fabric8:kubernetes-api:2.2.161'
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -115,7 +115,7 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
       cluster.name = clusterKey.name
       if (includeDetails) {
         cluster.loadBalancers = clusterDataEntry.relationships[Keys.Namespace.LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) }
-        cluster.serverGroups = serverGroups.get(cluster.name)
+        cluster.serverGroups = serverGroups[cluster.name]?.findAll { it.account == cluster.accountName } ?: []
       } else {
         cluster.loadBalancers = clusterDataEntry.relationships[Keys.Namespace.LOAD_BALANCERS.ns]?.collect { loadBalancerKey ->
           Map parts = Keys.parse(loadBalancerKey)
@@ -152,6 +152,7 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
       for (def container : serverGroup.deployDescription.containers) {
         imageList.add(KubernetesUtil.getImageIdWithoutRegistry(container.imageDescription))
       }
+
       Map buildInfo = [images: imageList]
       serverGroup.buildInfo = buildInfo
       serverGroups[Names.parseName(serverGroup.name).cluster].add(serverGroup)


### PR DESCRIPTION
@duftler 

I also found a bug (see the ClusterProvider) where accounts with the same cluster names would show the same server group more than once.