### PR TITLE
provider/appengine remove zero from load balancer traffic split allocations

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/UpsertAppEngineLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/UpsertAppEngineLoadBalancerAtomicOperation.groovy
@@ -117,13 +117,13 @@ class UpsertAppEngineLoadBalancerAtomicOperation implements AtomicOperation<Map>
     }
 
     if (update.allocations) {
-      override.allocations = update.allocations
+      override.allocations = update.allocations.findAll { it.value > 0 }
     }
 
     if (update.shardBy) {
       override.shardBy = update.shardBy
     }
 
-    override
+    return override
   }
 }


### PR DESCRIPTION
@duftler or @lwander please review.

From Deck, it seems reasonable to set a server group's allocation to zero - but the App Engine API rejects the call. 
