### PR TITLE
make EurekaSupportConfigurationProperties optional in AbstractEurekaSupport

### DIFF
--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
@@ -38,7 +38,7 @@ abstract class AbstractEurekaSupport {
                                              String instanceId,
                                              String asgName)
 
-  @Autowired
+  @Autowired(required = false)
   EurekaSupportConfigurationProperties eurekaSupportConfigurationProperties
 
   @Autowired
@@ -49,6 +49,10 @@ abstract class AbstractEurekaSupport {
                                          String phaseName,
                                          DiscoveryStatus discoveryStatus,
                                          List<String> instanceIds) {
+
+    if (eurekaSupportConfigurationProperties == null) {
+      throw new IllegalStateException("eureka configuration not supplied")
+    }
 
     def eureka = getEureka(description.credentials, description.region)
     def random = new Random()


### PR DESCRIPTION
EurekaSupportConfigurationProperties is only initialized if the EurekaProviderConfiguration is loaded, which is
Conditional on the eureka.provider.enabled property.

AbstractEurekaSupport is always initialized and only conditionally called if an account has the discoveryEnabled flag set on it