### PR TITLE
add flag to suppress copying forward of scheduled actions and scalingpolicies on aws deployment

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -46,6 +46,11 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   String base64UserData
   Boolean legacyUdf
 
+  /**
+   * If false, the newly created server group will not pick up scaling policies and actions from an ancestor group
+   */
+  boolean copySourceScalingPoliciesAndActions = true
+
   String classicLinkVpcId
   List<String> classicLinkVpcSecurityGroups
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -262,9 +262,11 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
       deploymentResult.serverGroupNames << "${region}:${asgName}".toString()
       deploymentResult.serverGroupNameByRegion[region] = asgName
 
-      copyScalingPoliciesAndScheduledActions(
-        task, sourceRegionScopedProvider, description.credentials, description.source.asgName, region, asgName
-      )
+      if (description.copySourceScalingPoliciesAndActions) {
+        copyScalingPoliciesAndScheduledActions(
+          task, sourceRegionScopedProvider, description.credentials, description.source.asgName, region, asgName
+        )
+      }
     }
 
     return deploymentResult


### PR DESCRIPTION
This is to enable the use case of creating a hot standby server group by copying from the source (don't want it autoscaling)

@spinnaker/netflix-reviewers PTAL