### PR TITLE
provider/google: Implemented SVG enable/disable for ILB.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -40,10 +40,7 @@ import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.google.model.*
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleHttpLoadBalancingPolicy
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerType
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerView
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancingPolicy
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleNetworkProvider
@@ -227,9 +224,9 @@ class GCEUtil {
     }
   }
 
-  static List<ForwardingRule> queryForwardingRules(
+  static List<ForwardingRule> queryRegionalForwardingRules(
           String projectName, String region, List<String> forwardingRuleNames, Compute compute, Task task, String phase) {
-    task.updateStatus phase, "Looking up network load balancers $forwardingRuleNames..."
+    task.updateStatus phase, "Looking up regional load balancers $forwardingRuleNames..."
 
     def forwardingRules = new SafeRetry<List<ForwardingRule>>().doRetry(
       { return compute.forwardingRules().list(projectName, region).execute().items },
@@ -249,7 +246,7 @@ class GCEUtil {
     } else {
       def foundNames = foundForwardingRules.collect { it.name }
 
-      updateStatusAndThrowNotFoundException("Network load balancers ${forwardingRuleNames - foundNames} not found.", task, phase)
+      updateStatusAndThrowNotFoundException("Regional load balancers ${forwardingRuleNames - foundNames} not found.", task, phase)
     }
   }
 
@@ -683,6 +680,41 @@ class GCEUtil {
         requestPath: healthCheckDescription.requestPath)
   }
 
+  static void addInternalLoadBalancerBackends(Compute compute,
+                                              String project,
+                                              GoogleServerGroup.View serverGroup,
+                                              GoogleLoadBalancerProvider googleLoadBalancerProvider,
+                                              Task task,
+                                              String phase) {
+    String serverGroupName = serverGroup.name
+    String region = serverGroup.region
+    Metadata instanceMetadata = serverGroup?.launchConfig?.instanceTemplate?.properties?.metadata
+    Map metadataMap = buildMapFromMetadata(instanceMetadata)
+    def regionalLoadBalancersInMetadata = metadataMap?.(GoogleServerGroup.View.REGIONAL_LOAD_BALANCER_NAMES)?.tokenize(",") ?: []
+    def internalLoadBalancersToAddTo = queryAllLoadBalancers(googleLoadBalancerProvider, regionalLoadBalancersInMetadata, task, phase)
+      .findAll { it.loadBalancerType == GoogleLoadBalancerType.INTERNAL }
+
+    if (internalLoadBalancersToAddTo) {
+      internalLoadBalancersToAddTo.each { GoogleLoadBalancerView loadBalancerView ->
+        def ilbView = loadBalancerView as GoogleInternalLoadBalancer.View
+        def backendServiceName = ilbView.backendService.name
+        BackendService backendService = compute.regionBackendServices().get(project, region, backendServiceName).execute()
+        Backend backendToAdd = new Backend(balancingMode: 'CONNECTION')
+        if (serverGroup.regional) {
+          backendToAdd.setGroup(buildRegionalServerGroupUrl(project, region, serverGroupName))
+        } else {
+          backendToAdd.setGroup(buildZonalServerGroupUrl(project, serverGroup.zone, serverGroupName))
+        }
+        if (backendService.backends == null) {
+          backendService.backends = []
+        }
+        backendService.backends << backendToAdd
+        compute.regionBackendServices().update(project, region, backendServiceName, backendService).execute()
+        task.updateStatus phase, "Enabled backend for server group ${serverGroupName} in Internal load balancer backend service ${backendServiceName}."
+      }
+    }
+  }
+
   static void addHttpLoadBalancerBackends(Compute compute,
                                           ObjectMapper objectMapper,
                                           String project,
@@ -757,6 +789,34 @@ class GCEUtil {
         backend.maxUtilization : null,
       capacityScaler: backend.capacityScaler,
     )
+  }
+
+  static void destroyInternalLoadBalancerBackends(Compute compute,
+                                                  String project,
+                                                  GoogleServerGroup.View serverGroup,
+                                                  GoogleLoadBalancerProvider googleLoadBalancerProvider,
+                                                  Task task,
+                                                  String phase) {
+    def serverGroupName = serverGroup.name
+    def region = serverGroup.region
+    def foundInternalLoadBalancers = googleLoadBalancerProvider.getApplicationLoadBalancers("").findAll {
+      it.name in serverGroup.loadBalancers && it.loadBalancerType == GoogleLoadBalancerType.INTERNAL
+    }
+    log.debug("Attempting to delete backends for ${serverGroup.name} from the following regional load balancers: ${foundInternalLoadBalancers.collect { it.name }}")
+
+    if (foundInternalLoadBalancers) {
+      foundInternalLoadBalancers.each { GoogleLoadBalancerView loadBalancerView ->
+        def ilbView = loadBalancerView as GoogleInternalLoadBalancer.View
+        String backendServiceName = ilbView.backendService.name
+        BackendService backendService = compute.regionBackendServices().get(project, region, backendServiceName).execute()
+        backendService?.backends?.removeAll { Backend backend ->
+          (getLocalName(backend.group) == serverGroupName) &&
+            (Utils.getRegionFromGroupUrl(backend.group) == region)
+        }
+        compute.regionBackendServices().update(project, region, backendServiceName, backendService).execute()
+        task.updateStatus phase, "Deleted backend for server group ${serverGroupName} from internal load balancer backend service ${backendServiceName}."
+      }
+    }
   }
 
   static void destroyHttpLoadBalancerBackends(Compute compute,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperation.groovy
@@ -57,7 +57,7 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperation implements Atomic
     def region = description.region
     def compute = description.credentials.compute
 
-    def forwardingRules = GCEUtil.queryForwardingRules(project, region, loadBalancerNames, compute, task, BASE_PHASE)
+    def forwardingRules = GCEUtil.queryRegionalForwardingRules(project, region, loadBalancerNames, compute, task, BASE_PHASE)
     def instanceUrls = GCEUtil.queryInstanceUrls(project, region, instanceIds, compute, task, BASE_PHASE)
 
     loadBalancerNames.each { lbName ->

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
@@ -90,6 +90,10 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
 
     destroy(destroyHttpLoadBalancerBackends(compute, project, serverGroup, googleLoadBalancerProvider), "Http load balancer backends")
 
+    task.updateStatus BASE_PHASE, "Checking for associated Internal load balancer backend services..."
+
+    destroy(destroyInternalLoadBalancerBackends(compute, project, serverGroup, googleLoadBalancerProvider), "Internal load balancer backends")
+
     destroy(destroyInstanceGroup(compute, serverGroupName, project, region, zone, isRegional), "instance group")
 
     task.updateStatus BASE_PHASE, "Deleted instance group."
@@ -145,6 +149,16 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
                                                  GoogleLoadBalancerProvider googleLoadBalancerProvider) {
     return {
       GCEUtil.destroyHttpLoadBalancerBackends(compute, project, serverGroup, googleLoadBalancerProvider, task, BASE_PHASE)
+      null
+    }
+  }
+
+  static Closure destroyInternalLoadBalancerBackends(Compute compute,
+                                                     String project,
+                                                     GoogleServerGroup.View serverGroup,
+                                                     GoogleLoadBalancerProvider googleLoadBalancerProvider) {
+    return {
+      GCEUtil.destroyInternalLoadBalancerBackends(compute, project, serverGroup, googleLoadBalancerProvider, task, BASE_PHASE)
       null
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RegisterInstancesWithGoogleLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RegisterInstancesWithGoogleLoadBalancerAtomicOperation.groovy
@@ -57,7 +57,7 @@ class RegisterInstancesWithGoogleLoadBalancerAtomicOperation implements AtomicOp
     def region = description.region
     def compute = description.credentials.compute
 
-    def forwardingRules = GCEUtil.queryForwardingRules(project, region, loadBalancerNames, compute, task, BASE_PHASE)
+    def forwardingRules = GCEUtil.queryRegionalForwardingRules(project, region, loadBalancerNames, compute, task, BASE_PHASE)
     def instanceUrls = GCEUtil.queryInstanceUrls(project, region, instanceIds, compute, task, BASE_PHASE)
 
     loadBalancerNames.each { lbName ->

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/EnableGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/EnableGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -18,13 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.services.compute.Compute
-import com.google.api.services.compute.model.ForwardingRule
-import com.google.api.services.compute.model.ForwardingRuleList
-import com.google.api.services.compute.model.InstanceGroupManager
-import com.google.api.services.compute.model.InstanceGroupsListInstances
-import com.google.api.services.compute.model.InstanceProperties
-import com.google.api.services.compute.model.InstanceTemplate
-import com.google.api.services.compute.model.InstanceWithNamedPorts
+import com.google.api.services.compute.model.*
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
@@ -210,6 +204,6 @@ class EnableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       1 * forwardingRulesListMock.execute() >> forwardingRulesList2
 
       def exc = thrown GoogleResourceNotFoundException
-      exc.message == "Network load balancers [$FORWARDING_RULE_1, $FORWARDING_RULE_2] not found."
+      exc.message == "Regional load balancers [$FORWARDING_RULE_1, $FORWARDING_RULE_2] not found."
   }
 }


### PR DESCRIPTION
Implemented destroy SVG for ILB as well. This follows quite closely with the patterns put in place with Http(s) LBs for manipulating server groups and backend services, but simpler since there is one backend service per ILB. @duftler or @danielpeach or @lwander please review.