### PR TITLE
provider/google: Guard against reusing listeners for different url maps.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -163,6 +163,12 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
           break
       }
       targetProxyExists = existingProxy as Boolean
+      if (existingProxy && GCEUtil.getLocalName(existingProxy.getUrlMap()) != description.urlMapName) {
+        throw new IllegalStateException(
+          "Listener with name ${existingRule.getName()} already exists and points to url map: ${GCEUtil.getLocalName(existingProxy.getUrlMap())}," +
+            " which is different from the description url map: ${description.urlMapName}."
+        )
+      }
     }
 
     // HttpHealthChecks


### PR DESCRIPTION
@duftler @danielpeach please review. If we allow the user to add multiple listeners and specify the names manually, we need to guard against reusing a listener to try and point to two different url maps. There should be a symmetric frontend change preventing this type of situation also.