### PR TITLE
provider/google: Make LB caching agents fail if GCP call fails.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -237,7 +237,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
   }
 
   // Note: The TargetProxyCallbacks assume that each proxy points to a unique urlMap.
-  class TargetHttpsProxyCallback<TargetHttpsProxy> extends JsonBatchCallback<TargetHttpsProxy> implements FailureLogger {
+  class TargetHttpsProxyCallback<TargetHttpsProxy> extends JsonBatchCallback<TargetHttpsProxy> implements PlatformErrorPropagator {
     GoogleHttpLoadBalancer googleLoadBalancer
     BatchRequest urlMapRequest
 
@@ -266,7 +266,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
   }
 
   // Note: The TargetProxyCallbacks assume that each proxy points to a unique urlMap.
-  class TargetProxyCallback<TargetHttpProxy> extends JsonBatchCallback<TargetHttpProxy> implements FailureLogger {
+  class TargetProxyCallback<TargetHttpProxy> extends JsonBatchCallback<TargetHttpProxy> implements PlatformErrorPropagator {
     GoogleHttpLoadBalancer googleLoadBalancer
     BatchRequest urlMapRequest
 
@@ -291,7 +291,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
     }
   }
 
-  class UrlMapCallback<UrlMap> extends JsonBatchCallback<UrlMap> implements FailureLogger {
+  class UrlMapCallback<UrlMap> extends JsonBatchCallback<UrlMap> implements PlatformErrorPropagator {
     GoogleHttpLoadBalancer googleLoadBalancer
     BatchRequest backendServiceRequest
 
@@ -361,7 +361,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
     }
   }
 
-  class BackendServiceCallback<BackendService> extends JsonBatchCallback<BackendService> implements FailureLogger {
+  class BackendServiceCallback<BackendService> extends JsonBatchCallback<BackendService> implements PlatformErrorPropagator {
     GoogleHttpLoadBalancer googleLoadBalancer
     BatchRequest httpHealthCheckRequest
     BatchRequest groupHealthRequest
@@ -415,7 +415,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
     }
   }
 
-  class HttpsHealthCheckCallback<HttpsHealthCheck> extends JsonBatchCallback<HttpsHealthCheck> implements FailureLogger {
+  class HttpsHealthCheckCallback<HttpsHealthCheck> extends JsonBatchCallback<HttpsHealthCheck> implements PlatformErrorPropagator {
     List<GoogleBackendService> googleBackendServices
 
     @Override
@@ -435,7 +435,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
     }
   }
 
-  class HttpHealthCheckCallback<HttpHealthCheck> extends JsonBatchCallback<HttpHealthCheck> implements FailureLogger {
+  class HttpHealthCheckCallback<HttpHealthCheck> extends JsonBatchCallback<HttpHealthCheck> implements PlatformErrorPropagator {
     List<GoogleBackendService> googleBackendServices
 
     @Override
@@ -455,7 +455,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
     }
   }
 
-  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> implements FailureLogger {
+  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> implements PlatformErrorPropagator {
     GoogleHttpLoadBalancer googleLoadBalancer
 
     @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
@@ -211,7 +211,7 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
     }
   }
 
-  class BackendServiceCallback<BackendService> extends JsonBatchCallback<BackendService> implements FailureLogger {
+  class BackendServiceCallback<BackendService> extends JsonBatchCallback<BackendService> implements PlatformErrorPropagator {
     GoogleInternalLoadBalancer googleLoadBalancer
     BatchRequest healthCheckRequest
     BatchRequest groupHealthRequest
@@ -273,7 +273,7 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
     }
   }
 
-  class HealthCheckCallback<HealthCheck> extends JsonBatchCallback<HealthCheck> implements FailureLogger {
+  class HealthCheckCallback<HealthCheck> extends JsonBatchCallback<HealthCheck> implements PlatformErrorPropagator {
     GoogleBackendService googleBackendService
 
     @Override
@@ -315,7 +315,7 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
     }
   }
 
-  class HttpsHealthCheckCallback<HttpsHealthCheck> extends JsonBatchCallback<HttpsHealthCheck> implements FailureLogger {
+  class HttpsHealthCheckCallback<HttpsHealthCheck> extends JsonBatchCallback<HttpsHealthCheck> implements PlatformErrorPropagator {
     GoogleBackendService googleBackendService
 
     @Override
@@ -333,7 +333,7 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
     }
   }
 
-  class HttpHealthCheckCallback<HttpHealthCheck> extends JsonBatchCallback<HttpHealthCheck> implements FailureLogger {
+  class HttpHealthCheckCallback<HttpHealthCheck> extends JsonBatchCallback<HttpHealthCheck> implements PlatformErrorPropagator {
     GoogleBackendService googleBackendService
 
     @Override
@@ -351,7 +351,7 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
     }
   }
 
-  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> implements FailureLogger {
+  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> implements PlatformErrorPropagator {
     GoogleInternalLoadBalancer googleLoadBalancer
 
     @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -208,7 +208,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
     }
   }
 
-  class TargetPoolCallback<TargetPool> extends JsonBatchCallback<TargetPool> implements FailureLogger {
+  class TargetPoolCallback<TargetPool> extends JsonBatchCallback<TargetPool> implements PlatformErrorPropagator {
 
     GoogleLoadBalancer googleLoadBalancer
 
@@ -235,7 +235,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
     }
   }
 
-  class HttpHealthCheckCallback<HttpHealthCheck> extends JsonBatchCallback<HttpHealthCheck> implements FailureLogger {
+  class HttpHealthCheckCallback<HttpHealthCheck> extends JsonBatchCallback<HttpHealthCheck> implements PlatformErrorPropagator {
 
     GoogleLoadBalancer googleLoadBalancer
     def targetPool
@@ -288,8 +288,7 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
   }
 
 
-  class TargetPoolInstanceHealthCallback<TargetPoolInstanceHealth> extends JsonBatchCallback<TargetPoolInstanceHealth> implements FailureLogger {
-
+  class TargetPoolInstanceHealthCallback<TargetPoolInstanceHealth> extends JsonBatchCallback<TargetPoolInstanceHealth> implements PlatformErrorPropagator {
     GoogleLoadBalancer googleLoadBalancer
     String instanceName
     String instanceZone

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -203,7 +203,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
     }
   }
 
-  class TargetSslProxyCallback<TargetSslProxy> extends JsonBatchCallback<TargetSslProxy> implements FailureLogger {
+  class TargetSslProxyCallback<TargetSslProxy> extends JsonBatchCallback<TargetSslProxy> implements PlatformErrorPropagator {
 
     GoogleSslLoadBalancer googleLoadBalancer
     BatchRequest backendServiceRequest
@@ -225,7 +225,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
     }
   }
 
-  class BackendServiceCallback<BackendService> extends JsonBatchCallback<BackendService> implements FailureLogger {
+  class BackendServiceCallback<BackendService> extends JsonBatchCallback<BackendService> implements PlatformErrorPropagator {
     GoogleSslLoadBalancer googleLoadBalancer
     BatchRequest healthCheckRequest
     BatchRequest groupHealthRequest
@@ -276,7 +276,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
     }
   }
 
-  class HealthCheckCallback<HealthCheck> extends JsonBatchCallback<HealthCheck> implements FailureLogger {
+  class HealthCheckCallback<HealthCheck> extends JsonBatchCallback<HealthCheck> implements PlatformErrorPropagator {
     GoogleBackendService googleBackendService
 
     @Override
@@ -318,7 +318,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
     }
   }
 
-  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> implements FailureLogger {
+  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> implements PlatformErrorPropagator {
     GoogleSslLoadBalancer googleLoadBalancer
 
     @Override

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/PlatformErrorPropagator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/PlatformErrorPropagator.groovy
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.clouddriver.google.provider.agent
 
 import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
+import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import groovy.util.logging.Slf4j
-import org.slf4j.LoggerFactory
 
 @Slf4j
-trait FailureLogger {
+trait PlatformErrorPropagator {
 
   void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
-    LoggerFactory.getLogger(this.class).error e.getMessage()
+    throw new GoogleOperationException(e.getMessage())
   }
 }


### PR DESCRIPTION
There are calls in a few caching agents that are failing and only logging the failure, not throwing an exception. This is causing the agents to return and cache partially-complete objects that cause NPE trouble when we read them. We should just cause the caching agent to fail in these cases (agents don't write anything to the cache if they fail) so the cache isn't corrupted.