### PR TITLE
Allow for Descriptions that do not contain `credentials`

### DIFF
--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverter.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverter.java
@@ -59,8 +59,6 @@ public class UpsertEntityTagsAtomicOperationConverter extends AbstractAtomicOper
   }
 
   public UpsertEntityTagsDescription convertDescription(Map input) {
-    UpsertEntityTagsDescription description = objectMapper.convertValue(input, UpsertEntityTagsDescription.class);
-    description.setCredentials(getCredentialsObject((String) description.getEntityRef().attributes().get("account")));
-    return description;
+    return objectMapper.convertValue(input, UpsertEntityTagsDescription.class);
   }
 }

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/DefaultAllowedAccountsValidator.groovy
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/DefaultAllowedAccountsValidator.groovy
@@ -17,11 +17,9 @@
 package com.netflix.spinnaker.clouddriver.security
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.discovery.converters.Auto
+import com.netflix.spinnaker.clouddriver.security.resources.NonCredentialed
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
-import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
 @Slf4j
@@ -52,7 +50,9 @@ class DefaultAllowedAccountsValidator implements AllowedAccountsValidator {
         validateTargetAccount(description.credentials, allowedAccounts, description, user, errors)
       }
     } else {
-      errors.rejectValue("credentials", "missing", "no credentials found in description: ${description.class.simpleName})")
+      if (!(description instanceof NonCredentialed)) {
+        errors.rejectValue("credentials", "missing", "no credentials found in description: ${description.class.simpleName})")
+      }
     }
   }
 

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/NonCredentialed.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/NonCredentialed.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.elasticsearch.descriptions;
+package com.netflix.spinnaker.clouddriver.security.resources;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.netflix.spinnaker.clouddriver.model.EntityTags;
-import com.netflix.spinnaker.clouddriver.security.resources.NonCredentialed;
-
-public class UpsertEntityTagsDescription extends EntityTags implements NonCredentialed {
-  // TODO-AJ partial is yet supported
-  @JsonProperty
-  boolean isPartial = false;
+/**
+ * Marker interface indicating that a description does not have account-level credentials specified.
+ */
+public interface NonCredentialed {
 }

--- a/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/DefaultAllowedAccountsValidatorSpec.groovy
+++ b/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/DefaultAllowedAccountsValidatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.security
 
+import com.netflix.spinnaker.clouddriver.security.resources.NonCredentialed
 import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
@@ -124,6 +125,22 @@ class DefaultAllowedAccountsValidatorSpec extends Specification {
     0 * errors.rejectValue(_, _, _)
   }
 
+  void "should allow if description is non-credentialed"() {
+    given:
+    def errors = Mock(Errors)
+    def validator = new DefaultAllowedAccountsValidator(
+      accountCredentialsProvider: Mock(AccountCredentialsProvider) {
+        1 * getAll() >> { [credentialsWithRequiredGroup] }
+        0 * _
+      })
+
+    when:
+    validator.validate("TestAccount", [], new TestGlobalDescription(), errors)
+
+    then:
+    0 * errors.rejectValue(_, _, _)
+  }
+
   void "should reject if no credentials in description"() {
     given:
     def errors = Mock(Errors)
@@ -151,6 +168,10 @@ class DefaultAllowedAccountsValidatorSpec extends Specification {
 
   static class TestDescription {
     TestAccountCredentials credentials
+  }
+
+  static class TestGlobalDescription implements NonCredentialed {
+
   }
 
   static class MultiAccountDescription {


### PR DESCRIPTION
- Supports the case where EntityTags may target all accounts (ie. `account: "*"`)