### PR TITLE
provider/google: Update instance metadata on L7 upsert.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/UpsertGoogleLoadBalancerDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/UpsertGoogleLoadBalancerDescription.groovy
@@ -37,6 +37,12 @@ class UpsertGoogleLoadBalancerDescription extends AbstractGoogleCredentialsDescr
   List<GoogleHostRule> hostRules
   String certificate
   List<String> listenersToDelete
+  /**
+   * If we update an L7 and change the backend services, this field is the difference between the old and new.
+   * We need this to update the instance metadata for the server groups that are no longer associated with
+   * this L7.
+   */
+  List<GoogleBackendService> backendServiceDiff
 
   // ILB attributes.
   String network

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
@@ -132,7 +132,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
     def newDescriptionProperties = [:] + originalDescription.properties + overriddenProperties
 
     // Remove the properties we don't want to compare or override.
-    newDescriptionProperties.keySet().removeAll(["class"])
+    newDescriptionProperties.keySet().removeAll(["class", "accountName", "credentials", "account"])
 
     // Resolve the auth scopes since the scopes returned on the existing instance template will be fully-resolved.
     newDescriptionProperties.authScopes = GCEUtil.resolveAuthScopes(newDescriptionProperties.authScopes)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.ops.loadbalancer
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -25,8 +26,13 @@ import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
+import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
+import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
+import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -43,6 +49,12 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
 
   @Autowired
   private GoogleOperationPoller googleOperationPoller
+
+  @Autowired
+  AtomicOperationsRegistry atomicOperationsRegistry
+
+  @Autowired
+  OrchestrationProcessor orchestrationProcessor
 
   private final UpsertGoogleLoadBalancerDescription description
 
@@ -271,19 +283,24 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
         def insertBackendServiceOperation = compute.backendServices().insert(project, bs).execute()
         googleOperationPoller.waitForGlobalOperation(compute, project, insertBackendServiceOperation.getName(),
           null, task, "backend service " + backendServiceName, BASE_PHASE)
-      } else if (serviceExistsSet.contains(backendService.name) &&
-                 serviceNeedsUpdatedSet.contains(backendService.name)) {
-        task.updateStatus BASE_PHASE, "Updating backend service $backendServiceName..."
-        def bsToUpdate = existingServices.find { it.name == backendServiceName }
-        def hcName = backendService.healthCheck.name
-        bsToUpdate.portName = GoogleHttpLoadBalancingPolicy.HTTP_PORT_NAME
-        bsToUpdate.healthChecks = [GCEUtil.buildHttpHealthCheckUrl(project, hcName)]
-        bsToUpdate.sessionAffinity = sessionAffinity
-        bsToUpdate.affinityCookieTtlSec = backendService.affinityCookieTtlSec
+      } else if (serviceExistsSet.contains(backendService.name)) {
 
-        def updateServiceOperation = compute.backendServices().update(project, backendServiceName, bsToUpdate).execute()
-        googleOperationPoller.waitForGlobalOperation(compute, project, updateServiceOperation.getName(),
-          null, task, "backend service  $backendServiceName", BASE_PHASE)
+        // Update the actual backend service if necessary.
+        if (serviceNeedsUpdatedSet.contains(backendService.name)) {
+          task.updateStatus BASE_PHASE, "Updating backend service $backendServiceName..."
+          def bsToUpdate = existingServices.find { it.name == backendServiceName }
+          def hcName = backendService.healthCheck.name
+          bsToUpdate.portName = GoogleHttpLoadBalancingPolicy.HTTP_PORT_NAME
+          bsToUpdate.healthChecks = [GCEUtil.buildHttpHealthCheckUrl(project, hcName)]
+          bsToUpdate.sessionAffinity = sessionAffinity
+          bsToUpdate.affinityCookieTtlSec = backendService.affinityCookieTtlSec
+
+          def updateServiceOperation = compute.backendServices().update(project, backendServiceName, bsToUpdate).execute()
+          googleOperationPoller.waitForGlobalOperation(compute, project, updateServiceOperation.getName(),
+            null, task, "backend service  $backendServiceName", BASE_PHASE)
+        }
+
+        fixBackendMetadata(compute, description.credentials, project, atomicOperationsRegistry, orchestrationProcessor, description.loadBalancerName, backendService)
       }
     }
 
