### PR TITLE
provider/google: Cached urlMapName for L7 LBs.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleHttpLoadBalancer.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleHttpLoadBalancer.groovy
@@ -50,6 +50,12 @@ class GoogleHttpLoadBalancer {
    */
   String certificate
 
+  /**
+   * The name of the UrlMap this load balancer uses to route traffic. In the Google
+   * Cloud Console, the L7 load balancer name is the same as this name.
+   */
+  String urlMapName
+
   @JsonIgnore
   GoogleLoadBalancerView getView() {
     new View()

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -307,6 +307,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
         log.error("Overwriting UrlMap ${urlMap.name}. You may have a TargetHttp(s)Proxy naming collision.")
       }
 
+      googleLoadBalancer.urlMapName = urlMap.name
       Set queuedServices = [] as Set
       // Default service is mandatory.
       def urlMapDefaultService = Utils.getLocalName(urlMap.defaultService)


### PR DESCRIPTION
We want to be able to group the L7 LBs by `urlMapName` in the UI, so we cache it with this PR. I'll follow up soon with another PR that requires a `urlMapName` in L7 upsert. @duftler @danielpeach please review.