### PR TITLE
provider/google: Added ability to remove listeners in L7 upsert.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/UpsertGoogleLoadBalancerDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/UpsertGoogleLoadBalancerDescription.groovy
@@ -36,6 +36,7 @@ class UpsertGoogleLoadBalancerDescription extends AbstractGoogleCredentialsDescr
   GoogleBackendService defaultService
   List<GoogleHostRule> hostRules
   String certificate
+  List<String> listenersToDelete
 
   GoogleLoadBalancerType loadBalancerType
 


### PR DESCRIPTION
We added the ability to add multiple listeners to one url map earlier this week - this is the symmetric 'delete' operation for listeners in upsert. This also adds a utility function to delete global listeners. I'm planning on using that in a future PR changing L7 delete. @duftler @danielpeach please review.