### PR TITLE
Makes searchResultHydrators keyed by provider and resource type.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsInfrastructureProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsInfrastructureProvider.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 
 import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.SECURITY_GROUPS
+import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
 
 class AwsInfrastructureProvider extends AgentSchedulerAware implements SearchableProvider {
   public static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
@@ -51,7 +52,7 @@ class AwsInfrastructureProvider extends AgentSchedulerAware implements Searchabl
     (SECURITY_GROUPS.ns): '/securityGroups/$account/$provider/$name?region=$region'
   ]
 
-  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
 
   @Override
   Map<String, String> parseKey(String key) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProvider.groovy
@@ -27,7 +27,9 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
 import java.util.regex.Pattern
+
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
+import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
 
 class AwsProvider extends AgentSchedulerAware implements SearchableProvider, EurekaAwareProvider {
 
@@ -48,8 +50,8 @@ class AwsProvider extends AgentSchedulerAware implements SearchableProvider, Eur
     (CLUSTERS.ns)      : '/applications/${application.toLowerCase()}/clusters/$account/$cluster'
   ].asImmutable()
 
-  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = [
-    (INSTANCES.ns): new InstanceSearchResultHydrator()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = [
+    (new AmazonSearchableResource(INSTANCES.ns)): new InstanceSearchResultHydrator(),
   ]
 
   final Collection<Agent> agents
@@ -137,4 +139,10 @@ class AwsProvider extends AgentSchedulerAware implements SearchableProvider, Eur
     }?.name
   }
 
+  private static class AmazonSearchableResource extends SearchableResource {
+    public AmazonSearchableResource(String resourceType) {
+      this.resourceType = resourceType.toLowerCase()
+      this.platform = 'aws'
+    }
+  }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/provider/AzureInfrastructureProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/provider/AzureInfrastructureProvider.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
 import static com.netflix.spinnaker.clouddriver.azure.resources.common.cache.Keys.Namespace.SECURITY_GROUPS
+import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
 
 @ConditionalOnProperty('azure.enabled')
 class AzureInfrastructureProvider extends AgentSchedulerAware implements SearchableProvider {
@@ -53,7 +54,7 @@ class AzureInfrastructureProvider extends AgentSchedulerAware implements Searcha
     (SECURITY_GROUPS.ns): '/securityGroups/$account/$provider/$name?region=$region'
   ]
 
