### PR TITLE
An AtomicOperation can now return an <optional> set of OperationEvents

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperation.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.orchestration
+package com.netflix.spinnaker.clouddriver.orchestration;
+
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * An AtomicOperation is the most fundamental, low-level unit of work in a workflow. Implementations of this interface
  * should perform the simplest form of work possible, often described by a description object (like {@link com.netflix.spinnaker.clouddriver.deploy.DeployDescription}
- *
- * @param the return type of the operation
- *
  */
 public interface AtomicOperation<R> {
   /**
@@ -31,5 +34,10 @@ public interface AtomicOperation<R> {
    * @param priorOutputs
    * @return parameterized type
    */
-  R operate(List priorOutputs)
+  R operate(List priorOutputs);
+
+  default Collection<OperationEvent> getEvents() {
+    return Collections.emptyList();
+  }
 }
+

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/events/DeleteServerGroupEvent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/events/DeleteServerGroupEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.orchestration.events;
+
+public class DeleteServerGroupEvent implements OperationEvent {
+  private final OperationEvent.Type type = OperationEvent.Type.SERVER_GROUP;
+  private final OperationEvent.Action action = OperationEvent.Action.DELETE;
+
+  private final String cloudProvider;
+
+  private final String accountId;
+  private final String region;
+  private final String name;
+
+  public DeleteServerGroupEvent(String cloudProvider, String accountId, String region, String name) {
+    this.cloudProvider = cloudProvider;
+    this.accountId = accountId;
+    this.region = region;
+    this.name = name;
+  }
+
+  @Override
+  public OperationEvent.Type getType() {
+    return type;
+  }
+
+  @Override
+  public OperationEvent.Action getAction() {
+    return action;
+  }
+
+  @Override
+  public String getCloudProvider() {
+    return cloudProvider;
+  }
+
+  public String getAccountId() {
+    return accountId;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return "DeleteServerGroupEvent{" +
+      "type=" + type +
+      ", action=" + action +
+      ", cloudProvider='" + cloudProvider + '\'' +
+      ", accountId='" + accountId + '\'' +
+      ", region='" + region + '\'' +
+      ", name='" + name + '\'' +
+      '}';
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/events/OperationEvent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/events/OperationEvent.java
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.tags;
+package com.netflix.spinnaker.clouddriver.orchestration.events;
 
-interface ServerGroupTagger {
-  void alert(String cloudProvider, String accountId, String region, String serverGroupName, String key, String value)
+public interface OperationEvent {
+  Type getType();
+  Action getAction();
 
-  void deleteAll(String cloudProvider, String accountId, String region, String serverGroupName)
+  String getCloudProvider();
+
+  enum Type {
+    SERVER_GROUP
+  }
+
+  enum Action {
+    DELETE,
+    CREATE
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/events/OperationEventHandler.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/events/OperationEventHandler.java
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.tags;
+package com.netflix.spinnaker.clouddriver.orchestration.events;
 
-interface ServerGroupTagger {
-  void alert(String cloudProvider, String accountId, String region, String serverGroupName, String key, String value)
-
-  void deleteAll(String cloudProvider, String accountId, String region, String serverGroupName)
+public interface OperationEventHandler {
+  void handle(OperationEvent operationEvent);
 }

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/EntityRefIdBuilder.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/EntityRefIdBuilder.java
@@ -22,13 +22,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class EntityRefIdBuilder {
-  public static EntityRefId buildId(String cloudProvider, String entityType, String entityId, String account, String region) {
+  public static EntityRefId buildId(String cloudProvider, String entityType, String entityId, String accountId, String region) {
     Objects.requireNonNull(cloudProvider, "cloudProvider must be non-null");
     Objects.requireNonNull(entityType, "entityType must be non-null");
     Objects.requireNonNull(entityId, "entityId must be non-null");
 
     String id = Stream
-      .of(cloudProvider, entityType, entityId, account, region)
+      .of(cloudProvider, entityType, entityId, accountId, region)
       .map(s -> Optional.ofNullable(s).orElse("*"))
       .collect(Collectors.joining(":"));
 

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/DeleteEntityTagsDescription.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/DeleteEntityTagsDescription.java
@@ -42,4 +42,16 @@ public class DeleteEntityTagsDescription implements NonCredentialed {
   public boolean isDeleteAll() {
     return deleteAll;
   }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+  public void setDeleteAll(boolean deleteAll) {
+    this.deleteAll = deleteAll;
+  }
 }

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/events/DeleteServerGroupEventHandler.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/events/DeleteServerGroupEventHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.events;
+
+import com.netflix.spinnaker.clouddriver.elasticsearch.ElasticSearchServerGroupTagger;
+import com.netflix.spinnaker.clouddriver.orchestration.events.DeleteServerGroupEvent;
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEventHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeleteServerGroupEventHandler implements OperationEventHandler {
+  private final ElasticSearchServerGroupTagger serverGroupTagger;
+
+  @Autowired
+  public DeleteServerGroupEventHandler(ElasticSearchServerGroupTagger serverGroupTagger) {
+    this.serverGroupTagger = serverGroupTagger;
+  }
+
+  @Override
+  public void handle(OperationEvent operationEvent) {
+    if (!(operationEvent instanceof DeleteServerGroupEvent)) {
+      return;
+    }
+
+    DeleteServerGroupEvent deleteServerGroupEvent = (DeleteServerGroupEvent) operationEvent;
+    serverGroupTagger.deleteAll(
+      deleteServerGroupEvent.getCloudProvider(),
+      deleteServerGroupEvent.getAccountId(),
+      deleteServerGroupEvent.getRegion(),
+      deleteServerGroupEvent.getName()
+    );
+  }
+}

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ElasticSearchServerGroupTaggerSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ElasticSearchServerGroupTaggerSpec.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch
+
+import spock.lang.Specification;
+
+class ElasticSearchServerGroupTaggerSpec extends Specification {
+  void "should construct valid UpsertEntityTagsDescription"() {
+    when:
+    def description = ElasticSearchServerGroupTagger.upsertEntityTagsDescription(
+      "myCloudProvider", "100", "us-east-1", "myServerGroup-v001", "MY_EVENT", "This server group failed to launch!"
+    )
+
+    then:
+    description.isPartial
+    description.entityRef.region == "us-east-1"
+    description.entityRef.accountId == "100"
+    description.entityRef.entityType == "servergroup"
+    description.entityRef.entityId == "myServerGroup-v001"
+    description.entityRef.cloudProvider == "myCloudProvider"
+
+    description.tags.size() == 1
+    description.tags[0].name == "spinnaker_ui_alert:my_event"
+    description.tags[0].value == [
+      message: "This server group failed to launch!",
+      type   : "alert"
+    ]
+  }
+
+  void "should construct valid DeleteEntityTagsDescription"() {
+    when:
+    def description = ElasticSearchServerGroupTagger.deleteEntityTagsDescription(
+      "myCloudProvider", "100", "us-east-1", "myServerGroup-v001"
+    )
+
+    then:
+    description.deleteAll
+    description.id == "mycloudprovider:servergroup:myservergroup-v001:100:us-east-1"
+    !description.tags
+  }
+}

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/events/DeleteServerGroupEventHandlerSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/events/DeleteServerGroupEventHandlerSpec.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.events
+
+import com.netflix.spinnaker.clouddriver.elasticsearch.ElasticSearchServerGroupTagger
+import com.netflix.spinnaker.clouddriver.orchestration.events.DeleteServerGroupEvent
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll;
+
+class DeleteServerGroupEventHandlerSpec extends Specification {
+  def serverGroupTagger = Mock(ElasticSearchServerGroupTagger)
+
+  @Subject
+  def eventHandler = new DeleteServerGroupEventHandler(serverGroupTagger)
+
+  @Unroll
+  void "should only handle DeleteServerGroupEvent"() {
+    given:
+    def operationEvent = Mock(OperationEvent) {
+      getType() >> { return OperationEvent.Type.SERVER_GROUP }
+      getAction() >> { return OperationEvent.Action.CREATE }
+      getCloudProvider() >> { return "aws" }
+    }
+
+    when:
+    eventHandler.handle(operationEvent)
+
+    then:
+    0 * serverGroupTagger.deleteAll(_, _, _, _)
+
+    when:
+    eventHandler.handle(new DeleteServerGroupEvent("aws", "accountId", "region", "serverGroup-v001"))
+
+    then:
+    1 * serverGroupTagger.deleteAll("aws", "accountId", "region", "serverGroup-v001")
+  }
+
+
+
+}


### PR DESCRIPTION
The `DeleteServerGroupEventHandler` will delete all tags associated with
a deleted server group (if ElasticSearch is enabled).