### PR TITLE
(kubernetes) assorted cache fixes

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
@@ -28,7 +28,7 @@ import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.client.internal.SerializationUtils
 
 @CompileStatic
-@EqualsAndHashCode(includes = ["name", "account"])
+@EqualsAndHashCode(includes = ["name", "namespace", "account"])
 class KubernetesLoadBalancer implements LoadBalancer, Serializable {
   String name
   final String type = KubernetesCloudProvider.ID

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesSecurityGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesSecurityGroup.groovy
@@ -23,8 +23,10 @@ import com.netflix.spinnaker.clouddriver.model.SecurityGroup
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.clouddriver.model.securitygroups.HttpRule
 import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule
+import groovy.transform.EqualsAndHashCode
 import io.fabric8.kubernetes.api.model.extensions.Ingress
 
+@EqualsAndHashCode(includes = ["name", "namespace", "accountName"])
 class KubernetesSecurityGroup implements SecurityGroup, Serializable {
   final String type = KubernetesCloudProvider.ID
   final String cloudProvider = KubernetesCloudProvider.ID

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -286,8 +286,8 @@ class KubernetesServerGroupCachingAgent extends KubernetesCachingAgent implement
     Map<String, Map<String, HorizontalPodAutoscaler>> rsAutoscalers = [:].withDefault { _ -> [:] }
     try {
       namespaces.each { String namespace ->
-        rcAutoscalers[namespace] == credentials.apiAdaptor.getAutoscalers(namespace, "replicationController")
-        rsAutoscalers[namespace] == credentials.apiAdaptor.getAutoscalers(namespace, "replicaSet")
+        rcAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, "replicationController")
+        rsAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, "replicaSet")
       }
     } catch (Exception e) {
       log.warn "Failure fetching autoscalers for all server groups in $namespaces", e

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -168,13 +168,6 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
         serverGroup.securityGroups.addAll(securityGroups[it])
       }
 
-      def imageList = []
-      for (def container : serverGroup.deployDescription.containers) {
-        imageList.add(KubernetesUtil.getImageIdWithoutRegistry(container.imageDescription))
-      }
-
-      Map buildInfo = [images: imageList]
-      serverGroup.buildInfo = buildInfo
       serverGroups[Names.parseName(serverGroup.name).cluster].add(serverGroup)
     }
 


### PR DESCRIPTION
 * autoscalers weren't showing up
 * buildInfo now shows what created a replicaset
 * hashcode implementation for load balancers, server groups, & security groups were incorrect, leading to omitted results.

@duftler PTAL