### PR TITLE
provider/google: Cache all types of health checks for SSL LBs.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -286,12 +286,24 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
     void onSuccess(HealthCheck healthCheck, HttpHeaders responseHeaders) throws IOException {
       def port = null
       def hcType = null
+      def requestPath = null
       if (healthCheck.tcpHealthCheck) {
         port = healthCheck.tcpHealthCheck.port
         hcType = GoogleHealthCheck.HealthCheckType.TCP
       } else if (healthCheck.sslHealthCheck) {
         port = healthCheck.sslHealthCheck.port
         hcType = GoogleHealthCheck.HealthCheckType.SSL
+      } else if (healthCheck.httpHealthCheck) {
+        port = healthCheck.httpHealthCheck.port
+        requestPath = healthCheck.httpHealthCheck.requestPath
+        hcType = GoogleHealthCheck.HealthCheckType.HTTP
+      } else if (healthCheck.httpsHealthCheck) {
+        port = healthCheck.httpsHealthCheck.port
+        requestPath = healthCheck.httpsHealthCheck.requestPath
+        hcType = GoogleHealthCheck.HealthCheckType.HTTPS
+      } else if (healthCheck.udpHealthCheck) {
+        port = healthCheck.udpHealthCheck.port
+        hcType = GoogleHealthCheck.HealthCheckType.UDP
       }
 
       if (port && hcType) {
@@ -299,6 +311,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
           name: healthCheck.name,
           healthCheckType: hcType,
           port: port,
+          requestPath: requestPath ?: "",
           checkIntervalSec: healthCheck.checkIntervalSec,
           timeoutSec: healthCheck.timeoutSec,
           unhealthyThreshold: healthCheck.unhealthyThreshold,


### PR DESCRIPTION
@duftler @danielpeach please review. The [docs](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/) say that only TCP and SSL health checks are supported, but I guess not... This adds the ability to cache all health check types for SSL LBs. This is a symmetrical fix to https://github.com/spinnaker/deck/pull/2933.