### PR TITLE
Ensuring that there are at most 5 security groups per instance (The max is configurable)

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -81,6 +81,7 @@ class AutoScalingWorker {
   private int desiredInstances
 
   private RegionScopedProviderFactory.RegionScopedProvider regionScopedProvider
+  private Integer maxSecurityGroupsPerInstance
 
   AutoScalingWorker() {
 
@@ -203,6 +204,10 @@ class AutoScalingWorker {
     // Favor subnetIds over availability zones
     def subnetIds = subnetIds?.join(',')
     if (subnetIds) {
+      if (securityGroups && maxSecurityGroupsPerInstance && securityGroups.size() > maxSecurityGroupsPerInstance) {
+        throw new IllegalArgumentException("An instance can have at most ${maxSecurityGroupsPerInstance} security groups")
+      }
+
       task.updateStatus AWS_PHASE, " > Deploying to subnetIds: $subnetIds"
       request.withVPCZoneIdentifier(subnetIds)
     } else if (subnetType && !subnets) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -256,7 +256,9 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         regionScopedProvider: regionScopedProvider,
         base64UserData: description.base64UserData,
         legacyUdf: description.legacyUdf,
-        tags: description.tags)
+        tags: description.tags,
+        maxSecurityGroupsPerInstance: deployDefaults.maxSecurityGroups
+      )
 
       def asgName = autoScalingWorker.deploy()
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
@@ -17,6 +17,10 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy
 
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.model.DescribeSubnetsResult
+import com.amazonaws.services.ec2.model.Subnet
+import com.amazonaws.services.ec2.model.Tag
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTask
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -37,6 +41,7 @@ class AutoScalingWorkerUnitSpec extends Specification {
 
   def lcBuilder = Mock(LaunchConfigurationBuilder)
   def asgService = Mock(AsgService)
+  def amazonEC2 = Mock(AmazonEC2)
   def clusterProvider = Mock(ClusterProvider)
   def awsServerGroupNameResolver = new AWSServerGroupNameResolver('test', 'us-east-1', asgService, [clusterProvider])
   def credential = TestCredential.named('foo')
@@ -44,11 +49,41 @@ class AutoScalingWorkerUnitSpec extends Specification {
     getLaunchConfigurationBuilder() >> lcBuilder
     getAsgService() >> asgService
     getAWSServerGroupNameResolver() >> awsServerGroupNameResolver
+    getAmazonEC2() >> amazonEC2
   }
 
   def setup() {
     Task task = new DefaultTask("task")
     TaskRepository.threadLocalTask.set(task)
+  }
+
+  void "should fail deployment if there are more than 5 security groups per instance"() {
+    given:
+    def maxSecurityGroups = 5
+    def tooManySecurityGroups = ["sg-test-1", "sg-test-2", "sg-test3", "sg-test4", "sg-test5", "sg-test6"]
+    def autoScalingWorker = new AutoScalingWorker(
+      regionScopedProvider : regionScopedProvider,
+      credentials: credential,
+      application : "myasg",
+      region : "us-east-1",
+      availabilityZones: ["us-east-1b"],
+      subnetType: "internal",
+      securityGroups: tooManySecurityGroups,
+      maxSecurityGroupsPerInstance: maxSecurityGroups
+    )
+
+    and:
+    def describeSubnetResult = Mock(DescribeSubnetsResult)
+    describeSubnetResult.getSubnets() >> [ new Subnet().withSubnetId("subnetId1")
+                                             .withAvailabilityZone("us-east-1b")
+                                             .withTags(new Tag("immutable_metadata","""{"target":"ec2", "purpose":"internal"}"""))]
+
+    when:
+    autoScalingWorker.deploy()
+
+    then:
+    1 * amazonEC2.describeSubnets() >> describeSubnetResult
+    thrown(IllegalArgumentException)
   }
 
   @Unroll


### PR DESCRIPTION
- added a check to guard against deploying a server group with more than 5 SGs per instance in VPC