### PR TITLE
(kubernetes) labeling bug fix

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -906,7 +906,9 @@ class KubernetesApiConverter {
    */
   static Map<String, String> baseServerGroupLabels(DeployKubernetesAtomicOperationDescription description, String name) {
     def parsedName = Names.parseName(name)
-    return hasDeployment(description) ? [(parsedName.cluster): "true"] : [(name): "true"]
+    def labels = [(KubernetesUtil.SERVER_GROUP_LABEL): name]
+    labels += hasDeployment(description) ? [(parsedName.cluster): "true"] : [(name): "true"]
+    return labels
   }
 
   /*


### PR DESCRIPTION
@duftler FYI

This missing label would cause server groups created before the recent deployment patch to no longer be affected by disable/enable ops