@@ -450,5 +467,81 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
 
     task.updateStatus BASE_PHASE, "Done upserting HTTP load balancer $httpLoadBalancerName"
     [loadBalancers: [("global"): [name: httpLoadBalancerName]]]
+  }
+
+  /**
+   * Update each instance template on all the server groups in the backend service to reflect being added to the new load balancer.
+   * @param compute
+   * @param credentials
+   * @param project
+   * @param loadBalancerName
+   * @param backendService
+   */
+  private static void fixBackendMetadata(Compute compute,
+                                         GoogleNamedAccountCredentials credentials,
+                                         String project,
+                                         AtomicOperationsRegistry atomicOperationsRegistry,
+                                         OrchestrationProcessor orchestrationProcessor,
+                                         String loadBalancerName,
+                                         GoogleBackendService backendService)  {
+    backendService.backends.each { GoogleLoadBalancedBackend backend ->
+      def groupName = Utils.getLocalName(backend.serverGroupUrl)
+      def groupRegion = Utils.getRegionFromGroupUrl(backend.serverGroupUrl)
+
+      String templateUrl = null
+      switch (Utils.determineServerGroupType(backend.serverGroupUrl)) {
+        case 'regions':
+          templateUrl = compute.regionInstanceGroupManagers().get(project, groupRegion, groupName).execute().getInstanceTemplate()
+          break
+        case 'zones':
+          def groupZone = Utils.getZoneFromGroupUrl(backend.serverGroupUrl)
+          templateUrl = compute.instanceGroupManagers().get(project, groupZone, groupName).execute().getInstanceTemplate()
+          break
+        default:
+          throw new IllegalStateException("Server group referenced by ${backend.serverGroupUrl} has illegal type.")
+          break
+      }
+
+      InstanceTemplate template = compute.instanceTemplates().get(project, Utils.getLocalName(templateUrl)).execute()
+      def instanceDescription = GCEUtil.buildInstanceDescriptionFromTemplate(template)
+
+      def templateOpMap = [
+        image: instanceDescription.image,
+        instanceType: instanceDescription.instanceType,
+        credentials: credentials.getName(),
+        disks: instanceDescription.disks,
+        instanceMetadata: instanceDescription.instanceMetadata,
+        tags: instanceDescription.tags,
+        network: instanceDescription.network,
+        subnet: instanceDescription.subnet,
+        serviceAccountEmail: instanceDescription.serviceAccountEmail,
+        authScopes: instanceDescription.authScopes,
+        preemptible: instanceDescription.preemptible,
+        automaticRestart: instanceDescription.automaticRestart,
+        onHostMaintenance: instanceDescription.onHostMaintenance,
+        region: groupRegion,
+        serverGroupName: groupName
+      ]
+
+      def instanceMetadata = templateOpMap?.instanceMetadata
+      if (instanceMetadata) {
+        List<String> globalLbs = instanceMetadata.(GoogleServerGroup.View.GLOBAL_LOAD_BALANCER_NAMES)?.split(',') ?: []
+        globalLbs = globalLbs  ? globalLbs + loadBalancerName : [loadBalancerName]
+        instanceMetadata.(GoogleServerGroup.View.GLOBAL_LOAD_BALANCER_NAMES) = globalLbs.unique().join(',')
+
+        List<String> bsNames = instanceMetadata.(GoogleServerGroup.View.BACKEND_SERVICE_NAMES)?.split(',') ?: []
+        bsNames = bsNames ? bsNames + backendService.name : [backendService.name]
+        instanceMetadata.(GoogleServerGroup.View.BACKEND_SERVICE_NAMES) = bsNames.unique().join(',')
+      } else {
+        templateOpMap.instanceMetadata = [
+          (GoogleServerGroup.View.GLOBAL_LOAD_BALANCER_NAMES): loadBalancerName,
+          (GoogleServerGroup.View.BACKEND_SERVICE_NAMES)     : backendService.name,
+        ]
+      }
+
+      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce')
+      AtomicOperation templateOp = converter.convertOperation(templateOpMap)
+      orchestrationProcessor.process([templateOp], UUID.randomUUID().toString())
+    }
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
@@ -187,4 +187,9 @@ class GoogleServerGroup {
       instances.findAll { Instance it -> it.getHealthState() == healthState }
     }
   }
