### PR TITLE
provider/google: Prevent name/key collisions in health check agent.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -89,7 +89,8 @@ class Keys {
       case Namespace.HEALTH_CHECKS.ns:
         result << [
             account: parts[2],
-            name   : parts[3],
+            kind   : parts[3],
+            name   : parts[4],
         ]
         break
       case Namespace.HTTP_HEALTH_CHECKS.ns:
@@ -194,8 +195,9 @@ class Keys {
   }
 
   static String getHealthCheckKey(String account,
+                                  String kind,
                                   String healthCheckName) {
-    "$GoogleCloudProvider.GCE:${Namespace.HEALTH_CHECKS}:${account}:${healthCheckName}"
+    "$GoogleCloudProvider.GCE:${Namespace.HEALTH_CHECKS}:${account}:${kind}:${healthCheckName}"
   }
 
   static String getHttpHealthCheckKey(String account,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
@@ -74,7 +74,7 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
       return result + [
           healthCheckLink: backendService.attributes.healthCheckLink as String,
           sessionAffinity: backendService.attributes.sessionAffinity as String,
-          affinityCookieTtlSec: backendService.attributes?.affinityCookieTtlSec as String,
+          affinityCookieTtlSec: backendService.attributes.affinityCookieTtlSec as String,
           region: GCEUtil.getLocalName(backendService.attributes?.region as String)
       ]
     }


### PR DESCRIPTION
Also provide context which health check 'family' a health check belongs to. There are three health check 'families': `compute#healthCheck`, `compute#httpHealthCheck`, and `compute#httpsHealthCheck`. Each has its own set of endpoints. @duftler @danielpeach please review -- also Dan we should think about how to cut the frontend over to use this new search provider.