### PR TITLE
provider/google: Interpret RUNNING instance health as up, not unknown.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleInstanceHealth.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/health/GoogleInstanceHealth.groovy
@@ -42,7 +42,7 @@ class GoogleInstanceHealth {
         case STAGING:
           return HealthState.Starting
         case RUNNING:
-          return HealthState.Unknown
+          return HealthState.Up
         default:
           return HealthState.Down
       }


### PR DESCRIPTION
@duftler @danielpeach @ttomsu thoughts? Currently, creating a single server group fails to complete because the instance is never 'UP', even though the platform says it's 'RUNNING'. So far, the only negative effect I've seen from the fix is that disabled server groups on an LB are green, as in 'UP' even though the LB health checks return 'UNKNOWN' because of the platform health.

Example:
![up](https://cloud.githubusercontent.com/assets/5456773/20225436/5b6fd87e-a811-11e6-9d02-651475c15cea.png)

Anyone have issues with this? It seems more broken to have operations failing than technically incorrect health states. Note that instances that are checked with a LB health check and fail will still be reported 'DOWN' via [this function](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance.groovy#L130).