### PR TITLE
provider/amazon: allow launch on cross-account migration

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.aws.agent.CleanupAlarmsAgent
 import com.netflix.spinnaker.clouddriver.aws.agent.CleanupDetachedInstancesAgent
 import com.netflix.spinnaker.clouddriver.aws.agent.ReconcileClassicLinkSecurityGroupsAgent
 import com.netflix.spinnaker.clouddriver.aws.bastion.BastionConfig
+import com.netflix.spinnaker.clouddriver.aws.deploy.converters.AllowLaunchAtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.BasicAmazonDeployHandler
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.DefaultMigrateClusterConfigurationStrategy
 import com.netflix.spinnaker.clouddriver.aws.deploy.handlers.DefaultMigrateLoadBalancerStrategy
@@ -176,9 +177,11 @@ class AwsConfiguration {
                                                         BasicAmazonDeployHandler basicAmazonDeployHandler,
                                                         RegionScopedProviderFactory regionScopedProviderFactory,
                                                         BasicAmazonDeployDescriptionValidator basicAmazonDeployDescriptionValidator,
+                                                        AllowLaunchAtomicOperationConverter allowLaunchAtomicOperationConverter,
                                                         DeployDefaults deployDefaults) {
     new DefaultMigrateServerGroupStrategy(amazonClientProvider, basicAmazonDeployHandler,
-      regionScopedProviderFactory, basicAmazonDeployDescriptionValidator, deployDefaults)
+      regionScopedProviderFactory, basicAmazonDeployDescriptionValidator, allowLaunchAtomicOperationConverter,
+      deployDefaults)
   }
 
   @Bean

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/AllowLaunchAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/AllowLaunchAtomicOperationConverter.groovy
@@ -19,13 +19,20 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.converters
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.AllowLaunchAtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
 import org.springframework.stereotype.Component
 
 @Component("allowLaunchDescription")
 class AllowLaunchAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  @Autowired
+  ApplicationContext applicationContext
+
   @Override
   AllowLaunchAtomicOperation convertOperation(Map input) {
-    new AllowLaunchAtomicOperation(convertDescription(input))
+    def op = new AllowLaunchAtomicOperation(convertDescription(input))
+    applicationContext?.autowireCapableBeanFactory?.autowireBean(op)
+    op
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/DefaultMigrateServerGroupStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/DefaultMigrateServerGroupStrategy.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.handlers;
 
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration.DeployDefaults;
+import com.netflix.spinnaker.clouddriver.aws.deploy.converters.AllowLaunchAtomicOperationConverter;
 import com.netflix.spinnaker.clouddriver.aws.deploy.validators.BasicAmazonDeployDescriptionValidator;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory;
@@ -28,17 +29,20 @@ public class DefaultMigrateServerGroupStrategy extends MigrateServerGroupStrateg
   private DeployDefaults deployDefaults;
   private BasicAmazonDeployHandler basicAmazonDeployHandler;
   private BasicAmazonDeployDescriptionValidator basicAmazonDeployDescriptionValidator;
+  private AllowLaunchAtomicOperationConverter allowLaunchAtomicOperationConverter;
 
   public DefaultMigrateServerGroupStrategy(AmazonClientProvider amazonClientProvider,
                                            BasicAmazonDeployHandler basicAmazonDeployHandler,
                                            RegionScopedProviderFactory regionScopedProviderFactory,
                                            BasicAmazonDeployDescriptionValidator basicAmazonDeployDescriptionValidator,
+                                           AllowLaunchAtomicOperationConverter allowLaunchAtomicOperationConverter,
                                            DeployDefaults deployDefaults) {
 
     this.amazonClientProvider = amazonClientProvider;
     this.basicAmazonDeployHandler = basicAmazonDeployHandler;
     this.regionScopedProviderFactory = regionScopedProviderFactory;
     this.basicAmazonDeployDescriptionValidator = basicAmazonDeployDescriptionValidator;
+    this.allowLaunchAtomicOperationConverter = allowLaunchAtomicOperationConverter;
     this.deployDefaults = deployDefaults;
   }
 
@@ -65,5 +69,10 @@ public class DefaultMigrateServerGroupStrategy extends MigrateServerGroupStrateg
   @Override
   public BasicAmazonDeployDescriptionValidator getBasicAmazonDeployDescriptionValidator() {
     return basicAmazonDeployDescriptionValidator;
+  }
+
+  @Override
+  AllowLaunchAtomicOperationConverter getAllowLaunchAtomicOperationConverter() {
+    return allowLaunchAtomicOperationConverter;
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupResult.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/servergroup/MigrateServerGroupResult.groovy
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.MigrateSec
 
 class MigrateServerGroupResult {
   List<String> serverGroupNames
-  List<String> warnings
+  List<String> warnings = []
   List<MigrateLoadBalancerResult> loadBalancers
   List<MigrateSecurityGroupResult> securityGroups
 }


### PR DESCRIPTION
If the source AMI has not been deployed in the target account yet, the migration will fail. This gets around that by adding launch permissions to the source AMI in the target account.

@cfieber or @ajordens PTAL. This is the least gross way I could find to do this. I tried to do it in Orca but it was even grosser.