### PR TITLE
Updating to use pagination-enabled project search endpoint from front50

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
@@ -33,8 +33,8 @@ interface Front50Service {
   @GET('/v2/projects/{project}')
   Map getProject(@Path('project') String project)
 
-  @GET('/v2/projects/search')
-  List<Map> searchForProjects(@Query("q") String query)
+  @GET('/v2/projects')
+  List<Map> searchForProjects(@QueryMap Map<String, String> params, @Query("pageSize") Integer pageSize)
 
   @POST('/snapshots')
   Response saveSnapshot(@Body Map snapshot)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/ProjectSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/ProjectSearchProvider.groovy
@@ -51,7 +51,7 @@ class ProjectSearchProvider implements SearchProvider {
       return new SearchResultSet(totalMatches: 0)
     }
 
-    def projects = front50Service.searchForProjects(query) as List<Map>
+    def projects = front50Service.searchForProjects([ name: query, applications: query ], pageSize) as List<Map>
     def results = (projects ?: []).collect { Map project ->
       project.type = PROJECTS_TYPE
       project.url = "/projects/${project.id}".toString()


### PR DESCRIPTION
- Going to cover the current usage of the search endpoint in front50 (searches against name & apps)