### PR TITLE
Adding null checks in kubernetes provider for caching.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -336,7 +336,7 @@ class KubernetesServerGroupCachingAgent extends KubernetesCachingAgent implement
           relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
         }
 
-        pods.forEach { pod ->
+        pods?.forEach { pod ->
           def key = Keys.getInstanceKey(accountName, pod.metadata.namespace, pod.metadata.name)
           instanceKeys << key
           cachedInstances[key].with {
@@ -347,7 +347,7 @@ class KubernetesServerGroupCachingAgent extends KubernetesCachingAgent implement
           }
         }
 
-        loadBalancerKeys.forEach { loadBalancerKey ->
+        loadBalancerKeys?.forEach { loadBalancerKey ->
           cachedLoadBalancers[loadBalancerKey].with {
             relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)
             relationships[Keys.Namespace.INSTANCES.ns].addAll(instanceKeys)


### PR DESCRIPTION
Kubernetes provider is failing on my juju charmed instance of kubernetes (the canonical distribution of kubernetes) because of missing null checks. This seems to fix my problem.

@lwander @varikin  take a look?