### PR TITLE
Support multiple Eureka hosts using the same AWS account ID

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider
+
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import spock.lang.Specification
+import spock.lang.Subject
+
+class AwsProviderSpec extends Specification {
+
+  @Subject
+  AwsProvider eurekaAwsProvider
+
+  @Subject
+  AwsProvider awsProvider
+
+  def setup() {
+    def eurekaAccount1 = new NetflixAmazonCredentials("my-ci-account",
+            "ci",
+            "my-ci-account",
+            "123",
+            "my-ci-account-keypair",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "1.0.0.2:8080/eureka/v2",
+            true,
+            null,
+            false,
+            null,
+            false)
+    def eurekaAccount2 = new NetflixAmazonCredentials("my-qa-account",
+            "qa",
+            "my-qa-account",
+            "123",
+            "my-qa-account-keypair",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "1.0.0.3:8080/eureka/v2",
+            true,
+            null,
+            false,
+            null,
+            false)
+
+    def eurekaAccounts = [ eurekaAccount1, eurekaAccount2 ]
+
+    def eurekaRepos = Stub(AccountCredentialsRepository) {
+      getAll() >> eurekaAccounts
+    }
+
+    eurekaAwsProvider = new AwsProvider(eurekaRepos, [])
+
+    def account1 = new NetflixAmazonCredentials("my-ci-account",
+            "ci",
+            "my-ci-account",
+            "123",
+            "my-ci-account-keypair",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true,
+            null,
+            false,
+            null,
+            false)
+    def account2 = new NetflixAmazonCredentials("my-qa-account",
+            "qa",
+            "my-qa-account",
+            "456",
+            "my-qa-account-keypair",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true,
+            null,
+            false,
+            null,
+            false)
+
+    def accounts = [ account1, account2 ]
+
+    def repos = Stub(AccountCredentialsRepository) {
+      getAll() >> accounts
+    }
+
+    awsProvider = new AwsProvider(repos, [])
+  }
+
+  void "getInstanceKey returns CI account that matches both AWS account ID and eureka host"() {
+    when:
+    def attributes = [accountId: "123", allowMultipleEurekaPerAccount: true, eurekaAccountName: "my-ci-account", instanceId: "i-045"]
+    def result = eurekaAwsProvider.getInstanceKey(attributes, "us-east-1")
+
+    then:
+    result == "aws:instances:my-ci-account:us-east-1:i-045"
+  }
+
+  void "getInstanceHealthKey returns CI account that matches both AWS account ID and eureka host"() {
+    when:
+    def attributes = [accountId: "123", allowMultipleEurekaPerAccount: true, eurekaAccountName: "my-ci-account", instanceId: "i-045"]
+    def result = eurekaAwsProvider.getInstanceHealthKey(attributes, "us-east-1", "xyz")
+
+    then:
+    result == "aws:health:i-045:my-ci-account:us-east-1:xyz"
+  }
+
+  void "getInstanceKey returns QA account that matches both AWS account ID and eureka host"() {
+    when:
+    def attributes = [accountId: "123", allowMultipleEurekaPerAccount: true, eurekaAccountName: "my-qa-account", instanceId: "i-032"]
+    def result = eurekaAwsProvider.getInstanceKey(attributes, "us-east-1")
+
+    then:
+    result == "aws:instances:my-qa-account:us-east-1:i-032"
+  }
+
+  void "getInstanceHealthKey returns QA account that matches both AWS account ID and eureka host"() {
+    when:
+    def attributes = [accountId: "123", allowMultipleEurekaPerAccount: true, eurekaAccountName: "my-qa-account", instanceId: "i-032"]
+    def result = eurekaAwsProvider.getInstanceHealthKey(attributes, "us-east-1", "jkl")
+
+    then:
+    result == "aws:health:i-032:my-qa-account:us-east-1:jkl"
+  }
+
+  void "getInstanceKey returns CI account that just matches AWS account ID, although multiple eurekas per account is allowed"() {
+    when:
+    def attributes = [accountId: "123", allowMultipleEurekaPerAccount: true, eurekaAccountName: "my-ci-account", instanceId: "i-045"]
+    def result = awsProvider.getInstanceKey(attributes, "us-east-1")
+
+    then:
+    result == "aws:instances:my-ci-account:us-east-1:i-045"
+  }
+
+  void "getInstanceHealthKey returns CI account that just matches AWS account ID, although multiple eurekas per account is allowed"() {
+    when:
+    def attributes = [accountId: "123", allowMultipleEurekaPerAccount: true, eurekaAccountName: "my-ci-account", instanceId: "i-045"]
+    def result = awsProvider.getInstanceHealthKey(attributes, "us-east-1", "xyz")
+
+    then:
+    result == "aws:health:i-045:my-ci-account:us-east-1:xyz"
+  }
+
+  void "getInstanceKey returns QA account that just matches AWS account ID, although multiple eurekas per account is allowed"() {
+    when:
+    def attributes = [accountId: "456", allowMultipleEurekaPerAccount: true, eurekaAccountName: "my-qa-account", instanceId: "i-032"]
+    def result = awsProvider.getInstanceKey(attributes, "us-east-1")
+
+    then:
+    result == "aws:instances:my-qa-account:us-east-1:i-032"
+  }
+
+  void "getInstanceHealthKey returns QA account that just matches AWS account ID, although multiple eurekas per account is allowed"() {
+    when:
+    def attributes = [accountId: "456", allowMultipleEurekaPerAccount: true, eurekaAccountName: "my-qa-account", instanceId: "i-032"]
+    def result = awsProvider.getInstanceHealthKey(attributes, "us-east-1", "jkl")
+
+    then:
+    result == "aws:health:i-032:my-qa-account:us-east-1:jkl"
+  }
+
+  void "getInstanceKey returns CI account that just matches AWS account ID, and multiple eurekas per account is not allowed"() {
+    when:
+    def attributes = [accountId: "123", allowMultipleEurekaPerAccount: false, eurekaAccountName: "my-ci-account", instanceId: "i-045"]
+    def result = awsProvider.getInstanceKey(attributes, "us-east-1")
+
+    then:
+    result == "aws:instances:my-ci-account:us-east-1:i-045"
+  }
+
+  void "getInstanceHealthKey returns CI account that just matches AWS account ID, and multiple eurekas per account is not allowed"() {
+    when:
+    def attributes = [accountId: "123", allowMultipleEurekaPerAccount: false, eurekaAccountName: "my-ci-account", instanceId: "i-045"]
+    def result = awsProvider.getInstanceHealthKey(attributes, "us-east-1", "xyz")
+
+    then:
+    result == "aws:health:i-045:my-ci-account:us-east-1:xyz"
+  }
+
+  void "getInstanceKey returns QA account that just matches AWS account ID, and multiple eurekas per account is not allowed"() {
+    when:
+    def attributes = [accountId: "456", allowMultipleEurekaPerAccount: false, eurekaAccountName: "my-qa-account", instanceId: "i-032"]
+    def result = awsProvider.getInstanceKey(attributes, "us-east-1")
+
+    then:
+    result == "aws:instances:my-qa-account:us-east-1:i-032"
+  }
+
+  void "getInstanceHealthKey returns QA account that just matches AWS account ID, and multiple eurekas per account is not allowed"() {
+    when:
+    def attributes = [accountId: "456", allowMultipleEurekaPerAccount: false, eurekaAccountName: "my-qa-account", instanceId: "i-032"]
+    def result = awsProvider.getInstanceHealthKey(attributes, "us-east-1", "jkl")
+
+    then:
+    result == "aws:health:i-032:my-qa-account:us-east-1:jkl"
+  }
+}

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/EurekaProviderConfiguration.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/EurekaProviderConfiguration.groovy
@@ -59,7 +59,8 @@ class EurekaProviderConfiguration {
     eurekaAccountConfigurationProperties.accounts.each { EurekaAccountConfigurationProperties.EurekaAccount accountConfig ->
       accountConfig.regions.each { region ->
         String eurekaHost = accountConfig.readOnlyUrl.replaceAll(Pattern.quote('{{region}}'), region)
-        agents << new EurekaCachingAgent(eurekaApiFactory.createApi(eurekaHost), region, objectMapper, eurekaHost, eurekaAwareProviderList)
+        boolean multipleEurekaPerAcc = eurekaAccountConfigurationProperties.allowMultipleEurekaPerAccount ?: false
+        agents << new EurekaCachingAgent(eurekaApiFactory.createApi(eurekaHost), region, objectMapper, eurekaHost, multipleEurekaPerAcc, accountConfig.name, eurekaAwareProviderList)
       }
     }
     EurekaCachingProvider eurekaCachingProvider = new EurekaCachingProvider(agents)

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/agent/EurekaCachingAgent.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/agent/EurekaCachingAgent.groovy
@@ -42,15 +42,19 @@ class EurekaCachingAgent implements CachingAgent, HealthProvidingCachingAgent {
   private final EurekaApi eurekaApi
   private final ObjectMapper objectMapper
   private final String eurekaHost
+  private final String eurekaAccountName
+  private final boolean allowMultipleEurekaPerAccount
   final String healthId = "Discovery"
 
   private List<EurekaAwareProvider> eurekaAwareProviderList
 
-  EurekaCachingAgent(EurekaApi eurekaApi, String region, ObjectMapper objectMapper, eurekaHost, eurekaAwareProviderList) {
+  EurekaCachingAgent(EurekaApi eurekaApi, String region, ObjectMapper objectMapper, eurekaHost, allowMultipleEurekaPerAccount, eurekaAccountName, eurekaAwareProviderList) {
     this.region = region
     this.eurekaApi = eurekaApi
     this.objectMapper = objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     this.eurekaHost = eurekaHost
+    this.allowMultipleEurekaPerAccount = allowMultipleEurekaPerAccount
+    this.eurekaAccountName = eurekaAccountName
     this.eurekaAwareProviderList = eurekaAwareProviderList
   }
 
@@ -81,6 +85,8 @@ class EurekaCachingAgent implements CachingAgent, HealthProvidingCachingAgent {
       for (EurekaInstance instance : application.instances) {
         if (instance.instanceId) {
           Map<String, Object> attributes = objectMapper.convertValue(instance, ATTRIBUTES)
+          attributes.eurekaAccountName = eurekaAccountName
+          attributes.allowMultipleEurekaPerAccount = allowMultipleEurekaPerAccount
           eurekaAwareProviderList.each { provider ->
             if (provider.isProviderForEurekaRecord(attributes)) {
               String instanceKey = provider.getInstanceKey(attributes, region)

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/config/EurekaAccountConfigurationProperties.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/config/EurekaAccountConfigurationProperties.groovy
@@ -28,4 +28,5 @@ class EurekaAccountConfigurationProperties {
     String url
   }
   List<EurekaAccount> accounts = []
+  boolean allowMultipleEurekaPerAccount
 }


### PR DESCRIPTION
Spinnaker allows you to configure multiple credentials/accounts in clouddriver that correspond to the same AWS account. However, if you use Eureka discovery to determine their health, instances will only show up as healthy in one credential/account because clouddriver uses only the AWS account ID to determine the credential name. This pull request will try to use the AWS account ID and eureka host URL in order to determine the credential name when possible--defaulting to simply matching AWS account ID when no such AWS & Eureka match can be found. This will allow users to successfully deploy to multiple 'environments' or accounts even when they only have one AWS account ID.

**Update: this merge request now uses attempts to match AWS account ID and account name, instead of eureka host URL, when retrieving the credential name.**