### PR TITLE
provider/google: Include session affinity in backend service caching.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleSessionAffinity.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleSessionAffinity.groovy
@@ -16,15 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.google.model.loadbalancing
 
-import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
-import groovy.transform.Canonical
-import groovy.transform.EqualsAndHashCode
-
-@EqualsAndHashCode(excludes="backends")
-class GoogleBackendService {
-  String name
-  GoogleHealthCheck healthCheck
-  List<GoogleLoadBalancedBackend> backends
-  GoogleSessionAffinity sessionAffinity
-  // TODO(jacobkiefer): Add 'loadBalancingScheme' when we support ILB.
+// TODO(jacobkiefer): Extend this when we include ILB support.
+enum GoogleSessionAffinity {
+  NONE,
+  CLIENT_IP,
+  GENERATED_COOKIE,
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
@@ -68,7 +68,8 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
     Map<String, String> hydrateResult(Cache cacheView, Map<String, String> result, String id) {
       CacheData backendService  = cacheView.get(BACKEND_SERVICES.ns, id)
       return result + [
-          healthCheckLink: backendService.attributes.healthCheckLink as String
+          healthCheckLink: backendService.attributes.healthCheckLink as String,
+          sessionAffinity: backendService.attributes.sessionAffinity as String
       ]
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
@@ -67,6 +67,7 @@ class GoogleBackendServiceCachingAgent extends AbstractGoogleCachingAgent {
       cacheResultBuilder.namespace(BACKEND_SERVICES.ns).keep(backendServiceKey).with {
         attributes.name = backendService.name
         attributes.healthCheckLink = backendService.healthChecks[0]
+        attributes.sessionAffinity = backendService.sessionAffinity
       }
     }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -379,6 +379,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
       List<GoogleBackendService> backendServicesInMap = Utils.getBackendServicesFromHttpLoadBalancerView(googleLoadBalancer.view)
       def backendServicesToUpdate = backendServicesInMap.findAll { it && it.name == backendService.name }
       backendServicesToUpdate.each { GoogleBackendService service ->
+        service.sessionAffinity = GoogleSessionAffinity.valueOf(backendService.sessionAffinity)
         service.backends = backendService.backends?.collect { Backend backend ->
           new GoogleLoadBalancedBackend(
               serverGroupUrl: backend.group,


### PR DESCRIPTION
Also surface session affinity in '/search' details for backend services. In order to support L7 session affinity in upsert, we need to cache and surface that piece of information properly.  @duftler please review. @danielpeach FYI.