### PR TITLE
use ssh-agent for bastion identity

### DIFF
--- a/clouddriver-aws/clouddriver-aws.gradle
+++ b/clouddriver-aws/clouddriver-aws.gradle
@@ -14,4 +14,6 @@ dependencies {
   compile spinnaker.dependency('guava')
 
   compile 'com.aestasit.infrastructure.sshoogr:sshoogr:0.9.25'
+  compile 'com.jcraft:jsch.agentproxy.jsch:0.0.9'
+  compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.9'
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/bastion/BastionConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/bastion/BastionConfig.groovy
@@ -24,17 +24,10 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableConfigurationProperties
+@ConditionalOnProperty('bastion.enabled')
+@EnableConfigurationProperties(BastionProperties)
 class BastionConfig {
-
   @Bean
-  @ConfigurationProperties("bastion")
-  BastionProperties bastionConfiguration() {
-    new BastionProperties()
-  }
-
-  @Bean
-  @ConditionalOnProperty('bastion.enabled')
   AWSCredentialsProvider bastionCredentialsProvider(BastionProperties bastionConfiguration) {
     def provider = new BastionCredentialsProvider(bastionConfiguration.user, bastionConfiguration.host, bastionConfiguration.port, bastionConfiguration.proxyCluster,
       bastionConfiguration.proxyRegion, bastionConfiguration.accountIamRole)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/bastion/BastionProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/bastion/BastionProperties.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.aws.bastion
 
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("bastion")
 class BastionProperties {
   Boolean enabled
   String host


### PR DESCRIPTION
This whole class is really Netflix specific and should probably just be removed from the project, but right now it is used also by front50 (via clouddriver-aws dependency).

I'll look at options to kill this off from this repo that don't also impact our ability to do local dev, but for now this makes it so that the BastionCredentialsProvider requires a running ssh-agent with valid identities added.

@spinnaker/netflix-reviewers FYI