### PR TITLE
(titus) Adjusting the retry settings for Titus calls

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
@@ -153,7 +153,7 @@ public class RegionScopedTitusClient implements TitusClient {
              .withTag("responseCode", Optional.ofNullable(responseCode).map(Object::toString).orElse("UNKNOWN"));
            registry.timer(timerId).record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
          }
-       }, 1000, 3 );
+       }, 100, 8 );
     }
 
     @Override


### PR DESCRIPTION
- Current sleep = 1000 * 2 ^ 3 => 1000 * 8, Changing to: sleep = 100 * 2 ^ 8 => 100 * 256
- First step at better handling of titus failures
- This is the current standard for most of our aws calls