### PR TITLE
Initial support for AWS autoscaling lifecycle hooks

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgLifecycleHookWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgLifecycleHookWorker.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling
+import com.amazonaws.services.autoscaling.model.PutLifecycleHookRequest
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import groovy.transform.Canonical
+
+import java.util.regex.Pattern
+
+@Canonical
+class AsgLifecycleHookWorker {
+
+  private final static REGION_TEMPLATE_PATTERN = Pattern.quote("{{region}}")
+
+  final AmazonClientProvider amazonClientProvider
+
+  final NetflixAmazonCredentials targetCredentials
+  final String targetRegion
+
+  IdGenerator idGenerator
+
+  void attach(Task task, List<AmazonAsgLifecycleHook> lifecycleHooks, String targetAsgName) {
+    if (lifecycleHooks?.size() == 0) {
+      return
+    }
+
+    AmazonAutoScaling autoScaling = amazonClientProvider.getAutoScaling(targetCredentials, targetRegion, true)
+    lifecycleHooks.each { lifecycleHook ->
+      String lifecycleHookName = lifecycleHook.name ?: [targetAsgName, 'lifecycle', idGenerator.nextId()].join('-')
+      def request = new PutLifecycleHookRequest(
+        autoScalingGroupName: targetAsgName,
+        lifecycleHookName: lifecycleHookName,
+        roleARN: lifecycleHook.roleARN,
+        notificationTargetARN: arnRegionTemplater(lifecycleHook.notificationTargetARN, targetRegion),
+        notificationMetadata: lifecycleHook.notificationMetadata,
+        lifecycleTransition: lifecycleHook.lifecycleTransition.toString(),
+        heartbeatTimeout: lifecycleHook.heartbeatTimeout,
+        defaultResult: lifecycleHook.defaultResult.toString()
+      )
+      autoScaling.putLifecycleHook(request)
+
+      task.updateStatus "AWS_DEPLOY", "Creating lifecycle hook (${request}) on ${targetRegion}/${targetAsgName}"
+    }
+  }
+
+  private static String arnRegionTemplater(String arnTemplate, String region) {
+    arnTemplate.replaceAll(REGION_TEMPLATE_PATTERN, region)
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/UpsertAsgLifecycleHookDescriptionAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/UpsertAsgLifecycleHookDescriptionAtomicOperationConverter.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.converters
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgLifecycleHookDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.UpsertAsgLifecycleHookAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component('upsertAsgLifecycleHookDescription')
+class UpsertAsgLifecycleHookDescriptionAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @Override
+  UpsertAsgLifecycleHookAtomicOperation convertOperation(Map input) {
+    new UpsertAsgLifecycleHookAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  UpsertAsgLifecycleHookDescription convertDescription(Map input) {
+    def converted = objectMapper.copy()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .convertValue(input, UpsertAsgLifecycleHookDescription)
+    converted.credentials = getCredentialsObject(input.credentials as String)
+    converted
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -16,8 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
+import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 
@@ -63,11 +64,13 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
 
   boolean ignoreSequence
   boolean startDisabled
+  boolean includeAccountLifecycleHooks = true
 
   List<AmazonBlockDevice> blockDevices
   Boolean useAmiBlockDeviceMappings
   List<String> loadBalancers
   List<String> securityGroups
+  List<AmazonAsgLifecycleHook> lifecycleHooks = []
   Map<String, List<String>> availabilityZones = [:]
   Capacity capacity = new Capacity()
   Source source = new Source()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAsgLifecycleHookDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAsgLifecycleHookDescription.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.description
+
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook.DefaultResult
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook.LifecycleTransition
+
+class UpsertAsgLifecycleHookDescription extends AbstractAmazonCredentialsDescription {
+
+  // required
+  String serverGroupName
+  String region
+  String roleARN
+  String notificationTargetARN
+
+  // optional
+  String name
+  LifecycleTransition lifecycleTransition = LifecycleTransition.EC2InstanceTerminating
+  String notificationMetadata
+  Integer heartbeatTimeout = 3600
+  DefaultResult defaultResult = DefaultResult.ABANDON
+}
+

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperation.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops
+
+import com.amazonaws.services.autoscaling.model.PutLifecycleHookRequest
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgLifecycleHookDescription
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
+
+class UpsertAsgLifecycleHookAtomicOperation implements AtomicOperation<Void> {
+
+  private static final String BASE_PHASE = "UPSERT_ASG_LIFECYCLE"
+
+  @Autowired
+  AmazonClientProvider amazonClientProvider
+
+  IdGenerator idGenerator = new IdGenerator()
+
+  UpsertAsgLifecycleHookDescription description
+
+  UpsertAsgLifecycleHookAtomicOperation(UpsertAsgLifecycleHookDescription description) {
+    this.description = description
+  }
+
+  @Override
+  Void operate(List priorOutputs) {
+    final lifecycleHookName = description.name ?: "${description.serverGroupName}-lifecycle-${idGenerator.nextId()}"
+    final request = new PutLifecycleHookRequest(
+      lifecycleHookName: lifecycleHookName,
+      autoScalingGroupName: description.serverGroupName,
+      lifecycleTransition: description.lifecycleTransition.toString(),
+      roleARN: description.roleARN,
+      notificationTargetARN: description.notificationTargetARN,
+      notificationMetadata: description.notificationMetadata,
+      heartbeatTimeout: description.heartbeatTimeout,
+      defaultResult: description.defaultResult.toString()
+    )
+
+    final autoScaling = amazonClientProvider.getAutoScaling(description.credentials, description.region, true)
+    autoScaling.putLifecycleHook(request)
+
+    return null
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgLifecycleHookDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgLifecycleHookDescriptionValidator.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgLifecycleHookDescription
+import org.springframework.stereotype.Component
+import org.springframework.validation.Errors
+
+@Component("upsertAsgLifecycleHookDescriptionValidator")
+class UpsertAsgLifecycleHookDescriptionValidator extends AmazonDescriptionValidationSupport<UpsertAsgLifecycleHookDescription> {
+
+  @Override
+  void validate(List priorDescriptions, UpsertAsgLifecycleHookDescription description, Errors errors) {
+    validateRegions(description, [description.region], "upsertAsgLifecycleHookDescription", errors)
+
+    if (!description.serverGroupName) {
+      rejectNull("serverGroupName", errors)
+    }
+
+    if (!description.roleARN) {
+      rejectNull("roleARN", errors)
+    }
+
+    if (!description.notificationTargetARN) {
+      rejectNull("notificationTargetARN", errors)
+    }
+
+    if (description.heartbeatTimeout > 3600) {
+      errors.rejectValue(
+        "heartbeatTimeout",
+        "upsertAsgLifecycleHookDescription.heartbeatTimeout.invalid",
+        "Heartbeat Timeout cannot be greater than 3600"
+      )
+    }
+  }
+
+  static void rejectNull(String field, Errors errors) {
+    errors.rejectValue(field, "upsertAsgLifecycleHookDescription.${field}.not.nullable")
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonAsgLifecycleHook.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonAsgLifecycleHook.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class AmazonAsgLifecycleHook {
+
+  String name
+  String roleARN
+  String notificationTargetARN
+  String notificationMetadata
+  LifecycleTransition lifecycleTransition
+  Integer heartbeatTimeout
+  DefaultResult defaultResult
+
+  enum LifecycleTransition {
+    EC2InstanceLaunching("autoscaling:EC2_INSTANCE_LAUNCHING"),
+    EC2InstanceTerminating("autoscaling:EC2_INSTANCE_TERMINATING")
+
+    final String value
+
+    LifecycleTransition(String value) {
+      this.value = value
+    }
+
+    String toString() {
+      value
+    }
+
+    static LifecycleTransition valueOfName(String name) {
+      values().find { it.value == name }
+    }
+  }
+
+  enum DefaultResult {
+    CONTINUE,
+    ABANDON
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
@@ -54,17 +54,18 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
                                        @JsonProperty("regions") List<AWSRegion> regions,
                                        @JsonProperty("defaultSecurityGroups") List<String> defaultSecurityGroups,
                                        @JsonProperty("requiredGroupMembership") List<String> requiredGroupMembership,
+                                       @JsonProperty("lifecycleHooks") List<LifecycleHook> lifecycleHooks,
                                        @JsonProperty("assumeRole") String assumeRole,
                                        @JsonProperty("sessionName") String sessionName) {
-        this(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, null, assumeRole, sessionName);
+        this(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, lifecycleHooks, null, assumeRole, sessionName);
     }
 
     public AssumeRoleAmazonCredentials(AssumeRoleAmazonCredentials copy, AWSCredentialsProvider credentialsProvider) {
-        this(copy.getName(), copy.getEnvironment(), copy.getAccountType(), copy.getAccountId(), copy.getDefaultKeyPair(), copy.getRegions(), copy.getDefaultSecurityGroups(), copy.getRequiredGroupMembership(), credentialsProvider, copy.getAssumeRole(), copy.getSessionName());
+        this(copy.getName(), copy.getEnvironment(), copy.getAccountType(), copy.getAccountId(), copy.getDefaultKeyPair(), copy.getRegions(), copy.getDefaultSecurityGroups(), copy.getRequiredGroupMembership(), copy.getLifecycleHooks(), credentialsProvider, copy.getAssumeRole(), copy.getSessionName());
     }
 
-    AssumeRoleAmazonCredentials(String name, String environment, String accountType, String accountId, String defaultKeyPair, List<AWSRegion> regions, List<String> defaultSecurityGroups, List<String> requiredGroupMembership, AWSCredentialsProvider credentialsProvider, String assumeRole, String sessionName) {
-        super(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, createSTSCredentialsProvider(credentialsProvider, accountId, assumeRole, sessionName == null ? DEFAULT_SESSION_NAME : sessionName));
+    AssumeRoleAmazonCredentials(String name, String environment, String accountType, String accountId, String defaultKeyPair, List<AWSRegion> regions, List<String> defaultSecurityGroups, List<String> requiredGroupMembership, List<LifecycleHook> lifecycleHooks, AWSCredentialsProvider credentialsProvider, String assumeRole, String sessionName) {
+        super(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, lifecycleHooks, createSTSCredentialsProvider(credentialsProvider, accountId, assumeRole, sessionName == null ? DEFAULT_SESSION_NAME : sessionName));
         this.assumeRole = assumeRole;
         this.sessionName = sessionName == null ? DEFAULT_SESSION_NAME : sessionName;
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAmazonCredentials.java
@@ -42,6 +42,7 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
                                     @JsonProperty("regions") List<AWSRegion> regions,
                                     @JsonProperty("defaultSecurityGroups") List<String> defaultSecurityGroups,
                                     @JsonProperty("requiredGroupMembership") List<String> requiredGroupMembership,
+                                    @JsonProperty("lifecycleHooks") List<LifecycleHook> lifecycleHooks,
                                     @JsonProperty("edda") String edda,
                                     @JsonProperty("eddaEnabled") Boolean eddaEnabled,
                                     @JsonProperty("discovery") String discovery,
@@ -50,7 +51,7 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
                                     @JsonProperty("front50Enabled") Boolean front50Enabled,
                                     @JsonProperty("bastionHost") String bastionHost,
                                     @JsonProperty("bastionEnabled") Boolean bastionEnabled) {
-        this(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, null, edda, eddaEnabled, discovery, discoveryEnabled, front50, front50Enabled, bastionHost, bastionEnabled);
+        this(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, lifecycleHooks, null, edda, eddaEnabled, discovery, discoveryEnabled, front50, front50Enabled, bastionHost, bastionEnabled);
     }
 
     private static boolean flagValue(String serviceUrl, Boolean flag) {
@@ -58,7 +59,7 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
     }
 
     public NetflixAmazonCredentials(NetflixAmazonCredentials copy, AWSCredentialsProvider credentialsProvider) {
-        this(copy.getName(), copy.getEnvironment(), copy.getAccountType(), copy.getAccountId(), copy.getDefaultKeyPair(), copy.getRegions(), copy.getDefaultSecurityGroups(), copy.getRequiredGroupMembership(), credentialsProvider, copy.getEdda(), copy.getEddaEnabled(), copy.getDiscovery(), copy.getDiscoveryEnabled(), copy.getFront50(), copy.getFront50Enabled(), copy.getBastionHost(), copy.getBastionEnabled());
+        this(copy.getName(), copy.getEnvironment(), copy.getAccountType(), copy.getAccountId(), copy.getDefaultKeyPair(), copy.getRegions(), copy.getDefaultSecurityGroups(), copy.getRequiredGroupMembership(), copy.getLifecycleHooks(), credentialsProvider, copy.getEdda(), copy.getEddaEnabled(), copy.getDiscovery(), copy.getDiscoveryEnabled(), copy.getFront50(), copy.getFront50Enabled(), copy.getBastionHost(), copy.getBastionEnabled());
     }
 
     NetflixAmazonCredentials(String name,
@@ -69,6 +70,7 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
                              List<AWSRegion> regions,
                              List<String> defaultSecurityGroups,
                              List<String> requiredGroupMembership,
+                             List<LifecycleHook> lifecycleHooks,
                              AWSCredentialsProvider credentialsProvider,
                              String edda,
                              Boolean eddaEnabled,
@@ -78,7 +80,7 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
                              Boolean front50Enabled,
                              String bastionHost,
                              Boolean bastionEnabled) {
-        super(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, credentialsProvider);
+        super(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, lifecycleHooks, credentialsProvider);
         this.edda = edda;
         this.eddaEnabled = flagValue(edda, eddaEnabled);
         this.discovery = discovery;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAssumeRoleAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAssumeRoleAmazonCredentials.java
@@ -41,6 +41,7 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
                                               @JsonProperty("regions") List<AWSRegion> regions,
                                               @JsonProperty("defaultSecurityGroups") List<String> defaultSecurityGroups,
                                               @JsonProperty("requiredGroupMembership") List<String> requiredGroupMembership,
+                                              @JsonProperty("lifecycleHooks") List<LifecycleHook> lifecycleHooks,
                                               @JsonProperty("edda") String edda,
                                               @JsonProperty("eddaEnabled") Boolean eddaEnabled,
                                               @JsonProperty("discovery") String discovery,
@@ -52,15 +53,15 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
                                               @JsonProperty("assumeRole") String assumeRole,
                                               @JsonProperty("sessionName") String sessionName) {
 
-        this(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, null, edda, eddaEnabled, discovery, discoveryEnabled, front50, front50Enabled, bastionHost, bastionEnabled, assumeRole, sessionName);
+        this(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, lifecycleHooks, null, edda, eddaEnabled, discovery, discoveryEnabled, front50, front50Enabled, bastionHost, bastionEnabled, assumeRole, sessionName);
     }
 
     public NetflixAssumeRoleAmazonCredentials(NetflixAssumeRoleAmazonCredentials copy, AWSCredentialsProvider credentialsProvider) {
-        this(copy.getName(), copy.getEnvironment(), copy.getAccountType(), copy.getAccountId(), copy.getDefaultKeyPair(), copy.getRegions(), copy.getDefaultSecurityGroups(), copy.getRequiredGroupMembership(), credentialsProvider, copy.getEdda(), copy.getEddaEnabled(), copy.getDiscovery(), copy.getDiscoveryEnabled(), copy.getFront50(), copy.getFront50Enabled(), copy.getBastionHost(), copy.getBastionEnabled(), copy.getAssumeRole(), copy.getSessionName());
+        this(copy.getName(), copy.getEnvironment(), copy.getAccountType(), copy.getAccountId(), copy.getDefaultKeyPair(), copy.getRegions(), copy.getDefaultSecurityGroups(), copy.getRequiredGroupMembership(), copy.getLifecycleHooks(), credentialsProvider, copy.getEdda(), copy.getEddaEnabled(), copy.getDiscovery(), copy.getDiscoveryEnabled(), copy.getFront50(), copy.getFront50Enabled(), copy.getBastionHost(), copy.getBastionEnabled(), copy.getAssumeRole(), copy.getSessionName());
     }
 
-    NetflixAssumeRoleAmazonCredentials(String name, String environment, String accountType, String accountId, String defaultKeyPair, List<AWSRegion> regions, List<String> defaultSecurityGroups, List<String> requiredGroupMembership, AWSCredentialsProvider credentialsProvider, String edda, Boolean eddaEnabled, String discovery, Boolean discoveryEnabled, String front50, Boolean front50Enabled, String bastionHost, Boolean bastionEnabled, String assumeRole, String sessionName) {
-        super(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, AssumeRoleAmazonCredentials.createSTSCredentialsProvider(credentialsProvider, accountId, assumeRole, sessionName == null ? AssumeRoleAmazonCredentials.DEFAULT_SESSION_NAME : sessionName), edda, eddaEnabled, discovery, discoveryEnabled, front50, front50Enabled, bastionHost, bastionEnabled);
+    NetflixAssumeRoleAmazonCredentials(String name, String environment, String accountType, String accountId, String defaultKeyPair, List<AWSRegion> regions, List<String> defaultSecurityGroups, List<String> requiredGroupMembership, List<LifecycleHook> lifecycleHooks, AWSCredentialsProvider credentialsProvider, String edda, Boolean eddaEnabled, String discovery, Boolean discoveryEnabled, String front50, Boolean front50Enabled, String bastionHost, Boolean bastionEnabled, String assumeRole, String sessionName) {
+        super(name, environment, accountType, accountId, defaultKeyPair, regions, defaultSecurityGroups, requiredGroupMembership, lifecycleHooks, AssumeRoleAmazonCredentials.createSTSCredentialsProvider(credentialsProvider, accountId, assumeRole, sessionName == null ? AssumeRoleAmazonCredentials.DEFAULT_SESSION_NAME : sessionName), edda, eddaEnabled, discovery, discoveryEnabled, front50, front50Enabled, bastionHost, bastionEnabled);
         this.assumeRole = assumeRole;
         this.sessionName = sessionName == null ? AssumeRoleAmazonCredentials.DEFAULT_SESSION_NAME : sessionName;
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
@@ -72,6 +72,64 @@ public class CredentialsConfig {
         }
     }
 
+    public static class LifecycleHook {
+      private String name;
+      private String roleARN;
+      private String notificationTargetARN;
+      private String lifecycleTransition;
+      private Integer heartbeatTimeout;
+      private String defaultResult;
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(String name) {
+        this.name = name;
+      }
+
+      public String getRoleARN() {
+        return roleARN;
+      }
+
+      public void setRoleARN(String roleARN) {
+        this.roleARN = roleARN;
+      }
+
+      public String getNotificationTargetARN() {
+        return notificationTargetARN;
+      }
+
+      public void setNotificationTargetARN(String notificationTargetARN) {
+        this.notificationTargetARN = notificationTargetARN;
+      }
+
+      public String getLifecycleTransition() {
+        return lifecycleTransition;
+      }
+
+      public void setLifecycleTransition(String lifecycleTransition) {
+        this.lifecycleTransition = lifecycleTransition;
+      }
+
+      public Integer getHeartbeatTimeout() {
+        return heartbeatTimeout;
+      }
+
+      public void setHeartbeatTimeout(Integer heartbeatTimeout) {
+        this.heartbeatTimeout = heartbeatTimeout;
+      }
+
+      public String getDefaultResult() {
+        return defaultResult;
+      }
+
+      public void setDefaultResult(String defaultResult) {
+        this.defaultResult = defaultResult;
+      }
+
+    }
+
     public static class Account {
         private String name;
         private String environment;
@@ -91,6 +149,7 @@ public class CredentialsConfig {
         private Boolean bastionEnabled;
         private String assumeRole;
         private String sessionName;
+        private List<LifecycleHook> lifecycleHooks;
 
         public String getName() {
             return name;
@@ -235,17 +294,28 @@ public class CredentialsConfig {
         public void setSessionName(String sessionName) {
             this.sessionName = sessionName;
         }
+
+        public List<LifecycleHook> getLifecycleHooks() {
+          return lifecycleHooks;
+        }
+
+        public void setLifecycleHooks(List<LifecycleHook> lifecycleHooks) {
+          this.lifecycleHooks = lifecycleHooks;
+        }
     }
 
     private String defaultKeyPairTemplate;
     private List<Region> defaultRegions;
     private List<String> defaultSecurityGroups;
+    private List<LifecycleHook> defaultLifecycleHooks;
     private String defaultEddaTemplate;
     private String defaultFront50Template;
     private String defaultBastionHostTemplate;
     private String defaultDiscoveryTemplate;
     private String defaultAssumeRole;
     private String defaultSessionName;
+    private String defaultLifecycleHookRoleARNTemplate;
+    private String defaultLifecycleHookNotificationTargetARNTemplate;
 
     private List<Account> accounts;
 
@@ -327,5 +397,29 @@ public class CredentialsConfig {
 
     public void setAccounts(List<Account> accounts) {
         this.accounts = accounts;
+    }
+
+    public List<LifecycleHook> getDefaultLifecycleHooks() {
+        return defaultLifecycleHooks;
+    }
+
+    public void setDefaultLifecycleHooks(List<LifecycleHook> defaultLifecycleHooks) {
+        this.defaultLifecycleHooks = defaultLifecycleHooks;
+    }
+
+    public String getDefaultLifecycleHookRoleARNTemplate() {
+      return defaultLifecycleHookRoleARNTemplate;
+    }
+
+    public void setDefaultLifecycleHookRoleARNTemplate(String defaultLifecycleHookRoleARNTemplate) {
+        this.defaultLifecycleHookRoleARNTemplate = defaultLifecycleHookRoleARNTemplate;
+    }
+
+    public String getDefaultLifecycleHookNotificationTargetARNTemplate() {
+        return defaultLifecycleHookNotificationTargetARNTemplate;
+    }
+
+    public void setDefaultLifecycleHookNotificationTargetARNTemplate(String defaultLifecycleHookNotificationTargetARNTemplate) {
+        this.defaultLifecycleHookNotificationTargetARNTemplate = defaultLifecycleHookNotificationTargetARNTemplate;
     }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoader.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoader.java
@@ -218,6 +218,7 @@ public class CredentialsLoader<T extends AmazonCredentials> {
 
             account.setRegions(initRegions(defaultRegions, account.getRegions()));
             account.setDefaultSecurityGroups(account.getDefaultSecurityGroups() != null ? account.getDefaultSecurityGroups() : config.getDefaultSecurityGroups());
+            account.setLifecycleHooks(account.getLifecycleHooks() != null ? account.getLifecycleHooks() : config.getDefaultLifecycleHooks());
 
             Map<String, String> templateContext = new HashMap<>(templateValues);
             templateContext.put("name", account.getName());
@@ -232,6 +233,14 @@ public class CredentialsLoader<T extends AmazonCredentials> {
             account.setAssumeRole(templateFirstNonNull(templateContext, account.getAssumeRole(), config.getDefaultAssumeRole()));
             account.setSessionName(templateFirstNonNull(templateContext, account.getSessionName(), config.getDefaultSessionName()));
             account.setBastionHost(templateFirstNonNull(templateContext, account.getBastionHost(), config.getDefaultBastionHostTemplate()));
+
+            if (account.getLifecycleHooks() != null) {
+                for (CredentialsConfig.LifecycleHook lifecycleHook : account.getLifecycleHooks()) {
+                  lifecycleHook.setRoleARN(templateFirstNonNull(templateContext, lifecycleHook.getRoleARN(), config.getDefaultLifecycleHookRoleARNTemplate()));
+                  lifecycleHook.setNotificationTargetARN(templateFirstNonNull(templateContext, lifecycleHook.getNotificationTargetARN(), config.getDefaultLifecycleHookNotificationTargetARNTemplate()));
+                }
+            }
+
             initializedAccounts.add(credentialTranslator.translate(credentialsProvider, account));
         }
         return initializedAccounts;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/RegionScopedProviderFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/RegionScopedProviderFactory.groovy
@@ -18,26 +18,21 @@ package com.netflix.spinnaker.clouddriver.aws.services
 import com.amazonaws.services.autoscaling.AmazonAutoScaling
 import com.amazonaws.services.ec2.AmazonEC2
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
-import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProperties
-import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.deploy.AWSServerGroupNameResolver
+import com.netflix.spinnaker.clouddriver.aws.deploy.AsgLifecycleHookWorker
 import com.netflix.spinnaker.clouddriver.aws.deploy.AsgReferenceCopier
 import com.netflix.spinnaker.clouddriver.aws.deploy.DefaultLaunchConfigurationBuilder
 import com.netflix.spinnaker.clouddriver.aws.deploy.LaunchConfigurationBuilder
-import com.netflix.spinnaker.clouddriver.eureka.api.Eureka
+import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataProperties
 import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.UserDataProvider
 import com.netflix.spinnaker.clouddriver.aws.model.SubnetAnalyzer
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.eureka.api.Eureka
 import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.EurekaUtil
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
-import org.apache.http.impl.client.HttpClients
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import retrofit.RestAdapter
-import retrofit.client.ApacheClient
-
-import java.util.concurrent.atomic.AtomicReference
-import java.util.regex.Pattern
 
 @Component
 class RegionScopedProviderFactory {
@@ -109,6 +104,10 @@ class RegionScopedProviderFactory {
 
     AsgReferenceCopier getAsgReferenceCopier(NetflixAmazonCredentials targetCredentials, String targetRegion) {
       new AsgReferenceCopier(amazonClientProvider, amazonCredentials, region, targetCredentials, targetRegion, new IdGenerator())
+    }
+
+    AsgLifecycleHookWorker getAsgLifecycleHookWorker() {
+      new AsgLifecycleHookWorker(amazonClientProvider, amazonCredentials, region, new IdGenerator())
     }
 
     LaunchConfigurationBuilder getLaunchConfigurationBuilder() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgLifecycleHookWorkerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgLifecycleHookWorkerSpec.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.deploy
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling
+import com.amazonaws.services.autoscaling.model.PutLifecycleHookRequest
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import spock.lang.Specification
+import spock.lang.Subject
+
+class AsgLifecycleHookWorkerSpec extends Specification {
+
+  def autoScaling = Mock(AmazonAutoScaling)
+  def amazonClientProvider = Stub(AmazonClientProvider) {
+    getAutoScaling(_, 'us-east-1', true) >> autoScaling
+  }
+
+  int count = 0
+  def idGenerator = Stub(IdGenerator) {
+    nextId() >> { (++count).toString() }
+  }
+
+  @Subject def asgLifecycleHookWorker = new AsgLifecycleHookWorker(amazonClientProvider, null, 'us-east-1', idGenerator)
+
+  void 'should no-op with no lifecycle hooks defined'() {
+    when:
+    asgLifecycleHookWorker.attach(Mock(Task), [], 'asg-v000')
+
+    then:
+    0 * autoScaling.putLifecycleHook(_)
+  }
+
+  void 'should create defined lifecycle hooks'() {
+    given:
+    def lifecycleHooks = [
+      new AmazonAsgLifecycleHook(
+        roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
+        notificationTargetARN: 'arn:aws:sns:us-east-1:123456789012:my-sns-topic',
+        lifecycleTransition: AmazonAsgLifecycleHook.LifecycleTransition.EC2InstanceTerminating,
+        heartbeatTimeout: 3600,
+        defaultResult: AmazonAsgLifecycleHook.DefaultResult.ABANDON
+      ),
+      new AmazonAsgLifecycleHook(
+        roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
+        notificationTargetARN: 'arn:aws:sns:{{region}}:123456789012:my-sns-topic',
+        lifecycleTransition: AmazonAsgLifecycleHook.LifecycleTransition.EC2InstanceLaunching,
+        heartbeatTimeout: 3600,
+        defaultResult: AmazonAsgLifecycleHook.DefaultResult.CONTINUE
+      )
+    ]
+
+    when:
+    asgLifecycleHookWorker.attach(Mock(Task), lifecycleHooks, 'asg-v000')
+
+    then:
+    1 * autoScaling.putLifecycleHook(new PutLifecycleHookRequest(
+      lifecycleHookName: 'asg-v000-lifecycle-1',
+      autoScalingGroupName: 'asg-v000',
+      lifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING',
+      notificationTargetARN: 'arn:aws:sns:us-east-1:123456789012:my-sns-topic',
+      roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
+      heartbeatTimeout: 3600,
+      defaultResult: 'ABANDON'
+    ))
+    1 * autoScaling.putLifecycleHook(new PutLifecycleHookRequest(
+      lifecycleHookName: 'asg-v000-lifecycle-2',
+      autoScalingGroupName: 'asg-v000',
+      lifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING',
+      notificationTargetARN: 'arn:aws:sns:us-east-1:123456789012:my-sns-topic',
+      roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
+      heartbeatTimeout: 3600,
+      defaultResult: 'CONTINUE'
+    ))
+
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperationUnitSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.deploy.ops
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling
+import com.amazonaws.services.autoscaling.model.PutLifecycleHookRequest
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgLifecycleHookDescription
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import spock.lang.Specification
+import spock.lang.Subject
+
+class UpsertAsgLifecycleHookAtomicOperationUnitSpec extends Specification {
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  final description = new UpsertAsgLifecycleHookDescription(
+    serverGroupName: 'asg-v000',
+    region: 'us-west-1',
+    roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
+    notificationTargetARN: 'arn:aws:sns:us-west-1:123456789012:my-sns-topic'
+  )
+
+  @Subject final op = new UpsertAsgLifecycleHookAtomicOperation(description)
+
+  final autoScaling = Mock(AmazonAutoScaling)
+  final amazonClientProvider = Stub(AmazonClientProvider) {
+    getAutoScaling(_, _, true) >> autoScaling
+  }
+
+  def setup() {
+    op.amazonClientProvider = amazonClientProvider
+    op.idGenerator = new IdGenerator() {
+      int nextId = 0
+      String nextId() {
+        ++nextId
+      }
+    }
+  }
+
+  def 'creates unnamed lifecycle hook'() {
+    when:
+    op.operate([])
+
+    then:
+    1 * autoScaling.putLifecycleHook(new PutLifecycleHookRequest(
+      lifecycleHookName: 'asg-v000-lifecycle-1',
+      autoScalingGroupName: 'asg-v000',
+      lifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING',
+      roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
+      notificationTargetARN: 'arn:aws:sns:us-west-1:123456789012:my-sns-topic',
+      heartbeatTimeout: 3600,
+      defaultResult: 'ABANDON'
+    ))
+    0 * _
+  }
+
+  def 'creates named lifecycle hook'() {
+    given:
+    description.name = 'fancyHook'
+
+    when:
+    op.operate([])
+
+    then:
+    1 * autoScaling.putLifecycleHook(new PutLifecycleHookRequest(
+      lifecycleHookName: 'fancyHook',
+      autoScalingGroupName: 'asg-v000',
+      lifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING',
+      roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
+      notificationTargetARN: 'arn:aws:sns:us-west-1:123456789012:my-sns-topic',
+      heartbeatTimeout: 3600,
+      defaultResult: 'ABANDON'
+    ))
+    0 * _
+  }
+}

--- a/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
+++ b/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
@@ -191,6 +191,7 @@ class ProviderUtilsSpec extends Specification {
                                  null,
                                  null,
                                  null,
+                                 null,
                                  null)
   }
 


### PR DESCRIPTION
Allows templated addition of account-wide autoscaling lifecycle hooks. If `defaultLifecycleHooks` are defined, or account-level `lifecycleHooks` is defined, any server group created within that account will have lifecycle hooks created and applied to it.

There's currently no way to delete lifecycle hooks from server groups outside of the deletion of the ASG.

@spinnaker/netflix-reviewers PTAL