### PR TITLE
provider/docker: do not cache images without tags

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/cache/Keys.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/cache/Keys.groovy
@@ -51,6 +51,9 @@ class Keys {
 
     switch (result.type) {
       case Namespace.TAGGED_IMAGE.ns:
+        if (parts.length < 5) {
+          return null
+        }
         result << [account: parts[2], repository: parts[3], tag: parts[4]]
         break
       case Namespace.IMAGE_ID.ns:

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -110,6 +110,10 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware {
 
     tagMap.forEach { repository, tags ->
       tags.forEach { tag ->
+        if (!tag) {
+          log.warn("Empty tag encountered for $accountName/$repository, not caching")
+          return
+        }
         def tagKey = Keys.getTaggedImageKey(accountName, repository, tag)
         def imageIdKey = Keys.getImageIdKey(DockerRegistryProviderUtils.imageId(registry, repository, tag))
         def digest = null


### PR DESCRIPTION
We ran into an issue over the weekend where we somehow cached an image with an empty tag. Later, when trying to read the image, we got an `ArrayIndexOutOfBoundsException` because splitting the key on `:` only gave us four `String`s.

This PR adds two guards: one on the caching, one on the read.

@tomaslin @lwander PTAL