### PR TITLE
normalize cloudProvider on Instance, ServerGroup

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/AppEngineCloudProvider.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/AppEngineCloudProvider.groovy
@@ -25,9 +25,8 @@ import org.springframework.stereotype.Component
  */
 @Component
 class AppEngineCloudProvider implements CloudProvider {
-  public static final String ID = 'appengine'
-
+  static final String ID = 'appengine'
   final String id = ID
   final String displayName = "App Engine"
-  final Class<Annotation> operationAnnotationType = AppEngineOperation.class
+  final Class<Annotation> operationAnnotationType = AppEngineOperation
 }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppEngineInstance.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppEngineInstance.groovy
@@ -28,7 +28,8 @@ class AppEngineInstance implements Instance, Serializable {
   String zone
   String serverGroup
   List<String> loadBalancers
-  String providerType = AppEngineCloudProvider.ID
+  final String providerType = AppEngineCloudProvider.ID
+  final String cloudProvider = AppEngineCloudProvider.ID
 
   AppEngineInstance() {}
 

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppEngineLoadBalancer.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppEngineLoadBalancer.groovy
@@ -26,7 +26,8 @@ import groovy.transform.EqualsAndHashCode
 @EqualsAndHashCode(includes = ["name", "account"])
 class AppEngineLoadBalancer implements LoadBalancer, Serializable {
   String name
-  String type = AppEngineCloudProvider.ID
+  final String type = AppEngineCloudProvider.ID
+  final String cloudProvider = AppEngineCloudProvider.ID
   String account
   Set<LoadBalancerServerGroup> serverGroups = new HashSet<>()
 }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppEngineServerGroup.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppEngineServerGroup.groovy
@@ -27,7 +27,8 @@ import groovy.transform.EqualsAndHashCode
 @EqualsAndHashCode(includes = ["name", "account"])
 class AppEngineServerGroup implements ServerGroup, Serializable {
   String name
-  String type = AppEngineCloudProvider.ID
+  final String type = AppEngineCloudProvider.ID
+  final String cloudProvider = AppEngineCloudProvider.ID
   String account
   String region
   Set<String> zones = []

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppEngineInstanceProvider.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppEngineInstanceProvider.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+import com.netflix.spinnaker.clouddriver.appengine.AppEngineCloudProvider
 import com.netflix.spinnaker.clouddriver.appengine.cache.Keys
 import com.netflix.spinnaker.clouddriver.appengine.model.AppEngineInstance
 import com.netflix.spinnaker.clouddriver.model.InstanceProvider
@@ -38,7 +39,7 @@ class AppEngineInstanceProvider implements InstanceProvider<AppEngineInstance> {
   @Autowired
   ObjectMapper objectMapper
 
-  String platform = Keys.Namespace.provider
+  final String cloudProvider = AppEngineCloudProvider.ID
 
   @Override
   AppEngineInstance getInstance(String account, String region, String instanceName) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AmazonCloudProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AmazonCloudProvider.groovy
@@ -22,8 +22,8 @@ import java.lang.annotation.Annotation
 
 @Component
 class AmazonCloudProvider implements CloudProvider {
-  public static final String AWS = "aws"
-  final String id = AWS
+  public static final String ID = "aws"
+  final String id = ID
   final String displayName = "Amazon"
-  final Class<? extends Annotation> operationAnnotationType = AmazonOperation
+  final Class<Annotation> operationAnnotationType = AmazonOperation
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.cache
 
 import com.netflix.frigga.Names
-import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.AWS
+import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.ID
 
 class Keys {
   static enum Namespace {
@@ -51,7 +51,7 @@ class Keys {
 
     def result = [provider: parts[0], type: parts[1]]
 
-    if (result.provider != AWS) {
+    if (result.provider != ID) {
       return null
     }
 
@@ -88,36 +88,36 @@ class Keys {
                                     String region,
                                     String account,
                                     String vpcId) {
-    "$AWS:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}:${vpcId}"
+    "$ID:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}:${vpcId}"
   }
 
   static String getSubnetKey(String subnetId,
                              String region,
                              String account) {
-    "$AWS:${Namespace.SUBNETS}:${subnetId}:${account}:${region}"
+    "$ID:${Namespace.SUBNETS}:${subnetId}:${account}:${region}"
   }
 
   static String getVpcKey(String vpcId,
                           String region,
                           String account) {
-    "$AWS:${Namespace.VPCS}:${vpcId}:${account}:${region}"
+    "$ID:${Namespace.VPCS}:${vpcId}:${account}:${region}"
   }
 
   static String getKeyPairKey(String keyName,
                               String region,
                               String account) {
-    "$AWS:${Namespace.KEY_PAIRS}:${keyName}:${account}:${region}"
+    "$ID:${Namespace.KEY_PAIRS}:${keyName}:${account}:${region}"
   }
 
   static String getInstanceTypeKey(String instanceType,
                                    String region,
                                    String account) {
-    "$AWS:${Namespace.INSTANCE_TYPES}:${instanceType}:${account}:${region}"
+    "$ID:${Namespace.INSTANCE_TYPES}:${instanceType}:${account}:${region}"
   }
 
   static String getElasticIpKey(String ipAddress,
                                 String region,
                                 String account) {
-    "$AWS:${Namespace.ELASTIC_IPS}:${ipAddress}:${account}:${region}"
+    "$ID:${Namespace.ELASTIC_IPS}:${ipAddress}:${account}:${region}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonLoadBalancerController.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonLoadBalancerController.groovy
@@ -31,7 +31,7 @@ import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LO
 @Component
 class AmazonLoadBalancerController implements LoadBalancerProviderTempShim {
 
-  final String cloudProvider = AmazonCloudProvider.AWS
+  final String cloudProvider = AmazonCloudProvider.ID
 
   private final Cache cacheView
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.data
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
 import groovy.transform.CompileStatic
-import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.AWS
+import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.ID
 
 @CompileStatic
 class Keys {
@@ -33,7 +33,7 @@ class Keys {
 
     def result = [provider: parts[0], type: parts[1]]
 
-    if (result.provider != AWS) {
+    if (result.provider != ID) {
       return null
     }
 
@@ -80,28 +80,28 @@ class Keys {
   }
 
   static String getImageKey(String imageId, String account, String region) {
-    "${AWS}:${Namespace.IMAGES}:${account}:${region}:${imageId}"
+    "${ID}:${Namespace.IMAGES}:${account}:${region}:${imageId}"
   }
 
   static String getNamedImageKey(String account, String imageName) {
-    "${AWS}:${Namespace.NAMED_IMAGES}:${account}:${imageName}"
+    "${ID}:${Namespace.NAMED_IMAGES}:${account}:${imageName}"
   }
 
   static String getServerGroupKey(String autoScalingGroupName, String account, String region) {
     Names names = Names.parseName(autoScalingGroupName)
-    "${AWS}:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}"
+    "${ID}:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}"
   }
 
   static String getInstanceKey(String instanceId, String account, String region) {
-    "${AWS}:${Namespace.INSTANCES}:${account}:${region}:${instanceId}"
+    "${ID}:${Namespace.INSTANCES}:${account}:${region}:${instanceId}"
   }
 
   static String getLaunchConfigKey(String launchConfigName, String account, String region) {
-    "${AWS}:${Namespace.LAUNCH_CONFIGS}:${account}:${region}:${launchConfigName}"
+    "${ID}:${Namespace.LAUNCH_CONFIGS}:${account}:${region}:${launchConfigName}"
   }
 
   static String getLoadBalancerKey(String loadBalancerName, String account, String region, String vpcId, String loadBalancerType) {
-    String key = "${AWS}:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}"
+    String key = "${ID}:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}"
     if (vpcId) {
       key += ":${vpcId}"
       if (loadBalancerType && loadBalancerType != 'classic') {
@@ -112,18 +112,18 @@ class Keys {
   }
 
   static String getClusterKey(String clusterName, String application, String account) {
-    "${AWS}:${Namespace.CLUSTERS}:${application.toLowerCase()}:${account}:${clusterName}"
+    "${ID}:${Namespace.CLUSTERS}:${application.toLowerCase()}:${account}:${clusterName}"
   }
 
   static String getApplicationKey(String application) {
-    "${AWS}:${Namespace.APPLICATIONS}:${application.toLowerCase()}"
+    "${ID}:${Namespace.APPLICATIONS}:${application.toLowerCase()}"
   }
 
   static String getInstanceHealthKey(String instanceId, String account, String region, String provider) {
-    "${AWS}:${Namespace.HEALTH}:${instanceId}:${account}:${region}:${provider}"
+    "${ID}:${Namespace.HEALTH}:${instanceId}:${account}:${region}:${provider}"
   }
 
   static String getReservedInstancesKey(String reservedInstancesId, String account, String region) {
-    "${AWS}:${Namespace.RESERVED_INSTANCES}:${account}:${region}:${reservedInstancesId}"
+    "${ID}:${Namespace.RESERVED_INSTANCES}:${account}:${region}:${reservedInstancesId}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstance.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstance.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.model
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
 
@@ -28,6 +29,8 @@ class AmazonInstance implements Instance, Serializable {
   String name
   Long launchTime
   List<Map<String, Object>> health = []
+  final String providerType = AmazonCloudProvider.ID
+  final String cloudProvider = AmazonCloudProvider.ID
 
   private Map<String, Object> dynamicProperties = new HashMap<String, Object>()
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonLoadBalancer.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonLoadBalancer.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.model
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import groovy.transform.CompileStatic
@@ -30,6 +31,8 @@ class AmazonLoadBalancer implements LoadBalancer {
   String region
   String vpcId
   Set<LoadBalancerServerGroup> serverGroups = []
+  final String type = AmazonCloudProvider.ID
+  final String cloudProvider = AmazonCloudProvider.ID
 
   private Map<String, Object> dynamicProperties = new HashMap<String, Object>()
 
@@ -41,11 +44,6 @@ class AmazonLoadBalancer implements LoadBalancer {
   @JsonAnySetter
   public void set(String name, Object value) {
     dynamicProperties.put(name, value);
-  }
-
-  @Override
-  String getType() {
-    return "aws"
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonSecurityGroup.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonSecurityGroup.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.model.SecurityGroup
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule
@@ -25,7 +26,8 @@ import groovy.transform.Immutable
 @Immutable
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 class AmazonSecurityGroup implements SecurityGroup {
-  final String type
+  final String type = AmazonCloudProvider.ID
+  final String cloudProvider = AmazonCloudProvider.ID
   final String id
   final String name
   final String vpcId

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.model
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
@@ -38,6 +39,8 @@ class AmazonServerGroup implements ServerGroup, Serializable {
   List<Map> scheduledActions
   Map buildInfo
   String vpcId
+  final String type = AmazonCloudProvider.ID
+  final String cloudProvider = AmazonCloudProvider.ID
 
   private Map<String, Object> dynamicProperties = new HashMap<String, Object>()
 
@@ -49,11 +52,6 @@ class AmazonServerGroup implements ServerGroup, Serializable {
   @JsonAnySetter
   public void set(String name, Object value) {
     dynamicProperties.put(name, value);
-  }
-
-  @Override
-  String getType() {
-    return "aws"
   }
 
   @Override
@@ -148,7 +146,7 @@ class AmazonServerGroup implements ServerGroup, Serializable {
     imagesSummary?.summaries?.get(0)
   }
 
-  static Collection<Instance> filterInstancesByHealthState(Set<Instance> instances, HealthState healthState) {
+  static Collection<Instance> filterInstancesByHealthState(Collection<Instance> instances, HealthState healthState) {
     instances.findAll { Instance it -> it.getHealthState() == healthState }
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
@@ -67,7 +67,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
     this.region = region
     this.objectMapper = objectMapper
     this.registry = registry
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${AmazonCloudProvider.AWS}:${OnDemandAgent.OnDemandType.SecurityGroup}")
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${AmazonCloudProvider.ID}:${OnDemandAgent.OnDemandType.SecurityGroup}")
     this.lastModifiedKey = Keys.getSecurityGroupKey('LAST_MODIFIED', 'LAST_MODIFIED', region, account.name, null)
   }
 
@@ -122,7 +122,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == AmazonCloudProvider.AWS
+    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == AmazonCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.provider.view
 import com.amazonaws.services.ec2.model.GetConsoleOutputRequest
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.core.provider.agent.ExternalHealthProvider
@@ -35,6 +36,7 @@ import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IN
 @Component
 class AmazonInstanceProvider implements InstanceProvider<AmazonInstance> {
 
+  final String cloudProvider = AmazonCloudProvider.ID
   private final Cache cacheView
 
   @Autowired(required = false)
@@ -50,8 +52,6 @@ class AmazonInstanceProvider implements InstanceProvider<AmazonInstance> {
 
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
-
-  String platform = "aws"
 
   @Override
   AmazonInstance getInstance(String account, String region, String id) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProvider.groovy
@@ -43,6 +43,7 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.SECURIT
 @Component
 class AmazonSecurityGroupProvider implements SecurityGroupProvider<AmazonSecurityGroup> {
 
+  final String cloudProvider = AmazonCloudProvider.ID
   final AccountCredentialsProvider accountCredentialsProvider
   final Cache cacheView
   final ObjectMapper objectMapper
@@ -60,11 +61,6 @@ class AmazonSecurityGroupProvider implements SecurityGroupProvider<AmazonSecurit
       it instanceof AmazonCredentials
     }
     accounts = ImmutableSet.copyOf(allAmazonCredentials)
-  }
-
-  @Override
-  String getType() {
-    return AmazonCloudProvider.AWS
   }
 
   @Override
@@ -134,7 +130,6 @@ class AmazonSecurityGroupProvider implements SecurityGroupProvider<AmazonSecurit
     }
 
     new AmazonSecurityGroup(
-      type: AmazonCloudProvider.AWS,
       id: securityGroup.groupId,
       name: securityGroup.groupName,
       vpcId: securityGroup.vpcId,
@@ -199,7 +194,6 @@ class AmazonSecurityGroupProvider implements SecurityGroupProvider<AmazonSecurit
           protocol     : permission.ipProtocol,
           securityGroup:
             new AmazonSecurityGroup(
-              type: AmazonCloudProvider.AWS,
               id: sg.groupId,
               name: ingressGroupSummary.name,
               accountId: sg.userId,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSubnetProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSubnetProvider.groovy
@@ -40,15 +40,12 @@ class AmazonSubnetProvider implements SubnetProvider<AmazonSubnet> {
   private final Cache cacheView
   private final AmazonObjectMapper objectMapper
 
+  final String cloudProvider = AmazonCloudProvider.ID
+
   @Autowired
   AmazonSubnetProvider(Cache cacheView, AmazonObjectMapper objectMapper) {
     this.cacheView = cacheView
     this.objectMapper = objectMapper
-  }
-
-  @Override
-  String getType() {
-    return AmazonCloudProvider.AWS
   }
 
   @Override
@@ -92,7 +89,7 @@ class AmazonSubnetProvider implements SubnetProvider<AmazonSubnet> {
     }
 
     new AmazonSubnet(
-      type: AmazonCloudProvider.AWS,
+      type: AmazonCloudProvider.ID,
       id: subnet.subnetId,
       state: subnet.state,
       vpcId: subnet.vpcId,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonVpcProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonVpcProvider.groovy
@@ -47,7 +47,7 @@ class AmazonVpcProvider implements NetworkProvider<AmazonVpc> {
 
   @Override
   String getCloudProvider() {
-    return AmazonCloudProvider.AWS
+    return AmazonCloudProvider.ID
   }
 
   @Override
@@ -60,7 +60,7 @@ class AmazonVpcProvider implements NetworkProvider<AmazonVpc> {
     def vpc = objectMapper.convertValue(cacheData.attributes, Vpc)
     def isDeprecated = vpc.tags.find { it.key == DEPRECATED_TAG_KEY }?.value
     new AmazonVpc(
-      cloudProvider: AmazonCloudProvider.AWS,
+      cloudProvider: AmazonCloudProvider.ID,
       id: vpc.vpcId,
       name: getVpcName(vpc),
       account: parts.account,

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/SimpleServerGroup.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/SimpleServerGroup.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.model.ServerGroup
 class SimpleServerGroup implements ServerGroup {
   String name
   String type
+  String cloudProvider
   String region
   Long createdTime
   Boolean disabled

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy
@@ -457,6 +457,7 @@ class DiscoverySupportUnitSpec extends Specification {
   private static class DefaultServerGroup implements ServerGroup {
     String name
     String type
+    String cloudProvider
     String region
     Boolean disabled
     Long createdTime

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
@@ -228,11 +228,10 @@ class AmazonSecurityGroupProviderSpec extends Specification {
     def sg = provider.get(account, region, 'name-b', null)
 
     then:
-    sg == new AmazonSecurityGroup(type: "aws", id: "id-b", name: "name-b", description: "b",
+    sg == new AmazonSecurityGroup(id: "id-b", name: "name-b", description: "b",
       accountName: account, region: region, inboundRules: [
       new SecurityGroupRule(protocol: "TCP",
         securityGroup: new AmazonSecurityGroup(
-          type: 'aws',
           id: 'id-a',
           name: 'name-a',
           accountName: "accountName1",
@@ -245,7 +244,6 @@ class AmazonSecurityGroupProviderSpec extends Specification {
       ),
       new SecurityGroupRule(protocol: "UDP",
         securityGroup: new AmazonSecurityGroup(
-          type: 'aws',
           id: 'id-a',
           name: 'name-a',
           accountName: "accountName1",

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/AzureCloudProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/AzureCloudProvider.groovy
@@ -20,11 +20,13 @@ import com.netflix.spinnaker.clouddriver.core.CloudProvider
 import java.lang.annotation.Annotation
 import org.springframework.stereotype.Component
 
+/**
+ * Azure declaration as a {@link CloudProvider}
+ */
 @Component
 class AzureCloudProvider implements CloudProvider {
-  public static final AZURE = "azure"
-
-  final String id = AZURE
+  static final ID = "azure"
+  final String id = ID
   final String displayName = "Azure"
-  final Class<Annotation> operationAnnotationType = AzureOperation.class
+  final Class<Annotation> operationAnnotationType = AzureOperation
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayController.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayController.groovy
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component
 @Component
 class AzureAppGatewayController implements LoadBalancerProviderTempShim {
 
-  final String cloudProvider = AzureCloudProvider.AZURE
+  final String cloudProvider = AzureCloudProvider.ID
 
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/cluster/model/AzureCluster.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/cluster/model/AzureCluster.groovy
@@ -25,7 +25,7 @@ class AzureCluster implements Cluster {
 
   String name
   String accountName
-  String type = AzureCloudProvider.AZURE
+  String type = AzureCloudProvider.ID
   Set<AzureServerGroupDescription> serverGroups = []
   Set<AzureLoadBalancer> loadBalancers = []
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/cluster/view/AzureClusterProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/cluster/view/AzureClusterProvider.groovy
@@ -107,7 +107,7 @@ class AzureClusterProvider implements ClusterProvider<AzureCluster> {
 
   @Override
   AzureServerGroupDescription getServerGroup(String account, String region, String name) {
-    String serverGroupKey = Keys.getServerGroupKey(AzureCloudProvider.AZURE, name, region, account)
+    String serverGroupKey = Keys.getServerGroupKey(AzureCloudProvider.ID, name, region, account)
     CacheData serverGroupData = cacheView.get(AZURE_SERVER_GROUPS.ns, serverGroupKey)
 
     if (!serverGroupData) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/cache/Keys.groovy
@@ -142,7 +142,7 @@ class Keys {
   }
 
   //TODO (scotm) remove all references to the methods that take azureCloudProvider as paramter
-  //TODO (scotm) use the AzureCloudProvider.AZURE static string for the id instead
+  //TODO (scotm) use the AzureCloudProvider.ID static string for the id instead
   //These changes are a stop-gap to enable testing without major refactoring (coming).
   // Long-term we will remove the method that takes the cloud provider and default the other version
   // to use the static member of the cloud provider

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancer.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancer.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 
@@ -28,11 +29,10 @@ class AzureLoadBalancer implements LoadBalancer {
   String region
   String vnet
   String subnet
-  String type = AZURE_LOAD_BALANCER_TYPE
   Set<LoadBalancerServerGroup> serverGroups = new HashSet<>()
   String cluster
-
-  private static final AZURE_LOAD_BALANCER_TYPE = "azure"
+  final String type = AzureCloudProvider.ID
+  final String cloudProvider = AzureCloudProvider.ID
 
   private Map<String, Object> dynamicProperties = new HashMap<String, Object>()
 
@@ -41,17 +41,12 @@ class AzureLoadBalancer implements LoadBalancer {
 
   @JsonAnyGetter
   Map<String,Object> any() {
-    return dynamicProperties;
+    return dynamicProperties
   }
 
   @JsonAnySetter
   void set(String name, Object value) {
-    dynamicProperties.put(name, value);
-  }
-
-  @Override
-  String getType() {
-    return AZURE_LOAD_BALANCER_TYPE
+    dynamicProperties.put(name, value)
   }
 
   @Override
@@ -60,7 +55,7 @@ class AzureLoadBalancer implements LoadBalancer {
       return false
     }
     AzureLoadBalancer a = (AzureLoadBalancer)o;
-    a.getAccount() == this.getAccount() && a.getName() == this.getName() && a.getType() == this.getType() && a.region == this.region;
+    a.getAccount() == this.getAccount() && a.getName() == this.getName() && a.getType() == this.getType() && a.region == this.region
 
     // TODO Implement logic to compare server groups and regions(?)
   }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/model/AzureSecurityGroup.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/model/AzureSecurityGroup.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.model.SecurityGroup
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule
@@ -26,7 +27,8 @@ import groovy.transform.Immutable
 @Immutable
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 class AzureSecurityGroup implements SecurityGroup {
-  final String type = "azure"
+  final String type = AzureCloudProvider.ID
+  final String cloudProvider = AzureCloudProvider.ID
   final String id
   final String name
   final String provider

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/view/AzureSecurityGroupProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/view/AzureSecurityGroupProvider.groovy
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component
 @Component
 class AzureSecurityGroupProvider implements SecurityGroupProvider<AzureSecurityGroup> {
 
+  final String cloudProvider = AzureCloudProvider.ID
   private final AzureCloudProvider azureCloudProvider
   private final Cache cacheView
   final ObjectMapper objectMapper
@@ -40,15 +41,6 @@ class AzureSecurityGroupProvider implements SecurityGroupProvider<AzureSecurityG
     this.azureCloudProvider = azureCloudProvider
     this.cacheView = cacheView
     this.objectMapper = objectMapper
-  }
-
-  String getCloudProvider() {
-    return azureCloudProvider.id
-  }
-
-  @Override
-  String getType() {
-    return azureCloudProvider.id
   }
 
   @Override

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -68,7 +68,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
       }
     }
 
-    Collection<String> keys = serverGroups.collect {Keys.getServerGroupKey(AzureCloudProvider.AZURE, it.name, region, accountName ) }
+    Collection<String> keys = serverGroups.collect {Keys.getServerGroupKey(AzureCloudProvider.ID, it.name, region, accountName ) }
     def onDemandCacheResults = providerCache.getAll(AZURE_ON_DEMAND.ns, keys, RelationshipCacheFilter.none())
 
     def (evictions, usableOnDemandCacheData) = parseOnDemandCache(onDemandCacheResults, start)
@@ -94,7 +94,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
   }
 
   CacheResult removeDeadCacheEntries(CacheResult cacheResult, ProviderCache providerCache) {
-    def sgIdentifiers = providerCache.filterIdentifiers(AZURE_SERVER_GROUPS.ns, Keys.getServerGroupKey(AzureCloudProvider.AZURE, "*", region, accountName))
+    def sgIdentifiers = providerCache.filterIdentifiers(AZURE_SERVER_GROUPS.ns, Keys.getServerGroupKey(AzureCloudProvider.ID, "*", region, accountName))
     def sgCacheResults = providerCache.getAll((AZURE_SERVER_GROUPS.ns), sgIdentifiers, RelationshipCacheFilter.none())
     def evictedSGList = sgCacheResults.collect{ cached ->
       if (!cacheResult.cacheResults[AZURE_SERVER_GROUPS.ns].find {it.id == cached.id}) {
@@ -107,7 +107,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
       cacheResult.evictions[AZURE_SERVER_GROUPS.ns] = evictedSGList
     }
 
-    def instanceIdentifiers = providerCache.filterIdentifiers(AZURE_INSTANCES.ns, Keys.getInstanceKey(AzureCloudProvider.AZURE, "*", "*", region, accountName))
+    def instanceIdentifiers = providerCache.filterIdentifiers(AZURE_INSTANCES.ns, Keys.getInstanceKey(AzureCloudProvider.ID, "*", "*", region, accountName))
     def instanceCacheResults = providerCache.getAll((AZURE_INSTANCES.ns), instanceIdentifiers, RelationshipCacheFilter.none())
     def evictedInstanceList = instanceCacheResults.collect{ cached ->
       if (!cacheResult.cacheResults[AZURE_INSTANCES.ns].find {it.id == cached.id}) {
@@ -162,7 +162,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
 
     AzureServerGroupDescription serverGroup = null
     String serverGroupName = data.serverGroupName as String
-    String serverGroupKey = Keys.getServerGroupKey(AzureCloudProvider.AZURE, serverGroupName, region, accountName)
+    String serverGroupKey = Keys.getServerGroupKey(AzureCloudProvider.ID, serverGroupName, region, accountName)
     String resourceGroupName = AzureUtilities.getResourceGroupName(AzureUtilities.getAppNameFromAzureResourceName(serverGroupName), region)
     if (resourceGroupName == null) {
       log.info("handle->Unexpected error retrieving resource group name: null")

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model
 
 import com.microsoft.azure.management.compute.models.VirtualMachineScaleSetVM
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
@@ -31,6 +32,8 @@ class AzureInstance implements Instance, Serializable {
   String zone
   String instanceType
   List<Map<String, String>> health
+  final String providerType = AzureCloudProvider.ID
+  final String cloudProvider = AzureCloudProvider.ID
 
   AzureInstance(){
     zone = 'N/A'

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model
 
 import com.microsoft.azure.management.compute.models.VirtualMachineScaleSet
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.common.AzureResourceOpsDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.model.AzureNamedImage
@@ -27,8 +28,6 @@ import com.netflix.spinnaker.clouddriver.model.ServerGroup
 
 class AzureServerGroupDescription extends AzureResourceOpsDescription implements ServerGroup {
 
-  private static final AZURE_SERVER_GROUP_TYPE = "azure"
-
   static enum UpgradePolicy {
     Automatic, Manual
   }
@@ -37,7 +36,8 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   Set<String> loadBalancers
   Set<String> securityGroups
   Set<String> zones
-  String type = AZURE_SERVER_GROUP_TYPE
+  final String type = AzureCloudProvider.ID
+  final String cloudProvider = AzureCloudProvider.ID
   Map<String, Object> launchConfig
   ServerGroup.Capacity capacity
   ServerGroup.ImagesSummary imagesSummary
@@ -147,7 +147,6 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   static AzureServerGroupDescription build(VirtualMachineScaleSet scaleSet) {
     def azureSG = new AzureServerGroupDescription()
     azureSG.name = scaleSet.name
-    azureSG.cloudProvider = "azure"
     def parsedName = Names.parseName(scaleSet.name)
     // Get the values from the tags if they exist
     azureSG.tags = scaleSet.tags ? scaleSet.tags : [:]

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/view/AzureInstanceProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/view/AzureInstanceProvider.groovy
@@ -29,8 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class AzureInstanceProvider implements InstanceProvider<AzureInstance>
-{
+class AzureInstanceProvider implements InstanceProvider<AzureInstance> {
+  final String cloudProvider = AzureCloudProvider.ID
   private final AzureCloudProvider azureCloudProvider
   private final Cache cacheView
   final ObjectMapper objectMapper
@@ -42,11 +42,9 @@ class AzureInstanceProvider implements InstanceProvider<AzureInstance>
     this.objectMapper = objectMapper
   }
 
-  String platform = AzureCloudProvider.AZURE
-
   @Override
   AzureInstance getInstance(String account, String region, String id) {
-    String pattern = Keys.getInstanceKey(AzureCloudProvider.AZURE, "*", id, region, account)
+    String pattern = Keys.getInstanceKey(AzureCloudProvider.ID, "*", id, region, account)
     def identifiers = cacheView.filterIdentifiers(AZURE_INSTANCES.ns, pattern)
 
     Set<CacheData> instances = cacheView.getAll(AZURE_INSTANCES.ns, identifiers, RelationshipCacheFilter.none())

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/subnet/view/AzureSubnetProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/subnet/view/AzureSubnetProvider.groovy
@@ -35,15 +35,13 @@ class AzureSubnetProvider implements SubnetProvider<AzureSubnet> {
   private final Cache cacheView
   final ObjectMapper objectMapper
 
+  final String cloudProvider = AzureCloudProvider.ID
+
   @Autowired
   AzureSubnetProvider(AzureCloudProvider azureCloudProvider, Cache cacheView, ObjectMapper objectMapper) {
     this.azureCloudProvider = azureCloudProvider
     this.cacheView = cacheView
     this.objectMapper = objectMapper
-  }
-
-  String getType() {
-    return azureCloudProvider.id
   }
 
   @Override

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/cache/KeysSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/cache/KeysSpec.groovy
@@ -19,13 +19,9 @@ package com.netflix.spinnaker.clouddriver.azure.cache
 import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.azure.resources.common.cache.Keys
 import static com.netflix.spinnaker.clouddriver.azure.resources.common.cache.Keys.Namespace.*
-import org.springframework.beans.factory.annotation.Autowired
 
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import java.security.Key
-
 
 class KeysSpec extends Specification {
   static final String PROVIDER = 'azure'
@@ -61,10 +57,10 @@ class KeysSpec extends Specification {
 
   def 'key parsing'() {
     expect:
-    Keys.parse(AzureCloudProvider.AZURE, Keys.getApplicationKey(AzureCloudProvider.AZURE, APP_NAME)) == [provider: PROVIDER, type: AZURE_APPLICATIONS.ns, application: APP_NAME]
-    Keys.parse(AzureCloudProvider.AZURE, Keys.getClusterKey(AzureCloudProvider.AZURE, APP_NAME, CLUSTER_NAME, ACCOUNT)) == [provider: PROVIDER, type: AZURE_CLUSTERS.ns, application: APP_NAME, name: CLUSTER_NAME, account: ACCOUNT, stack: STACK_NAME, detail: DETAIL]
-    Keys.parse(AzureCloudProvider.AZURE, Keys.getServerGroupKey(AzureCloudProvider.AZURE, SERVER_GROUP_NAME, REGION, ACCOUNT)) == [provider: PROVIDER, type: AZURE_SERVER_GROUPS.ns, application: APP_NAME, serverGroup: SERVER_GROUP_NAME, account: ACCOUNT, region: REGION, detail: DETAIL, stack: STACK_NAME]
-    Keys.parse(AzureCloudProvider.AZURE, Keys.getLoadBalancerKey(AzureCloudProvider.AZURE, LOAD_BALANCER_NAME , LOAD_BALANCER_ID, APP_NAME, CLUSTER_NAME, REGION, ACCOUNT )) == [provider: PROVIDER, type: AZURE_LOAD_BALANCERS.ns, application: APP_NAME, name: LOAD_BALANCER_NAME, id: LOAD_BALANCER_ID, cluster: CLUSTER_NAME, appname: APP_NAME, account: ACCOUNT, region: REGION]
-    Keys.parse(AzureCloudProvider.AZURE, Keys.getInstanceKey(AzureCloudProvider.AZURE, SERVER_GROUP_NAME, INSTANCE, REGION, ACCOUNT)) == [provider: PROVIDER, type: AZURE_INSTANCES.ns, application: APP_NAME, serverGroup: SERVER_GROUP_NAME, name: INSTANCE, region: REGION, account: ACCOUNT]
+    Keys.parse(AzureCloudProvider.ID, Keys.getApplicationKey(AzureCloudProvider.ID, APP_NAME)) == [provider: PROVIDER, type: AZURE_APPLICATIONS.ns, application: APP_NAME]
+    Keys.parse(AzureCloudProvider.ID, Keys.getClusterKey(AzureCloudProvider.ID, APP_NAME, CLUSTER_NAME, ACCOUNT)) == [provider: PROVIDER, type: AZURE_CLUSTERS.ns, application: APP_NAME, name: CLUSTER_NAME, account: ACCOUNT, stack: STACK_NAME, detail: DETAIL]
+    Keys.parse(AzureCloudProvider.ID, Keys.getServerGroupKey(AzureCloudProvider.ID, SERVER_GROUP_NAME, REGION, ACCOUNT)) == [provider: PROVIDER, type: AZURE_SERVER_GROUPS.ns, application: APP_NAME, serverGroup: SERVER_GROUP_NAME, account: ACCOUNT, region: REGION, detail: DETAIL, stack: STACK_NAME]
+    Keys.parse(AzureCloudProvider.ID, Keys.getLoadBalancerKey(AzureCloudProvider.ID, LOAD_BALANCER_NAME , LOAD_BALANCER_ID, APP_NAME, CLUSTER_NAME, REGION, ACCOUNT )) == [provider: PROVIDER, type: AZURE_LOAD_BALANCERS.ns, application: APP_NAME, name: LOAD_BALANCER_NAME, id: LOAD_BALANCER_ID, cluster: CLUSTER_NAME, appname: APP_NAME, account: ACCOUNT, region: REGION]
+    Keys.parse(AzureCloudProvider.ID, Keys.getInstanceKey(AzureCloudProvider.ID, SERVER_GROUP_NAME, INSTANCE, REGION, ACCOUNT)) == [provider: PROVIDER, type: AZURE_INSTANCES.ns, application: APP_NAME, serverGroup: SERVER_GROUP_NAME, name: INSTANCE, region: REGION, account: ACCOUNT]
   }
 }

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/CloudFoundryCloudProvider.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/CloudFoundryCloudProvider.groovy
@@ -23,19 +23,11 @@ import java.lang.annotation.Annotation
 
 /**
  * Cloud Foundry declaration as a {@link CloudProvider}
- *
- *
  */
 @Component
 class CloudFoundryCloudProvider implements CloudProvider {
-
-	static final String ID = 'cf'
-
-	final String displayName = "Cloud Foundry"
-	final Class<Annotation> operationAnnotationType = CloudFoundryOperation.class
-
-	@Override
-	String getId() {
-		ID
-	}
+  static final String ID = 'cf'
+  final String id = ID
+  final String displayName = "Cloud Foundry"
+  final Class<Annotation> operationAnnotationType = CloudFoundryOperation
 }

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryApplicationInstance.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryApplicationInstance.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.cf.model
 
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryCloudProvider
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
 import groovy.transform.EqualsAndHashCode
@@ -33,6 +34,8 @@ class CloudFoundryApplicationInstance implements Instance, Serializable {
   InstanceInfo nativeInstance
   String consoleLink
   String logsLink
+  final String providerType = CloudFoundryCloudProvider.ID
+  final String cloudProvider = CloudFoundryCloudProvider.ID
 
   @Override
   Long getLaunchTime() {

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryLoadBalancer.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryLoadBalancer.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.cf.model
 
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryCloudProvider
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import groovy.transform.CompileStatic
@@ -27,7 +28,8 @@ import org.cloudfoundry.client.lib.domain.CloudRoute
 class CloudFoundryLoadBalancer implements LoadBalancer {
 
   String name
-  String type = 'cf'
+  final String type = CloudFoundryCloudProvider.ID
+  final String cloudProvider = CloudFoundryCloudProvider.ID
   Set<LoadBalancerServerGroup> serverGroups = new HashSet<>()
   String region
   String account

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryServerGroup.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/model/CloudFoundryServerGroup.groovy
@@ -15,6 +15,8 @@
  */
 
 package com.netflix.spinnaker.clouddriver.cf.model
+
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryCloudProvider
 import com.netflix.spinnaker.clouddriver.cf.config.CloudFoundryConstants
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
@@ -28,7 +30,8 @@ import org.cloudfoundry.client.lib.domain.CloudApplication
 class CloudFoundryServerGroup implements ServerGroup, Serializable {
 
   String name
-  String type = 'cf'
+  final String type = CloudFoundryCloudProvider.ID
+  final String cloudProvider = CloudFoundryCloudProvider.ID
   CloudApplication nativeApplication
   Boolean disabled = true
   Set<CloudFoundryApplicationInstance> instances = new HashSet<>()

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/view/CloudFoundryInstanceProvider.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/view/CloudFoundryInstanceProvider.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.cf.provider.view
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.clouddriver.cf.CloudFoundryCloudProvider
 import com.netflix.spinnaker.clouddriver.cf.cache.CacheUtils
 import com.netflix.spinnaker.clouddriver.cf.cache.Keys
 import com.netflix.spinnaker.clouddriver.cf.model.CloudFoundryApplicationInstance
@@ -35,7 +36,7 @@ import static com.netflix.spinnaker.clouddriver.cf.cache.Keys.Namespace.SERVER_G
 @CompileStatic
 class CloudFoundryInstanceProvider implements InstanceProvider<CloudFoundryApplicationInstance> {
 
-  String platform = 'cf'
+  final String cloudProvider = CloudFoundryCloudProvider.ID
 
   private final Cache cacheView
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Instance.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Instance.groovy
@@ -57,4 +57,15 @@ interface Instance {
    * and may include others, depending on the health metric
    */
   List<Map<String, String>> getHealth()
+
+  /**
+   * @deprecated use #getCloudProvider
+   */
+  String getProviderType()
+
+  /**
+   * Cloud-provider key, e.g. "aws", "titus"
+   * @return
+   */
+  String getCloudProvider()
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/InstanceProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/InstanceProvider.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.model
 
-public interface InstanceProvider<T extends Instance> {
+interface InstanceProvider<T extends Instance> {
 
   /**
    * Returns the platform the instance provider
    * @return a String, e.g. 'aws', 'gce'
    */
-  String getPlatform()
+  String getCloudProvider()
 
   T getInstance(String account, String region, String id)
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancer.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancer.groovy
@@ -34,10 +34,15 @@ interface LoadBalancer {
 
   /**
    * The type of this load balancer. Can indicate some vendor-specific designation, or cloud provider
-   *
+   * @deprecated use #getCloudProvider
    * @return type
    */
   String getType()
+
+  /**
+   * Provider-specific identifier
+   */
+  String getCloudProvider()
 
   /**
    * The names of the server groups that this load balancer is servicing.

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopInstanceProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopInstanceProvider.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.model
 
 class NoopInstanceProvider implements InstanceProvider<Instance> {
 
-  String platform = "none"
+  final String cloudProvider = "none"
 
   @Override
   Instance getInstance(String account, String region, String id) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopSecurityGroupProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopSecurityGroupProvider.groovy
@@ -17,38 +17,36 @@
 package com.netflix.spinnaker.clouddriver.model
 
 class NoopSecurityGroupProvider implements SecurityGroupProvider {
-    @Override
-    String getType() {
-        'noop'
-    }
 
-    @Override
-    Set<SecurityGroup> getAll(boolean includeRules) {
-        Collections.emptySet()
-    }
+  final String cloudProvider = 'noop'
 
-    @Override
-    Set<SecurityGroup> getAllByRegion(boolean includeRules, String region) {
-        Collections.emptySet()
-    }
+  @Override
+  Set<SecurityGroup> getAll(boolean includeRules) {
+    Collections.emptySet()
+  }
 
-    @Override
-    Set<SecurityGroup> getAllByAccount(boolean includeRules, String account) {
-        Collections.emptySet()
-    }
+  @Override
+  Set<SecurityGroup> getAllByRegion(boolean includeRules, String region) {
+    Collections.emptySet()
+  }
 
-    @Override
-    Set<SecurityGroup> getAllByAccountAndName(boolean includeRules, String account, String name) {
-        Collections.emptySet()
-    }
+  @Override
+  Set<SecurityGroup> getAllByAccount(boolean includeRules, String account) {
+    Collections.emptySet()
+  }
 
-    @Override
-    Set<SecurityGroup> getAllByAccountAndRegion(boolean includeRules, String account, String region) {
-        Collections.emptySet()
-    }
+  @Override
+  Set<SecurityGroup> getAllByAccountAndName(boolean includeRules, String account, String name) {
+    Collections.emptySet()
+  }
 
-    @Override
-    SecurityGroup get(String account, String region, String name, String vpcId) {
-        null
-    }
+  @Override
+  Set<SecurityGroup> getAllByAccountAndRegion(boolean includeRules, String account, String region) {
+    Collections.emptySet()
+  }
+
+  @Override
+  SecurityGroup get(String account, String region, String name, String vpcId) {
+    null
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopSubnetProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopSubnetProvider.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.model
 
 class NoopSubnetProvider implements SubnetProvider<Subnet> {
   @Override
-  String getType() {
+  String getCloudProvider() {
     return null
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SecurityGroup.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SecurityGroup.groovy
@@ -27,10 +27,15 @@ interface SecurityGroup {
 
   /**
    * The type of this security group. May reference the cloud provider to which it is associated
-   *
+   * @deprecated use #getCloudProvider
    * @return
    */
   String getType()
+
+  /**
+   * Provider-specific identifier
+   */
+  String getCloudProvider()
 
   /**
    * The ID associated with this security group

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SecurityGroupProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SecurityGroupProvider.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.model
 
 interface SecurityGroupProvider<T extends SecurityGroup> {
 
-  String getType()
+  String getCloudProvider()
 
   Set<T> getAll(boolean includeRules)
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.java
@@ -39,10 +39,15 @@ public interface ServerGroup {
 
   /**
    * Some arbitrary identifying type for this server group. May provide vendor-specific identification or data-center awareness to callers.
-   *
+   * @deprecated use #getCloudProvider
    * @return type
    */
   String getType();
+
+  /**
+   * Provider-specific identifier
+   */
+  String getCloudProvider();
 
   /**
    * The region in which the instances of this server group are known to exist.

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SubnetProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SubnetProvider.groovy
@@ -17,6 +17,6 @@
 package com.netflix.spinnaker.clouddriver.model
 
 interface SubnetProvider<T extends Subnet> {
-  String getType()
+  String getCloudProvider()
   Set<T> getAll()
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/DockerRegistryCloudProvider.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/DockerRegistryCloudProvider.groovy
@@ -28,9 +28,8 @@ import java.lang.annotation.Annotation
  */
 @Component
 class DockerRegistryCloudProvider implements CloudProvider {
-  public static final String DOCKER_REGISTRY = "dockerRegistry"
-  final String id = DOCKER_REGISTRY
+  final String id = "dockerRegistry"
   final String displayName = "Docker Registry"
   // The docker registry is only used for caching, so none of the op/ endpoints will be hit.
-  final Class<Annotation> operationAnnotationType = Annotation.class
+  final Class<Annotation> operationAnnotationType = Annotation
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleCloudProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleCloudProvider.groovy
@@ -26,9 +26,8 @@ import java.lang.annotation.Annotation
  */
 @Component
 class GoogleCloudProvider implements CloudProvider {
-  public static final String GCE = "gce"
-
-  final String id = GCE
+  static final String ID = "gce"
+  final String id = ID
   final String displayName = "Google"
-  final Class<Annotation> operationAnnotationType = GoogleOperation.class
+  final Class<Annotation> operationAnnotationType = GoogleOperation
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy
@@ -55,11 +55,11 @@ class Keys {
   static Map<String, String> parse(String key) {
     def parts = key.split(':')
 
-    if (parts.length < 2 || parts[0] != GoogleCloudProvider.GCE) {
+    if (parts.length < 2 || parts[0] != GoogleCloudProvider.ID) {
       return null
     }
 
-    if (parts[0] != GoogleCloudProvider.GCE) {
+    if (parts[0] != GoogleCloudProvider.ID) {
       return null
     }
 
@@ -181,60 +181,60 @@ class Keys {
   }
 
   static String getApplicationKey(String application) {
-    "$GoogleCloudProvider.GCE:${Namespace.APPLICATIONS}:${application}"
+    "$GoogleCloudProvider.ID:${Namespace.APPLICATIONS}:${application}"
   }
 
   static String getBackendServiceKey(String account,
                                      String kind,
                                      String backendServiceName) {
-    "$GoogleCloudProvider.GCE:${Namespace.BACKEND_SERVICES}:${account}:${kind}:${backendServiceName}"
+    "$GoogleCloudProvider.ID:${Namespace.BACKEND_SERVICES}:${account}:${kind}:${backendServiceName}"
   }
 
   static String getClusterKey(String account,
                               String application,
                               String clusterName) {
-    "$GoogleCloudProvider.GCE:${Namespace.CLUSTERS}:${account}:${application}:${clusterName}"
+    "$GoogleCloudProvider.ID:${Namespace.CLUSTERS}:${account}:${application}:${clusterName}"
   }
 
   static String getHealthCheckKey(String account,
                                   String kind,
                                   String healthCheckName) {
-    "$GoogleCloudProvider.GCE:${Namespace.HEALTH_CHECKS}:${account}:${kind}:${healthCheckName}"
+    "$GoogleCloudProvider.ID:${Namespace.HEALTH_CHECKS}:${account}:${kind}:${healthCheckName}"
   }
 
   static String getHttpHealthCheckKey(String account,
                                       String httpHealthCheckName) {
-    "$GoogleCloudProvider.GCE:${Namespace.HTTP_HEALTH_CHECKS}:${account}:${httpHealthCheckName}"
+    "$GoogleCloudProvider.ID:${Namespace.HTTP_HEALTH_CHECKS}:${account}:${httpHealthCheckName}"
   }
 
   static String getImageKey(String account,
                             String imageId) {
-    "$GoogleCloudProvider.GCE:${Namespace.IMAGES}:${account}:${imageId}"
+    "$GoogleCloudProvider.ID:${Namespace.IMAGES}:${account}:${imageId}"
   }
 
   static String getInstanceKey(String account,
                                String region,
                                String name) {
-    "$GoogleCloudProvider.GCE:${Namespace.INSTANCES}:${account}:${region}:${name}"
+    "$GoogleCloudProvider.ID:${Namespace.INSTANCES}:${account}:${region}:${name}"
   }
 
   static String getLoadBalancerKey(String region,
                                    String account,
                                    String loadBalancerName) {
-    "$GoogleCloudProvider.GCE:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}"
+    "$GoogleCloudProvider.ID:${Namespace.LOAD_BALANCERS}:${account}:${region}:${loadBalancerName}"
   }
 
   static String getNetworkKey(String networkName,
                               String region,
                               String account) {
-    "$GoogleCloudProvider.GCE:${Namespace.NETWORKS}:${networkName}:${account}:${region}"
+    "$GoogleCloudProvider.ID:${Namespace.NETWORKS}:${networkName}:${account}:${region}"
   }
 
   static String getSecurityGroupKey(String securityGroupName,
                                     String securityGroupId,
                                     String region,
                                     String account) {
-    "$GoogleCloudProvider.GCE:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}"
+    "$GoogleCloudProvider.ID:${Namespace.SECURITY_GROUPS}:${securityGroupName}:${securityGroupId}:${region}:${account}"
   }
 
   static String getServerGroupKey(String managedInstanceGroupName,
@@ -248,17 +248,17 @@ class Keys {
                                   String region,
                                   String zone) {
     Names names = Names.parseName(managedInstanceGroupName)
-    "$GoogleCloudProvider.GCE:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}${zone ? ":$zone" : ""}"
+    "$GoogleCloudProvider.ID:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${names.group}${zone ? ":$zone" : ""}"
   }
 
   static String getSslCertificateKey(String account,
                                      String sslCertificateName) {
-    "$GoogleCloudProvider.GCE:${Namespace.SSL_CERTIFICATES}:${account}:${sslCertificateName}"
+    "$GoogleCloudProvider.ID:${Namespace.SSL_CERTIFICATES}:${account}:${sslCertificateName}"
   }
 
   static String getSubnetKey(String subnetName,
                              String region,
                              String account) {
-    "$GoogleCloudProvider.GCE:${Namespace.SUBNETS}:${subnetName}:${account}:${region}"
+    "$GoogleCloudProvider.ID:${Namespace.SUBNETS}:${subnetName}:${account}:${region}"
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/controllers/GoogleLoadBalancerController.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/controllers/GoogleLoadBalancerController.groovy
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Component
 @Component
 class GoogleLoadBalancerController implements LoadBalancerProviderTempShim {
 
-  final String cloudProvider = GoogleCloudProvider.GCE
+  final String cloudProvider = GoogleCloudProvider.ID
 
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
@@ -204,7 +204,7 @@ class GoogleLoadBalancerController implements LoadBalancerProviderTempShim {
     String account
     String region
     String name
-    String type = GoogleCloudProvider.GCE
+    String type = GoogleCloudProvider.ID
     List<String> backendServices
     String urlMapName
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleCluster.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleCluster.groovy
@@ -38,7 +38,7 @@ class GoogleCluster {
   @Canonical
   class View implements Cluster {
 
-    final String type = GoogleCloudProvider.GCE
+    final String type = GoogleCloudProvider.ID
 
     String name = GoogleCluster.this.name
     String accountName = GoogleCluster.this.accountName

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleInstance.groovy
@@ -73,7 +73,8 @@ class GoogleInstance {
   @Canonical
   class View implements Instance {
 
-    final String providerType = GoogleCloudProvider.GCE
+    final String providerType = GoogleCloudProvider.ID
+    final String cloudProvider = GoogleCloudProvider.ID
 
     String name = GoogleInstance.this.name
     String instanceId = GoogleInstance.this.name

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleSecurityGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleSecurityGroup.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
 import com.netflix.spinnaker.clouddriver.model.SecurityGroup
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule
@@ -25,7 +26,8 @@ import groovy.transform.Immutable
 @Immutable
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 class GoogleSecurityGroup implements SecurityGroup {
-  final String type
+  final String type = GoogleCloudProvider.ID
+  final String cloudProvider = GoogleCloudProvider.ID
   final String id
   final String name
   final String description

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
@@ -71,7 +71,8 @@ class GoogleServerGroup {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @Canonical
   class View implements ServerGroup {
-    final String type = GoogleCloudProvider.GCE
+    final String type = GoogleCloudProvider.ID
+    final String cloudProvider = GoogleCloudProvider.ID
     static final String REGIONAL_LOAD_BALANCER_NAMES = "load-balancer-names"
     static final String GLOBAL_LOAD_BALANCER_NAMES = "global-load-balancer-names"
     static final String BACKEND_SERVICE_NAMES = "backend-service-names"

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleLoadBalancer.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleLoadBalancer.groovy
@@ -45,7 +45,7 @@ class GoogleLoadBalancer {
   }
 
   class View extends GoogleLoadBalancerView {
-    final String type = GoogleCloudProvider.GCE
+    final String type = GoogleCloudProvider.ID
     GoogleLoadBalancerType loadBalancerType = GoogleLoadBalancer.this.type
     GoogleLoadBalancingScheme loadBalancingScheme = GoogleLoadBalancer.this.loadBalancingScheme
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleLoadBalancerView.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleLoadBalancerView.groovy
@@ -24,7 +24,8 @@ import groovy.transform.Canonical
 
 @Canonical
 abstract class GoogleLoadBalancerView implements LoadBalancer {
-  final String type = GoogleCloudProvider.GCE
+  final String type = GoogleCloudProvider.ID
+  final String cloudProvider = GoogleCloudProvider.ID
   GoogleLoadBalancerType loadBalancerType
   GoogleLoadBalancingScheme loadBalancingScheme
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -63,7 +63,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
     this.metricsSupport = new OnDemandMetricsSupport(
         registry,
         this,
-        "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.LoadBalancer}"
+        "${GoogleCloudProvider.ID}:${OnDemandAgent.OnDemandType.LoadBalancer}"
     )
   }
 
@@ -139,7 +139,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.GCE
+    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
@@ -66,7 +66,7 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
                                          Registry registry) {
     super(clouddriverUserAgentApplicationName, credentials, objectMapper)
     this.region = region
-    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.LoadBalancer}")
+    this.metricsSupport = new OnDemandMetricsSupport(registry, this, "${GoogleCloudProvider.ID}:${OnDemandAgent.OnDemandType.LoadBalancer}")
   }
 
   @Override
@@ -132,7 +132,7 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.GCE
+    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -70,7 +70,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
     this.metricsSupport = new OnDemandMetricsSupport(
         registry,
         this,
-        "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.LoadBalancer}")
+        "${GoogleCloudProvider.ID}:${OnDemandAgent.OnDemandType.LoadBalancer}")
   }
 
   @Override
@@ -132,7 +132,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.GCE
+    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -76,7 +76,7 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
     this.metricsSupport = new OnDemandMetricsSupport(
       registry,
       this,
-      "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.ServerGroup}")
+      "${GoogleCloudProvider.ID}:${OnDemandAgent.OnDemandType.ServerGroup}")
   }
 
   @Override
@@ -155,7 +155,7 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == GoogleCloudProvider.GCE
+    type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == GoogleCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -54,7 +54,7 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
     this.metricsSupport = new OnDemandMetricsSupport(
         registry,
         this,
-        "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.SecurityGroup}")
+        "${GoogleCloudProvider.ID}:${OnDemandAgent.OnDemandType.SecurityGroup}")
   }
 
   @Override
@@ -85,7 +85,7 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == GoogleCloudProvider.GCE
+    type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == GoogleCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -66,7 +66,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
     this.metricsSupport = new OnDemandMetricsSupport(
         registry,
         this,
-        "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.LoadBalancer}"
+        "${GoogleCloudProvider.ID}:${OnDemandAgent.OnDemandType.LoadBalancer}"
     )
   }
 
@@ -135,7 +135,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
   }
 
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.GCE
+    type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
@@ -83,7 +83,7 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
     this.metricsSupport = new OnDemandMetricsSupport(
       registry,
       this,
-      "${GoogleCloudProvider.GCE}:${OnDemandAgent.OnDemandType.ServerGroup}")
+      "${GoogleCloudProvider.ID}:${OnDemandAgent.OnDemandType.ServerGroup}")
   }
 
   @Override
@@ -157,7 +157,7 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == GoogleCloudProvider.GCE
+    type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == GoogleCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.groovy
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleApplication
 import com.netflix.spinnaker.clouddriver.model.ApplicationProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.APPLICATIONS
@@ -51,7 +50,7 @@ class GoogleApplicationProvider implements ApplicationProvider {
   Set<GoogleApplication.View> getApplications(boolean expand) {
     def filter = expand ? RelationshipCacheFilter.include(CLUSTERS.ns) : RelationshipCacheFilter.none()
     cacheView.getAll(APPLICATIONS.ns,
-                     cacheView.filterIdentifiers(APPLICATIONS.ns, "$GoogleCloudProvider.GCE:*"),
+                     cacheView.filterIdentifiers(APPLICATIONS.ns, "$GoogleCloudProvider.ID:*"),
                      filter).collect { applicationFromCacheData(it) } as Set
   }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleImageProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleImageProvider.groovy
@@ -24,8 +24,6 @@ import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.controllers.GoogleNamedImageLookupController.ImageProvider
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.IMAGES
@@ -38,7 +36,7 @@ class GoogleImageProvider implements ImageProvider {
   Cache cacheView
 
   Map<String, List<Image>> listImagesByAccount() {
-    def filter = cacheView.filterIdentifiers(IMAGES.ns, "$GoogleCloudProvider.GCE:*")
+    def filter = cacheView.filterIdentifiers(IMAGES.ns, "$GoogleCloudProvider.ID:*")
     def result = [:].withDefault { _ -> []}
 
     cacheView.getAll(IMAGES.ns, filter).each { CacheData cacheData ->

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
@@ -51,7 +51,7 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance.View> {
   @Autowired
   GoogleSecurityGroupProvider securityGroupProvider
 
-  final String platform = GoogleCloudProvider.GCE
+  final String cloudProvider = GoogleCloudProvider.ID
 
   @Override
   GoogleInstance.View getInstance(String account, String region, String id) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
@@ -49,7 +49,7 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
 
     def applicationServerGroups = cacheView.getAll(
         SERVER_GROUPS.ns,
-        cacheView.filterIdentifiers(SERVER_GROUPS.ns, "${GoogleCloudProvider.GCE}:*:${application}-*")
+        cacheView.filterIdentifiers(SERVER_GROUPS.ns, "${GoogleCloudProvider.ID}:*:${application}-*")
     )
     applicationServerGroups.each { CacheData serverGroup ->
       identifiers.addAll(serverGroup.relationships[LOAD_BALANCERS.ns] ?: [])

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleNetworkProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleNetworkProvider.groovy
@@ -36,7 +36,7 @@ class GoogleNetworkProvider implements NetworkProvider<GoogleNetwork> {
   private final Cache cacheView
   final ObjectMapper objectMapper
 
-  final String cloudProvider = GoogleCloudProvider.GCE
+  final String cloudProvider = GoogleCloudProvider.ID
 
   @Autowired
   GoogleNetworkProvider(Cache cacheView, ObjectMapper objectMapper) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProvider.groovy
@@ -41,7 +41,7 @@ class GoogleSecurityGroupProvider implements SecurityGroupProvider<GoogleSecurit
   final Cache cacheView
   final ObjectMapper objectMapper
 
-  String type = GoogleCloudProvider.GCE
+  final String cloudProvider = GoogleCloudProvider.ID
 
   @Autowired
   GoogleSecurityGroupProvider(Cache cacheView, ObjectMapper objectMapper) {
@@ -107,7 +107,6 @@ class GoogleSecurityGroupProvider implements SecurityGroupProvider<GoogleSecurit
     List<Rule> inboundRules = includeRules ? buildInboundIpRangeRules(firewall) : []
 
     new GoogleSecurityGroup(
-      type: this.type,
       id: firewall.name,
       name: firewall.name,
       description: firewall.description,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSubnetProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSubnetProvider.groovy
@@ -37,7 +37,7 @@ class GoogleSubnetProvider implements SubnetProvider<GoogleSubnet> {
   private final Cache cacheView
   final ObjectMapper objectMapper
 
-  final String type = GoogleCloudProvider.GCE
+  final String cloudProvider = GoogleCloudProvider.ID
 
   @Autowired
   GoogleSubnetProvider(Cache cacheView, ObjectMapper objectMapper) {
@@ -70,7 +70,7 @@ class GoogleSubnetProvider implements SubnetProvider<GoogleSubnet> {
     Map<String, String> parts = Keys.parse(cacheData.id)
 
     new GoogleSubnet(
-      type: this.type,
+      type: this.cloudProvider,
       id: subnet.name,
       name: subnet.name,
       gatewayAddress: subnet.gatewayAddress,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.groovy
@@ -34,7 +34,7 @@ class GoogleNamedAccountCredentials implements AccountCredentials<GoogleCredenti
   final String name // aka accountName
   final String environment
   final String accountType
-  final String cloudProvider = GoogleCloudProvider.GCE // duh.
+  final String cloudProvider = GoogleCloudProvider.ID // duh.
   final List<String> requiredGroupMembership
   final GoogleCredentials credentials
 
@@ -173,7 +173,7 @@ class GoogleNamedAccountCredentials implements AccountCredentials<GoogleCredenti
       new GoogleNamedAccountCredentials(name,
                                         environment,
                                         accountType,
-                                        GoogleCloudProvider.GCE,
+                                        GoogleCloudProvider.ID,
                                         requiredGroupMembership,
                                         credentials,
                                         project,

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProviderSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProviderSpec.groovy
@@ -143,7 +143,6 @@ class GoogleSecurityGroupProviderSpec extends Specification {
 
     then:
       sg == new GoogleSecurityGroup(
-        type: 'gce',
         id: 'name-a',
         name: 'name-a',
         network: 'default',

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/KubernetesCloudProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/KubernetesCloudProvider.groovy
@@ -27,8 +27,7 @@ import java.lang.annotation.Annotation
 @Component
 class KubernetesCloudProvider implements CloudProvider {
   static final String ID = "kubernetes"
-
   final String id = ID
   final String displayName = "Kubernetes"
-  final Class<Annotation> operationAnnotationType = KubernetesOperation.class
+  final Class<Annotation> operationAnnotationType = KubernetesOperation
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstance.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesInstance.groovy
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.model
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
@@ -37,7 +37,8 @@ class KubernetesInstance implements Instance, Serializable {
   Pod pod
   List<String> loadBalancers
   List<KubernetesEvent> events
-  String providerType = "kubernetes"
+  final String providerType = KubernetesCloudProvider.ID
+  final String cloudProvider = KubernetesCloudProvider.ID
   String yaml
 
   boolean isAttached(String serviceName) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.model
 
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiConverter
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
@@ -30,7 +31,8 @@ import io.fabric8.kubernetes.client.internal.SerializationUtils
 @EqualsAndHashCode(includes = ["name", "account"])
 class KubernetesLoadBalancer implements LoadBalancer, Serializable {
   String name
-  String type = "kubernetes"
+  final String type = KubernetesCloudProvider.ID
+  final String cloudProvider = KubernetesCloudProvider.ID
   String region
   String namespace
   String account

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesSecurityGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesSecurityGroup.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.model
 
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiConverter
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.securitygroup.KubernetesSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.model.SecurityGroup
@@ -25,7 +26,8 @@ import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule
 import io.fabric8.kubernetes.api.model.extensions.Ingress
 
 class KubernetesSecurityGroup implements SecurityGroup, Serializable {
-  String type = "kubernetes"
+  final String type = KubernetesCloudProvider.ID
+  final String cloudProvider = KubernetesCloudProvider.ID
 
   static final private HTTP_PORT = 80
   static final private HTTPS_PORT = 443

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.model
 
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiConverter
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.DeployKubernetesAtomicOperationDescription
@@ -34,7 +35,8 @@ import io.fabric8.kubernetes.client.internal.SerializationUtils
 @EqualsAndHashCode(includes = ["name", "namespace"])
 class KubernetesServerGroup implements ServerGroup, Serializable {
   String name
-  String type = "kubernetes"
+  final String type = KubernetesCloudProvider.ID
+  final String cloudProvider = KubernetesCloudProvider.ID
   String region
   String namespace
   String account

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesInstanceProvider.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesInstance
 import com.netflix.spinnaker.clouddriver.model.InstanceProvider
@@ -38,7 +39,7 @@ class KubernetesInstanceProvider implements InstanceProvider<KubernetesInstance>
     this.objectMapper = objectMapper
   }
 
-  String platform = Keys.Namespace.provider
+  final String cloudProvider = KubernetesCloudProvider.ID
 
   @Override
   KubernetesInstance getInstance(String account, String namespace, String name) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesSecurityGroupProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesSecurityGroupProvider.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.provider.view
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesSecurityGroup
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupProvider
@@ -28,6 +29,8 @@ import org.springframework.stereotype.Component
 
 @Component
 class KubernetesSecurityGroupProvider implements SecurityGroupProvider<KubernetesSecurityGroup> {
+
+  final String cloudProvider = KubernetesCloudProvider.ID
   private final Cache cacheView
   private final ObjectMapper objectMapper
 
@@ -36,8 +39,6 @@ class KubernetesSecurityGroupProvider implements SecurityGroupProvider<Kubernete
     this.cacheView = cacheView
     this.objectMapper = objectMapper
   }
-
-  String type = 'kubernetes'
 
   @Override
   Set<KubernetesSecurityGroup> getAll(boolean includeRules) {

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/OpenstackCloudProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/OpenstackCloudProvider.groovy
@@ -21,15 +21,13 @@ import org.springframework.stereotype.Component
 
 import java.lang.annotation.Annotation
 
-
+/**
+ * Openstack declaration as a {@link CloudProvider}.
+ */
 @Component
 class OpenstackCloudProvider implements CloudProvider {
   static final String ID = "openstack"
+  final String id = ID
   final String displayName = "Openstack"
-  final Class<Annotation> operationAnnotationType = OpenstackOperation.class
-
-  @Override
-  String getId() {
-    ID
-  }
+  final Class<Annotation> operationAnnotationType = OpenstackOperation
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackInstance.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackInstance.groovy
@@ -80,6 +80,7 @@ class OpenstackInstance {
   class View implements Instance {
 
     final String providerType = OpenstackCloudProvider.ID //expected by deck
+    final String cloudProvider = OpenstackCloudProvider.ID //expected by deck
 
     String name = OpenstackInstance.this.instanceId //expected by deck
     String instanceId = OpenstackInstance.this.instanceId

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackLoadBalancer.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackLoadBalancer.groovy
@@ -31,9 +31,10 @@ import org.openstack4j.model.network.ext.LoadBalancerV2
 
 @Canonical
 @JsonIgnoreProperties(['createdRegex', 'createdPattern'])
-class OpenstackLoadBalancer implements LoadBalancerResolver {
+class OpenstackLoadBalancer implements LoadBalancerResolver, LoadBalancer {
 
-  String type = OpenstackCloudProvider.ID
+  final String type = OpenstackCloudProvider.ID
+  final String cloudProvider = OpenstackCloudProvider.ID
   String account
   String region
   String id
@@ -80,7 +81,7 @@ class OpenstackLoadBalancer implements LoadBalancerResolver {
     new View(account: account, region: region, id: id, name: name,
       description: description, status: status, algorithm: algorithm,
       listeners: listeners, healthMonitor: healthMonitor, ip: floatingIP?.floatingIpAddress,
-      subnetId: subnet?.id, subnetName: subnet?.name, healths: healths, type: type,
+      subnetId: subnet?.id, subnetName: subnet?.name, healths: healths,
       networkId: network?.id, networkName: network?.name, serverGroups: serverGroups ?: [].toSet(), securityGroups: securityGroups ?: [].toSet())
   }
 
@@ -111,7 +112,7 @@ class OpenstackLoadBalancer implements LoadBalancerResolver {
 
   @Canonical
   @JsonIgnoreProperties(['createdRegex', 'createdPattern'])
-  static class View extends OpenstackLoadBalancer implements LoadBalancer, LoadBalancerProviderTempShim.Details {
+  static class View extends OpenstackLoadBalancer implements LoadBalancerProviderTempShim.Details {
     String ip = ""
     String subnetId = ""
     String subnetName = ""

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackSecurityGroup.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackSecurityGroup.groovy
@@ -29,6 +29,7 @@ import groovy.transform.Immutable
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 class OpenstackSecurityGroup implements SecurityGroup {
   final String type = OpenstackCloudProvider.ID
+  final String cloudProvider = OpenstackCloudProvider.ID
   final String id
   final String name
   final String description

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackServerGroup.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackServerGroup.groovy
@@ -75,6 +75,7 @@ class OpenstackServerGroup {
     Map<String, Object> buildInfo = OpenstackServerGroup.this.buildInfo
     Boolean disabled = OpenstackServerGroup.this.disabled
     String type = OpenstackServerGroup.this.type
+    String cloudProvider = OpenstackServerGroup.this.type
     String subnetId = OpenstackServerGroup.this.subnetId
     Map<String, Object> advancedConfig = OpenstackServerGroup.this.advancedConfig
     Map<String, String> tags = OpenstackServerGroup.this.tags

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackInstanceProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackInstanceProvider.groovy
@@ -36,6 +36,7 @@ import static com.netflix.spinnaker.clouddriver.openstack.cache.Keys.Namespace.L
 
 @Component
 class OpenstackInstanceProvider implements InstanceProvider<OpenstackInstance.View> {
+  final String cloudProvider = OpenstackCloudProvider.ID
   final Cache cacheView
   final AccountCredentialsProvider accountCredentialsProvider
   final ObjectMapper objectMapper
@@ -45,11 +46,6 @@ class OpenstackInstanceProvider implements InstanceProvider<OpenstackInstance.Vi
     this.cacheView = cacheView
     this.accountCredentialsProvider = accountCredentialsProvider
     this.objectMapper = objectMapper
-  }
-
-  @Override
-  String getPlatform() {
-    OpenstackCloudProvider.ID
   }
 
   Set<OpenstackInstance.View> getInstances(Collection<String> cacheKeys) {

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackSecurityGroupProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackSecurityGroupProvider.groovy
@@ -38,6 +38,7 @@ import static com.netflix.spinnaker.clouddriver.openstack.cache.Keys.Namespace.S
 @Component
 class OpenstackSecurityGroupProvider implements SecurityGroupProvider<OpenstackSecurityGroup> {
 
+  final String cloudProvider = OpenstackCloudProvider.ID
   final Cache cacheView
   final ObjectMapper objectMapper
 
@@ -45,11 +46,6 @@ class OpenstackSecurityGroupProvider implements SecurityGroupProvider<OpenstackS
   OpenstackSecurityGroupProvider(Cache cacheView, ObjectMapper objectMapper) {
     this.cacheView = cacheView
     this.objectMapper = objectMapper
-  }
-
-  @Override
-  String getType() {
-    OpenstackCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackSubnetProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackSubnetProvider.groovy
@@ -36,15 +36,12 @@ class OpenstackSubnetProvider implements SubnetProvider<OpenstackSubnet> {
   final Cache cacheView
   final ObjectMapper objectMapper
 
+  final String cloudProvider = OpenstackCloudProvider.ID
+
   @Autowired
   OpenstackSubnetProvider(final Cache cacheView, final ObjectMapper objectMapper) {
     this.cacheView = cacheView
     this.objectMapper = objectMapper
-  }
-
-  @Override
-  String getType() {
-    OpenstackCloudProvider.ID
   }
 
   @Override

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackLoadBalancerProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackLoadBalancerProviderSpec.groovy
@@ -268,7 +268,7 @@ class OpenstackLoadBalancerProviderSpec extends Specification {
   @Ignore
   OpenstackLoadBalancer.View buildLoadBalancerView(OpenstackLoadBalancer loadBalancer, OpenstackFloatingIP floatingIP, OpenstackNetwork network, OpenstackSubnet subnet) {
     new OpenstackLoadBalancer.View(id: loadBalancer.id, name: loadBalancer.name, description: loadBalancer.description,
-      account: account, region: region, type: loadBalancer.type,
+      account: account, region: region,
       ip: floatingIP.id, subnetId: subnet.id,
       subnetName: subnet.name, networkId: network.id, networkName: network.name,
       serverGroups: [new LoadBalancerServerGroup(name: 'myapp-teststack-v002')])

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackSecurityGroupProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackSecurityGroupProviderSpec.groovy
@@ -59,9 +59,9 @@ class OpenstackSecurityGroupProviderSpec extends Specification {
     cache.mergeAll(Keys.Namespace.SECURITY_GROUPS.ns, getAllCacheData())
   }
 
-  def "type is openstack"() {
+  def "cloudProvider is openstack"() {
     when:
-    def type = provider.getType()
+    def type = provider.getCloudProvider()
 
     then:
     type == OpenstackCloudProvider.ID

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusCloudProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusCloudProvider.groovy
@@ -22,9 +22,13 @@ import org.springframework.stereotype.Component
 
 import java.lang.annotation.Annotation
 
+/**
+ * Titus declaration as a {@link CloudProvider}.
+ */
 @Component
 class TitusCloudProvider implements CloudProvider {
-  final String id = Keys.PROVIDER
+  static final String ID = Keys.PROVIDER
+  final String id = ID
   final String displayName = "Titus"
-  final Class<? extends Annotation> operationAnnotationType = TitusOperation
+  final Class<Annotation> operationAnnotationType = TitusOperation
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusInstanceProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusInstanceProvider.groovy
@@ -35,7 +35,7 @@ import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IN
 
 @Component
 class TitusInstanceProvider implements InstanceProvider<TitusInstance> {
-
+  final String cloudProvider = TitusCloudProvider.ID
   private final Cache cacheView
   private final ObjectMapper objectMapper
   private final TitusCloudProvider titusCloudProvider
@@ -82,11 +82,6 @@ class TitusInstanceProvider implements InstanceProvider<TitusInstance> {
       }
     }
     instance
-  }
-
-  @Override
-  String getPlatform() {
-    titusCloudProvider.id
   }
 
   @Override

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.titus.model
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
+import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 import com.netflix.spinnaker.clouddriver.titus.client.model.Efs
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
 import com.netflix.spinnaker.clouddriver.titus.client.model.TaskState
@@ -41,6 +42,8 @@ class TitusInstance implements Instance {
   TitusInstanceResources resources = new TitusInstanceResources()
   TitusInstancePlacement placement = new TitusInstancePlacement()
   Set<TitusSecurityGroup> securityGroups
+  final String providerType = TitusCloudProvider.ID
+  final String cloudProvider = TitusCloudProvider.ID
 
   TitusInstance(Job job, Job.TaskSummary task) {
     id = task.id

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
@@ -20,7 +20,7 @@ import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
-import com.netflix.spinnaker.clouddriver.titus.caching.Keys
+import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 import com.netflix.spinnaker.clouddriver.titus.client.model.Efs
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
 
@@ -30,11 +30,10 @@ import com.netflix.spinnaker.clouddriver.titus.client.model.Job
  */
 class TitusServerGroup implements ServerGroup, Serializable {
 
-  public static final String TYPE = Keys.PROVIDER
-
   String id
   String name
-  String type = TYPE
+  final String type = TitusCloudProvider.ID
+  final String cloudProvider = TitusCloudProvider.ID
   String entryPoint
   String iamProfile
   List<String> securityGroups

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/InstanceController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/InstanceController.groovy
@@ -57,12 +57,14 @@ class InstanceController {
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
   @RequestMapping(value = "{account}/{region}/{id}/console", method = RequestMethod.GET)
-  Map getConsoleOutput(@RequestParam(value = "provider", required = false) String provider,
+  Map getConsoleOutput(@RequestParam(value = "provider", required = false) String provider, // deprecated
+                       @RequestParam(value = "cloudProvider", required = false) String cloudProvider,
                        @PathVariable String account,
                        @PathVariable String region,
                        @PathVariable String id) {
+    String providerParam = cloudProvider ?: provider
     Collection<String> outputs = instanceProviders.findResults {
-      if (!provider || it.platform == provider) {
+      if (!providerParam || it.cloudProvider == providerParam) {
         return it.getConsoleOutput(account, region, id)
       }
       null

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
@@ -131,6 +131,7 @@ class ServerGroupController {
     String cluster
     String vpcId
     String type
+    String cloudProvider
     String instanceType
     Boolean isDisabled
     Map buildInfo
@@ -144,6 +145,7 @@ class ServerGroupController {
     ServerGroupViewModel(ServerGroup serverGroup, Cluster cluster) {
       this.cluster = cluster.name
       type = serverGroup.type
+      cloudProvider = serverGroup.cloudProvider
       name = serverGroup.name
       account = cluster.accountName
       region = serverGroup.region

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SubnetController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SubnetController.groovy
@@ -41,7 +41,7 @@ class SubnetController {
   @RequestMapping(method = RequestMethod.GET, value = "/{cloudProvider}")
   Set<Subnet> listByCloudProvider(@PathVariable String cloudProvider) {
     subnetProviders.findAll { subnetProvider ->
-      subnetProvider.type == cloudProvider
+      subnetProvider.cloudProvider == cloudProvider
     } collectMany {
       it.all
     }

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectControllerSpec.groovy
@@ -455,6 +455,7 @@ class ProjectControllerSpec extends Specification {
     Long createdTime
     InstanceCounts instanceCounts
     String type = "test"
+    String cloudProvider = "test"
     String region
     Boolean disabled
     Set<String> instances = []


### PR DESCRIPTION
As part of an effort to clean up the provider/cloudProvider/providerType/cloudProviderType/plathform/type mess, this PR normalizes around `cloudProvider` as the preferred field for the `Instance`, `ServerGroup`, 'SecurityGroup`, and `LoadBalancer` interfaces.

Since a number of dependent services (deck and orca at a minimum) seem to depend on `providerType`, I'm leaving it in place and deprecating.

Also cleaning up all the `CloudProvider` interfaces to get rid of the snowflake implementations.

These changes should be non-breaking. I'd like to clean up Orca next to stop sending `providerType` to Clouddriver (but accept it and convert it to `cloudProvider` if it's present), then clean up Deck to get rid of `providerType` altogether.