### PR TITLE
provider/amazon: guard against missing credentials when serializing AACD

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/MigrateSecurityGroupReference.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/MigrateSecurityGroupReference.groovy
@@ -40,4 +40,9 @@ class MigrateSecurityGroupReference extends AbstractAmazonCredentialsDescription
     this.sourceId = pair.groupId
     this.credentials = credentials
   }
+
+  @Override
+  String getAccount() {
+    getCredentialAccount()
+  }
 }


### PR DESCRIPTION
We don't always set the `credentials` when migrating a security group, so we can get a NPE on migration (especially if the reference is to an unknown account).

@ajordens PTAL