### PR TITLE
Added instrumentation on [google] APIs duration.

### DIFF
--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -6,6 +6,8 @@ dependencies {
   compile spinnaker.dependency('frigga')
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
+
+  testCompile("org.springframework.boot:spring-boot-starter-test")
 }
 
 // export tests for use in clouddriver-security

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleExecutor.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleExecutor.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.google
+
+import com.google.api.client.googleapis.batch.BatchRequest
+import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+
+public class GoogleExecutor {
+  public static final  String TAG_SCOPE = GoogleExecutorTraits.TAG_SCOPE
+  public static final  String TAG_REGION = GoogleExecutorTraits.TAG_REGION
+  public static final  String TAG_ZONE = GoogleExecutorTraits.TAG_ZONE
+  public static final  String TAG_BATCH_CONTEXT = "context"
+  public static final  String SCOPE_BATCH = "batch"
+  public static final  String SCOPE_GLOBAL = GoogleExecutorTraits.SCOPE_GLOBAL
+  public static final  String SCOPE_REGIONAL = GoogleExecutorTraits.SCOPE_REGIONAL
+  public static final  String SCOPE_ZONAL = GoogleExecutorTraits.SCOPE_ZONAL
+
+  static Registry globalRegistry
+
+  public static void setGlobalRegisry(Registry registry) {
+    globalRegistry = registry;
+  }
+
+  public static Registry getGlobalRegistry() {
+    return globalRegistry
+  }
+
+  public static void timeExecuteBatch(BatchRequest batch, String batchContext, String... tags)
+    throws IOException {
+     Registry registry = globalRegistry
+     Id id = registry.createId("google.batch.execute", tags).withTags(TAG_BATCH_CONTEXT, batchContext, TAG_SCOPE, SCOPE_BATCH)
+     Id sizeId = registry.createId("google.batchSize", tags).withTag(TAG_BATCH_CONTEXT, batchContext)
+
+     long startTime = System.nanoTime()
+
+     try {
+       batch.execute()
+       long nanos = System.nanoTime() - startTime
+       registry.timer(id.withTag("success", "true")).record(nanos, TimeUnit.NANOSECONDS)
+       registry.counter(sizeId.withTag("success", "true")).increment(batch.size())
+     } catch (IOException ioex) {
+       registry.timer(id.withTag("success", "false")).record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS)
+       registry.counter(sizeId.withTag("success", "false")).increment(batch.size())
+       throw ioex
+     } catch (Exception ex) {
+       registry.timer(id.withTag("success", "false")).record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS)
+       registry.counter(sizeId.withTag("success", "false")).increment(batch.size())
+       throw new IllegalStateException(ex);
+     }
+  }
+
+  public static <T> T timeExecute(AbstractGoogleClientRequest<T> request, String api, String... tags) throws IOException {
+     Registry registry = globalRegistry
+     Id id = registry.createId("google.api", tags).withTag("api", api)
+     long startTime = System.nanoTime()
+
+     try {
+       T result = request.execute()
+       long nanos = System.nanoTime() - startTime
+       registry.timer(id.withTag("success", "true")).record(nanos, TimeUnit.NANOSECONDS)
+       return result
+     } catch (IOException ioex) {
+       registry.timer(id.withTag("success", "false")).record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS)
+       throw ioex;
+     } catch (Exception ex) {
+       registry.timer(id.withTag("success", "false")).record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS)
+       throw new IllegalStateException(ex);
+     }
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleExecutorTraits.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/GoogleExecutorTraits.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.google
+
+public interface GoogleExecutorTraits {
+  public static final  String TAG_SCOPE = "scope"
+  public static final  String TAG_REGION = "region"
+  public static final  String TAG_ZONE = "zone"
+  public static final  String SCOPE_GLOBAL = "global"
+  public static final  String SCOPE_REGIONAL = "regional"
+  public static final  String SCOPE_ZONAL = "zonal"
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -25,7 +25,9 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.deploy.DeployHandler
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
+
 import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutorTraits
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEServerGroupNameResolver
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
@@ -40,14 +42,19 @@ import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvi
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleNetworkProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleSubnetProvider
+
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
 import org.springframework.stereotype.Component
+
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutorTraits
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
+
 
 @Component
 @Slf4j
-class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescription> {
-
+class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescription>, GoogleExecutorTraits {
   // TODO(duftler): This should move to a common location.
   private static final String BASE_PHASE = "DEPLOY"
 
@@ -209,7 +216,9 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
       def loadBalancingPolicy = description.loadBalancingPolicy
 
       backendServices.each { String backendServiceName ->
-        BackendService backendService = compute.backendServices().get(project, backendServiceName).execute()
+        BackendService backendService = GoogleExecutor.timeExecute(
+            compute.backendServices().get(project, backendServiceName),
+            "compute.backendServices.get", TAG_SCOPE, SCOPE_GLOBAL)
 
         Backend backendToAdd
         if (loadBalancingPolicy?.balancingMode) {
@@ -259,7 +268,9 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
       instanceMetadata[GoogleServerGroup.View.REGIONAL_LOAD_BALANCER_NAMES] = existingRegionalLbs.join(",")
 
       ilbServices.each { String backendServiceName ->
-        BackendService backendService = compute.regionBackendServices().get(project, region, backendServiceName).execute()
+        BackendService backendService = GoogleExecutor.timeExecute(
+            compute.regionBackendServices().get(project, region, backendServiceName),
+            "compute.regionBackendServices", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
         Backend backendToAdd = new Backend()
         if (isRegional) {
           backendToAdd.setGroup(GCEUtil.buildRegionalServerGroupUrl(project, region, serverGroupName))
@@ -297,7 +308,8 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
 
     def instanceTemplate = new InstanceTemplate(name: "$serverGroupName-${System.currentTimeMillis()}",
                                                 properties: instanceProperties)
-    def instanceTemplateCreateOperation = compute.instanceTemplates().insert(project, instanceTemplate).execute()
+    def instanceTemplateCreateOperation = GoogleExecutor.timeExecute(compute.instanceTemplates().insert(project, instanceTemplate),
+                                                                     "compute.instanceTemplates.insert", TAG_SCOPE, SCOPE_GLOBAL)
     def instanceTemplateUrl = instanceTemplateCreateOperation.targetLink
 
     // Before building the managed instance group we must check and wait until the instance template is built.
@@ -374,7 +386,9 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
     def willUpdateIlbs = !description.disableTraffic && internalLoadBalancers
 
     if (isRegional) {
-      migCreateOperation = compute.regionInstanceGroupManagers().insert(project, region, instanceGroupManager).execute()
+      migCreateOperation = GoogleExecutor.timeExecute(
+          compute.regionInstanceGroupManagers().insert(project, region, instanceGroupManager),
+          "compute.regionInstanceGroupManagers", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
 
       if (willUpdateBackendServices || willCreateAutoscaler || willUpdateIlbs) {
         // Before updating the Backend Services or creating the Autoscaler we must wait until the managed instance group is created.
@@ -388,11 +402,15 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
                                                           migCreateOperation.targetLink,
                                                           description.autoscalingPolicy)
 
-          compute.regionAutoscalers().insert(project, region, autoscaler).execute()
+          GoogleExecutor.timeExecute(
+              compute.regionAutoscalers().insert(project, region, autoscaler),
+              "compute.regionAutoscalers.insert", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
         }
       }
     } else {
-      migCreateOperation = compute.instanceGroupManagers().insert(project, zone, instanceGroupManager).execute()
+      migCreateOperation = GoogleExecutor.timeExecute(
+          compute.instanceGroupManagers().insert(project, zone, instanceGroupManager),
+          "compute.instanceGroupManagers.insert", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
 
       if (willUpdateBackendServices || willCreateAutoscaler || willUpdateIlbs) {
         // Before updating the Backend Services or creating the Autoscaler we must wait until the managed instance group is created.
@@ -406,7 +424,9 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
                                                           migCreateOperation.targetLink,
                                                           description.autoscalingPolicy)
 
-          compute.autoscalers().insert(project, zone, autoscaler).execute()
+          GoogleExecutor.timeExecute(
+               compute.autoscalers().insert(project, zone, autoscaler),
+               "compute.autoscalers.insert", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
         }
       }
     }
@@ -458,26 +478,32 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
 
   private Closure updateRegionBackendServices(Compute compute, String project, String region, String backendServiceName, BackendService backendService) {
     return {
-      BackendService serviceToUpdate = compute.regionBackendServices().get(project, region, backendServiceName).execute()
+      BackendService serviceToUpdate = GoogleExecutor.timeExecute(
+          compute.regionBackendServices().get(project, region, backendServiceName),
+          "compute.regionBackendServices.get", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
       if (serviceToUpdate.backends == null) {
         serviceToUpdate.backends = new ArrayList<Backend>()
       }
       backendService?.backends?.each { serviceToUpdate.backends << it }
       serviceToUpdate.getBackends().unique { backend -> backend.group }
-      compute.regionBackendServices().update(project, region, backendServiceName, serviceToUpdate).execute()
+      GoogleExecutor.timeExecute(compute.regionBackendServices().update(project, region, backendServiceName, serviceToUpdate),
+                                 "compute.regionBackendServices.update", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
       null
     }
   }
 
   private Closure updateBackendServices(Compute compute, String project, String backendServiceName, BackendService backendService) {
     return {
-      BackendService serviceToUpdate = compute.backendServices().get(project, backendServiceName).execute()
+      BackendService serviceToUpdate = GoogleExecutor.timeExecute(
+          compute.backendServices().get(project, backendServiceName),
+          "compute.backendServices.get", TAG_SCOPE, SCOPE_GLOBAL)
       if (serviceToUpdate.backends == null) {
         serviceToUpdate.backends = new ArrayList<Backend>()
       }
       backendService?.backends?.each { serviceToUpdate.backends << it }
       serviceToUpdate.getBackends().unique { backend -> backend.group }
-      compute.backendServices().update(project, backendServiceName, serviceToUpdate).execute()
+      GoogleExecutor.timeExecute(compute.backendServices().update(project, backendServiceName, serviceToUpdate),
+                                 "compute.backendServices.update", TAG_SCOPE, SCOPE_GLOBAL)
       null
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbandonAndDecrementGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbandonAndDecrementGoogleServerGroupAtomicOperation.groovy
@@ -20,6 +20,7 @@ import com.google.api.services.compute.model.InstanceGroupManagersAbandonInstanc
 import com.google.api.services.compute.model.RegionInstanceGroupManagersAbandonInstancesRequest
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.AbandonAndDecrementGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
@@ -34,7 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired
  *
  * @see TerminateAndDecrementGoogleServerGroupAtomicOperation
  */
-class AbandonAndDecrementGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
+class AbandonAndDecrementGoogleServerGroupAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "ABANDON_AND_DEC_INSTANCES"
 
   private static Task getTask() {
@@ -77,12 +78,18 @@ class AbandonAndDecrementGoogleServerGroupAtomicOperation implements AtomicOpera
       def instanceGroupManagers = compute.regionInstanceGroupManagers()
       def abandonRequest = new RegionInstanceGroupManagersAbandonInstancesRequest().setInstances(instanceUrls)
 
-      instanceGroupManagers.abandonInstances(project, region, serverGroupName, abandonRequest).execute()
+      GoogleExecutor.timeExecute(
+          instanceGroupManagers.abandonInstances(project, region, serverGroupName, abandonRequest),
+          "compute.regionInstanceGroupManagers.abandonInstances",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     } else {
       def instanceGroupManagers = compute.instanceGroupManagers()
       def abandonRequest = new InstanceGroupManagersAbandonInstancesRequest().setInstances(instanceUrls)
 
-      instanceGroupManagers.abandonInstances(project, zone, serverGroupName, abandonRequest).execute()
+      GoogleExecutor.timeExecute(
+          instanceGroupManagers.abandonInstances(project, zone, serverGroupName, abandonRequest),
+          "compute.instanceGroupManagers.abandonInstances",
+          TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
     }
 
     task.updateStatus BASE_PHASE, "Done abandoning and decrementing instances " +

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -17,20 +17,21 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
 import com.google.api.services.compute.model.*
 import com.netflix.spinnaker.clouddriver.consul.deploy.ops.EnableDisableConsulInstance
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.EnableDisableGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 import retrofit.RetrofitError
 
-abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<Void> {
+abstract class AbstractEnableDisableAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final List<Integer> RETRY_ERROR_CODES = [400, 403, 412]
   private static final List<Integer> SUCCESSFUL_ERROR_CODES = [404]
 
@@ -83,10 +84,18 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
 
     if (credentials.consulConfig?.enabled) {
       task.updateStatus phaseName, "$presentParticipling server group in Consul..."
-      def instances =
-        isRegional
-        ? compute.regionInstanceGroupManagers().listManagedInstances(project, region, serverGroupName).execute().getManagedInstances()
-        : compute.instanceGroupManagers().listManagedInstances(project, zone, serverGroupName).execute().getManagedInstances()
+      def instances = []
+      if (isRegional) {
+        instances = GoogleExecutor.timeExecute(
+          compute.regionInstanceGroupManagers().listManagedInstances(project, region, serverGroupName),
+          "compute.regionInstanceGroupManagers.listManagedInstances",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region).getManagedInstances()
+      } else {
+        instances = GoogleExecutor.timeExecute(
+          compute.instanceGroupManagers().listManagedInstances(project, zone, serverGroupName),
+          "compute.instanceGroupManagers.listManagedInstances",
+          TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone).getManagedInstances()
+      }
 
       instances.each { ManagedInstance instance ->
         try {
@@ -295,19 +304,25 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
 
       instanceGroupManagersSetTargetPoolsRequest.setFingerprint(managedInstanceGroup.getFingerprint())
 
-      compute.regionInstanceGroupManagers().setTargetPools(project,
-                                                           region,
-                                                           serverGroupName,
-                                                           instanceGroupManagersSetTargetPoolsRequest).execute()
+      GoogleExecutor.timeExecute(
+        compute.regionInstanceGroupManagers().setTargetPools(project,
+                                                             region,
+                                                             serverGroupName,
+                                                             instanceGroupManagersSetTargetPoolsRequest),
+        "compute.regionInstanceGroupManagers.setTargetPools",
+        TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     } else {
       def instanceGroupManagersSetTargetPoolsRequest = new InstanceGroupManagersSetTargetPoolsRequest(targetPools: newTargetPoolUrls)
 
       instanceGroupManagersSetTargetPoolsRequest.setFingerprint(managedInstanceGroup.getFingerprint())
 
-      compute.instanceGroupManagers().setTargetPools(project,
-                                                     zone,
-                                                     serverGroupName,
-                                                     instanceGroupManagersSetTargetPoolsRequest).execute()
+      GoogleExecutor.timeExecute(
+        compute.instanceGroupManagers().setTargetPools(project,
+                                                       zone,
+                                                       serverGroupName,
+                                                       instanceGroupManagersSetTargetPoolsRequest),
+        "compute.regionInstanceGroupManagers.setTargetPools",
+        TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
     }
 
     task.updateStatus phaseName, "Done ${presentParticipling.toLowerCase()} server group $description.serverGroupName in $region."
@@ -362,39 +377,53 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
 
   Closure getTargetPool(compute, project, region, targetPoolLocalName) {
     return {
-      return compute.targetPools().get(project, region, targetPoolLocalName).execute()
+      return GoogleExecutor.timeExecute(compute.targetPools().get(project, region, targetPoolLocalName),
+                                        "compute.targetPools.get", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     }
   }
 
   Closure listInstancesInRegionalGroup(compute, project, region, serverGroupName, regionInstanceGroupsListInstancesRequest) {
     return {
-      return compute.regionInstanceGroups().listInstances(project, region, serverGroupName, regionInstanceGroupsListInstancesRequest).execute().items
+      return GoogleExecutor.timeExecute(
+          compute.regionInstanceGroups().listInstances(project, region, serverGroupName, regionInstanceGroupsListInstancesRequest),
+          "compute.regionInstanceGroups.listInstances",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region).items
     }
   }
 
   Closure listInstancesInZonalGroup(compute, project, zone, serverGroupName, instanceGroupsListInstancesRequest) {
     return {
-      return compute.instanceGroups().listInstances(project, zone, serverGroupName, instanceGroupsListInstancesRequest).execute().items
+      return GoogleExecutor.timeExecute(
+          compute.instanceGroups().listInstances(project, zone, serverGroupName, instanceGroupsListInstancesRequest),
+          "compute.instanceGroups.listInstances",
+          TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone).items
     }
   }
 
   Closure getInstanceTemplate(compute, project, instanceTemplateUrl) {
     return {
-      return compute.instanceTemplates().get(project, GCEUtil.getLocalName(instanceTemplateUrl)).execute()
+      return GoogleExecutor.timeExecute(
+          compute.instanceTemplates().get(project, GCEUtil.getLocalName(instanceTemplateUrl)),
+          "compute.instanceTemplates.get",
+          TAG_SCOPE, SCOPE_GLOBAL)
     }
   }
 
   Closure removeInstancesFromTargetPool(compute, project, region, targetPoolLocalName, targetPoolsRemoveInstanceRequest) {
     return {
-      compute.targetPools().removeInstance(project, region, targetPoolLocalName, targetPoolsRemoveInstanceRequest).execute()
-      null
+        GoogleExecutor.timeExecute(
+            compute.targetPools().removeInstance(project, region, targetPoolLocalName, targetPoolsRemoveInstanceRequest),
+            "compute.targetPools.removeInstance",
+            TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     }
   }
 
   Closure addInstancesToTargetPool(compute, project, region, targetPoolLocalName, targetPoolsAddInstanceRequest) {
     return {
-      compute.targetPools().addInstance(project, region, targetPoolLocalName, targetPoolsAddInstanceRequest).execute()
-      null
+      GoogleExecutor.timeExecute(
+          compute.targetPools().addInstance(project, region, targetPoolLocalName, targetPoolsAddInstanceRequest),
+          "compute.targetPools.addInstance",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     }
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
@@ -21,15 +21,15 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.CreateGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleNetworkProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleSubnetProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
-class CreateGoogleInstanceAtomicOperation implements AtomicOperation<DeploymentResult> {
+class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<DeploymentResult> {
   private static final String BASE_PHASE = "DEPLOY"
 
   // TODO(duftler): These should be exposed/configurable.
@@ -131,7 +131,8 @@ class CreateGoogleInstanceAtomicOperation implements AtomicOperation<DeploymentR
                                 serviceAccounts: serviceAccount)
 
     task.updateStatus BASE_PHASE, "Creating instance $description.instanceName..."
-    compute.instances().insert(project, zone, instance).execute()
+    GoogleExecutor.timeExecute(compute.instances().insert(project, zone, instance),
+        "compute.instances.insert", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
 
     task.updateStatus BASE_PHASE, "Done creating instance $description.instanceName in $description.zone."
     new DeploymentResult(serverGroupNames: [description.instanceName])

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
-class DeleteGoogleAutoscalingPolicyAtomicOperation implements AtomicOperation<Void>{
+class DeleteGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation<Void>{
 
   private static final String BASE_PHASE = "DELETE_SCALING_POLICY"
   private final DeleteGoogleAutoscalingPolicyDescription description
@@ -60,9 +60,11 @@ class DeleteGoogleAutoscalingPolicyAtomicOperation implements AtomicOperation<Vo
     def zone = serverGroup.zone
 
     if (isRegional) {
-      compute.regionAutoscalers().delete(project, region, serverGroupName).execute()
+      GoogleExecutor.timeExecute(compute.regionAutoscalers().delete(project, region, serverGroupName),
+          "compute.regionAutoscalers.delete", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     } else {
-      compute.autoscalers().delete(project, zone, serverGroupName).execute()
+      GoogleExecutor.timeExecute(compute.autoscalers().delete(project, zone, serverGroupName),
+          "compute.autoscalers.delete", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
     }
 
     task.updateStatus BASE_PHASE, "Done deleting scaling policy for $serverGroupName..."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleSecurityGroupAtomicOperation.groovy
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleSecurityGroupDescription
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 
 /**
  * Delete a firewall rule from the specified project.
  *
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/firewalls/delete}
  */
-class DeleteGoogleSecurityGroupAtomicOperation implements AtomicOperation<Void> {
+class DeleteGoogleSecurityGroupAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "DELETE_SECURITY_GROUP"
 
   private static Task getTask() {
@@ -50,7 +50,8 @@ class DeleteGoogleSecurityGroupAtomicOperation implements AtomicOperation<Void> 
     def project = description.credentials.project
     def firewallRuleName = description.securityGroupName
 
-    compute.firewalls().delete(project, firewallRuleName).execute()
+    GoogleExecutor.timeExecute(compute.firewalls().delete(project, firewallRuleName),
+        "compute.firewalls.delete", TAG_SCOPE, SCOPE_GLOBAL);
 
     task.updateStatus BASE_PHASE, "Done deleting security group $firewallRuleName."
     null

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperation.groovy
@@ -20,10 +20,10 @@ import com.google.api.services.compute.model.InstanceReference
 import com.google.api.services.compute.model.TargetPoolsRemoveInstanceRequest
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeregisterInstancesFromGoogleLoadBalancerDescription
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired
  *
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/targetPools/removeInstance}
  */
-class DeregisterInstancesFromGoogleLoadBalancerAtomicOperation implements AtomicOperation<Void> {
+class DeregisterInstancesFromGoogleLoadBalancerAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "DEREGISTER_INSTANCES"
 
   private static Task getTask() {
@@ -73,7 +73,9 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperation implements Atomic
 
       def removeInstanceRequest = new TargetPoolsRemoveInstanceRequest()
       removeInstanceRequest.instances = instanceUrls.collect { url -> new InstanceReference(instance: url) }
-      compute.targetPools().removeInstance(project, region, targetPoolName, removeInstanceRequest).execute()
+      GoogleExecutor.timeExecute(
+          compute.targetPools().removeInstance(project, region, targetPoolName, removeInstanceRequest),
+          "compute.targetPools.removeInstance", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     }
 
     task.updateStatus BASE_PHASE, "Done deregistering instances (${instanceIds.join(", ")}) from load balancers " +

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperation.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 import com.google.api.services.compute.Compute
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
@@ -26,12 +27,11 @@ import com.netflix.spinnaker.clouddriver.google.deploy.description.DestroyGoogle
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
 @Slf4j
-class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
+class DestroyGoogleServerGroupAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "DESTROY_SERVER_GROUP"
   private static final List<Integer> RETRY_ERROR_CODES = [400, 412]
   private static final List<Integer> SUCCESSFUL_ERROR_CODES = [404]
@@ -119,7 +119,9 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
 
   Closure destroyInstanceTemplate(Compute compute, String instanceTemplateName, String project) {
     return {
-      compute.instanceTemplates().delete(project, instanceTemplateName).execute()
+      GoogleExecutor.timeExecute(
+          compute.instanceTemplates().delete(project, instanceTemplateName),
+          "compute.instanceTemplates.delete", TAG_SCOPE, SCOPE_GLOBAL)
       null
     }
   }
@@ -127,7 +129,9 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
   Closure destroyAutoscaler(Compute compute, String serverGroupName, String project, String region, String zone, Boolean isRegional) {
     return {
       if (isRegional) {
-        def autoscalerDeleteOperation = compute.regionAutoscalers().delete(project, region, serverGroupName).execute()
+        def autoscalerDeleteOperation = GoogleExecutor.timeExecute(
+            compute.regionAutoscalers().delete(project, region, serverGroupName),
+            "compute.regionAutoscalers.delete", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region);
         def autoscalerDeleteOperationName = autoscalerDeleteOperation.getName()
 
         task.updateStatus BASE_PHASE, "Waiting on delete operation for autoscaler..."
@@ -136,7 +140,9 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
         googleOperationPoller.waitForRegionalOperation(compute, project, region, autoscalerDeleteOperationName, null, task,
           "regional autoscaler $serverGroupName", BASE_PHASE)
       } else {
-        def autoscalerDeleteOperation = compute.autoscalers().delete(project, zone, serverGroupName).execute()
+        def autoscalerDeleteOperation = GoogleExecutor.timeExecute(
+            compute.autoscalers().delete(project, zone, serverGroupName),
+            "compute.autoscalers.delete", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
         def autoscalerDeleteOperationName = autoscalerDeleteOperation.getName()
 
         task.updateStatus BASE_PHASE, "Waiting on delete operation for autoscaler..."
@@ -182,8 +188,12 @@ class DestroyGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
   Closure destroyInstanceGroup(Compute compute, String serverGroupName, String project, String region, String zone, Boolean isRegional) {
     return {
       def instanceGroupManagerDeleteOperation = isRegional ?
-        compute.regionInstanceGroupManagers().delete(project, region, serverGroupName).execute() :
-        compute.instanceGroupManagers().delete(project, zone, serverGroupName).execute()
+        GoogleExecutor.timeExecute(
+            compute.regionInstanceGroupManagers().delete(project, region, serverGroupName),
+            "compute.regionInstanceGroupManagers.delete", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) :
+        GoogleExecutor.timeExecute(
+            compute.instanceGroupManagers().delete(project, zone, serverGroupName),
+            "compute.instanceGroupManagers.delete", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
 
       def instanceGroupOperationName = instanceGroupManagerDeleteOperation.getName()
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/GoogleAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/GoogleAtomicOperation.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.google.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutorTraits
+
+import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+
+import org.springframework.beans.factory.annotation.Autowired
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public abstract class GoogleAtomicOperation<ResultType> implements AtomicOperation<ResultType>, GoogleExecutorTraits {
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
@@ -21,6 +21,7 @@ import com.google.api.services.compute.model.RegionInstanceGroupManagersSetTempl
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
@@ -30,7 +31,6 @@ import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceN
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleNetworkProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleSubnetProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
@@ -40,7 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired
  *
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers/setInstanceTemplate}
  */
-class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOperation<Void> {
+class ModifyGoogleServerGroupInstanceTemplateAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "MODIFY_SERVER_GROUP_INSTANCE_TEMPLATE"
 
   private static final String accessConfigName = "External NAT"
@@ -103,8 +103,10 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
     // Retrieve the managed instance group.
     def managedInstanceGroup =
       isRegional
-      ? instanceGroupManagers.get(project, region, serverGroupName).execute()
-      : instanceGroupManagers.get(project, zone, serverGroupName).execute()
+      ? GoogleExecutor.timeExecute(instanceGroupManagers.get(project, region, serverGroupName),
+                                   "compute.regionalInstanceGroupManagers", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
+      : GoogleExecutor.timeExecute(instanceGroupManagers.get(project, zone, serverGroupName),
+                                   "compute.instanceGroupManagers.get", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
     def origInstanceTemplateName = GCEUtil.getLocalName(managedInstanceGroup.instanceTemplate)
 
     if (!origInstanceTemplateName) {
@@ -112,7 +114,9 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
     }
 
     // Retrieve the managed instance group's current instance template.
-    def instanceTemplate = instanceTemplates.get(project, origInstanceTemplateName).execute()
+    def instanceTemplate = GoogleExecutor.timeExecute(
+        instanceTemplates.get(project, origInstanceTemplateName),
+        "compute.instanceTemplates.get", TAG_SCOPE, SCOPE_GLOBAL)
 
     // Create a description to represent the current instance template.
     def originalDescription = GCEUtil.buildInstanceDescriptionFromTemplate(instanceTemplate)
@@ -219,7 +223,9 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
       // Create a new instance template resource using the modified instance template.
       task.updateStatus BASE_PHASE, "Inserting new instance template $instanceTemplate.name..."
 
-      def instanceTemplateCreateOperation = instanceTemplates.insert(project, instanceTemplate).execute()
+      def instanceTemplateCreateOperation = GoogleExecutor.timeExecute(
+          instanceTemplates.insert(project, instanceTemplate),
+          "compute.instanceTemplates.insert", TAG_SCOPE, SCOPE_GLOBAL)
       def instanceTemplateUrl = instanceTemplateCreateOperation.targetLink
 
       // Block on creating the instance template.
@@ -232,8 +238,10 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
       if (isRegional) {
         def regionInstanceGroupManagersSetTemplateRequest =
           new RegionInstanceGroupManagersSetTemplateRequest(instanceTemplate: instanceTemplateUrl)
-        def setInstanceTemplateOperation = instanceGroupManagers.setInstanceTemplate(
-          project, region, serverGroupName, regionInstanceGroupManagersSetTemplateRequest).execute()
+        def setInstanceTemplateOperation = GoogleExecutor.timeExecute(
+          instanceGroupManagers.setInstanceTemplate(
+            project, region, serverGroupName, regionInstanceGroupManagersSetTemplateRequest),
+          "compute.regionalInstanceGroupManagers.setInstanceTemplate", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
 
         // Block on setting the instance template on the managed instance group.
         googleOperationPoller.waitForRegionalOperation(compute, project, region,
@@ -241,8 +249,10 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
       } else {
         def instanceGroupManagersSetInstanceTemplateRequest =
           new InstanceGroupManagersSetInstanceTemplateRequest(instanceTemplate: instanceTemplateUrl)
-        def setInstanceTemplateOperation = instanceGroupManagers.setInstanceTemplate(
-          project, zone, serverGroupName, instanceGroupManagersSetInstanceTemplateRequest).execute()
+        def setInstanceTemplateOperation = GoogleExecutor.timeExecute(
+          instanceGroupManagers.setInstanceTemplate(
+            project, zone, serverGroupName, instanceGroupManagersSetInstanceTemplateRequest),
+          "compute.instanceGroupManagers.setInstanceTemplate", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
 
         // Block on setting the instance template on the managed instance group.
         googleOperationPoller.waitForZonalOperation(compute, project, zone,
@@ -252,7 +262,9 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation implements AtomicOp
       // Delete the original instance template.
       task.updateStatus BASE_PHASE, "Deleting original instance template $origInstanceTemplateName..."
 
-      instanceTemplates.delete(project, origInstanceTemplateName).execute()
+      GoogleExecutor.timeExecute(
+          instanceTemplates.delete(project, origInstanceTemplateName),
+          "compute.instanceTemplates.delete", TAG_SCOPE, SCOPE_GLOBAL)
     }
 
     task.updateStatus BASE_PHASE, "Done modifying instance template of $serverGroupName in $region."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RebootGoogleInstancesAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RebootGoogleInstancesAtomicOperation.groovy
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RebootGoogleInstancesDescription
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 
 /**
  * Resets each specified instance back to the initial state of its underlying virtual machine.
  *
  * @see https://cloud.google.com/compute/docs/instances/restarting-an-instance
  */
-class RebootGoogleInstancesAtomicOperation implements AtomicOperation<Void> {
+class RebootGoogleInstancesAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "REBOOT_INSTANCES"
 
   private static Task getTask() {
@@ -63,7 +63,9 @@ class RebootGoogleInstancesAtomicOperation implements AtomicOperation<Void> {
       task.updateStatus BASE_PHASE, "Attempting to reset instance $instanceId in $zone..."
 
       try {
-        compute.instances().reset(project, zone, instanceId).execute()
+        GoogleExecutor.timeExecute(
+            compute.instances().reset(project, zone, instanceId),
+            "compute.instances.reset", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
         okIds.add(instanceId)
       } catch (Exception e) {
         task.updateStatus BASE_PHASE, "Failed to reset instance $instanceId in $zone: $e.message."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RegisterInstancesWithGoogleLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RegisterInstancesWithGoogleLoadBalancerAtomicOperation.groovy
@@ -20,10 +20,10 @@ import com.google.api.services.compute.model.InstanceReference
 import com.google.api.services.compute.model.TargetPoolsAddInstanceRequest
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RegisterInstancesWithGoogleLoadBalancerDescription
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired
  *
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/targetPools/addInstance}
  */
-class RegisterInstancesWithGoogleLoadBalancerAtomicOperation implements AtomicOperation<Void> {
+class RegisterInstancesWithGoogleLoadBalancerAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "REGISTER_INSTANCES"
 
   private static Task getTask() {
@@ -73,7 +73,9 @@ class RegisterInstancesWithGoogleLoadBalancerAtomicOperation implements AtomicOp
 
       def addInstanceRequest = new TargetPoolsAddInstanceRequest()
       addInstanceRequest.instances = instanceUrls.collect{ url -> new InstanceReference(instance: url) }
-      compute.targetPools().addInstance(project, region, targetPoolName, addInstanceRequest).execute()
+      GoogleExecutor.timeExecute(
+          compute.targetPools().addInstance(project, region, targetPoolName, addInstanceRequest),
+          "compute.targetPools.addInstance", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     }
 
     task.updateStatus BASE_PHASE, "Done registering instances (${instanceIds.join(", ")}) with load balancers " +

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ResizeGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ResizeGoogleServerGroupAtomicOperation.groovy
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.ResizeGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
-class ResizeGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
+class ResizeGoogleServerGroupAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "RESIZE_SERVER_GROUP"
 
   private static Task getTask() {
@@ -63,17 +63,21 @@ class ResizeGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
     if (isRegional) {
       def instanceGroupManagers = compute.regionInstanceGroupManagers()
 
-      instanceGroupManagers.resize(project,
-                                   region,
-                                   serverGroupName,
-                                   targetSize).execute()
+      GoogleExecutor.timeExecute(
+          instanceGroupManagers.resize(project,
+                                       region,
+                                       serverGroupName,
+                                       targetSize),
+          "compute.regionInstanceGroupManagers.resize", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     } else {
       def instanceGroupManagers = compute.instanceGroupManagers()
 
-      instanceGroupManagers.resize(project,
-                                   zone,
-                                   serverGroupName,
-                                   targetSize).execute()
+      GoogleExecutor.timeExecute(
+          instanceGroupManagers.resize(project,
+                                       zone,
+                                       serverGroupName,
+                                       targetSize),
+              "compute.instanceGroupManagers.resize", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
     }
 
     task.updateStatus BASE_PHASE, "Done resizing server group $serverGroupName in $region."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/TerminateGoogleInstancesAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/TerminateGoogleInstancesAtomicOperation.groovy
@@ -20,10 +20,10 @@ import com.google.api.services.compute.model.InstanceGroupManagersRecreateInstan
 import com.google.api.services.compute.model.RegionInstanceGroupManagersRecreateRequest
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.TerminateGoogleInstancesDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
@@ -38,7 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired
  * group to terminate and recreate the instances. More information:
  * {@link https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers/recreateInstances}
  */
-class TerminateGoogleInstancesAtomicOperation implements AtomicOperation<Void> {
+class TerminateGoogleInstancesAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "TERMINATE_INSTANCES"
 
   private static Task getTask() {
@@ -94,12 +94,16 @@ class TerminateGoogleInstancesAtomicOperation implements AtomicOperation<Void> {
         def instanceGroupManagers = compute.regionInstanceGroupManagers()
         def recreateRequest = new RegionInstanceGroupManagersRecreateRequest().setInstances(instanceUrls)
 
-        instanceGroupManagers.recreateInstances(project, region, serverGroupName, recreateRequest).execute()
+        GoogleExecutor.timeExecute(
+            instanceGroupManagers.recreateInstances(project, region, serverGroupName, recreateRequest),
+            "compute.regionInstanceGroupManagers.recreateInstances", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
       } else {
         def instanceGroupManagers = compute.instanceGroupManagers()
         def recreateRequest = new InstanceGroupManagersRecreateInstancesRequest().setInstances(instanceUrls)
 
-        instanceGroupManagers.recreateInstances(project, zone, serverGroupName, recreateRequest).execute()
+        GoogleExecutor.timeExecute(
+            instanceGroupManagers.recreateInstances(project, zone, serverGroupName, recreateRequest),
+            "compute.instanceGroupManagers.recreateInstances", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
       }
 
       task.updateStatus BASE_PHASE, "Done recreating instances (${instanceIds.join(", ")}) in $region."
@@ -113,7 +117,9 @@ class TerminateGoogleInstancesAtomicOperation implements AtomicOperation<Void> {
         task.updateStatus BASE_PHASE, "Terminating instance $instanceId in $zone..."
 
         try {
-          compute.instances().delete(project, zone, instanceId).execute()
+          GoogleExecutor.timeExecute(
+              compute.instances().delete(project, zone, instanceId),
+              "compute.instances.delete", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
           okIds.add(instanceId)
         } catch (Exception e) {
           task.updateStatus BASE_PHASE, "Failed to terminate instance $instanceId in $zone: $e.message."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -18,14 +18,14 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
-class UpsertGoogleAutoscalingPolicyAtomicOperation implements AtomicOperation<Void> {
+class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "UPSERT_SCALING_POLICY"
 
   private static Task getTask() {
@@ -75,9 +75,13 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation implements AtomicOperation<Vo
                                                                        description.autoscalingPolicy))
 
       if (isRegional) {
-        compute.regionAutoscalers().update(project, region, autoscaler).execute()
+        GoogleExecutor.timeExecute(
+            compute.regionAutoscalers().update(project, region, autoscaler),
+            "compute.regionAutoscalers.update", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
       } else {
-        compute.autoscalers().update(project, zone, autoscaler).execute()
+        GoogleExecutor.timeExecute(
+            compute.autoscalers().update(project, zone, autoscaler),
+            "compute.autoscalers.update", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
       }
     } else {
       task.updateStatus BASE_PHASE, "Creating new autoscaler for $serverGroupName..."
@@ -87,9 +91,13 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation implements AtomicOperation<Vo
                                                normalizeNewPolicy(description.autoscalingPolicy))
 
       if (isRegional) {
-        compute.regionAutoscalers().insert(project, region, autoscaler).execute()
+        GoogleExecutor.timeExecute(
+            compute.regionAutoscalers().insert(project, region, autoscaler),
+            "compute.regionAutoscalers.insert", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
       } else {
-        compute.autoscalers().insert(project, zone, autoscaler).execute()
+        GoogleExecutor.timeExecute(
+            compute.autoscalers().insert(project, zone, autoscaler),
+            "compute.autoscalers.insert", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
       }
     }
     null

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleServerGroupTagsAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleServerGroupTagsAtomicOperation.groovy
@@ -23,12 +23,12 @@ import com.google.api.services.compute.model.RegionInstanceGroupsListInstancesRe
 import com.google.api.services.compute.model.Tags
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleServerGroupTagsDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
@@ -39,7 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers/setInstanceTemplate}
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/instances/setTags}
  */
-class UpsertGoogleServerGroupTagsAtomicOperation implements AtomicOperation<Void> {
+class UpsertGoogleServerGroupTagsAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "UPSERT_SERVER_GROUP_TAGS"
 
   private static Task getTask() {
@@ -85,8 +85,12 @@ class UpsertGoogleServerGroupTagsAtomicOperation implements AtomicOperation<Void
     // Retrieve the managed instance group.
     def managedInstanceGroup =
       isRegional
-      ? instanceGroupManagers.get(project, region, serverGroupName).execute()
-      : instanceGroupManagers.get(project, zone, serverGroupName).execute()
+      ? GoogleExecutor.timeExecute(
+            instanceGroupManagers.get(project, region, serverGroupName),
+            "compute.regionInstanceGroupManagers.get", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
+      : GoogleExecutor.timeExecute(
+            instanceGroupManagers.get(project, zone, serverGroupName),
+            "compute.instanceGroupManagers.get", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
     def origInstanceTemplateName = GCEUtil.getLocalName(managedInstanceGroup.instanceTemplate)
 
     if (!origInstanceTemplateName) {
@@ -94,7 +98,9 @@ class UpsertGoogleServerGroupTagsAtomicOperation implements AtomicOperation<Void
     }
 
     // Retrieve the managed instance group's current instance template.
-    def instanceTemplate = instanceTemplates.get(project, origInstanceTemplateName).execute()
+    def instanceTemplate = GoogleExecutor.timeExecute(
+            instanceTemplates.get(project, origInstanceTemplateName),
+            "compute.instanceTemplates.get", TAG_SCOPE, SCOPE_GLOBAL)
 
     // Override the instance template's name.
     instanceTemplate.setName("$serverGroupName-${System.currentTimeMillis()}")
@@ -106,7 +112,9 @@ class UpsertGoogleServerGroupTagsAtomicOperation implements AtomicOperation<Void
     // Create a new instance template resource using the modified instance template.
     task.updateStatus BASE_PHASE, "Inserting new instance template $instanceTemplate.name with $tagsDescription..."
 
-    def instanceTemplateCreateOperation = instanceTemplates.insert(project, instanceTemplate).execute()
+    def instanceTemplateCreateOperation = GoogleExecutor.timeExecute(
+            instanceTemplates.insert(project, instanceTemplate),
+            "compute.instanceTemplates.insert", TAG_SCOPE, SCOPE_GLOBAL)
     def instanceTemplateUrl = instanceTemplateCreateOperation.targetLink
 
     // Block on creating the instance template.
@@ -121,33 +129,42 @@ class UpsertGoogleServerGroupTagsAtomicOperation implements AtomicOperation<Void
     if (isRegional) {
       def regionInstanceGroupManagersSetTemplateRequest =
         new RegionInstanceGroupManagersSetTemplateRequest(instanceTemplate: instanceTemplateUrl)
-      def setInstanceTemplateOperation = instanceGroupManagers.setInstanceTemplate(
-        project, region, serverGroupName, regionInstanceGroupManagersSetTemplateRequest).execute()
+      def setInstanceTemplateOperation = GoogleExecutor.timeExecute(
+              instanceGroupManagers.setInstanceTemplate(
+              project, region, serverGroupName, regionInstanceGroupManagersSetTemplateRequest),
+              "compute.regionalInstanceGroupManagers.setInstanceTemplate", TAG_SCOPE, SCOPE_REGIONAL. TAG_REGION, region)
 
       // Block on setting the instance template on the managed instance group.
       googleOperationPoller.waitForRegionalOperation(compute, project, region,
         setInstanceTemplateOperation.getName(), null, task, "server group $serverGroupName", BASE_PHASE)
 
       // Retrieve the instances in the instance group.
-      groupInstances = compute.regionInstanceGroups().listInstances(project,
-                                                                    region,
-                                                                    serverGroupName,
-                                                                    new RegionInstanceGroupsListInstancesRequest()).execute().items
+      groupInstances = GoogleExecutor.timeExecute(
+        compute.regionInstanceGroups().listInstances(project,
+                                                     region,
+                                                     serverGroupName,
+                                                     new RegionInstanceGroupsListInstancesRequest()),
+        "compute.regionInstanceGroups.listInstances", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region).items
+
     } else {
       def instanceGroupManagersSetInstanceTemplateRequest =
         new InstanceGroupManagersSetInstanceTemplateRequest(instanceTemplate: instanceTemplateUrl)
-      def setInstanceTemplateOperation = instanceGroupManagers.setInstanceTemplate(
-        project, zone, serverGroupName, instanceGroupManagersSetInstanceTemplateRequest).execute()
+      def setInstanceTemplateOperation = GoogleExecutor.timeExecute(
+          instanceGroupManagers.setInstanceTemplate(
+        project, zone, serverGroupName, instanceGroupManagersSetInstanceTemplateRequest),
+        "compute.instanceGroupManagers.setInstanceTemplate", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
 
       // Block on setting the instance template on the managed instance group.
       googleOperationPoller.waitForZonalOperation(compute, project, zone,
         setInstanceTemplateOperation.getName(), null, task, "server group $serverGroupName", BASE_PHASE)
 
       // Retrieve the instances in the instance group.
-      groupInstances = compute.instanceGroups().listInstances(project,
-                                                              zone,
-                                                              serverGroupName,
-                                                              new InstanceGroupsListInstancesRequest()).execute().items
+      groupInstances = GoogleExecutor.timeExecute(
+        compute.instanceGroups().listInstances(project,
+                                               zone,
+                                               serverGroupName,
+                                               new InstanceGroupsListInstancesRequest()),
+        "compute.instanceGroups.listInstance", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone).items
     }
 
     // Set the new tags on all instances in the group (in parallel).
@@ -158,12 +175,15 @@ class UpsertGoogleServerGroupTagsAtomicOperation implements AtomicOperation<Void
     groupInstances.each { groupInstance ->
       def localInstanceName = GCEUtil.getLocalName(groupInstance.instance)
       def instanceZone = getZoneFromInstanceUrl(groupInstance.instance)
-      def instance = instances.get(project, instanceZone, localInstanceName).execute()
+      def instance = GoogleExecutor.timeExecute(instances.get(project, instanceZone, localInstanceName),
+              "compute.instances.get", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, instanceZone)
       def tagsFingerprint = instance.tags.fingerprint
 
       tags.fingerprint = tagsFingerprint
 
-      instanceUpdateOperations << instances.setTags(project, instanceZone, localInstanceName, tags).execute()
+      instanceUpdateOperations << GoogleExecutor.timeExecute(
+          instances.setTags(project, instanceZone, localInstanceName, tags),
+          "compute.instances.setTags", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, instanceZone)
     }
 
     // Block on setting the tags on each instance.
@@ -183,7 +203,9 @@ class UpsertGoogleServerGroupTagsAtomicOperation implements AtomicOperation<Void
     // Delete the original instance template.
     task.updateStatus BASE_PHASE, "Deleting original instance template $origInstanceTemplateName..."
 
-    instanceTemplates.delete(project, origInstanceTemplateName).execute()
+    GoogleExecutor.timeExecute(
+        instanceTemplates.delete(project, origInstanceTemplateName),
+        "compute.instanceTemplates.delete", TAG_SCOPE, SCOPE_GLOBAL)
 
     task.updateStatus BASE_PHASE, "Done tagging server group $serverGroupName in $region."
     null

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperation.groovy
@@ -22,17 +22,19 @@ import com.google.api.services.compute.model.Operation
 import com.google.common.annotations.VisibleForTesting
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.GoogleAtomicOperation
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
 @Slf4j
-class DeleteGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation<Void> {
+class DeleteGoogleInternalLoadBalancerAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "DELETE_INTERNAL_LOAD_BALANCER"
 
   private static Task getTask() {
@@ -76,7 +78,9 @@ class DeleteGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
     task.updateStatus BASE_PHASE, "Retrieving forwarding rule $forwardingRuleName in $region..."
 
     ForwardingRule forwardingRule = safeRetry.doRetry(
-      { compute.forwardingRules().get(project, region, forwardingRuleName).execute() },
+      { GoogleExecutor.timeExecute(
+            compute.forwardingRules().get(project, region, forwardingRuleName),
+            "compute.forwardingRules.get", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       'Get',
       "Regional forwarding rule $forwardingRuleName",
       task,
@@ -94,7 +98,9 @@ class DeleteGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
     task.updateStatus BASE_PHASE, "Retrieving backend service $backendServiceName in $region..."
 
     BackendService backendService = safeRetry.doRetry(
-      { compute.regionBackendServices().get(project, region, backendServiceName).execute() },
+      { GoogleExecutor.timeExecute(
+            compute.regionBackendServices().get(project, region, backendServiceName),
+            "compute.regionBackendServices.get", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       'Get',
       "Region backend service $backendServiceName",
       task,
@@ -113,13 +119,22 @@ class DeleteGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
     def healthCheckGet = null
     switch (healthCheckType) {
       case "httpHealthChecks":
-        healthCheckGet = { compute.httpHealthChecks().get(project, healthCheckName).execute() }
+        healthCheckGet = {
+            GoogleExecutor.timeExecute(
+                compute.httpHealthChecks().get(project, healthCheckName),
+                "compute.httpHealthChecks", TAG_SCOPE, SCOPE_GLOBAL) }
         break
       case "httpsHealthChecks":
-        healthCheckGet = { compute.httpsHealthChecks().get(project, healthCheckName).execute() }
+        healthCheckGet = {
+            GoogleExecutor.timeExecute(
+                compute.httpsHealthChecks().get(project, healthCheckName),
+                "compute.httpsHealthChecks", TAG_SCOPE, SCOPE_GLOBAL) }
         break
       case "healthChecks":
-        healthCheckGet = { compute.healthChecks().get(project, healthCheckName).execute() }
+        healthCheckGet = {
+            GoogleExecutor.timeExecute(
+                compute.healthChecks().get(project, healthCheckName),
+                "compute.healthChecks.get", TAG_SCOPE, SCOPE_GLOBAL) }
         break
       default:
         throw new IllegalStateException("Unknown health check type for health check named: ${healthCheckName}.")
@@ -145,7 +160,10 @@ class DeleteGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
     def timeoutSeconds = description.deleteOperationTimeoutSeconds
 
     Operation deleteForwardingRuleOp = safeRetry.doRetry(
-      { compute.forwardingRules().delete(project, region, forwardingRuleName).execute() },
+      {
+          GoogleExecutor.timeExecute(
+              compute.forwardingRules().delete(project, region, forwardingRuleName),
+              "compute.forwardingRules.delete", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       'Delete',
       "Regional forwarding rule $forwardingRuleName",
       task,
@@ -160,7 +178,9 @@ class DeleteGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
     }
 
     Operation deleteBackendServiceOp = GCEUtil.deleteIfNotInUse(
-      { compute.regionBackendServices().delete(project, region, backendServiceName).execute() },
+      { GoogleExecutor.timeExecute(
+            compute.regionBackendServices().delete(project, region, backendServiceName),
+            "compute.regionBackendServices.delete", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       "Region backend service $backendServiceName",
       project,
       task,
@@ -175,13 +195,22 @@ class DeleteGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
     Closure<Operation> deleteHealthCheckClosure = null
     switch (healthCheckType) {
       case "httpHealthChecks":
-        deleteHealthCheckClosure = { compute.httpHealthChecks().delete(project, healthCheckName).execute() }
+        deleteHealthCheckClosure = {
+            GoogleExecutor.timeExecute(
+                compute.httpHealthChecks().delete(project, healthCheckName),
+                "compute.httpHealthChecks.delete", TAG_SCOPE, SCOPE_GLOBAL) }
         break
       case "httpsHealthChecks":
-        deleteHealthCheckClosure = { compute.httpsHealthChecks().delete(project, healthCheckName).execute() }
+        deleteHealthCheckClosure = {
+            GoogleExecutor.timeExecute(
+                compute.httpsHealthChecks().delete(project, healthCheckName),
+                "compute.httpsHealthChecks.delete", TAG_SCOPE, SCOPE_GLOBAL) }
         break
       case "healthChecks":
-        deleteHealthCheckClosure = { compute.healthChecks().delete(project, healthCheckName).execute() }
+        deleteHealthCheckClosure = {
+            GoogleExecutor.timeExecute(
+                compute.healthChecks().delete(project, healthCheckName),
+                "compute.healthChecks.delete", TAG_SCOPE, SCOPE_GLOBAL) }
         break
       default:
         log.warn("Unknown health check type for health check named: ${healthCheckName}.")

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -21,6 +21,7 @@ import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
@@ -119,11 +120,19 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
     String urlMapName = httpLoadBalancer?.urlMapName ?: httpLoadBalancerName // An L7 load balancer is identified by its UrlMap name in Google Cloud Console.
 
     // Get all the existing infrastructure.
-    Set<HttpHealthCheck> existingHealthChecks = compute.httpHealthChecks().list(project).execute().getItems() as Set
-    Set<BackendService> existingServices = compute.backendServices().list(project).execute().getItems() as Set
+    Set<HttpHealthCheck> existingHealthChecks = GoogleExecutor.timeExecute(
+        compute.httpHealthChecks().list(project),
+        "compute.httpHealthChecks.list", TAG_SCOPE, SCOPE_GLOBAL)
+        .getItems() as Set
+    Set<BackendService> existingServices = GoogleExecutor.timeExecute(
+        compute.backendServices().list(project),
+        "compute.backendServices.list", TAG_SCOPE, SCOPE_GLOBAL)
+        .getItems() as Set
     UrlMap existingUrlMap = null
     try {
-      existingUrlMap = compute.urlMaps().get(project, urlMapName).execute()
+      existingUrlMap = GoogleExecutor.timeExecute(
+          compute.urlMaps().get(project, urlMapName),
+          "compute.urlMaps.get", TAG_SCOPE, SCOPE_GLOBAL)
     } catch (GoogleJsonResponseException e) {
       // 404 is thrown if the url map doesn't exist. Any other exception needs to be propagated.
       if (e.getStatusCode() != 404) {
@@ -140,7 +149,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
     // ForwardingRule
     ForwardingRule existingRule = null
     try {
-      existingRule = compute.globalForwardingRules().get(project, httpLoadBalancerName).execute()
+      existingRule = GoogleExecutor.timeExecute(
+          compute.globalForwardingRules().get(project, httpLoadBalancerName),
+          "compute.globalForwardingRules.get", TAG_SCOPE, SCOPE_GLOBAL)
     } catch (GoogleJsonResponseException e) {
       if (e.getStatusCode() != 404) {
         throw e
@@ -154,11 +165,15 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
       String targetProxyName = GCEUtil.getLocalName(existingRule.getTarget())
       switch (Utils.getTargetProxyType(existingRule.getTarget())) {
         case GoogleTargetProxyType.HTTP:
-          existingProxy = compute.targetHttpProxies().get(project, targetProxyName).execute()
+          existingProxy = GoogleExecutor.timeExecute(
+              compute.targetHttpProxies().get(project, targetProxyName),
+              "compute.targetHttpProxies.get", TAG_SCOPE, SCOPE_GLOBAL)
           // Http target proxies aren't updated. If you want to add a Https listener, there are options for that in the frontend.
           break
         case GoogleTargetProxyType.HTTPS:
-          existingProxy = compute.targetHttpsProxies().get(project, targetProxyName).execute()
+          existingProxy = GoogleExecutor.timeExecute(
+              compute.targetHttpsProxies().get(project, targetProxyName),
+              "compute.targetHttpsProxies.get", TAG_SCOPE, SCOPE_GLOBAL)
           if (!httpLoadBalancer.certificate) {
             throw new IllegalArgumentException("${httpLoadBalancerName} is an Https load balancer, but the upsert description does not contain a certificate.")
           }
@@ -241,7 +256,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
           unhealthyThreshold: healthCheck.unhealthyThreshold,
           timeoutSec: healthCheck.timeoutSec,
         )
-        def insertHealthCheckOperation = compute.httpHealthChecks().insert(project, newHealthCheck).execute()
+        def insertHealthCheckOperation = GoogleExecutor.timeExecute(
+              compute.httpHealthChecks().insert(project, newHealthCheck),
+              "compute.httpHealthChecks.insert", TAG_SCOPE, SCOPE_GLOBAL)
         googleOperationPoller.waitForGlobalOperation(compute, project, insertHealthCheckOperation.getName(),
           null, task, "health check " + healthCheckName, BASE_PHASE)
       } else if (healthCheckExistsSet.contains(healthCheck.name) &&
@@ -257,7 +274,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
           unhealthyThreshold = healthCheck.unhealthyThreshold
           timeoutSec = healthCheck.timeoutSec
         }
-        def updateHealthCheckOperation = compute.httpHealthChecks().update(project, healthCheckName, hcToUpdate).execute()
+        def updateHealthCheckOperation = GoogleExecutor.timeExecute(
+           compute.httpHealthChecks().update(project, healthCheckName, hcToUpdate),
+           "compute.httpHealthChecks.update", TAG_SCOPE, SCOPE_GLOBAL)
         googleOperationPoller.waitForGlobalOperation(compute, project, updateHealthCheckOperation.getName(),
           null, task, "health check $healthCheckName", BASE_PHASE)
       }
@@ -278,7 +297,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
           enableCDN: backendService.enableCDN,
           affinityCookieTtlSec: backendService.affinityCookieTtlSec
         )
-        def insertBackendServiceOperation = compute.backendServices().insert(project, bs).execute()
+        def insertBackendServiceOperation = GoogleExecutor.timeExecute(
+                compute.backendServices().insert(project, bs),
+                "compute.backendServices.insert", TAG_SCOPE, SCOPE_GLOBAL)
         googleOperationPoller.waitForGlobalOperation(compute, project, insertBackendServiceOperation.getName(),
           null, task, "backend service " + backendServiceName, BASE_PHASE)
       } else if (serviceExistsSet.contains(backendService.name)) {
@@ -293,7 +314,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
           bsToUpdate.enableCDN = backendService.enableCDN
           bsToUpdate.affinityCookieTtlSec = backendService.affinityCookieTtlSec
 
-          def updateServiceOperation = compute.backendServices().update(project, backendServiceName, bsToUpdate).execute()
+          def updateServiceOperation = GoogleExecutor.timeExecute(
+                  compute.backendServices().update(project, backendServiceName, bsToUpdate),
+                  "compute.backendServices.update", TAG_SCOPE, SCOPE_GLOBAL)
           googleOperationPoller.waitForGlobalOperation(compute, project, updateServiceOperation.getName(),
             null, task, "backend service  $backendServiceName", BASE_PHASE)
         }
@@ -329,7 +352,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
         newUrlMap.pathMatchers << newPathMatcher
         newUrlMap.hostRules << new HostRule(pathMatcher: pathMatcherName, hosts: hostRule.hostPatterns)
       }
-      def insertUrlMapOperation = compute.urlMaps().insert(project, newUrlMap).execute()
+      def insertUrlMapOperation = GoogleExecutor.timeExecute(
+              compute.urlMaps().insert(project, newUrlMap),
+              "compute.urlMaps.insert", TAG_SCOPE, SCOPE_GLOBAL)
       googleOperationPoller.waitForGlobalOperation(compute, project, insertUrlMapOperation.getName(),
         null, task, "url map " + urlMapName, BASE_PHASE)
       urlMapUrl = insertUrlMapOperation.getTargetLink()
@@ -355,7 +380,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
         existingUrlMap.pathMatchers << newPathMatcher
         existingUrlMap.hostRules << new HostRule(pathMatcher: pathMatcherName, hosts: hostRule.hostPatterns)
       }
-      def updateUrlMapOperation = compute.urlMaps().update(project, urlMapName, existingUrlMap).execute()
+      def updateUrlMapOperation = GoogleExecutor.timeExecute(
+              compute.urlMaps().update(project, urlMapName, existingUrlMap),
+              "copute.urlMaps.update", TAG_SCOPE, SCOPE_GLOBAL)
       googleOperationPoller.waitForGlobalOperation(compute, project, updateUrlMapOperation.getName(),
         null, task, "url map $urlMapName", BASE_PHASE)
       urlMapUrl = updateUrlMapOperation.getTargetLink()
@@ -377,12 +404,15 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
           sslCertificates: [GCEUtil.buildCertificateUrl(project, httpLoadBalancer.certificate)],
           urlMap: urlMapUrl,
         )
-        insertTargetProxyOperation = compute.targetHttpsProxies().insert(project, targetProxy).execute()
+        insertTargetProxyOperation = GoogleExecutor.timeExecute(
+            compute.targetHttpsProxies().insert(project, targetProxy),
+            "compute.targetHttpsProxies.insert", TAG_SCOPE, SCOPE_GLOBAL)
       } else {
         targetProxyName = "$httpLoadBalancerName-$TARGET_HTTP_PROXY_NAME_PREFIX"
         task.updateStatus BASE_PHASE, "Creating target proxy $targetProxyName..."
         targetProxy = new TargetHttpProxy(name: targetProxyName, urlMap: urlMapUrl)
-        insertTargetProxyOperation = compute.targetHttpProxies().insert(project, targetProxy).execute()
+        insertTargetProxyOperation = GoogleExecutor.timeExecute(compute.targetHttpProxies().insert(project, targetProxy),
+                                                 "compute.targetHttpProxies.insert", TAG_SCOPE, SCOPE_GLOBAL)
       }
 
       googleOperationPoller.waitForGlobalOperation(compute, project, insertTargetProxyOperation.getName(),
@@ -400,9 +430,13 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
           TargetHttpsProxiesSetSslCertificatesRequest setSslReq = new TargetHttpsProxiesSetSslCertificatesRequest(
             sslCertificates: [GCEUtil.buildCertificateUrl(project, httpLoadBalancer.certificate)],
           )
-          compute.targetHttpsProxies().setSslCertificates(project, targetProxyName, setSslReq).execute()
+          GoogleExecutor.timeExecute(
+              compute.targetHttpsProxies().setSslCertificates(project, targetProxyName, setSslReq),
+              "compute.targetHttpsProxies.setSslCertificates", TAG_SCOPE, SCOPE_GLOBAL)
           UrlMapReference urlMapRef = new UrlMapReference(urlMap: urlMapUrl)
-          def setUrlMapOp = compute.targetHttpsProxies().setUrlMap(project, targetProxyName, urlMapRef).execute()
+          def setUrlMapOp = GoogleExecutor.timeExecute(
+                  compute.targetHttpsProxies().setUrlMap(project, targetProxyName, urlMapRef),
+                  "compute.targetHttpsProxies.setUrlMap", TAG_SCOPE, SCOPE_GLOBAL)
           targetProxyUrl = setUrlMapOp.getTargetLink()
           break
         default:
@@ -424,7 +458,9 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
         portRange: httpLoadBalancer.certificate ? "443" : httpLoadBalancer.portRange,
         target: targetProxyUrl,
       )
-      compute.globalForwardingRules().insert(project, forwardingRule).execute()
+      GoogleExecutor.timeExecute(
+          compute.globalForwardingRules().insert(project, forwardingRule),
+          "compute.globalForwardingRules.insert", TAG_SCOPE, SCOPE_GLOBAL)
     }
     // NOTE: there is no update for forwarding rules because we support adding/deleting multiple listeners in the frontend.
     // Rotating or changing certificates updates the targetProxy only, so the forwarding rule doesn't need to change.
@@ -461,18 +497,26 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
       String templateUrl = null
       switch (Utils.determineServerGroupType(backend.serverGroupUrl)) {
         case GoogleServerGroup.ServerGroupType.REGIONAL:
-          templateUrl = compute.regionInstanceGroupManagers().get(project, groupRegion, groupName).execute().getInstanceTemplate()
+          templateUrl = GoogleExecutor.timeExecute(
+              compute.regionInstanceGroupManagers().get(project, groupRegion, groupName),
+              "compute.regionInstanceGroupManagers.get", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, groupRegion)
+              .getInstanceTemplate()
           break
         case GoogleServerGroup.ServerGroupType.ZONAL:
           def groupZone = Utils.getZoneFromGroupUrl(backend.serverGroupUrl)
-          templateUrl = compute.instanceGroupManagers().get(project, groupZone, groupName).execute().getInstanceTemplate()
+          templateUrl = GoogleExecutor.timeExecute(
+              compute.instanceGroupManagers().get(project, groupZone, groupName),
+              "compute.instanceGroupManagers.get", TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, groupZone)
+              .getInstanceTemplate()
           break
         default:
           throw new IllegalStateException("Server group referenced by ${backend.serverGroupUrl} has illegal type.")
           break
       }
 
-      InstanceTemplate template = compute.instanceTemplates().get(project, Utils.getLocalName(templateUrl)).execute()
+      InstanceTemplate template = GoogleExecutor.timeExecute(
+          compute.instanceTemplates().get(project, Utils.getLocalName(templateUrl)),
+          "compute.instancesTemplates.get", TAG_SCOPE, SCOPE_GLOBAL)
       def instanceDescription = GCEUtil.buildInstanceDescriptionFromTemplate(template)
 
       def templateOpMap = [

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -382,7 +382,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
       }
       def updateUrlMapOperation = GoogleExecutor.timeExecute(
               compute.urlMaps().update(project, urlMapName, existingUrlMap),
-              "copute.urlMaps.update", TAG_SCOPE, SCOPE_GLOBAL)
+              "compute.urlMaps.update", TAG_SCOPE, SCOPE_GLOBAL)
       googleOperationPoller.waitForGlobalOperation(compute, project, updateUrlMapOperation.getName(),
         null, task, "url map $urlMapName", BASE_PHASE)
       urlMapUrl = updateUrlMapOperation.getTargetLink()

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleCachingAgent.groovy
@@ -23,13 +23,16 @@ import com.google.api.client.http.HttpRequest
 import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.services.compute.Compute
 import com.google.common.annotations.VisibleForTesting
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.AccountAware
 import com.netflix.spinnaker.cats.agent.CachingAgent
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutorTraits
 import com.netflix.spinnaker.clouddriver.google.provider.GoogleInfrastructureProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 
-abstract class AbstractGoogleCachingAgent implements CachingAgent, AccountAware {
 
+abstract class AbstractGoogleCachingAgent implements CachingAgent, AccountAware, GoogleExecutorTraits {
   final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
 
   final String providerName = GoogleInfrastructureProvider.name
@@ -61,9 +64,9 @@ abstract class AbstractGoogleCachingAgent implements CachingAgent, AccountAware 
     credentials?.name
   }
 
-  def executeIfRequestsAreQueued(BatchRequest batch) {
+  def executeIfRequestsAreQueued(BatchRequest batch, String instrumentationContext) {
     if (batch.size()) {
-      batch.execute()
+      GoogleExecutor.timeExecuteBatch(batch, instrumentationContext)
     }
   }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHealthCheckCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHealthCheckCachingAgent.groovy
@@ -23,6 +23,7 @@ import com.google.api.services.compute.model.HttpsHealthCheck
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
@@ -67,7 +68,9 @@ class GoogleHealthCheckCachingAgent extends AbstractGoogleCachingAgent {
    */
   List<GoogleHealthCheck> loadHealthChecks() {
     List<GoogleHealthCheck> ret = []
-    def httpHealthChecks = compute.httpHealthChecks().list(project).execute().items as List
+    def httpHealthChecks = GoogleExecutor.timeExecute(
+            compute.httpHealthChecks().list(project),
+            "compute.httpHealthChecks.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
     httpHealthChecks.each { HttpHealthCheck hc ->
       ret << new GoogleHealthCheck(
         name: hc.getName(),
@@ -82,7 +85,9 @@ class GoogleHealthCheckCachingAgent extends AbstractGoogleCachingAgent {
       )
     }
 
-    def httpsHealthChecks = compute.httpsHealthChecks().list(project).execute().items as List
+    def httpsHealthChecks = GoogleExecutor.timeExecute(
+            compute.httpsHealthChecks().list(project),
+            "compute.httpsHealthChecks.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
     httpsHealthChecks.each { HttpsHealthCheck hc ->
       ret << new GoogleHealthCheck(
         name: hc.getName(),
@@ -97,7 +102,9 @@ class GoogleHealthCheckCachingAgent extends AbstractGoogleCachingAgent {
       )
     }
 
-    def healthChecks = compute.healthChecks().list(project).execute().items as List
+    def healthChecks = GoogleExecutor.timeExecute(
+            compute.healthChecks().list(project),
+            "compute.healthChecks.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
     healthChecks.each { HealthCheck hc ->
       def newHC = new GoogleHealthCheck(
         name: hc.getName(),

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpHealthCheckCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpHealthCheckCachingAgent.groovy
@@ -21,6 +21,7 @@ import com.google.api.services.compute.model.HttpHealthCheck
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
@@ -53,7 +54,9 @@ class GoogleHttpHealthCheckCachingAgent extends AbstractGoogleCachingAgent {
   }
 
   List<HttpHealthCheck> loadHttpHealthChecks() {
-    compute.httpHealthChecks().list(project).execute().items as List
+    GoogleExecutor.timeExecute(
+        compute.httpHealthChecks().list(project),
+        "compute.httpHealthChecks.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
   }
 
   private CacheResult buildCacheResult(ProviderCache _, List<HttpHealthCheck> httpHealthCheckList) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -96,12 +96,12 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
     )
     compute.globalForwardingRules().list(project).queue(forwardingRulesRequest, callback)
 
-    executeIfRequestsAreQueued(forwardingRulesRequest)
-    executeIfRequestsAreQueued(targetProxyRequest)
-    executeIfRequestsAreQueued(urlMapRequest)
-    executeIfRequestsAreQueued(backendServiceRequest)
-    executeIfRequestsAreQueued(httpHealthCheckRequest)
-    executeIfRequestsAreQueued(groupHealthRequest)
+    executeIfRequestsAreQueued(forwardingRulesRequest, "HttpLoadBalancerCaching.forwardingRules")
+    executeIfRequestsAreQueued(targetProxyRequest, "HttpLoadBalancerCaching.targetProxy")
+    executeIfRequestsAreQueued(urlMapRequest, "HttpLoadBalancerCaching.urlMapRequest")
+    executeIfRequestsAreQueued(backendServiceRequest, "HttpLoadBalancerCaching.backendService")
+    executeIfRequestsAreQueued(httpHealthCheckRequest, "HttpLoadBalancerCaching.httpHealthCheck")
+    executeIfRequestsAreQueued(groupHealthRequest, "HttpLoadBalancerCaching.groupHealth")
 
     return loadBalancers
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleImageCachingAgent.groovy
@@ -79,7 +79,7 @@ class GoogleImageCachingAgent extends AbstractGoogleCachingAgent {
     baseImageProjects.each {
       compute.images().list(it).queue(imageRequest, new AllImagesCallback<ImageList>(imageList: imageList))
     }
-    executeIfRequestsAreQueued(imageRequest)
+    executeIfRequestsAreQueued(imageRequest, "ImageCaching.image")
 
     imageList
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInstanceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInstanceCachingAgent.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulHealth
 import com.netflix.spinnaker.clouddriver.consul.provider.ConsulProviderUtils
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstance
@@ -58,8 +59,9 @@ class GoogleInstanceCachingAgent extends AbstractGoogleCachingAgent {
     String pageToken = null
 
     while (true) {
-      InstanceAggregatedList instanceAggregatedList =
-        compute.instances().aggregatedList(project).setPageToken(pageToken).execute()
+      InstanceAggregatedList instanceAggregatedList = GoogleExecutor.timeExecute(
+          compute.instances().aggregatedList(project).setPageToken(pageToken),
+          "compute.instances.aggregatedList", TAG_SCOPE, SCOPE_GLOBAL)
 
       instances += transformInstances(instanceAggregatedList)
       pageToken = instanceAggregatedList.getNextPageToken()

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
@@ -91,10 +91,10 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleCachingAgent 
     )
     compute.forwardingRules().list(project, region).queue(forwardingRulesRequest, callback)
 
-    executeIfRequestsAreQueued(forwardingRulesRequest)
-    executeIfRequestsAreQueued(backendServiceRequest)
-    executeIfRequestsAreQueued(healthCheckRequest)
-    executeIfRequestsAreQueued(groupHealthRequest)
+    executeIfRequestsAreQueued(forwardingRulesRequest, "internalLoadBalancerCaching.forwardingRules")
+    executeIfRequestsAreQueued(backendServiceRequest, "internalLoadBalancerCaching.backendService")
+    executeIfRequestsAreQueued(healthCheckRequest, "internalLoadBalancerCaching.healthCheck")
+    executeIfRequestsAreQueued(groupHealthRequest, "internalLoadBalancerCaching.groupHealth")
 
     return loadBalancers
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -93,10 +93,10 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
                                                                    instanceHealthRequest: instanceHealthRequest)
     compute.forwardingRules().list(project, region).queue(forwardingRulesRequest, callback)
 
-    executeIfRequestsAreQueued(forwardingRulesRequest)
-    executeIfRequestsAreQueued(targetPoolsRequest)
-    executeIfRequestsAreQueued(httpHealthChecksRequest)
-    executeIfRequestsAreQueued(instanceHealthRequest)
+    executeIfRequestsAreQueued(forwardingRulesRequest, "LoadBalancerCaching.forwardingRules")
+    executeIfRequestsAreQueued(targetPoolsRequest, "LoadBalancerCaching.targetPools")
+    executeIfRequestsAreQueued(httpHealthChecksRequest, "LoadBalancerCaching.httpHealthChecks")
+    executeIfRequestsAreQueued(instanceHealthRequest, "LoadBalancerCaching.instanceHealth")
 
     return loadBalancers
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleNetworkCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleNetworkCachingAgent.groovy
@@ -20,6 +20,7 @@ import com.google.api.services.compute.model.Network
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import groovy.transform.InheritConstructors
@@ -45,7 +46,8 @@ class GoogleNetworkCachingAgent extends AbstractGoogleCachingAgent {
   }
 
   List<Network> loadNetworks() {
-    compute.networks().list(project).execute().items as List
+    GoogleExecutor.timeExecute(
+        compute.networks().list(project), "compute.networks.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
   }
 
   private CacheResult buildCacheResult(ProviderCache _, List<Network> networkList) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -146,9 +146,9 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
         instanceGroupManagerCallbacks.newInstanceGroupManagerListCallback()
       compute.regionInstanceGroupManagers().list(project, region).queue(igmRequest, igmlCallback)
     }
-    executeIfRequestsAreQueued(igmRequest, "RegionalSerfverGroupCaching.igm")
-    executeIfRequestsAreQueued(instanceGroupsRequest, "RegionalSerfverGroupCaching.instanceGroups")
-    executeIfRequestsAreQueued(autoscalerRequest, "RegionalSerfverGroupCaching.autoscaler")
+    executeIfRequestsAreQueued(igmRequest, "RegionalServerGroupCaching.igm")
+    executeIfRequestsAreQueued(instanceGroupsRequest, "RegionalServerGroupCaching.instanceGroups")
+    executeIfRequestsAreQueued(autoscalerRequest, "RegionalServerGroupCaching.autoscaler")
 
     serverGroups
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -146,9 +146,9 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
         instanceGroupManagerCallbacks.newInstanceGroupManagerListCallback()
       compute.regionInstanceGroupManagers().list(project, region).queue(igmRequest, igmlCallback)
     }
-    executeIfRequestsAreQueued(igmRequest)
-    executeIfRequestsAreQueued(instanceGroupsRequest)
-    executeIfRequestsAreQueued(autoscalerRequest)
+    executeIfRequestsAreQueued(igmRequest, "RegionalSerfverGroupCaching.igm")
+    executeIfRequestsAreQueued(instanceGroupsRequest, "RegionalSerfverGroupCaching.instanceGroups")
+    executeIfRequestsAreQueued(autoscalerRequest, "RegionalSerfverGroupCaching.autoscaler")
 
     serverGroups
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import com.netflix.spinnaker.clouddriver.google.GoogleCloudProvider
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
@@ -95,7 +96,9 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
   }
 
   List<Firewall> loadFirewalls() {
-    compute.firewalls().list(project).execute().items as List<Firewall>
+    GoogleExecutor.timeExecute(
+        compute.firewalls().list(project),
+        "compute.firewalls.list", TAG_SCOPE, SCOPE_GLOBAL).items as List<Firewall>
   }
 
   private CacheResult buildCacheResult(ProviderCache providerCache, List<Firewall> firewallList) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslCertificateCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslCertificateCachingAgent.groovy
@@ -21,6 +21,7 @@ import com.google.api.services.compute.model.SslCertificate
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
@@ -53,7 +54,9 @@ class GoogleSslCertificateCachingAgent extends AbstractGoogleCachingAgent  {
   }
 
   List<SslCertificate> loadSslCertificates() {
-    compute.sslCertificates().list(project).execute().items as List
+    GoogleExecutor.timeExecute(
+        compute.sslCertificates().list(project),
+        "compute.sslCertificates.list", TAG_SCOPE, SCOPE_GLOBAL).items as List
   }
 
   private CacheResult buildCacheResult(ProviderCache _, List<SslCertificate> sslCertificateList) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -94,11 +94,11 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
     )
     compute.globalForwardingRules().list(project).queue(forwardingRulesRequest, frCallback)
 
-    executeIfRequestsAreQueued(forwardingRulesRequest)
-    executeIfRequestsAreQueued(targetSslProxyRequest)
-    executeIfRequestsAreQueued(backendServiceRequest)
-    executeIfRequestsAreQueued(healthCheckRequest)
-    executeIfRequestsAreQueued(groupHealthRequest)
+    executeIfRequestsAreQueued(forwardingRulesRequest, "SslLoadBalancerCaching.forwardingRules")
+    executeIfRequestsAreQueued(targetSslProxyRequest, "SslLoadBalancerCaching.targetSslProxy")
+    executeIfRequestsAreQueued(backendServiceRequest, "SslLoadBalancerCaching.backendService")
+    executeIfRequestsAreQueued(healthCheckRequest, "SslLoadBalancerCaching.healthCheck")
+    executeIfRequestsAreQueued(groupHealthRequest, "SslLoadBalancerCaching.groupHealthCheck")
 
     loadBalancers
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSubnetCachingAgent.groovy
@@ -21,6 +21,7 @@ import com.google.api.services.compute.model.Subnetwork
 import com.netflix.spinnaker.cats.agent.AgentDataType
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 import com.netflix.spinnaker.clouddriver.google.cache.CacheResultBuilder
 import com.netflix.spinnaker.clouddriver.google.cache.Keys
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
@@ -57,7 +58,9 @@ class GoogleSubnetCachingAgent extends AbstractGoogleCachingAgent {
   }
 
   List<Subnetwork> loadSubnets() {
-    compute.subnetworks().list(project, region).execute().items as List
+    GoogleExecutor.timeExecute(
+        compute.subnetworks().list(project, region),
+        "compute.subnetworks.list", TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region).items as List
   }
 
   private CacheResult buildCacheResult(ProviderCache _, List<Subnetwork> subnetList) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
@@ -148,9 +148,9 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
         compute.instanceGroupManagers().list(project, zone).queue(igmRequest, igmlCallback)
       }
     }
-    executeIfRequestsAreQueued(igmRequest)
-    executeIfRequestsAreQueued(instanceGroupsRequest)
-    executeIfRequestsAreQueued(autoscalerRequest)
+    executeIfRequestsAreQueued(igmRequest, "ZonalServerGroupCaching.igm")
+    executeIfRequestsAreQueued(instanceGroupsRequest, "ZonalServerGroupCaching.instanceGroups")
+    executeIfRequestsAreQueued(autoscalerRequest, "ZonalServerGroupCaching.autoscaler")
 
     serverGroups
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/config/GoogleInfrastructureProviderConfig.groovy
@@ -34,6 +34,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.*
 
 import java.util.concurrent.ConcurrentHashMap
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutor
 
 @Configuration
 @Import(GoogleConfiguration)
@@ -47,6 +48,7 @@ class GoogleInfrastructureProviderConfig {
                                                             AccountCredentialsRepository accountCredentialsRepository,
                                                             ObjectMapper objectMapper,
                                                             Registry registry) {
+    GoogleExecutor.setGlobalRegistry(registry)
     def googleInfrastructureProvider =
         new GoogleInfrastructureProvider(Collections.newSetFromMap(new ConcurrentHashMap<Agent, Boolean>()))
 

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/BaseOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/BaseOperationUnitSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
+import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import spock.lang.Specification
+import spock.lang.Shared
+
+
+class BaseOperationUnitSpec extends Specification {
+  @Shared
+  Registry registry
+
+  @Shared
+  SafeRetry safeRetry
+
+  @Shared
+  def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+
+  def doSetupSpec() {
+    System.out.println("**** doSetupSpec")
+    TaskRepository.threadLocalTask.set(Mock(Task))
+    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0, jitterMultiplier: 0)
+    registry = new DefaultRegistry()
+  }
+
+  def preparePollingOperation(AtomicOperation operation) {
+      operation.googleOperationPoller =
+        new GoogleOperationPoller(
+          googleConfigurationProperties: new GoogleConfigurationProperties(),
+          threadSleeper: threadSleeperMock,
+          safeRetry: safeRetry
+        )
+      operation.safeRetry = safeRetry
+      return operation
+  }
+}

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -18,22 +18,16 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops.loadbalancer
 
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
-import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationTimedOutException
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.BaseOperationUnitSpec
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
-import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification {
+class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends BaseOperationUnitSpec {
   private static final ACCOUNT_NAME = "auto"
   private static final PROJECT_NAME = "my_project"
   private static final HTTP_LOAD_BALANCER_NAME = "default"
@@ -52,16 +46,6 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
   private static final HEALTH_CHECK_DELETE_OP_NAME = "delete-health-check"
   private static final PENDING = "PENDING"
   private static final DONE = "DONE"
-
-  @Shared
-  def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
-  @Shared
-  SafeRetry safeRetry
-
-  def setupSpec() {
-    TaskRepository.threadLocalTask.set(Mock(Task))
-    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0, jitterMultiplier: 0)
-  }
 
   void "should delete Http Load Balancer with one backend service"() {
     setup:
@@ -114,13 +98,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -242,13 +220,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -389,13 +361,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -473,13 +439,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -565,13 +525,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -664,13 +618,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         credentials: credentials)
       def conflictingMap = new UrlMap(defaultService: BACKEND_SERVICE_URL, name: "conflicting")
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -734,13 +682,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
@@ -22,19 +22,14 @@ import com.google.api.client.http.HttpHeaders
 import com.google.api.client.http.HttpResponseException
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
-import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.BaseOperationUnitSpec
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 
-class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specification {
+class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends BaseOperationUnitSpec {
   private static final ACCOUNT_NAME = "auto"
   private static final PROJECT_NAME = "my_project"
   private static final REGION = "us-central1"
@@ -49,16 +44,6 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
   private static final HTTPS_HC_URL = "/projects/$PROJECT_NAME/global/httpsHealthChecks/$HEALTH_CHECK_NAME"
   private static final HC_URL = "/projects/$PROJECT_NAME/global/healthChecks/$HEALTH_CHECK_NAME"
   private static final HEALTH_CHECK_DELETE_OP_NAME = "delete-health-check"
-
-  @Shared
-  def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
-  @Shared
-  SafeRetry safeRetry
-
-  def setupSpec() {
-    TaskRepository.threadLocalTask.set(Mock(Task))
-    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0, jitterMultiplier: 0)
-  }
 
   void "should delete an Internal Load Balancer with http health check"() {
     setup:
@@ -104,12 +89,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller = new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-      )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -188,12 +168,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller = new GoogleOperationPoller(
-        googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock,
-        safeRetry: safeRetry
-      )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -272,12 +247,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller = new GoogleOperationPoller(
-        googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock,
-        safeRetry: safeRetry
-      )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -367,12 +337,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller = new GoogleOperationPoller(
-        googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock,
-        safeRetry: safeRetry
-      )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -457,12 +422,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller = new GoogleOperationPoller(
-        googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock,
-        safeRetry: safeRetry
-      )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -506,12 +466,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleInternalLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller = new GoogleOperationPoller(
-        googleConfigurationProperties: new GoogleConfigurationProperties(),
-        threadSleeper: threadSleeperMock,
-        safeRetry: safeRetry
-      )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -24,21 +24,16 @@ import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.ForwardingRule
 import com.google.api.services.compute.model.Operation
 import com.google.api.services.compute.model.TargetPool
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
-import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationTimedOutException
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.BaseOperationUnitSpec
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 
-class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
+class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends BaseOperationUnitSpec {
   private static final ACCOUNT_NAME = "auto"
   private static final PROJECT_NAME = "my_project"
   private static final LOAD_BALANCER_NAME = "default"
@@ -51,14 +46,8 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
   private static final HEALTH_CHECK_NAME = "health-check"
   private static final HEALTH_CHECK_DELETE_OP_NAME = "delete-health-check"
 
-  @Shared
-  def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
-  @Shared
-  SafeRetry safeRetry
-
-  def setupSpec() {
-    TaskRepository.threadLocalTask.set(Mock(Task))
-    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0, jitterMultiplier: 0)
+  void setupSpec() {
+    super.doSetupSpec()
   }
 
   void "should delete a Network Load Balancer with health checks"() {
@@ -95,13 +84,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -157,13 +140,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -199,7 +176,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
-      operation.safeRetry = safeRetry
+//      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -237,13 +214,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -286,13 +257,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -342,13 +307,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -420,16 +379,8 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           "Bad Request",
           new HttpHeaders()).setMessage("400 Bad Request")
       def googleJsonResponseException = new GoogleJsonResponseException(httpResponseExceptionBuilder, details)
-      def operationRetryThreadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
-      operation.threadSleeper = operationRetryThreadSleeperMock
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -507,16 +458,8 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           "Bad Request",
           new HttpHeaders()).setMessage("400 Bad Request")
       def googleJsonResponseException = new GoogleJsonResponseException(httpResponseExceptionBuilder, details)
-      def operationRetryThreadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
-      operation.threadSleeper = operationRetryThreadSleeperMock
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
@@ -18,21 +18,16 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops.loadbalancer
 
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
-import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
-import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationTimedOutException
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.BaseOperationUnitSpec
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 
-class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
+class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends BaseOperationUnitSpec {
   private static final ACCOUNT_NAME = "auto"
   private static final PROJECT_NAME = "my_project"
   private static final SSL_LOAD_BALANCER_NAME = "default"
@@ -48,16 +43,6 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
   private static final HEALTH_CHECK_DELETE_OP_NAME = "delete-health-check"
   private static final PENDING = "PENDING"
   private static final DONE = "DONE"
-
-  @Shared
-  def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
-  @Shared
-  SafeRetry safeRetry
-
-  def setupSpec() {
-    TaskRepository.threadLocalTask.set(Mock(Task))
-    safeRetry = new SafeRetry(maxRetries: 10, maxWaitInterval: 60000, retryIntervalBase: 0, jitterMultiplier: 0)
-  }
 
   void "should delete ssl load balancer"() {
     setup:
@@ -108,13 +93,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleSslLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -175,13 +154,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleSslLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -234,13 +207,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleSslLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])
@@ -299,13 +266,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new DeleteGoogleSslLoadBalancerAtomicOperation(description)
-      operation.googleOperationPoller =
-        new GoogleOperationPoller(
-          googleConfigurationProperties: new GoogleConfigurationProperties(),
-          threadSleeper: threadSleeperMock,
-          safeRetry: safeRetry
-        )
-      operation.safeRetry = safeRetry
+      preparePollingOperation(operation)
 
     when:
       operation.operate([])


### PR DESCRIPTION
@duftler 

The tests dont run yet, but before investing the effort in getting them working I want to run this by you because it is a big change.

This instruments most of the compute calls in clouddriver to give latency metrics.
I thought I might be able to create an interceptor in spring. This would have been pretty simple (just a few paragraphs of code) but the API has so many levels of factories that the proxies would have to create other proxies and there numerous final classes and methods so you get lots of warnings and not everything needs to be proxied so the runtime is a mess and feels scary.

The other approach is to figure out how to use the pre/post interceptors in the API itself. This would be less impactful in the code since only the compute factory would need to change. However I couldnt do much with tags there. I think it might be interesting to have tags for zones and regions to isolate latency if it really does matter since different regions are going to have different loads.

It could also be that we dont need any of this and just use the built-in platform metrics. The API panel in the developer's console already shows latency. However that is aggregated for the whole project, not just spinnaker. So not only do you not have the region/zone breakdown, but it isnt just Spinnaker so it might make using the instrumentation to debug issues harder since it is adding noise into the data.

To make the tests easier, I might see if I can accomodate a null Registry and not capture metrics in that case. Or maybe add some helper class or base to setup a global registry. At some point a test can test the metric writing, but not all the tests need to do that.

The changes in tests is old from my first stab at this PR. I havent looked to see if they are current or not so just ignore the tests for your first pass.

I can show you dashboard data if you need.

The gist is that most of the execute methods are instrumented with a timer (count/time).
In addition the polling wait operations are instrumented separately. As a rule of thumb, I do not instrument the internal get calls for those since I dont think that latency matters since you are already waiting on the effects.

The batch operations are counted separate. I added a context to each batch to indicate what it was for. and a counter for the size of the batch in addition to the timer for the batch.execute. I dont know if this is helpful or not, but could facilitate debugging and review.