### PR TITLE
provider/google: Make SafeRetry a configurable bean.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEServerGroupNameResolver.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEServerGroupNameResolver.groovy
@@ -30,10 +30,13 @@ class GCEServerGroupNameResolver extends AbstractServerGroupNameResolver {
   private final String region
   private final GoogleNamedAccountCredentials credentials
 
-  GCEServerGroupNameResolver(String project, String region, GoogleNamedAccountCredentials credentials) {
+  private SafeRetry safeRetry
+
+  GCEServerGroupNameResolver(String project, String region, GoogleNamedAccountCredentials credentials, SafeRetry safeRetry) {
     this.project = project
     this.region = region
     this.credentials = credentials
+    this.safeRetry = safeRetry
   }
 
   @Override
@@ -48,7 +51,7 @@ class GCEServerGroupNameResolver extends AbstractServerGroupNameResolver {
 
   @Override
   List<AbstractServerGroupNameResolver.TakenSlot> getTakenSlots(String clusterName) {
-    def managedInstanceGroups = GCEUtil.queryAllManagedInstanceGroups(project, region, credentials, task, phase)
+    def managedInstanceGroups = GCEUtil.queryAllManagedInstanceGroups(project, region, credentials, task, phase, safeRetry)
 
     return findMatchingManagedInstanceGroups(managedInstanceGroups, clusterName)
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GoogleOperationPoller.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GoogleOperationPoller.groovy
@@ -37,6 +37,9 @@ class GoogleOperationPoller {
   @Autowired
   GoogleConfigurationProperties googleConfigurationProperties
 
+  @Autowired
+  SafeRetry safeRetry
+
   @VisibleForTesting
   ThreadSleeper threadSleeper = new ThreadSleeper()
 
@@ -105,8 +108,7 @@ class GoogleOperationPoller {
 
       totalTimePollingSeconds += pollInterval
 
-      def retry = new SafeRetry<Operation>()
-      Operation operation = retry.doRetry(getOperation, "wait", "operation", null, null, [], [])
+      Operation operation = safeRetry.doRetry(getOperation, "wait", "operation", null, null, [], []) as Operation
 
       if (operation.getStatus() == "DONE") {
         return operation

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperation.groovy
@@ -21,8 +21,10 @@ import com.google.api.services.compute.model.TargetPoolsRemoveInstanceRequest
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeregisterInstancesFromGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
 
 /**
  * Remove specified instances from an existing NetworkLoadBalancer.
@@ -37,6 +39,9 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperation implements Atomic
   }
 
   private final DeregisterInstancesFromGoogleLoadBalancerDescription description
+
+  @Autowired
+  SafeRetry safeRetry
 
   DeregisterInstancesFromGoogleLoadBalancerAtomicOperation(
     DeregisterInstancesFromGoogleLoadBalancerDescription description) {
@@ -57,7 +62,7 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperation implements Atomic
     def region = description.region
     def compute = description.credentials.compute
 
-    def forwardingRules = GCEUtil.queryRegionalForwardingRules(project, region, loadBalancerNames, compute, task, BASE_PHASE)
+    def forwardingRules = GCEUtil.queryRegionalForwardingRules(project, region, loadBalancerNames, compute, task, BASE_PHASE, safeRetry)
     def instanceUrls = GCEUtil.queryInstanceUrls(project, region, instanceIds, compute, task, BASE_PHASE)
 
     loadBalancerNames.each { lbName ->

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
@@ -51,6 +51,9 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
   @Autowired
   GoogleLoadBalancerProvider googleLoadBalancerProvider
 
+  @Autowired
+  SafeRetry safeRetry
+
   DestroyGoogleServerGroupAtomicOperation(DestroyGoogleServerGroupDescription description) {
     this.description = description
   }
@@ -110,9 +113,8 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
     null
   }
 
-  static void destroy(Closure operation, String resource) {
-    def retry = new SafeRetry<Void>()
-    retry.doRetry(operation, "destroy", resource, task, BASE_PHASE, RETRY_ERROR_CODES, SUCCESSFUL_ERROR_CODES)
+  void destroy(Closure operation, String resource) {
+    safeRetry.doRetry(operation, "destroy", resource, task, BASE_PHASE, RETRY_ERROR_CODES, SUCCESSFUL_ERROR_CODES)
   }
 
   Closure destroyInstanceTemplate(Compute compute, String instanceTemplateName, String project) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RegisterInstancesWithGoogleLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RegisterInstancesWithGoogleLoadBalancerAtomicOperation.groovy
@@ -21,8 +21,10 @@ import com.google.api.services.compute.model.TargetPoolsAddInstanceRequest
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RegisterInstancesWithGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
 
 /**
  * Add additional instances to an existing NetworkLoadBalancer.
@@ -37,6 +39,9 @@ class RegisterInstancesWithGoogleLoadBalancerAtomicOperation implements AtomicOp
   }
 
   private final RegisterInstancesWithGoogleLoadBalancerDescription description
+
+  @Autowired
+  SafeRetry safeRetry
 
   RegisterInstancesWithGoogleLoadBalancerAtomicOperation(
     RegisterInstancesWithGoogleLoadBalancerDescription description) {
@@ -57,7 +62,7 @@ class RegisterInstancesWithGoogleLoadBalancerAtomicOperation implements AtomicOp
     def region = description.region
     def compute = description.credentials.compute
 
-    def forwardingRules = GCEUtil.queryRegionalForwardingRules(project, region, loadBalancerNames, compute, task, BASE_PHASE)
+    def forwardingRules = GCEUtil.queryRegionalForwardingRules(project, region, loadBalancerNames, compute, task, BASE_PHASE, safeRetry)
     def instanceUrls = GCEUtil.queryInstanceUrls(project, region, instanceIds, compute, task, BASE_PHASE)
 
     loadBalancerNames.each { lbName ->

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
@@ -55,6 +56,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
 
   @Autowired
   OrchestrationProcessor orchestrationProcessor
+
+  @Autowired
+  SafeRetry safeRetry
 
   private final UpsertGoogleLoadBalancerDescription description
 
@@ -464,7 +468,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
     // Delete extraneous listeners.
     description.listenersToDelete?.each { String forwardingRuleName ->
       task.updateStatus BASE_PHASE, "Deleting listener ${forwardingRuleName}..."
-      GCEUtil.deleteGlobalListener(compute, project, forwardingRuleName)
+      GCEUtil.deleteGlobalListener(compute, project, forwardingRuleName, safeRetry)
     }
 
     task.updateStatus BASE_PHASE, "Done upserting HTTP load balancer $httpLoadBalancerName"

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -26,9 +26,11 @@ import com.google.api.services.compute.model.InstancesScopedList
 import com.google.api.services.compute.model.TargetPoolsRemoveInstanceRequest
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeregisterInstancesFromGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -51,8 +53,11 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec extends S
   private static final INSTANCE_IDS = [INSTANCE_ID1, INSTANCE_ID2]
   private static final INSTANCE_URLS = [INSTANCE_URL1, INSTANCE_URL2]
 
+  @Shared SafeRetry safeRetry
+
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should deregister instances"() {
@@ -89,6 +94,7 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec extends S
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeregisterInstancesFromGoogleLoadBalancerAtomicOperation(description)
+      operation.safeRetry = safeRetry
 
       def request = new TargetPoolsRemoveInstanceRequest()
       request.instances = INSTANCE_URLS.collect { url -> new InstanceReference(instance: url) }
@@ -134,6 +140,7 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec extends S
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeregisterInstancesFromGoogleLoadBalancerAtomicOperation(description)
+      operation.safeRetry = safeRetry
 
       def request = new TargetPoolsRemoveInstanceRequest()
       request.instances = INSTANCE_URLS.collect { url -> new InstanceReference(instance: url) }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DisableGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DisableGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -23,12 +23,13 @@ import com.google.api.services.compute.model.InstanceGroupManagersSetTargetPools
 import com.google.api.services.compute.model.TargetPool
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.EnableDisableGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -67,8 +68,12 @@ class DisableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
   def credentials
   def description
 
+  @Shared
+  SafeRetry safeRetry
+
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   def setup() {
@@ -104,6 +109,7 @@ class DisableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       @Subject def operation = new DisableGoogleServerGroupAtomicOperation(description)
       operation.googleClusterProvider = googleClusterProviderMock
       operation.googleLoadBalancerProvider = googleLoadBalancerProviderMock
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/EnableGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/EnableGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -22,12 +22,14 @@ import com.google.api.services.compute.model.*
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.EnableDisableGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -84,8 +86,11 @@ class EnableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
   def credentials
   def description
 
+  @Shared SafeRetry safeRetry
+
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   def setup() {
@@ -137,6 +142,7 @@ class EnableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       operation.googleClusterProvider = googleClusterProviderMock
       operation.googleLoadBalancerProvider = googleLoadBalancerProviderMock
       operation.objectMapper = objectMapperMock
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -188,6 +194,7 @@ class EnableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       operation.googleClusterProvider = googleClusterProviderMock
       operation.googleLoadBalancerProvider = googleLoadBalancerProviderMock
       operation.objectMapper = objectMapperMock
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec.groovy
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.ModifyGoogleServerGroupInstanceTemplateDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
@@ -72,9 +73,12 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should not make any changes if no properties are overridden"() {
@@ -112,8 +116,11 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                    threadSleeper: threadSleeperMock)
+          new GoogleOperationPoller(
+            googleConfigurationProperties: new GoogleConfigurationProperties(),
+            threadSleeper: threadSleeperMock,
+            safeRetry: safeRetry
+          )
       operation.googleClusterProvider = googleClusterProviderMock
 
     when:
@@ -182,8 +189,11 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                    threadSleeper: threadSleeperMock)
+          new GoogleOperationPoller(
+            googleConfigurationProperties: new GoogleConfigurationProperties(),
+            threadSleeper: threadSleeperMock,
+            safeRetry: safeRetry
+          )
       operation.googleClusterProvider = googleClusterProviderMock
 
     when:
@@ -246,8 +256,11 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                    threadSleeper: threadSleeperMock)
+          new GoogleOperationPoller(
+            googleConfigurationProperties: new GoogleConfigurationProperties(),
+            threadSleeper: threadSleeperMock,
+            safeRetry: safeRetry
+          )
       operation.googleClusterProvider = googleClusterProviderMock
 
     when:
@@ -304,8 +317,11 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                    threadSleeper: threadSleeperMock)
+          new GoogleOperationPoller(
+            googleConfigurationProperties: new GoogleConfigurationProperties(),
+            threadSleeper: threadSleeperMock,
+            safeRetry: safeRetry
+          )
       operation.googleClusterProvider = googleClusterProviderMock
 
     when:
@@ -364,8 +380,11 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
                                                                                credentials: credentials)
       @Subject def operation = new ModifyGoogleServerGroupInstanceTemplateAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                    threadSleeper: threadSleeperMock)
+          new GoogleOperationPoller(
+            googleConfigurationProperties: new GoogleConfigurationProperties(),
+            threadSleeper: threadSleeperMock,
+            safeRetry: safeRetry
+          )
       operation.googleClusterProvider = googleClusterProviderMock
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -55,10 +55,12 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
-    SafeRetry.RETRY_INTERVAL_SEC = 0
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should delete Http Load Balancer with one backend service"() {
@@ -113,8 +115,12 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -237,8 +243,12 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -380,8 +390,12 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -450,7 +464,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def targetHttpProxiesDeleteOp = new Operation(
         name: TARGET_HTTP_PROXY_DELETE_OP_NAME,
         status: PENDING)
-      GCEUtil.deleteGlobalListener(computeMock, PROJECT_NAME, HTTP_LOAD_BALANCER_NAME) >> targetHttpProxiesDeleteOp
+      GCEUtil.deleteGlobalListener(computeMock, PROJECT_NAME, HTTP_LOAD_BALANCER_NAME, safeRetry) >> targetHttpProxiesDeleteOp
 
       def credentials = new GoogleNamedAccountCredentials.Builder().project(PROJECT_NAME).compute(computeMock).build()
       def description = new DeleteGoogleLoadBalancerDescription(
@@ -460,8 +474,12 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -548,8 +566,12 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -643,8 +665,12 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def conflictingMap = new UrlMap(defaultService: BACKEND_SERVICE_URL, name: "conflicting")
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                    threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -709,8 +735,12 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                    threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
@@ -52,10 +52,12 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
-    SafeRetry.RETRY_INTERVAL_SEC = 0
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should delete an Internal Load Balancer with http health check"() {
@@ -104,8 +106,10 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller = new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
       )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -186,8 +190,10 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock
+        threadSleeper: threadSleeperMock,
+        safeRetry: safeRetry
       )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -268,8 +274,10 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock
+        threadSleeper: threadSleeperMock,
+        safeRetry: safeRetry
       )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -361,8 +369,10 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock
+        threadSleeper: threadSleeperMock,
+        safeRetry: safeRetry
       )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -449,8 +459,10 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock
+        threadSleeper: threadSleeperMock,
+        safeRetry: safeRetry
       )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -496,8 +508,10 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock
+        threadSleeper: threadSleeperMock,
+        safeRetry: safeRetry
       )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -53,10 +53,12 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
-    SafeRetry.RETRY_INTERVAL_SEC = 0
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should delete a Network Load Balancer with health checks"() {
@@ -94,8 +96,12 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -152,8 +158,12 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -189,6 +199,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -227,8 +238,12 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -272,8 +287,12 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -324,8 +343,12 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -401,8 +424,12 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
       operation.threadSleeper = operationRetryThreadSleeperMock
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -484,8 +511,12 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
       operation.threadSleeper = operationRetryThreadSleeperMock
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
@@ -51,10 +51,12 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
-    SafeRetry.RETRY_INTERVAL_SEC = 0
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should delete ssl load balancer"() {
@@ -107,8 +109,12 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         credentials: credentials)
       @Subject def operation = new DeleteGoogleSslLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -170,8 +176,12 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         credentials: credentials)
       @Subject def operation = new DeleteGoogleSslLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -212,7 +222,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
       def targetSslProxiesDeleteOp = new Operation(
         name: TARGET_SSL_PROXY_DELETE_OP_NAME,
         status: PENDING)
-      GCEUtil.deleteGlobalListener(computeMock, PROJECT_NAME, SSL_LOAD_BALANCER_NAME) >> targetSslProxiesDeleteOp
+      GCEUtil.deleteGlobalListener(computeMock, PROJECT_NAME, SSL_LOAD_BALANCER_NAME, safeRetry) >> targetSslProxiesDeleteOp
 
       def globalOperations = Mock(Compute.GlobalOperations)
       def targetSslProxiesOperationGet = Mock(Compute.GlobalOperations.Get)
@@ -225,8 +235,12 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         credentials: credentials)
       @Subject def operation = new DeleteGoogleSslLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -286,8 +300,12 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         credentials: credentials)
       @Subject def operation = new DeleteGoogleSslLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.converters.UpsertGoogleLoadBalancerAtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
@@ -44,6 +45,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
   private static final DONE = "DONE"
 
   @Shared GoogleHealthCheck hc
+  @Shared SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -56,6 +58,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         "healthyThreshold"  : 1,
         "unhealthyThreshold": 1
     ]
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should create an HTTP Load Balancer with host rule, path matcher, path rules, etc with no existing infrastructure"() {
@@ -160,7 +163,11 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def description = converter.convertDescription(input)
       @Subject def operation = new UpsertGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
      operation.operate([])
@@ -277,7 +284,11 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def description = converter.convertDescription(input)
       @Subject def operation = new UpsertGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+          new GoogleOperationPoller(
+            googleConfigurationProperties: new GoogleConfigurationProperties(),
+            safeRetry: safeRetry
+          )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -394,7 +405,11 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def description = converter.convertDescription(input)
       @Subject def operation = new UpsertGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-          new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+          new GoogleOperationPoller(
+            googleConfigurationProperties: new GoogleConfigurationProperties(),
+            safeRetry: safeRetry
+          )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -541,7 +556,11 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def description = converter.convertDescription(input)
       @Subject def operation = new UpsertGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -693,7 +712,11 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def description = converter.convertDescription(input)
       @Subject def operation = new UpsertGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -850,7 +873,11 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def description = converter.convertDescription(input)
       @Subject def operation = new UpsertGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])
@@ -1020,7 +1047,11 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def description = converter.convertDescription(input)
       @Subject def operation = new UpsertGoogleHttpLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
@@ -72,9 +73,12 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should create a network load balancer with health checks"() {
@@ -121,8 +125,11 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
 
     when:
       operation.operate([])
@@ -207,8 +214,11 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
 
     when:
       operation.operate([])
@@ -274,8 +284,11 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
 
     when:
       operation.operate([])
@@ -331,8 +344,11 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
 
     when:
       operation.operate([])
@@ -672,8 +688,11 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
 
     when:
       operation.operate([])
@@ -761,8 +780,11 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
 
     when:
       operation.operate([])
@@ -857,8 +879,11 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
       operation.googleOperationPoller =
-        new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties(),
-                                  threadSleeper: threadSleeperMock)
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
@@ -50,10 +50,10 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
   private static final TARGET_PROXY_NAME = "$LOAD_BALANCER_NAME-${UpsertGoogleSslLoadBalancerAtomicOperation.TARGET_SSL_PROXY_NAME_SUFFIX}"
 
   @Shared GoogleHealthCheck hc
+  @Shared SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
-    SafeRetry.RETRY_INTERVAL_SEC = 0
     hc = [
       "name"              : "basic-check",
       "healthCheckType"   : "HTTP",
@@ -64,6 +64,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
       "healthyThreshold"  : 1,
       "unhealthyThreshold": 1
     ]
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0)
   }
 
   void "should create ssl load balancer if no infrastructure present."() {
@@ -134,7 +135,11 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
     def description = converter.convertDescription(input)
     @Subject def operation = new UpsertGoogleSslLoadBalancerAtomicOperation(description)
     operation.googleOperationPoller =
-      new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+      new GoogleOperationPoller(
+        googleConfigurationProperties: new GoogleConfigurationProperties(),
+        safeRetry: safeRetry
+      )
+    operation.safeRetry = safeRetry
 
     when:
     operation.operate([])
@@ -241,7 +246,11 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
     def description = converter.convertDescription(input)
     @Subject def operation = new UpsertGoogleSslLoadBalancerAtomicOperation(description)
     operation.googleOperationPoller =
-      new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+      new GoogleOperationPoller(
+        googleConfigurationProperties: new GoogleConfigurationProperties(),
+        safeRetry: safeRetry
+      )
+    operation.safeRetry = safeRetry
 
     when:
     operation.operate([])
@@ -348,7 +357,11 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
     def description = converter.convertDescription(input)
     @Subject def operation = new UpsertGoogleSslLoadBalancerAtomicOperation(description)
     operation.googleOperationPoller =
-      new GoogleOperationPoller(googleConfigurationProperties: new GoogleConfigurationProperties())
+      new GoogleOperationPoller(
+        googleConfigurationProperties: new GoogleConfigurationProperties(),
+        safeRetry: safeRetry
+      )
+    operation.safeRetry = safeRetry
 
     when:
     operation.operate([])


### PR DESCRIPTION
`SafeRetry` initially used hardcoded values for the max number of retries and the timing jitter between retries. This caused timeouts and operation failures with a large number of parallel operations on the same component. With this PR, these are now configurable to control the retry behavior.

**new config for clouddriver:**
```yaml
google:
  safeRetryMaxWaitIntervalMs: 60000 # maximum interval to wait between retries in ms.
  safeRetryRetryIntevalBaseSec: 2 # base for wait calculation in exponential backoff, e.g. {base sec}^{attempt number}. This should be an integer > 1.
  safeRetryMaxRetries: 10 # maximum number of retries
```

@duftler please review.