### PR TITLE
(kubernetes) fix clone from non-default namespace

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/CloneKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/CloneKubernetesAtomicOperationDescription.groovy
@@ -25,5 +25,7 @@ class CloneKubernetesAtomicOperationDescription extends DeployKubernetesAtomicOp
 @Canonical
 class KubernetesCloneServerGroupSource {
   String serverGroupName
+  String region
   String namespace
+  String account
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
@@ -47,10 +47,12 @@ class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult
   */
   @Override
   DeploymentResult operate(List priorOutputs) {
-    CloneKubernetesAtomicOperationDescription newDescription = cloneAndOverrideDescription()
+    description.source.namespace = description.source.namespace ?: description.source.region
 
     task.updateStatus BASE_PHASE, "Initializing copy of server group for " +
       "${description.source.serverGroupName}..."
+
+    CloneKubernetesAtomicOperationDescription newDescription = cloneAndOverrideDescription()
 
     DeployKubernetesAtomicOperation deployer = new DeployKubernetesAtomicOperation(newDescription)
     DeploymentResult deploymentResult = deployer.operate(priorOutputs)


### PR DESCRIPTION
@duflter, I found this bug while refactoring the kubernetes caching agents. Orca strips the namespace field, and clones out of the default namespace fail in clouddriver.