### PR TITLE
provider/google: Make provider calls when cache fails to find LBs.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
@@ -64,7 +64,7 @@ class Utils {
     return lastIndex != -1 ? fullUrl.substring(lastIndex + 1) : fullUrl
   }
 
-  static String getTargetProxyType(String fullUrl) {
+  static GoogleTargetProxyType getTargetProxyType(String fullUrl) {
     if (!fullUrl) {
       throw new IllegalFormatException("Target proxy url ${fullUrl} malformed.")
     }
@@ -74,7 +74,20 @@ class Utils {
       throw new IllegalFormatException("Target proxy url ${fullUrl} malformed.")
     }
     String withoutName = fullUrl.substring(0, lastIndex)
-    return getLocalName(withoutName)
+    switch (getLocalName(withoutName)) {
+      case 'targetHttpProxies':
+        return GoogleTargetProxyType.HTTP
+        break
+      case 'targetHttpsProxies':
+        return GoogleTargetProxyType.HTTPS
+        break
+      case 'targetSslProxies':
+        return GoogleTargetProxyType.SSL
+        break
+      default:
+        throw new IllegalFormatException("Target proxy url ${fullUrl} has unknown type.")
+        break
+    }
   }
 
   static String getZoneFromInstanceUrl(String fullUrl) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleTargetProxyType.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleTargetProxyType.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.model.loadbalancing
+
+enum GoogleTargetProxyType {
+  HTTP,
+  HTTPS,
+  SSL
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -190,7 +190,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
     @Override
     void onSuccess(ForwardingRuleList forwardingRuleList, HttpHeaders responseHeaders) throws IOException {
       forwardingRuleList?.items?.each { ForwardingRule forwardingRule ->
-        if (forwardingRule.target && Utils.getTargetProxyType(forwardingRule.target) != 'targetSslProxies') {
+        if (forwardingRule.target && Utils.getTargetProxyType(forwardingRule.target) != GoogleTargetProxyType.SSL) {
           def newLoadBalancer = new GoogleHttpLoadBalancer(
             name: forwardingRule.name,
             account: accountName,
@@ -220,12 +220,11 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
             groupHealthRequest: groupHealthRequest,
           )
 
-          String targetType = Utils.getTargetProxyType(forwardingRule.target)
-          switch (targetType) {
-            case "targetHttpProxies":
+          switch (Utils.getTargetProxyType(forwardingRule.target)) {
+            case GoogleTargetProxyType.HTTP:
               compute.targetHttpProxies().get(project, targetProxyName).queue(targetProxyRequest, targetProxyCallback)
               break
-            case "targetHttpsProxies":
+            case GoogleTargetProxyType.HTTPS:
               compute.targetHttpsProxies().get(project, targetProxyName).queue(targetProxyRequest, targetHttpsProxyCallback)
               break
             default:

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -37,10 +37,7 @@ import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.model.health.GoogleLoadBalancerHealth
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleBackendService
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancedBackend
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancingScheme
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleSslLoadBalancer
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import groovy.util.logging.Slf4j
 
@@ -179,7 +176,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
     @Override
     void onSuccess(ForwardingRuleList forwardingRuleList, HttpHeaders responseHeaders) throws IOException {
       forwardingRuleList?.items?.each { ForwardingRule forwardingRule ->
-        if (forwardingRule.target && Utils.getTargetProxyType(forwardingRule.target) == 'targetSslProxies') {
+        if (forwardingRule.target && Utils.getTargetProxyType(forwardingRule.target) == GoogleTargetProxyType.SSL) {
           def newLoadBalancer = new GoogleSslLoadBalancer(
             name: forwardingRule.name,
             account: accountName,

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtilSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtilSpec.groovy
@@ -489,6 +489,12 @@ class GCEUtilSpec extends Specification {
       def backendSvcGetMock = Mock(Compute.BackendServices.Get)
       def backendUpdateMock = Mock(Compute.BackendServices.Update)
       def googleLoadBalancerProviderMock = Mock(GoogleLoadBalancerProvider)
+
+      def forwardingRules = Mock(Compute.ForwardingRules)
+      def forwardingRulesList = Mock(Compute.ForwardingRules.List)
+      def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
+      def globalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+
       googleLoadBalancerProviderMock.getApplicationLoadBalancers("") >> loadBalancerList
       def task = Mock(Task)
       def bs = new BackendService(backends: [])
@@ -511,6 +517,14 @@ class GCEUtilSpec extends Specification {
       _ * backendSvcGetMock.execute() >> bs
       _ * backendServicesMock.update(PROJECT_NAME, 'backend-service', bs) >> backendUpdateMock
       _ * backendUpdateMock.execute()
+
+      _ * computeMock.globalForwardingRules() >> globalForwardingRules
+      _ * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList
+      _ * globalForwardingRulesList.execute() >> new ForwardingRuleList(items: [])
+
+      _ * computeMock.forwardingRules() >> forwardingRules
+      _ * forwardingRules.list(PROJECT_NAME, _) >> forwardingRulesList
+      _ * forwardingRulesList.execute() >> new ForwardingRuleList(items: [])
       bs.backends.size == lbNames.size
 
     where:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -80,6 +80,12 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       def instanceTemplatesMock = Mock(Compute.InstanceTemplates)
       def instanceTemplatesDeleteMock = Mock(Compute.InstanceTemplates.Delete)
       def googleLoadBalancerProviderMock = Mock(GoogleLoadBalancerProvider)
+
+      def forwardingRules = Mock(Compute.ForwardingRules)
+      def forwardingRulesList = Mock(Compute.ForwardingRules.List)
+      def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
+      def globalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+
       googleLoadBalancerProviderMock.getApplicationLoadBalancers(APPLICATION_NAME) >> []
       def credentials = new GoogleNamedAccountCredentials.Builder().project(PROJECT_NAME).compute(computeMock).build()
       def description = new DestroyGoogleServerGroupDescription(serverGroupName: SERVER_GROUP_NAME,
@@ -110,6 +116,14 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       1 * computeMock.instanceTemplates() >> instanceTemplatesMock
       1 * instanceTemplatesMock.delete(PROJECT_NAME, INSTANCE_TEMPLATE_NAME) >> instanceTemplatesDeleteMock
       1 * instanceTemplatesDeleteMock.execute()
+
+      2 * computeMock.globalForwardingRules() >> globalForwardingRules
+      2 * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList
+      2 * globalForwardingRulesList.execute() >> new ForwardingRuleList(items: [])
+
+      1 * computeMock.forwardingRules() >> forwardingRules
+      1 * forwardingRules.list(PROJECT_NAME, _) >> forwardingRulesList
+      1 * forwardingRulesList.execute() >> new ForwardingRuleList(items: [])
   }
 
   @Unroll
@@ -141,6 +155,12 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       def autoscalersMock = Mock(Compute.Autoscalers)
       def autoscalersDeleteMock = Mock(Compute.Autoscalers.Delete)
       def autoscalersDeleteOp = new Operation(name: AUTOSCALERS_OP_NAME, status: DONE)
+
+      def forwardingRules = Mock(Compute.ForwardingRules)
+      def forwardingRulesList = Mock(Compute.ForwardingRules.List)
+      def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
+      def globalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+
       def credentials = new GoogleNamedAccountCredentials.Builder().project(PROJECT_NAME).compute(computeMock).build()
       def description = new DestroyGoogleServerGroupDescription(serverGroupName: SERVER_GROUP_NAME,
                                                                 region: REGION,
@@ -160,6 +180,14 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
 
     then:
       1 * googleClusterProviderMock.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
+
+      2 * computeMock.globalForwardingRules() >> globalForwardingRules
+      2 * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList
+      2 * globalForwardingRulesList.execute() >> new ForwardingRuleList(items: [])
+
+      1 * computeMock.forwardingRules() >> forwardingRules
+      1 * forwardingRules.list(PROJECT_NAME, _) >> forwardingRulesList
+      1 * forwardingRulesList.execute() >> new ForwardingRuleList(items: [])
 
       if (isRegional) {
         1 * computeMock.regionAutoscalers() >> regionAutoscalersMock
@@ -242,6 +270,12 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       def backendServicesMock = Mock(Compute.BackendServices)
       def backendSvcGetMock = Mock(Compute.BackendServices.Get)
       def backendUpdateMock = Mock(Compute.BackendServices.Update)
+
+      def forwardingRules = Mock(Compute.ForwardingRules)
+      def forwardingRulesList = Mock(Compute.ForwardingRules.List)
+      def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
+      def globalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+
       def googleLoadBalancerProviderMock = Mock(GoogleLoadBalancerProvider)
       googleLoadBalancerProviderMock.getApplicationLoadBalancers("") >> loadBalancerList
       def credentials = new GoogleNamedAccountCredentials.Builder().project(PROJECT_NAME).compute(computeMock).build()
@@ -271,6 +305,14 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       _ * backendSvcGetMock.execute() >> bs
       _ * backendServicesMock.update(PROJECT_NAME, 'backend-service', bs) >> backendUpdateMock
       _ * backendUpdateMock.execute()
+
+      _ * computeMock.globalForwardingRules() >> globalForwardingRules
+      _ * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList
+      _ * globalForwardingRulesList.execute() >> new ForwardingRuleList(items: [])
+
+      _ * computeMock.forwardingRules() >> forwardingRules
+      _ * forwardingRules.list(PROJECT_NAME, _) >> forwardingRulesList
+      _ * forwardingRulesList.execute() >> new ForwardingRuleList(items: [])
       bs.backends.size == 0
 
     where:
@@ -313,6 +355,12 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
     def backendSvcGetMock = Mock(Compute.RegionBackendServices.Get)
     def backendUpdateMock = Mock(Compute.RegionBackendServices.Update)
     def googleLoadBalancerProviderMock = Mock(GoogleLoadBalancerProvider)
+
+    def forwardingRules = Mock(Compute.ForwardingRules)
+    def forwardingRulesList = Mock(Compute.ForwardingRules.List)
+    def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
+    def globalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+
     googleLoadBalancerProviderMock.getApplicationLoadBalancers("") >> loadBalancerList
     def credentials = new GoogleNamedAccountCredentials.Builder().project(PROJECT_NAME).compute(computeMock).build()
     def bs = isRegional ?
@@ -340,6 +388,14 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
     _ * backendSvcGetMock.execute() >> bs
     _ * backendServicesMock.update(PROJECT_NAME, REGION, 'backend-service', bs) >> backendUpdateMock
     _ * backendUpdateMock.execute()
+
+    _ * computeMock.globalForwardingRules() >> globalForwardingRules
+    _ * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList
+    _ * globalForwardingRulesList.execute() >> new ForwardingRuleList(items: [])
+
+    _ * computeMock.forwardingRules() >> forwardingRules
+    _ * forwardingRules.list(PROJECT_NAME, _) >> forwardingRulesList
+    _ * forwardingRulesList.execute() >> new ForwardingRuleList(items: [])
     bs.backends.size == 0
 
     where:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/UtilsSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/UtilsSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.model.callbacks
 
-
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleTargetProxyType
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -78,10 +78,12 @@ class UtilsSpec extends Specification {
 
     where:
       input                                                                                                  | expected
-      "https://www.googleapis.com/compute/v1/projects/spinnaker-jtk54/global/targetHttpsProxies/https-proxy" | "targetHttpsProxies"
-      "https://www.googleapis.com/compute/v1/projects/spinnaker-jtk54/global/targetHttpProxies/http-proxy"   | "targetHttpProxies"
-      "projects/spinnaker-jtk54/global/targetHttpsProxies/https-proxy"                                       | "targetHttpsProxies"
-      "projects/spinnaker-jtk54/global/targetHttpProxies/http-proxy"                                         | "targetHttpProxies"
+      "https://www.googleapis.com/compute/v1/projects/spinnaker-jtk54/global/targetHttpsProxies/https-proxy" | GoogleTargetProxyType.HTTPS
+      "https://www.googleapis.com/compute/v1/projects/spinnaker-jtk54/global/targetHttpProxies/http-proxy"   | GoogleTargetProxyType.HTTP
+      "https://www.googleapis.com/compute/v1/projects/spinnaker-jtk54/global/targetSslProxies/ssl-proxy"     | GoogleTargetProxyType.SSL
+      "projects/spinnaker-jtk54/global/targetHttpsProxies/https-proxy"                                       | GoogleTargetProxyType.HTTPS
+      "projects/spinnaker-jtk54/global/targetHttpProxies/http-proxy"                                         | GoogleTargetProxyType.HTTP
+      "projects/spinnaker-jtk54/global/targetSslProxies/ssl-proxy"                                           | GoogleTargetProxyType.SSL
   }
 
   def "should get region from a full group Url"() {


### PR DESCRIPTION
Since none of the load balancer caching agents handle on-demand caching properly, there's a race condition that can cause load balancers to disappear from the cache for one cycle (30s) after an upsert. This only occurrs if we delete and recreate the forwarding rule (since there's no update). Instead of looking only in the cache, if there's a cache miss, we'll make a live call to GCP to get the load balancer.

A few caveats:
* The cases we can address with this method check the existence of the LB only, hence we can check _just_ the forwarding rules.
* This doesn't cover deploys, since we need the full cached LB to properly set up the state.
* This is only a problem if you start operating on the LBs < 30s after creating them. If you let the cache cycle again, you most likely will be fine. This is likely why we haven't heard complaints about this. Note that this is probably > 98% of our use cases.

I also refactored the target proxy type determination to an `enum`. @duftler @lwander please review.