### PR TITLE
provider/google: Handle partial LB cache data in fetch calls.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
@@ -29,14 +29,12 @@ import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
-import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.*
 
 @Component
-@Slf4j
 class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalancerView> {
 
   @Autowired
@@ -65,7 +63,6 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
   }
 
   GoogleLoadBalancerView loadBalancersFromCacheData(CacheData loadBalancerCacheData) {
-    log.info("Raw load balancer cache data we are loading the load balancer from: ${loadBalancerCacheData.attributes}")
     def loadBalancer = null
     switch (GoogleLoadBalancerType.valueOf(loadBalancerCacheData.attributes?.type as String)) {
       case GoogleLoadBalancerType.INTERNAL:
@@ -86,7 +83,6 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
     }
 
     GoogleLoadBalancerView loadBalancerView = loadBalancer?.view
-    log.info("Load balancer view loaded from the cache: ${loadBalancerView}")
 
     def serverGroupKeys = loadBalancerCacheData.relationships[SERVER_GROUPS.ns]
     if (!serverGroupKeys) {


### PR DESCRIPTION
@duftler please review. The LB cache call [here](https://www.google.com/url?q=https://github.com/spinnaker/clouddriver/blob/master/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy%23L48&sa=D&usg=AFQjCNGxYKGnvVXnp4-FgSiHCw2HX4xT3A) loops over all the cached LBs, which can be malformed in funky timing cases (e.g. if one of the GCP calls in the caching agent hangs, etc). This seems to be the only place this isn't handled properly.

We have been experiencing very intermittent issues where the load balancer we are operating on is well-formed, but another in the cache occasionally seems to be malformed, causing failures. This will give us some resiliency to these timing issues so completely unrelated operations don't fail for bad LB cache entries.