### PR TITLE
provider/appengine use service account email in deploy operation

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/AppEngineJobExecutor.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/AppEngineJobExecutor.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine
+
+import com.netflix.spinnaker.clouddriver.jobs.JobExecutor
+import com.netflix.spinnaker.clouddriver.jobs.JobRequest
+import com.netflix.spinnaker.clouddriver.jobs.JobStatus
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class AppEngineJobExecutor {
+  @Value('${appengine.jobSleepMs:1000}')
+  Long sleepMs
+
+  @Autowired
+  JobExecutor jobExecutor
+
+  void runCommand(List<String> command) {
+    String jobId = jobExecutor.startJob(new JobRequest(tokenizedCommand: command),
+                                        System.getenv(),
+                                        new ByteArrayInputStream())
+    waitForJobCompletion(jobId)
+  }
+
+  void waitForJobCompletion(String jobId) {
+    sleep(sleepMs)
+    JobStatus jobStatus = jobExecutor.updateJob(jobId)
+    while (jobStatus.state == JobStatus.State.RUNNING) {
+      sleep(sleepMs)
+      jobStatus = jobExecutor.updateJob(jobId)
+    }
+    if (jobStatus.result == JobStatus.Result.FAILURE && jobStatus.stdOut) {
+      throw new IllegalArgumentException("$jobStatus.stdOut + $jobStatus.stdErr")
+    }
+  }
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppEngineNamedAccountCredentials.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppEngineNamedAccountCredentials.groovy
@@ -38,6 +38,7 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
   final AppEngineCredentials credentials
   final String applicationName
   final Appengine appengine
+  final String serviceAccountEmail
 
   static class Builder {
     String name
@@ -52,6 +53,7 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
     String jsonPath
     String applicationName
     Appengine appengine
+    String serviceAccountEmail
 
     /*
     * If true, the builder will overwrite region with a value from the platform.
@@ -114,6 +116,11 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
       return this
     }
 
+    Builder serviceAccountEmail(String serviceAccountEmail) {
+      this.serviceAccountEmail = serviceAccountEmail
+      return this
+    }
+
     AppEngineNamedAccountCredentials build() {
       credentials = credentials ?:
         jsonKey ?
@@ -137,7 +144,8 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
                                                   jsonPath,
                                                   credentials,
                                                   applicationName,
-                                                  appengine)
+                                                  appengine,
+                                                  serviceAccountEmail)
     }
   }
 }


### PR DESCRIPTION
@lwander or @duftler please review.

Slightly reworks how the deploy operation works. Rather than activating a service account for every deploy operation, service accounts are activated on start-up. The deploy command runs just using the service account email and project name.