+
+  static enum ServerGroupType {
+    REGIONAL,
+    ZONAL
+  }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
@@ -137,6 +137,54 @@ class Utils {
     }
   }
 
+  static String getZoneFromGroupUrl(String fullUrl) {
+    if (!fullUrl) {
+      return fullUrl
+    }
+
+    def urlParts = fullUrl.split("/")
+
+    if (urlParts.length < 4) {
+      throw new IllegalFormatException("Server group Url ${fullUrl} malformed.")
+    }
+
+    String regionsOrZones = urlParts[urlParts.length - 4]
+    switch (regionsOrZones) {
+      case "regions":
+        throw new IllegalFormatException("Can't parse a zone from regional group url ${fullUrl}.")
+        break
+      case "zones":
+        return urlParts[urlParts.length - 3]
+        break
+      default:
+        throw new IllegalFormatException("Server group Url ${fullUrl} malformed.")
+        break
+    }
+  }
+
+  /**
+   * Determine if a server group is regional or zonal from the fullUrl.
+   * @param fullUrl
+   * @return 'regions' if regional, 'zones' if zonal.
+   */
+  static String determineServerGroupType(String fullUrl) {
+    if (!fullUrl) {
+      return fullUrl
+    }
+
+    def urlParts = fullUrl.split("/")
+
+    if (urlParts.length < 4) {
+      throw new IllegalFormatException("Server group Url ${fullUrl} malformed.")
+    }
+
+    String regionsOrZones = urlParts[urlParts.length - 4]
+    if (regionsOrZones != 'regions' && regionsOrZones != 'zones') {
+      throw new IllegalFormatException("Server group Url ${fullUrl} malformed.")
+    }
+    return regionsOrZones
+  }
+
   // TODO(duftler): Consolidate this method with the same one from kato/GCEUtil and move to a common library.
   static List<String> deriveNetworkLoadBalancerNamesFromTargetPoolUrls(List<String> targetPoolUrls) {
     if (targetPoolUrls) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
@@ -145,7 +145,7 @@ class Utils {
     def urlParts = fullUrl.split("/")
 
     if (urlParts.length < 4) {
-      throw new IllegalFormatException("Server group Url ${fullUrl} malformed.")
+      throw new IllegalFormatException("Server group url ${fullUrl} malformed.")
     }
 
     String regionsOrZones = urlParts[urlParts.length - 4]
@@ -157,7 +157,7 @@ class Utils {
         return urlParts[urlParts.length - 3]
         break
       default:
-        throw new IllegalFormatException("Server group Url ${fullUrl} malformed.")
+        throw new IllegalFormatException("Server group url ${fullUrl} malformed.")
         break
     }
   }
@@ -165,9 +165,9 @@ class Utils {
   /**
    * Determine if a server group is regional or zonal from the fullUrl.
    * @param fullUrl
-   * @return 'regions' if regional, 'zones' if zonal.
+   * @return Type of server group.
    */
-  static String determineServerGroupType(String fullUrl) {
+  static GoogleServerGroup.ServerGroupType determineServerGroupType(String fullUrl) {
     if (!fullUrl) {
       return fullUrl
     }
@@ -179,8 +179,16 @@ class Utils {
     }
 
     String regionsOrZones = urlParts[urlParts.length - 4]
-    if (regionsOrZones != 'regions' && regionsOrZones != 'zones') {
-      throw new IllegalFormatException("Server group Url ${fullUrl} malformed.")
+    switch (regionsOrZones) {
+      case 'regions':
+        return GoogleServerGroup.ServerGroupType.REGIONAL
+        break
+      case 'zones':
+        return GoogleServerGroup.ServerGroupType.ZONAL
+        break
+      default:
+        throw new IllegalFormatException("Server group Url ${fullUrl} malformed.")
+        break
     }
     return regionsOrZones
   }


### PR DESCRIPTION
@duftler @lwander @danielpeach please review. If a new L7 re-uses a backend service that contains instances, the metadata on the instances will be stale. This PR handles updating the metadata in the 'constructive' case, where we point a new L7 to an old BS. There is another 'desctructive' case, where an existing L7 changes the backend service it points to. I'll handle this in another PR once I level with Dan to get the necessary changes in the frontend.
