### PR TITLE
provider/google: Removed 'delete/insert' forwarding rule pattern from…

### DIFF
--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
@@ -47,7 +47,6 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
   private static final FORWARDING_RULE_OP_NAME = "forwarding-rule-op"
   private static final CERT = "ye-olde-cert"
   private static final DONE = "DONE"
-  private static final TARGET_PROXY_NAME = "$LOAD_BALANCER_NAME-${UpsertGoogleSslLoadBalancerAtomicOperation.TARGET_SSL_PROXY_NAME_SUFFIX}"
 
   @Shared GoogleHealthCheck hc
   @Shared SafeRetry safeRetry


### PR DESCRIPTION
… SSL LB upsert. None of the removed paths were supported from the UI. Also changed `targetSslProxies` to use `setX` operations instead of the delete/insert pattern.