### PR TITLE
(kubernetes) Update percent enable disable semantics

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
@@ -52,56 +52,62 @@ abstract class AbstractEnableDisableKubernetesAtomicOperation implements AtomicO
 
     def credentials = description.credentials.credentials
     def namespace = KubernetesUtil.validateNamespace(credentials, description.namespace)
+    def desiredPercentage = description.desiredPercentage ?: 100
+    def pods = []
 
     task.updateStatus basePhase, "Finding requisite server group..."
 
     def replicationController = credentials.apiAdaptor.getReplicationController(namespace, description.serverGroupName)
     def replicaSet = credentials.apiAdaptor.getReplicaSet(namespace, description.serverGroupName)
 
-    task.updateStatus basePhase, "Getting list of attached services..."
+    // If we edit the spec when disabling less than 100% of pods, we won't be able to handle autoscaling
+    // actively correctly.
+    if (desiredPercentage == 100 || action == "true") {
+      task.updateStatus basePhase, "Getting list of attached services..."
 
-    List<String> services = KubernetesUtil.getLoadBalancers(replicationController ?: replicaSet)
-    services = services.collect {
-      KubernetesUtil.loadBalancerKey(it)
-    }
+      List<String> services = KubernetesUtil.getLoadBalancers(replicationController ?: replicaSet)
+      services = services.collect {
+        KubernetesUtil.loadBalancerKey(it)
+      }
 
-    task.updateStatus basePhase, "Resetting server group service template labels and selectors..."
+      task.updateStatus basePhase, "Resetting server group service template labels and selectors..."
 
-    def getGeneration = null
-    def getResource = null
-    def desired = null
-    def pods = []
-    if (replicationController) {
-      desired = credentials.apiAdaptor.toggleReplicationControllerSpecLabels(namespace, description.serverGroupName, services, action)
-      getGeneration = { ReplicationController rc ->
-        return rc.metadata.generation
+      def getGeneration = null
+      def getResource = null
+      def desired = null
+      if (replicationController) {
+        desired = credentials.apiAdaptor.toggleReplicationControllerSpecLabels(namespace, description.serverGroupName, services, action)
+        getGeneration = { ReplicationController rc ->
+          return rc.metadata.generation
+        }
+        getResource = {
+          return credentials.apiAdaptor.getReplicationController(namespace, description.serverGroupName)
+        }
+        pods = credentials.apiAdaptor.getReplicationControllerPods(namespace, description.serverGroupName)
+      } else if (replicaSet) {
+        desired = credentials.apiAdaptor.toggleReplicaSetSpecLabels(namespace, description.serverGroupName, services, action)
+        getGeneration = { ReplicaSet rs ->
+          return rs.metadata.generation
+        }
+        getResource = {
+          return credentials.apiAdaptor.getReplicaSet(namespace, description.serverGroupName)
+        }
+        pods = credentials.apiAdaptor.getReplicaSetPods(namespace, description.serverGroupName)
+      } else {
+        throw new KubernetesOperationException("No replication controller or replica set $description.serverGroupName in $namespace.")
       }
-      getResource = {
-        return credentials.apiAdaptor.getReplicationController(namespace, description.serverGroupName)
-      }
-      pods = credentials.apiAdaptor.getReplicationControllerPods(namespace, description.serverGroupName)
-    } else if (replicaSet) {
-      desired = credentials.apiAdaptor.toggleReplicaSetSpecLabels(namespace, description.serverGroupName, services, action)
-      getGeneration = { ReplicaSet rs ->
-        return rs.metadata.generation
-      }
-      getResource = {
-        return credentials.apiAdaptor.getReplicaSet(namespace, description.serverGroupName)
-      }
-      pods = credentials.apiAdaptor.getReplicaSetPods(namespace, description.serverGroupName)
-    } else {
-      throw new KubernetesOperationException("No replication controller or replica set $description.serverGroupName in $namespace.")
-    }
 
-    if (!credentials.apiAdaptor.blockUntilResourceConsistent(desired, getGeneration, getResource)) {
-      throw new KubernetesOperationException("Server group failed to reach a consistent state. This is likely a bug with Kubernetes itself.")
+      if (!credentials.apiAdaptor.blockUntilResourceConsistent(desired, getGeneration, getResource)) {
+        throw new KubernetesOperationException("Server group failed to reach a consistent state. This is likely a bug with Kubernetes itself.")
+      }
     }
 
     task.updateStatus basePhase, "Resetting service labels for each pod..."
 
     def pool = Executors.newWorkStealingPool((int) (pods.size() / 2) + 1)
 
-    if (description.desiredPercentage != null) {
+    if (desiredPercentage != null) {
+      task.updateStatus basePhase, "Operating on $desiredPercentage% of pods"
       List<Pod> modifiedPods = pods.findAll { pod ->
         KubernetesUtil.getPodLoadBalancerStates(pod).every { it.value == action }
       }
@@ -110,7 +116,7 @@ abstract class AbstractEnableDisableKubernetesAtomicOperation implements AtomicO
         KubernetesUtil.getPodLoadBalancerStates(pod).any { it.value != action }
       }
 
-      pods = EnableDisablePercentageCategorizer.getInstancesToModify(modifiedPods, unmodifiedPods, description.desiredPercentage)
+      pods = EnableDisablePercentageCategorizer.getInstancesToModify(modifiedPods, unmodifiedPods, desiredPercentage)
     }
 
     pods.each { Pod pod ->


### PR DESCRIPTION
This fix is important, because if we prematurely switch a replica set's
behavior to spawn disabled pods when owned by an autoscaler, the autoscaler
becomes useless, since it cannot create pods to reduce load on the pods still
serving traffic.

@duftler or @jtk54 or @danielpeach PTAL