### PR TITLE
Allow instance monitoring to be disabled on a launch configuration.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilder.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilder.groovy
@@ -247,10 +247,7 @@ class DefaultLaunchConfigurationBuilder implements LaunchConfigurationBuilder {
       .withSpotPrice(settings.spotPrice)
       .withClassicLinkVPCId(settings.classicLinkVpcId)
       .withClassicLinkVPCSecurityGroups(settings.classicLinkVpcSecurityGroups)
-
-    if (settings.instanceMonitoring) {
-      request.withInstanceMonitoring(new InstanceMonitoring(enabled: settings.instanceMonitoring))
-    }
+      .withInstanceMonitoring(new InstanceMonitoring(enabled: settings.instanceMonitoring))
 
     if (settings.blockDevices) {
       def mappings = []


### PR DESCRIPTION
Currently instance monitoring is only set if the value is explicitly true, however the default is also to enable instance monitoring so there is currently no way to disable instance monitoring in a deployment.

cc @ndcampbell

@spinnaker/netflix-reviewers PTAL