### PR TITLE
provider/core: include tag metadata, allow partial upsert/deletes

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
@@ -30,6 +30,7 @@ class EntityTags {
   String lastModifiedBy
 
   Map<String, Object> tags = [:]
+  Map<String, EntityTagMetadata> tagsMetadata = [:]
   EntityRef entityRef
 
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -53,5 +54,12 @@ class EntityTags {
     String getEntityType() {
       return entityType?.toLowerCase()
     }
+  }
+
+  static class EntityTagMetadata {
+    Long lastModified
+    String lastModifiedBy
+    Long created
+    String createdBy
   }
 }

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/DeleteEntityTagsDescription.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/DeleteEntityTagsDescription.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.resources.CredentialsNameable;
 
+import java.util.List;
+
 public class DeleteEntityTagsDescription implements CredentialsNameable {
   @JsonIgnore
   private AccountCredentials credentials;
@@ -31,6 +33,12 @@ public class DeleteEntityTagsDescription implements CredentialsNameable {
   @JsonProperty
   private String account;
 
+  @JsonProperty
+  private List<String> tags;
+
+  @JsonProperty
+  private boolean deleteAll = false;
+
   public String getId() {
     return id;
   }
@@ -38,6 +46,14 @@ public class DeleteEntityTagsDescription implements CredentialsNameable {
   @Override
   public String getAccount() {
     return account;
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public boolean isDeleteAll() {
+    return deleteAll;
   }
 
   @Override

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/UpsertEntityTagsDescription.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/UpsertEntityTagsDescription.java
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.clouddriver.model.EntityTags;
 import com.netflix.spinnaker.clouddriver.security.resources.NonCredentialed;
 
 public class UpsertEntityTagsDescription extends EntityTags implements NonCredentialed {
-  // TODO-AJ partial is yet supported
   @JsonProperty
-  boolean isPartial = false;
+  public boolean isPartial = false;
 }

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperationSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperationSpec.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.ops
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.DeleteEntityTagsDescription
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider
+import com.netflix.spinnaker.clouddriver.model.EntityTags
+import retrofit.RetrofitError
+import spock.lang.Specification
+
+class DeleteEntityTagsAtomicOperationSpec extends Specification {
+
+  Front50Service front50Service
+  ElasticSearchEntityTagsProvider entityTagsProvider
+  DeleteEntityTagsDescription description
+  DeleteEntityTagsAtomicOperation operation
+
+  def setup() {
+    front50Service = Mock(Front50Service)
+    entityTagsProvider = Mock(ElasticSearchEntityTagsProvider)
+    description = new DeleteEntityTagsDescription()
+    operation = new DeleteEntityTagsAtomicOperation(front50Service, entityTagsProvider, description)
+  }
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  void 'should return immediately if tag not found'() {
+    when:
+    description.id = 'abc'
+    operation.operate([])
+
+    then:
+    1 * front50Service.getEntityTags('abc') >> { throw new RetrofitError("a", null, null, null, null, null, null) }
+    0 * _
+  }
+
+  void 'should delete entire entityTag if deleteAll flag is set'() {
+    given:
+    description.id = 'abc'
+    description.deleteAll = true
+    description.tags = ['a']
+    EntityTags current = new EntityTags(tags: [a: 'something', b: 'something else'])
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * front50Service.getEntityTags('abc') >> current
+    1 * entityTagsProvider.delete('abc')
+    1 * front50Service.deleteEntityTags('abc')
+    0 * _
+  }
+
+  void 'should delete entire entityTag if all existing tags requested for deletion'() {
+    given:
+    description.id = 'abc'
+    description.tags = ['a', 'b']
+    EntityTags current = new EntityTags(tags: [a: 'something', b: 'something else'])
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * front50Service.getEntityTags('abc') >> current
+    1 * entityTagsProvider.delete('abc')
+    1 * front50Service.deleteEntityTags('abc')
+    0 * _
+  }
+
+  void 'should only delete requested tags and metadata if other tags exist'() {
+    given:
+    description.id = 'abc'
+    description.tags = ['a']
+    EntityTags current = new EntityTags(
+      id: 'abc',
+      tags: [a: 'something', b: 'something else'],
+      tagsMetadata: [
+        a: new EntityTags.EntityTagMetadata(),
+        b: new EntityTags.EntityTagMetadata()
+      ])
+
+    when:
+    operation.operate([])
+
+    then:
+    current.tags == [b: 'something else']
+    current.tagsMetadata.keySet().asList() == ['b']
+    1 * front50Service.getEntityTags('abc') >> current
+    1 * entityTagsProvider.index(current)
+    1 * entityTagsProvider.verifyIndex(current)
+    1 * front50Service.saveEntityTags(current) >> current
+    0 * _
+  }
+}

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/UpsertEntityTagsAtomicOperationSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/UpsertEntityTagsAtomicOperationSpec.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.ops
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.UpsertEntityTagsDescription
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider
+import com.netflix.spinnaker.clouddriver.model.EntityTags
+import com.netflix.spinnaker.clouddriver.model.EntityTags.EntityRef
+import com.netflix.spinnaker.clouddriver.model.EntityTags.EntityTagMetadata
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+
+class UpsertEntityTagsAtomicOperationSpec extends Specification {
+
+  Front50Service front50Service
+  AccountCredentialsProvider accountCredentialsProvider
+  ElasticSearchEntityTagsProvider entityTagsProvider
+  UpsertEntityTagsDescription description
+  UpsertEntityTagsAtomicOperation operation
+
+  def setup() {
+    front50Service = Mock(Front50Service)
+    entityTagsProvider = Mock(ElasticSearchEntityTagsProvider)
+    accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    description = new UpsertEntityTagsDescription()
+    operation = new UpsertEntityTagsAtomicOperation(front50Service, accountCredentialsProvider, entityTagsProvider, description)
+  }
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  void 'should set id and pattern to default if none supplied'() {
+    given:
+    description.entityRef = new EntityRef(cloudProvider: "aws", entityType: "servergroup", entityId: "orca-v001",
+      attributes: [account: "test", region: "us-east-1"])
+    description.tags = [ "tag1": "some tag" ]
+
+    when:
+    operation.setIdAndIdPattern(description)
+
+    then:
+    description.id == "aws:servergroup:orca-v001:test:us-east-1"
+    description.idPattern == "{{cloudProvider}}:{{entityType}}:{{entityId}}:{{account}}:{{region}}"
+    1 * accountCredentialsProvider.getCredentials('test') >> null
+  }
+
+  void 'should create new tag if none exists'() {
+    given:
+    description.entityRef = new EntityRef(cloudProvider: "aws", entityType: "servergroup", entityId: "orca-v001",
+      attributes: [account: "test", region: "us-east-1"])
+    description.tags = [ "tag1": "some tag" ]
+
+    when:
+    operation.operate([])
+
+    then:
+    description.tagsMetadata.keySet().asList() == ["tag1"]
+    description.tagsMetadata.tag1.createdBy == 'unknown'
+    description.tagsMetadata.tag1.created != null
+    description.tagsMetadata.tag1.lastModified == description.tagsMetadata.tag1.created
+    description.tagsMetadata.tag1.lastModifiedBy == description.tagsMetadata.tag1.createdBy
+    1 * accountCredentialsProvider.getCredentials('test') >> null
+    1 * front50Service.saveEntityTags(description) >> new EntityTags(lastModified: 123, lastModifiedBy: "unknown")
+    1 * entityTagsProvider.index(description)
+    1 * entityTagsProvider.verifyIndex(description)
+  }
+
+
+  void 'should only set modified/by metadata for partial upsert when tag exists'() {
+    given:
+    EntityTags current = new EntityTags(
+      tags: [tag1: "old tag", tag2: "unchanged tag"],
+      tagsMetadata: [
+        tag1: new EntityTagMetadata(created: 1L, createdBy: "chris", lastModified: 2L, lastModifiedBy: "adam"),
+        tag2: new EntityTagMetadata(created: 1L, createdBy: "chris", lastModified: 2L, lastModifiedBy: "adam")
+      ])
+    description.entityRef = new EntityRef(cloudProvider: "aws", entityType: "servergroup", entityId: "orca-v001",
+      attributes: [account: "test", region: "us-east-1"])
+    description.tags = [ "tag1": "some tag" ]
+    description.isPartial = true
+
+    when:
+    operation.mergeExistingTagsAndMetadata(current, description)
+
+    then:
+    description.tagsMetadata.tag1.created == 1L
+    description.tagsMetadata.tag1.createdBy == "chris"
+    description.tagsMetadata.tag1.lastModified != 2L
+    description.tagsMetadata.tag1.lastModifiedBy == "unknown"
+    description.tagsMetadata.tag2.created == 1L
+    description.tagsMetadata.tag2.createdBy == "chris"
+    description.tagsMetadata.tag2.lastModified == 2L
+    description.tagsMetadata.tag2.lastModifiedBy == "adam"
+  }
+
+  void 'should preserve existing tags when merging'() {
+    given:
+    EntityTags current = new EntityTags(
+      tags: [tag1: "old tag", tag2: "unchanged tag"],
+      tagsMetadata: [
+        tag1: new EntityTagMetadata(created: 1L, createdBy: "chris", lastModified: 2L, lastModifiedBy: "adam"),
+        tag2: new EntityTagMetadata(created: 1L, createdBy: "chris", lastModified: 2L, lastModifiedBy: "adam")
+      ])
+    description.entityRef = new EntityRef(cloudProvider: "aws", entityType: "servergroup", entityId: "orca-v001",
+      attributes: [account: "test", region: "us-east-1"])
+    description.tags = [ "tag1": "updated tag" ]
+
+    when:
+    operation.mergeExistingTagsAndMetadata(current, description)
+
+    then:
+    description.tags.size() == 2
+    description.tags.tag1 == "updated tag"
+    description.tags.tag2 == "unchanged tag"
+  }
+}


### PR DESCRIPTION
* allow delete operation to specific a list of keys to delete, or `deleteAll` to remove a tag altogether
* allow partial update of entity tags, e.g. upsert operations against only specified tag members

@ajordens PTAL