### PR TITLE
provider/google: Added support for L7 session affinity cookie ttl.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleBackendService.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleBackendService.groovy
@@ -26,5 +26,6 @@ class GoogleBackendService {
   GoogleHealthCheck healthCheck
   List<GoogleLoadBalancedBackend> backends
   GoogleSessionAffinity sessionAffinity
+  Integer affinityCookieTtlSec
   // TODO(jacobkiefer): Add 'loadBalancingScheme' when we support ILB.
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
@@ -68,6 +68,7 @@ class GoogleBackendServiceCachingAgent extends AbstractGoogleCachingAgent {
         attributes.name = backendService.name
         attributes.healthCheckLink = backendService.healthChecks[0]
         attributes.sessionAffinity = backendService.sessionAffinity
+        attributes.affinityCookieTtlSec = backendService.affinityCookieTtlSec
       }
     }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -381,6 +381,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
       def backendServicesToUpdate = backendServicesInMap.findAll { it && it.name == backendService.name }
       backendServicesToUpdate.each { GoogleBackendService service ->
         service.sessionAffinity = GoogleSessionAffinity.valueOf(backendService.sessionAffinity)
+        service.affinityCookieTtlSec = backendService.affinityCookieTtlSec
         service.backends = backendService.backends?.collect { Backend backend ->
           new GoogleLoadBalancedBackend(
               serverGroupUrl: backend.group,


### PR DESCRIPTION
We added support earlier for setting session affinity for an L7 backend service, but not the cookie TTL in the case of `GENERATED_COOKIE` session affinity. @danielpeach @duftler please review.