### PR TITLE
provider/cf: Ignore test with live calls until TravisCI issue corrected.

### DIFF
--- a/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/utils/DefaultCloudFoundryClientFactorySpec.groovy
+++ b/clouddriver-cf/src/test/groovy/com/netflix/spinnaker/clouddriver/cf/utils/DefaultCloudFoundryClientFactorySpec.groovy
@@ -18,8 +18,11 @@ package com.netflix.spinnaker.clouddriver.cf.utils
 import com.netflix.spinnaker.clouddriver.cf.security.CloudFoundryAccountCredentials
 import org.cloudfoundry.client.lib.CloudFoundryException
 import org.springframework.http.HttpStatus
+import spock.lang.Ignore
 import spock.lang.Specification
 
+// TODO(jacobkiefer): Re-enable this test once TravisCI DNS issues are solved.
+@Ignore
 class DefaultCloudFoundryClientFactorySpec extends Specification {
 
   void "fails to connect to PWS with fake credentials"() {


### PR DESCRIPTION
TravisCI was failing to resolve 'api.run.pivotal.io' as a host, so we are ignoring this test for the time being. I'll file a bug against TravisCI to investigate what was going on. @gregturn @duftler FYI.