### PR TITLE
provider/appengine start and stop operations

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/StartAppEngineAtomicOperationConverter.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/StartAppEngineAtomicOperationConverter.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.converters
+
+import com.netflix.spinnaker.clouddriver.appengine.AppEngineOperation
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+import com.netflix.spinnaker.clouddriver.appengine.deploy.ops.StartAppEngineAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+@AppEngineOperation(AtomicOperations.START_SERVER_GROUP)
+@Component
+class StartAppEngineAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  AtomicOperation convertOperation(Map input) {
+    new StartAppEngineAtomicOperation(convertDescription(input))
+  }
+
+  StartStopAppEngineDescription convertDescription(Map input) {
+    AppEngineAtomicOperationConverterHelper.convertDescription(input, this, StartStopAppEngineDescription)
+  }
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/StopAppEngineAtomicOperationConverter.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/StopAppEngineAtomicOperationConverter.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.converters
+
+import com.netflix.spinnaker.clouddriver.appengine.AppEngineOperation
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+import com.netflix.spinnaker.clouddriver.appengine.deploy.ops.StopAppEngineAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+@AppEngineOperation(AtomicOperations.STOP_SERVER_GROUP)
+@Component
+class StopAppEngineAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  AtomicOperation convertOperation(Map input) {
+    new StopAppEngineAtomicOperation(convertDescription(input))
+  }
+
+  StartStopAppEngineDescription convertDescription(Map input) {
+    AppEngineAtomicOperationConverterHelper.convertDescription(input, this, StartStopAppEngineDescription)
+  }
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/StartStopAppEngineDescription.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/StartStopAppEngineDescription.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.description
+
+class StartStopAppEngineDescription extends AbstractAppEngineCredentialsDescription {
+  String accountName
+  String serverGroupName
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/AbstractStartStopAppEngineAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/AbstractStartStopAppEngineAtomicOperation.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.ops
+
+import com.google.api.services.appengine.v1.model.Version
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+import com.netflix.spinnaker.clouddriver.appengine.model.AppEngineServerGroup
+import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppEngineClusterProvider
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import org.springframework.beans.factory.annotation.Autowired
+
+
+abstract class AbstractStartStopAppEngineAtomicOperation implements AtomicOperation<Void> {
+  @Autowired
+  AppEngineClusterProvider appEngineClusterProvider
+
+  abstract String getBasePhase()
+
+  abstract boolean isStart()
+
+  Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  private final StartStopAppEngineDescription description
+
+  AbstractStartStopAppEngineAtomicOperation(StartStopAppEngineDescription description) {
+    this.description = description
+  }
+
+  @Override
+  Void operate(List priorOutputs) {
+    String verb = start ? 'start' : 'stop'
+    String presentParticipling = start ? 'Starting' : 'Stopping'
+
+    task.updateStatus basePhase, "Initializing $verb server group operation on $description.serverGroupName in" +
+      " $description.credentials.region..."
+
+    def credentials = description.credentials
+    def serverGroupName = description.serverGroupName
+    def appengine = credentials.appengine
+    def project = credentials.project
+
+    task.updateStatus basePhase, "Looking up server group $serverGroupName..."
+    def serverGroup = appEngineClusterProvider.getServerGroup(credentials.name, credentials.region, serverGroupName)
+    def loadBalancerName = serverGroup.loadBalancers.first()
+
+    def newServingStatus = start ? AppEngineServerGroup.ServingStatus.SERVING : AppEngineServerGroup.ServingStatus.STOPPED
+    def version = new Version(servingStatus: newServingStatus.toString())
+
+    task.updateStatus basePhase, "$presentParticipling $serverGroupName..."
+    appengine.apps().services().versions().patch(project, loadBalancerName, serverGroupName, version)
+      .setUpdateMask("servingStatus")
+      .execute()
+
+    task.updateStatus basePhase, "Done ${presentParticipling.toLowerCase()} $serverGroupName."
+    return null
+  }
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/StartAppEngineAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/StartAppEngineAtomicOperation.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+
+/**
+ * curl -X POST -H "Content-Type: application/json" -d '[ { "startServerGroup": { "serverGroupName": "app-stack-detail-v000", "credentials": "my-appengine-account" }} ]' localhost:7002/appengine/ops
+ */
+class StartAppEngineAtomicOperation extends AbstractStartStopAppEngineAtomicOperation {
+  StartAppEngineAtomicOperation(StartStopAppEngineDescription description) {
+    super(description)
+  }
+
+  boolean start = true
+  String basePhase = "START_SERVER_GROUP"
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/StopAppEngineAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/StopAppEngineAtomicOperation.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+
+/**
+ * curl -X POST -H "Content-Type: application/json" -d '[ { "stopServerGroup": { "serverGroupName": "app-stack-detail-v000", "credentials": "my-appengine-account" }} ]' localhost:7002/appengine/ops
+ */
+class StopAppEngineAtomicOperation extends AbstractStartStopAppEngineAtomicOperation {
+  StopAppEngineAtomicOperation(StartStopAppEngineDescription description) {
+    super(description)
+  }
+
+  boolean start = false
+  String basePhase = "STOP_SERVER_GROUP"
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/AbstractStartStopAppEngineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/AbstractStartStopAppEngineDescriptionValidator.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppEngineClusterProvider
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.validation.Errors
+
+
+abstract class AbstractStartStopAppEngineDescriptionValidator extends DescriptionValidator<StartStopAppEngineDescription> {
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Autowired
+  AppEngineClusterProvider appEngineClusterProvider
+
+  abstract String getDescriptionName()
+
+  @Override
+  void validate(List priorDescriptions, StartStopAppEngineDescription description, Errors errors) {
+    def helper = new StandardAppEngineAttributeValidator(descriptionName, errors)
+
+    helper.validateCredentials(description.accountName, accountCredentialsProvider)
+    def nameNotEmpty = helper.validateNotEmpty(description.serverGroupName, "serverGroupName")
+
+    if (nameNotEmpty) {
+      helper.validateServingStatusCanBeChanged(description.serverGroupName,
+                                               description.credentials,
+                                               appEngineClusterProvider,
+                                               "serverGroupName")
+    }
+  }
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StartAppEngineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StartAppEngineDescriptionValidator.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.appengine.AppEngineOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import org.springframework.stereotype.Component
+
+@AppEngineOperation(AtomicOperations.START_SERVER_GROUP)
+@Component
+class StartAppEngineDescriptionValidator extends AbstractStartStopAppEngineDescriptionValidator {
+  String descriptionName = "startAppEngineAtomicOperationDescription"
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StopAppEngineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StopAppEngineDescriptionValidator.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.appengine.AppEngineOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import org.springframework.stereotype.Component
+
+@AppEngineOperation(AtomicOperations.STOP_SERVER_GROUP)
+@Component
+class StopAppEngineDescriptionValidator extends AbstractStartStopAppEngineDescriptionValidator {
+  String descriptionName = "stopAppEngineAtomicOperationDescription"
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppEngineClusterProvider.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppEngineClusterProvider.groovy
@@ -81,7 +81,7 @@ class AppEngineClusterProvider implements ClusterProvider<AppEngineCluster> {
     }
 
     Set<AppEngineInstance> instances = cacheView.getAll(INSTANCES.ns, serverGroupData.relationships[INSTANCES.ns])
-      .collect { AppEngineProviderUtils.instanceFromCacheData(objectMapper, it) }
+      .findResults { AppEngineProviderUtils.instanceFromCacheData(objectMapper, it) }
 
     AppEngineProviderUtils.serverGroupFromCacheData(objectMapper, serverGroupData, instances)
   }
@@ -165,7 +165,7 @@ class AppEngineClusterProvider implements ClusterProvider<AppEngineCluster> {
                                              RelationshipCacheFilter.none())
 
     def instances = instanceCacheDataMap.collectEntries { String key, Collection<CacheData> cacheData ->
-        [(key): cacheData.collect { AppEngineProviderUtils.instanceFromCacheData(objectMapper, it) } as Set ]
+        [(key): cacheData.findResults { AppEngineProviderUtils.instanceFromCacheData(objectMapper, it) } as Set ]
     }
 
     return serverGroupData

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppEngineLoadBalancerProvider.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppEngineLoadBalancerProvider.groovy
@@ -76,7 +76,7 @@ class AppEngineLoadBalancerProvider implements LoadBalancerProvider<AppEngineLoa
         .collect {
           Set<AppEngineInstance> instances = AppEngineProviderUtils
             .resolveRelationshipData(cacheView, it, Namespace.INSTANCES.ns)
-            .collect { AppEngineProviderUtils.instanceFromCacheData(objectMapper, it) }
+            .findResults { AppEngineProviderUtils.instanceFromCacheData(objectMapper, it) }
           AppEngineProviderUtils.serverGroupFromCacheData(objectMapper, it, instances)
         }
 

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/StartAppEngineAtomicOperationConverterSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/StartAppEngineAtomicOperationConverterSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.converters
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+import com.netflix.spinnaker.clouddriver.appengine.deploy.ops.StartAppEngineAtomicOperation
+import com.netflix.spinnaker.clouddriver.appengine.security.AppEngineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Shared
+import spock.lang.Specification
+
+class StartAppEngineAtomicOperationConverterSpec extends Specification {
+  private static final ACCOUNT_NAME = "my-appengine-account"
+  private static final SERVER_GROUP_NAME = 'app-stack-detail-v000'
+
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared
+  StartAppEngineAtomicOperationConverter converter
+
+  def setupSpec() {
+    converter = new StartAppEngineAtomicOperationConverter(objectMapper: mapper)
+    def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    def mockCredentials = Mock(AppEngineNamedAccountCredentials)
+    accountCredentialsProvider.getCredentials(_) >> mockCredentials
+    converter.accountCredentialsProvider = accountCredentialsProvider
+  }
+
+  void "startAppEngineDescription type returns StartStopAppEngineDescription and StartAppEngineAtomicOperation"() {
+    setup:
+      def input = [ credentials: ACCOUNT_NAME, serverGroupName: SERVER_GROUP_NAME ]
+
+    when:
+      def description = converter.convertDescription(input)
+
+    then:
+      description instanceof StartStopAppEngineDescription
+
+    when:
+      def operation = converter.convertOperation(input)
+
+    then:
+      operation instanceof StartAppEngineAtomicOperation
+  }
+}

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/StartStopAppEngineAtomicOperationSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/StartStopAppEngineAtomicOperationSpec.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.ops
+
+import com.google.api.services.appengine.v1.Appengine
+import com.google.api.services.appengine.v1.model.Version
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+import com.netflix.spinnaker.clouddriver.appengine.model.AppEngineServerGroup
+import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppEngineClusterProvider
+import com.netflix.spinnaker.clouddriver.appengine.security.AppEngineCredentials
+import com.netflix.spinnaker.clouddriver.appengine.security.AppEngineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class StartStopAppEngineAtomicOperationSpec extends Specification {
+  private static final ACCOUNT_NAME = 'my-appengine-account'
+  private static final SERVER_GROUP_NAME = 'app-stack-detail-v000'
+  private static final REGION = 'us-central'
+  private static final LOAD_BALANCER_NAME = 'default'
+  private static final PROJECT = 'my-gcp-project'
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  @Unroll
+  void "start and stop operations should call version.patch API with appropriate versions"() {
+    setup:
+      def clusterProviderMock = Mock(AppEngineClusterProvider)
+
+      def appEngineMock = Mock(Appengine)
+      def appsMock = Mock(Appengine.Apps)
+      def servicesMock = Mock(Appengine.Apps.Services)
+      def versionsMock = Mock(Appengine.Apps.Services.Versions)
+      def patchMock = Mock(Appengine.Apps.Services.Versions.Patch)
+
+      def credentials = new AppEngineNamedAccountCredentials.Builder()
+        .credentials(Mock(AppEngineCredentials))
+        .name(ACCOUNT_NAME)
+        .region(REGION)
+        .project(PROJECT)
+        .appengine(appEngineMock)
+        .build()
+
+      def description = new StartStopAppEngineDescription(
+        accountName: ACCOUNT_NAME,
+        serverGroupName: SERVER_GROUP_NAME,
+        credentials: credentials,
+      )
+
+      def serverGroup = new AppEngineServerGroup(name: SERVER_GROUP_NAME, loadBalancers: [LOAD_BALANCER_NAME])
+
+      @Subject def operation = start ?
+        new StartAppEngineAtomicOperation(description) :
+        new StopAppEngineAtomicOperation(description)
+      operation.appEngineClusterProvider = clusterProviderMock
+
+    when:
+      operation.operate([])
+
+    then:
+      1 * clusterProviderMock.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
+
+      1 * appEngineMock.apps() >> appsMock
+      1 * appsMock.services() >> servicesMock
+      1 * servicesMock.versions() >> versionsMock
+      1 * versionsMock.patch(PROJECT, LOAD_BALANCER_NAME, SERVER_GROUP_NAME, expectedVersion) >> patchMock
+      1 * patchMock.setUpdateMask("servingStatus") >> patchMock
+      1 * patchMock.execute()
+
+    where:
+      start | expectedVersion
+      true  | new Version(servingStatus: "SERVING")
+      false | new Version(servingStatus: "STOPPED")
+  }
+}

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StartAppEngineDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StartAppEngineDescriptionValidatorSpec.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppEngineDescription
+import com.netflix.spinnaker.clouddriver.appengine.model.AppEngineScalingPolicy
+import com.netflix.spinnaker.clouddriver.appengine.model.AppEngineServerGroup
+import com.netflix.spinnaker.clouddriver.appengine.model.ScalingPolicyType
+import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppEngineClusterProvider
+import com.netflix.spinnaker.clouddriver.appengine.security.AppEngineCredentials
+import com.netflix.spinnaker.clouddriver.appengine.security.AppEngineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
+import org.springframework.validation.Errors
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class StartAppEngineDescriptionValidatorSpec extends Specification {
+  private static final ACCOUNT_NAME = "my-appengine-account"
+  private static final REGION = "us-central"
+  private static final APPLICATION_NAME = "myapp"
+  private static final SERVER_GROUP_NAME = "app-stack-detail"
+
+  @Shared
+  StartAppEngineDescriptionValidator validator
+
+  @Shared
+  AppEngineNamedAccountCredentials credentials
+
+  void setupSpec() {
+    validator = new StartAppEngineDescriptionValidator()
+
+    def credentialsRepo = new MapBackedAccountCredentialsRepository()
+    def mockCredentials = Mock(AppEngineCredentials)
+    credentials = new AppEngineNamedAccountCredentials.Builder()
+      .name(ACCOUNT_NAME)
+      .region(REGION)
+      .applicationName(APPLICATION_NAME)
+      .credentials(mockCredentials)
+      .build()
+    credentialsRepo.save(ACCOUNT_NAME, credentials)
+
+    validator.accountCredentialsProvider = new DefaultAccountCredentialsProvider(credentialsRepo)
+  }
+
+  @Unroll
+  void "pass validation with proper description inputs"() {
+    setup:
+      def description = new StartStopAppEngineDescription(
+        accountName: ACCOUNT_NAME,
+        serverGroupName: SERVER_GROUP_NAME,
+        credentials: credentials
+      )
+      def errors = Mock(Errors)
+      validator.appEngineClusterProvider = Mock(AppEngineClusterProvider)
+      validator.appEngineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
+
+    when:
+      validator.validate([], description, errors)
+
+    then:
+      0 * errors._
+
+    where:
+      serverGroup << [
+        new AppEngineServerGroup(env: AppEngineServerGroup.Environment.FLEXIBLE),
+        new AppEngineServerGroup(scalingPolicy: new AppEngineScalingPolicy(type: ScalingPolicyType.BASIC)),
+        new AppEngineServerGroup(scalingPolicy: new AppEngineScalingPolicy(type: ScalingPolicyType.MANUAL))
+      ]
+  }
+
+  @Unroll
+  void "fails validation if server group has wrong type"() {
+    setup:
+      def description = new StartStopAppEngineDescription(
+        accountName: ACCOUNT_NAME,
+        serverGroupName: SERVER_GROUP_NAME,
+        credentials: credentials
+      )
+      def errors = Mock(Errors)
+      validator.appEngineClusterProvider = Mock(AppEngineClusterProvider)
+      validator.appEngineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
+
+    when:
+      validator.validate([], description, errors)
+
+    then:
+      1 * errors.rejectValue('startAppEngineAtomicOperationDescription.serverGroupName',
+                             'startAppEngineAtomicOperationDescription.serverGroupName.invalid ' +
+                             '(Only server groups that use the flexible environment, or use basic ' +
+                             'or manual scaling can be started or stopped).')
+
+    where:
+      serverGroup << [
+        new AppEngineServerGroup(env: AppEngineServerGroup.Environment.STANDARD),
+        new AppEngineServerGroup(scalingPolicy: new AppEngineScalingPolicy(type: ScalingPolicyType.AUTOMATIC))
+      ]
+  }
+
+  void "fails validation if server group not found"() {
+    setup:
+      def description = new StartStopAppEngineDescription(
+        accountName: ACCOUNT_NAME,
+        serverGroupName: SERVER_GROUP_NAME,
+        credentials: credentials
+      )
+      def errors = Mock(Errors)
+      validator.appEngineClusterProvider = Mock(AppEngineClusterProvider)
+      validator.appEngineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> null
+
+    when:
+      validator.validate([], description, errors)
+
+    then:
+      1 * errors.rejectValue('startAppEngineAtomicOperationDescription.serverGroupName',
+                             'startAppEngineAtomicOperationDescription.serverGroupName.invalid ' +
+                             '(Server group app-stack-detail not found).')
+  }
+
+  void "null input fails validation"() {
+    setup:
+      def description = new StartStopAppEngineDescription()
+      def errors = Mock(Errors)
+
+    when:
+      validator.validate([], description, errors)
+
+    then:
+      1 * errors.rejectValue("startAppEngineAtomicOperationDescription.account",
+                             "startAppEngineAtomicOperationDescription.account.empty")
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.groovy
@@ -35,6 +35,8 @@ final class AtomicOperations {
   public static final String DELETE_SCALING_POLICY = "deleteScalingPolicy"
   public static final String MIGRATE_SERVER_GROUP = "migrateServerGroup"
   public static final String MIGRATE_CLUSTER_CONFIGURATIONS = "migrateClusterConfigurations"
+  public static final String START_SERVER_GROUP = "startServerGroup"
+  public static final String STOP_SERVER_GROUP = "stopServerGroup"
 
   // Instance operations
   public static final String REBOOT_INSTANCES = "rebootInstances"


### PR DESCRIPTION
@duftler or @lwander please review.

In the API, a version's serving status is either `SERVING` or `STOPPED`. The cloud console UI and gcloud use `start` and `stop` when modifying serving status, so I've used those verbs.