### PR TITLE
(docker) ignore 401 on docker health check when unauthenticated

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -279,11 +279,15 @@ class DockerRegistryClient {
    * This method will hit the /v2/ endpoint of the configured docker registry. If it this endpoint is up,
    * it will return silently. Otherwise, an exception is thrown detailing why the endpoint isn't available.
    */
-
   public void checkV2Availability() {
     try {
       doCheckV2Availability()
     } catch (RetrofitError error) {
+      // If no credentials are supplied, and we got a 401, the best[1] we can do is assume the registry is OK.
+      // [1] https://docs.docker.com/registry/spec/api/#/api-version-check
+      if (!tokenService.basicAuthHeader && error.response?.status == 401) {
+        return
+      }
       Response response = doCheckV2Availability(tokenService.basicAuthHeader)
       if (!response){
         LOG.error "checkV2Availability", error


### PR DESCRIPTION
@skim1420, @tomaslin FYI

Steven noticed this morning that unauthenticated calls to the /v2/ endpoint of quay were returning a 401. I'm guessing this is a recent change since the Kubernetes-Spinnaker deployment has relied on quay working without authentication for some time to display the Spinnaker quay images. This is OK according to the spec I realize now: https://docs.docker.com/registry/spec/api/#/api-version-check, but frustrating, since unauthenticated clients can't properly check if their registry supports the v2 endpoint. This endpoint is only used to determine if the docker provider is healthy in clouddriver, and only affects (helps) users who don't authenticate against their registry.