### PR TITLE
adds support for fine grained service limits.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -20,6 +20,7 @@ import com.amazonaws.retry.RetryPolicy.BackoffStrategy
 import com.amazonaws.retry.RetryPolicy.RetryCondition
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.awsobjectmapper.AmazonObjectMapper
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.aws.agent.CleanupAlarmsAgent
@@ -50,6 +51,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig
 import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig.Builder
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils
 import com.netflix.spinnaker.kork.aws.AwsComponents
@@ -90,7 +92,7 @@ class AwsConfiguration {
   }
 
   @Bean
-  AmazonClientProvider amazonClientProvider(AwsConfigurationProperties awsConfigurationProperties, RetryCondition instrumentedRetryCondition, BackoffStrategy instrumentedBackoffStrategy, AWSProxy proxy, EddaTimeoutConfig eddaTimeoutConfig) {
+  AmazonClientProvider amazonClientProvider(AwsConfigurationProperties awsConfigurationProperties, RetryCondition instrumentedRetryCondition, BackoffStrategy instrumentedBackoffStrategy, AWSProxy proxy, EddaTimeoutConfig eddaTimeoutConfig, ServiceLimitConfiguration serviceLimitConfiguration, Registry registry) {
     new AmazonClientProvider.Builder()
       .backoffStrategy(instrumentedBackoffStrategy)
       .retryCondition(instrumentedRetryCondition)
@@ -101,12 +103,14 @@ class AwsConfiguration {
       .proxy(proxy)
       .eddaTimeoutConfig(eddaTimeoutConfig)
       .useGzip(awsConfigurationProperties.client.useGzip)
+      .serviceLimitConfiguration(serviceLimitConfiguration)
+      .registry(registry)
       .build()
   }
 
   @Bean
   ObjectMapper amazonObjectMapper() {
-    new AmazonObjectMapper()
+    return new AmazonObjectMapper()
   }
 
   @Bean

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/ReconcileClassicLinkSecurityGroupsAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/ReconcileClassicLinkSecurityGroupsAgent.java
@@ -32,7 +32,6 @@ import com.amazonaws.services.ec2.model.SecurityGroup;
 import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.services.ec2.model.VpcClassicLink;
 import com.google.common.base.Strings;
-import com.google.common.util.concurrent.RateLimiter;
 import com.netflix.frigga.Names;
 import com.netflix.spinnaker.cats.agent.AccountAware;
 import com.netflix.spinnaker.cats.agent.RunnableAgent;
@@ -127,11 +126,9 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
     }
     String classicLinkVpcId = classicLinkVpcIds.get(0);
 
-    RateLimiter apiRequestRateLimit = RateLimiter.create(5);
     final Map<String, ClassicLinkInstance> classicLinkInstances = new HashMap<>();
     DescribeInstancesRequest describeInstances = new DescribeInstancesRequest().withMaxResults(500);
     while (true) {
-      apiRequestRateLimit.acquire();
       DescribeInstancesResult instanceResult = ec2.describeInstances(describeInstances);
       instanceResult.getReservations().stream()
         .flatMap(r -> r.getInstances().stream())
@@ -149,7 +146,6 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
 
     DescribeClassicLinkInstancesRequest request = new DescribeClassicLinkInstancesRequest().withMaxResults(1000);
     while (true) {
-      apiRequestRateLimit.acquire();
       DescribeClassicLinkInstancesResult result = ec2.describeClassicLinkInstances(request);
       result.getInstances().forEach(i -> classicLinkInstances.put(i.getInstanceId(), i));
       if (result.getNextToken() == null) {
@@ -183,7 +179,6 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
   }
 
   void reconcileInstances(AmazonEC2 ec2, Map<String, String> groupNamesToIds, Collection<ClassicLinkInstance> instances) {
-    RateLimiter apiRequestRateLimit = RateLimiter.create(5);
     StringBuilder report = new StringBuilder();
     for (ClassicLinkInstance i : instances) {
       List<String> existingClassicLinkGroups = i.getGroups().stream()
@@ -212,7 +207,6 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
           List<String> groupIds = new ArrayList<>(existingClassicLinkGroups);
           groupIds.addAll(missingGroupIds);
           if (deployDefaults.getReconcileClassicLinkSecurityGroups() == AwsConfiguration.DeployDefaults.ReconcileMode.MODIFY) {
-            apiRequestRateLimit.acquire();
             try {
               ec2.attachClassicLinkVpc(new AttachClassicLinkVpcRequest()
                 .withVpcId(i.getVpcId())

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -30,7 +30,6 @@ import com.amazonaws.services.elasticloadbalancingv2.model.InvalidTargetExceptio
 import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -193,10 +192,8 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
 
   private static void handleInstancesWithLoadBalancing(Collection<String> lbIdentifiers, Collection<String> instanceIds, Closure instanceIdTransform, Closure actOnInstancesAndLoadBalancer) {
     if (instanceIds && lbIdentifiers) {
-      RateLimiter rateLimiter = RateLimiter.create(5)
       def instances = instanceIds.collect(instanceIdTransform)
       for (String lbId : lbIdentifiers) {
-        rateLimiter.acquire()
         actOnInstancesAndLoadBalancer(lbId, instances)
       }
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DetachInstancesAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DetachInstancesAtomicOperation.groovy
@@ -24,7 +24,6 @@ import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
 import com.amazonaws.services.ec2.model.CreateTagsRequest
 import com.amazonaws.services.ec2.model.Tag
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -106,11 +105,8 @@ class DetachInstancesAtomicOperation implements AtomicOperation<Void> {
       amazonEC2.createTags(new CreateTagsRequest().withResources(validInstanceIds).withTags(tags))
       task.updateStatus BASE_PHASE, "Tagged instances (${validInstanceIds.join(", ")})."
 
-      RateLimiter limiter = RateLimiter.create(0.2)
-
       validInstanceIds.collate(MAX_DETACH).each {
         // AWS has a restriction on the # of instances that can be detached at any one time, hence batching is required.
-        limiter.acquire()
         task.updateStatus BASE_PHASE, "Detaching instances (${it.join(", ")}) from ASG (${description.asgName})."
         amazonAutoScaling.detachInstances(
           new DetachInstancesRequest()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpdateInstancesAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpdateInstancesAtomicOperation.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsRequest
 import com.amazonaws.services.ec2.model.ModifyInstanceAttributeRequest
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpdateInstancesDescription
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -72,9 +71,7 @@ class UpdateInstancesAtomicOperation implements AtomicOperation<Void> {
       }
       groups = groups + launchConfigs.launchConfigurations.get(0).securityGroups
     }
-    def limiter = RateLimiter.create(MAX_REQUESTS_PER_SECOND)
     instances.each { instanceId ->
-      limiter.acquire()
       task.updateStatus PHASE, "Updating security groups for ${instanceId}..."
       try {
         regionScopedProvider.amazonEC2.modifyInstanceAttribute(new ModifyInstanceAttributeRequest(instanceId: instanceId).withGroups(groups))

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerLookupHelper.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/LoadBalancerLookupHelper.groovy
@@ -20,7 +20,6 @@ import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeLoadBalancersRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 
 /**
@@ -34,14 +33,7 @@ class LoadBalancerLookupHelper {
     Set<String> unknownLoadBalancers = []
   }
 
-  private final RateLimiter limiter
-
   public LoadBalancerLookupHelper() {
-    this(RateLimiter.create(1))
-  }
-
-  public LoadBalancerLookupHelper(RateLimiter limiter) {
-    this.limiter = Objects.requireNonNull(limiter)
   }
 
   LoadBalancerLookupResult getLoadBalancersFromAsg(AutoScalingGroup asg) {
@@ -64,10 +56,8 @@ class LoadBalancerLookupHelper {
       //at the moment, '--' is not allowed in lbv2 load balancer names, and asking for it throws a ValidationError not a LoadBalancerNotFoundException
       if (!lbName.contains("--")) {
         try {
-          limiter.acquire()
           def lb = lbv2.describeLoadBalancers(new DescribeLoadBalancersRequest().withNames(lbName)).loadBalancers.first()
           v2LoadBalancers.add(lbName)
-          limiter.acquire()
           result.targetGroupArns.addAll(lbv2.describeTargetGroups(new DescribeTargetGroupsRequest().withLoadBalancerArn(lb.loadBalancerArn)).targetGroups*.targetGroupArn)
         } catch (LoadBalancerNotFoundException lbnfe) {
           //ignore
@@ -75,7 +65,6 @@ class LoadBalancerLookupHelper {
       }
 
       try {
-        limiter.acquire()
         lbv1.describeLoadBalancers(new com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest().withLoadBalancerNames(lbName))
         result.classicLoadBalancers.add(lbName)
       } catch (com.amazonaws.services.elasticloadbalancing.model.LoadBalancerNotFoundException lbnfe) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -16,64 +16,57 @@
 
 package com.netflix.spinnaker.clouddriver.aws.security;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.AmazonWebServiceClient;
-import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.handlers.RequestHandler2;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.autoscaling.AmazonAutoScaling;
-import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
+import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing;
-import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient;
+import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClientBuilder;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClientBuilder;
 import com.amazonaws.services.lambda.AWSLambda;
 import com.amazonaws.services.lambda.AWSLambdaAsync;
-import com.amazonaws.services.lambda.AWSLambdaAsyncClient;
-import com.amazonaws.services.lambda.AWSLambdaClient;
+import com.amazonaws.services.lambda.AWSLambdaAsyncClientBuilder;
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
 import com.amazonaws.services.route53.AmazonRoute53;
-import com.amazonaws.services.route53.AmazonRoute53Client;
+import com.amazonaws.services.route53.AmazonRoute53ClientBuilder;
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
-import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClient;
+import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.awsobjectmapper.AmazonObjectMapper;
+import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.AmazonClientInvocationHandler;
+import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.AwsSdkClientSupplier;
+import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.ProxyHandlerBuilder;
+import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.RateLimiterSupplier;
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration;
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfigurationBuilder;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static java.util.Objects.requireNonNull;
-
 /**
- * Provides of Amazon SDK Clients that can read through Edda.
+ * Provider of Amazon SDK Clients that can read through Edda.
  */
 public class AmazonClientProvider {
 
   public static final String DEFAULT_REGION = null;
 
-  private final HttpClient httpClient;
-  private final ObjectMapper objectMapper;
-  private final EddaTemplater eddaTemplater;
-  private final RetryPolicy retryPolicy;
-  private final List<RequestHandler2> requestHandlers;
-  private final AWSProxy proxy;
-  private final EddaTimeoutConfig eddaTimeoutConfig;
-  private final boolean useGzip;
+  private final AwsSdkClientSupplier awsSdkClientSupplier;
+  private final ProxyHandlerBuilder proxyHandlerBuilder;
 
   public static class Builder {
     private HttpClient httpClient;
@@ -88,6 +81,8 @@ public class AmazonClientProvider {
     private int maxConnections = 200;
     private int maxConnectionsPerRoute = 20;
     private boolean uzeGzip = true;
+    private ServiceLimitConfiguration serviceLimitConfiguration = new ServiceLimitConfigurationBuilder().build();
+    private Registry registry = new NoopRegistry();
 
     public Builder httpClient(HttpClient httpClient) {
       this.httpClient = httpClient;
@@ -149,6 +144,16 @@ public class AmazonClientProvider {
       return this;
     }
 
+    public Builder serviceLimitConfiguration(ServiceLimitConfiguration serviceLimitConfiguration) {
+      this.serviceLimitConfiguration = serviceLimitConfiguration;
+      return this;
+    }
+
+    public Builder registry(Registry registry) {
+      this.registry = registry;
+      return this;
+    }
+
     public AmazonClientProvider build() {
       HttpClient client = this.httpClient;
       if (client == null) {
@@ -158,13 +163,13 @@ public class AmazonClientProvider {
         client = builder.build();
       }
 
-      ObjectMapper mapper = this.objectMapper == null ? new AmazonObjectMapper() : this.objectMapper;
+      ObjectMapper mapper = this.objectMapper == null ? AmazonObjectMapperConfigurer.createConfigured() : this.objectMapper;
       EddaTemplater templater = this.eddaTemplater == null ? EddaTemplater.defaultTemplater() : this.eddaTemplater;
       RetryPolicy policy = buildPolicy();
       AWSProxy proxy = this.proxy;
       EddaTimeoutConfig eddaTimeoutConfig = this.eddaTimeoutConfig == null ? EddaTimeoutConfig.DEFAULT : this.eddaTimeoutConfig;
 
-      return new AmazonClientProvider(client, mapper, templater, policy, requestHandlers, proxy, eddaTimeoutConfig, uzeGzip);
+      return new AmazonClientProvider(client, mapper, templater, policy, requestHandlers, proxy, eddaTimeoutConfig, uzeGzip, serviceLimitConfiguration, registry);
     }
 
     private RetryPolicy buildPolicy() {
@@ -187,7 +192,7 @@ public class AmazonClientProvider {
   }
 
   public AmazonClientProvider(HttpClient httpClient) {
-    this(httpClient, new AmazonObjectMapper());
+    this(httpClient, AmazonObjectMapperConfigurer.createConfigured());
   }
 
   public AmazonClientProvider(ObjectMapper objectMapper) {
@@ -196,13 +201,15 @@ public class AmazonClientProvider {
 
   public AmazonClientProvider(HttpClient httpClient, ObjectMapper objectMapper) {
     this(httpClient == null ? HttpClients.createDefault() : httpClient,
-      objectMapper == null ? new AmazonObjectMapper() : objectMapper,
+      objectMapper == null ? AmazonObjectMapperConfigurer.createConfigured() : objectMapper,
       EddaTemplater.defaultTemplater(),
       PredefinedRetryPolicies.getDefaultRetryPolicy(),
       Collections.emptyList(),
       null,
       EddaTimeoutConfig.DEFAULT,
-      true);
+      true,
+      new ServiceLimitConfigurationBuilder().build(),
+      new NoopRegistry());
   }
 
   public AmazonClientProvider(HttpClient httpClient,
@@ -212,15 +219,12 @@ public class AmazonClientProvider {
                               List<RequestHandler2> requestHandlers,
                               AWSProxy proxy,
                               EddaTimeoutConfig eddaTimeoutConfig,
-                              boolean useGzip) {
-    this.httpClient = requireNonNull(httpClient, "httpClient");
-    this.objectMapper = requireNonNull(objectMapper, "objectMapper");
-    this.eddaTemplater = requireNonNull(eddaTemplater, "eddaTemplater");
-    this.retryPolicy = requireNonNull(retryPolicy, "retryPolicy");
-    this.requestHandlers = requestHandlers == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(requestHandlers));
-    this.proxy = proxy;
-    this.eddaTimeoutConfig = eddaTimeoutConfig;
-    this.useGzip = useGzip;
+                              boolean useGzip,
+                              ServiceLimitConfiguration serviceLimitConfiguration,
+                              Registry registry) {
+    RateLimiterSupplier rateLimiterSupplier = new RateLimiterSupplier(serviceLimitConfiguration);
+    this.awsSdkClientSupplier = new AwsSdkClientSupplier(rateLimiterSupplier, registry, retryPolicy, requestHandlers, proxy, useGzip);
+    this.proxyHandlerBuilder = new ProxyHandlerBuilder(awsSdkClientSupplier, httpClient, objectMapper, eddaTemplater, eddaTimeoutConfig);
   }
 
   /**
@@ -236,27 +240,31 @@ public class AmazonClientProvider {
   }
 
   public AmazonEC2 getAmazonEC2(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(AmazonEC2.class, AmazonEC2Client.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(AmazonEC2.class, AmazonEC2ClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
   public AmazonEC2 getAmazonEC2(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AmazonEC2Client.class, awsCredentialsProvider, region);
+    return awsSdkClientSupplier.getClient(AmazonEC2ClientBuilder.class, AmazonEC2.class, "UNSPECIFIED_ACCOUNT", awsCredentialsProvider, region);
+  }
+
+  public AmazonEC2 getAmazonEC2(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AmazonEC2ClientBuilder.class, AmazonEC2.class, accountName, awsCredentialsProvider, region);
   }
 
   public AWSLambda getAmazonLambda(NetflixAmazonCredentials amazonCredentials, String region) {
-    return getProxyHandler(AWSLambda.class, AWSLambdaClient.class, amazonCredentials, region);
+    return proxyHandlerBuilder.getProxyHandler(AWSLambda.class, AWSLambdaClientBuilder.class, amazonCredentials, region);
   }
 
-  public AWSLambda getAmazonLambda(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AWSLambdaClient.class, awsCredentialsProvider, region);
+  public AWSLambda getAmazonLambda(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AWSLambdaClientBuilder.class, AWSLambda.class, accountName, awsCredentialsProvider, region);
   }
 
   public AWSLambdaAsync getAmazonLambdaAsync(NetflixAmazonCredentials amazonCredentials, String region) {
-    return getProxyHandler(AWSLambdaAsync.class, AWSLambdaAsyncClient.class, amazonCredentials, region);
+    return proxyHandlerBuilder.getProxyHandler(AWSLambdaAsync.class, AWSLambdaAsyncClientBuilder.class, amazonCredentials, region);
   }
 
-  public AWSLambdaAsync getAmazonLambdaAsync(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AWSLambdaAsyncClient.class, awsCredentialsProvider, region);
+  public AWSLambdaAsync getAmazonLambdaAsync(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AWSLambdaAsyncClientBuilder.class, AWSLambdaAsync.class, accountName, awsCredentialsProvider, region);
   }
 
   public AmazonAutoScaling getAutoScaling(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -264,11 +272,11 @@ public class AmazonClientProvider {
   }
 
   public AmazonAutoScaling getAutoScaling(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(AmazonAutoScaling.class, AmazonAutoScalingClient.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(AmazonAutoScaling.class, AmazonAutoScalingClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonAutoScaling getAutoScaling(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AmazonAutoScalingClient.class, awsCredentialsProvider, region);
+  public AmazonAutoScaling getAutoScaling(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AmazonAutoScalingClientBuilder.class, AmazonAutoScaling.class, accountName, awsCredentialsProvider, region);
   }
 
   public AmazonRoute53 getAmazonRoute53(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -276,11 +284,11 @@ public class AmazonClientProvider {
   }
 
   public AmazonRoute53 getAmazonRoute53(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(AmazonRoute53.class, AmazonRoute53Client.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(AmazonRoute53.class, AmazonRoute53ClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonRoute53 getAmazonRoute53(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AmazonRoute53Client.class, awsCredentialsProvider, region);
+  public AmazonRoute53 getAmazonRoute53(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AmazonRoute53ClientBuilder.class, AmazonRoute53.class, accountName, awsCredentialsProvider, region);
   }
 
   public AmazonElasticLoadBalancing getAmazonElasticLoadBalancing(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -288,11 +296,11 @@ public class AmazonClientProvider {
   }
 
   public AmazonElasticLoadBalancing getAmazonElasticLoadBalancing(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(AmazonElasticLoadBalancing.class, AmazonElasticLoadBalancingClient.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(AmazonElasticLoadBalancing.class, AmazonElasticLoadBalancingClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonElasticLoadBalancing getAmazonElasticLoadBalancing(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AmazonElasticLoadBalancingClient.class, awsCredentialsProvider, region);
+  public AmazonElasticLoadBalancing getAmazonElasticLoadBalancing(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AmazonElasticLoadBalancingClientBuilder.class, AmazonElasticLoadBalancing.class, accountName, awsCredentialsProvider, region);
   }
 
   public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -300,11 +308,16 @@ public class AmazonClientProvider {
   }
 
   public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing.class, com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClient.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing.class, com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClient.class, awsCredentialsProvider, region);
+  public com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing getAmazonElasticLoadBalancingV2(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(
+      com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancingClientBuilder.class,
+      com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing.class,
+      accountName,
+      awsCredentialsProvider,
+      region);
   }
 
   public AmazonSimpleWorkflow getAmazonSimpleWorkflow(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -312,11 +325,11 @@ public class AmazonClientProvider {
   }
 
   public AmazonSimpleWorkflow getAmazonSimpleWorkflow(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(AmazonSimpleWorkflow.class, AmazonSimpleWorkflowClient.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(AmazonSimpleWorkflow.class, AmazonSimpleWorkflowClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonSimpleWorkflow getAmazonSimpleWorkflow(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AmazonSimpleWorkflowClient.class, awsCredentialsProvider, region);
+  public AmazonSimpleWorkflow getAmazonSimpleWorkflow(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AmazonSimpleWorkflowClientBuilder.class, AmazonSimpleWorkflow.class, accountName, awsCredentialsProvider, region);
   }
 
   public AmazonCloudWatch getAmazonCloudWatch(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -324,11 +337,11 @@ public class AmazonClientProvider {
   }
 
   public AmazonCloudWatch getAmazonCloudWatch(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(AmazonCloudWatch.class, AmazonCloudWatchClient.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(AmazonCloudWatch.class, AmazonCloudWatchClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonCloudWatch getAmazonCloudWatch(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AmazonCloudWatchClient.class, awsCredentialsProvider, region);
+  public AmazonCloudWatch getAmazonCloudWatch(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AmazonCloudWatchClientBuilder.class, AmazonCloudWatch.class, accountName, awsCredentialsProvider, region);
   }
 
   public AmazonCloudWatch getCloudWatch(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -344,11 +357,11 @@ public class AmazonClientProvider {
   }
 
   public AmazonSNS getAmazonSNS(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(AmazonSNS.class, AmazonSNSClient.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(AmazonSNS.class, AmazonSNSClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonSNS getAmazonSNS(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AmazonSNSClient.class, awsCredentialsProvider, region);
+  public AmazonSNS getAmazonSNS(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AmazonSNSClientBuilder.class, AmazonSNS.class, accountName, awsCredentialsProvider, region);
   }
 
   public AmazonIdentityManagement getAmazonIdentityManagement(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -356,90 +369,10 @@ public class AmazonClientProvider {
   }
 
   public AmazonIdentityManagement getAmazonIdentityManagement(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    return getProxyHandler(AmazonIdentityManagement.class, AmazonIdentityManagementClient.class, amazonCredentials, region, skipEdda);
+    return proxyHandlerBuilder.getProxyHandler(AmazonIdentityManagement.class, AmazonIdentityManagementClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonIdentityManagement getAmazonIdentityManagement(AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return getClient(AmazonIdentityManagementClient.class, awsCredentialsProvider, region);
-  }
-
-  protected <T extends AmazonWebServiceClient, U> U getProxyHandler(Class<U> interfaceKlazz, Class<T> impl, NetflixAmazonCredentials amazonCredentials, String region) {
-    return getProxyHandler(interfaceKlazz, impl, amazonCredentials, region, false);
-  }
-
-  protected <T extends AmazonWebServiceClient, U> U getProxyHandler(Class<U> interfaceKlazz, Class<T> impl, NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
-    checkCredentials(amazonCredentials);
-    try {
-      T delegate = getClient(impl, amazonCredentials.getCredentialsProvider(), region);
-      if (amazonCredentials.getEddaEnabled() && !skipEdda) {
-        return interfaceKlazz.cast(Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{interfaceKlazz},
-          getInvocationHandler(delegate, delegate.getServiceName(), region, amazonCredentials)));
-      } else {
-        return interfaceKlazz.cast(delegate);
-      }
-    } catch (RuntimeException re) {
-      throw re;
-    } catch (Exception e) {
-      throw new RuntimeException("Instantiation of client implementation failed!", e);
-    }
-  }
-
-  protected <T extends AmazonWebServiceClient> T getClient(Class<T> impl, AWSCredentialsProvider awsCredentialsProvider, String region) {
-    checkAWSCredentialsProvider(awsCredentialsProvider);
-    try {
-      Constructor<T> constructor = impl.getConstructor(AWSCredentialsProvider.class, ClientConfiguration.class);
-
-      ClientConfiguration clientConfiguration = new ClientConfiguration();
-
-      if (awsCredentialsProvider instanceof NetflixSTSAssumeRoleSessionCredentialsProvider) {
-        RetryPolicy.RetryCondition delegatingRetryCondition = (originalRequest, exception, retriesAttempted) -> {
-          NetflixSTSAssumeRoleSessionCredentialsProvider stsCredentialsProvider = (NetflixSTSAssumeRoleSessionCredentialsProvider) awsCredentialsProvider;
-          if (exception instanceof AmazonServiceException) {
-            ((AmazonServiceException) exception).getHttpHeaders().put("targetAccountId", stsCredentialsProvider.getAccountId());
-          }
-          return retryPolicy.getRetryCondition().shouldRetry(originalRequest, exception, retriesAttempted);
-        };
-
-        RetryPolicy delegatingRetryPolicy = new RetryPolicy(
-          delegatingRetryCondition,
-          retryPolicy.getBackoffStrategy(),
-          retryPolicy.getMaxErrorRetry(),
-          retryPolicy.isMaxErrorRetryInClientConfigHonored()
-        );
-        clientConfiguration.setRetryPolicy(delegatingRetryPolicy);
-      } else {
-        clientConfiguration.setRetryPolicy(retryPolicy);
-      }
-
-      if (proxy != null && proxy.isProxyConfigMode()) {
-        proxy.apply(clientConfiguration);
-      }
-
-      clientConfiguration.setUseGzip(useGzip);
-
-      T delegate = constructor.newInstance(awsCredentialsProvider, clientConfiguration);
-      for (RequestHandler2 requestHandler : requestHandlers) {
-        delegate.addRequestHandler(requestHandler);
-      }
-      if (region != null && region.length() > 0) {
-        delegate.setRegion(Region.getRegion(Regions.fromName(region)));
-      }
-      return delegate;
-    } catch (Exception e) {
-      throw new RuntimeException("Instantiation of client implementation failed!", e);
-    }
-  }
-
-  protected AmazonClientInvocationHandler getInvocationHandler(Object client, String serviceName, String region, NetflixAmazonCredentials amazonCredentials) {
-    return new AmazonClientInvocationHandler(client, serviceName, eddaTemplater.getUrl(amazonCredentials.getEdda(), region),
-      this.httpClient, objectMapper, eddaTimeoutConfig);
-  }
-
-  private static void checkCredentials(NetflixAmazonCredentials amazonCredentials) {
-    requireNonNull(amazonCredentials, "Credentials cannot be null");
-  }
-
-  private static void checkAWSCredentialsProvider(AWSCredentialsProvider awsCredentialsProvider) {
-    requireNonNull(awsCredentialsProvider, "AWSCredentialsProvider cannot be null");
+  public AmazonIdentityManagement getAmazonIdentityManagement(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AmazonIdentityManagementClientBuilder.class, AmazonIdentityManagement.class, accountName, awsCredentialsProvider, region);
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.security;
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -49,11 +50,11 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.*;
 
-class AmazonClientInvocationHandler implements InvocationHandler {
+public class AmazonClientInvocationHandler implements InvocationHandler {
 
   private static final Logger log = LoggerFactory.getLogger(AmazonClientInvocationHandler.class);
 
-  static final ThreadLocal<Long> lastModified = new ThreadLocal<>();
+  public static final ThreadLocal<Long> lastModified = new ThreadLocal<>();
 
   private final String edda;
   private final HttpClient httpClient;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.retry.RetryPolicy;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.RateLimiter;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.aws.security.AWSProxy;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixSTSAssumeRoleSessionCredentialsProvider;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Factory for shared instances of AWS SDK clients.
+ */
+public class AwsSdkClientSupplier {
+
+  private final Registry registry;
+  private final LoadingCache<AmazonClientKey<?>, ?> awsSdkClients;
+  private final RateLimiterSupplier rateLimiterSupplier;
+
+  public AwsSdkClientSupplier(RateLimiterSupplier rateLimiterSupplier, Registry registry, RetryPolicy retryPolicy, List<RequestHandler2> requestHandlers, AWSProxy proxy, boolean useGzip) {
+    this.rateLimiterSupplier = Objects.requireNonNull(rateLimiterSupplier);
+    this.registry = Objects.requireNonNull(registry);
+    awsSdkClients = CacheBuilder.newBuilder().build(new SdkClientCacheLoader(retryPolicy, requestHandlers, proxy, useGzip));
+  }
+
+  public <T> T getClient(Class<? extends AwsClientBuilder<?, T>> impl, Class<T> iface, String account, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    final RequestHandler2 handler = getRateLimiterHandler(iface, account, region);
+    final AmazonClientKey<T> key = new AmazonClientKey<>(impl, awsCredentialsProvider, region, handler);
+
+    try {
+      return iface.cast(awsSdkClients.get(key));
+    } catch (ExecutionException executionException) {
+      if (executionException.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) executionException.getCause();
+      }
+      throw new RuntimeException("Failed creating amazon client", executionException.getCause());
+    }
+  }
+
+  private RequestHandler2 getRateLimiterHandler(Class<?> sdkInterface, String account, String region) {
+    final RateLimiter limiter = rateLimiterSupplier.getRateLimiter(sdkInterface, account, region);
+    final Counter rateLimitCounter = registry.counter("amazonClientProvider.rateLimitDelayMillis",
+      "clientType", sdkInterface.getSimpleName(),
+      "account", account,
+      "region", region == null ? "UNSPECIFIED" : region);
+    return new RateLimitingRequestHandler(rateLimitCounter, limiter);
+  }
+
+  private static class SdkClientCacheLoader extends CacheLoader<AmazonClientKey<?>, Object> {
+    private final RetryPolicy retryPolicy;
+    private final List<RequestHandler2> requestHandlers;
+    private final AWSProxy proxy;
+    private final boolean useGzip;
+
+    public SdkClientCacheLoader(RetryPolicy retryPolicy, List<RequestHandler2> requestHandlers, AWSProxy proxy, boolean useGzip) {
+      this.retryPolicy = Objects.requireNonNull(retryPolicy);
+      this.requestHandlers = requestHandlers == null ? Collections.emptyList() : ImmutableList.copyOf(requestHandlers);
+      this.proxy = proxy;
+      this.useGzip = useGzip;
+    }
+
+    @Override
+    public Object load(AmazonClientKey<?> key) throws Exception {
+      Method m = key.implClass.getDeclaredMethod("standard");
+      AwsClientBuilder<?, ?> builder = key.implClass.cast(m.invoke(null));
+
+      ClientConfiguration clientConfiguration = new ClientConfiguration();
+      clientConfiguration.setRetryPolicy(getRetryPolicy(key));
+      clientConfiguration.setUseGzip(useGzip);
+
+      if (proxy != null && proxy.isProxyConfigMode()) {
+        proxy.apply(clientConfiguration);
+      }
+
+      builder.withCredentials(key.awsCredentialsProvider)
+        .withClientConfiguration(clientConfiguration);
+      getRequestHandlers(key).ifPresent(builder::withRequestHandlers);
+      key.getRegion().ifPresent(builder::withRegion);
+
+      return builder.build();
+    }
+
+    private Optional<RequestHandler2[]> getRequestHandlers(AmazonClientKey<?> key) {
+      List<RequestHandler2> handlers = new ArrayList<>(requestHandlers.size() + 1);
+      key.getRequestHandler().ifPresent(handlers::add);
+      handlers.addAll(requestHandlers);
+      if (handlers.isEmpty()) {
+        return Optional.empty();
+      }
+      return Optional.of(handlers.toArray(new RequestHandler2[handlers.size()]));
+    }
+
+    private RetryPolicy getRetryPolicy(AmazonClientKey<?> key) {
+
+      if (!(key.getAwsCredentialsProvider() instanceof NetflixSTSAssumeRoleSessionCredentialsProvider)) {
+        return retryPolicy;
+      }
+
+      final RetryPolicy.RetryCondition delegatingRetryCondition = (originalRequest, exception, retriesAttempted) -> {
+        NetflixSTSAssumeRoleSessionCredentialsProvider stsCredentialsProvider = (NetflixSTSAssumeRoleSessionCredentialsProvider) key.getAwsCredentialsProvider();
+        if (exception instanceof AmazonServiceException) {
+          ((AmazonServiceException) exception).getHttpHeaders().put("targetAccountId", stsCredentialsProvider.getAccountId());
+        }
+        return retryPolicy.getRetryCondition().shouldRetry(originalRequest, exception, retriesAttempted);
+      };
+
+      return new RetryPolicy(
+        delegatingRetryCondition,
+        retryPolicy.getBackoffStrategy(),
+        retryPolicy.getMaxErrorRetry(),
+        retryPolicy.isMaxErrorRetryInClientConfigHonored()
+      );
+
+    }
+  }
+
+  private static class AmazonClientKey<T> {
+    private final Class<? extends AwsClientBuilder<?, T>> implClass;
+    private final AWSCredentialsProvider awsCredentialsProvider;
+    private final Regions region;
+    private final RequestHandler2 requestHandler;
+
+    public AmazonClientKey(Class<? extends AwsClientBuilder<?, T>> implClass, AWSCredentialsProvider awsCredentialsProvider, String region, RequestHandler2 requestHandler) {
+      this.implClass = requireNonNull(implClass);
+      this.awsCredentialsProvider = requireNonNull(awsCredentialsProvider);
+      this.region = region == null ? null : Regions.fromName(region);
+      this.requestHandler = requestHandler;
+    }
+
+    public Class<? extends AwsClientBuilder<?, T>> getImplClass() {
+      return implClass;
+    }
+
+    public AWSCredentialsProvider getAwsCredentialsProvider() {
+      return awsCredentialsProvider;
+    }
+
+    public Optional<Regions> getRegion() {
+      return Optional.ofNullable(region);
+    }
+
+    public Optional<RequestHandler2> getRequestHandler() {
+      return Optional.ofNullable(requestHandler);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      AmazonClientKey<?> that = (AmazonClientKey<?>) o;
+
+      if (!implClass.equals(that.implClass)) return false;
+      if (!awsCredentialsProvider.equals(that.awsCredentialsProvider)) return false;
+      if (region != that.region) return false;
+      return requestHandler != null ? requestHandler.equals(that.requestHandler) : that.requestHandler == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = implClass.hashCode();
+      result = 31 * result + awsCredentialsProvider.hashCode();
+      result = 31 * result + (region != null ? region.hashCode() : 0);
+      result = 31 * result + (requestHandler != null ? requestHandler.hashCode() : 0);
+      return result;
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/ProxyHandlerBuilder.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/ProxyHandlerBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.aws.security.EddaTemplater;
+import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import org.apache.http.client.HttpClient;
+
+import java.lang.reflect.Proxy;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Constructs a JDK dynamic proxy for an AWS service interface that (if enabled for an account) will
+ * delegate read requests to Edda and otherwise fallback to the underlying SDK client.
+ */
+public class ProxyHandlerBuilder {
+  private final AwsSdkClientSupplier awsSdkClientSupplier;
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final EddaTemplater eddaTemplater;
+  private final EddaTimeoutConfig eddaTimeoutConfig;
+
+  public ProxyHandlerBuilder(AwsSdkClientSupplier awsSdkClientSupplier, HttpClient httpClient, ObjectMapper objectMapper, EddaTemplater eddaTemplater, EddaTimeoutConfig eddaTimeoutConfig) {
+    this.awsSdkClientSupplier = requireNonNull(awsSdkClientSupplier);
+    this.httpClient = requireNonNull(httpClient);
+    this.objectMapper = requireNonNull(objectMapper);
+    this.eddaTemplater = requireNonNull(eddaTemplater);
+    this.eddaTimeoutConfig = eddaTimeoutConfig;
+  }
+
+  public <T extends AwsClientBuilder<T, U>, U> U getProxyHandler(Class<U> interfaceKlazz, Class<T> impl, NetflixAmazonCredentials amazonCredentials, String region) {
+    return getProxyHandler(interfaceKlazz, impl, amazonCredentials, region, false);
+  }
+
+  public <T extends AwsClientBuilder<T, U>, U> U getProxyHandler(Class<U> interfaceKlazz, Class<T> impl, NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
+    requireNonNull(amazonCredentials, "Credentials cannot be null");
+    try {
+      U delegate = awsSdkClientSupplier.getClient(impl, interfaceKlazz, amazonCredentials.getName(), amazonCredentials.getCredentialsProvider(), region);
+      if (skipEdda || !amazonCredentials.getEddaEnabled()) {
+        return delegate;
+      }
+      return interfaceKlazz.cast(Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{interfaceKlazz},
+        getInvocationHandler(delegate, interfaceKlazz.getSimpleName(), region, amazonCredentials)));
+    } catch (RuntimeException re) {
+      throw re;
+    } catch (Exception e) {
+      throw new RuntimeException("Instantiation of client implementation failed!", e);
+    }
+  }
+
+  protected AmazonClientInvocationHandler getInvocationHandler(Object client, String serviceName, String region, NetflixAmazonCredentials amazonCredentials) {
+    return new AmazonClientInvocationHandler(client, serviceName, eddaTemplater.getUrl(amazonCredentials.getEdda(), region),
+      this.httpClient, objectMapper, eddaTimeoutConfig);
+  }
+
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimiterSupplier.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimiterSupplier.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.RateLimiter;
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+
+/**
+ * Factory for shared RateLimiters by SDK client interface/account/region.
+ */
+public class RateLimiterSupplier {
+
+  private final LoadingCache<RateLimitKey, RateLimiter> rateLimiters;
+
+  public RateLimiterSupplier(ServiceLimitConfiguration serviceLimitConfiguration) {
+    rateLimiters = CacheBuilder.newBuilder().build(new RateLimitCacheLoader(serviceLimitConfiguration));
+  }
+
+  public RateLimiter getRateLimiter(Class<?> implementation, String account, String region) {
+    try {
+      return rateLimiters.get(new RateLimitKey(implementation, account, region));
+    } catch (ExecutionException executionException) {
+      if (executionException.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) executionException.getCause();
+      }
+      throw new RuntimeException("Failed creating rate limiter", executionException.getCause());
+    }
+  }
+
+  private static class RateLimitCacheLoader extends CacheLoader<RateLimitKey, RateLimiter> {
+    private static final double DEFAULT_LIMIT = 10.0d;
+
+    private final ServiceLimitConfiguration serviceLimitConfiguration;
+    private final double defaultLimit;
+
+    public RateLimitCacheLoader(ServiceLimitConfiguration serviceLimitConfiguration) {
+      this(serviceLimitConfiguration, DEFAULT_LIMIT);
+    }
+
+    public RateLimitCacheLoader(ServiceLimitConfiguration serviceLimitConfiguration, double defaultLimit) {
+      this.serviceLimitConfiguration = Objects.requireNonNull(serviceLimitConfiguration);
+      this.defaultLimit = defaultLimit;
+    }
+
+    @Override
+    public RateLimiter load(RateLimitKey key) throws Exception {
+      double rateLimit = serviceLimitConfiguration.getLimit(
+        ServiceLimitConfiguration.API_RATE_LIMIT,
+        key.implementationClass.getSimpleName(),
+        key.account,
+        AmazonCloudProvider.ID,
+        defaultLimit);
+
+      return RateLimiter.create(rateLimit);
+    }
+  }
+
+  private static class RateLimitKey {
+    private final Class<?> implementationClass;
+    private final String account;
+    private final String region;
+
+    public RateLimitKey(Class<?> implementationClass, String account, String region) {
+      this.implementationClass = Objects.requireNonNull(implementationClass);
+      this.account = Objects.requireNonNull(account);
+      this.region = region;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      RateLimitKey that = (RateLimitKey) o;
+
+      if (!implementationClass.equals(that.implementationClass)) return false;
+      if (!account.equals(that.account)) return false;
+      return region != null ? region.equals(that.region) : that.region == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = implementationClass.hashCode();
+      result = 31 * result + account.hashCode();
+      result = 31 * result + (region != null ? region.hashCode() : 0);
+      return result;
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimitingRequestHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimitingRequestHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.amazonaws.Request;
+import com.amazonaws.handlers.RequestHandler2;
+import com.google.common.util.concurrent.RateLimiter;
+import com.netflix.spectator.api.Counter;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A RequestHandler that will throttle requests via the supplied RateLimiter.
+ */
+public class RateLimitingRequestHandler extends RequestHandler2 {
+  private final Counter counter;
+  private final RateLimiter rateLimiter;
+
+  public RateLimitingRequestHandler(Counter counter, RateLimiter rateLimiter) {
+    this.counter = requireNonNull(counter);
+    this.rateLimiter = requireNonNull(rateLimiter);
+  }
+
+  @Override
+  public void beforeRequest(Request<?> request) {
+    double rateLimitedSeconds = rateLimiter.acquire();
+    long rateLimitedMillis = Double.valueOf(rateLimitedSeconds * 1000).longValue();
+    counter.increment(rateLimitedMillis);
+    super.beforeRequest(request);
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -39,7 +39,6 @@ import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsR
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancer
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration.DeployDefaults
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
@@ -104,7 +103,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     credsRepo.save('baz', TestCredential.named('baz'))
     this.handler = new BasicAmazonDeployHandler(rspf, credsRepo, defaults) {
       @Override LoadBalancerLookupHelper lookupHelper() {
-        return new LoadBalancerLookupHelper(RateLimiter.create(1000000))
+        return new LoadBalancerLookupHelper()
       }
     }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
@@ -23,7 +23,6 @@ import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRe
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -35,7 +34,7 @@ class DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec extends Instanc
     description.instanceIds = ["i-123456"]
     op = new DeregisterInstancesFromLoadBalancerAtomicOperation(description) {
       @Override LoadBalancerLookupHelper lookupHelper() {
-        return new LoadBalancerLookupHelper(RateLimiter.create(100000))
+        return new LoadBalancerLookupHelper()
       }
     }
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
@@ -23,7 +23,6 @@ import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRe
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
 import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -35,7 +34,7 @@ class RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec extends InstanceL
     description.instanceIds = ["i-123456"]
     op = new RegisterInstancesWithLoadBalancerAtomicOperation(description) {
       @Override LoadBalancerLookupHelper lookupHelper() {
-        return new LoadBalancerLookupHelper(RateLimiter.create(100000))
+        return new LoadBalancerLookupHelper()
       }
     }
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -23,6 +23,8 @@ import com.netflix.spinnaker.clouddriver.cache.CacheConfig
 import com.netflix.spinnaker.clouddriver.cache.NoopOnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.core.agent.CleanupPendingOnDemandCachesAgent
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfigurationBuilder
 import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.clouddriver.model.ApplicationProvider
@@ -59,6 +61,7 @@ import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvi
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -78,6 +81,17 @@ class CloudDriverConfig {
   @Bean
   String clouddriverUserAgentApplicationName(Environment environment) {
     return "Spinnaker/${environment.getProperty("Implementation-Version", "Unknown")}"
+  }
+
+  @Bean
+  @ConfigurationProperties('serviceLimits')
+  ServiceLimitConfigurationBuilder serviceLimitConfigProperties() {
+    return new ServiceLimitConfigurationBuilder()
+  }
+
+  @Bean
+  ServiceLimitConfiguration serviceLimitConfiguration(ServiceLimitConfigurationBuilder serviceLimitConfigProperties) {
+    return serviceLimitConfigProperties.build()
   }
 
   @Bean

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ImplementationLimits.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ImplementationLimits.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * ImplementationLimits.
+ */
+public class ImplementationLimits {
+  private final ServiceLimits defaults;
+  private final Map<String, ServiceLimits> accountOverrides;
+
+  public ImplementationLimits(ServiceLimits defaults, Map<String, ServiceLimits> accountOverrides) {
+    this.defaults = defaults == null ? new ServiceLimits(null) : defaults;
+    this.accountOverrides = accountOverrides == null ? Collections.emptyMap() : ImmutableMap.copyOf(accountOverrides);
+  }
+
+  public Double getLimit(String limit, String account) {
+    return Optional
+      .ofNullable(account)
+      .map(accountOverrides::get)
+      .map(sl -> sl.getLimit(limit))
+      .orElse(defaults.getLimit(limit));
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfiguration.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+public class ServiceLimitConfiguration {
+  public static final String POLL_INTERVAL_MILLIS = "agentPollIntervalMs";
+  public static final String POLL_TIMEOUT_MILLIS = "agentPollTimeoutMs";
+  public static final String API_RATE_LIMIT = "rateLimit";
+
+
+  private final ServiceLimits defaults;
+  private final Map<String, ServiceLimits> cloudProviderOverrides;
+  private final Map<String, ServiceLimits> accountOverrides;
+  private final Map<String, ImplementationLimits> implementationLimits;
+
+  public ServiceLimitConfiguration(ServiceLimits defaults, Map<String, ServiceLimits> cloudProviderOverrides, Map<String, ServiceLimits> accountOverrides, Map<String, ImplementationLimits> implementationLimits) {
+    this.defaults = defaults == null ? new ServiceLimits(null) : defaults;
+    this.cloudProviderOverrides = cloudProviderOverrides == null ? Collections.emptyMap() : ImmutableMap.copyOf(cloudProviderOverrides);
+    this.accountOverrides = accountOverrides == null ? Collections.emptyMap() : ImmutableMap.copyOf(accountOverrides);
+    this.implementationLimits = implementationLimits == null ? Collections.emptyMap() : ImmutableMap.copyOf(implementationLimits);
+  }
+
+  public Double getLimit(String limit, String implementation, String account, String cloudProvider, Double defaultValue) {
+    return Optional
+      .ofNullable(getImplementationLimit(limit, implementation, account))
+      .orElse(Optional.ofNullable(getAccountLimit(limit, account))
+        .orElse(Optional.ofNullable(getCloudProviderLimit(limit, cloudProvider))
+          .orElse(Optional.ofNullable(defaults.getLimit(limit))
+            .orElse(defaultValue))));
+  }
+
+  private Double getAccountLimit(String limit, String account) {
+    return Optional
+      .ofNullable(account)
+      .map(accountOverrides::get)
+      .map(sl -> sl.getLimit(limit))
+      .orElse(null);
+  }
+
+  private Double getCloudProviderLimit(String limit, String cloudProvider) {
+    return Optional
+      .ofNullable(cloudProvider)
+      .map(cloudProviderOverrides::get)
+      .map(sl -> sl.getLimit(limit))
+      .orElse(null);
+  }
+
+  private Double getImplementationLimit(String limit, String implementation, String account) {
+    return Optional
+      .ofNullable(implementation)
+      .map(implementationLimits::get)
+      .map(il -> il.getLimit(limit, account))
+      .orElse(null);
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfigurationBuilder.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfigurationBuilder.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+/**
+ * Mutable structure for construction of ServiceLimitConfiguration.
+ */
+public class ServiceLimitConfigurationBuilder {
+
+  private MutableLimits defaults = new MutableLimits();
+  private Map<String, MutableLimits> cloudProviderOverrides = new HashMap<>();
+  private Map<String, MutableLimits> accountOverrides = new HashMap<>();
+  private Map<String, MutableImplementationLimits> implementationLimits = new HashMap<>();
+
+  public MutableLimits getDefaults() {
+    return defaults;
+  }
+
+  public void setDefaults(MutableLimits defaults) {
+    this.defaults = defaults;
+  }
+
+  public ServiceLimitConfigurationBuilder withDefault(String limit, Double value) {
+    if (defaults == null) {
+      defaults = new MutableLimits();
+    }
+    defaults.setLimit(limit, value);
+    return this;
+  }
+
+  public Map<String, MutableLimits> getCloudProviderOverrides() {
+    return cloudProviderOverrides;
+  }
+
+  public void setCloudProviderOverrides(Map<String, MutableLimits> cloudProviderOverrides) {
+    this.cloudProviderOverrides = cloudProviderOverrides;
+  }
+
+  public ServiceLimitConfigurationBuilder withCloudProviderOverride(String cloudProvider, String limit, Double value) {
+    if (cloudProviderOverrides == null) {
+      cloudProviderOverrides = new HashMap<>();
+    }
+    cloudProviderOverrides.computeIfAbsent(cloudProvider, k -> new MutableLimits()).setLimit(limit, value);
+    return this;
+  }
+
+  public Map<String, MutableLimits> getAccountOverrides() {
+    return accountOverrides;
+  }
+
+  public void setAccountOverrides(Map<String, MutableLimits> accountOverrides) {
+    this.accountOverrides = accountOverrides;
+  }
+
+  public ServiceLimitConfigurationBuilder withAccountOverride(String account, String limit, Double value) {
+    if (accountOverrides == null) {
+      accountOverrides = new HashMap<>();
+    }
+
+    accountOverrides.computeIfAbsent(account, k -> new MutableLimits()).setLimit(limit, value);
+    return this;
+  }
+
+  public Map<String, MutableImplementationLimits> getImplementationLimits() {
+    return implementationLimits;
+  }
+
+  public void setImplementationLimits(Map<String, MutableImplementationLimits> implementationLimits) {
+    this.implementationLimits = implementationLimits;
+  }
+
+  public ServiceLimitConfigurationBuilder withImplementationDefault(String implementation, String limit, Double value) {
+    if (implementationLimits == null) {
+      implementationLimits = new HashMap<>();
+    }
+    implementationLimits.computeIfAbsent(implementation, k -> new MutableImplementationLimits()).defaults.setLimit(limit, value);
+    return this;
+  }
+
+  public ServiceLimitConfigurationBuilder withImplementationAccountOverride(String implementation, String account, String limit, Double value) {
+    if (implementationLimits == null) {
+      implementationLimits = new HashMap<>();
+    }
+
+    implementationLimits
+      .computeIfAbsent(implementation, k -> new MutableImplementationLimits())
+      .accountOverrides.computeIfAbsent(account, k -> new MutableLimits())
+      .setLimit(limit, value);
+
+    return this;
+  }
+
+  public ServiceLimitConfiguration build() {
+    return new ServiceLimitConfiguration(new ServiceLimits(defaults), toServiceLimits(cloudProviderOverrides), toServiceLimits(accountOverrides), toImplementationLimits(implementationLimits));
+  }
+
+  public static class MutableLimits extends HashMap<String, Double> {
+    public void setLimit(String limit, Double value) {
+      put(limit, value);
+    }
+
+    public Double getLimit(String limit) {
+      return get(limit);
+    }
+  }
+
+  public static class MutableImplementationLimits {
+    MutableLimits defaults = new MutableLimits();
+    Map<String, MutableLimits> accountOverrides = new HashMap<>();
+
+    public ImplementationLimits toImplementationLimits() {
+      return new ImplementationLimits(new ServiceLimits(defaults), toServiceLimits(accountOverrides));
+    }
+
+    public MutableLimits getDefaults() {
+      return defaults;
+    }
+
+    public void setDefaults(MutableLimits defaults) {
+      this.defaults = defaults;
+    }
+
+    public Map<String, MutableLimits> getAccountOverrides() {
+      return accountOverrides;
+    }
+
+    public void setAccountOverrides(Map<String, MutableLimits> accountOverrides) {
+      this.accountOverrides = accountOverrides;
+    }
+  }
+
+  private static <S, D> Map<String, D> toImmutable(Map<String, S> src, Function<Map.Entry<String, S>, D> converter) {
+    return java.util.Optional.ofNullable(src)
+      .map(Map::entrySet)
+      .map(Set::stream)
+      .map(s -> s.collect(
+        Collectors.toMap(
+          Map.Entry::getKey,
+          converter)))
+      .orElse(Collections.emptyMap());
+  }
+
+  private static Map<String, ServiceLimits> toServiceLimits(Map<String, MutableLimits> limits) {
+    return toImmutable(limits, mapEntry -> new ServiceLimits(mapEntry.getValue()));
+  }
+
+  private static Map<String, ImplementationLimits> toImplementationLimits(Map<String, MutableImplementationLimits> implementationLimits) {
+    return toImmutable(implementationLimits, mapEntry -> mapEntry.getValue().toImplementationLimits());
+  }
+
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimits.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimits.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ServiceLimits {
+  private final Map<String, Double> limits;
+
+  public ServiceLimits(Map<String, Double> limits) {
+    this.limits = limits == null ? Collections.emptyMap() : ImmutableMap.copyOf(limits);
+  }
+
+  public Double getLimit(String limit) {
+    return limits.get(limit);
+  }
+}

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfigurationSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfigurationSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits
+
+import spock.lang.Specification
+
+/**
+ * ServiceLimitConfigurationSpec.
+ */
+class ServiceLimitConfigurationSpec extends Specification {
+
+  def 'should accept all null filters'() {
+    given:
+    ServiceLimitConfiguration cfg = new ServiceLimitConfigurationBuilder()
+      .withDefault(limit, configuredDefaultsVal)
+      .build()
+
+    expect:
+    cfg.getLimit(limit, null, null, null, suppliedDefaultsVal) == configuredDefaultsVal
+
+    where:
+    limit = 'foo'
+    configuredDefaultsVal = 1.0d
+    suppliedDefaultsVal = 2.0d
+  }
+
+  def 'should override values'() {
+    given:
+    ServiceLimitConfiguration cfg = new ServiceLimitConfigurationBuilder()
+      .withDefault(limit, defaultLimit)
+      .withCloudProviderOverride(cloudProvider, limit, cloudProviderLimit)
+      .withAccountOverride(accountA, limit, accountALimit)
+      .withAccountOverride(accountB, limit, accountBLimit)
+      .withImplementationDefault(implementation, limit, implementationDefault)
+      .withImplementationAccountOverride(implementation, implementationAccount, limit, implementationAccountLimit)
+      .build()
+
+
+    expect:
+    cfg.getLimit(limit, implementationName, accountName, cloudProviderName, defaultValue) == expectedValue
+
+    where:
+    defaultValue = 0.5d
+    limit = 'foo'
+    defaultLimit = 1.0d
+    cloudProvider = 'cloudProvider'
+    cloudProviderLimit = 2.0d
+    accountA = 'accountA'
+    accountALimit = 3.0d
+    accountB = 'accountB'
+    accountBLimit = 3.5d
+    implementation = 'implementation'
+    implementationDefault = 4.0d
+    implementationAccount = 'accountA'
+    implementationAccountLimit = 5.0d
+
+
+
+    limitName | accountName | cloudProviderName | implementationName | expectedValue
+    'foo' | 'accountC'| 'cloudProvider' | 'implementationB' | 2.0d
+    'foo' | 'accountB'| 'cloudProvider' | 'implementationB' | 3.5d
+    'foo' | 'accountB'| 'cloudProvider' | 'implementation'  | 4.0d
+    'foo' | 'accountA'| 'cloudProvider' | 'implementation'  | 5.0d
+  }
+}


### PR DESCRIPTION
a service limit is a key to Double value pair, for example a rateLimit against an API.

limits can be configured at a fine grained level (implementation and account) and fall back through
several levels of defaults (implementation default, account default, cloud provider default, global default).

configuration looks like:

````yaml
serviceLimits:
  defaults:
    rateLimit: 10

  cloudProviderOverrides:
    aws:
      rateLimit: 15

  accountOverrides:
    test:
      rateLimit: 5
    prod:
      rateLimit: 100

  implementationLimits:

    AmazonEC2:
      defaults:
        rateLimit: 200
      accountOverrides:
        prod:
          rateLimit: 500

    AmazonElasticLoadBalancing:
      defaults:
        rateLimit: 10
````

In this example:
* requesting the rateLimit for AmazonElasticLoadBalancing for any account would return 10
* requesting the rateLimit for AmazonEC2 for the prod account would return 500, and any other account 200
* requesting the rateLimit for AmazonCloudWatch for the prod account would return 100, test 5, any other account 15

This configuration should extend to support per caching-agent level configuration (pollInterval) and can be applied in other cloud provider api clients as well.

The initial application of this configuration is to configure a rateLimit (maximum requests per second) for the various Amazon API clients returned by AmazonClientProvider. If unconfigured a default of 10 requests per second is used.

The rate limits in AmazonClientProvider are scoped to a client type (e.g. AmazonEC2) in a specific account and region.
The rate limits are applied globally to all clients requested by AmazonClientProvider and enforced by a request handler that acquires an object from a guava RateLimiter before request execution.

Additionally, this change updates AmazonClientProvider to keep a cache of API clients it has created (again per client type, account, and region) instead of always creating a new SDK client for each call.

closes #1284 

@andrewbackes PTAL (In playing with my prototype implementation and working through some scenarios I ended up getting this close enough that I just polished it off)
@spinnaker/netflix-reviewers PTAL
@spinnaker/google-reviewers FYI (config mechanism may be useful in the near term if you have any similar API throttling issues to contend with, and I expect to extend this into the caching agent scheduler as a followup)


I'm still doing some testing around this, so not up for merge yet