### PR TITLE
provider/docker: handle find via key parsing if trackDigests disabled

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/DockerRegistryCloudProvider.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/DockerRegistryCloudProvider.groovy
@@ -28,7 +28,8 @@ import java.lang.annotation.Annotation
  */
 @Component
 class DockerRegistryCloudProvider implements CloudProvider {
-  final String id = "dockerRegistry"
+  public static final String DOCKER_REGISTRY = "dockerRegistry"
+  final String id = DOCKER_REGISTRY
   final String displayName = "Docker Registry"
   // The docker registry is only used for caching, so none of the op/ endpoints will be hit.
   final Class<Annotation> operationAnnotationType = Annotation.class


### PR DESCRIPTION
We are hitting the `/find` endpoint a lot more these days, but it's frequently slow (15-40s), as it fetches > 40k images and their attributes.

We don't have trackDigests enabled, so there's no sense in fetching all the data for each key in this scenario - all the info is available in the key itself, so we can just parse it to get the data.

This change is tactical, performing the "find to get a list of all images" function in a lighter way when appropriate, i.e. when all Docker credentials are configured with trackDigests disabled.

@lwander @tomaslin PTAL - running this locally, I am getting the same results back in ~1s