### PR TITLE
provider/appengine cleanup api utils

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/AppEngineServerGroupNameResolver.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/AppEngineServerGroupNameResolver.groovy
@@ -59,7 +59,7 @@ class AppEngineServerGroupNameResolver extends AbstractServerGroupNameResolver {
     }
 
     return versions.findResults { version ->
-      def versionName = AppEngineUtils.parseResourceName(version.getName())
+      def versionName = version.getId()
       def friggaNames = Names.parseName(versionName)
 
       if (friggaNames.cluster == clusterName) {


### PR DESCRIPTION
@lwander or @duftler 

Cleans up Appengine api `queryAllVersions` utility so that it uses a batch request instead of making separate calls for each service.