### PR TITLE
(Openstack) Support another time format.

### DIFF
--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/utils/DateUtilsSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/utils/DateUtilsSpec.groovy
@@ -65,9 +65,35 @@ class DateUtilsSpec extends Specification {
     noExceptionThrown()
   }
 
-  def 'exception when invalid date time format'() {
+  def 'parse zoned date time format'() {
+    given:
+    def time = '2011-12-03T10:15:30+01:00'
+    def expected = ZonedDateTime.parse(time, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
     when:
-    DateUtils.parseZonedDateTime('2011-12-03T10:15:30+01:00')
+    def actual = DateUtils.parseZonedDateTime(time)
+
+    then:
+    actual == expected
+    noExceptionThrown()
+  }
+
+  def 'parse UTC date time'() {
+    given:
+    def time = '2017-01-18T01:38:53Z'
+    def expected = ZonedDateTime.parse(time, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+    when:
+    def actual = DateUtils.parseZonedDateTime(time)
+
+    then:
+    actual == expected
+    noExceptionThrown()
+  }
+
+  def 'throws exception with unknown format'() {
+    when:
+    DateUtils.parseZonedDateTime('10:15:30+01:00')
 
     then:
     thrown(DateTimeParseException)


### PR DESCRIPTION
OpenStack has another time format it uses.

So, we have:

2011-12-03T10:15:30 (local time)
2011-12-03T10:15:30Z (UTC time)
2011-12-03T10:15:30+01:00 (With time zone offset)

The last possibly not supported in OpenStack anymore, but why take a
chance. Also, it is parsed by the same formatter as the UTC time. There
must be a config option in OpenStack controlling this.