### PR TITLE
update dependencies for groovy 2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.56.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.57.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -13,5 +13,5 @@ dependencies {
   compile spinnaker.dependency('httpclient')
   compile spinnaker.dependency('guava')
 
-  compile 'com.aestasit.infrastructure.sshoogr:sshoogr:0.9.15'
+  compile 'com.aestasit.infrastructure.sshoogr:sshoogr:0.9.25'
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AmazonCloudProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AmazonCloudProvider.groovy
@@ -22,7 +22,7 @@ import java.lang.annotation.Annotation
 
 @Component
 class AmazonCloudProvider implements CloudProvider {
-  static final String AWS = "aws"
+  public static final String AWS = "aws"
   final String id = AWS
   final String displayName = "Amazon"
   final Class<? extends Annotation> operationAnnotationType = AmazonOperation

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -102,6 +102,9 @@ class AwsConfiguration {
   @Value('${aws.migration.infrastructureApplications}')
   List<String> infrastructureApplications
 
+  @Value('${aws.client.useGzip:true}')
+  boolean awsClientUseGzip
+
   @Autowired
   SpectatorMetricCollector spectatorMetricCollector
 
@@ -134,6 +137,7 @@ class AwsConfiguration {
       .maxConnectionsPerRoute(maxConnectionsPerRoute)
       .proxy(proxy)
       .eddaTimeoutConfig(eddaTimeoutConfig)
+      .useGzip(awsClientUseGzip)
       .build()
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/ReconcileClassicLinkSecurityGroupsAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/ReconcileClassicLinkSecurityGroupsAgent.java
@@ -129,7 +129,7 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
 
     RateLimiter apiRequestRateLimit = RateLimiter.create(5);
     final Map<String, ClassicLinkInstance> classicLinkInstances = new HashMap<>();
-    DescribeInstancesRequest describeInstances = new DescribeInstancesRequest().withMaxResults(1000);
+    DescribeInstancesRequest describeInstances = new DescribeInstancesRequest().withMaxResults(500);
     while (true) {
       apiRequestRateLimit.acquire();
       DescribeInstancesResult instanceResult = ec2.describeInstances(describeInstances);

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/bastion/BastionCredentialsProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/bastion/BastionCredentialsProvider.groovy
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.bastion
 
-import com.aestasit.ssh.SshOptions
-import com.aestasit.ssh.dsl.CommandOutput
-import com.aestasit.ssh.dsl.SshDslEngine
+import com.aestasit.infrastructure.ssh.SshOptions
+import com.aestasit.infrastructure.ssh.dsl.CommandOutput
+import com.aestasit.infrastructure.ssh.dsl.SshDslEngine
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.auth.BasicSessionCredentials
@@ -70,10 +70,11 @@ class BastionCredentialsProvider implements AWSCredentialsProvider {
   private AWSCredentials getRemoteCredentials() {
     SimpleDateFormat format = new SimpleDateFormat(
       "yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
-    def engine = new SshDslEngine(new SshOptions(defaultKeyFile: new File(sshKey)))
+    def engine = new SshDslEngine(new SshOptions(defaultKeyFile: new File(sshKey), trustUnknownHosts: true))
     def command = "oq-ssh -r ${proxyRegion} ${proxyCluster},0 'curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${iamRole}'".toString()
-    CommandOutput output = engine.remoteSession("${user}@${host}:${port}") {
-      exec command: command
+    CommandOutput output
+    engine.remoteSession("${user}@${host}:${port}") {
+      output = exec command: command
     }
     def jsonText = output.output.substring(output.output.indexOf('{'))
     def json = slurper.parseText(jsonText) as Map

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
@@ -123,7 +123,7 @@ class AmazonServerGroup implements ServerGroup, Serializable {
     def bi = buildInfo
     return new ServerGroup.ImagesSummary() {
       @Override
-      List<ServerGroup.ImageSummary> getSummaries() {
+      List<? extends ServerGroup.ImageSummary> getSummaries() {
         return [new ServerGroup.ImageSummary() {
           String serverGroupName = name
           String imageName = i?.name

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
@@ -107,7 +107,7 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
     def amazonEC2 = amazonClientProvider.getAmazonEC2(account, region)
 
     Long start = null
-    def request = new DescribeInstancesRequest()
+    def request = new DescribeInstancesRequest().withMaxResults(500)
     List<Instance> awsInstances = []
     while (true) {
       def resp = amazonEC2.describeInstances(request)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
@@ -265,7 +265,7 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
         }
 
         startTime = System.currentTimeMillis()
-        def describeInstancesRequest = new DescribeInstancesRequest()
+        def describeInstancesRequest = new DescribeInstancesRequest().withMaxResults(500)
         def allowedStates = ["pending", "running", "shutting-down", "stopping", "stopped"] as Set<String>
         while (true) {
           def result = amazonEC2.describeInstances(describeInstancesRequest)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureNamedAccountCredentials.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureNamedAccountCredentials.groovy
@@ -19,11 +19,9 @@ package com.netflix.spinnaker.clouddriver.azure.security
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureCustomImageStorage
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureVMImage
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
-import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
 @Slf4j
-@CompileStatic
 public class AzureNamedAccountCredentials implements AccountCredentials<AzureCredentials> {
   private static final String CLOUD_PROVIDER = "azure"
   final String accountName

--- a/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/CloudFoundryOperationsSpec.groovy
+++ b/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/CloudFoundryOperationsSpec.groovy
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvi
 import com.netflix.spinnaker.clouddriver.cf.deploy.handlers.CloudFoundryDeployHandler
 import com.netflix.spinnaker.clouddriver.cf.utils.CloudFoundryClientFactory
 import groovy.json.JsonSlurper
-import groovy.json.internal.Charsets
 import org.cloudfoundry.client.lib.CloudFoundryClient
 import org.cloudfoundry.client.lib.CloudFoundryOperations
 import org.cloudfoundry.client.lib.domain.*

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.groovy
@@ -51,7 +51,7 @@ public class DefaultTask implements Task {
     statusHistory.addLast(currentStatus().update(TaskState.COMPLETED))
   }
 
-  public List<Status> getHistory() {
+  public List<? extends Status> getHistory() {
     statusHistory.collect { new TaskDisplayStatus(it) }
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Task.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Task.groovy
@@ -42,7 +42,7 @@ public interface Task {
   /**
    * A comprehensive history of this task's execution.
    */
-  List<Status> getHistory()
+  List<? extends Status> getHistory()
 
   /**
    * This method is used to update the status of the Task with given phase and status strings.

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.groovy
@@ -73,7 +73,7 @@ class JedisTask implements Task {
     repository.getResultObjects(this)
   }
 
-  public List<Status> getHistory() {
+  public List<? extends Status> getHistory() {
     def status = repository.getHistory(this)
     if (status && status.last().isCompleted()) {
       status.subList(0, status.size()  - 1)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.groovy
@@ -203,7 +203,7 @@ interface ServerGroup {
    */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   interface ImagesSummary extends Summary {
-    List<ImageSummary> getSummaries()
+    List<? extends ImageSummary> getSummaries()
   }
 
   static class SimpleServerGroup implements ServerGroup {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -135,7 +135,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
     def bi = buildInfo
     return new ServerGroup.ImagesSummary() {
       @Override
-      List<ServerGroup.ImageSummary> getSummaries () {
+      List<? extends ServerGroup.ImageSummary> getSummaries () {
         deployDescription.containers.collect({ KubernetesContainerDescription it ->
           new ServerGroup.ImageSummary() {
             String serverGroupName = name
@@ -149,7 +149,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
 
             @Override
             Map<String, Object> getImage() {
-              return [
+              return (Map<String, Object>) [
                 container: it.name,
                 registry: it.imageDescription.registry,
                 tag: it.imageDescription.tag,

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/cache/OnDemandAware.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/cache/OnDemandAware.groovy
@@ -58,8 +58,8 @@ trait OnDemandAware {
     onDemandData.each { String namespace, List<MutableCacheData> cacheDatas ->
       cacheDatas.each { MutableCacheData cacheData ->
         cacheResultBuilder.namespace(namespace).keep(cacheData.id).with {
-          attributes = cacheData.attributes
-          relationships = cacheData.relationships
+          it.attributes = cacheData.attributes
+          it.relationships = cacheData.relationships
         }
         cacheResultBuilder.onDemand.toKeep.remove(cacheData.id)
       }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/discovery/AbstractEnableDisableInstancesInDiscoveryAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/discovery/AbstractEnableDisableInstancesInDiscoveryAtomicOperationSpec.groovy
@@ -52,7 +52,7 @@ class AbstractEnableDisableInstancesInDiscoveryAtomicOperationSpec extends Speci
     OpenstackClientProvider provider = Mock(OpenstackClientProvider)
     GroovyMock(OpenstackProviderFactory, global: true)
     ConsulConfig consulConfig = Mock(ConsulConfig) {
-      isEnabled() >> consulEnabled
+      getEnabled() >> consulEnabled
       applyDefaults() >> {}
     }
     OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), consulConfig)

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DisableTitusServerGroupAtomicOperation.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DisableTitusServerGroupAtomicOperation.groovy
@@ -19,7 +19,7 @@ import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.EnableDisableServerGroupDescription
 
 class DisableTitusServerGroupAtomicOperation extends AbstractEnableDisableAtomicOperation {
-  static final String phaseName = "DISABLE_TITUS_SERVER_GROUP"
+  final String phaseName = "DISABLE_TITUS_SERVER_GROUP"
 
   DisableTitusServerGroupAtomicOperation(TitusClientProvider titusClientProvider, EnableDisableServerGroupDescription description) {
     super(titusClientProvider, description)

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/EnableTitusServerGroupAtomicOperation.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/EnableTitusServerGroupAtomicOperation.groovy
@@ -19,7 +19,7 @@ import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.EnableDisableServerGroupDescription
 
 class EnableTitusServerGroupAtomicOperation extends AbstractEnableDisableAtomicOperation {
-  static final String phaseName = "ENABLE_TITUS_SERVER_GROUP"
+  final String phaseName = "ENABLE_TITUS_SERVER_GROUP"
 
   EnableTitusServerGroupAtomicOperation(TitusClientProvider titusClientProvider, EnableDisableServerGroupDescription description) {
     super(titusClientProvider, description)


### PR DESCRIPTION
* includes a change to request less instances per describeInstances request when crawling the entire region ( d640704 )
* adds an option to enable gzip compression for AWS SDK requests ( eb1f70b )

enabling gzip had a measurable improvement in time to read the full instance collection - looking at the docs it looks like gzip is off by default. If that is the case this may do quite a bit to address spinnaker/spinnaker#1099

