### PR TITLE
provider/google: Support 'enableCDN' flag in L7 upsert.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleBackendService.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleBackendService.groovy
@@ -43,6 +43,11 @@ class GoogleBackendService {
   Integer affinityCookieTtlSec
   GoogleLoadBalancingScheme loadBalancingScheme
 
+  /**
+   * Specifies whether edge caching is enabled or not. Only applicable for Https LBs.
+   */
+  Boolean enableCDN
+
   // Note: This enum has non-standard style constants because we use these constants as strings directly
   // in the redis cache keys for backend services, where we want to avoid underscores and camelcase is the norm.
   static enum BackendServiceKind {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/GoogleInfrastructureProvider.groovy
@@ -75,6 +75,7 @@ class GoogleInfrastructureProvider extends AgentSchedulerAware implements Search
           healthCheckLink: backendService.attributes.healthCheckLink as String,
           sessionAffinity: backendService.attributes.sessionAffinity as String,
           affinityCookieTtlSec: backendService.attributes.affinityCookieTtlSec as String,
+          enableCDN: backendService.attributes.enableCDN as String,
           region: GCEUtil.getLocalName(backendService.attributes?.region as String)
       ]
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
@@ -84,6 +84,7 @@ class GoogleBackendServiceCachingAgent extends AbstractGoogleCachingAgent {
         attributes.sessionAffinity = backendService.sessionAffinity
         attributes.affinityCookieTtlSec = backendService.affinityCookieTtlSec
         attributes.region = backendService.region
+        attributes.enableCDN = backendService.enableCDN
       }
     }
 
@@ -99,6 +100,7 @@ class GoogleBackendServiceCachingAgent extends AbstractGoogleCachingAgent {
       healthCheckLink: bs.healthChecks[0],
       sessionAffinity: bs.sessionAffinity,
       affinityCookieTtlSec: bs.affinityCookieTtlSec,
+      enableCDN: bs.enableCDN,
       region: bs.region ?: 'global'
     )
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -381,6 +381,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
       backendServicesToUpdate.each { GoogleBackendService service ->
         service.sessionAffinity = GoogleSessionAffinity.valueOf(backendService.sessionAffinity)
         service.affinityCookieTtlSec = backendService.affinityCookieTtlSec
+        service.enableCDN = backendService.enableCDN
         service.backends = backendService.backends?.collect { Backend backend ->
           new GoogleLoadBalancedBackend(
               serverGroupUrl: backend.group,


### PR DESCRIPTION
@duftler @danielpeach please review. This PR caches `enableCDN` in the L7 and `backendService` caching agents and surfaces it for modification in L7 upsert.