### PR TITLE
provider/appengine fixes NPE when project has no services

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/AppEngineUtils.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/AppEngineUtils.groovy
@@ -46,7 +46,7 @@ class AppEngineUtils {
         }
 
       credentials.appengine.apps().services().versions().list(project, service.getId()).queue(batch, callback)
-    }.flatten() as List<Version>
+    }
 
     batch.execute()
     return allVersions.flatten()


### PR DESCRIPTION
Fixes bug where a query for services fails if an App Engine application has no services.

@jtk54 

I think this is a relic from an earlier refactor, since it is really, egregiously wrong.