### PR TITLE
(kubernetes) desiredPercentage enable/disable

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/EnableDisableAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/EnableDisableAsgDescription.groovy
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
+import com.netflix.spinnaker.clouddriver.deploy.description.EnableDisableDescriptionTrait
+
 /**
  * Description for "enabling" a supplied ASG. "Enabling" means Resuming "AddToLoadBalancer", "Launch", and "Terminate" processes on an ASG. If Eureka/Discovery is available, setting a status
  * override will also be achieved.
@@ -22,9 +24,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
  * Description for "disabling" a supplied ASG. "Disabling" means Suspending "AddToLoadBalancer", "Launch", and "Terminate" processes on an ASG. If Eureka/Discovery is available, setting a status
  * override will also be achieved.
  */
-class EnableDisableAsgDescription extends AbstractAmazonCredentialsDescription {
-
-  String serverGroupName
+class EnableDisableAsgDescription extends AbstractAmazonCredentialsDescription implements EnableDisableDescriptionTrait {
   String region
 
   List<AsgDescription> asgs = []

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/EnableDisableDestroyAzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/EnableDisableDestroyAzureServerGroupDescription.groovy
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model
 
-class EnableDisableDestroyAzureServerGroupDescription extends AzureServerGroupDescription {
-  String serverGroupName
+import com.netflix.spinnaker.clouddriver.deploy.description.EnableDisableDescriptionTrait
 
+class EnableDisableDestroyAzureServerGroupDescription extends AzureServerGroupDescription implements EnableDisableDescriptionTrait  {
   @Deprecated
   List<String> regions
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/description/EnableDisableDescriptionTrait.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/description/EnableDisableDescriptionTrait.groovy
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup
+package com.netflix.spinnaker.clouddriver.deploy.description
 
-import com.netflix.spinnaker.clouddriver.deploy.description.EnableDisableDescriptionTrait
+trait EnableDisableDescriptionTrait {
+  String serverGroupName
 
-class EnableDisableKubernetesAtomicOperationDescription extends KubernetesServerGroupDescription implements EnableDisableDescriptionTrait {
-  Integer desiredPercentage
+  Integer getDesiredPercentage() {
+    throw new IllegalArgumentException("The selected provider hasn't implemented enabling/disabling by percentage yet")
+  }
+
+  void setDesiredPercentage(Integer _) {
+    throw new IllegalArgumentException("The selected provider hasn't implemented enabling/disabling by percentage yet")
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/EnableDisablePercentCategorizer.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/EnableDisablePercentCategorizer.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.helpers
+
+
+class EnableDisablePercentCategorizer<T> {
+  /**
+   * During an enable/disable operation that accepts a desired percentage of instances to leave enabled/disabled, this acts
+   * as a helper function to return which instances still need to be enabled/disabled.
+   *
+   * @param modified are the instances that don't need to be enabled/disabled (presumably have already been enabled/disabled).
+   * @param unmodified are the instances that do need to be enabled/disabled.
+   * @param desiredPercent is the end desired percent. If the percent has already been achieved or exceeded by the input instances, we return an empty list.
+   * @return the list of instances to be enabled/disabled.
+   *
+   * @note modified + unmodified should be the total list of instances managed by one server group
+   */
+  static List<T> getInstancesToModify(List<T> modified, List<T> unmodified, int desiredPercent) {
+    if (desiredPercent < 0 || desiredPercent > 100) {
+      throw new RuntimeException("Desired target percentage must be between 0 and 100 inclusive")
+    }
+
+    int totalSize = modified.size() + unmodified.size()
+    // Check desired percent to prevent floating-point error + integer-cast truncation from removing one instance from the modify pool
+    int newSize = desiredPercent == 100 ? totalSize : (int) (totalSize * (float) (desiredPercent / 100))
+
+    int returnSize = modified.size() > newSize ? 0 : newSize - modified.size();
+
+    return unmodified.take(returnSize);
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/EnableDisablePercentageCategorizer.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/EnableDisablePercentageCategorizer.groovy
@@ -17,29 +17,28 @@
 package com.netflix.spinnaker.clouddriver.helpers
 
 
-class EnableDisablePercentCategorizer<T> {
+class EnableDisablePercentageCategorizer<T> {
   /**
    * During an enable/disable operation that accepts a desired percentage of instances to leave enabled/disabled, this acts
    * as a helper function to return which instances still need to be enabled/disabled.
    *
    * @param modified are the instances that don't need to be enabled/disabled (presumably have already been enabled/disabled).
    * @param unmodified are the instances that do need to be enabled/disabled.
-   * @param desiredPercent is the end desired percent. If the percent has already been achieved or exceeded by the input instances, we return an empty list.
-   * @return the list of instances to be enabled/disabled.
+   * @param desiredPercentage is the end desired percentage.
+   * @return the list of instances to be enabled/disabled. If the percentage has already been achieved or exceeded by the input instances, we return an empty list.
    *
    * @note modified + unmodified should be the total list of instances managed by one server group
    */
-  static List<T> getInstancesToModify(List<T> modified, List<T> unmodified, int desiredPercent) {
-    if (desiredPercent < 0 || desiredPercent > 100) {
+  static List<T> getInstancesToModify(List<T> modified, List<T> unmodified, int desiredPercentage) {
+    if (desiredPercentage < 0 || desiredPercentage > 100) {
       throw new RuntimeException("Desired target percentage must be between 0 and 100 inclusive")
     }
 
     int totalSize = modified.size() + unmodified.size()
-    // Check desired percent to prevent floating-point error + integer-cast truncation from removing one instance from the modify pool
-    int newSize = desiredPercent == 100 ? totalSize : (int) (totalSize * (float) (desiredPercent / 100))
+    int newSize = (int) (totalSize * (float) (desiredPercentage / 100))
 
-    int returnSize = modified.size() > newSize ? 0 : newSize - modified.size();
+    int returnSize = modified.size() > newSize ? 0 : newSize - modified.size()
 
-    return unmodified.take(returnSize);
+    return unmodified.take(returnSize)
   }
 }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/helpers/EnableDisablePercentageCategorizerSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/helpers/EnableDisablePercentageCategorizerSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.helpers
+
+import spock.lang.Specification
+
+
+class EnableDisablePercentageCategorizerSpec extends Specification {
+  void "should pick the right number of elements to move between lists"() {
+    when:
+    def output = EnableDisablePercentageCategorizer.getInstancesToModify(modified, unmodified, percent)
+
+    then:
+    if (modified.size() + unmodified.size() == 0) {
+      output.size() == 0
+    } else {
+      (output.size() + modified.size()) / (modified.size() + unmodified.size()) >= (float) percent / 1000
+    }
+
+    where:
+    modified || unmodified || percent
+    [1] * 0  || [1] * 4    || 100
+    [1] * 0  || [1] * 4    || 25
+    [1] * 0  || [1] * 7    || 10
+
+    [1] * 4  || [1] * 0    || 100
+    [1] * 3  || [1] * 0    || 10
+    [1] * 9  || [1] * 0    || 60
+
+    [1] * 0  || [1] * 0    || 0
+    [1] * 0  || [1] * 0    || 100
+    [1] * 0  || [1] * 0    || 40
+
+    [1] * 9  || [1] * 9    || 60
+    [1] * 7  || [1] * 3    || 10
+    [1] * 4  || [1] * 4    || 100
+    [1] * 5  || [1] * 10   || 0
+    [1] * 9  || [1] * 10   || 90
+}
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/EnableDisableGoogleServerGroupDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/EnableDisableGoogleServerGroupDescription.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.description
 
+import com.netflix.spinnaker.clouddriver.deploy.description.EnableDisableDescriptionTrait
 import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
 
 /**
@@ -23,8 +24,7 @@ import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
  *
  * "Disabling" means removing a server group from the target pool of each of its network load balancers.
  */
-class EnableDisableGoogleServerGroupDescription extends AbstractGoogleCredentialsDescription implements ServerGroupNameable {
-  String serverGroupName
+class EnableDisableGoogleServerGroupDescription extends AbstractGoogleCredentialsDescription implements ServerGroupNameable, EnableDisableDescriptionTrait {
   String region
   String accountName
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/DisableKubernetesAtomicOperationConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/DisableKubernetesAtomicOperationConverter.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.servergro
 
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.EnableDisableKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesServerGroupDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup.DisableKubernetesAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
@@ -33,6 +34,6 @@ class DisableKubernetesAtomicOperationConverter extends AbstractAtomicOperations
   }
 
   KubernetesServerGroupDescription convertDescription(Map input) {
-    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, KubernetesServerGroupDescription)
+    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, EnableDisableKubernetesAtomicOperationDescription)
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/EnableKubernetesAtomicOperationConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/EnableKubernetesAtomicOperationConverter.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.servergro
 
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.EnableDisableKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesServerGroupDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup.EnableKubernetesAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
@@ -33,6 +34,6 @@ class EnableKubernetesAtomicOperationConverter extends AbstractAtomicOperationsC
   }
 
   KubernetesServerGroupDescription convertDescription(Map input) {
-    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, KubernetesServerGroupDescription)
+    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, EnableDisableKubernetesAtomicOperationDescription)
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/EnableDisableKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/EnableDisableKubernetesAtomicOperationDescription.groovy
@@ -16,6 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup
 
-class ResizeKubernetesAtomicOperationDescription extends KubernetesServerGroupDescription {
-  Capacity capacity
+class EnableDisableKubernetesAtomicOperationDescription extends KubernetesServerGroupDescription {
+  Integer desiredPercent
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.helpers.EnableDisablePercentCategorizer
+import com.netflix.spinnaker.clouddriver.helpers.EnableDisablePercentageCategorizer
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.EnableDisableKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesServerGroupDescription
@@ -101,7 +101,7 @@ abstract class AbstractEnableDisableKubernetesAtomicOperation implements AtomicO
 
     def pool = Executors.newWorkStealingPool((int) (pods.size() / 2) + 1)
 
-    if (description.desiredPercent != null) {
+    if (description.desiredPercentage != null) {
       List<Pod> modifiedPods = pods.findAll { pod ->
         KubernetesUtil.getPodLoadBalancerStates(pod).every { it.value == action }
       }
@@ -110,7 +110,7 @@ abstract class AbstractEnableDisableKubernetesAtomicOperation implements AtomicO
         KubernetesUtil.getPodLoadBalancerStates(pod).any { it.value != action }
       }
 
-      pods = EnableDisablePercentCategorizer.getInstancesToModify(modifiedPods, unmodifiedPods, description.desiredPercent)
+      pods = EnableDisablePercentageCategorizer.getInstancesToModify(modifiedPods, unmodifiedPods, description.desiredPercentage)
     }
 
     pods.each { Pod pod ->

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/StandardKubernetesAttributeValidator.groovy
@@ -258,4 +258,14 @@ class StandardKubernetesAttributeValidator {
       errors.rejectValue("${context}.${attribute1}", "${context}.${attribute1}.lessThan ${context}.${attribute2}")
     }
   }
+
+  def validateInRangeInclusive(Integer value, int min, int max, String attribute) {
+    if (min > value) {
+      errors.rejectValue("${context}.${attribute}", "${context}.${attribute}.greaterThan $min")
+    }
+
+    if (max < value) {
+      errors.rejectValue("${context}.${attribute}", "${context}.${attribute}.lessThan $max")
+    }
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DisableKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/DisableKubernetesAtomicOperationValidator.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergro
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
-import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesServerGroupDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.EnableDisableKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
@@ -28,14 +28,15 @@ import org.springframework.validation.Errors
 
 @KubernetesOperation(AtomicOperations.DISABLE_SERVER_GROUP)
 @Component
-class DisableKubernetesAtomicOperationValidator extends DescriptionValidator<KubernetesServerGroupDescription> {
+class DisableKubernetesAtomicOperationValidator extends DescriptionValidator<EnableDisableKubernetesAtomicOperationDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, KubernetesServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableKubernetesAtomicOperationDescription description, Errors errors) {
     def helper = new StandardKubernetesAttributeValidator("disableKubernetesAtomicOperationDescription", errors)
 
+    EnableDisableKubernetesAtomicOperationValidator.validate(description, helper)
     KubernetesServerGroupDescriptionValidator.validate(description, helper, accountCredentialsProvider)
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/EnableDisableKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/EnableDisableKubernetesAtomicOperationValidator.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergroup
+
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.EnableDisableKubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
+
+class EnableDisableKubernetesAtomicOperationValidator {
+  static void validate(EnableDisableKubernetesAtomicOperationDescription description, StandardKubernetesAttributeValidator helper) {
+    if (description.desiredPercent != null) {
+      helper.validateInRangeInclusive(description.desiredPercent, 0, 100, "desiredPercent")
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/EnableDisableKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/EnableDisableKubernetesAtomicOperationValidator.groovy
@@ -21,8 +21,8 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKu
 
 class EnableDisableKubernetesAtomicOperationValidator {
   static void validate(EnableDisableKubernetesAtomicOperationDescription description, StandardKubernetesAttributeValidator helper) {
-    if (description.desiredPercent != null) {
-      helper.validateInRangeInclusive(description.desiredPercent, 0, 100, "desiredPercent")
+    if (description.desiredPercentage != null) {
+      helper.validateInRangeInclusive(description.desiredPercentage, 0, 100, "desiredPercent")
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/EnableKubernetesAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/servergroup/EnableKubernetesAtomicOperationValidator.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.servergro
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.EnableDisableKubernetesAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesServerGroupDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
@@ -28,14 +29,15 @@ import org.springframework.validation.Errors
 
 @KubernetesOperation(AtomicOperations.ENABLE_SERVER_GROUP)
 @Component
-class EnableKubernetesAtomicOperationValidator extends DescriptionValidator<KubernetesServerGroupDescription> {
+class EnableKubernetesAtomicOperationValidator extends DescriptionValidator<EnableDisableKubernetesAtomicOperationDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, KubernetesServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableKubernetesAtomicOperationDescription description, Errors errors) {
     def helper = new StandardKubernetesAttributeValidator("enableKubernetesAtomicOperationDescription", errors)
 
+    EnableDisableKubernetesAtomicOperationValidator.validate(description, helper)
     KubernetesServerGroupDescriptionValidator.validate(description, helper, accountCredentialsProvider)
   }
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/converters/servergroup/DisableOpenstackAtomicOperationConverter.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/converters/servergroup/DisableOpenstackAtomicOperationConverter.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.converters.servergrou
 
 import com.netflix.spinnaker.clouddriver.openstack.OpenstackOperation
 import com.netflix.spinnaker.clouddriver.openstack.deploy.converters.OpenstackAtomicOperationConverterHelper
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.EnableDisableAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.OpenstackServerGroupAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.servergroup.DisableOpenstackAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
@@ -35,7 +36,7 @@ class DisableOpenstackAtomicOperationConverter extends AbstractAtomicOperationsC
   }
 
   @Override
-  OpenstackServerGroupAtomicOperationDescription convertDescription(Map input) {
-    OpenstackAtomicOperationConverterHelper.convertDescription(input, this, OpenstackServerGroupAtomicOperationDescription)
+  EnableDisableAtomicOperationDescription convertDescription(Map input) {
+    OpenstackAtomicOperationConverterHelper.convertDescription(input, this, EnableDisableAtomicOperationDescription)
   }
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/converters/servergroup/EnableOpenstackAtomicOperationConverter.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/converters/servergroup/EnableOpenstackAtomicOperationConverter.groovy
@@ -18,13 +18,12 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.converters.servergrou
 
 import com.netflix.spinnaker.clouddriver.openstack.OpenstackOperation
 import com.netflix.spinnaker.clouddriver.openstack.deploy.converters.OpenstackAtomicOperationConverterHelper
-import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.OpenstackServerGroupAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.EnableDisableAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.servergroup.EnableOpenstackAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import org.springframework.stereotype.Component
-
 
 @OpenstackOperation(AtomicOperations.ENABLE_SERVER_GROUP)
 @Component
@@ -36,7 +35,7 @@ class EnableOpenstackAtomicOperationConverter extends AbstractAtomicOperationsCr
   }
 
   @Override
-  OpenstackServerGroupAtomicOperationDescription convertDescription(Map input) {
-    OpenstackAtomicOperationConverterHelper.convertDescription(input, this, OpenstackServerGroupAtomicOperationDescription)
+  EnableDisableAtomicOperationDescription convertDescription(Map input) {
+    OpenstackAtomicOperationConverterHelper.convertDescription(input, this, EnableDisableAtomicOperationDescription)
   }
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/EnableDisableAtomicOperationDescription.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/EnableDisableAtomicOperationDescription.groovy
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup
+package com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup
 
+import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.deploy.description.EnableDisableDescriptionTrait
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.OpenstackAtomicOperationDescription
+import groovy.transform.AutoClone
+import groovy.transform.Canonical
 
-class EnableDisableKubernetesAtomicOperationDescription extends KubernetesServerGroupDescription implements EnableDisableDescriptionTrait {
-  Integer desiredPercentage
+@AutoClone
+@Canonical
+class EnableDisableAtomicOperationDescription extends OpenstackAtomicOperationDescription implements EnableDisableDescriptionTrait, DeployDescription {
 }
+
+

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/AbstractEnableDisableOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/AbstractEnableDisableOpenstackAtomicOperation.groovy
@@ -20,15 +20,11 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.openstack.client.BlockingStatusChecker
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
-import com.netflix.spinnaker.clouddriver.openstack.config.OpenstackConfigurationProperties
-import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.OpenstackServerGroupAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.EnableDisableAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
-import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
 import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.LoadBalancerStatusAware
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.openstack4j.model.heat.Stack
-import org.openstack4j.model.network.ext.LbProvisioningStatus
-import org.openstack4j.model.network.ext.LoadBalancerV2
 import org.openstack4j.model.network.ext.LoadBalancerV2StatusTree
 
 import java.util.concurrent.CompletableFuture
@@ -44,9 +40,9 @@ abstract class AbstractEnableDisableOpenstackAtomicOperation implements AtomicOp
 
   static final int DEFAULT_WEIGHT = 1
 
-  OpenstackServerGroupAtomicOperationDescription description
+  EnableDisableAtomicOperationDescription description
 
-  AbstractEnableDisableOpenstackAtomicOperation(OpenstackServerGroupAtomicOperationDescription description) {
+  AbstractEnableDisableOpenstackAtomicOperation(EnableDisableAtomicOperationDescription description) {
     this.description = description
   }
 

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DisableOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DisableOpenstackAtomicOperation.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.openstack.deploy.ops.servergroup
 
-import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.OpenstackServerGroupAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.EnableDisableAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 
 /**
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 class DisableOpenstackAtomicOperation extends AbstractEnableDisableOpenstackAtomicOperation {
   final String phaseName = "DISABLE_SERVER_GROUP"
   final String operation = AtomicOperations.DISABLE_SERVER_GROUP
-  DisableOpenstackAtomicOperation(OpenstackServerGroupAtomicOperationDescription description) {
+  DisableOpenstackAtomicOperation(EnableDisableAtomicOperationDescription description) {
     super(description)
   }
 

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/EnableOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/EnableOpenstackAtomicOperation.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.openstack.deploy.ops.servergroup
 
-import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.OpenstackServerGroupAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.EnableDisableAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 
 /**
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 class EnableOpenstackAtomicOperation extends AbstractEnableDisableOpenstackAtomicOperation {
   final String phaseName = "ENABLE_SERVER_GROUP"
   final String operation = AtomicOperations.ENABLE_SERVER_GROUP
-  EnableOpenstackAtomicOperation(OpenstackServerGroupAtomicOperationDescription description) {
+  EnableOpenstackAtomicOperation(EnableDisableAtomicOperationDescription description) {
     super(description)
   }
 

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/DisableOpenstackAtomicOperationValidator.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/DisableOpenstackAtomicOperationValidator.groovy
@@ -17,21 +17,21 @@
 package com.netflix.spinnaker.clouddriver.openstack.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.openstack.OpenstackOperation
-import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.OpenstackServerGroupAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.OpenstackAttributeValidator
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.EnableDisableAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.AbstractOpenstackDescriptionValidator
+import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.OpenstackAttributeValidator
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
 @OpenstackOperation(AtomicOperations.DISABLE_SERVER_GROUP)
 @Component
-class DisableOpenstackAtomicOperationValidator extends AbstractOpenstackDescriptionValidator<OpenstackServerGroupAtomicOperationDescription> {
+class DisableOpenstackAtomicOperationValidator extends AbstractOpenstackDescriptionValidator<EnableDisableAtomicOperationDescription> {
 
   String context = "disableOpenstackServerGroupAtomicOperationDescription"
 
   @Override
-  void validate(OpenstackAttributeValidator validator, List priorDescriptions, OpenstackServerGroupAtomicOperationDescription description, Errors errors) {
+  void validate(OpenstackAttributeValidator validator, List priorDescriptions, EnableDisableAtomicOperationDescription description, Errors errors) {
     validator.validateNotEmpty(description.serverGroupName, "serverGroupName")
   }
 

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/EnableOpenstackAtomicOperationValidator.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/validators/servergroup/EnableOpenstackAtomicOperationValidator.groovy
@@ -17,20 +17,20 @@
 package com.netflix.spinnaker.clouddriver.openstack.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.openstack.OpenstackOperation
-import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.OpenstackServerGroupAtomicOperationDescription
-import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.OpenstackAttributeValidator
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.EnableDisableAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.AbstractOpenstackDescriptionValidator
+import com.netflix.spinnaker.clouddriver.openstack.deploy.validators.OpenstackAttributeValidator
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
 @OpenstackOperation(AtomicOperations.ENABLE_SERVER_GROUP)
 @Component
-class EnableOpenstackAtomicOperationValidator extends AbstractOpenstackDescriptionValidator<OpenstackServerGroupAtomicOperationDescription> {
+class EnableOpenstackAtomicOperationValidator extends AbstractOpenstackDescriptionValidator<EnableDisableAtomicOperationDescription> {
 
   String context = "enableOpenstackServerGroupAtomicOperationDescription"
   @Override
-  void validate(OpenstackAttributeValidator validator, List priorDescriptions, OpenstackServerGroupAtomicOperationDescription description, Errors errors) {
+  void validate(OpenstackAttributeValidator validator, List priorDescriptions, EnableDisableAtomicOperationDescription description, Errors errors) {
     validator.validateNotEmpty(description.serverGroupName, "serverGroupName")
   }
 

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/EnableDisableOpenstackAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/EnableDisableOpenstackAtomicOperationSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackClientProvider
 import com.netflix.spinnaker.clouddriver.openstack.client.OpenstackProviderFactory
 import com.netflix.spinnaker.clouddriver.openstack.config.OpenstackConfigurationProperties
+import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.EnableDisableAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.OpenstackServerGroupAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOperationException
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
@@ -71,7 +72,7 @@ class EnableDisableOpenstackAtomicOperationSpec extends Specification {
     OpenstackNamedAccountCredentials creds = new OpenstackNamedAccountCredentials("name", "test", "main", "user", "pw", "tenant", "domain", "endpoint", [], false, "", new OpenstackConfigurationProperties.LbaasConfig(pollTimeout: 60, pollInterval: 5), new ConsulConfig(), null)
     OpenstackProviderFactory.createProvider(creds) >> { provider }
     credentials = new OpenstackCredentials(creds)
-    description = new OpenstackServerGroupAtomicOperationDescription(serverGroupName: STACK, region: REGION, credentials: credentials)
+    description = new EnableDisableAtomicOperationDescription(serverGroupName: STACK, region: REGION, credentials: credentials)
     stack = Mock(Stack) {
       it.tags >> { lbIds }
     }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DisableTitusServerGroupDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DisableTitusServerGroupDescription.groovy
@@ -16,7 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
-class DisableTitusServerGroupDescription extends AbstractTitusCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.deploy.description.EnableDisableDescriptionTrait
+
+class DisableTitusServerGroupDescription extends AbstractTitusCredentialsDescription implements EnableDisableDescriptionTrait {
   String region
-  String serverGroupName
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/EnableDisableServerGroupDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/EnableDisableServerGroupDescription.groovy
@@ -16,7 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
-class EnableDisableServerGroupDescription extends AbstractTitusCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.deploy.description.EnableDisableDescriptionTrait
+
+class EnableDisableServerGroupDescription extends AbstractTitusCredentialsDescription implements EnableDisableDescriptionTrait {
   String region
-  String serverGroupName
 }


### PR DESCRIPTION
@duftler @cfieber PTAL

@spinnaker/reviewers FYI

As per @duftler's suggestion I made sure that any enable/disable that's been passed a "desiredPercentage" that doesn't implement this yet fails immediately. This was a fairly trivial change for all cloud providers, except for Openstack, so could @varikin or @derekolk or @drmaas PTAL?