### PR TITLE
refactors UserDataProvider interface to accept full LaunchConfigurationSettings

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilder.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilder.groovy
@@ -165,15 +165,7 @@ class DefaultLaunchConfigurationBuilder implements LaunchConfigurationBuilder {
     }
 
     String name = createName(settings)
-    String userData = getUserData(
-      settings.baseName,
-      name,
-      settings.region,
-      settings.account,
-      settings.environment,
-      settings.accountType,
-      settings.base64UserData ?: "",
-      legacyUdf)
+    String userData = getUserData(name, settings, legacyUdf)
     createLaunchConfiguration(name, userData, settings)
   }
 
@@ -220,11 +212,11 @@ class DefaultLaunchConfigurationBuilder implements LaunchConfigurationBuilder {
     }
   }
 
-  private String getUserData(String asgName, String launchConfigName, String region, String account, String environment, String accountType, String base64UserData, Boolean legacyUdf) {
+  private String getUserData(String launchConfigName, LaunchConfigurationSettings settings, Boolean legacyUdf) {
     String data = userDataProviders?.collect { udp ->
-      udp.getUserData(asgName, launchConfigName, region, account, environment, accountType, legacyUdf)
+      udp.getUserData(launchConfigName, settings, legacyUdf)
     }?.join("\n")
-    String userDataDecoded = new String(base64UserData.decodeBase64(), Charset.forName("UTF-8"))
+    String userDataDecoded = new String((settings.base64UserData ?: '').decodeBase64(), Charset.forName("UTF-8"))
     data = [data, userDataDecoded].findResults { it }.join("\n")
     if (data && data.startsWith("\n")) {
       data = data.substring(1)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProvider.groovy
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.userdata
 
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.aws.deploy.LaunchConfigurationBuilder
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import org.springframework.beans.factory.annotation.Autowired
 import retrofit.RetrofitError
@@ -61,11 +62,11 @@ class LocalFileUserDataProvider implements UserDataProvider {
   }
 
   @Override
-  String getUserData(String asgName, String launchConfigName, String region, String account, String environment, String accountType, Boolean legacyUdf) {
-    def names = Names.parseName(asgName)
-    boolean useLegacyUdf = legacyUdf != null ? legacyUdf : isLegacyUdf(account, names.app)
-    def rawUserData = assembleUserData(useLegacyUdf, names, region, account)
-    replaceUserDataTokens useLegacyUdf, names, launchConfigName, region, account, environment, accountType, rawUserData
+  String getUserData(String launchConfigName, LaunchConfigurationBuilder.LaunchConfigurationSettings settings, Boolean legacyUdf) {
+    def names = Names.parseName(settings.baseName)
+    boolean useLegacyUdf = legacyUdf != null ? legacyUdf : isLegacyUdf(settings.account, names.app)
+    def rawUserData = assembleUserData(useLegacyUdf, names, settings.region, settings.account)
+    replaceUserDataTokens useLegacyUdf, names, launchConfigName, settings.region, settings.account, settings.environment, settings.accountType, rawUserData
   }
 
   String assembleUserData(boolean legacyUdf, Names names, String region, String account) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/NullOpUserDataProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/NullOpUserDataProvider.groovy
@@ -17,8 +17,4 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.userdata
 
 class NullOpUserDataProvider implements UserDataProvider {
-  @Override
-  String getUserData(String asgName, String launchConfigName, String region, String account, String environment, String accountType, Boolean legacyUdf) {
-    ""
-  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/UserDataProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/UserDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,26 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.deploy.userdata
+package com.netflix.spinnaker.clouddriver.aws.deploy.userdata;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.LaunchConfigurationBuilder.LaunchConfigurationSettings;
 
 /**
  * Implementations of this interface will provide user data to instances during the deployment process
- *
- *
  */
 public interface UserDataProvider {
   /**
    * Returns user data that will be applied to a new instance. The launch configuration will not have been created at
    * this point in the workflow, but the name is provided, as it may be needed when building user data detail.
    *
-   * @param asgName
-   * @param launchConfigName
-   * @param region
-   *
-   * @return user data string
+   * @deprecated use getUserData(launchConfigName, settings, legacyUdf) instead
    */
-  String getUserData(String asgName, String launchConfigName, String region, String account, String environment, String accountType, Boolean legacyUdf)
+  @Deprecated
+  default String getUserData(String asgName, String launchConfigName, String region, String account, String environment, String accountType, Boolean legacyUdf) {
+    return "";
+  }
+
+  default String getUserData(String launchConfigName, LaunchConfigurationSettings settings, Boolean legacyUdf) {
+    return getUserData(settings.getBaseName(), launchConfigName, settings.getRegion(), settings.getAccount(), settings.getEnvironment(), settings.getAccountType(), legacyUdf);
+  }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilderSpec.groovy
@@ -31,7 +31,7 @@ class DefaultLaunchConfigurationBuilderSpec extends Specification {
   def asgService = Mock(AsgService)
   def securityGroupService = Mock(SecurityGroupService)
   def userDataProvider = Stub(UserDataProvider) {
-    getUserData(_, _, _, _, _, _, _) >> 'userdata'
+    getUserData(_, _, _) >> 'userdata'
   }
   def deployDefaults = new AwsConfiguration.DeployDefaults()
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProviderSpec.groovy
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.userdata
 
+import com.netflix.spinnaker.clouddriver.aws.deploy.LaunchConfigurationBuilder.LaunchConfigurationSettings
 import spock.lang.Specification
 
 class LocalFileUserDataProviderSpec extends Specification {
@@ -38,6 +39,13 @@ class LocalFileUserDataProviderSpec extends Specification {
   static final String ASG_NAME = "${APP}-${STACK}-${DETAIL}-c0${COUNTRIES}-d0${DEV_PHASE}-h0${HARDWARE}-p0${PARTNERS}-r0${REVISION}-z0${ZONE}"
   static final String LAUNCH_CONFIG_NAME = 'launchConfigName'
 
+  static final LaunchConfigurationSettings SETTINGS = new LaunchConfigurationSettings(
+      baseName: ASG_NAME,
+      region: REGION,
+      account: ACCOUNT,
+      environment: ENVIRONMENT,
+      accountType: ACCOUNT_TYPE)
+
   void "replaces expected strings"() {
     given:
     LocalFileUserDataProvider localFileUserDataProvider = GroovySpy()
@@ -46,7 +54,7 @@ class LocalFileUserDataProviderSpec extends Specification {
     localFileUserDataProvider.assembleUserData(legacyUdf, _, _, _) >> getRawUserData()
 
     when:
-    def userData = localFileUserDataProvider.getUserData(ASG_NAME, LAUNCH_CONFIG_NAME, REGION, ACCOUNT, ENVIRONMENT, ACCOUNT_TYPE, null)
+    def userData = localFileUserDataProvider.getUserData(LAUNCH_CONFIG_NAME, SETTINGS, null)
 
     then:
     userData == getFormattedUserData(expectedEnvironment)


### PR DESCRIPTION
Assuming someone had actually implemented a UserDataProvider in their own codebase, this change would be compatible (introduced new preferred method with a default impl that delegates to the deprecated method)