### PR TITLE
(docker) Don't log stacktrace when catalog is empty

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -263,7 +263,7 @@ class DockerRegistryClient {
           registryService.getCatalog(paginateSize, token, clouddriverUserAgentApplicationName)
       }, "_catalog")
     } catch (Exception e) {
-      log.warn("Error encountered during catalog of $path", e)
+      log.warn("Error encountered during catalog of $path" + e.getMessage())
       return new DockerRegistryCatalog(repositories: [])
     }
 


### PR DESCRIPTION
Dockerhub doesn't implement /v2/_catalog, adding a lot of noise to the logs.

@duftler PTAL