### PR TITLE
provider/google: Exclude caching L7 LBs containing backend buckets.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleHttpLoadBalancer.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleHttpLoadBalancer.groovy
@@ -56,6 +56,12 @@ class GoogleHttpLoadBalancer {
    */
   String urlMapName
 
+  /**
+   * Flag for filtering out load balancers that contain backend buckets in the caching agent.
+   * TODO(jacobkiefer): Support backend buckets.
+   */
+  Boolean containsBackendBucket = false
+
   @JsonIgnore
   GoogleLoadBalancerView getView() {
     new View()


### PR DESCRIPTION
There is a valid case where an L7 LB can contain a backend bucket. This looks the same in the url map (it's a url string), but causes the backend service lookup callback to fail in the caching agent. In #1336 we made the caching agent fail for a cycle if one of the callbacks fails. If a user has a backend bucket in an L7, this will fail for _all_ cache cycles, which isn't desirable.

This PR filters out LBs that contain backend buckets in the caching agent so we don't write them to the cache.