### PR TITLE
Add the assume role'd `accountId` to an AmazonServiceException

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.aws.security;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -33,8 +32,12 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
     static final String DEFAULT_SESSION_NAME = "Spinnaker";
 
     static AWSCredentialsProvider createSTSCredentialsProvider(AWSCredentialsProvider credentialsProvider, String accountId, String assumeRole, String sessionName) {
-        return credentialsProvider == null ? null : new STSAssumeRoleSessionCredentialsProvider(credentialsProvider,
-                String.format("arn:aws:iam::%s:%s", Objects.requireNonNull(accountId, "accountId"), Objects.requireNonNull(assumeRole, "assumeRole")), Objects.requireNonNull(sessionName, "sessionName"));
+        return credentialsProvider == null ? null : new NetflixSTSAssumeRoleSessionCredentialsProvider(
+          credentialsProvider,
+          String.format("arn:aws:iam::%s:%s", Objects.requireNonNull(accountId, "accountId"), Objects.requireNonNull(assumeRole, "assumeRole")),
+          Objects.requireNonNull(sessionName, "sessionName"),
+          accountId
+        );
     }
 
     /**

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+
+public class NetflixSTSAssumeRoleSessionCredentialsProvider extends STSAssumeRoleSessionCredentialsProvider {
+  private final String accountId;
+
+  public NetflixSTSAssumeRoleSessionCredentialsProvider(AWSCredentialsProvider longLivedCredentialsProvider,
+                                                        String roleArn,
+                                                        String roleSessionName,
+                                                        String accountId) {
+    super(longLivedCredentialsProvider, roleArn, roleSessionName);
+    this.accountId = accountId;
+  }
+
+  public String getAccountId() {
+    return accountId;
+  }
+}


### PR DESCRIPTION
This supports using the `accountId` in metrics generated by the
`InstrumentedRetryPolicy` in `kork`.