### PR TITLE
provider/google: Fix disabled state for unassociated SVGs.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -219,7 +219,9 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
 
     def isDisabled = true
     // TODO: Extend this for future load balancers that calculate disabled state after caching.
-    def ilbAndHttpOnly = internalDisabledStates.size() + httpDisabledStates.size() == loadBalancers.size()
+    def ilbAndHttpOnly = (internalDisabledStates || httpDisabledStates) &&
+      internalDisabledStates.size() + httpDisabledStates.size() == loadBalancers.size()
+
     if (httpDisabledStates) {
       isDisabled &= httpDisabledStates.every { it }
     }


### PR DESCRIPTION
@duftler please review. Turns out I calculated disabled state incorrectly for unassociated server groups in #1122. Now I check to see that the ILBs and L7s are non-empty before altering the disabled state.