### PR TITLE
Revert "Sorting AWS instance types by family and class size"

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgent.groovy
@@ -134,51 +134,6 @@ class AmazonInstanceTypeCachingAgent implements CachingAgent, CustomScheduledAge
       }
     }
     log.info("Caching ${data.size()} items in ${agentType}")
-    data.sort(new InstanceTypeComparator())
     new DefaultCacheResult([(INSTANCE_TYPES.ns): data])
-  }
-
-  private class InstanceTypeComparator implements Comparator<CacheData> {
-
-    final static String[] INSTANCE_SIZE_HIERARCHY = [
-      'xlarge',
-      'large',
-      'medium',
-      'small',
-      'micro',
-      'nano'
-    ]
-
-    @Override
-    int compare(CacheData o1, CacheData o2) {
-      def type1 = o1.attributes['name'].split(/\./)
-      def type2 = o2.attributes['name'].split(/\./)
-
-      if (type1.size() != 2 || type2.size() != 2) {
-        return 0
-      }
-
-      def (family1, class1) = type1
-      def (family2, class2) = type2
-
-      if (family1 != family2) {
-        return family1 <=> family2
-      }
-
-      def t1Idx = INSTANCE_SIZE_HIERARCHY.findIndexOf { class1.endsWith(it) }
-      def t2Idx = INSTANCE_SIZE_HIERARCHY.findIndexOf { class2.endsWith(it) }
-
-      if (t1Idx == -1 || t2Idx == -1) {
-        return 0
-      }
-
-      if (t1Idx == 0 && t2Idx == 0) {
-        def size1 = (class1.replaceFirst('xlarge', '') ?: '0').toInteger()
-        def size2 = (class2.replaceFirst('xlarge', '') ?: '0').toInteger()
-        return size2 <=> size1
-      }
-
-      return t1Idx <=> t2Idx
-    }
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonInstanceTypeCachingAgentSpec.groovy
@@ -111,38 +111,4 @@ class AmazonInstanceTypeCachingAgentSpec extends Specification {
     0 * _
   }
 
-  void "should sort all by instance type then size"() {
-    when:
-    def result = agent.loadData(providerCache)
-    then:
-    1 * ec2.describeReservedInstancesOfferings(new DescribeReservedInstancesOfferingsRequest()) >> new DescribeReservedInstancesOfferingsResult(
-      reservedInstancesOfferings: [
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '1', instanceType: 'm4.2xlarge'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '2', instanceType: 't2.nano'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '3', instanceType: 't2.micro'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '4', instanceType: 'm4.xlarge'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '5', instanceType: 't2.medium'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '6', instanceType: 'm4.4xlarge'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '7', instanceType: 'm4.large'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '8', instanceType: 'm4.16xlarge'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '9', instanceType: 'm4.10xlarge'),
-        new ReservedInstancesOffering(reservedInstancesOfferingId: '10', instanceType: 't2.loltiny')
-      ]
-    )
-
-    with (result.cacheResults.get(Keys.Namespace.INSTANCE_TYPES.ns)) { List<CacheData> cd ->
-      cd.size() == 10
-      cd[0].id == Keys.getInstanceTypeKey('m4.16xlarge', region, account)
-      cd[1].id == Keys.getInstanceTypeKey('m4.10xlarge', region, account)
-      cd[2].id == Keys.getInstanceTypeKey('m4.4xlarge', region, account)
-      cd[3].id == Keys.getInstanceTypeKey('m4.2xlarge', region, account)
-      cd[4].id == Keys.getInstanceTypeKey('m4.xlarge', region, account)
-      cd[5].id == Keys.getInstanceTypeKey('m4.large', region, account)
-      cd[6].id == Keys.getInstanceTypeKey('t2.medium', region, account)
-      cd[7].id == Keys.getInstanceTypeKey('t2.micro', region, account)
-      cd[8].id == Keys.getInstanceTypeKey('t2.nano', region, account)
-      cd[9].id == Keys.getInstanceTypeKey('t2.loltiny', region, account)
-    }
-    0 * _
-  }
 }


### PR DESCRIPTION
Cache didn't persist sort order, so I've moved this work into deck: https://github.com/spinnaker/deck/pull/2858

Reverts spinnaker/clouddriver#1128