### PR TITLE
provider/google: Health check 'target' display fix.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleHealthCheck.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleHealthCheck.groovy
@@ -57,6 +57,42 @@ class GoogleHealthCheck {
     new View()
   }
 
+  /**
+   * Health check endpoint of the form '{PROTO}:{PORT}{PATH}'.
+   */
+  String getTarget() {
+    switch (healthCheckType) {
+      case HealthCheckType.HTTP:
+        return this.port ?
+          "HTTP:${this.port}${this.requestPath ?: '/'}" :
+          null
+        break
+      case HealthCheckType.HTTPS:
+        break
+        return this.port ?
+          "HTTPS:${this.port}${this.requestPath ?: '/'}" :
+          null
+      case HealthCheckType.SSL:
+        return this.port ?
+          "SSL:${this.port}" :
+          null
+        break
+      case HealthCheckType.TCP:
+        return this.port ?
+          "TCP:${this.port}" :
+          null
+        break
+      case HealthCheckType.UDP:
+        return this.port ?
+          "UDP:${this.port}" :
+          null
+        break
+      default:
+        break
+    }
+  }
+
+
   @Canonical
   class View implements Serializable {
     String name = GoogleHealthCheck.this.name
@@ -68,13 +104,7 @@ class GoogleHealthCheck {
     int port = GoogleHealthCheck.this.port
     String requestPath = GoogleHealthCheck.this.requestPath
     String kind = GoogleHealthCheck.this.kind
-
-    String getTarget() {
-      GoogleHealthCheck.this.port ?
-          "HTTP:${GoogleHealthCheck.this.port}${GoogleHealthCheck.this.requestPath ?: '/'}" :
-          null
-    }
-
+    String target = GoogleHealthCheck.this.target
   }
 
   static enum HealthCheckType {


### PR DESCRIPTION
@duftler @danielpeach please review. `target` was not rendering properly for load balancers not using the `GoogleHealthCheckView` object and using the raw `GoogleHealthCheck` object (i.e. LBs where the health check is reported through a `BackendService`).  I moved the `target` calculation into the actual model object rather than in the `View`, so that it's present regardless if you use the `View` or not.