-  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
 
   @Override
   Map<String, String> parseKey(String key) {

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/CloudFoundryProvider.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/CloudFoundryProvider.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.cf.cache.Keys
 
 import static com.netflix.spinnaker.clouddriver.cf.cache.Keys.Namespace.CLUSTERS
 import static com.netflix.spinnaker.clouddriver.cf.cache.Keys.Namespace.SERVER_GROUPS
+import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
 
 class CloudFoundryProvider extends AgentSchedulerAware implements SearchableProvider {
 
@@ -50,7 +51,7 @@ class CloudFoundryProvider extends AgentSchedulerAware implements SearchableProv
       (CLUSTERS.ns): '/applications/${application.toLowerCase()}/clusters/$account/$cluster'
   ].asImmutable()
 
-  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
 
   @Override
   Map<String, String> parseKey(String key) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SearchableProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SearchableProvider.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.cache
 
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.provider.Provider
+import groovy.transform.Canonical
 
 interface SearchableProvider extends Provider {
 
@@ -36,7 +37,7 @@ interface SearchableProvider extends Provider {
   /**
    * SearchResultHydrators for cache types
    */
-  Map<String, SearchResultHydrator> getSearchResultHydrators()
+  Map<SearchableResource, SearchResultHydrator> getSearchResultHydrators()
 
   /**
    * The parts of the key, if this Provider supports keys of this type, otherwise null.
@@ -48,5 +49,20 @@ interface SearchableProvider extends Provider {
    */
   public static interface SearchResultHydrator {
     Map<String, String> hydrateResult(Cache cacheView, Map<String, String> result, String id)
+  }
+
+  @Canonical
+  public static class SearchableResource {
+    /**
+     * Lowercase name of a resource type.
+     * e.g. 'instances', 'load_balancers'
+     */
+    String resourceType
+
+    /**
+     * Lowercase name of the platform.
+     * e.g. 'aws', 'gce'
+     */
+    String platform
   }
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/DockerRegistryProvider.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/DockerRegistryProvider.groovy
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
 import com.netflix.spinnaker.clouddriver.docker.registry.DockerRegistryCloudProvider
 import com.netflix.spinnaker.clouddriver.docker.registry.cache.Keys
 
+import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
+
 class DockerRegistryProvider extends AgentSchedulerAware implements SearchableProvider {
   public static final String PROVIDER_NAME = DockerRegistryProvider.name
 
@@ -42,7 +44,7 @@ class DockerRegistryProvider extends AgentSchedulerAware implements SearchablePr
     return PROVIDER_NAME
   }
 
-  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
 
   @Override
   Map<String, String> parseKey(String key) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import groovy.json.JsonOutput
 
+import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
 import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.*
 
 class GoogleInfrastructureProvider extends AgentSchedulerAware implements SearchableProvider {
@@ -51,10 +52,10 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
       (SECURITY_GROUPS.ns): '/securityGroups/$account/$provider/$name?region=$region'
   ]
 
-  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = [
-    (BACKEND_SERVICES.ns): new BackendServiceResultHydrator(),
-    (HTTP_HEALTH_CHECKS.ns): new HttpHealthCheckResultHydrator(),
-    (INSTANCES.ns): new InstanceSearchResultHydrator()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = [
+    (new GoogleSearchableResource(BACKEND_SERVICES.ns)): new BackendServiceResultHydrator(),
+    (new GoogleSearchableResource(HTTP_HEALTH_CHECKS.ns)): new HttpHealthCheckResultHydrator(),
+    (new GoogleSearchableResource(INSTANCES.ns)): new InstanceSearchResultHydrator()
   ]
 
   @Override
@@ -100,6 +101,13 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
           cluster: serverGroup.cluster as String,
           serverGroup: serverGroup.serverGroup as String
       ]
+    }
+  }
+
+  private static class GoogleSearchableResource extends SearchableResource {
+    public GoogleSearchableResource(String resourceType) {
+      this.resourceType = resourceType.toLowerCase()
+      this.platform = 'gce'
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesProvider.groovy
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
 
+import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
+
 class KubernetesProvider extends AgentSchedulerAware implements SearchableProvider {
   public static final String PROVIDER_NAME = KubernetesProvider.name
 
@@ -48,7 +50,7 @@ class KubernetesProvider extends AgentSchedulerAware implements SearchableProvid
     return PROVIDER_NAME
   }
 
-  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
 
   @Override
   Map<String, String> parseKey(String key) {

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/OpenstackInfrastructureProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/OpenstackInfrastructureProvider.groovy
@@ -31,6 +31,8 @@ import static com.netflix.spinnaker.clouddriver.openstack.cache.Keys.Namespace.L
 import static com.netflix.spinnaker.clouddriver.openstack.cache.Keys.Namespace.SECURITY_GROUPS
 import static com.netflix.spinnaker.clouddriver.openstack.cache.Keys.Namespace.SERVER_GROUPS
 
+import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
+
 @ConditionalOnProperty('openstack.enabled')
 class OpenstackInfrastructureProvider extends AgentSchedulerAware implements SearchableProvider {
   public static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
@@ -56,7 +58,7 @@ class OpenstackInfrastructureProvider extends AgentSchedulerAware implements Sea
   //TODO - Need to define urlMappingTemplates
   final Map<String, String> urlMappingTemplates = Collections.emptyMap()
   //TODO - Need to define (if applicable)
-  final Map<String, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
 
   @Override
   Map<String, String> parseKey(String key) {


### PR DESCRIPTION
Not just resource type. This was causing collisions where hydrators for one provider's resource type would try to hydrate another's cache entries, which caused some havoc. Fixes https://github.com/spinnaker/spinnaker/issues/1175. @ttomsu @duftler @cfieber @ajordens please review.