### PR TITLE
provider/google: Adds session affinities for ILBs.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleSessionAffinity.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleSessionAffinity.groovy
@@ -16,9 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.google.model.loadbalancing
 
-// TODO(jacobkiefer): Extend this when we include ILB support.
 enum GoogleSessionAffinity {
   NONE,
   CLIENT_IP,
+  CLIENT_IP_PORT_PROTO,
+  CLIENT_IP_PROTO,
   GENERATED_COOKIE,
 }


### PR DESCRIPTION
ILBs have more options for session affinities in backend services than external load balancers, so I added them. @duftler @danielpeach please review.