### PR TITLE
Allow Spinnaker to authenticate with k8s service accounts

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -6,5 +6,5 @@ dependencies {
   compile spinnaker.dependency('bootWeb')
 
   // TODO (move to https://github.com/spinnaker/spinnaker-dependencies/blob/master/src/spinnaker-dependencies.yml)
-  compile 'io.fabric8:kubernetes-api:2.2.175'
+  compile 'io.fabric8:kubernetes-api:2.2.184'
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.api
 
-import com.netflix.frigga.NameBuilder
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.autoscaler.KubernetesAutoscalerDescription
@@ -24,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalan
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.loadbalancer.KubernetesNamedServicePort
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.securitygroup.*
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.*
-import io.fabric8.kubernetes.api.builder.BaseFluent
 import io.fabric8.kubernetes.api.model.*
 import io.fabric8.kubernetes.api.model.extensions.*
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -29,6 +29,7 @@ class KubernetesConfigurationProperties {
     String cluster
     String user
     String kubeconfigFile
+    Boolean serviceAccount
     List<String> namespaces
     int cacheThreads
     List<LinkedDockerRegistryConfiguration> dockerRegistries

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsInitializer.groovy
@@ -79,6 +79,7 @@ class KubernetesCredentialsInitializer implements CredentialsInitializerSynchron
           .cluster(managedAccount.cluster)
           .user(managedAccount.user)
           .kubeconfigFile(managedAccount.kubeconfigFile)
+          .serviceAccount(managedAccount.serviceAccount)
           .namespaces(managedAccount.namespaces)
           .cacheThreads(managedAccount.cacheThreads ?: DEFAULT_CACHE_THREADS)
           .dockerRegistries(managedAccount.dockerRegistries)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.groovy
@@ -32,6 +32,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
   final String user
   final String userAgent
   final String kubeconfigFile
+  final Boolean serviceAccount
   List<String> namespaces
   final int cacheThreads
   KubernetesCredentials credentials
@@ -48,6 +49,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
                                            String cluster,
                                            String user,
                                            String kubeconfigFile,
+                                           Boolean serviceAccount,
                                            List<String> namespaces,
                                            int cacheThreads,
                                            List<LinkedDockerRegistryConfiguration> dockerRegistries,
@@ -61,6 +63,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
     this.user = user
     this.userAgent = userAgent
     this.kubeconfigFile = kubeconfigFile
+    this.serviceAccount = serviceAccount
     this.namespaces = namespaces
     this.cacheThreads = cacheThreads
     this.requiredGroupMembership = requiredGroupMembership
@@ -82,6 +85,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
     String user
     String userAgent
     String kubeconfigFile
+    Boolean serviceAccount
     List<String> namespaces
     int cacheThreads
     KubernetesCredentials credentials
@@ -129,6 +133,11 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
       return this
     }
 
+    Builder serviceAccount(Boolean serviceAccount) {
+      this.serviceAccount = serviceAccount;
+      return this
+    }
+
     Builder requiredGroupMembership(List<String> requiredGroupMembership) {
       this.requiredGroupMembership = requiredGroupMembership
       return this
@@ -160,7 +169,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
     }
 
     private KubernetesCredentials buildCredentials() {
-      Config config = KubernetesConfigParser.parse(kubeconfigFile, context, cluster, user, namespaces)
+      Config config = KubernetesConfigParser.parse(kubeconfigFile, context, cluster, user, namespaces, serviceAccount)
       config.setUserAgent(userAgent)
 
       for (LinkedDockerRegistryConfiguration registry : dockerRegistries) {
@@ -200,6 +209,7 @@ public class KubernetesNamedAccountCredentials implements AccountCredentials<Kub
           cluster,
           user,
           kubeconfigFile,
+          serviceAccount,
           namespaces,
           cacheThreads,
           dockerRegistries,


### PR DESCRIPTION
The service account's cert is always placed in `KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH`, and the token in `KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH` by Kubernetes in every pod. If the user specifies `serviceAccount: true` in their clouddriver config, Spinnaker will read the cert & token out of those paths for authentication.

@duftler @danielpeach  PTAL