### PR TITLE
(Openstack) Added user data file to use with every deploy.

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/config/OpenstackConfigurationProperties.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/config/OpenstackConfigurationProperties.groovy
@@ -37,6 +37,7 @@ class OpenstackConfigurationProperties {
     String heatTemplatePath
     LbaasConfig lbaas
     ConsulConfig consul
+    String userDataFile
   }
 
   static class LbaasConfig {

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/OpenstackUserDataProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/OpenstackUserDataProvider.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.openstack.deploy.ops
+
+import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
+import groovy.transform.PackageScope
+import groovy.util.logging.Slf4j
+
+// TODO (jshimek) Refactor the LocalFileUserDataProvider the AWS driver uses to be more driver agnostic
+// See https://github.com/spinnaker/spinnaker/issues/1274
+/**
+ * Provides the common user data from a local file to be applied to all OpenStack deployments.
+ *
+ * Any custom user data specified for each deployment will be appended to common user data, allowing custom user data
+ * to override the common user data.
+ */
+@Slf4j
+public class OpenstackUserDataProvider {
+
+  final OpenstackNamedAccountCredentials credentials
+
+  OpenstackUserDataProvider(OpenstackNamedAccountCredentials credentials) {
+    this.credentials = credentials
+  }
+
+  /**
+   * Returns the custom user data or the empty string if non is found.
+   */
+  String getUserData(final String serverGroupName, final String region, final String customUserData) {
+
+    String userDataFile = credentials.getUserDataFile()
+    String rawUserData = getFileContents(userDataFile)
+    String commonUserData = replaceTokens(rawUserData, serverGroupName, region)
+
+
+    StringBuilder userData = new StringBuilder();
+    if (commonUserData) {
+      userData.append(commonUserData)
+      userData.append('\n')
+    }
+    if (customUserData) {
+      userData.append(customUserData)
+    }
+
+    userData.toString()
+  }
+
+  /**
+   * Returns the contents of a file or an empty string if the file doesn't exist.
+   */
+  @PackageScope
+  String getFileContents(String filename) {
+
+    if (!filename) {
+      return ''
+    }
+
+    try {
+      File file = new File(filename)
+      String contents = file.getText('UTF-8')
+      if (contents.length() && !contents.endsWith("\n")) {
+        contents = contents + '\n'
+      }
+      return contents
+    } catch (IOException e) {
+      log.warn("Failed to read user data file ${filename}; ${e.message}")
+      return ''
+    }
+  }
+  /**
+   * Returns the user data with the tokens replaced.
+   *
+   * Currently supports the following tokens:
+   *
+   * %%account%% 	    the name of the account
+   * %%accounttype%% 	the accountType of the account
+   * %%env%%        	the environment of the account
+   * %%app%%          the name of the app
+   * %%region%% 	    the deployment region
+   * %%group%% 	      the name of the server group
+   * %%autogrp%% 	    the name of the server group
+   * %%cluster%% 	    the name of the cluster
+   * %%stack%% 	      the stack component of the cluster name
+   * %%detail%% 	    the detail component of the cluster name
+   * %%launchconfig%% the name of the launch configuration (server group name)
+   */
+  private String replaceTokens(String rawUserData, String serverGroupName, String region) {
+
+    if (!rawUserData) {
+      return ''
+    }
+
+    Names names = Names.parseName(serverGroupName)
+
+    // Replace the tokens & return the result
+    String result = rawUserData
+      .replace('%%account%%', credentials.name ?: '')
+      .replace('%%accounttype%%', credentials.accountType ?: '')
+      .replace('%%env%%', credentials.environment ?: '')
+      .replace('%%app%%', names.app ?: '')
+      .replace('%%region%%', region ?: '')
+      .replace('%%group%%', names.group ?: '')
+      .replace('%%autogrp%%', names.group ?: '')
+      .replace('%%cluster%%', names.cluster ?: '')
+      .replace('%%stack%%', names.stack ?: '')
+      .replace('%%detail%%', names.detail ?: '')
+      .replace('%%launchconfig%%', serverGroupName ?: '')
+
+    result
+  }
+}

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackCredentials.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackCredentials.groovy
@@ -18,15 +18,18 @@ package com.netflix.spinnaker.clouddriver.openstack.security
 
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFactory
+import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.OpenstackUserDataProvider
 
 public class OpenstackCredentials {
 
   final OpenstackClientProvider provider
   final OpenstackNamedAccountCredentials credentials
+  final OpenstackUserDataProvider userDataProvider
 
   OpenstackCredentials(OpenstackNamedAccountCredentials accountCredentials) {
     this.provider = OpenstackProviderFactory.createProvider(accountCredentials)
     this.credentials = accountCredentials
+    this.userDataProvider = new OpenstackUserDataProvider(this.credentials)
   }
 
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackCredentialsInitializer.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackCredentialsInitializer.groovy
@@ -79,7 +79,8 @@ class OpenstackCredentialsInitializer implements CredentialsInitializerSynchroni
                                                                     managedAccount.insecure,
                                                                     managedAccount.heatTemplatePath,
                                                                     managedAccount.lbaas,
-                                                                    managedAccount.consul
+                                                                    managedAccount.consul,
+                                                                    managedAccount.userDataFile
                                                                     )
         LOG.info("Saving openstack account $openstackAccount")
         accountCredentialsRepository.save(managedAccount.name, openstackAccount)

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentials.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentials.groovy
@@ -41,6 +41,8 @@ class OpenstackNamedAccountCredentials implements AccountCredentials<OpenstackCr
   final String heatTemplateLocation
   final LbaasConfig lbaasConfig
   final ConsulConfig consulConfig
+  final String userDataFile
+
 
   OpenstackNamedAccountCredentials(String accountName,
                                    String environment,
@@ -54,8 +56,9 @@ class OpenstackNamedAccountCredentials implements AccountCredentials<OpenstackCr
                                    Boolean insecure,
                                    String heatTemplateLocation,
                                    LbaasConfig lbaasConfig,
-                                   ConsulConfig consulConfig) {
-    this(accountName, environment, accountType, username, password, null, projectName, domainName, authUrl, regions, insecure, heatTemplateLocation, lbaasConfig, consulConfig)
+                                   ConsulConfig consulConfig,
+                                   String userDataFile) {
+    this(accountName, environment, accountType, username, password, null, projectName, domainName, authUrl, regions, insecure, heatTemplateLocation, lbaasConfig, consulConfig, userDataFile)
   }
 
   OpenstackNamedAccountCredentials(String accountName,
@@ -71,7 +74,8 @@ class OpenstackNamedAccountCredentials implements AccountCredentials<OpenstackCr
                                    Boolean insecure,
                                    String heatTemplateLocation,
                                    LbaasConfig lbaasConfig,
-                                   ConsulConfig consulConfig) {
+                                   ConsulConfig consulConfig,
+                                   String userDataFile) {
     this.name = accountName
     this.environment = environment
     this.accountType = accountType
@@ -86,6 +90,7 @@ class OpenstackNamedAccountCredentials implements AccountCredentials<OpenstackCr
     this.heatTemplateLocation = heatTemplateLocation
     this.lbaasConfig = lbaasConfig
     this.consulConfig = consulConfig
+    this.userDataFile = userDataFile
     if (this.consulConfig?.enabled) {
       this.consulConfig.applyDefaults()
     }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackIdentityV3ProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackIdentityV3ProviderSpec.groovy
@@ -49,7 +49,7 @@ class OpenstackIdentityV3ProviderSpec extends Specification {
     Boolean insecure = true
     LbaasConfig config = new LbaasConfig(pollInterval: 5, pollTimeout: 60)
     ConsulConfig consulConfig = new ConsulConfig()
-    credentials = new OpenstackNamedAccountCredentials(accountName, environment, accountType, username, password, projectName, domainName, authUrl, [], insecure, "", config, consulConfig)
+    credentials = new OpenstackNamedAccountCredentials(accountName, environment, accountType, username, password, projectName, domainName, authUrl, [], insecure, "", config, consulConfig, null)
     mockClient = Mock(OSClient.OSClientV3) {
       getToken() >> { Mock(Token) }
     }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/OpenstackUserDataProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/OpenstackUserDataProviderSpec.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Target, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.openstack.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class OpenstackUserDataProviderSpec extends Specification {
+
+  def "combines common and custom user data"() {
+    given:
+    def credentials = new OpenstackNamedAccountCredentials('account', 'test', 'main', 'user', 'pw', 'project', 'domain',
+      'endpoint', [], false, '', null, null, '/some/user/data/file/udf')
+    def provider = Spy(OpenstackUserDataProvider, constructorArgs: [credentials]) {
+      it.getFileContents(_) >> commonUserData
+    }
+    def serverGroupName = 'app-stack-detail-v001'
+    def region = 'west'
+
+    when:
+    def userData = provider.getUserData(serverGroupName, region, customUserData)
+
+    then:
+    userData == expectedUserData
+    noExceptionThrown()
+
+    where:
+    customUserData            | commonUserData           || expectedUserData
+    null                      | null                      | ''
+    ''                        | null                      | ''
+    null                      | ''                        | ''
+    null                      | 'echo "common user data"' | 'echo "common user data"\n'
+    ''                        | 'echo "common user data"' | 'echo "common user data"\n'
+    'echo "custom user data"' | null                      | 'echo "custom user data"'
+    'echo "custom user data"' | ''                        | 'echo "custom user data"'
+    'echo "custom user data"' | 'echo "common user data"' | 'echo "common user data"\necho "custom user data"'
+    '%%account%%'             | '%%region%%'              | 'west\n%%account%%'
+  }
+
+
+  def "handles unreadable user data file"() {
+      given:
+      def credentials = new OpenstackNamedAccountCredentials('account', 'test', 'main', 'user', 'pw', 'project', 'domain',
+        'endpoint', [], false, '', null, null, userDataFile)
+      def provider = new OpenstackUserDataProvider(credentials)
+      def serverGroupName = 'app-stack-detail-v001'
+      def region = 'west'
+
+      when:
+      def userData = provider.getUserData(serverGroupName, region, 'custom user data')
+
+      then:
+      userData == 'custom user data'
+      noExceptionThrown()
+
+      where:
+      userDataFile << [null, '', '/a/non/existant/file/udf']
+  }
+
+   def "ensure replace tokens works"() {
+     given:
+     def credentials = new OpenstackNamedAccountCredentials('my-account', 'test', 'main', 'user', 'pw', 'project', 'domain',
+       'endpoint', [], false, '', null, null, '/user/data/file/udf')
+     def provider = Spy(OpenstackUserDataProvider, constructorArgs: [credentials]) {
+       it.getFileContents(_) >> rawUserData
+     }
+     def serverGroupName = 'myapp-dev-green-v001'
+     def region = 'west'
+
+     when:
+     def userData = provider.getUserData(serverGroupName, region, '')
+
+     then:
+     userData == expectedUserData
+
+     where:
+     rawUserData           | expectedUserData
+     ''                    | ''
+     null                  | ''
+     '%%account%%'         | 'my-account\n'
+     '%account%'           | '%account%\n'
+     '%%accounttype%%'     | 'main\n'
+     '%%env%%'             | 'test\n'
+     '%%region%%'          | 'west\n'
+     '%%env%%\n%%region%%' | 'test\nwest\n'
+     '%%app%%'             | 'myapp\n'
+     '%%stack%%'           | 'dev\n'
+     '%%detail%%'          | 'green\n'
+     '%%cluster%%'         | 'myapp-dev-green\n'
+     '%%group%%'           | 'myapp-dev-green-v001\n'
+     '%%autogrp%%'         | 'myapp-dev-green-v001\n'
+     '%%launchconfig%%'    | 'myapp-dev-green-v001\n'
+   }
+}

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/discovery/AbstractEnableDisableInstancesInDiscoveryAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/discovery/AbstractEnableDisableInstancesInDiscoveryAtomicOperationSpec.groovy
@@ -55,7 +55,7 @@ class AbstractEnableDisableInstancesInDiscoveryAtomicOperationSpec extends Speci
       getEnabled() >> consulEnabled
       applyDefaults() >> {}
     }
-    OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), consulConfig)
+    OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), consulConfig, null)
     OpenstackProviderFactory.createProvider(credz) >> { provider }
     credentials = new OpenstackCredentials(credz)
     description = new OpenstackInstancesDescription(credentials: credentials, region: region, instanceIds: INSTANCE_IDS, account: ACCOUNT_NAME)

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/AbstractRegistrationOpenstackInstancesAtomicOperationUnitSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/AbstractRegistrationOpenstackInstancesAtomicOperationUnitSpec.groovy
@@ -61,7 +61,7 @@ class AbstractRegistrationOpenstackInstancesAtomicOperationUnitSpec extends Spec
   def setup() {
     OpenstackClientProvider provider = Mock(OpenstackClientProvider)
     GroovyMock(OpenstackProviderFactory, global: true)
-    OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig())
+    OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig(), null)
     OpenstackProviderFactory.createProvider(credz) >> { provider }
     credentials = new OpenstackCredentials(credz)
     description = new OpenstackInstancesRegistrationDescription(region: region, loadBalancerIds: LB_IDS, instanceIds: INSTANCE_IDS, weight: 1, account: ACCOUNT_NAME, credentials: credentials)

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/AbstractOpenstackLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/AbstractOpenstackLoadBalancerAtomicOperationSpec.groovy
@@ -61,7 +61,7 @@ class AbstractOpenstackLoadBalancerAtomicOperationSpec extends Specification {
   def setup() {
     provider = Mock(OpenstackClientProvider)
     GroovyMock(OpenstackProviderFactory, global: true)
-    OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "project", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig())
+    OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "project", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig(), null)
     OpenstackProviderFactory.createProvider(credz) >> { provider }
     credentials = new OpenstackCredentials(credz)
 

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/UpsertOpenstackLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/UpsertOpenstackLoadBalancerAtomicOperationSpec.groovy
@@ -73,7 +73,7 @@ class UpsertOpenstackLoadBalancerAtomicOperationSpec extends Specification imple
   def setup() {
     provider = Mock(OpenstackClientProvider)
     GroovyMock(OpenstackProviderFactory, global: true)
-    OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig())
+    OpenstackNamedAccountCredentials credz = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig(), null)
     OpenstackProviderFactory.createProvider(credz) >> { provider }
     credentials = new OpenstackCredentials(credz)
     description = new OpenstackLoadBalancerDescription(credentials: credentials, region: region, account: account)

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/EnableDisableOpenstackAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/EnableDisableOpenstackAtomicOperationSpec.groovy
@@ -68,7 +68,7 @@ class EnableDisableOpenstackAtomicOperationSpec extends Specification {
   def setup() {
     provider = Mock(OpenstackClientProvider)
     GroovyMock(OpenstackProviderFactory, global: true)
-    OpenstackNamedAccountCredentials creds = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig())
+    OpenstackNamedAccountCredentials creds = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig(), null)
     OpenstackProviderFactory.createProvider(creds) >> { provider }
     credentials = new OpenstackCredentials(creds)
     description = new OpenstackServerGroupAtomicOperationDescription(serverGroupName: STACK, region: REGION, credentials: credentials)

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentialsSpec.groovy
@@ -39,7 +39,7 @@ class OpenstackNamedAccountCredentialsSpec extends Specification {
     IOSClientBuilder.V3.metaClass.authenticate = { mockClient }
 
     when:
-    def credentials = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "project", "domain", "endpoint", [], false, "", new LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig())
+    def credentials = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "project", "domain", "endpoint", [], false, "", new LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig(), null)
     def client = credentials.credentials.provider.client
 
     then:


### PR DESCRIPTION
Provides common user data that every Openstack deployment will use. The
user data provided per app will be appended to this userdata.

Ideally, this will be replaced/moved into a core location where it is
available for all providers. See spinnaker/spinnaker#1274