### PR TITLE
Strongly typed DefaultAllowedAccountsValidator

### DIFF
--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AllowedAccountsValidator.groovy
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AllowedAccountsValidator.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.security
 
+import com.netflix.spinnaker.clouddriver.security.resources.CredentialsNameable
 import org.springframework.validation.Errors
 
 interface AllowedAccountsValidator {
@@ -24,5 +25,5 @@ interface AllowedAccountsValidator {
    *
    * If not authorized, an appropriate rejection should be added to <code>errors</code>.
    */
-  void validate(String user, Collection<String> allowedAccounts, Object description, Errors errors)
+  void validate(String user, Collection<String> allowedAccounts, CredentialsNameable description, Errors errors)
 }

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/DefaultAllowedAccountsValidator.groovy
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/DefaultAllowedAccountsValidator.groovy
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.clouddriver.security
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.discovery.converters.Auto
+import com.netflix.spinnaker.clouddriver.security.resources.AccountNameable
+import com.netflix.spinnaker.clouddriver.security.resources.CredentialsNameable
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
@@ -32,7 +34,7 @@ class DefaultAllowedAccountsValidator implements AllowedAccountsValidator {
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(String user, Collection<String> allowedAccounts, Object description, Errors errors) {
+  void validate(String user, Collection<String> allowedAccounts, CredentialsNameable description, Errors errors) {
     if (!accountCredentialsProvider.all.find { it.requiredGroupMembership }) {
       // no accounts have group restrictions so no need to validate / log
       return
@@ -43,7 +45,7 @@ class DefaultAllowedAccountsValidator implements AllowedAccountsValidator {
      * - the account is not restricted (has no requiredGroupMembership)
      * - the user has been granted specific access (has the target account in its set of allowed accounts)
      */
-    if (description.hasProperty("credentials")) {
+    if (description) {
       if (description.credentials instanceof Collection) {
         description.credentials.each { AccountCredentials credentials ->
           validateTargetAccount(credentials, allowedAccounts, description, user, errors)
@@ -52,7 +54,7 @@ class DefaultAllowedAccountsValidator implements AllowedAccountsValidator {
         validateTargetAccount(description.credentials, allowedAccounts, description, user, errors)
       }
     } else {
-      errors.rejectValue("credentials", "missing", "no credentials found in description: ${description.class.simpleName})")
+      errors.rejectValue("credentials", "missing", "no credentials found in description: ${description?.class?.simpleName})")
     }
   }
 

--- a/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/DefaultAllowedAccountsValidatorSpec.groovy
+++ b/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/DefaultAllowedAccountsValidatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.security
 
+import com.netflix.spinnaker.clouddriver.security.resources.CredentialsNameable
 import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
@@ -134,7 +135,7 @@ class DefaultAllowedAccountsValidatorSpec extends Specification {
     })
 
     when:
-    validator.validate("TestAccount", [], new InvalidDescription(), errors)
+    validator.validate("TestAccount", [], null, errors)
 
     then:
     1 * errors.rejectValue("credentials", "missing", _)
@@ -149,7 +150,7 @@ class DefaultAllowedAccountsValidatorSpec extends Specification {
     List<String> requiredGroupMembership
   }
 
-  static class TestDescription {
+  static class TestDescription implements CredentialsNameable {
     TestAccountCredentials credentials
   }
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationDescriptionPreProcessor
 import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
 import com.netflix.spinnaker.clouddriver.security.AllowedAccountsValidator
+import com.netflix.spinnaker.clouddriver.security.resources.CredentialsNameable
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.Canonical
 import org.springframework.beans.factory.annotation.Autowired
@@ -173,7 +174,7 @@ class OperationsController {
         }
 
         allowedAccountValidators.each {
-          it.validate(username, allowedAccounts, description, errors)
+          it.validate(username, allowedAccounts, description as CredentialsNameable, errors)
         }
 
         AtomicOperation atomicOperation = converter.convertOperation(v)


### PR DESCRIPTION
@anotherchrisberry You added the ability to specify multiple credentials within a single operation. This inhibits strongly typing this validator. What was the catalyst for that change, and can we find a different/better workaround?

This is half baked PR showing what I'm trying to do. Tests obviously won't pass until we can agree on a workaround.

tag: spinnaker/spinnaker#1164