### PR TITLE
provider/google: Made all LB delete ops resilient with SafeRetry.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/SafeRetry.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/SafeRetry.groovy
@@ -83,9 +83,18 @@ class SafeRetry<T> {
       if (lastSeenException && lastSeenException instanceof GoogleJsonResponseException) {
         def lastSeenError = lastSeenException?.getDetails()?.getErrors()[0] ?: null
         if (lastSeenError) {
-          throw new GoogleOperationException("Failed to $action $resource after #$tries."
-            + " Last seen exception has status code ${lastSeenException.getStatusCode()} with error message ${lastSeenError.getMessage()}"
-            + " and reason ${lastSeenError.getReason()}.")
+          if (lastSeenError.getReason() == 'resourceInUseByAnotherResource') {
+            // Don't fail the operation if the resource is in use. The main use case for this is resiliency in delete operations -
+            // we don't want to fail the operation if something is in use by another resource.
+            log.warn("Failed to $action $resource after #$tries."
+              + " Last seen exception has status code ${lastSeenException.getStatusCode()} with error message ${lastSeenError.getMessage()}"
+              + " and reason ${lastSeenError.getReason()}.")
+            return null
+          } else {
+            throw new GoogleOperationException("Failed to $action $resource after #$tries."
+              + " Last seen exception has status code ${lastSeenException.getStatusCode()} with error message ${lastSeenError.getMessage()}"
+              + " and reason ${lastSeenError.getReason()}.")
+          }
         } else {
           throw new GoogleOperationException("Failed to $action $resource after #$tries."
             + " Last seen exception has status code ${lastSeenException.getStatusCode()} with message ${lastSeenException.getMessage()}.")

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Google, Inc.
+ * Copyright 2015 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationTimedOutException
@@ -57,6 +58,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
+    SafeRetry.SAFE_RETRY_INTERVAL_MILLIS = 1
   }
 
   void "should delete Http Load Balancer with one backend service"() {


### PR DESCRIPTION
@duftler @lwander please review. Previously, we made no retry attempts if an operation during an LB delete failed. This PR makes those operations much more resilient to failures in GCP. We should probably include retry behavior in upsert as well -- that will be twice as fun since there's twice the code (4x for L7). I'll look into that once I implement upsert for ILB.