### PR TITLE
(kubernetes) register non-ready pods as down to stall pipelines

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesHealth.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesHealth.groovy
@@ -82,7 +82,7 @@ class KubernetesHealth implements Health {
       }
     } else if (containerStatus.state.waiting) {
       if (!containerStatus.ready) {
-        state = HealthState.Starting
+        state = HealthState.Down
       }
     }
   }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstanceSpec.groovy
@@ -90,14 +90,12 @@ class KubernetesInstanceSpec extends Specification {
 
     then:
       state == HealthState.Down
-  }
 
-  void "Should report state as Starting"() {
     when:
-      def state = (new KubernetesHealth('', containerStatusAsWaitingMock)).state
+      state = (new KubernetesHealth('', containerStatusAsWaitingMock)).state
 
     then:
-      state == HealthState.Starting
+      state == HealthState.Down
   }
 
   void "Should report state as Up"() {


### PR DESCRIPTION
@duftler 

I was incorrectly considering non-ready pods as "Starting" causing pipelines to succeed when health checks were failing.