### PR TITLE
Simplify spring Configuration classes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ application.yml
 *.hprof
 README.html
 *~
+es-tmp/

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     maven { url "http://spinnaker.bintray.com/gradle" }
   }
   dependencies {
-    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.9.0'
+    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.10.0'
     classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
   }
 }
@@ -34,7 +34,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.63.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.65.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
+
+@Canonical
+@ConfigurationProperties('aws')
+class AwsConfigurationProperties {
+
+  @Canonical
+  static class ClientConfig {
+    int maxErrorRetry = 3
+    int maxConnections = 200
+    int maxConnectionsPerRoute = 20
+    boolean useGzip = true
+  }
+
+  @Canonical
+  static class CleanupConfig {
+    @Canonical
+    static class AlarmsConfig {
+      boolean enabled = false
+      int daysToKeep = 90
+    }
+
+    @NestedConfigurationProperty
+    final AlarmsConfig alarms = new AlarmsConfig()
+  }
+
+  @Canonical
+  static class MigrationConfig {
+    List<String> infrastructureApplications = []
+  }
+
+  @NestedConfigurationProperty
+  final ClientConfig client = new ClientConfig()
+  @NestedConfigurationProperty
+  final CleanupConfig cleanup = new CleanupConfig()
+  @NestedConfigurationProperty
+  final MigrationConfig migration = new MigrationConfig()
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -39,8 +39,8 @@ import com.netflix.spinnaker.clouddriver.aws.provider.agent.InstanceCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.LaunchConfigCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.LoadBalancerCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -53,6 +53,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
 @Configuration
+@EnableConfigurationProperties(ReservationReportConfigurationProperties)
 class AwsProviderConfig {
   @Bean
   @DependsOn('netflixAmazonCredentials')
@@ -81,8 +82,8 @@ class AwsProviderConfig {
   }
 
   @Bean
-  Scheduler reservationReportScheduler(@Value('${reports.reservation.threadPoolSize:5}') int reservationReportThreadPoolSize) {
-    return Schedulers.from(Executors.newFixedThreadPool(reservationReportThreadPoolSize))
+  Scheduler reservationReportScheduler(ReservationReportConfigurationProperties reservationReportConfigurationProperties) {
+    return Schedulers.from(Executors.newFixedThreadPool(reservationReportConfigurationProperties.threadPoolSize))
   }
 
   @Bean

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ReservationReportConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/ReservationReportConfigurationProperties.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties('reports.reservation')
+class ReservationReportConfigurationProperties {
+  int threadPoolSize = 5
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/DefaultAccountConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/DefaultAccountConfigurationProperties.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@Canonical
+@ConfigurationProperties('default.account')
+class DefaultAccountConfigurationProperties {
+  String env = 'default'
+  String environment = null
+  String accountType = null
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableDisableAtomicOperationUnitSpecSupport.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableDisableAtomicOperationUnitSpecSupport.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.aws.services.AsgService
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.EurekaSupportConfigurationProperties
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -87,6 +88,7 @@ abstract class EnableDisableAtomicOperationUnitSpecSupport extends Specification
       }
     }
     op.discoverySupport.regionScopedProviderFactory = regionScopedProviderFactory
+    op.discoverySupport.eurekaSupportConfigurationProperties = new EurekaSupportConfigurationProperties()
     op.regionScopedProviderFactory = regionScopedProviderFactory
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/AzureConfiguration.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/AzureConfiguration.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.clouddriver.azure.config.AzureConfigurationProperti
 import com.netflix.spinnaker.clouddriver.azure.health.AzureHealthIndicator
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentialsInitializer
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -29,7 +28,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.context.annotation.PropertySource
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
@@ -37,7 +35,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableScheduling
 @ConditionalOnProperty('azure.enabled')
 @ComponentScan(["com.netflix.spinnaker.clouddriver.azure"])
-@PropertySource(value = "classpath:META-INF/clouddriver-core.properties", ignoreResourceNotFound = true)
 @Import([ AzureCredentialsInitializer ])
 class AzureConfiguration {
   @Bean
@@ -49,10 +46,5 @@ class AzureConfiguration {
   @Bean
   AzureHealthIndicator azureHealthIndicator() {
     new AzureHealthIndicator()
-  }
-
-  @Bean
-  String azureApplicationName(@Value('${Implementation-Version:Unknown}') String implementationVersion) {
-    "Spinnaker/$implementationVersion"
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/view/AzureInfrastructureProviderConfig.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/config/view/AzureInfrastructureProviderConfig.groovy
@@ -22,13 +22,10 @@ import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.cache.AzureAppGatewayCachingAgent
-import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.cache.AzureLoadBalancerCachingAgent
 import com.netflix.spinnaker.clouddriver.azure.resources.network.cache.AzureNetworkCachingAgent
 import com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.cache.AzureSecurityGroupCachingAgent
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.cache.AzureServerGroupCachingAgent
-import com.netflix.spinnaker.clouddriver.azure.resources.subnet.cache.AzureSubnetCachingAgent
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.cache.AzureCustomImageCachingAgent
-import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.cache.AzureVMImageCachingAgent
 import com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.azure.resources.common.cache.provider.AzureInfrastructureProvider

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsInitializer.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsInitializer.groovy
@@ -19,20 +19,19 @@ package com.netflix.spinnaker.clouddriver.azure.security
 import com.netflix.spinnaker.clouddriver.azure.config.AzureConfigurationProperties
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import groovy.transform.CompileStatic
-import org.apache.log4j.Logger
-import org.springframework.beans.factory.annotation.Autowired
+import groovy.util.logging.Slf4j
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
+@Slf4j
 @CompileStatic
+@Configuration
 class AzureCredentialsInitializer {
-  private static final Logger log = Logger.getLogger(this.class.simpleName)
-
-  @Autowired
-  String azureApplicationName
 
   @Bean
   List<AzureNamedAccountCredentials> azureNamedAccountCredentials(AzureConfigurationProperties azureConfigurationProperties,
-                                                                  AccountCredentialsRepository accountCredentialsRepository) {
+                                                                  AccountCredentialsRepository accountCredentialsRepository,
+                                                                  String clouddriverUserAgentApplicationName) {
 
     def azureAccounts = []
     azureConfigurationProperties.accounts.each { AzureConfigurationProperties.ManagedAccount managedAccount ->
@@ -50,7 +49,7 @@ class AzureCredentialsInitializer {
           managedAccount.customImages,
           managedAccount.defaultResourceGroup,
           managedAccount.defaultKeyVault,
-          azureApplicationName
+          clouddriverUserAgentApplicationName
         )
 
         azureAccounts << (accountCredentialsRepository.save(managedAccount.name, azureAccount) as AzureNamedAccountCredentials)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -63,8 +63,8 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.core.convert.ConversionService
-import org.springframework.core.convert.support.DefaultConversionService
+import org.springframework.context.annotation.PropertySource
+import org.springframework.core.env.Environment
 import org.springframework.web.client.RestTemplate
 
 @Configuration
@@ -72,7 +72,14 @@ import org.springframework.web.client.RestTemplate
   RedisConfig,
   CacheConfig
 ])
+@PropertySource(value = "classpath:META-INF/clouddriver-core.properties", ignoreResourceNotFound = true)
 class CloudDriverConfig {
+
+  @Bean
+  String clouddriverUserAgentApplicationName(Environment environment) {
+    return "Spinnaker/${environment.getProperty("Implementation-Version", "Unknown")}"
+  }
+
   @Bean
   @ConditionalOnMissingBean(AccountCredentialsRepository)
   AccountCredentialsRepository accountCredentialsRepository() {
@@ -203,11 +210,5 @@ class CloudDriverConfig {
     return new CoreProvider([
       new CleanupPendingOnDemandCachesAgent(jedisSource, applicationContext)
     ])
-  }
-
-  // Allows @Value annotation to tokenize a list of strings.
-  @Bean
-  ConversionService conversionService() {
-    new DefaultConversionService()
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/Front50ConfigurationProperties.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/Front50ConfigurationProperties.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@Canonical
+@ConfigurationProperties('services.front50')
+class Front50ConfigurationProperties {
+  boolean enabled = true
+  String baseUrl
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfig.groovy
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.clouddriver.core
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.data.task.jedis.JedisTaskRepository
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import redis.clients.jedis.Jedis
@@ -32,6 +32,7 @@ import redis.clients.jedis.Protocol
 
 @Configuration
 @ConditionalOnProperty('redis.connection')
+@EnableConfigurationProperties(RedisConfigurationProperties)
 class RedisConfig {
   @Bean
   @ConfigurationProperties('redis')
@@ -45,10 +46,9 @@ class RedisConfig {
   }
 
   @Bean
-  JedisPool jedisPool(@Value('${redis.connection:redis://localhost:6379}') String connection,
-                      @Value('${redis.timeout:2000}') int timeout,
+  JedisPool jedisPool(RedisConfigurationProperties redisConfigurationProperties,
                       GenericObjectPoolConfig redisPoolConfig) {
-    return createPool(redisPoolConfig, connection, timeout)
+    return createPool(redisPoolConfig, redisConfigurationProperties.connection, redisConfigurationProperties.timeout)
   }
 
   private static JedisPool createPool(GenericObjectPoolConfig redisPoolConfig, String connection, int timeout) {
@@ -65,12 +65,11 @@ class RedisConfig {
   }
 
   @Bean
-  JedisPool jedisPoolPrevious(@Value('${redis.connection:redis://localhost:6379}') String mainConnection,
-                              @Value('${redis.connection.previous:#{null}}') String connection) {
-    if (mainConnection == connection || connection == null) {
+  JedisPool jedisPoolPrevious(RedisConfigurationProperties redisConfigurationProperties) {
+    if (redisConfigurationProperties.connection == redisConfigurationProperties.connectionPrevious || redisConfigurationProperties.connectionPrevious == null) {
       return null
     }
-    return createPool(null, connection, 1000)
+    return createPool(null, redisConfigurationProperties.connectionPrevious, 1000)
   }
 
   @Bean

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfigurationProperties.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfigurationProperties.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
+
+@Canonical
+@ConfigurationProperties('redis')
+class RedisConfigurationProperties {
+
+  @Canonical
+  static class PollConfiguration {
+    int intervalSeconds = 30
+    int timeoutSeconds = 300
+  }
+
+  @NestedConfigurationProperty
+  final PollConfiguration poll = new PollConfiguration()
+
+  String connection = "redis://localhost:6379"
+  String connectionPrevious = null
+
+  int timeout = 2000
+
+  String scheduler = 'default'
+  int parallelism = -1
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RetrofitConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RetrofitConfig.groovy
@@ -18,13 +18,10 @@ package com.netflix.spinnaker.clouddriver.core
 
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
-import com.squareup.okhttp.ConnectionPool
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
+import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Scope
@@ -36,64 +33,28 @@ import retrofit.converter.JacksonConverter
 import static retrofit.Endpoints.newFixedEndpoint
 
 @Configuration
+@EnableConfigurationProperties(Front50ConfigurationProperties)
 class RetrofitConfig {
-  @Autowired
-  OkHttpClientConfiguration okHttpClientConfig
-
-  @Value('${okHttpClient.connectionPool.maxIdleConnections:5}')
-  int maxIdleConnections
-
-  @Value('${okHttpClient.connectionPool.keepAliveDurationMs:300000}')
-  int keepAliveDurationMs
-
-  @Value('${okHttpClient.retryOnConnectionFailure:true}')
-  boolean retryOnConnectionFailure
-
-  @Autowired
-  RequestInterceptor spinnakerRequestInterceptor
-
-  @Bean RestAdapter.LogLevel retrofitLogLevel(@Value('${retrofit.logLevel:BASIC}') String retrofitLogLevel) {
-    return RestAdapter.LogLevel.valueOf(retrofitLogLevel)
-  }
 
   @Bean
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-  OkClient okClient() {
-    def client = okHttpClientConfig.create()
-    client.connectionPool = new ConnectionPool(maxIdleConnections, keepAliveDurationMs)
-    client.retryOnConnectionFailure = retryOnConnectionFailure
+  OkClient okClient(OkHttpClientConfiguration okHttpClientConfiguration) {
+    def client = okHttpClientConfiguration.create()
     return new OkClient(client)
   }
 
   @Bean
-  @ConditionalOnExpression('${services.front50.enabled:true}')
-  Front50Service front50Service(@Value('${services.front50.baseUrl}') String front50BaseUrl, RestAdapter.LogLevel retrofitLogLevel) {
-    def endpoint = newFixedEndpoint(front50BaseUrl)
+  @ConditionalOnProperty(name = 'services.front50.enabled', matchIfMissing = true)
+  Front50Service front50Service(Front50ConfigurationProperties front50ConfigurationProperties, RestAdapter.LogLevel retrofitLogLevel, OkClient okClient, RequestInterceptor spinnakerRequestInterceptor) {
+    def endpoint = newFixedEndpoint(front50ConfigurationProperties.baseUrl)
     new RestAdapter.Builder()
       .setRequestInterceptor(spinnakerRequestInterceptor)
       .setEndpoint(endpoint)
-      .setClient(okClient())
+      .setClient(okClient)
       .setConverter(new JacksonConverter())
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(Front50Service))
       .build()
       .create(Front50Service)
-  }
-
-  static class Slf4jRetrofitLogger implements RestAdapter.Log {
-    private final Logger logger
-
-    public Slf4jRetrofitLogger(Class type) {
-      this(LoggerFactory.getLogger(type))
-    }
-
-    public Slf4jRetrofitLogger(Logger logger) {
-      this.logger = logger
-    }
-
-    @Override
-    void log(String message) {
-      logger.info(message)
-    }
   }
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/DockerRegistryConfiguration.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/DockerRegistryConfiguration.groovy
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.docker.registry
 import com.netflix.spinnaker.clouddriver.docker.registry.config.DockerRegistryConfigurationProperties
 import com.netflix.spinnaker.clouddriver.docker.registry.health.DockerRegistryHealthIndicator
 import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryCredentialsInitializer
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -28,7 +27,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.context.annotation.PropertySource
 import org.springframework.context.annotation.Scope
 import org.springframework.scheduling.annotation.EnableScheduling
 
@@ -37,7 +35,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableScheduling
 @ConditionalOnProperty('dockerRegistry.enabled')
 @ComponentScan(["com.netflix.spinnaker.clouddriver.docker.registry"])
-@PropertySource(value = "classpath:META-INF/clouddriver-core.properties", ignoreResourceNotFound = true)
 @Import([ DockerRegistryCredentialsInitializer ])
 class DockerRegistryConfiguration {
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -50,10 +47,5 @@ class DockerRegistryConfiguration {
   @Bean
   DockerRegistryHealthIndicator dockerRegistryHealthIndicator() {
     new DockerRegistryHealthIndicator()
-  }
-
-  @Bean
-  String dockerApplicationName(@Value('${Implementation-Version:Unknown}') String implementationVersion) {
-    "Spinnaker/$implementationVersion"
   }
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
@@ -35,7 +35,7 @@ class DockerBearerTokenService {
   File passwordFile
 
   @Autowired
-  String dockerApplicationName
+  String clouddriverUserAgentApplicationName
 
   DockerBearerTokenService() {
     realmToService = new HashMap<String, TokenService>()
@@ -214,10 +214,10 @@ class DockerBearerTokenService {
     def tokenService = getTokenService(authenticateDetails.realm)
     def token
     if (basicAuthHeader) {
-      token = tokenService.getToken(authenticateDetails.path, authenticateDetails.service, authenticateDetails.scope, basicAuthHeader, dockerApplicationName)
+      token = tokenService.getToken(authenticateDetails.path, authenticateDetails.service, authenticateDetails.scope, basicAuthHeader, clouddriverUserAgentApplicationName)
     }
     else {
-      token = tokenService.getToken(authenticateDetails.path, authenticateDetails.service, authenticateDetails.scope, dockerApplicationName)
+      token = tokenService.getToken(authenticateDetails.path, authenticateDetails.service, authenticateDetails.scope, clouddriverUserAgentApplicationName)
     }
 
     cachedTokens[repository] = token

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -116,7 +116,7 @@ class DockerRegistryClient {
   }
 
   @Autowired
-  String dockerApplicationName
+  String clouddriverUserAgentApplicationName
 
   final int paginateSize
 
@@ -182,9 +182,9 @@ class DockerRegistryClient {
 
   public DockerRegistryTags getTags(String repository) {
     def response = request({
-      registryService.getTags(repository, tokenService.basicAuthHeader, dockerApplicationName)
+      registryService.getTags(repository, tokenService.basicAuthHeader, clouddriverUserAgentApplicationName)
     }, { token ->
-      registryService.getTags(repository, token, dockerApplicationName)
+      registryService.getTags(repository, token, clouddriverUserAgentApplicationName)
     }, repository)
 
     (DockerRegistryTags) converter.fromBody(response.body, DockerRegistryTags)
@@ -192,9 +192,9 @@ class DockerRegistryClient {
 
   public String getDigest(String name, String tag) {
     def response = request({
-      registryService.getManifest(name, tag, tokenService.basicAuthHeader, dockerApplicationName)
+      registryService.getManifest(name, tag, tokenService.basicAuthHeader, clouddriverUserAgentApplicationName)
     }, { token ->
-      registryService.getManifest(name, tag, token, dockerApplicationName)
+      registryService.getManifest(name, tag, token, clouddriverUserAgentApplicationName)
     }, name)
 
     def headers = response.headers
@@ -253,11 +253,11 @@ class DockerRegistryClient {
     def response
     try {
       response = request({
-        path ? registryService.get(path, tokenService.basicAuthHeader, dockerApplicationName) :
-          registryService.getCatalog(paginateSize, tokenService.basicAuthHeader, dockerApplicationName)
+        path ? registryService.get(path, tokenService.basicAuthHeader, clouddriverUserAgentApplicationName) :
+          registryService.getCatalog(paginateSize, tokenService.basicAuthHeader, clouddriverUserAgentApplicationName)
       }, { token ->
-        path ? registryService.get(path, token, dockerApplicationName) :
-          registryService.getCatalog(paginateSize, token, dockerApplicationName)
+        path ? registryService.get(path, token, clouddriverUserAgentApplicationName) :
+          registryService.getCatalog(paginateSize, token, clouddriverUserAgentApplicationName)
       }, "_catalog")
     } catch (Exception e) {
       log.warn("Error encountered during catalog of $path", e)
@@ -296,9 +296,9 @@ class DockerRegistryClient {
 
   private Response doCheckV2Availability(String basicAuthHeader = null) {
     request({
-      registryService.checkVersion(basicAuthHeader, dockerApplicationName)
+      registryService.checkVersion(basicAuthHeader, clouddriverUserAgentApplicationName)
     }, { token ->
-      registryService.checkVersion(token, dockerApplicationName)
+      registryService.checkVersion(token, clouddriverUserAgentApplicationName)
     }, "v2 version check")
   }
 

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/EurekaProviderConfiguration.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/EurekaProviderConfiguration.groovy
@@ -18,11 +18,11 @@ package com.netflix.spinnaker.clouddriver.eureka
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.eureka.api.EurekaApiFactory
+import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.EurekaSupportConfigurationProperties
 import com.netflix.spinnaker.clouddriver.eureka.provider.agent.EurekaAwareProvider
 import com.netflix.spinnaker.clouddriver.eureka.provider.agent.EurekaCachingAgent
 import com.netflix.spinnaker.clouddriver.eureka.provider.EurekaCachingProvider
 import com.netflix.spinnaker.clouddriver.eureka.provider.config.EurekaAccountConfigurationProperties
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -30,13 +30,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.PropertySource
 import org.springframework.context.annotation.Scope
 
 import java.util.regex.Pattern
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties(EurekaSupportConfigurationProperties)
 @ConditionalOnProperty('eureka.provider.enabled')
 @ComponentScan(["com.netflix.spinnaker.clouddriver.eureka"])
 class EurekaProviderConfiguration {
@@ -47,14 +46,11 @@ class EurekaProviderConfiguration {
     new EurekaAccountConfigurationProperties()
   }
 
-  @Autowired
-  ObjectMapper objectMapper
-
-  @Autowired
-  EurekaApiFactory eurekaApiFactory
-
   @Bean
-  EurekaCachingProvider eurekaCachingProvider(EurekaAccountConfigurationProperties eurekaAccountConfigurationProperties, List<EurekaAwareProvider> eurekaAwareProviderList) {
+  EurekaCachingProvider eurekaCachingProvider(EurekaAccountConfigurationProperties eurekaAccountConfigurationProperties,
+                                              List<EurekaAwareProvider> eurekaAwareProviderList,
+                                              ObjectMapper objectMapper,
+                                              EurekaApiFactory eurekaApiFactory) {
     List<EurekaCachingAgent> agents = []
     eurekaAccountConfigurationProperties.accounts.each { EurekaAccountConfigurationProperties.EurekaAccount accountConfig ->
       accountConfig.regions.each { region ->

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -39,17 +38,8 @@ abstract class AbstractEurekaSupport {
                                              String instanceId,
                                              String asgName)
 
-  private static final long THROTTLE_MS = 150
-
-  static final int ATTEMPT_SHORT_CIRCUIT_EVERY = 100
-  static final int DISCOVERY_RETRY_MAX = 10
-  private static final long DEFAULT_DISCOVERY_RETRY_MS = 3000
-
-  @Value('${discovery.retry.max:#{T(com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport).DISCOVERY_RETRY_MAX}}')
-  int discoveryRetry = DISCOVERY_RETRY_MAX
-
-  @Value('${discovery.attemptShortCurcuitEvery:#{T(com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport).ATTEMPT_SHORT_CIRCUIT_EVERY}}')
-  int attemptShortCircuitEveryNInstances = ATTEMPT_SHORT_CIRCUIT_EVERY
+  @Autowired
+  EurekaSupportConfigurationProperties eurekaSupportConfigurationProperties
 
   @Autowired
   List<ClusterProvider> clusterProviders
@@ -64,7 +54,7 @@ abstract class AbstractEurekaSupport {
     def random = new Random()
     def applicationName = null
     try {
-      applicationName = retry(task, discoveryRetry) { retryCount ->
+      applicationName = retry(task, eurekaSupportConfigurationProperties.retryMax) { retryCount ->
         def instanceId = instanceIds[random.nextInt(instanceIds.size())]
         task.updateStatus phaseName, "Looking up discovery application name for instance $instanceId"
 
@@ -86,11 +76,11 @@ abstract class AbstractEurekaSupport {
     int index = 0
     for (String instanceId : instanceIds) {
       if (index > 0) {
-        sleep AbstractEurekaSupport.THROTTLE_MS
+        sleep eurekaSupportConfigurationProperties.throttleMillis
       }
 
       if (discoveryStatus == DiscoveryStatus.Disable) {
-        if (index % attemptShortCircuitEveryNInstances == 0) {
+        if (index % eurekaSupportConfigurationProperties.attemptShortCircuitEveryNInstances == 0) {
           try {
             def hasUpInstances = doesCachedClusterContainDiscoveryStatus(
               clusterProviders, description.credentialAccount, description.region, description.asgName, "UP"
@@ -110,7 +100,7 @@ abstract class AbstractEurekaSupport {
       }
 
       try {
-        retry(task, discoveryRetry) { retryCount ->
+        retry(task, eurekaSupportConfigurationProperties.retryMax) { retryCount ->
           task.updateStatus phaseName, "Attempting to mark ${instanceId} as '${discoveryStatus.value}' in discovery (attempt: ${retryCount})."
 
           Response resp = eureka.updateInstanceStatus(applicationName, instanceId, discoveryStatus.value)
@@ -225,7 +215,7 @@ abstract class AbstractEurekaSupport {
   }
 
   protected long getDiscoveryRetryMs() {
-    return AbstractEurekaSupport.DEFAULT_DISCOVERY_RETRY_MS
+    return eurekaSupportConfigurationProperties.retryIntervalMillis
   }
 
   @InheritConstructors

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/EurekaSupportConfigurationProperties.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/EurekaSupportConfigurationProperties.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.eureka.deploy.ops
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties('discovery')
+class EurekaSupportConfigurationProperties {
+  int retryMax = 10
+  int attemptShortCircuitEveryNInstances = 100
+  int retryIntervalMillis = 3000
+  int throttleMillis = 150
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleConfiguration.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleConfiguration.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleDisk
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstanceTypeDisk
 import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentialsInitializer
 import groovy.transform.ToString
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -32,7 +31,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.context.annotation.PropertySource
 import org.springframework.context.annotation.Scope
 import org.springframework.scheduling.annotation.EnableScheduling
 
@@ -41,7 +39,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableScheduling
 @ConditionalOnProperty('google.enabled')
 @ComponentScan(["com.netflix.spinnaker.clouddriver.google"])
-@PropertySource(value = "classpath:META-INF/clouddriver-core.properties", ignoreResourceNotFound = true)
 @Import([ GoogleCredentialsInitializer ])
 class GoogleConfiguration {
 
@@ -59,11 +56,6 @@ class GoogleConfiguration {
   @Bean
   GoogleHealthIndicator googleHealthIndicator() {
     new GoogleHealthIndicator()
-  }
-
-  @Bean
-  String googleApplicationName(@Value('${Implementation-Version:Unknown}') String implementationVersion) {
-    "Spinnaker/$implementationVersion"
   }
 
   @Bean

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -75,7 +75,7 @@ class GCEUtil {
                                 Compute compute,
                                 Task task,
                                 String phase,
-                                String googleApplicationName,
+                                String clouddriverUserAgentApplicationName,
                                 List<String> baseImageProjects) {
     task.updateStatus phase, "Looking up source image $description.image..."
 
@@ -83,7 +83,7 @@ class GCEUtil {
     def sourceImageName = description.image
     def sourceImage = null
 
-    def imageListBatch = buildBatchRequest(compute, googleApplicationName)
+    def imageListBatch = buildBatchRequest(compute, clouddriverUserAgentApplicationName)
     def imageListCallback = new JsonBatchCallback<ImageList>() {
       @Override
       void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
@@ -116,12 +116,12 @@ class GCEUtil {
     }
   }
 
-  private static BatchRequest buildBatchRequest(def compute, def googleApplicationName) {
+  private static BatchRequest buildBatchRequest(def compute, String clouddriverUserAgentApplicationName) {
     return compute.batch(
       new HttpRequestInitializer() {
         @Override
         void initialize(HttpRequest request) throws IOException {
-          request.headers.setUserAgent(googleApplicationName);
+          request.headers.setUserAgent(clouddriverUserAgentApplicationName);
         }
       }
     )

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -79,7 +79,7 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
   GoogleSubnetProvider googleSubnetProvider
 
   @Autowired
-  String googleApplicationName
+  String clouddriverUserAgentApplicationName
 
   @Autowired
   Cache cacheView
@@ -141,7 +141,7 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
                                                compute,
                                                task,
                                                BASE_PHASE,
-                                               googleApplicationName,
+                                               clouddriverUserAgentApplicationName,
                                                googleConfigurationProperties.baseImageProjects)
 
     def network = GCEUtil.queryNetwork(accountName, description.network ?: DEFAULT_NETWORK_NAME, task, BASE_PHASE, googleNetworkProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
@@ -50,7 +50,7 @@ class CreateGoogleInstanceAtomicOperation implements AtomicOperation<DeploymentR
   GoogleSubnetProvider googleSubnetProvider
 
   @Autowired
-  String googleApplicationName
+  String clouddriverUserAgentApplicationName
 
   private static Task getTask() {
     TaskRepository.threadLocalTask.get()
@@ -92,7 +92,7 @@ class CreateGoogleInstanceAtomicOperation implements AtomicOperation<DeploymentR
                                                compute,
                                                task,
                                                BASE_PHASE,
-                                               googleApplicationName,
+                                               clouddriverUserAgentApplicationName,
                                                googleConfigurationProperties.baseImageProjects)
 
     def network = GCEUtil.queryNetwork(accountName, description.network ?: DEFAULT_NETWORK_NAME, task, BASE_PHASE, googleNetworkProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
@@ -71,7 +71,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
   GoogleSubnetProvider googleSubnetProvider
 
   @Autowired
-  String googleApplicationName
+  String clouddriverUserAgentApplicationName
 
   ModifyGoogleServerGroupInstanceTemplateAtomicOperation(ModifyGoogleServerGroupInstanceTemplateDescription description) {
     this.description = description
@@ -157,7 +157,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
                                                    compute,
                                                    task,
                                                    BASE_PHASE,
-                                                   googleApplicationName,
+                                                   clouddriverUserAgentApplicationName,
                                                    googleConfigurationProperties.baseImageProjects)
         def attachedDisks = GCEUtil.buildAttachedDisks(project,
                                                        null,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleCachingAgent.groovy
@@ -34,17 +34,17 @@ abstract class AbstractGoogleCachingAgent implements CachingAgent, AccountAware 
 
   final String providerName = GoogleInfrastructureProvider.name
 
-  String googleApplicationName // "Spinnaker/${version}" HTTP header string
+  String clouddriverUserAgentApplicationName // "Spinnaker/${version}" HTTP header string
   GoogleNamedAccountCredentials credentials
   ObjectMapper objectMapper
 
   @VisibleForTesting
   AbstractGoogleCachingAgent() {}
 
-  AbstractGoogleCachingAgent(String googleApplicationName,
+  AbstractGoogleCachingAgent(String clouddriverUserAgentApplicationName,
                              GoogleNamedAccountCredentials credentials,
                              ObjectMapper objectMapper) {
-    this.googleApplicationName = googleApplicationName
+    this.clouddriverUserAgentApplicationName = clouddriverUserAgentApplicationName
     this.credentials = credentials
     this.objectMapper = objectMapper
   }
@@ -72,7 +72,7 @@ abstract class AbstractGoogleCachingAgent implements CachingAgent, AccountAware 
         new HttpRequestInitializer() {
           @Override
           void initialize(HttpRequest request) throws IOException {
-            request.headers.setUserAgent(googleApplicationName);
+            request.headers.setUserAgent(clouddriverUserAgentApplicationName);
           }
         }
     )

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
@@ -40,10 +40,10 @@ class GoogleBackendServiceCachingAgent extends AbstractGoogleCachingAgent {
 
   String agentType = "$accountName/$GoogleBackendServiceCachingAgent.simpleName"
 
-  GoogleBackendServiceCachingAgent(String googleApplicationName,
+  GoogleBackendServiceCachingAgent(String clouddriverUserAgentApplicationName,
                                    GoogleNamedAccountCredentials credentials,
                                    ObjectMapper objectMapper) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
       credentials,
       objectMapper)
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHealthCheckCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHealthCheckCachingAgent.groovy
@@ -41,10 +41,10 @@ class GoogleHealthCheckCachingAgent extends AbstractGoogleCachingAgent {
 
   String agentType = "$accountName/$GoogleHealthCheckCachingAgent.simpleName"
 
-  GoogleHealthCheckCachingAgent(String googleApplicationName,
+  GoogleHealthCheckCachingAgent(String clouddriverUserAgentApplicationName,
                                 GoogleNamedAccountCredentials credentials,
                                 ObjectMapper objectMapper) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
           credentials,
           objectMapper)
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpHealthCheckCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpHealthCheckCachingAgent.groovy
@@ -38,10 +38,10 @@ class GoogleHttpHealthCheckCachingAgent extends AbstractGoogleCachingAgent {
 
   String agentType = "$accountName/$GoogleHttpHealthCheckCachingAgent.simpleName"
 
-  GoogleHttpHealthCheckCachingAgent(String googleApplicationName,
+  GoogleHttpHealthCheckCachingAgent(String clouddriverUserAgentApplicationName,
                                     GoogleNamedAccountCredentials credentials,
                                     ObjectMapper objectMapper) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
           credentials,
           objectMapper)
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -55,11 +55,11 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
   String onDemandAgentType = "${agentType}-OnDemand"
   final OnDemandMetricsSupport metricsSupport
 
-  GoogleHttpLoadBalancerCachingAgent(String googleApplicationName,
+  GoogleHttpLoadBalancerCachingAgent(String clouddriverUserAgentApplicationName,
                                      GoogleNamedAccountCredentials credentials,
                                      ObjectMapper objectMapper,
                                      Registry registry) {
-    super(googleApplicationName, credentials, objectMapper)
+    super(clouddriverUserAgentApplicationName, credentials, objectMapper)
     this.metricsSupport = new OnDemandMetricsSupport(
         registry,
         this,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgent.groovy
@@ -49,12 +49,12 @@ class GoogleImageCachingAgent extends AbstractGoogleCachingAgent {
   @VisibleForTesting
   GoogleImageCachingAgent() {}
 
-  GoogleImageCachingAgent(String googleApplicationName,
+  GoogleImageCachingAgent(String clouddriverUserAgentApplicationName,
                           GoogleNamedAccountCredentials credentials,
                           ObjectMapper objectMapper,
                           List<String> imageProjects,
                           List<String> baseImageProjects) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
           credentials,
           objectMapper)
     this.imageProjects = imageProjects

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
@@ -59,12 +59,12 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
   String onDemandAgentType = "${agentType}-OnDemand"
   final OnDemandMetricsSupport metricsSupport
 
-  GoogleInternalLoadBalancerCachingAgent(String googleApplicationName,
+  GoogleInternalLoadBalancerCachingAgent(String clouddriverUserAgentApplicationName,
                                          GoogleNamedAccountCredentials credentials,
                                          ObjectMapper objectMapper,
                                          String region,
                                          Registry registry) {
-    super(googleApplicationName, credentials, objectMapper)
+    super(clouddriverUserAgentApplicationName, credentials, objectMapper)
     this.region = region
     this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.LoadBalancer}")
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -58,12 +58,12 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
   String onDemandAgentType = "${agentType}-OnDemand"
   final OnDemandMetricsSupport metricsSupport
 
-  GoogleLoadBalancerCachingAgent(String googleApplicationName,
+  GoogleLoadBalancerCachingAgent(String clouddriverUserAgentApplicationName,
                                  GoogleNamedAccountCredentials credentials,
                                  ObjectMapper objectMapper,
                                  String region,
                                  Registry registry) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
           credentials,
           objectMapper)
     this.region = region

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -64,12 +64,12 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
   String onDemandAgentType = "${agentType}-OnDemand"
   final OnDemandMetricsSupport metricsSupport
 
-  GoogleRegionalServerGroupCachingAgent(String googleApplicationName,
+  GoogleRegionalServerGroupCachingAgent(String clouddriverUserAgentApplicationName,
                                         GoogleNamedAccountCredentials credentials,
                                         ObjectMapper objectMapper,
                                         String region,
                                         Registry registry) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
           credentials,
           objectMapper)
     this.region = region

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -44,11 +44,11 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
   String onDemandAgentType = "${agentType}-OnDemand"
   final OnDemandMetricsSupport metricsSupport
 
-  GoogleSecurityGroupCachingAgent(String googleApplicationName,
+  GoogleSecurityGroupCachingAgent(String clouddriverUserAgentApplicationName,
                                   GoogleNamedAccountCredentials credentials,
                                   ObjectMapper objectMapper,
                                   Registry registry) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
           credentials,
           objectMapper)
     this.metricsSupport = new OnDemandMetricsSupport(

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslCertificateCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslCertificateCachingAgent.groovy
@@ -38,10 +38,10 @@ class GoogleSslCertificateCachingAgent extends AbstractGoogleCachingAgent  {
 
   String agentType = "$accountName/$GoogleSslCertificateCachingAgent.simpleName"
 
-  GoogleSslCertificateCachingAgent(String googleApplicationName,
+  GoogleSslCertificateCachingAgent(String clouddriverUserAgentApplicationName,
                                    GoogleNamedAccountCredentials credentials,
                                    ObjectMapper objectMapper) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
       credentials,
       objectMapper)
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
@@ -40,11 +40,11 @@ class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
 
   String agentType = "$accountName/$region/$GoogleSubnetCachingAgent.simpleName"
 
-  GoogleSubnetCachingAgent(String googleApplicationName,
+  GoogleSubnetCachingAgent(String clouddriverUserAgentApplicationName,
                            GoogleNamedAccountCredentials credentials,
                            ObjectMapper objectMapper,
                            String region) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
           credentials,
           objectMapper)
     this.region = region

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
@@ -71,12 +71,12 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
   String onDemandAgentType = "${agentType}-OnDemand"
   final OnDemandMetricsSupport metricsSupport
 
-  GoogleZonalServerGroupCachingAgent(String googleApplicationName,
+  GoogleZonalServerGroupCachingAgent(String clouddriverUserAgentApplicationName,
                                      GoogleNamedAccountCredentials credentials,
                                      ObjectMapper objectMapper,
                                      String region,
                                      Registry registry) {
-    super(googleApplicationName,
+    super(clouddriverUserAgentApplicationName,
           credentials,
           objectMapper)
     this.region = region

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.provider.GoogleInfrastructureProvider
 import com.netflix.spinnaker.clouddriver.google.provider.agent.*
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
@@ -38,9 +39,6 @@ import java.util.concurrent.ConcurrentHashMap
 @Import(GoogleConfiguration)
 @EnableConfigurationProperties
 class GoogleInfrastructureProviderConfig {
-
-  @Autowired
-  GoogleConfiguration googleConfiguration
 
   @Bean
   @DependsOn('googleNamedAccountCredentials')
@@ -75,6 +73,8 @@ class GoogleInfrastructureProviderConfig {
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @Bean
   GoogleInfrastructureProviderSynchronizer synchronizeGoogleInfrastructureProvider(
+      String clouddriverUserAgentApplicationName,
+      GoogleConfigurationProperties googleConfigurationProperties,
       GoogleInfrastructureProvider googleInfrastructureProvider,
       AccountCredentialsRepository accountCredentialsRepository,
       ObjectMapper objectMapper,
@@ -90,66 +90,66 @@ class GoogleInfrastructureProviderConfig {
         def newlyAddedAgents = []
         def regions = credentials.regions.collect { it.name }
 
-        newlyAddedAgents << new GoogleSecurityGroupCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleSecurityGroupCachingAgent(clouddriverUserAgentApplicationName,
                                                                 credentials,
                                                                 objectMapper,
                                                                 registry)
-        newlyAddedAgents << new GoogleNetworkCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleNetworkCachingAgent(clouddriverUserAgentApplicationName,
                                                           credentials,
                                                           objectMapper)
 
         regions.each { String region ->
-          newlyAddedAgents << new GoogleSubnetCachingAgent(googleConfiguration.googleApplicationName(),
+          newlyAddedAgents << new GoogleSubnetCachingAgent(clouddriverUserAgentApplicationName,
                                                            credentials,
                                                            objectMapper,
                                                            region)
         }
 
-        newlyAddedAgents << new GoogleHealthCheckCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleHealthCheckCachingAgent(clouddriverUserAgentApplicationName,
                                                               credentials,
                                                               objectMapper)
-        newlyAddedAgents << new GoogleHttpHealthCheckCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleHttpHealthCheckCachingAgent(clouddriverUserAgentApplicationName,
                                                                   credentials,
                                                                   objectMapper)
-        newlyAddedAgents << new GoogleSslLoadBalancerCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleSslLoadBalancerCachingAgent(clouddriverUserAgentApplicationName,
                                                                   credentials,
                                                                   objectMapper,
                                                                   registry)
-        newlyAddedAgents << new GoogleSslCertificateCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleSslCertificateCachingAgent(clouddriverUserAgentApplicationName,
                                                                  credentials,
                                                                  objectMapper)
-        newlyAddedAgents << new GoogleBackendServiceCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleBackendServiceCachingAgent(clouddriverUserAgentApplicationName,
                                                                  credentials,
                                                                  objectMapper)
-        newlyAddedAgents << new GoogleInstanceCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleInstanceCachingAgent(clouddriverUserAgentApplicationName,
                                                            credentials,
                                                            objectMapper)
-        newlyAddedAgents << new GoogleImageCachingAgent(googleConfiguration.googleApplicationName(),
+        newlyAddedAgents << new GoogleImageCachingAgent(clouddriverUserAgentApplicationName,
                                                         credentials,
                                                         objectMapper,
                                                         credentials.imageProjects,
-                                                        googleConfiguration.googleConfigurationProperties().baseImageProjects)
-        newlyAddedAgents << new GoogleHttpLoadBalancerCachingAgent(googleConfiguration.googleApplicationName(),
+                                                        googleConfigurationProperties.baseImageProjects)
+        newlyAddedAgents << new GoogleHttpLoadBalancerCachingAgent(clouddriverUserAgentApplicationName,
                                                                    credentials,
                                                                    objectMapper,
                                                                    registry)
         regions.each { String region ->
-          newlyAddedAgents << new GoogleInternalLoadBalancerCachingAgent(googleConfiguration.googleApplicationName(),
+          newlyAddedAgents << new GoogleInternalLoadBalancerCachingAgent(clouddriverUserAgentApplicationName,
                                                                          credentials,
                                                                          objectMapper,
                                                                          region,
                                                                          registry)
-          newlyAddedAgents << new GoogleLoadBalancerCachingAgent(googleConfiguration.googleApplicationName(),
+          newlyAddedAgents << new GoogleLoadBalancerCachingAgent(clouddriverUserAgentApplicationName,
                                                                  credentials,
                                                                  objectMapper,
                                                                  region,
                                                                  registry)
-          newlyAddedAgents << new GoogleRegionalServerGroupCachingAgent(googleConfiguration.googleApplicationName(),
+          newlyAddedAgents << new GoogleRegionalServerGroupCachingAgent(clouddriverUserAgentApplicationName,
                                                                         credentials,
                                                                         objectMapper,
                                                                         region,
                                                                         registry)
-          newlyAddedAgents << new GoogleZonalServerGroupCachingAgent(googleConfiguration.googleApplicationName(),
+          newlyAddedAgents << new GoogleZonalServerGroupCachingAgent(clouddriverUserAgentApplicationName,
                                                                      credentials,
                                                                      objectMapper,
                                                                      region,

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/KubernetesConfiguration.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/KubernetesConfiguration.groovy
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurati
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.health.KubernetesHealthIndicator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentialsInitializer
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -33,7 +32,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableScheduling
 @ConditionalOnProperty('kubernetes.enabled')
 @ComponentScan(["com.netflix.spinnaker.clouddriver.kubernetes"])
-@PropertySource(value = "classpath:META-INF/clouddriver-core.properties", ignoreResourceNotFound = true)
 @Import([ KubernetesCredentialsInitializer ])
 class KubernetesConfiguration {
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -46,11 +44,6 @@ class KubernetesConfiguration {
   @Bean
   KubernetesHealthIndicator kubernetesHealthIndicator() {
     new KubernetesHealthIndicator()
-  }
-
-  @Bean
-  String kubernetesApplicationName(@Value('${Implementation-Version:Unknown}') String implementationVersion) {
-    "Spinnaker/$implementationVersion"
   }
 
   @Bean

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/health/TitusHealthIndicator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/health/TitusHealthIndicator.groovy
@@ -16,31 +16,27 @@
 
 package com.netflix.spinnaker.clouddriver.titus.health
 
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider
 import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials
 import com.netflix.spinnaker.clouddriver.titus.client.TitusRegion
 import com.netflix.spinnaker.clouddriver.titus.client.model.HealthStatus
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.actuate.health.Status
 import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Component
 
 import java.util.concurrent.atomic.AtomicReference
 
-@Component
 class TitusHealthIndicator implements HealthIndicator {
 
-  private final List<NetflixTitusCredentials> credentialsList
+  private final AccountCredentialsProvider accountCredentialsProvider
   private final TitusClientProvider titusClientProvider
   private AtomicReference<Health> health = new AtomicReference<>(new Health.Builder().up().build())
 
-  @Autowired
-  TitusHealthIndicator(@Value('#{netflixTitusCredentials}') List<NetflixTitusCredentials> credentialsList,
+  TitusHealthIndicator(AccountCredentialsProvider accountCredentialsProvider,
                        TitusClientProvider titusClientProvider) {
-    this.credentialsList = credentialsList
+    this.accountCredentialsProvider = accountCredentialsProvider
     this.titusClientProvider = titusClientProvider
   }
 
@@ -53,7 +49,7 @@ class TitusHealthIndicator implements HealthIndicator {
   void checkHealth() {
     Status status = Status.UP
     Map<String, Object> details = [:]
-    for (NetflixTitusCredentials account in credentialsList) {
+    for (NetflixTitusCredentials account : accountCredentialsProvider.all.findAll { it instanceof NetflixTitusCredentials }) {
       for (TitusRegion region in account.regions) {
         Status regionStatus
         Map regionDetails = [:]

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
@@ -17,11 +17,14 @@
 package com.netflix.spinnaker.clouddriver
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.configuration.CredentialsConfiguration
+import com.netflix.spinnaker.clouddriver.configuration.ThreadPoolConfiguration
 import com.netflix.spinnaker.clouddriver.filters.SimpleCORSFilter
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.embedded.FilterRegistrationBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
@@ -44,6 +47,7 @@ import javax.servlet.http.HttpServletResponse
   'com.netflix.spinnaker.clouddriver.listeners',
   'com.netflix.spinnaker.clouddriver.security',
 ])
+@EnableConfigurationProperties([CredentialsConfiguration, ThreadPoolConfiguration])
 public class WebConfig extends WebMvcConfigurerAdapter {
   @Autowired
   Registry registry
@@ -81,7 +85,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
   }
 
   @ControllerAdvice
-  static class AccessDeniedExceptionHanlder {
+  static class AccessDeniedExceptionHandler {
     @ExceptionHandler(AccessDeniedException)
     public void handle(HttpServletResponse response, AccessDeniedException ex) {
       response.sendError(HttpServletResponse.SC_FORBIDDEN, ex.getMessage())

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/configuration/CredentialsConfiguration.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/configuration/CredentialsConfiguration.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.configuration
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Canonical
+@ConfigurationProperties('credentials')
+class CredentialsConfiguration {
+  List<String> primaryAccountTypes = ['default']
+  List<String> challengeDestructiveActionsEnvironments = ['default']
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/configuration/ThreadPoolConfiguration.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/configuration/ThreadPoolConfiguration.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.configuration
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@Canonical
+@ConfigurationProperties
+class ThreadPoolConfiguration {
+  int queryCluster = 25
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.groovy
@@ -17,10 +17,10 @@
 package com.netflix.spinnaker.clouddriver.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.configuration.CredentialsConfiguration
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.HttpStatus
@@ -35,11 +35,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/credentials")
 class CredentialsController {
 
-  @Value('${credentials.primaryAccountTypes:default}')
-  List<String> primaryAccountTypes = []
-
-  @Value('${credentials.challengeDestructiveActionsEnvironments:default}')
-  List<String> challengeDestructiveActionsEnvironments = []
+  @Autowired
+  CredentialsConfiguration credentialsConfiguration
 
   @Autowired
   ObjectMapper objectMapper
@@ -83,8 +80,8 @@ class CredentialsController {
     }
 
     cred.type = accountCredentials.cloudProvider
-    cred.challengeDestructiveActions = challengeDestructiveActionsEnvironments.contains(accountCredentials.environment)
-    cred.primaryAccount = primaryAccountTypes.contains(accountCredentials.accountType)
+    cred.challengeDestructiveActions = credentialsConfiguration.challengeDestructiveActionsEnvironments.contains(accountCredentials.environment)
+    cred.primaryAccount = credentialsConfiguration.primaryAccountTypes.contains(accountCredentials.accountType)
 
     return cred
   }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectController.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.controllers
 
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.configuration.ThreadPoolConfiguration
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.clouddriver.model.Cluster
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.HttpStatus
@@ -48,8 +48,8 @@ class ProjectController {
   private final Scheduler queryClusterScheduler
 
   @Autowired
-  ProjectController(@Value('${threadPool.queryCluster:25}') int threadPoolSize) {
-    this(Schedulers.from(newFixedThreadPool(threadPoolSize)))
+  ProjectController(ThreadPoolConfiguration threadPoolConfiguration) {
+    this(Schedulers.from(newFixedThreadPool(threadPoolConfiguration.queryCluster)))
   }
 
   ProjectController(Scheduler queryClusterScheduler) {

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.controllers
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.configuration.CredentialsConfiguration
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
@@ -42,7 +43,7 @@ class CredentialsControllerSpec extends Specification {
     def credsRepo = new MapBackedAccountCredentialsRepository()
     def credsProvider = new DefaultAccountCredentialsProvider(credsRepo)
     credsRepo.save("test", new TestNamedAccountCredentials())
-    def mvc = MockMvcBuilders.standaloneSetup(new CredentialsController(accountCredentialsProvider: credsProvider, objectMapper: objectMapper)).build()
+    def mvc = MockMvcBuilders.standaloneSetup(new CredentialsController(accountCredentialsProvider: credsProvider, objectMapper: objectMapper, credentialsConfiguration: new CredentialsConfiguration())).build()
 
     when:
     def result = mvc.perform(MockMvcRequestBuilders.get("/credentials").accept(MediaType.APPLICATION_JSON)).andReturn()

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectControllerSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.controllers
 
+import com.netflix.spinnaker.clouddriver.configuration.ThreadPoolConfiguration
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.clouddriver.model.Cluster
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
@@ -45,7 +46,7 @@ class ProjectControllerSpec extends Specification {
   Map projectConfig
 
   def setup() {
-    projectController = new ProjectController(1)
+    projectController = new ProjectController(new ThreadPoolConfiguration())
 
     front50Service = Mock(Front50Service)
     projectController.front50Service = front50Service


### PR DESCRIPTION
This will be broken pending release of spinnaker/kork#62

Eliminates use of `@Value` in `@Configuration` classes.. creates `@ConfigurationProperties` objects instead.
Eliminates most use of `@Autowired` into `@Configuration` classes, instead passes dependencies around the `@Bean` method parameters

Other cleanups include:
- Consolodate duplication of user agent (via reading the gradle produced META-INF file for version) into `clouddriver-core`
- Clean up titus bootstrapping to eliminate some nasty circular dependencies that were being resolved via `@Value` and a SpEL expression
- Removes `ConversionService` bean now that properties are injected via `@ConfigurationProperties`
- Pushed some configuration upstream to kork around retrofit logging and okhttp connection pools
