### PR TITLE
(kubernetes) cleanup cache entries for old namespaces

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -30,6 +30,7 @@ class KubernetesConfigurationProperties {
     String user
     String kubeconfigFile
     List<String> namespaces
+    int cacheThreads
     List<LinkedDockerRegistryConfiguration> dockerRegistries
     List<String> requiredGroupMembership
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -31,7 +31,7 @@ import io.fabric8.kubernetes.api.model.extensions.ReplicaSet
 import io.fabric8.kubernetes.client.internal.SerializationUtils
 
 @CompileStatic
-@EqualsAndHashCode(includes = ["name"])
+@EqualsAndHashCode(includes = ["name", "namespace"])
 class KubernetesServerGroup implements ServerGroup, Serializable {
   String name
   String type = "kubernetes"
@@ -80,7 +80,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
     this.deployDescription = KubernetesApiConverter.fromReplicaSet(replicaSet)
     this.yaml = SerializationUtils.dumpWithoutRuntimeStateAsYaml(replicaSet)
     this.kind = replicaSet.kind
-    this.events = events.collect {
+    this.events = events?.collect {
       new KubernetesEvent(it)
     }
     if (autoscaler) {
@@ -104,7 +104,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
     this.deployDescription = KubernetesApiConverter.fromReplicationController(replicationController)
     this.yaml = SerializationUtils.dumpWithoutRuntimeStateAsYaml(replicationController)
     this.kind = replicationController.kind
-    this.events = events.collect {
+    this.events = events?.collect {
       new KubernetesEvent(it)
     }
     if (autoscaler) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesCachingAgent.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.agent.AccountAware
+import com.netflix.spinnaker.cats.agent.CachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+
+abstract class KubernetesCachingAgent implements CachingAgent, AccountAware {
+  final String accountName
+  final String providerName = KubernetesProvider.PROVIDER_NAME
+  final KubernetesCloudProvider kubernetesCloudProvider = new KubernetesCloudProvider()
+  final ObjectMapper objectMapper
+  final KubernetesCredentials credentials
+  final int agentIndex
+  final int agentCount
+  List<String> namespaces
+
+  KubernetesCachingAgent(String accountName,
+                         ObjectMapper objectMapper,
+                         KubernetesCredentials credentials,
+                         int agentIndex,
+                         int agentCount) {
+    this.accountName = accountName
+    this.objectMapper = objectMapper
+    this.credentials = credentials
+    this.agentIndex = agentIndex
+    this.agentCount = agentCount
+    reloadNamespaces()
+  }
+
+  @Override
+  String getAgentType() {
+    return "${accountName}/${getSimpleName()}[${agentIndex + 1}/$agentCount]"
+  }
+
+  void reloadNamespaces() {
+    namespaces = credentials.getNamespaces().findAll { String namespace ->
+      // Short circuit when one thread is provided to avoid doing the hashCode calculation
+      agentCount == 1 || (namespace.hashCode() % agentCount).abs() == agentIndex
+    }
+  }
+
+  abstract String getSimpleName()
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
@@ -99,11 +99,14 @@ class KubernetesProviderConfig implements Runnable {
       def newlyAddedAgents = []
 
       credentials.getNamespaces().forEach({ namespace ->
-        newlyAddedAgents << new KubernetesServerGroupCachingAgent(kubernetesCloudProvider, credentials.name, credentials.credentials, namespace, objectMapper, registry)
         newlyAddedAgents << new KubernetesLoadBalancerCachingAgent(kubernetesCloudProvider, credentials.name, credentials.credentials, namespace, objectMapper, registry)
-        newlyAddedAgents << new KubernetesInstanceCachingAgent(kubernetesCloudProvider, credentials.name, credentials.credentials, namespace, objectMapper, registry)
         newlyAddedAgents << new KubernetesSecurityGroupCachingAgent(kubernetesCloudProvider, credentials.name, credentials.credentials, namespace, objectMapper, registry)
       })
+
+      (0..<credentials.cacheThreads).each { int index ->
+        newlyAddedAgents << new KubernetesServerGroupCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads, registry)
+        newlyAddedAgents << new KubernetesInstanceCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)
+      }
 
       // If there is an agent scheduler, then this provider has been through the AgentController in the past.
       // In that case, we need to do the scheduling here (because accounts have been added to a running system).

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
@@ -34,7 +34,6 @@ import org.springframework.context.annotation.Scope
 @Slf4j
 @Configuration
 class KubernetesCredentialsInitializer implements CredentialsInitializerSynchronizable {
-
   @Bean
   List<? extends KubernetesNamedAccountCredentials> kubernetesNamedAccountCredentials(
     String clouddriverUserAgentApplicationName,
@@ -80,6 +79,7 @@ class KubernetesCredentialsInitializer implements CredentialsInitializerSynchron
           .user(managedAccount.user)
           .kubeconfigFile(managedAccount.kubeconfigFile)
           .namespaces(managedAccount.namespaces)
+          .cacheThreads(managedAccount.cacheThreads ?: DEFAULT_CACHE_THREADS)
           .dockerRegistries(managedAccount.dockerRegistries)
           .requiredGroupMembership(managedAccount.requiredGroupMembership)
           .build()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.groovy
@@ -33,6 +33,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
   final String userAgent
   final String kubeconfigFile
   List<String> namespaces
+  final int cacheThreads
   KubernetesCredentials credentials
   final List<String> requiredGroupMembership
   final List<LinkedDockerRegistryConfiguration> dockerRegistries
@@ -48,6 +49,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
                                            String user,
                                            String kubeconfigFile,
                                            List<String> namespaces,
+                                           int cacheThreads,
                                            List<LinkedDockerRegistryConfiguration> dockerRegistries,
                                            List<String> requiredGroupMembership,
                                            KubernetesCredentials credentials) {
@@ -60,6 +62,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
     this.userAgent = userAgent
     this.kubeconfigFile = kubeconfigFile
     this.namespaces = namespaces
+    this.cacheThreads = cacheThreads
     this.requiredGroupMembership = requiredGroupMembership
     this.dockerRegistries = dockerRegistries
     this.accountCredentialsRepository = accountCredentialsRepository
@@ -80,6 +83,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
     String userAgent
     String kubeconfigFile
     List<String> namespaces
+    int cacheThreads
     KubernetesCredentials credentials
     List<String> requiredGroupMembership
     List<LinkedDockerRegistryConfiguration> dockerRegistries
@@ -140,6 +144,11 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
       return this
     }
 
+    Builder cacheThreads(int cacheThreads) {
+      this.cacheThreads = cacheThreads
+      return this
+    }
+
     Builder credentials(KubernetesCredentials credentials) {
       this.credentials = credentials
       return this
@@ -192,6 +201,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
           user,
           kubeconfigFile,
           namespaces,
+          cacheThreads,
           dockerRegistries,
           requiredGroupMembership,
           credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -63,6 +63,8 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
     podList = Mock(PodList)
     apiMock = Mock(KubernetesApiAdaptor)
 
+    apiMock.getNamespacesByName() >> [NAMESPACE]
+
     def accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
 
     kubernetesCredentials = new KubernetesCredentials(apiMock, [], [], accountCredentialsRepositoryMock)
@@ -72,7 +74,7 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
     serverGroupKey = Keys.getServerGroupKey(ACCOUNT_NAME, NAMESPACE, REPLICATION_CONTROLLER)
     instanceKey = Keys.getInstanceKey(ACCOUNT_NAME, NAMESPACE, POD)
 
-    cachingAgent = new KubernetesServerGroupCachingAgent(new KubernetesCloudProvider(), ACCOUNT_NAME, kubernetesCredentials, NAMESPACE, new ObjectMapper(), registryMock)
+    cachingAgent = new KubernetesServerGroupCachingAgent(ACCOUNT_NAME, kubernetesCredentials, new ObjectMapper(), 0, 1, registryMock)
   }
 
   void "Should store a single replication controller object and relationships"() {
@@ -83,14 +85,15 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
       def selector = ['replicationController': REPLICATION_CONTROLLER.toString()]
       replicationControllerSpecMock.getSelector() >> selector
       replicationControllerMetadataMock.getName() >> REPLICATION_CONTROLLER
+      replicationControllerMetadataMock.getNamespace() >> NAMESPACE
       replicationControllerMock.getMetadata() >> replicationControllerMetadataMock
       replicationControllerMock.getSpec() >> replicationControllerSpecMock
 
       def podMock = Mock(ReplicationController)
       def podMetadataMock = Mock(ObjectMeta)
       podMetadataMock.getName() >> POD
+      podMetadataMock.getNamespace() >> NAMESPACE
       podMock.getMetadata() >> podMetadataMock
-
       apiMock.getReplicationControllers(NAMESPACE) >> [replicationControllerMock]
       apiMock.getEvents(NAMESPACE, "ReplicationController") >> [:].withDefault { _ -> [] }
       apiMock.getAutoscalers(NAMESPACE, "replicationController") >> [:]


### PR DESCRIPTION
This only fixes the problem for instances & server groups. Load balancers & security groups will be done next. 

What used to happen was each periodically the list of caching agents would be repopulated so there would always be one per account per namespace for each resource. There was a window where if a namespace was deleted, and before the entries in the namespace disappeared, some the members of that namespace (instances, server groups, etc...) could be orphaned in the cache, and never deleted. 

Now, the caching agents aren't repopulated, and instead come from a fixed pool specified by the `kubernetes.accounts.cacheThreads` parameter. Namespaces are assigned to agents based on the hash of their name for a (hopefully) even distribution of work. 

@duftler PTAL