### PR TITLE
(amazon) retry deployment operations on failure

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/OperationPoller.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/OperationPoller.groovy
@@ -62,6 +62,10 @@ class OperationPoller {
         pollOperation(operation, ifDone, getTimeout(timeoutSeconds)), task, resourceString, basePhase)
   }
 
+  static void retryWithBackoff(Function operation) {
+    retryWithBackoff(operation, 200, 5)
+  }
+
   static void retryWithBackoff(Function operation, long backOff, int maxRetries) {
     int retries = 0
     boolean succeeded = false


### PR DESCRIPTION
Guarding against some inconsistent error messages we're seeing in AWS, which I don't think will allow an operation to retry, e.g. an error code of `ValidationException` but an error message of `EC2 Request limit exceeded.`

@ajordens or @cfieber PTAL and feel free to close if you believe this is a one-off situation and not worth adding the extra guard in the codebase. I can DM you info on the pipeline that started this changeset.