### PR TITLE
Periodically cleanup the onDemand:members sets if the referenced keys…

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -18,9 +18,12 @@ package com.netflix.spinnaker.clouddriver.core
 
 import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation
 import com.netflix.spinnaker.cats.agent.NoopExecutionInstrumentation
+import com.netflix.spinnaker.cats.redis.JedisSource
 import com.netflix.spinnaker.clouddriver.cache.CacheConfig
 import com.netflix.spinnaker.clouddriver.cache.NoopOnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
+import com.netflix.spinnaker.clouddriver.core.agent.CleanupPendingOnDemandCachesAgent
+import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.clouddriver.model.ApplicationProvider
 import com.netflix.spinnaker.clouddriver.model.CloudMetricProvider
@@ -56,6 +59,7 @@ import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvi
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -192,6 +196,13 @@ class CloudDriverConfig {
   @ConditionalOnMissingBean(ElasticIpProvider)
   ElasticIpProvider noopElasticIpProvider() {
     new NoopElasticIpProvider()
+  }
+
+  @Bean
+  CoreProvider coreProvider(JedisSource jedisSource, ApplicationContext applicationContext) {
+    return new CoreProvider([
+      new CleanupPendingOnDemandCachesAgent(jedisSource, applicationContext)
+    ])
   }
 
   // Allows @Value annotation to tokenize a list of strings.

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/agent/CleanupPendingOnDemandCachesAgent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/agent/CleanupPendingOnDemandCachesAgent.java
@@ -1,0 +1,122 @@
+package com.netflix.spinnaker.clouddriver.core.agent;
+
+import com.netflix.spinnaker.cats.agent.RunnableAgent;
+import com.netflix.spinnaker.cats.module.CatsModule;
+import com.netflix.spinnaker.cats.provider.Provider;
+import com.netflix.spinnaker.cats.redis.JedisSource;
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent;
+import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class CleanupPendingOnDemandCachesAgent implements RunnableAgent, CustomScheduledAgent {
+  private static final Logger log = LoggerFactory.getLogger(CleanupPendingOnDemandCachesAgent.class);
+
+  private static final long DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(30);
+  private static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+  private final JedisSource jedisSource;
+  private final ApplicationContext applicationContext;
+  private final long pollIntervalMillis;
+  private final long timeoutMillis;
+
+  public CleanupPendingOnDemandCachesAgent(JedisSource jedisSource,
+                                           ApplicationContext applicationContext) {
+    this(jedisSource, applicationContext, DEFAULT_POLL_INTERVAL_MILLIS, DEFAULT_TIMEOUT_MILLIS);
+  }
+
+  private CleanupPendingOnDemandCachesAgent(JedisSource jedisSource,
+                                            ApplicationContext applicationContext,
+                                            long pollIntervalMillis,
+                                            long timeoutMillis) {
+    this.jedisSource = jedisSource;
+    this.applicationContext = applicationContext;
+    this.pollIntervalMillis = pollIntervalMillis;
+    this.timeoutMillis = timeoutMillis;
+  }
+
+  @Override
+  public String getAgentType() {
+    return CleanupPendingOnDemandCachesAgent.class.getSimpleName();
+  }
+
+  @Override
+  public String getProviderName() {
+    return CoreProvider.PROVIDER_NAME;
+  }
+
+  @Override
+  public void run() {
+    run(getCatsModule().getProviderRegistry().getProviders());
+  }
+
+  void run(Collection<Provider> providers) {
+   providers.forEach(provider -> {
+      String onDemandSetName = provider.getProviderName() + ":onDemand:members";
+      List<String> onDemandKeys = scanMembers(onDemandSetName).stream()
+        .filter(s -> !s.equals("_ALL_"))
+        .collect(Collectors.toList());
+
+      try (Jedis jedis = jedisSource.getJedis()) {
+        Pipeline pipeline = jedis.pipelined();
+        onDemandKeys.forEach(k -> pipeline.get(provider.getProviderName() + ":onDemand:attributes:" + k));
+
+        List existingOnDemandKeys = pipeline.syncAndReturnAll();
+
+        Set<String> onDemandKeysToRemove = new HashSet<>();
+        for (int i = 0; i < onDemandKeys.size(); i++) {
+          if (existingOnDemandKeys.get(i) == null) {
+            onDemandKeysToRemove.add(onDemandKeys.get(i));
+          }
+        }
+
+        if (!onDemandKeysToRemove.isEmpty()) {
+          log.info("Removing {} from {}", onDemandKeysToRemove.size(), onDemandSetName);
+          log.debug("Removing {} from {}", onDemandKeysToRemove, onDemandSetName);
+
+          jedis.srem(onDemandSetName, onDemandKeysToRemove.toArray(new String[onDemandKeysToRemove.size()]));
+        }
+      }
+    });
+  }
+
+  public long getPollIntervalMillis() {
+    return pollIntervalMillis;
+  }
+
+  public long getTimeoutMillis() {
+    return timeoutMillis;
+  }
+
+  private Set<String> scanMembers(String setKey) {
+    try (Jedis jedis = jedisSource.getJedis()) {
+      final Set<String> matches = new HashSet<>();
+      final ScanParams scanParams = new ScanParams().count(25000);
+      String cursor = "0";
+      while (true) {
+        final ScanResult<String> scanResult = jedis.sscan(setKey, cursor, scanParams);
+        matches.addAll(scanResult.getResult());
+        cursor = scanResult.getStringCursor();
+        if ("0".equals(cursor)) {
+          return matches;
+        }
+      }
+    }
+  }
+
+  private CatsModule getCatsModule() {
+    return applicationContext.getBean(CatsModule.class);
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/CoreProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/CoreProvider.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.core.provider
+
+import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
+import com.netflix.spinnaker.cats.provider.Provider
+
+class CoreProvider extends AgentSchedulerAware implements Provider {
+  public static final String PROVIDER_NAME = CoreProvider.name
+
+  private final Collection<Agent> agents
+
+  CoreProvider(Collection<Agent> agents) {
+    this.agents = agents
+  }
+
+  @Override
+  String getProviderName() {
+    return PROVIDER_NAME
+  }
+
+  @Override
+  Collection<Agent> getAgents() {
+    return agents
+  }
+}

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/agent/CleanupPendingOnDemandCachesAgentSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/agent/CleanupPendingOnDemandCachesAgentSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.core.agent
+
+import com.netflix.spinnaker.cats.redis.JedisPoolSource
+import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import org.springframework.context.ApplicationContext
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CleanupPendingOnDemandCachesAgentSpec extends Specification {
+  @Shared
+  @AutoCleanup("destroy")
+  EmbeddedRedis embeddedRedis = EmbeddedRedis.embed()
+
+  def jedisSource = new JedisPoolSource(embeddedRedis.pool as JedisPool)
+
+  def "should cleanup onDemand:members set for a provider"() {
+    given:
+    def agent = new CleanupPendingOnDemandCachesAgent(jedisSource, Stub(ApplicationContext))
+    def providers = [
+        new CoreProvider([])
+    ]
+    jedisSource.jedis.withCloseable { Jedis jedis ->
+      // two keys in set
+      jedis.sadd(CoreProvider.name + ":onDemand:members", "does-not-exist")
+      jedis.sadd(CoreProvider.name + ":onDemand:members", "exists")
+
+      // only one key exists
+      jedis.set(CoreProvider.name + ":onDemand:attributes:exists", "this value exists!")
+    }
+
+    when:
+    agent.run(providers)
+
+    then:
+    jedisSource.jedis.withCloseable { Jedis jedis ->
+      // only the key that exists should remain in the set
+      (jedis.smembers(CoreProvider.name + ":onDemand:members") as List<String>) == ["exists"]
+    }
+
+  }
+}


### PR DESCRIPTION
… no longer exist

- keys are being TTL'd out so this just keeps the onDemand:members  set in-sync
- runs as part of a new core provider