### PR TITLE
Ensure that the regular caching cycle sets a ttl for OnDemand records

### DIFF
--- a/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/cache/DefaultCacheDataSpec.groovy
+++ b/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/cache/DefaultCacheDataSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.cats.cache
+
+import spock.lang.Specification
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class DefaultCacheDataSpec extends Specification {
+  def "should set cacheExpiry attribute based on ttlSeconds"() {
+    given:
+    def cacheData = new DefaultCacheData("id", 100, [:], [:], Clock.fixed(Instant.EPOCH, ZoneOffset.UTC))
+
+    expect:
+    cacheData.ttlSeconds == 100
+    cacheData.attributes.cacheExpiry == 100 * 1000
+  }
+
+  def "should set ttlSeconds attribute based on cacheExpiry"() {
+    given:
+    def cacheData = new DefaultCacheData("id", -1, [cacheExpiry: 150L * 1000], [:], Clock.fixed(Instant.EPOCH, ZoneOffset.UTC))
+
+    expect:
+    cacheData.ttlSeconds == 150
+    cacheData.attributes.cacheExpiry == 150 * 1000
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -444,6 +444,7 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
         id: it.id,
         details  : Keys.parse(it.id),
         cacheTime: it.attributes.cacheTime,
+        cacheExpiry: it.attributes.cacheExpiry,
         processedCount: it.attributes.processedCount,
         processedTime: it.attributes.processedTime
       ]

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackFloatingIPCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackFloatingIPCachingAgentSpec.groovy
@@ -60,7 +60,7 @@ class OpenstackFloatingIPCachingAgentSpec extends Specification {
     NetFloatingIP floatingIP = Mock(NetFloatingIP) {
       it.id >> { ipId }
     }
-    Map<String, Object> ipAttributes = Mock(Map)
+    Map<String, Object> ipAttributes = new HashMap<>()
     String ipKey = Keys.getFloatingIPKey(ipId, account, region)
 
     when:

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackImageCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackImageCachingAgentSpec.groovy
@@ -53,7 +53,7 @@ class OpenstackImageCachingAgentSpec extends Specification {
     Image image = Mock(Image)
     String id = UUID.randomUUID().toString()
     String imageKey = Keys.getImageKey(id, account, region)
-    Map<String, Object> imageAttributes = Mock(Map)
+    Map<String, Object> imageAttributes = new HashMap<>()
 
     when:
     CacheResult result = cachingAgent.loadData(providerCache)

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackInstanceCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackInstanceCachingAgentSpec.groovy
@@ -53,7 +53,7 @@ class OpenstackInstanceCachingAgentSpec extends Specification {
     Server server = Mock(Server)
     String id = UUID.randomUUID().toString()
     String instanceKey = Keys.getInstanceKey(id, account, region)
-    Map<String, Object> instanceAttributes = Mock(Map)
+    Map<String, Object> instanceAttributes = new HashMap<>()
 
     when:
     CacheResult result = cachingAgent.loadData(providerCache)

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackLoadBalancerCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackLoadBalancerCachingAgentSpec.groovy
@@ -161,7 +161,7 @@ class OpenstackLoadBalancerCachingAgentSpec extends Specification {
       it.healthMonitorId >> { healthId }
     }
     HealthMonitorV2 healthMonitor = Mock(HealthMonitorV2)
-    Map<String, Object> lbAttributes = Mock(Map)
+    Map<String, Object> lbAttributes = new HashMap<>()
     String lbKey = Keys.getLoadBalancerKey(lbName, loadBalancerId, account, region)
     MemberV2Status memberV2Status = Mock(MemberV2Status) {
       it.address >> { ipv6 }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackNetworkCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackNetworkCachingAgentSpec.groovy
@@ -52,7 +52,7 @@ class OpenstackNetworkCachingAgentSpec extends Specification {
     OpenstackClientProvider provider = Mock(OpenstackClientProvider)
     Network network = Mock(Network)
     String networkId = UUID.randomUUID().toString()
-    Map<String, Object> networkAttributes = Mock(Map)
+    Map<String, Object> networkAttributes = new HashMap<>()
     String networkKey = Keys.getNetworkKey(networkId, account, region)
 
     when:

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackSubnetCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackSubnetCachingAgentSpec.groovy
@@ -52,7 +52,7 @@ class OpenstackSubnetCachingAgentSpec extends Specification {
     OpenstackClientProvider provider = Mock()
     Subnet subnet = Mock(Subnet)
     String subnetId = UUID.randomUUID().toString()
-    Map<String, Object> subnetAttributes = Mock(Map)
+    Map<String, Object> subnetAttributes = new HashMap<>()
     String subnetKey = Keys.getSubnetKey(subnetId, account, region)
 
     when:


### PR DESCRIPTION
Previously the OnDemand records were loaded, incremented and re-saved w/o a TTL.