### PR TITLE
provider/appengine guard for instances without availability

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppEngineInstance.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppEngineInstance.groovy
@@ -33,7 +33,10 @@ class AppEngineInstance implements Instance, Serializable {
   AppEngineInstance() {}
 
   AppEngineInstance(AppEngineApiInstance instance) {
-    this.instanceStatus = AppEngineInstanceStatus.valueOf(instance.getAvailability())
+    this.instanceStatus = instance.getAvailability() ?
+      AppEngineInstanceStatus.valueOf(instance.getAvailability()) :
+      null
+
     this.name = instance.getId()
     this.launchTime = AppEngineModelUtil.translateTime(instance.getStartTime())
   }


### PR DESCRIPTION
@lwander 

App Engine flex instances don't have availability.