### PR TITLE
Prevent NPE if a namespace doesn't have any replicaSets.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -413,7 +413,8 @@ class KubernetesApiAdaptor {
 
   Map<String, HorizontalPodAutoscaler> getAutoscalers(String namespace, String kind) {
     exceptionWrapper("Get Autoscalers", namespace) {
-      client.extensions().horizontalPodAutoscalers().inNamespace(namespace).list().items.collectEntries { def autoscaler ->
+      def items = client.extensions().horizontalPodAutoscalers().inNamespace(namespace).list().items ?: []
+      items.collectEntries { def autoscaler ->
         autoscaler.spec.scaleRef.kind == kind ? [(autoscaler.metadata.name): autoscaler] : [:]
       }
     }


### PR DESCRIPTION
We had namespaces without replicaSets. This caused an NPE in caching the server groups.

```
2016-12-30 12:51:41.397  WARN 3277 --- [ecutionAction-6] .k.p.a.KubernetesServerGroupCachingAgent : Failure fetching autoscalers for all server groups in [list of namespaces]                                                                                                                                                       
        java.lang.NullPointerException: Cannot invoke method collectEntries() on null object                                                                                       
        at org.codehaus.groovy.runtime.NullObject.invokeMethod(NullObject.java:91)                                                                                         
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:48)                                                                          
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)                                                                           
        at org.codehaus.groovy.runtime.callsite.NullCallSite.call(NullCallSite.java:35)                                                                                    
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)                                                                           
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:58)                                                                        
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)                                                                           
        at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor$_getAutoscalers_closure46.doCall(KubernetesApiAdaptor.groovy:407)                         
        at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor$_getAutoscalers_closure46.doCall(KubernetesApiAdaptor.groovy)                             
        at sun.reflect.GeneratedMethodAccessor490.invoke(Unknown Source)                                                                                                   
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)                                                                                                 
        at java.lang.reflect.Method.invoke(Unknown Source)                                                                                                                 
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)                                                                                        
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)                                                                                                      
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)                                                                  
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)                                                                                                 
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:42)                                                                          
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)                                                                           
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:57)                                                                          
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:117)                                                                           
        at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor.exceptionWrapper(KubernetesApiAdaptor.groovy:89)                                          
        at sun.reflect.GeneratedMethodAccessor90.invoke(Unknown Source)                                                                                                    
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)                                                                                                 
        at java.lang.reflect.Method.invoke(Unknown Source)                                                                                                                 
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)                                
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)                                                                 
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:182)                                                                    
        at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor.getAutoscalers(KubernetesApiAdaptor.groovy:406)                                           
        at com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor$getAutoscalers$6.call(Unknown Source)                                                     
        at com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent$_buildCacheResult_closure21.doCall(KubernetesServerGroupCachingAge
nt.groovy:289)
        at sun.reflect.GeneratedMethodAccessor495.invoke(Unknown Source)                                                                                                   
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)                                                                                                 
        at java.lang.reflect.Method.invoke(Unknown Source)                                                                                                                 
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)                                                                                        
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)                                                                                                      
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)                                                                  
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)                                                                                                 
        at groovy.lang.Closure.call(Closure.java:414)                                                                                                                      
        at groovy.lang.Closure.call(Closure.java:430)                                                                                                                      
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2030)                                                                           
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2015)                                                                           
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2056)                                                                           
        at org.codehaus.groovy.runtime.dgm$162.invoke(Unknown Source)                                                                                                      
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:274)                                  
        at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56)                                                                        
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)                                                                           
        at com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent.buildCacheResult(KubernetesServerGroupCachingAgent.groovy:288)    
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)                                                                                                     
        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)                                                                                                     
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)                                                                                                 
        at java.lang.reflect.Method.invoke(Unknown Source)                                                                                                                 
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)                                
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:59)                                                                 
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:190)                                                                    
        at com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent.loadData(KubernetesServerGroupCachingAgent.groovy:237)            
        at com.netflix.spinnaker.cats.agent.CachingAgent$CacheExecution.executeAgentWithoutStore(CachingAgent.java:66)                                                     
        at com.netflix.spinnaker.cats.agent.CachingAgent$CacheExecution.executeAgent(CachingAgent.java:59)                                                                 
        at com.netflix.spinnaker.cats.redis.cluster.ClusteredAgentScheduler$AgentExecutionAction.execute(ClusteredAgentScheduler.java:193)                                 
        at com.netflix.spinnaker.cats.redis.cluster.ClusteredAgentScheduler$AgentJob.run(ClusteredAgentScheduler.java:167)                                                 
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)                                                                                             
        at java.util.concurrent.FutureTask.run(Unknown Source)                                                                                                             
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)                                                                                               
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)                                                                                              
        at java.lang.Thread.run(Unknown Source)
```     