### PR TITLE
(kubernetes) correctly handle empty list of instances

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -105,7 +105,7 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
     }
 
     return sources.collectEntries { CacheData source ->
-      [(source.id): source.relationships[relationship].collect { String key -> allData[key] }]
+      [(source.id): source.relationships[relationship].collect { String key -> allData[key] } - null]
     }
   }
 


### PR DESCRIPTION
My recent cache refactor left the list of instances as [null] rather than []
for a server group without instances attached. This caused stages that shrink
server groups to no instances to fail

@jtk54 PTAL, @skim1420 FYI