### PR TITLE
For AWS health indicator, don't explicitly set a region.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicator.groovy
@@ -65,9 +65,9 @@ class AmazonHealthIndicator implements HealthIndicator {
       } as Set<NetflixAmazonCredentials>
       for (NetflixAmazonCredentials credentials in amazonCredentials) {
         try {
-          def ec2 = amazonClientProvider.getAmazonEC2(credentials, "us-east-1")
+          def ec2 = amazonClientProvider.getAmazonEC2(credentials, AmazonClientProvider.DEFAULT_REGION, true)
           if (!ec2) {
-            throw new AmazonClientException("Could not create Amazon client for ${credentials.name} in us-east-1")
+            throw new AmazonClientException("Could not create Amazon client for ${credentials.name}")
           }
           ec2.describeAccountAttributes()
         } catch (AmazonServiceException e) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicatorSpec.groovy
@@ -38,7 +38,7 @@ class AmazonHealthIndicatorSpec extends Specification {
       describeAccountAttributes() >> { throw new AmazonServiceException("fail") }
     }
     def mockAmazonClientProvider = Stub(AmazonClientProvider) {
-      getAmazonEC2(_, _) >> mockEc2
+      getAmazonEC2(*_) >> mockEc2
     }
     def indicator = new AmazonHealthIndicator(accountCredentialsProvider: holder, amazonClientProvider: mockAmazonClientProvider)
 
@@ -61,7 +61,7 @@ class AmazonHealthIndicatorSpec extends Specification {
       describeAccountAttributes() >> { Mock(DescribeAccountAttributesResult) }
     }
     def mockAmazonClientProvider = Stub(AmazonClientProvider) {
-      getAmazonEC2(_, _) >> mockEc2
+      getAmazonEC2(*_) >> mockEc2
     }
     def indicator = new AmazonHealthIndicator(accountCredentialsProvider: holder, amazonClientProvider: mockAmazonClientProvider)
 


### PR DESCRIPTION
Fixes spinnaker/spinnaker#1357

Prefers SDK current region determination methods from the AmazonClientProvider to
work around issues where connectivity to us-east-1 is not available.