### PR TITLE
provider/google: Support urlMapName in L7 upsert description.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/UpsertGoogleLoadBalancerDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/UpsertGoogleLoadBalancerDescription.groovy
@@ -32,6 +32,7 @@ class UpsertGoogleLoadBalancerDescription extends AbstractGoogleCredentialsDescr
   String accountName
 
   // Http(s) attributes.
+  String urlMapName
   GoogleBackendService defaultService
   List<GoogleHostRule> hostRules
   String certificate

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -65,6 +65,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
   Map operate(List priorOutputs) {
     def httpLoadBalancer = new GoogleHttpLoadBalancer(
         name: description.loadBalancerName,
+        urlMapName: description.urlMapName,
         defaultService: description.defaultService,
         hostRules: description.hostRules,
         certificate: description.certificate,
@@ -101,7 +102,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
     List<GoogleBackendService> backendServicesFromDescription = Utils.getBackendServicesFromHttpLoadBalancerView(httpLoadBalancer.view).unique()
     List<GoogleHealthCheck> healthChecksFromDescription = backendServicesFromDescription.collect { it.healthCheck }.unique()
 
-    String urlMapName = httpLoadBalancerName // An L7 load balancer is identified by its UrlMap name in Google Cloud Console.
+    String urlMapName = httpLoadBalancer?.urlMapName ?: httpLoadBalancerName // An L7 load balancer is identified by its UrlMap name in Google Cloud Console.
 
     // Get all the existing infrastructure.
     Set<HttpHealthCheck> existingHealthChecks = compute.httpHealthChecks().list(project).execute().getItems() as Set


### PR DESCRIPTION
To wire up more than one listener to a urlMap, we need an explicit `urlMapName` in the L7 upsert description. I tested this PR with create, upsert with one listener, and then another upsert that adds a listener to the same urlMap. We'll need to change L7 delete to deal with all the possible cases this enables. @duftler or @lwander or @danielpeach please review.