### PR TITLE
enable filtering out of specific instance types from the instanceTypes endpoint

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceTypeProviderConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceTypeProviderConfiguration.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.view
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties('aws.instanceTypes')
+@Canonical
+class AmazonInstanceTypeProviderConfiguration {
+  @Canonical
+  static class InstanceTypeOption {
+    String name
+    List<String> regions = null
+  }
+
+  List<InstanceTypeOption> excluded = []
+}


### PR DESCRIPTION
example configuration:

````yaml
aws:
  instanceTypes:
    excluded:
      # exclude all m1.large
      - name: m1.large
      # exclude x1.32xlarge in us-east-1 only
      - name: x1.32xlarge
        regions:
          - us-east-1
````