### PR TITLE
add support for UpsertEntityFlags operation

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
@@ -42,12 +42,12 @@ class EntityTags {
 
     @JsonAnyGetter
     Map<String,Object> attributes() {
-      return attributes;
+      return attributes
     }
 
     @JsonAnySetter
     void set(String name, Object value) {
-      attributes.put(name, value);
+      attributes.put(name, value)
     }
 
     String getEntityType() {

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityFlagsAtomicOperationConverter.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityFlagsAtomicOperationConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.converters;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.UpsertEntityFlagsDescription;
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
+import com.netflix.spinnaker.clouddriver.elasticsearch.ops.UpsertEntityFlagsAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component("upsertEntityFlags")
+public class UpsertEntityFlagsAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  private final ObjectMapper objectMapper;
+  private final Front50Service front50Service;
+  private final ElasticSearchEntityTagsProvider entityTagsProvider;
+
+  @Autowired
+  public UpsertEntityFlagsAtomicOperationConverter(ObjectMapper objectMapper,
+                                                  Front50Service front50Service,
+                                                  ElasticSearchEntityTagsProvider entityTagsProvider) {
+    this.objectMapper = objectMapper
+      .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    this.front50Service = front50Service;
+    this.entityTagsProvider = entityTagsProvider;
+  }
+
+  public AtomicOperation convertOperation(Map input) {
+    return new UpsertEntityFlagsAtomicOperation(
+      front50Service, entityTagsProvider, this.convertDescription(input)
+    );
+  }
+
+  public UpsertEntityFlagsDescription convertDescription(Map input) {
+    return objectMapper.convertValue(input, UpsertEntityFlagsDescription.class);
+  }
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/UpsertEntityFlagsDescription.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/UpsertEntityFlagsDescription.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.descriptions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.EntityFlag;
+import com.netflix.spinnaker.clouddriver.model.EntityTags;
+import com.netflix.spinnaker.clouddriver.security.resources.NonCredentialed;
+
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UpsertEntityFlagsDescription extends EntityTags implements NonCredentialed {
+
+  private Map<String, EntityFlag> flags;
+
+  public Map<String, EntityFlag> getFlags() {
+    return flags;
+  }
+
+  public void setFlags(Map<String, EntityFlag> flags) {
+    this.flags = flags;
+  }
+
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/EntityFlag.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/EntityFlag.java
@@ -1,0 +1,61 @@
+package com.netflix.spinnaker.clouddriver.elasticsearch.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EntityFlag {
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+  }
+
+  public Long getCreated() {
+    return created;
+  }
+
+  public void setCreated(Long created) {
+    this.created = created;
+  }
+
+  public String getModifiedBy() {
+    return modifiedBy;
+  }
+
+  public void setModifiedBy(String modifiedBy) {
+    this.modifiedBy = modifiedBy;
+  }
+
+  public Long getModified() {
+    return modified;
+  }
+
+  public void setModified(Long modified) {
+    this.modified = modified;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  private String message;
+  private String createdBy;
+  private Long created;
+  private String modifiedBy;
+  private Long modified;
+  private String status;
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/UpsertEntityFlagsAtomicOperation.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/UpsertEntityFlagsAtomicOperation.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.ops;
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.elasticsearch.EntityRefIdBuilder;
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.UpsertEntityFlagsDescription;
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.EntityFlag;
+import com.netflix.spinnaker.clouddriver.model.EntityTags;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+public class UpsertEntityFlagsAtomicOperation implements AtomicOperation<Void> {
+
+  private static final String BASE_PHASE = "ENTITY_FLAGS";
+  public static final String UI_FLAGS_KEY = "spinnaker_ui_flags";
+
+  private final Front50Service front50Service;
+  private final ElasticSearchEntityTagsProvider entityTagsProvider;
+  private final UpsertEntityFlagsDescription entityFlagsDescription;
+
+  public UpsertEntityFlagsAtomicOperation(Front50Service front50Service,
+                                          ElasticSearchEntityTagsProvider entityTagsProvider,
+                                          UpsertEntityFlagsDescription entityFlagsDescription) {
+    this.front50Service = front50Service;
+    this.entityTagsProvider = entityTagsProvider;
+    this.entityFlagsDescription = entityFlagsDescription;
+  }
+
+  public Void operate(List priorOutputs) {
+    EntityTags.EntityRef entityRef = entityFlagsDescription.getEntityRef();
+
+    if (entityFlagsDescription.getId() == null) {
+      EntityRefIdBuilder.EntityRefId entityRefId = EntityRefIdBuilder.buildId(
+        entityRef.getCloudProvider(),
+        entityRef.getEntityType(),
+        entityRef.getEntityId(),
+        (String) entityRef.attributes().get("account"),
+        (String) entityRef.attributes().get("region")
+      );
+      entityFlagsDescription.setId(entityRefId.id);
+      entityFlagsDescription.setIdPattern(entityRefId.idPattern);
+    }
+
+    EntityTags currentTags = entityTagsProvider.get(entityFlagsDescription.getId()).orElse(entityFlagsDescription);
+    if (!currentTags.getTags().containsKey(UI_FLAGS_KEY) || !(currentTags.getTags().get(UI_FLAGS_KEY) instanceof Map)) {
+      currentTags.getTags().put(UI_FLAGS_KEY, new HashMap<String, EntityFlag>());
+    }
+    synchronizeFlags(currentTags);
+
+    getTask().updateStatus(
+      BASE_PHASE,
+      format("Updating flags on %s with %s", entityFlagsDescription.getId(), entityFlagsDescription.getFlags())
+    );
+
+    EntityTags durableEntityTags = front50Service.saveEntityTags(entityFlagsDescription);
+    getTask().updateStatus(BASE_PHASE, format("Updated flags for %s in Front50", durableEntityTags.getId()));
+
+    entityFlagsDescription.setLastModified(durableEntityTags.getLastModified());
+    entityFlagsDescription.setLastModifiedBy(durableEntityTags.getLastModifiedBy());
+
+    entityTagsProvider.index(entityFlagsDescription);
+    entityTagsProvider.verifyIndex(entityFlagsDescription);
+
+    getTask().updateStatus(BASE_PHASE, format("Indexed %s in ElasticSearch", entityFlagsDescription.getId()));
+    return null;
+  }
+
+  private void synchronizeFlags(EntityTags currentTags) {
+    String user = AuthenticatedRequest.getSpinnakerUser().orElse("unknown");
+    Long now = System.currentTimeMillis();
+
+    Map<String, EntityFlag> currentFlags =
+      (Map<String, EntityFlag>) currentTags.getTags().get(UI_FLAGS_KEY);
+
+    entityFlagsDescription.getFlags().forEach((String key, EntityFlag flag) -> {
+      if (flag.getCreatedBy() == null) {
+        flag.setCreatedBy(user);
+        flag.setCreated(now);
+      }
+      flag.setModifiedBy(user);
+      flag.setModified(now);
+      if (currentFlags.containsKey(key)) {
+        flag.setCreatedBy(currentFlags.get(key).getCreatedBy());
+        flag.setCreated(currentFlags.get(key).getCreated());
+        flag.setStatus(currentFlags.get(key).getStatus());
+      }
+      currentFlags.put(key, flag);
+
+    });
+    entityFlagsDescription.setTags(currentTags.getTags());
+  }
+
+  private static Task getTask() {
+    return TaskRepository.threadLocalTask.get();
+  }
+}

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/UpsertEntityFlagsAtomicOperationSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/UpsertEntityFlagsAtomicOperationSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.UpsertEntityFlagsDescription
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.EntityFlag
+import com.netflix.spinnaker.clouddriver.elasticsearch.ops.UpsertEntityFlagsAtomicOperation
+import com.netflix.spinnaker.clouddriver.model.EntityTags
+import com.netflix.spinnaker.clouddriver.model.EntityTags.EntityRef
+import spock.lang.Specification
+
+class UpsertEntityFlagsAtomicOperationSpec extends Specification {
+
+  Front50Service front50Service
+  ElasticSearchEntityTagsProvider entityTagsProvider
+  UpsertEntityFlagsDescription description
+  UpsertEntityFlagsAtomicOperation operation
+
+  def setup() {
+    front50Service = Mock(Front50Service)
+    entityTagsProvider = Mock(ElasticSearchEntityTagsProvider)
+    description = new UpsertEntityFlagsDescription()
+    operation = new UpsertEntityFlagsAtomicOperation(front50Service, entityTagsProvider, description)
+  }
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  void 'should create new tag if none exists already'() {
+    given:
+    EntityFlag flag = new EntityFlag(status: "info", message: "message1")
+    description.entityRef = new EntityRef(cloudProvider: "aws", entityType: "servergroup", entityId: "orca-v001",
+      attributes: [account: "test", region: "us-east-1"])
+    description.flags = ["flag1": flag]
+
+    when:
+    operation.operate([])
+
+    then:
+    flag.created != null
+    flag.createdBy == "unknown"
+    flag.modified != null
+    flag.modifiedBy == "unknown"
+    description.tags == [ spinnaker_ui_flags: [ flag1: flag ] ]
+    1 * entityTagsProvider.get('aws:servergroup:orca-v001:test:us-east-1') >> Optional.empty()
+    1 * front50Service.saveEntityTags(description) >> new EntityTags(lastModified: 123, lastModifiedBy: "unknown")
+    1 * entityTagsProvider.index(description)
+    1 * entityTagsProvider.verifyIndex(description)
+  }
+
+  void 'should update lastModified fields, message, status on existing flags'() {
+    given:
+    EntityFlag existingFlag = new EntityFlag(status: "alert", message: "message0", created: 2, createdBy: "chrisb")
+    EntityFlag unmodifiedFlag = new EntityFlag(status: "alert", message: "message0", created: 2, createdBy: "chrisb")
+    EntityTags existingTag = new EntityTags(lastModified: 100, lastModifiedBy: "known", tags: [
+            spinnaker_ui_flags: [ changing: existingFlag, unmodified: unmodifiedFlag ],
+            otherTag: 'zzz'
+    ])
+    EntityFlag updatedFlag = new EntityFlag(status: "info", message: "message1")
+    EntityFlag newFlag = new EntityFlag(status: "alert", message: "message2")
+    description.entityRef = new EntityRef(cloudProvider: "aws", entityType: "servergroup", entityId: "orca-v001",
+      attributes: [account: "test", region: "us-east-1"])
+    description.flags = [changing: updatedFlag, brand_new: newFlag]
+
+    when:
+    operation.operate([])
+
+    then:
+    updatedFlag.created == 2L
+    updatedFlag.createdBy == "chrisb"
+    updatedFlag.modified != null
+    updatedFlag.modifiedBy == "unknown"
+    description.tags == [ spinnaker_ui_flags: [ changing: updatedFlag, unmodified: unmodifiedFlag, brand_new: newFlag ], otherTag: 'zzz' ]
+    1 * entityTagsProvider.get('aws:servergroup:orca-v001:test:us-east-1') >> Optional.of(existingTag)
+    1 * front50Service.saveEntityTags(description) >> new EntityTags(lastModified: 123, lastModifiedBy: "unknown")
+    1 * entityTagsProvider.index(description)
+    1 * entityTagsProvider.verifyIndex(description)
+  }
+
+}


### PR DESCRIPTION
Much like the `EntityTags` operation, but with some key differences:
* only performs a partial update, adding or updating existing fields in the `spinnaker_ui_flags` tag
* leaves existing tags alone
* sets created/modified fields within the tags themselves

**Not tested beyond unit tests** - submitted for review by @ajordens with that caveat