### PR TITLE
provider/google: Support CONNECTION balancing mode in SSL LB.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -863,6 +863,8 @@ class GCEUtil {
         policy.maxRatePerInstance : null,
       maxUtilization: balancingMode == GoogleLoadBalancingPolicy.BalancingMode.UTILIZATION ?
         policy.maxUtilization : null,
+      maxConnectionsPerInstance: balancingMode == GoogleLoadBalancingPolicy.BalancingMode.CONNECTION ?
+        policy.maxConnectionsPerInstance : null,
       capacityScaler: policy.capacityScaler != null ? policy.capacityScaler : 1.0,
     )
   }
@@ -876,6 +878,8 @@ class GCEUtil {
         backend.maxRatePerInstance : null,
       maxUtilization: backendBalancingMode == GoogleLoadBalancingPolicy.BalancingMode.UTILIZATION ?
         backend.maxUtilization : null,
+      maxConnectionsPerInstance: backendBalancingMode == GoogleLoadBalancingPolicy.BalancingMode.CONNECTION ?
+        backend.maxConnectionsPerInstance : null,
       capacityScaler: backend.capacityScaler,
     )
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleHttpLoadBalancingPolicy.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleHttpLoadBalancingPolicy.groovy
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 /**
  * For Http(s), balancingMode must be either UTILIZATION or RATE.
  * maxRatePerInstance must be set if RATE, and maxUtilization must be set if UTILIZATION.
+ *
+ * For Ssl, balancingMode must be either UTILIZATION or CONNECTION.
+ * maxUtilization must be set if UTILIZATION, maxConnectionsPerInstance if CONNECTION.
  */
 class GoogleHttpLoadBalancingPolicy extends GoogleLoadBalancingPolicy {
   @JsonIgnore
@@ -33,6 +36,8 @@ class GoogleHttpLoadBalancingPolicy extends GoogleLoadBalancingPolicy {
 
   Float maxUtilization
 
+  Float maxConnectionsPerInstance
+
   /**
    * Additional scaler option that sets the current max usage of the server group for either balancingMode.
    * Valid values are 0.0 through 1.0.
@@ -44,5 +49,4 @@ class GoogleHttpLoadBalancingPolicy extends GoogleLoadBalancingPolicy {
    * Port that the HTTP LB will forward traffic to on the server group.
    */
   Integer listeningPort
-
 }


### PR DESCRIPTION
@duftler @danielpeach please review. From the [docs](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/), SSL LBs can support `UTILIZATION` and `CONNECTION` balancing modes. We had `UTILIZATION`, so this adds `CONNECTION`. We'll have to add support to the server group wizard on the frontend as well.