### PR TITLE
Support for registering notification hooks when an ASG is launched

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/AgentProvider.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/AgentProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.agent;
+
+import java.util.Collection;
+
+public interface AgentProvider {
+  boolean supports(String providerName);
+  Collection<Agent> agents();
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAsgLifecycleHookDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAsgLifecycleHookDescription.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook.DefaultResult
-import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook.LifecycleTransition
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook.Transition
 
 class UpsertAsgLifecycleHookDescription extends AbstractAmazonCredentialsDescription {
 
@@ -29,7 +29,7 @@ class UpsertAsgLifecycleHookDescription extends AbstractAmazonCredentialsDescrip
 
   // optional
   String name
-  LifecycleTransition lifecycleTransition = LifecycleTransition.EC2InstanceTerminating
+  Transition lifecycleTransition = Transition.EC2InstanceTerminating
   String notificationMetadata
   Integer heartbeatTimeout = 3600
   DefaultResult defaultResult = DefaultResult.ABANDON

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -364,9 +364,9 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         new AmazonAsgLifecycleHook(
           roleARN: it.roleARN,
           notificationTargetARN: it.notificationTargetARN,
-          lifecycleTransition: AmazonAsgLifecycleHook.LifecycleTransition.valueOfName(it.lifecycleTransition),
+          lifecycleTransition: AmazonAsgLifecycleHook.Transition.valueOfName(it.lifecycleTransition),
           heartbeatTimeout: it.heartbeatTimeout,
-          defaultResult: AmazonAsgLifecycleHook.DefaultResult.valueOf(it.defaultResult)
+          defaultResult: it.defaultResult ? AmazonAsgLifecycleHook.DefaultResult.valueOf(it.defaultResult) : null
         )
       })
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureConfigurationProperties.groovy
@@ -1,0 +1,49 @@
+package com.netflix.spinnaker.clouddriver.aws.lifecycle
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ConfigurationProperties("aws.lifecycleSubscribers.launchFailure")
+class LaunchFailureConfigurationProperties {
+  String accountName
+  String topicARN
+  String queueARN
+
+  int maxMessagesPerCycle = 1000
+  int visibilityTimeout = 60
+  int waitTimeSeconds = 5
+
+  LaunchFailureConfigurationProperties() {
+    // default constructor
+  }
+
+  LaunchFailureConfigurationProperties(String accountName,
+                                       String topicARN,
+                                       String queueARN,
+                                       int maxMessagesPerCycle,
+                                       int visibilityTimeout,
+                                       int waitTimeSeconds) {
+    this.accountName = accountName
+    this.topicARN = topicARN
+    this.queueARN = queueARN
+    this.maxMessagesPerCycle = maxMessagesPerCycle
+    this.visibilityTimeout = visibilityTimeout
+    this.waitTimeSeconds = waitTimeSeconds
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgent.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.amazonaws.auth.policy.Condition;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Principal;
+import com.amazonaws.auth.policy.Resource;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.actions.SNSActions;
+import com.amazonaws.auth.policy.actions.SQSActions;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.SetTopicAttributesRequest;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiptHandleIsInvalidException;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.RunnableAgent;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * An Agent that subscribes to a particular SQS queue and tags any server groups that had launch errors.
+ */
+class LaunchFailureNotificationAgent implements RunnableAgent {
+  private static final Logger log = LoggerFactory.getLogger(LaunchFailureNotificationAgent.class);
+
+  private static final Pattern ARN_PATTERN = Pattern.compile("arn:aws:.*:(.*):(\\d+):(.*)");
+  private static final String SUPPORTED_LIFECYCLE_TRANSITION = "autoscaling:EC2_INSTANCE_LAUNCH_ERROR";
+  private static final int AWS_MAX_NUMBER_OF_MESSAGES = 10;
+
+  private final ObjectMapper objectMapper;
+  private final AmazonClientProvider amazonClientProvider;
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final LaunchFailureConfigurationProperties properties;
+
+  private final ARN topicARN;
+  private final ARN queueARN;
+
+  private String topicId = null; // the ARN for the topic
+  private String queueId = null; // the URL for the queue
+
+  LaunchFailureNotificationAgent(ObjectMapper objectMapper,
+                                 AmazonClientProvider amazonClientProvider,
+                                 AccountCredentialsProvider accountCredentialsProvider,
+                                 LaunchFailureConfigurationProperties properties) {
+    this.objectMapper = objectMapper;
+    this.amazonClientProvider = amazonClientProvider;
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.properties = properties;
+
+    Set<? extends AccountCredentials> accountCredentials = accountCredentialsProvider.getAll();
+    this.topicARN = new ARN(accountCredentials, properties.getTopicARN());
+    this.queueARN = new ARN(accountCredentials, properties.getQueueARN());
+  }
+
+  @Override
+  public String getAgentType() {
+    return queueARN.account.getName() + "/" + queueARN.region + "/" + LaunchFailureNotificationAgent.class.getSimpleName();
+  }
+
+  @Override
+  public String getProviderName() {
+    return AwsProvider.PROVIDER_NAME;
+  }
+
+  @Override
+  public void run() {
+    List<String> allAccountIds = accountCredentialsProvider.getAll().stream()
+      .filter(c -> c instanceof NetflixAmazonCredentials)
+      .map(AccountCredentials::getAccountId)
+      .collect(Collectors.toList());
+
+    AmazonSQS amazonSQS = amazonClientProvider.getAmazonSQS(queueARN.account, queueARN.region);
+    this.queueId = ensureQueueExists(amazonSQS, queueId, queueARN, topicARN);
+
+    AmazonSNS amazonSNS = amazonClientProvider.getAmazonSNS(topicARN.account, topicARN.region);
+    this.topicId = ensureTopicExists(amazonSNS, topicId, topicARN, allAccountIds, queueARN);
+
+    AtomicInteger messagesProcessed = new AtomicInteger(0);
+    while (messagesProcessed.get() < properties.getMaxMessagesPerCycle()) {
+      ReceiveMessageResult receiveMessageResult = amazonSQS.receiveMessage(
+        new ReceiveMessageRequest(queueId)
+          .withMaxNumberOfMessages(AWS_MAX_NUMBER_OF_MESSAGES)
+          .withVisibilityTimeout(properties.getVisibilityTimeout())
+          .withWaitTimeSeconds(properties.getWaitTimeSeconds())
+      );
+
+      receiveMessageResult.getMessages().forEach(message -> {
+        log.debug("Received message (queue: {}, message: {})", queueARN.name, message.getBody());
+
+        try {
+          NotificationMessageWrapper notificationMessageWrapper = objectMapper.readValue(
+            message.getBody(), NotificationMessageWrapper.class
+          );
+
+          NotificationMessage notificationMessage = objectMapper.readValue(
+            notificationMessageWrapper.message, NotificationMessage.class
+          );
+
+          if (SUPPORTED_LIFECYCLE_TRANSITION.equalsIgnoreCase(notificationMessage.event)) {
+            handleMessage(notificationMessage);
+          }
+        } catch (IOException e) {
+          log.error("Unable to convert NotificationMessage (body: {})", message.getBody(), e);
+        }
+
+        deleteMessage(amazonSQS, queueId, message);
+        messagesProcessed.incrementAndGet();
+      });
+
+      if (receiveMessageResult.getMessages().size() < AWS_MAX_NUMBER_OF_MESSAGES) {
+        break;
+      }
+    }
+  }
+
+  private void handleMessage(NotificationMessage notificationMessage) {
+    // TODO-AJ This should eventually tag the ASG with an alert
+    log.info(
+      "Failure to launch instance (asgName: {}, reason: {})",
+      notificationMessage.autoScalingGroupName,
+      notificationMessage.statusMessage
+    );
+  }
+
+  /**
+   * Ensure that the topic exists and has a policy granting all accounts permission to publish messages to it
+   */
+  private static String ensureTopicExists(AmazonSNS amazonSNS,
+                                          String topicUrl,
+                                          ARN topicARN,
+                                          List<String> allAccountIds,
+                                          ARN queueARN) {
+    if (topicUrl == null) {
+      topicARN.arn = amazonSNS.createTopic(topicARN.name).getTopicArn();
+
+      amazonSNS.setTopicAttributes(
+        new SetTopicAttributesRequest()
+          .withTopicArn(topicARN.arn)
+          .withAttributeName("Policy")
+          .withAttributeValue(buildSNSPolicy(topicARN, allAccountIds).toJson())
+      );
+
+      amazonSNS.subscribe(topicARN.arn, "sqs", queueARN.arn);
+    }
+
+    return topicARN.arn;
+  }
+
+  /**
+   * Ensure that the queue exists and has a policy granting the source topic permission to send messages to it
+   */
+  private static String ensureQueueExists(AmazonSQS amazonSQS, String queueUrl, ARN queueARN, ARN topicARN) {
+    if (queueUrl == null) {
+      try {
+        queueUrl = amazonSQS.getQueueUrl(queueARN.name).getQueueUrl();
+      } catch (Exception e) {
+        queueUrl = amazonSQS.createQueue(queueARN.name).getQueueUrl();
+      }
+
+      amazonSQS.setQueueAttributes(
+        queueUrl, Collections.singletonMap("Policy", buildSQSPolicy(queueARN, topicARN).toJson())
+      );
+    }
+
+    return queueUrl;
+  }
+
+  private static Policy buildSNSPolicy(ARN topicARN, List<String> allAccountIds) {
+    Statement statement = new Statement(Statement.Effect.Allow).withActions(SNSActions.Publish);
+    statement.setPrincipals(allAccountIds.stream().map(Principal::new).collect(Collectors.toList()));
+    statement.setResources(Collections.singletonList(new Resource(topicARN.arn)));
+
+    return new Policy("allow-remote-account-send", Collections.singletonList(statement));
+  }
+
+  private static Policy buildSQSPolicy(ARN queue, ARN topic) {
+    Statement statement = new Statement(Statement.Effect.Allow).withActions(SQSActions.SendMessage);
+    statement.setPrincipals(Principal.All);
+    statement.setResources(Collections.singletonList(new Resource(queue.arn)));
+    statement.setConditions(Collections.singletonList(
+      new Condition().withType("StringEqualsIgnoreCase").withConditionKey("aws:SourceArn").withValues(topic.arn)
+    ));
+
+    return new Policy("allow-sns-topic-send", Collections.singletonList(statement));
+  }
+
+  private static void deleteMessage(AmazonSQS amazonSQS, String queueUrl, Message message) {
+    try {
+      amazonSQS.deleteMessage(queueUrl, message.getReceiptHandle());
+    } catch (ReceiptHandleIsInvalidException e) {
+      log.warn("Error deleting lifecycle message, reason: {} (receiptHandle: {})", e.getMessage(), message.getReceiptHandle());
+    }
+  }
+
+  private static class ARN {
+    String arn;
+    String region;
+    String name;
+
+    NetflixAmazonCredentials account;
+
+    ARN(Collection<? extends AccountCredentials> accountCredentials, String arn) {
+      this.arn = arn;
+
+      Matcher sqsMatcher = ARN_PATTERN.matcher(arn);
+      if (!sqsMatcher.matches()) {
+        throw new IllegalArgumentException(arn + " is not a valid SNS or SQS ARN");
+      }
+
+      this.region = sqsMatcher.group(1);
+      this.name = sqsMatcher.group(3);
+
+      String accountId = sqsMatcher.group(2);
+      this.account = (NetflixAmazonCredentials) accountCredentials.stream()
+        .filter(c -> accountId.equals(c.getAccountId()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("No account credentials found for " + accountId));
+
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.Agent;
+import com.netflix.spinnaker.cats.agent.AgentProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+
+import java.util.Collection;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class LaunchFailureNotificationAgentProvider implements AgentProvider {
+  private final static String REGION_TEMPLATE_PATTERN = Pattern.quote("{{region}}");
+  private final static String ACCOUNT_ID_TEMPLATE_PATTERN = Pattern.quote("{{accountId}}");
+
+  private final ObjectMapper objectMapper;
+  private final AmazonClientProvider amazonClientProvider;
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final LaunchFailureConfigurationProperties properties;
+
+  LaunchFailureNotificationAgentProvider(ObjectMapper objectMapper,
+                                         AmazonClientProvider amazonClientProvider,
+                                         AccountCredentialsProvider accountCredentialsProvider,
+                                         LaunchFailureConfigurationProperties properties) {
+    this.objectMapper = objectMapper;
+    this.amazonClientProvider = amazonClientProvider;
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.properties = properties;
+  }
+
+  @Override
+  public boolean supports(String providerName) {
+    return providerName.equalsIgnoreCase(AwsProvider.PROVIDER_NAME);
+  }
+
+  @Override
+  public Collection<Agent> agents() {
+    NetflixAmazonCredentials credentials = (NetflixAmazonCredentials) accountCredentialsProvider.getCredentials(
+      properties.getAccountName()
+    );
+
+    // create an agent for each region in the specified account
+    return credentials.getRegions().stream()
+      .map(region -> new LaunchFailureNotificationAgent(
+        objectMapper,
+        amazonClientProvider,
+        accountCredentialsProvider,
+        new LaunchFailureConfigurationProperties(
+          properties.getAccountName(),
+          properties
+            .getTopicARN()
+            .replaceAll(REGION_TEMPLATE_PATTERN, region.getName())
+            .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
+          properties
+            .getQueueARN()
+            .replaceAll(REGION_TEMPLATE_PATTERN, region.getName())
+            .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
+          properties.getMaxMessagesPerCycle(),
+          properties.getVisibilityTimeout(),
+          properties.getWaitTimeSeconds()
+        )
+      ))
+      .collect(Collectors.toList());
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LifecycleSubscriberConfiguration.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LifecycleSubscriberConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(LaunchFailureConfigurationProperties.class)
+class LifecycleSubscriberConfiguration {
+  @Bean
+  @ConditionalOnProperty("aws.lifecycleSubscribers.launchFailure.enabled")
+  LaunchFailureNotificationAgentProvider launchFailureNotificationAgentProvider(ObjectMapper objectMapper,
+                                                                                AmazonClientProvider amazonClientProvider,
+                                                                                AccountCredentialsProvider accountCredentialsProvider,
+                                                                                LaunchFailureConfigurationProperties properties) {
+    return new LaunchFailureNotificationAgentProvider(
+      objectMapper, amazonClientProvider, accountCredentialsProvider, properties
+    );
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/NotificationMessage.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/NotificationMessage.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NotificationMessage {
+  @JsonProperty("LifecycleActionToken")
+  String lifecycleActionToken;
+
+  @JsonProperty("AccountID")
+  Integer accountId;
+
+  @JsonProperty("Description")
+  String description;
+
+  @JsonProperty("StatusMessage")
+  String statusMessage;
+
+  @JsonProperty("Details")
+  Map<String, String> details;
+
+  @JsonProperty("RequestID")
+  Integer requestId;
+
+  @JsonProperty("AutoScalingGroupName")
+  String autoScalingGroupName;
+
+  @JsonProperty("AutoScalingGroupARN")
+  String autoScalingGroupARN;
+
+  @JsonProperty("EC2InstanceID")
+  String ec2InstanceId;
+
+  @JsonProperty("Event")
+  String event;
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/NotificationMessageWrapper.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/NotificationMessageWrapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NotificationMessageWrapper {
+  @JsonProperty("Subject")
+  String subject;
+
+  @JsonProperty("Message")
+  String message;
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonAsgLifecycleHook.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonAsgLifecycleHook.groovy
@@ -25,25 +25,33 @@ class AmazonAsgLifecycleHook {
   String roleARN
   String notificationTargetARN
   String notificationMetadata
-  LifecycleTransition lifecycleTransition
+  Transition lifecycleTransition
   Integer heartbeatTimeout
   DefaultResult defaultResult
 
-  enum LifecycleTransition {
-    EC2InstanceLaunching("autoscaling:EC2_INSTANCE_LAUNCHING"),
-    EC2InstanceTerminating("autoscaling:EC2_INSTANCE_TERMINATING")
+  static enum TransitionType {
+    NOTIFICATION,
+    LIFECYCLE
+  }
+
+  static enum Transition {
+    EC2InstanceLaunching("autoscaling:EC2_INSTANCE_LAUNCHING", TransitionType.LIFECYCLE),
+    EC2InstanceTerminating("autoscaling:EC2_INSTANCE_TERMINATING", TransitionType.LIFECYCLE),
+    EC2InstanceLaunchError("autoscaling:EC2_INSTANCE_LAUNCH_ERROR", TransitionType.NOTIFICATION)
 
     final String value
+    final TransitionType type
 
-    LifecycleTransition(String value) {
+    Transition(String value, TransitionType transitionType) {
       this.value = value
+      this.type = transitionType
     }
 
     String toString() {
       value
     }
 
-    static LifecycleTransition valueOfName(String name) {
+    static Transition valueOfName(String name) {
       values().find { it.value == name }
     }
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -40,6 +40,8 @@ import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
@@ -362,6 +364,10 @@ public class AmazonClientProvider {
 
   public AmazonSNS getAmazonSNS(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
     return awsSdkClientSupplier.getClient(AmazonSNSClientBuilder.class, AmazonSNS.class, accountName, awsCredentialsProvider, region);
+  }
+
+  public AmazonSQS getAmazonSQS(NetflixAmazonCredentials amazonCredentials, String region) {
+    return proxyHandlerBuilder.getProxyHandler(AmazonSQS.class, AmazonSQSClientBuilder.class, amazonCredentials, region, false);
   }
 
   public AmazonIdentityManagement getAmazonIdentityManagement(NetflixAmazonCredentials amazonCredentials, String region) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentProviderSpec.groovy
@@ -1,0 +1,79 @@
+package com.netflix.spinnaker.clouddriver.aws.lifecycle
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+import spock.lang.Subject
+
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class LaunchFailureNotificationAgentProviderSpec extends Specification {
+  def objectMapper = Mock(ObjectMapper)
+  def amazonClientProvider = Mock(AmazonClientProvider)
+  def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+
+  def launchFailureConfigurationProperties = new LaunchFailureConfigurationProperties(
+    "mgmt",
+    "arn:aws:sns:{{region}}:{{accountId}}:topicName",
+    "arn:aws:sqs:{{region}}:{{accountId}}:queueName",
+    -1,
+    -1,
+    -1
+  )
+
+  @Subject
+  def agentProvider = new LaunchFailureNotificationAgentProvider(
+    objectMapper,
+    amazonClientProvider,
+    accountCredentialsProvider,
+    launchFailureConfigurationProperties
+  )
+
+  void "should support AwsProvider"() {
+    expect:
+    agentProvider.supports(AwsProvider.PROVIDER_NAME)
+    !agentProvider.supports(AwsCleanupProvider.PROVIDER_NAME)
+  }
+
+  void "should return an agent per region in specified account"() {
+    given:
+    def regions = ["us-west-1", "us-west-2", "us-east-1", "eu-west-1"]
+    def mgmtCredentials = Mock(NetflixAmazonCredentials) {
+      getRegions() >> {
+        return regions.collect { new AmazonCredentials.AWSRegion(it, [])}
+      }
+      getAccountId() >> { return "100" }
+      getName() >> { return "mgmt" }
+    }
+
+    when:
+    def agents = agentProvider.agents()
+
+    then:
+    regions.each { String region ->
+      assert agents.find { it.agentType == "mgmt/${region}/LaunchFailureNotificationAgent".toString() } != null
+    }
+
+    1 * accountCredentialsProvider.getCredentials("mgmt") >> { return mgmtCredentials }
+    4 * accountCredentialsProvider.getAll() >> { return [mgmtCredentials] }
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentSpec.groovy
@@ -1,0 +1,128 @@
+package com.netflix.spinnaker.clouddriver.aws.lifecycle
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.model.CreateTopicResult
+import com.amazonaws.services.sns.model.SetTopicAttributesRequest
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.CreateQueueResult
+import com.amazonaws.services.sqs.model.QueueDoesNotExistException
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class LaunchFailureNotificationAgentSpec extends Specification {
+  def mgmtCredentials = Mock(NetflixAmazonCredentials) {
+    getAccountId() >> { return "100" }
+    getName() >> { return "mgmt" }
+  }
+
+  def amazonSNS = Mock(AmazonSNS)
+  def amazonSQS = Mock(AmazonSQS)
+
+  def queueARN = new LaunchFailureNotificationAgent.ARN([mgmtCredentials], "arn:aws:sqs:us-west-2:100:queueName")
+  def topicARN = new LaunchFailureNotificationAgent.ARN([mgmtCredentials], "arn:aws:sns:us-west-2:100:topicName")
+  def allAccountIds = [topicARN.account.accountId, queueARN.account.accountId].unique()
+
+  void "should create topic if it does not exist"() {
+    when:
+    def topicId = LaunchFailureNotificationAgent.ensureTopicExists(amazonSNS, null, topicARN, allAccountIds, queueARN)
+
+    then:
+    topicId == topicARN.arn
+
+    1 * amazonSNS.createTopic(topicARN.name) >> { new CreateTopicResult().withTopicArn(topicARN.arn) }
+
+    // should attach a policy granting SendMessage rights to the source topic
+    1 * amazonSNS.setTopicAttributes(new SetTopicAttributesRequest()
+      .withTopicArn(topicARN.arn)
+      .withAttributeName("Policy")
+      .withAttributeValue(LaunchFailureNotificationAgent.buildSNSPolicy(topicARN, allAccountIds).toJson()))
+
+    // should subscribe the queue to this topic
+    1 * amazonSNS.subscribe(topicARN.arn, "sqs", queueARN.arn)
+    0 * _
+
+
+    when:
+    topicId = LaunchFailureNotificationAgent.ensureQueueExists(amazonSQS, "existing-topic-arn", queueARN, topicARN)
+
+    then:
+    topicId == "existing-topic-arn"
+
+    0 * _
+  }
+
+  void "should create queue if it does not exist"() {
+    when:
+    def queueId = LaunchFailureNotificationAgent.ensureQueueExists(amazonSQS, null, queueARN, topicARN)
+
+    then:
+    queueId == "my-queue-url"
+
+    1 * amazonSQS.getQueueUrl(_) >> { throw new QueueDoesNotExistException("This queue does not exist")}
+    1 * amazonSQS.createQueue(queueARN.name) >> { new CreateQueueResult().withQueueUrl("my-queue-url") }
+
+    // should attach a policy granting SendMessage rights to the source topic
+    1 * amazonSQS.setQueueAttributes("my-queue-url", [
+        "Policy": LaunchFailureNotificationAgent.buildSQSPolicy(queueARN, topicARN).toJson()
+    ])
+    0 * _
+
+    when:
+    queueId = LaunchFailureNotificationAgent.ensureQueueExists(amazonSQS, "existing-queue-url", queueARN, topicARN)
+
+    then:
+    queueId == "existing-queue-url"
+
+    0 * _
+  }
+
+  @Unroll
+  void "should extract accountId, region and name from SQS or SNS ARN"() {
+    when:
+    def parsedARN = new LaunchFailureNotificationAgent.ARN(
+      [mgmtCredentials],
+      arn,
+    )
+
+    then:
+    parsedARN.account == mgmtCredentials
+    parsedARN.region == expectedRegion
+    parsedARN.name == expectedName
+
+    when:
+    new LaunchFailureNotificationAgent.ARN([mgmtCredentials], "invalid-arn")
+
+    then:
+    def e1 = thrown(IllegalArgumentException)
+    e1.message == "invalid-arn is not a valid SNS or SQS ARN"
+
+    when:
+    new LaunchFailureNotificationAgent.ARN([], arn)
+
+    then:
+    def e2 = thrown(IllegalArgumentException)
+    e2.message == "No account credentials found for 100"
+
+    where:
+    arn                                   || expectedRegion || expectedName
+    "arn:aws:sqs:us-west-2:100:queueName" || "us-west-2"    || "queueName"
+    "arn:aws:sns:us-west-2:100:topicName" || "us-west-2"    || "topicName"
+  }
+}


### PR DESCRIPTION
This also includes a subscriber capable of handling launch failure
notifications (subsequent PR will see this subscriber tag the ASG upon
failure).

This is <optional> and not enabled by default.