### PR TITLE
(google) ~6x faster application loads

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
@@ -57,7 +57,7 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance.View> {
   GoogleInstance.View getInstance(String account, String region, String id) {
     Set<GoogleSecurityGroup> securityGroups = securityGroupProvider.getAll(false)
     def key = Keys.getInstanceKey(account, region, id)
-    getInstanceCacheDatas([key])?.findResult { CacheData cacheData ->
+    getInstanceCacheData([key])?.findResult { CacheData cacheData ->
       instanceFromCacheData(cacheData, account, securityGroups)?.view
     }
   }
@@ -66,12 +66,12 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance.View> {
    * Non-interface method for efficient building of GoogleInstance models during cluster or server group requests.
    */
   List<GoogleInstance> getInstances(String account, List<String> instanceKeys, Set<GoogleSecurityGroup> securityGroups) {
-    getInstanceCacheDatas(instanceKeys)?.collect {
+    getInstanceCacheData(instanceKeys)?.collect {
       instanceFromCacheData(it, account, securityGroups)
     }
   }
 
-  Collection<CacheData> getInstanceCacheDatas(List<String> keys) {
+  Collection<CacheData> getInstanceCacheData(List<String> keys) {
     cacheView.getAll(INSTANCES.ns,
                      keys,
                      RelationshipCacheFilter.include(LOAD_BALANCERS.ns,


### PR DESCRIPTION
By frontloading most of the instance & security group loading, I was able to significantly cut down application load times. Here are the benchmarks (where `load(N) = s` means `N` server groups, `s` milliseconds)

**Before**
```
load(17) = 8240
load(17) = 8619
load(17) = 8412
load(17) = 8428
```

**After**
```
load(17) = 1310
load(17) = 1211
load(17) = 1214
load(17) = 1198
```

I've also captured diffs before & after with multiple server groups, load balancers & security groups w/o any differences.