### PR TITLE
fix loading cache key in AwsSdkClientSupplier.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
@@ -56,7 +56,7 @@ public class AwsSdkClientSupplier {
   public AwsSdkClientSupplier(RateLimiterSupplier rateLimiterSupplier, Registry registry, RetryPolicy retryPolicy, List<RequestHandler2> requestHandlers, AWSProxy proxy, boolean useGzip) {
     this.rateLimiterSupplier = Objects.requireNonNull(rateLimiterSupplier);
     this.registry = Objects.requireNonNull(registry);
-    awsSdkClients = CacheBuilder.newBuilder().recordStats().expireAfterWrite(10, TimeUnit.MINUTES).build(new SdkClientCacheLoader(retryPolicy, requestHandlers, proxy, useGzip));
+    awsSdkClients = CacheBuilder.newBuilder().recordStats().build(new SdkClientCacheLoader(retryPolicy, requestHandlers, proxy, useGzip));
     LoadingCacheMetrics.instrument("awsSdkClientSupplier", registry, awsSdkClients);
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimitingRequestHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimitingRequestHandler.java
@@ -42,4 +42,22 @@ public class RateLimitingRequestHandler extends RequestHandler2 {
     counter.increment(rateLimitedMillis);
     super.beforeRequest(request);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    RateLimitingRequestHandler that = (RateLimitingRequestHandler) o;
+
+    if (!counter.equals(that.counter)) return false;
+    return rateLimiter.equals(that.rateLimiter);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = counter.hashCode();
+    result = 31 * result + rateLimiter.hashCode();
+    return result;
+  }
 }


### PR DESCRIPTION
request handler was missing equals/hashcode so always resulting in a cache miss/new SDK client