### PR TITLE
Revert "Revert "adds support for fine grained service limits.""

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -51,6 +51,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig
 import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig.Builder
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils
 import com.netflix.spinnaker.kork.aws.AwsComponents
@@ -91,7 +92,7 @@ class AwsConfiguration {
   }
 
   @Bean
-  AmazonClientProvider amazonClientProvider(AwsConfigurationProperties awsConfigurationProperties, RetryCondition instrumentedRetryCondition, BackoffStrategy instrumentedBackoffStrategy, AWSProxy proxy, EddaTimeoutConfig eddaTimeoutConfig, Registry registry) {
+  AmazonClientProvider amazonClientProvider(AwsConfigurationProperties awsConfigurationProperties, RetryCondition instrumentedRetryCondition, BackoffStrategy instrumentedBackoffStrategy, AWSProxy proxy, EddaTimeoutConfig eddaTimeoutConfig, ServiceLimitConfiguration serviceLimitConfiguration, Registry registry) {
     new AmazonClientProvider.Builder()
       .backoffStrategy(instrumentedBackoffStrategy)
       .retryCondition(instrumentedRetryCondition)
@@ -102,13 +103,14 @@ class AwsConfiguration {
       .proxy(proxy)
       .eddaTimeoutConfig(eddaTimeoutConfig)
       .useGzip(awsConfigurationProperties.client.useGzip)
+      .serviceLimitConfiguration(serviceLimitConfiguration)
       .registry(registry)
       .build()
   }
 
   @Bean
   ObjectMapper amazonObjectMapper() {
-    new AmazonObjectMapper()
+    return new AmazonObjectMapper()
   }
 
   @Bean

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/ReconcileClassicLinkSecurityGroupsAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/ReconcileClassicLinkSecurityGroupsAgent.java
@@ -32,7 +32,6 @@ import com.amazonaws.services.ec2.model.SecurityGroup;
 import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.services.ec2.model.VpcClassicLink;
 import com.google.common.base.Strings;
-import com.google.common.util.concurrent.RateLimiter;
 import com.netflix.frigga.Names;
 import com.netflix.spinnaker.cats.agent.AccountAware;
 import com.netflix.spinnaker.cats.agent.RunnableAgent;
@@ -127,11 +126,9 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
     }
     String classicLinkVpcId = classicLinkVpcIds.get(0);
 
-    RateLimiter apiRequestRateLimit = RateLimiter.create(5);
     final Map<String, ClassicLinkInstance> classicLinkInstances = new HashMap<>();
     DescribeInstancesRequest describeInstances = new DescribeInstancesRequest().withMaxResults(500);
     while (true) {
-      apiRequestRateLimit.acquire();
       DescribeInstancesResult instanceResult = ec2.describeInstances(describeInstances);
       instanceResult.getReservations().stream()
         .flatMap(r -> r.getInstances().stream())
@@ -149,7 +146,6 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
 
     DescribeClassicLinkInstancesRequest request = new DescribeClassicLinkInstancesRequest().withMaxResults(1000);
     while (true) {
-      apiRequestRateLimit.acquire();
       DescribeClassicLinkInstancesResult result = ec2.describeClassicLinkInstances(request);
       result.getInstances().forEach(i -> classicLinkInstances.put(i.getInstanceId(), i));
       if (result.getNextToken() == null) {
@@ -183,7 +179,6 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
   }
 
   void reconcileInstances(AmazonEC2 ec2, Map<String, String> groupNamesToIds, Collection<ClassicLinkInstance> instances) {
-    RateLimiter apiRequestRateLimit = RateLimiter.create(5);
     StringBuilder report = new StringBuilder();
     for (ClassicLinkInstance i : instances) {
       List<String> existingClassicLinkGroups = i.getGroups().stream()
@@ -212,7 +207,6 @@ public class ReconcileClassicLinkSecurityGroupsAgent implements RunnableAgent, C
           List<String> groupIds = new ArrayList<>(existingClassicLinkGroups);
           groupIds.addAll(missingGroupIds);
           if (deployDefaults.getReconcileClassicLinkSecurityGroups() == AwsConfiguration.DeployDefaults.ReconcileMode.MODIFY) {
-            apiRequestRateLimit.acquire();
             try {
               ec2.attachClassicLinkVpc(new AttachClassicLinkVpcRequest()
                 .withVpcId(i.getVpcId())

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -30,7 +30,6 @@ import com.amazonaws.services.elasticloadbalancingv2.model.InvalidTargetExceptio
 import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -193,10 +192,8 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
 
   private static void handleInstancesWithLoadBalancing(Collection<String> lbIdentifiers, Collection<String> instanceIds, Closure instanceIdTransform, Closure actOnInstancesAndLoadBalancer) {
     if (instanceIds && lbIdentifiers) {
-      RateLimiter rateLimiter = RateLimiter.create(5)
       def instances = instanceIds.collect(instanceIdTransform)
       for (String lbId : lbIdentifiers) {
-        rateLimiter.acquire()
         actOnInstancesAndLoadBalancer(lbId, instances)
       }
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DetachInstancesAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DetachInstancesAtomicOperation.groovy
@@ -24,7 +24,6 @@ import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
 import com.amazonaws.services.ec2.model.CreateTagsRequest
 import com.amazonaws.services.ec2.model.Tag
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -106,11 +105,8 @@ class DetachInstancesAtomicOperation implements AtomicOperation<Void> {
       amazonEC2.createTags(new CreateTagsRequest().withResources(validInstanceIds).withTags(tags))
       task.updateStatus BASE_PHASE, "Tagged instances (${validInstanceIds.join(", ")})."
 
-      RateLimiter limiter = RateLimiter.create(0.2)
-
       validInstanceIds.collate(MAX_DETACH).each {
         // AWS has a restriction on the # of instances that can be detached at any one time, hence batching is required.
-        limiter.acquire()
         task.updateStatus BASE_PHASE, "Detaching instances (${it.join(", ")}) from ASG (${description.asgName})."
         amazonAutoScaling.detachInstances(
           new DetachInstancesRequest()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpdateInstancesAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpdateInstancesAtomicOperation.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsRequest
 import com.amazonaws.services.ec2.model.ModifyInstanceAttributeRequest
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpdateInstancesDescription
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.data.task.Task
@@ -72,9 +71,7 @@ class UpdateInstancesAtomicOperation implements AtomicOperation<Void> {
       }
       groups = groups + launchConfigs.launchConfigurations.get(0).securityGroups
     }
-    def limiter = RateLimiter.create(MAX_REQUESTS_PER_SECOND)
     instances.each { instanceId ->
-      limiter.acquire()
       task.updateStatus PHASE, "Updating security groups for ${instanceId}..."
       try {
         regionScopedProvider.amazonEC2.modifyInstanceAttribute(new ModifyInstanceAttributeRequest(instanceId: instanceId).withGroups(groups))

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/DefaultAWSAccountInfoLookup.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/DefaultAWSAccountInfoLookup.java
@@ -119,8 +119,8 @@ public class DefaultAWSAccountInfoLookup implements AWSAccountInfoLookup {
         }
         List<AWSRegion> awsRegions = new ArrayList<>(regions.size());
         for (Region region : regions) {
-            ec2.setEndpoint(region.getEndpoint());
-            List<AvailabilityZone> azs = ec2.describeAvailabilityZones().getAvailabilityZones();
+            AmazonEC2 regionalEc2 = amazonClientProvider.getAmazonEC2(credentialsProvider, region.getRegionName());
+            List<AvailabilityZone> azs = regionalEc2.describeAvailabilityZones().getAvailabilityZones();
             List<String> availabilityZoneNames = new ArrayList<>(azs.size());
             for (AvailabilityZone az : azs) {
                 availabilityZoneNames.add(az.getZoneName());

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2016 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.security;
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -53,11 +54,11 @@ import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-class AmazonClientInvocationHandler implements InvocationHandler {
+public class AmazonClientInvocationHandler implements InvocationHandler {
 
   private static final Logger log = LoggerFactory.getLogger(AmazonClientInvocationHandler.class);
 
-  static final ThreadLocal<Long> lastModified = new ThreadLocal<>();
+  public static final ThreadLocal<Long> lastModified = new ThreadLocal<>();
 
   private final String edda;
   private final HttpClient httpClient;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.retry.RetryPolicy;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.RateLimiter;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.aws.security.AWSProxy;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixSTSAssumeRoleSessionCredentialsProvider;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Factory for shared instances of AWS SDK clients.
+ */
+public class AwsSdkClientSupplier {
+
+  private final Registry registry;
+  private final LoadingCache<AmazonClientKey<?>, ?> awsSdkClients;
+  private final RateLimiterSupplier rateLimiterSupplier;
+
+  public AwsSdkClientSupplier(RateLimiterSupplier rateLimiterSupplier, Registry registry, RetryPolicy retryPolicy, List<RequestHandler2> requestHandlers, AWSProxy proxy, boolean useGzip) {
+    this.rateLimiterSupplier = Objects.requireNonNull(rateLimiterSupplier);
+    this.registry = Objects.requireNonNull(registry);
+    awsSdkClients = CacheBuilder.newBuilder().recordStats().expireAfterWrite(10, TimeUnit.MINUTES).build(new SdkClientCacheLoader(retryPolicy, requestHandlers, proxy, useGzip));
+    LoadingCacheMetrics.instrument("awsSdkClientSupplier", registry, awsSdkClients);
+  }
+
+  public <T> T getClient(Class<? extends AwsClientBuilder<?, T>> impl, Class<T> iface, String account, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    final RequestHandler2 handler = getRateLimiterHandler(iface, account, region);
+    final AmazonClientKey<T> key = new AmazonClientKey<>(impl, awsCredentialsProvider, region, handler);
+
+    try {
+      return iface.cast(awsSdkClients.get(key));
+    } catch (ExecutionException executionException) {
+      if (executionException.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) executionException.getCause();
+      }
+      throw new RuntimeException("Failed creating amazon client", executionException.getCause());
+    }
+  }
+
+  private RequestHandler2 getRateLimiterHandler(Class<?> sdkInterface, String account, String region) {
+    final RateLimiter limiter = rateLimiterSupplier.getRateLimiter(sdkInterface, account, region);
+    final Counter rateLimitCounter = registry.counter("amazonClientProvider.rateLimitDelayMillis",
+      "clientType", sdkInterface.getSimpleName(),
+      "account", account,
+      "region", region == null ? "UNSPECIFIED" : region);
+    return new RateLimitingRequestHandler(rateLimitCounter, limiter);
+  }
+
+  private static class SdkClientCacheLoader extends CacheLoader<AmazonClientKey<?>, Object> {
+    private final RetryPolicy retryPolicy;
+    private final List<RequestHandler2> requestHandlers;
+    private final AWSProxy proxy;
+    private final boolean useGzip;
+
+    public SdkClientCacheLoader(RetryPolicy retryPolicy, List<RequestHandler2> requestHandlers, AWSProxy proxy, boolean useGzip) {
+      this.retryPolicy = Objects.requireNonNull(retryPolicy);
+      this.requestHandlers = requestHandlers == null ? Collections.emptyList() : ImmutableList.copyOf(requestHandlers);
+      this.proxy = proxy;
+      this.useGzip = useGzip;
+    }
+
+    @Override
+    public Object load(AmazonClientKey<?> key) throws Exception {
+      Method m = key.implClass.getDeclaredMethod("standard");
+      AwsClientBuilder<?, ?> builder = key.implClass.cast(m.invoke(null));
+
+      ClientConfiguration clientConfiguration = new ClientConfiguration();
+      clientConfiguration.setRetryPolicy(getRetryPolicy(key));
+      clientConfiguration.setUseGzip(useGzip);
+
+      if (proxy != null && proxy.isProxyConfigMode()) {
+        proxy.apply(clientConfiguration);
+      }
+
+      builder.withCredentials(key.awsCredentialsProvider)
+        .withClientConfiguration(clientConfiguration);
+      getRequestHandlers(key).ifPresent(builder::withRequestHandlers);
+      builder.withRegion(key.getRegion().orElseGet(() -> new SpinnakerAwsRegionProvider().getRegion()));
+
+      return builder.build();
+    }
+
+    private Optional<RequestHandler2[]> getRequestHandlers(AmazonClientKey<?> key) {
+      List<RequestHandler2> handlers = new ArrayList<>(requestHandlers.size() + 1);
+      key.getRequestHandler().ifPresent(handlers::add);
+      handlers.addAll(requestHandlers);
+      if (handlers.isEmpty()) {
+        return Optional.empty();
+      }
+      return Optional.of(handlers.toArray(new RequestHandler2[handlers.size()]));
+    }
+
+    private RetryPolicy getRetryPolicy(AmazonClientKey<?> key) {
+
+      if (!(key.getAwsCredentialsProvider() instanceof NetflixSTSAssumeRoleSessionCredentialsProvider)) {
+        return retryPolicy;
+      }
+
+      final RetryPolicy.RetryCondition delegatingRetryCondition = (originalRequest, exception, retriesAttempted) -> {
+        NetflixSTSAssumeRoleSessionCredentialsProvider stsCredentialsProvider = (NetflixSTSAssumeRoleSessionCredentialsProvider) key.getAwsCredentialsProvider();
+        if (exception instanceof AmazonServiceException) {
+          ((AmazonServiceException) exception).getHttpHeaders().put("targetAccountId", stsCredentialsProvider.getAccountId());
+        }
+        return retryPolicy.getRetryCondition().shouldRetry(originalRequest, exception, retriesAttempted);
+      };
+
+      return new RetryPolicy(
+        delegatingRetryCondition,
+        retryPolicy.getBackoffStrategy(),
+        retryPolicy.getMaxErrorRetry(),
+        retryPolicy.isMaxErrorRetryInClientConfigHonored()
+      );
+
+    }
+  }
+
+  private static class AmazonClientKey<T> {
+    private final Class<? extends AwsClientBuilder<?, T>> implClass;
+    private final AWSCredentialsProvider awsCredentialsProvider;
+    private final Regions region;
+    private final RequestHandler2 requestHandler;
+
+    public AmazonClientKey(Class<? extends AwsClientBuilder<?, T>> implClass, AWSCredentialsProvider awsCredentialsProvider, String region, RequestHandler2 requestHandler) {
+      this.implClass = requireNonNull(implClass);
+      this.awsCredentialsProvider = requireNonNull(awsCredentialsProvider);
+      this.region = region == null ? null : Regions.fromName(region);
+      this.requestHandler = requestHandler;
+    }
+
+    public Class<? extends AwsClientBuilder<?, T>> getImplClass() {
+      return implClass;
+    }
+
+    public AWSCredentialsProvider getAwsCredentialsProvider() {
+      return awsCredentialsProvider;
+    }
+
+    public Optional<String> getRegion() {
+      return Optional.ofNullable(region).map(Regions::getName);
+    }
+
+    public Optional<RequestHandler2> getRequestHandler() {
+      return Optional.ofNullable(requestHandler);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      AmazonClientKey<?> that = (AmazonClientKey<?>) o;
+
+      if (!implClass.equals(that.implClass)) return false;
+      if (!awsCredentialsProvider.equals(that.awsCredentialsProvider)) return false;
+      if (region != that.region) return false;
+      return requestHandler != null ? requestHandler.equals(that.requestHandler) : that.requestHandler == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = implClass.hashCode();
+      result = 31 * result + awsCredentialsProvider.hashCode();
+      result = 31 * result + (region != null ? region.hashCode() : 0);
+      result = 31 * result + (requestHandler != null ? requestHandler.hashCode() : 0);
+      return result;
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/LoadingCacheMetrics.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/LoadingCacheMetrics.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.google.common.cache.Cache;
+import com.netflix.spectator.api.Registry;
+
+public class LoadingCacheMetrics {
+  public static void instrument(String prefix, Registry registry, Cache<?, ?> cache) {
+    registry.gauge(prefix + ".averageLoadPenalty", cache, (c) -> c.stats().averageLoadPenalty());
+    registry.gauge(prefix + ".evictionCount", cache, (c) -> c.stats().evictionCount());
+    registry.gauge(prefix + ".hitCount", cache, (c) -> c.stats().hitCount());
+    registry.gauge(prefix + ".hitRate", cache, (c) -> c.stats().hitRate());
+    registry.gauge(prefix + ".loadCount", cache, (c) -> c.stats().loadCount());
+    registry.gauge(prefix + ".loadExceptionCount", cache, (c) -> c.stats().loadExceptionCount());
+    registry.gauge(prefix + ".loadExceptionRate", cache, (c) -> c.stats().loadExceptionRate());
+    registry.gauge(prefix + ".loadSuccessCount", cache, (c) -> c.stats().loadSuccessCount());
+    registry.gauge(prefix + ".missCount", cache, (c) -> c.stats().missCount());
+    registry.gauge(prefix + ".missRate", cache, (c) -> c.stats().missRate());
+    registry.gauge(prefix + ".requestCount", cache, (c) -> c.stats().requestCount());
+    registry.gauge(prefix + ".totalLoadTime", cache, (c) -> c.stats().totalLoadTime());
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/ProxyHandlerBuilder.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/ProxyHandlerBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.aws.security.EddaTemplater;
+import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import org.apache.http.client.HttpClient;
+
+import java.lang.reflect.Proxy;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Constructs a JDK dynamic proxy for an AWS service interface that (if enabled for an account) will
+ * delegate read requests to Edda and otherwise fallback to the underlying SDK client.
+ */
+public class ProxyHandlerBuilder {
+  private final AwsSdkClientSupplier awsSdkClientSupplier;
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final EddaTemplater eddaTemplater;
+  private final EddaTimeoutConfig eddaTimeoutConfig;
+  private final Registry registry;
+
+  public ProxyHandlerBuilder(AwsSdkClientSupplier awsSdkClientSupplier, HttpClient httpClient, ObjectMapper objectMapper, EddaTemplater eddaTemplater, EddaTimeoutConfig eddaTimeoutConfig, Registry registry) {
+    this.awsSdkClientSupplier = requireNonNull(awsSdkClientSupplier);
+    this.httpClient = requireNonNull(httpClient);
+    this.objectMapper = requireNonNull(objectMapper);
+    this.eddaTemplater = requireNonNull(eddaTemplater);
+    this.eddaTimeoutConfig = eddaTimeoutConfig;
+    this.registry = requireNonNull(registry);
+  }
+
+  public <T extends AwsClientBuilder<T, U>, U> U getProxyHandler(Class<U> interfaceKlazz, Class<T> impl, NetflixAmazonCredentials amazonCredentials, String region) {
+    return getProxyHandler(interfaceKlazz, impl, amazonCredentials, region, false);
+  }
+
+  public <T extends AwsClientBuilder<T, U>, U> U getProxyHandler(Class<U> interfaceKlazz, Class<T> impl, NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
+    requireNonNull(amazonCredentials, "Credentials cannot be null");
+    try {
+      U delegate = awsSdkClientSupplier.getClient(impl, interfaceKlazz, amazonCredentials.getName(), amazonCredentials.getCredentialsProvider(), region);
+      if (skipEdda || !amazonCredentials.getEddaEnabled()) {
+        return delegate;
+      }
+      return interfaceKlazz.cast(Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{interfaceKlazz},
+        getInvocationHandler(delegate, interfaceKlazz.getSimpleName(), region, amazonCredentials)));
+    } catch (RuntimeException re) {
+      throw re;
+    } catch (Exception e) {
+      throw new RuntimeException("Instantiation of client implementation failed!", e);
+    }
+  }
+
+  protected AmazonClientInvocationHandler getInvocationHandler(Object client, String serviceName, String region, NetflixAmazonCredentials amazonCredentials) {
+    final Map<String, String> baseTags = ImmutableMap.of(
+      "account", amazonCredentials.getName(),
+      "region", region,
+      "serviceName", serviceName);
+    return new AmazonClientInvocationHandler(client, serviceName, eddaTemplater.getUrl(amazonCredentials.getEdda(), region),
+      this.httpClient, objectMapper, eddaTimeoutConfig, registry, baseTags);
+  }
+
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimiterSupplier.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimiterSupplier.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.RateLimiter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+
+/**
+ * Factory for shared RateLimiters by SDK client interface/account/region.
+ */
+public class RateLimiterSupplier {
+
+  private final LoadingCache<RateLimitKey, RateLimiter> rateLimiters;
+
+  public RateLimiterSupplier(ServiceLimitConfiguration serviceLimitConfiguration, Registry registry) {
+    rateLimiters = CacheBuilder.newBuilder().recordStats().build(new RateLimitCacheLoader(serviceLimitConfiguration));
+    LoadingCacheMetrics.instrument("rateLimiterSupplier", registry, rateLimiters);
+  }
+
+  public RateLimiter getRateLimiter(Class<?> implementation, String account, String region) {
+    try {
+      return rateLimiters.get(new RateLimitKey(implementation, account, region));
+    } catch (ExecutionException executionException) {
+      if (executionException.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) executionException.getCause();
+      }
+      throw new RuntimeException("Failed creating rate limiter", executionException.getCause());
+    }
+  }
+
+  private static class RateLimitCacheLoader extends CacheLoader<RateLimitKey, RateLimiter> {
+    private static final double DEFAULT_LIMIT = 10.0d;
+
+    private final ServiceLimitConfiguration serviceLimitConfiguration;
+    private final double defaultLimit;
+
+    public RateLimitCacheLoader(ServiceLimitConfiguration serviceLimitConfiguration) {
+      this(serviceLimitConfiguration, DEFAULT_LIMIT);
+    }
+
+    public RateLimitCacheLoader(ServiceLimitConfiguration serviceLimitConfiguration, double defaultLimit) {
+      this.serviceLimitConfiguration = Objects.requireNonNull(serviceLimitConfiguration);
+      this.defaultLimit = defaultLimit;
+    }
+
+    @Override
+    public RateLimiter load(RateLimitKey key) throws Exception {
+      double rateLimit = serviceLimitConfiguration.getLimit(
+        ServiceLimitConfiguration.API_RATE_LIMIT,
+        key.implementationClass.getSimpleName(),
+        key.account,
+        AmazonCloudProvider.ID,
+        defaultLimit);
+
+      return RateLimiter.create(rateLimit);
+    }
+  }
+
+  private static class RateLimitKey {
+    private final Class<?> implementationClass;
+    private final String account;
+    private final String region;
+
+    public RateLimitKey(Class<?> implementationClass, String account, String region) {
+      this.implementationClass = Objects.requireNonNull(implementationClass);
+      this.account = Objects.requireNonNull(account);
+      this.region = region;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      RateLimitKey that = (RateLimitKey) o;
+
+      if (!implementationClass.equals(that.implementationClass)) return false;
+      if (!account.equals(that.account)) return false;
+      return region != null ? region.equals(that.region) : that.region == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = implementationClass.hashCode();
+      result = 31 * result + account.hashCode();
+      result = 31 * result + (region != null ? region.hashCode() : 0);
+      return result;
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimitingRequestHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimitingRequestHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.amazonaws.Request;
+import com.amazonaws.handlers.RequestHandler2;
+import com.google.common.util.concurrent.RateLimiter;
+import com.netflix.spectator.api.Counter;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A RequestHandler that will throttle requests via the supplied RateLimiter.
+ */
+public class RateLimitingRequestHandler extends RequestHandler2 {
+  private final Counter counter;
+  private final RateLimiter rateLimiter;
+
+  public RateLimitingRequestHandler(Counter counter, RateLimiter rateLimiter) {
+    this.counter = requireNonNull(counter);
+    this.rateLimiter = requireNonNull(rateLimiter);
+  }
+
+  @Override
+  public void beforeRequest(Request<?> request) {
+    double rateLimitedSeconds = rateLimiter.acquire();
+    long rateLimitedMillis = Double.valueOf(rateLimitedSeconds * 1000).longValue();
+    counter.increment(rateLimitedMillis);
+    super.beforeRequest(request);
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/SpinnakerAwsRegionProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/SpinnakerAwsRegionProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.regions.AwsRegionProvider;
+import com.amazonaws.regions.AwsRegionProviderChain;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.regions.Regions;
+
+public class SpinnakerAwsRegionProvider extends AwsRegionProviderChain {
+
+  public SpinnakerAwsRegionProvider() {
+    super(
+      new Ec2RegionEnvVarRegionProvider(),
+      new DefaultAwsRegionProviderChain(),
+      new RegionsCurrentRegionProvider(),
+      new DefaultRegionProvider()
+    );
+  }
+
+  private static class Ec2RegionEnvVarRegionProvider extends AwsRegionProvider {
+    @Override
+    public String getRegion() throws SdkClientException {
+      return System.getenv("EC2_REGION");
+    }
+  }
+
+  private static class RegionsCurrentRegionProvider extends AwsRegionProvider {
+    @Override
+    public String getRegion() throws SdkClientException {
+      return Regions.getCurrentRegion().getName();
+    }
+  }
+
+  private static class DefaultRegionProvider extends AwsRegionProvider {
+    @Override
+    public String getRegion() throws SdkClientException {
+      return Regions.DEFAULT_REGION.getName();
+    }
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -39,7 +39,6 @@ import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsR
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancer
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration.DeployDefaults
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
@@ -104,7 +103,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     credsRepo.save('baz', TestCredential.named('baz'))
     this.handler = new BasicAmazonDeployHandler(rspf, credsRepo, defaults) {
       @Override LoadBalancerLookupHelper lookupHelper() {
-        return new LoadBalancerLookupHelper(RateLimiter.create(1000000))
+        return new LoadBalancerLookupHelper()
       }
     }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec.groovy
@@ -23,7 +23,6 @@ import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRe
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -35,7 +34,7 @@ class DeregisterInstancesFromLoadBalancerAtomicOperationUnitSpec extends Instanc
     description.instanceIds = ["i-123456"]
     op = new DeregisterInstancesFromLoadBalancerAtomicOperation(description) {
       @Override LoadBalancerLookupHelper lookupHelper() {
-        return new LoadBalancerLookupHelper(RateLimiter.create(100000))
+        return new LoadBalancerLookupHelper()
       }
     }
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec.groovy
@@ -23,7 +23,6 @@ import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRe
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
 import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancerNotFoundException
-import com.google.common.util.concurrent.RateLimiter
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.LoadBalancerLookupHelper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -35,7 +34,7 @@ class RegisterInstancesWithLoadBalancerAtomicOperationUnitSpec extends InstanceL
     description.instanceIds = ["i-123456"]
     op = new RegisterInstancesWithLoadBalancerAtomicOperation(description) {
       @Override LoadBalancerLookupHelper lookupHelper() {
-        return new LoadBalancerLookupHelper(RateLimiter.create(100000))
+        return new LoadBalancerLookupHelper()
       }
     }
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -23,6 +23,8 @@ import com.netflix.spinnaker.clouddriver.cache.CacheConfig
 import com.netflix.spinnaker.clouddriver.cache.NoopOnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.core.agent.CleanupPendingOnDemandCachesAgent
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration
+import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfigurationBuilder
 import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.clouddriver.model.ApplicationProvider
@@ -59,6 +61,7 @@ import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvi
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -78,6 +81,17 @@ class CloudDriverConfig {
   @Bean
   String clouddriverUserAgentApplicationName(Environment environment) {
     return "Spinnaker/${environment.getProperty("Implementation-Version", "Unknown")}"
+  }
+
+  @Bean
+  @ConfigurationProperties('serviceLimits')
+  ServiceLimitConfigurationBuilder serviceLimitConfigProperties() {
+    return new ServiceLimitConfigurationBuilder()
+  }
+
+  @Bean
+  ServiceLimitConfiguration serviceLimitConfiguration(ServiceLimitConfigurationBuilder serviceLimitConfigProperties) {
+    return serviceLimitConfigProperties.build()
   }
 
   @Bean

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ImplementationLimits.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ImplementationLimits.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+public class ImplementationLimits {
+  private final ServiceLimits defaults;
+  private final Map<String, ServiceLimits> accountOverrides;
+
+  public ImplementationLimits(ServiceLimits defaults, Map<String, ServiceLimits> accountOverrides) {
+    this.defaults = defaults == null ? new ServiceLimits(null) : defaults;
+    this.accountOverrides = accountOverrides == null ? Collections.emptyMap() : ImmutableMap.copyOf(accountOverrides);
+  }
+
+  public Double getLimit(String limit, String account) {
+    return Optional
+      .ofNullable(account)
+      .map(accountOverrides::get)
+      .map(sl -> sl.getLimit(limit))
+      .orElse(defaults.getLimit(limit));
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfiguration.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+public class ServiceLimitConfiguration {
+  public static final String POLL_INTERVAL_MILLIS = "agentPollIntervalMs";
+  public static final String POLL_TIMEOUT_MILLIS = "agentPollTimeoutMs";
+  public static final String API_RATE_LIMIT = "rateLimit";
+
+
+  private final ServiceLimits defaults;
+  private final Map<String, ServiceLimits> cloudProviderOverrides;
+  private final Map<String, ServiceLimits> accountOverrides;
+  private final Map<String, ImplementationLimits> implementationLimits;
+
+  public ServiceLimitConfiguration(ServiceLimits defaults, Map<String, ServiceLimits> cloudProviderOverrides, Map<String, ServiceLimits> accountOverrides, Map<String, ImplementationLimits> implementationLimits) {
+    this.defaults = defaults == null ? new ServiceLimits(null) : defaults;
+    this.cloudProviderOverrides = cloudProviderOverrides == null ? Collections.emptyMap() : ImmutableMap.copyOf(cloudProviderOverrides);
+    this.accountOverrides = accountOverrides == null ? Collections.emptyMap() : ImmutableMap.copyOf(accountOverrides);
+    this.implementationLimits = implementationLimits == null ? Collections.emptyMap() : ImmutableMap.copyOf(implementationLimits);
+  }
+
+  public Double getLimit(String limit, String implementation, String account, String cloudProvider, Double defaultValue) {
+    return Optional
+      .ofNullable(getImplementationLimit(limit, implementation, account))
+      .orElse(Optional.ofNullable(getAccountLimit(limit, account))
+        .orElse(Optional.ofNullable(getCloudProviderLimit(limit, cloudProvider))
+          .orElse(Optional.ofNullable(defaults.getLimit(limit))
+            .orElse(defaultValue))));
+  }
+
+  private Double getAccountLimit(String limit, String account) {
+    return Optional
+      .ofNullable(account)
+      .map(accountOverrides::get)
+      .map(sl -> sl.getLimit(limit))
+      .orElse(null);
+  }
+
+  private Double getCloudProviderLimit(String limit, String cloudProvider) {
+    return Optional
+      .ofNullable(cloudProvider)
+      .map(cloudProviderOverrides::get)
+      .map(sl -> sl.getLimit(limit))
+      .orElse(null);
+  }
+
+  private Double getImplementationLimit(String limit, String implementation, String account) {
+    return Optional
+      .ofNullable(implementation)
+      .map(implementationLimits::get)
+      .map(il -> il.getLimit(limit, account))
+      .orElse(null);
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfigurationBuilder.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfigurationBuilder.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+/**
+ * Mutable structure for construction of ServiceLimitConfiguration.
+ */
+public class ServiceLimitConfigurationBuilder {
+
+  private MutableLimits defaults = new MutableLimits();
+  private Map<String, MutableLimits> cloudProviderOverrides = new HashMap<>();
+  private Map<String, MutableLimits> accountOverrides = new HashMap<>();
+  private Map<String, MutableImplementationLimits> implementationLimits = new HashMap<>();
+
+  public MutableLimits getDefaults() {
+    return defaults;
+  }
+
+  public void setDefaults(MutableLimits defaults) {
+    this.defaults = defaults;
+  }
+
+  public ServiceLimitConfigurationBuilder withDefault(String limit, Double value) {
+    if (defaults == null) {
+      defaults = new MutableLimits();
+    }
+    defaults.setLimit(limit, value);
+    return this;
+  }
+
+  public Map<String, MutableLimits> getCloudProviderOverrides() {
+    return cloudProviderOverrides;
+  }
+
+  public void setCloudProviderOverrides(Map<String, MutableLimits> cloudProviderOverrides) {
+    this.cloudProviderOverrides = cloudProviderOverrides;
+  }
+
+  public ServiceLimitConfigurationBuilder withCloudProviderOverride(String cloudProvider, String limit, Double value) {
+    if (cloudProviderOverrides == null) {
+      cloudProviderOverrides = new HashMap<>();
+    }
+    cloudProviderOverrides.computeIfAbsent(cloudProvider, k -> new MutableLimits()).setLimit(limit, value);
+    return this;
+  }
+
+  public Map<String, MutableLimits> getAccountOverrides() {
+    return accountOverrides;
+  }
+
+  public void setAccountOverrides(Map<String, MutableLimits> accountOverrides) {
+    this.accountOverrides = accountOverrides;
+  }
+
+  public ServiceLimitConfigurationBuilder withAccountOverride(String account, String limit, Double value) {
+    if (accountOverrides == null) {
+      accountOverrides = new HashMap<>();
+    }
+
+    accountOverrides.computeIfAbsent(account, k -> new MutableLimits()).setLimit(limit, value);
+    return this;
+  }
+
+  public Map<String, MutableImplementationLimits> getImplementationLimits() {
+    return implementationLimits;
+  }
+
+  public void setImplementationLimits(Map<String, MutableImplementationLimits> implementationLimits) {
+    this.implementationLimits = implementationLimits;
+  }
+
+  public ServiceLimitConfigurationBuilder withImplementationDefault(String implementation, String limit, Double value) {
+    if (implementationLimits == null) {
+      implementationLimits = new HashMap<>();
+    }
+    implementationLimits.computeIfAbsent(implementation, k -> new MutableImplementationLimits()).defaults.setLimit(limit, value);
+    return this;
+  }
+
+  public ServiceLimitConfigurationBuilder withImplementationAccountOverride(String implementation, String account, String limit, Double value) {
+    if (implementationLimits == null) {
+      implementationLimits = new HashMap<>();
+    }
+
+    implementationLimits
+      .computeIfAbsent(implementation, k -> new MutableImplementationLimits())
+      .accountOverrides.computeIfAbsent(account, k -> new MutableLimits())
+      .setLimit(limit, value);
+
+    return this;
+  }
+
+  public ServiceLimitConfiguration build() {
+    return new ServiceLimitConfiguration(new ServiceLimits(defaults), toServiceLimits(cloudProviderOverrides), toServiceLimits(accountOverrides), toImplementationLimits(implementationLimits));
+  }
+
+  public static class MutableLimits extends HashMap<String, Double> {
+    public void setLimit(String limit, Double value) {
+      put(limit, value);
+    }
+
+    public Double getLimit(String limit) {
+      return get(limit);
+    }
+  }
+
+  public static class MutableImplementationLimits {
+    MutableLimits defaults = new MutableLimits();
+    Map<String, MutableLimits> accountOverrides = new HashMap<>();
+
+    public ImplementationLimits toImplementationLimits() {
+      return new ImplementationLimits(new ServiceLimits(defaults), toServiceLimits(accountOverrides));
+    }
+
+    public MutableLimits getDefaults() {
+      return defaults;
+    }
+
+    public void setDefaults(MutableLimits defaults) {
+      this.defaults = defaults;
+    }
+
+    public Map<String, MutableLimits> getAccountOverrides() {
+      return accountOverrides;
+    }
+
+    public void setAccountOverrides(Map<String, MutableLimits> accountOverrides) {
+      this.accountOverrides = accountOverrides;
+    }
+  }
+
+  private static <S, D> Map<String, D> toImmutable(Map<String, S> src, Function<Map.Entry<String, S>, D> converter) {
+    return java.util.Optional.ofNullable(src)
+      .map(Map::entrySet)
+      .map(Set::stream)
+      .map(s -> s.collect(
+        Collectors.toMap(
+          Map.Entry::getKey,
+          converter)))
+      .orElse(Collections.emptyMap());
+  }
+
+  private static Map<String, ServiceLimits> toServiceLimits(Map<String, MutableLimits> limits) {
+    return toImmutable(limits, mapEntry -> new ServiceLimits(mapEntry.getValue()));
+  }
+
+  private static Map<String, ImplementationLimits> toImplementationLimits(Map<String, MutableImplementationLimits> implementationLimits) {
+    return toImmutable(implementationLimits, mapEntry -> mapEntry.getValue().toImplementationLimits());
+  }
+
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimits.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimits.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ServiceLimits {
+  private final Map<String, Double> limits;
+
+  public ServiceLimits(Map<String, Double> limits) {
+    this.limits = limits == null ? Collections.emptyMap() : ImmutableMap.copyOf(limits);
+  }
+
+  public Double getLimit(String limit) {
+    return limits.get(limit);
+  }
+}

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfigurationSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/limits/ServiceLimitConfigurationSpec.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core.limits
+
+import spock.lang.Specification
+
+class ServiceLimitConfigurationSpec extends Specification {
+
+  def 'should accept all null filters'() {
+    given:
+    ServiceLimitConfiguration cfg = new ServiceLimitConfigurationBuilder()
+      .withDefault(limit, configuredDefaultsVal)
+      .build()
+
+    expect:
+    cfg.getLimit(limit, null, null, null, suppliedDefaultsVal) == configuredDefaultsVal
+
+    where:
+    limit = 'foo'
+    configuredDefaultsVal = 1.0d
+    suppliedDefaultsVal = 2.0d
+  }
+
+  def 'should override values'() {
+    given:
+    ServiceLimitConfiguration cfg = new ServiceLimitConfigurationBuilder()
+      .withDefault(limit, defaultLimit)
+      .withCloudProviderOverride(cloudProvider, limit, cloudProviderLimit)
+      .withAccountOverride(accountA, limit, accountALimit)
+      .withAccountOverride(accountB, limit, accountBLimit)
+      .withImplementationDefault(implementation, limit, implementationDefault)
+      .withImplementationAccountOverride(implementation, implementationAccount, limit, implementationAccountLimit)
+      .build()
+
+
+    expect:
+    cfg.getLimit(limit, implementationName, accountName, cloudProviderName, defaultValue) == expectedValue
+
+    where:
+    defaultValue = 0.5d
+    limit = 'foo'
+    defaultLimit = 1.0d
+    cloudProvider = 'cloudProvider'
+    cloudProviderLimit = 2.0d
+    accountA = 'accountA'
+    accountALimit = 3.0d
+    accountB = 'accountB'
+    accountBLimit = 3.5d
+    implementation = 'implementation'
+    implementationDefault = 4.0d
+    implementationAccount = 'accountA'
+    implementationAccountLimit = 5.0d
+
+
+
+    limitName | accountName | cloudProviderName | implementationName | expectedValue
+    'foo' | 'accountC'| 'cloudProvider' | 'implementationB' | 2.0d
+    'foo' | 'accountB'| 'cloudProvider' | 'implementationB' | 3.5d
+    'foo' | 'accountB'| 'cloudProvider' | 'implementation'  | 4.0d
+    'foo' | 'accountA'| 'cloudProvider' | 'implementation'  | 5.0d
+  }
+}


### PR DESCRIPTION
Yo dog, I heard you like reverts.

This reverts commit 251798241ee340239e04b43481fbb69f1e5a47ac.

Includes a fix for describing regions/zones at startup time.
Includes some extra instrumentation around the cached SDK clients.
Includes updates to how the SDK clients are constructed to support the standard AWS resolver chain for determining the current regional endpoint