### PR TITLE
provider/google: Represent L4/L7 single port range as a single port.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/controllers/GoogleLoadBalancerController.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/controllers/GoogleLoadBalancerController.groovy
@@ -104,17 +104,21 @@ class GoogleLoadBalancerController {
       }
     }
 
+    def isHttp = view.loadBalancerType == GoogleLoadBalancerType.HTTP
     [new GoogleLoadBalancerDetails(loadBalancerName: view.name,
+                                   loadBalancerType: view.loadBalancerType,
                                    createdTime: view.createdTime,
                                    dnsname: view.ipAddress,
                                    ipAddress: view.ipAddress,
                                    healthCheck: view.healthCheck ?: null,
                                    backendServiceHealthChecks: backendServiceHealthChecks ?: null,
                                    listenerDescriptions: [[
-                                       listener: new ListenerDescription(instancePort: view.portRange,
-                                                                         loadBalancerPort: view.portRange,
-                                                                         instanceProtocol: view.ipProtocol,
-                                                                         protocol: view.ipProtocol)
+                                       listener: new ListenerDescription(
+                                         instancePort: isHttp ? 'http' : Utils.derivePortOrPortRange(view.portRange), // Https forwards traffic to a 'named' port.
+                                         loadBalancerPort: Utils.derivePortOrPortRange(view.portRange),
+                                         instanceProtocol: view.ipProtocol,
+                                         protocol: view.ipProtocol
+                                       )
                                    ]])]
   }
 
@@ -167,6 +171,7 @@ class GoogleLoadBalancerController {
     String dnsname
     String ipAddress
     String loadBalancerName
+    GoogleLoadBalancerType loadBalancerType
     GoogleHealthCheck.View healthCheck
     Map<String, GoogleHealthCheck.View> backendServiceHealthChecks = [:]
     // TODO(ttomsu): Bizarre nesting of data. Necessary?

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
@@ -36,6 +36,24 @@ class Utils {
     }
   }
 
+  /**
+   * Return a single port string if a port range refers to a single port (e.g. 80-80).
+   *
+   * @param portRange - Port range to parse.
+   * @return - Single port if the ports in the port range are the same.
+   */
+  static String derivePortOrPortRange(String portRange) {
+    if (!portRange || !portRange.contains('-')) {
+      return portRange
+    }
+    def tokens = portRange.split('-')
+    if (tokens.length != 2) {
+      throw new IllegalFormatException("Port range ${portRange} formatted improperly.")
+    }
+
+    tokens[0] != tokens[1] ? portRange : tokens[0]
+  }
+
   static String getLocalName(String fullUrl) {
     if (!fullUrl) {
       return fullUrl

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/UtilsSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/UtilsSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.model.callbacks
 
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class UtilsSpec extends Specification {
 
@@ -93,5 +94,17 @@ class UtilsSpec extends Specification {
       "/projects/PROJECT/zones/us-central1-f/instanceGroups/svg-stack-v000"                                      | "us-central1"
       "https://www.googleapis.com/compute/v1/projects/PROJECT/regions/us-central1/instanceGroups/svg-stack-v00"  | "us-central1"
       "projects/PROJECT/regions/us-central1/instanceGroups/svg-stack-v00"                                        | "us-central1"
+  }
+
+  @Unroll
+  def "should represent port range as a single port string if ports equal"() {
+    expect:
+      expected == Utils.derivePortOrPortRange(input)
+
+    where:
+      input       | expected
+      ""          | ""
+      "80-90"     | "80-90"
+      "8080-8080" | "8080"
   }
 }


### PR DESCRIPTION
L4/L7 port ranges were represented previously as a "range" of the same port, e.g. 8080-8080. This PR expresses that string as a single port. Additionally fixes the `instancePort` detail for Https to be the named port 'http'. @duftler @danielpeach please review.