### PR TITLE
[TESTING REQUIRED] Consolidates provider-specific Load balancer controllers under a sing…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonLoadBalancerController.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonLoadBalancerController.groovy
@@ -20,19 +20,18 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProviderTempShim
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LOAD_BALANCERS
 
-@RestController
-@RequestMapping("/aws/loadBalancers")
+@Component
 class AmazonLoadBalancerController implements LoadBalancerProviderTempShim {
+
+  final String cloudProvider = AmazonCloudProvider.AWS
 
   private final Cache cacheView
 
@@ -41,15 +40,13 @@ class AmazonLoadBalancerController implements LoadBalancerProviderTempShim {
     this.cacheView = cacheView
   }
 
-  @RequestMapping(method = RequestMethod.GET)
   List<AmazonLoadBalancerSummary> list() {
     def searchKey = Keys.getLoadBalancerKey('*', '*', '*', null, null) + '*'
     Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey)
     getSummaryForLoadBalancers(identifiers).values() as List
   }
 
-  @RequestMapping(value = "/{name:.+}", method = RequestMethod.GET)
-  AmazonLoadBalancerSummary get(@PathVariable String name) {
+  AmazonLoadBalancerSummary get(String name) {
     def searchKey = Keys.getLoadBalancerKey(name, '*', '*', null, null)  + "*"
     Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey).findAll {
       def key = Keys.parse(it)
@@ -58,18 +55,17 @@ class AmazonLoadBalancerController implements LoadBalancerProviderTempShim {
     getSummaryForLoadBalancers(identifiers).get(name)
   }
 
-  @RequestMapping(value = "/{account}/{region}", method = RequestMethod.GET)
-  List<AmazonLoadBalancerSummary> getInAccountAndRegion(@PathVariable String account,
-                                                        @PathVariable String region) {
+  // TODO: Remove, doesn't appear to be used.
+  List<AmazonLoadBalancerSummary> getInAccountAndRegion(String account,
+                                                        String region) {
     def searchKey = Keys.getLoadBalancerKey('*', account, region, null, null)
     Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey)
     getSummaryForLoadBalancers(identifiers).values() as List
   }
 
-  @RequestMapping(value = "/{account}/{region}/{name:.+}", method = RequestMethod.GET)
-  List<Map> byAccountAndRegionAndName(@PathVariable String account,
-                                      @PathVariable String region,
-                                      @PathVariable String name) {
+  List<Map> byAccountAndRegionAndName(String account,
+                                      String region,
+                                      String name) {
     def searchKey = Keys.getLoadBalancerKey(name, account, region, null, null) + '*'
     Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey).findAll {
       def key = Keys.parse(it)
@@ -79,11 +75,11 @@ class AmazonLoadBalancerController implements LoadBalancerProviderTempShim {
     cacheView.getAll(LOAD_BALANCERS.ns, identifiers).attributes
   }
 
-  @RequestMapping(value = "/{account}/{region}/{name}/{vpcId}", method = RequestMethod.GET)
-  Map getDetailsInAccountAndRegionByName(@PathVariable String account,
-                                         @PathVariable String region,
-                                         @PathVariable String name,
-                                         @PathVariable String vpcId) {
+  // TODO: Remove, doesn't appear to be used.
+  Map getDetailsInAccountAndRegionByName(String account,
+                                         String region,
+                                         String name,
+                                         String vpcId) {
     def key = Keys.getLoadBalancerKey(name, account, region, vpcId, null)
     cacheView.get(LOAD_BALANCERS.ns, key)?.attributes
   }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayController.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayController.groovy
@@ -17,19 +17,18 @@
 package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.view
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProviderTempShim
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Component
 
-@RestController
-@RequestMapping("/azure/loadBalancers")
+@Component
 class AzureAppGatewayController implements LoadBalancerProviderTempShim {
+
+  final String cloudProvider = AzureCloudProvider.AZURE
 
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
@@ -37,7 +36,6 @@ class AzureAppGatewayController implements LoadBalancerProviderTempShim {
   @Autowired
   AzureAppGatewayProvider azureAppGatewayProvider
 
-  @RequestMapping(method = RequestMethod.GET)
   List<AzureAppGatewaySummary> list() {
     getSummaryForAppGateways().values() as List
   }
@@ -66,8 +64,7 @@ class AzureAppGatewayController implements LoadBalancerProviderTempShim {
     throw new UnsupportedOperationException("TODO: Implement single getter.")
   }
 
-  @RequestMapping(value = "/{account}/{region}/{name:.+}", method = RequestMethod.GET)
-  List<Map> byAccountAndRegionAndName(@PathVariable String account, @PathVariable String region, @PathVariable String name) {
+  List<Map> byAccountAndRegionAndName(String account, String region, String name) {
     String appName = AzureUtilities.getAppNameFromAzureResourceName(name)
     AzureAppGatewayDescription description = azureAppGatewayProvider.getAppGatewayDescription(account, appName, region, name)
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerController.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerController.groovy
@@ -17,19 +17,22 @@
 package com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.view
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProviderTempShim
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Component
 
-@RestController
-@RequestMapping("/azure/loadBalancersL4")
+
+/**
+ * @deprecated - Use AzureAppGatewayController instead.
+ */
+@Deprecated
 class AzureLoadBalancerController implements LoadBalancerProviderTempShim {
+
+  final String cloudProvider = "DoNotUse"
 
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
@@ -37,7 +40,6 @@ class AzureLoadBalancerController implements LoadBalancerProviderTempShim {
   @Autowired
   AzureLoadBalancerProvider azureLoadBalancerProvider
 
-  @RequestMapping(method = RequestMethod.GET)
   List<AzureLoadBalancerSummary> list() {
     getSummaryForLoadBalancers().values() as List
   }
@@ -66,8 +68,7 @@ class AzureLoadBalancerController implements LoadBalancerProviderTempShim {
     throw new UnsupportedOperationException("TODO: Implement single getter.")
   }
 
-  @RequestMapping(value = "/{account}/{region}/{name:.+}", method = RequestMethod.GET)
-  List<Map> byAccountAndRegionAndName(@PathVariable String account, @PathVariable String region, @PathVariable String name) {
+  List<Map> byAccountAndRegionAndName(String account, String region, String name) {
     String appName = AzureUtilities.getAppNameFromAzureResourceName(name)
     AzureLoadBalancerDescription azureLoadBalancerDescription = azureLoadBalancerProvider.getLoadBalancerDescription(account, appName, region, name)
 

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/controllers/CloudFoundryLoadBalancerController.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/controllers/CloudFoundryLoadBalancerController.groovy
@@ -20,19 +20,18 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryCloudProvider
 import com.netflix.spinnaker.clouddriver.cf.cache.Keys
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProviderTempShim
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.cf.cache.Keys.Namespace.LOAD_BALANCERS
 
-@RestController
-@RequestMapping("/cf/loadBalancers")
+@Component
 class CloudFoundryLoadBalancerController implements LoadBalancerProviderTempShim {
+
+  final String cloudProvider = CloudFoundryCloudProvider.ID
 
   private final Cache cacheView
 
@@ -41,22 +40,19 @@ class CloudFoundryLoadBalancerController implements LoadBalancerProviderTempShim
     this.cacheView = cacheView
   }
 
-  @RequestMapping(method = RequestMethod.GET)
   List<CloudFoundryLoadBalancerSummary> list() {
     def searchKey = Keys.getLoadBalancerKey('*', '*', '*')
     Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey)
     getSummaryForLoadBalancers(identifiers).values() as List
   }
 
-  @RequestMapping(value = "/{name:.+}", method = RequestMethod.GET)
-  CloudFoundryLoadBalancerSummary get(@PathVariable String name) {
+  CloudFoundryLoadBalancerSummary get(String name) {
     def searchKey = Keys.getLoadBalancerKey(name, '*', '*')
     Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey)
     getSummaryForLoadBalancers(identifiers).get(name)
   }
 
-  @RequestMapping(value = "/{account}/{region}/{name:.+}", method = RequestMethod.GET)
-  List<Map> byAccountAndRegionAndName(@PathVariable String account, @PathVariable String region, @PathVariable String name) {
+  List<Map> byAccountAndRegionAndName(String account, String region, String name) {
     def searchKey = Keys.getLoadBalancerKey(name, account, region)
     Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey)
     cacheView.getAll(LOAD_BALANCERS.ns, identifiers).attributes

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerProviderTempShim.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerProviderTempShim.groovy
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
  */
 interface LoadBalancerProviderTempShim {
 
+  String getCloudProvider()
+
   List<Item> list()
 
   Item get(String name)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/controllers/GoogleLoadBalancerController.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/controllers/GoogleLoadBalancerController.groovy
@@ -21,19 +21,24 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleBackendService
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleHostRule
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleHttpLoadBalancer
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleInternalLoadBalancer
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerType
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerView
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GooglePathRule
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleSslLoadBalancer
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProviderTempShim
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Component
 
-@RestController
-@RequestMapping("/gce/loadBalancers")
+@Component
 class GoogleLoadBalancerController implements LoadBalancerProviderTempShim {
+
+  final String cloudProvider = GoogleCloudProvider.GCE
 
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
@@ -41,7 +46,6 @@ class GoogleLoadBalancerController implements LoadBalancerProviderTempShim {
   @Autowired
   GoogleLoadBalancerProvider googleLoadBalancerProvider
 
-  @RequestMapping(method = RequestMethod.GET)
   List<GoogleLoadBalancerAccountRegionSummary> list() {
     def loadBalancerViewsByName = googleLoadBalancerProvider.getApplicationLoadBalancers("").groupBy { it.name }
 
@@ -92,17 +96,15 @@ class GoogleLoadBalancerController implements LoadBalancerProviderTempShim {
     }
   }
 
-  @RequestMapping(value = "/{name:.+}", method = RequestMethod.GET)
-  GoogleLoadBalancerAccountRegionSummary get(@PathVariable String name) {
+  GoogleLoadBalancerAccountRegionSummary get(String name) {
     // TODO(ttomsu): It's inefficient to pull everything back and (possibly) discard most of it.
     // Refactor when addressing https://github.com/spinnaker/spinnaker/issues/807
     list().find { it.name == name }
   }
 
-  @RequestMapping(value = "/{account}/{region}/{name:.+}", method = RequestMethod.GET)
-  List<GoogleLoadBalancerDetails> byAccountAndRegionAndName(@PathVariable String account,
-                                                            @PathVariable String region,
-                                                            @PathVariable String name) {
+  List<GoogleLoadBalancerDetails> byAccountAndRegionAndName(String account,
+                                                            String region,
+                                                            String name) {
     GoogleLoadBalancerView view = googleLoadBalancerProvider.getApplicationLoadBalancers(name).find { view ->
       view.account == account && view.region == region
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/KubernetesCloudProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/KubernetesCloudProvider.groovy
@@ -26,7 +26,9 @@ import java.lang.annotation.Annotation
  */
 @Component
 class KubernetesCloudProvider implements CloudProvider {
-  final String id = "kubernetes"
+  static final String ID = "kubernetes"
+
+  final String id = ID
   final String displayName = "Kubernetes"
   final Class<Annotation> operationAnnotationType = KubernetesOperation.class
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/controllers/KubernetesLoadBalancerController.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/controllers/KubernetesLoadBalancerController.groovy
@@ -17,19 +17,20 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.controllers
 
 import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesLoadBalancer
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProviderTempShim
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Component
 
 import javax.naming.OperationNotSupportedException
 
-@RestController
-@RequestMapping("/kubernetes/loadBalancers")
+@Component
 class KubernetesLoadBalancerController implements LoadBalancerProviderTempShim {
+
+  final String cloudProvider = KubernetesCloudProvider.ID
+
   private final Cache cacheView
 
   @Autowired
@@ -40,7 +41,6 @@ class KubernetesLoadBalancerController implements LoadBalancerProviderTempShim {
   // TODO(lwander): Groovy allows this to compile just fine, even though KubernetesLoadBalancer does
   // not implement the LoadBalancerProviderTempShim.list interface.
   @Override
-  @RequestMapping(method = RequestMethod.GET)
   List<KubernetesLoadBalancer> list() {
     Collection<String> loadBalancers = cacheView.getIdentifiers(Keys.Namespace.LOAD_BALANCERS.ns)
     loadBalancers.findResults {

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/controllers/OpenstackLoadBalancerController.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/controllers/OpenstackLoadBalancerController.groovy
@@ -17,21 +17,20 @@
 package com.netflix.spinnaker.clouddriver.openstack.controllers
 
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProviderTempShim
+import com.netflix.spinnaker.clouddriver.openstack.OpenstackCloudProvider
 import com.netflix.spinnaker.clouddriver.openstack.model.OpenstackLoadBalancer
 import com.netflix.spinnaker.clouddriver.openstack.model.OpenstackLoadBalancerSummary
 import com.netflix.spinnaker.clouddriver.openstack.provider.view.OpenstackLoadBalancerProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Component
 
 /**
  * TODO Refactor when addressing https://github.com/spinnaker/spinnaker/issues/807
  */
-@RestController
-@RequestMapping("/openstack/loadBalancers")
+@Component
 class OpenstackLoadBalancerController implements LoadBalancerProviderTempShim {
+
+  final String cloudProvider = OpenstackCloudProvider.ID
 
   OpenstackLoadBalancerProvider provider
 
@@ -42,22 +41,19 @@ class OpenstackLoadBalancerController implements LoadBalancerProviderTempShim {
 
   // TODO: OpenstackLoadBalancerSummary is not a LoadBalancerProviderTempShim.Item, but still
   // compiles anyway because of groovy magic.
-  @RequestMapping(method = RequestMethod.GET)
   List<OpenstackLoadBalancerSummary> list() {
     provider.getLoadBalancers('*', '*', '*').collect { lb ->
       new OpenstackLoadBalancerSummary(account: lb.account, region: lb.region, id: lb.id, name: lb.name)
     }.sort { it.name }
   }
 
-  @RequestMapping(value = "/{name:.+}", method = RequestMethod.GET)
-  LoadBalancerProviderTempShim.Item get(@PathVariable String name) {
+  LoadBalancerProviderTempShim.Item get(String name) {
     throw new UnsupportedOperationException("TODO: Support a single getter")
   }
 
-  @RequestMapping(value = "/{account}/{region}/{name:.+}", method = RequestMethod.GET)
-  List<OpenstackLoadBalancer.View> byAccountAndRegionAndName(@PathVariable String account,
-                                                             @PathVariable String region,
-                                                             @PathVariable String name) {
+  List<OpenstackLoadBalancer.View> byAccountAndRegionAndName(String account,
+                                                             String region,
+                                                             String name) {
     provider.getLoadBalancers(account, region, name) as List
   }
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/LoadBalancerController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/LoadBalancerController.groovy
@@ -16,8 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.controllers
 
+import com.netflix.spinnaker.clouddriver.exceptions.CloudProviderNotFoundException
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerProviderTempShim
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
@@ -31,6 +33,9 @@ class LoadBalancerController {
   @Autowired
   List<LoadBalancerProvider> loadBalancerProviders
 
+  @Autowired(required = false)
+  List<LoadBalancerProviderTempShim> tempShims
+
   @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")
   @RequestMapping(value = "/applications/{application}/loadBalancers", method = RequestMethod.GET)
   List<LoadBalancer> list(@PathVariable String application) {
@@ -39,5 +44,33 @@ class LoadBalancerController {
     }
     .flatten()
     .sort { a, b -> a.name.toLowerCase() <=> b.name.toLowerCase() } as List<LoadBalancer>
+  }
+
+  @RequestMapping(value = "/{cloudProvider:.+}/loadBalancers", method = RequestMethod.GET)
+  List<LoadBalancerProviderTempShim.Item> listForCloudProvider(@PathVariable String cloudProvider) {
+    return findLoadBalancerProvider(cloudProvider).list()
+  }
+
+  @RequestMapping(value = "/{cloudProvider:.+}/loadBalancers/{name:.+}", method = RequestMethod.GET)
+  LoadBalancerProviderTempShim.Item get(@PathVariable String cloudProvider,
+                                        @PathVariable String name) {
+    return findLoadBalancerProvider(cloudProvider).get(name)
+  }
+
+  @RequestMapping(value = "/{cloudProvider:.+}/loadBalancers/{account:.+}/{region:.+}/{name:.+}",
+                  method = RequestMethod.GET)
+  List<LoadBalancerProviderTempShim.Details> getByAccountRegionName(@PathVariable String cloudProvider,
+                                                                    @PathVariable String account,
+                                                                    @PathVariable String region,
+                                                                    @PathVariable String name) {
+    return findLoadBalancerProvider(cloudProvider).byAccountAndRegionAndName(account, region, name)
+  }
+
+  private LoadBalancerProviderTempShim findLoadBalancerProvider(String cloudProvider) {
+    return tempShims
+        .stream()
+        .filter({ it.cloudProvider == cloudProvider })
+        .findFirst()
+        .orElseThrow({ new CloudProviderNotFoundException("No cloud provider named ${cloudProvider} found") })
   }
 }


### PR DESCRIPTION
Consolidates provider-specific Load balancer controllers under a single point-of-entry controller, similar to the same pattern used everywhere else in Clouddriver.

If you are mentioned in this bug, please test out this PR locally against your cloud provider (since I don't have access to each one to confirm that it works as expected). A simple smoke test confirming LBs show up in deck should be sufficient.

Google: @jtk54 @duftler 
Amazon: @ajordens @cfieber 
Kubernetes: @lwander 
Cloud Foundry: @gregturn 
Open Stack: @varikin 

Azure: Still waiting on https://github.com/spinnaker/clouddriver/pull/1233 to be OK'ed. There is additional work that will need to be done (similar to the changes for each provider-specific LBController here). @scotmoor @rguthriemsft 

tag: 
* https://github.com/spinnaker/fiat/issues/99 
* https://github.com/spinnaker/spinnaker/issues/807 
* https://github.com/spinnaker/spinnaker/issues/755