### PR TITLE
Support for querying by `entityRef.entityId` (both single and multiple)

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
@@ -48,6 +48,9 @@ interface Front50Service {
   @GET('/v2/tags/{id}')
   EntityTags getEntityTags(@Path('id') String id)
 
+  @GET('/v2/tags?prefix=')
+  Collection<EntityTags> getAllEntityTags()
+
   @DELETE('/v2/tags/{id}')
   Response deleteEntityTags(@Path('id') String id)
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTagsProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTagsProvider.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.model;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -26,6 +27,7 @@ public interface EntityTagsProvider {
    */
   Collection<EntityTags> getAll(String cloudProvider,
                                 String entityType,
+                                List<String> entityIds,
                                 String idPrefix,
                                 Map<String, Object> tags,
                                 int maxResults);
@@ -54,4 +56,9 @@ public interface EntityTagsProvider {
    * Delete EntityTags by {@code id}
    */
   void delete(String id);
+
+  /**
+   * Reindex all EntityTags
+   */
+  void reindex();
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/EntityTagsController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/EntityTagsController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.HandlerMapping;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,6 +55,7 @@ public class EntityTagsController {
   @RequestMapping(method = RequestMethod.GET)
   public Collection<EntityTags> list(@RequestParam(value = "cloudProvider", required = false) String cloudProvider,
                                      @RequestParam(value = "entityType", required = false) String entityType,
+                                     @RequestParam(value = "entityId", required = false) String entityId,
                                      @RequestParam(value = "idPrefix", required = false) String idPrefix,
                                      @RequestParam(value = "maxResults", required = false, defaultValue = "100") int maxResults,
                                      @RequestParam Map<String, Object> allParameters) {
@@ -62,7 +64,14 @@ public class EntityTagsController {
       .filter(m -> m.getKey().toLowerCase().startsWith("tag"))
       .collect(Collectors.toMap(p -> p.getKey().toLowerCase().replaceAll("tag:", ""), Map.Entry::getValue));
 
-    return tagProvider.getAll(cloudProvider, entityType, idPrefix, tags, maxResults);
+    return tagProvider.getAll(
+      cloudProvider,
+      entityType,
+      entityId != null ? Arrays.asList(entityId.split(",")) : null,
+      idPrefix,
+      tags,
+      maxResults
+      );
   }
 
   @RequestMapping(value = "/**", method = RequestMethod.GET)

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/admin/EntityTagsAdminController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/admin/EntityTagsAdminController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers.admin;
+
+import com.netflix.spinnaker.clouddriver.model.EntityTagsProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/tags")
+public class EntityTagsAdminController {
+  private final EntityTagsProvider entityTagsProvider;
+
+  @Autowired
+  public EntityTagsAdminController(EntityTagsProvider entityTagsProvider) {
+    this.entityTagsProvider = entityTagsProvider;
+  }
+
+  @RequestMapping(value="/reindex", method = RequestMethod.POST)
+  void reindex() {
+    entityTagsProvider.reindex();
+  }
+}


### PR DESCRIPTION
Also added an EntityTagsAdminController that exposes `reindex` behavior.

The `reindex` is destructive in that it:
- Deletes the current active index
- Creates a new active index
- Indexes all entity tags (from `Front50`) into the new index

It's highly suggested to have an index template configured on the elasticsearch cluster:

```
{
  "order": 0,
  "template": "tags_v*",
  "settings": {
    "index": {
      "number_of_shards": "6",
      "number_of_replicas": "2",
      "refresh_interval": "1s"
    }
  },
  "mappings": {
    "_default_": {
      "properties": {
        "entityRef": {
          "properties": {
            "entityId": {
              "type": "string",
              "index": "not_analyzed"
            }
          }
        }
      }
    }
  },
  "aliases": {}
}
```