### PR TITLE
Added instrumentation into GoogleOperationPoller.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GoogleOperationPoller.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GoogleOperationPoller.groovy
@@ -19,13 +19,20 @@ package com.netflix.spinnaker.clouddriver.google.deploy
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Operation
 import com.google.common.annotations.VisibleForTesting
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationTimedOutException
 import org.springframework.beans.factory.annotation.Autowired
+import java.util.concurrent.TimeUnit;
+
 
 class GoogleOperationPoller {
+  static final String METRIC_NAME = "google.operationWaits"  // Timer
+  static final String STARTED_METRIC_NAME = "google.operationWaitRequests"  // Counter
 
   // This only exists to facilitate testing.
   static class ThreadSleeper {
@@ -33,6 +40,9 @@ class GoogleOperationPoller {
       Thread.currentThread().sleep(seconds * 1000)
     }
   }
+
+  @Autowired
+  Registry registry
 
   @Autowired
   GoogleConfigurationProperties googleConfigurationProperties
@@ -48,23 +58,32 @@ class GoogleOperationPoller {
   // either state is DONE or |timeoutSeconds| is reached.
   Operation waitForZonalOperation(Compute compute, String projectName, String zone, String operationName,
                                   Long timeoutSeconds, Task task, String resourceString, String basePhase) {
+    def tags = [basePhase: basePhase, scope: "zonal", zone:zone]
+    registry.counter(registry.createId(STARTED_METRIC_NAME, tags)).increment()
+    Id metricId = registry.createId(METRIC_NAME, tags)
     return handleFinishedAsyncOperation(
       waitForOperation({compute.zoneOperations().get(projectName, zone, operationName).execute()},
-        getTimeout(timeoutSeconds)), task, resourceString, basePhase)
+        metricId, getTimeout(timeoutSeconds)), task, resourceString, basePhase)
   }
 
   Operation waitForRegionalOperation(Compute compute, String projectName, String region, String operationName,
                                      Long timeoutSeconds, Task task, String resourceString, String basePhase) {
+    def tags = [basePhase: basePhase, scope: "regional", region: region]
+    registry.counter(registry.createId(STARTED_METRIC_NAME, tags)).increment()
+    Id metricId = registry.createId(METRIC_NAME, tags)
     return handleFinishedAsyncOperation(
         waitForOperation({compute.regionOperations().get(projectName, region, operationName).execute()},
-                         getTimeout(timeoutSeconds)), task, resourceString, basePhase)
+                         metricId, getTimeout(timeoutSeconds)), task, resourceString, basePhase)
   }
 
   Operation waitForGlobalOperation(Compute compute, String projectName, String operationName,
                                    Long timeoutSeconds, Task task, String resourceString, String basePhase) {
+    def tags = [basePhase: basePhase, scope: "global"]
+    registry.counter(registry.createId(STARTED_METRIC_NAME, tags)).increment()
+    Id metricId = registry.createId(METRIC_NAME, tags)
     return handleFinishedAsyncOperation(
         waitForOperation({compute.globalOperations().get(projectName, operationName).execute()},
-                         getTimeout(timeoutSeconds)), task, resourceString, basePhase)
+                         metricId, getTimeout(timeoutSeconds)), task, resourceString, basePhase)
   }
 
   private long getTimeout(Long timeoutSeconds) {
@@ -95,7 +114,9 @@ class GoogleOperationPoller {
     The timeoutSeconds parameter is really treated as a lower-bound. We will poll until the operation reaches a DONE
     state or until <em>at least</em> that many seconds have passed.
    */
-  private Operation waitForOperation(Closure<Operation> getOperation, long timeoutSeconds) {
+  private Operation waitForOperation(Closure<Operation> getOperation, Id metricId, long timeoutSeconds) {
+    Clock clock = registry.clock()
+    long startNs = clock.monotonicTime();
     int totalTimePollingSeconds = 0
     boolean timeoutExceeded = false
 
@@ -111,10 +132,12 @@ class GoogleOperationPoller {
       Operation operation = safeRetry.doRetry(getOperation, "wait", "operation", null, null, [], []) as Operation
 
       if (operation.getStatus() == "DONE") {
+        registry.timer(metricId.withTag("status", "DONE")).record(clock.monotonicTime() - startNs, TimeUnit.NANOSECONDS);
         return operation
       }
 
       if (totalTimePollingSeconds > timeoutSeconds) {
+        registry.timer(metricId.withTag("status", "TIMEOUT")).record(clock.monotonicTime() - startNs, TimeUnit.NANOSECONDS);
         timeoutExceeded = true
       } else {
         // Update polling interval.

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -23,6 +23,7 @@ import com.google.api.client.http.HttpResponseException
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
 import com.netflix.frigga.Names
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -54,6 +55,8 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
   private static final ZONE = "us-central1-b"
   private static final DONE = "DONE"
 
+  @Shared
+  def registry = new DefaultRegistry()
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
   @Shared
@@ -99,6 +102,7 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -179,6 +183,7 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -303,6 +308,7 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -390,6 +396,7 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -519,6 +526,7 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       destroy.safeRetry = safeRetry

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec.groovy
@@ -26,6 +26,7 @@ import com.google.api.services.compute.model.Metadata
 import com.google.api.services.compute.model.NetworkInterface
 import com.google.api.services.compute.model.Operation
 import com.google.api.services.compute.model.Tags
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -192,6 +193,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
           new GoogleOperationPoller(
             googleConfigurationProperties: new GoogleConfigurationProperties(),
             threadSleeper: threadSleeperMock,
+            registry: new DefaultRegistry(),
             safeRetry: safeRetry
           )
       operation.googleClusterProvider = googleClusterProviderMock

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleServerGroupTagsAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleServerGroupTagsAtomicOperationUnitSpec.groovy
@@ -25,6 +25,7 @@ import com.google.api.services.compute.model.InstanceTemplate
 import com.google.api.services.compute.model.InstanceWithNamedPorts
 import com.google.api.services.compute.model.Operation
 import com.google.api.services.compute.model.Tags
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -63,6 +64,8 @@ class UpsertGoogleServerGroupTagsAtomicOperationUnitSpec extends Specification {
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  def registry = new DefaultRegistry()
   @Shared
   SafeRetry safeRetry
 
@@ -131,6 +134,7 @@ class UpsertGoogleServerGroupTagsAtomicOperationUnitSpec extends Specification {
           new GoogleOperationPoller(
             googleConfigurationProperties: new GoogleConfigurationProperties(),
             threadSleeper: threadSleeperMock,
+            registry: registry,
             safeRetry: safeRetry
           )
       operation.googleClusterProvider = googleClusterProviderMock
@@ -243,6 +247,7 @@ class UpsertGoogleServerGroupTagsAtomicOperationUnitSpec extends Specification {
           new GoogleOperationPoller(
             googleConfigurationProperties: new GoogleConfigurationProperties(),
             threadSleeper: threadSleeperMock,
+            registry: registry,
             safeRetry: safeRetry
           )
       operation.googleClusterProvider = googleClusterProviderMock

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops.loadbalancer
 
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -55,6 +56,8 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  def registry = new DefaultRegistry()
   @Shared
   SafeRetry safeRetry
 
@@ -118,6 +121,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -246,6 +250,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -393,6 +398,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -477,6 +483,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -569,6 +576,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -668,6 +676,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -738,6 +747,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
@@ -22,6 +22,7 @@ import com.google.api.client.http.HttpHeaders
 import com.google.api.client.http.HttpResponseException
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -52,6 +53,8 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  def registry = new DefaultRegistry()
   @Shared
   SafeRetry safeRetry
 
@@ -107,6 +110,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       operation.googleOperationPoller = new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
       )
       operation.safeRetry = safeRetry
@@ -191,6 +195,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
       operation.safeRetry = safeRetry
@@ -275,6 +280,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
       operation.safeRetry = safeRetry
@@ -370,6 +376,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
       operation.safeRetry = safeRetry
@@ -460,6 +467,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
       operation.safeRetry = safeRetry
@@ -509,6 +517,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       operation.googleOperationPoller = new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
       operation.safeRetry = safeRetry

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -24,6 +24,7 @@ import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.ForwardingRule
 import com.google.api.services.compute.model.Operation
 import com.google.api.services.compute.model.TargetPool
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -53,6 +54,8 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  def registry = new DefaultRegistry()
   @Shared
   SafeRetry safeRetry
 
@@ -99,6 +102,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -161,6 +165,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -241,6 +246,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -290,6 +296,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -346,6 +353,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -427,6 +435,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -514,6 +523,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops.loadbalancer
 
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -51,6 +52,8 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  def registry = new DefaultRegistry()
   @Shared
   SafeRetry safeRetry
 
@@ -112,6 +115,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -238,6 +242,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops.loadbalancer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -46,6 +47,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
 
   @Shared GoogleHealthCheck hc
   @Shared def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared def registry = new DefaultRegistry()
   @Shared SafeRetry safeRetry
 
   def setupSpec() {
@@ -167,6 +169,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -289,6 +292,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           new GoogleOperationPoller(
             googleConfigurationProperties: new GoogleConfigurationProperties(),
             threadSleeper: threadSleeperMock,
+            registry: registry,
             safeRetry: safeRetry
           )
       operation.safeRetry = safeRetry
@@ -411,6 +415,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           new GoogleOperationPoller(
             googleConfigurationProperties: new GoogleConfigurationProperties(),
             threadSleeper: threadSleeperMock,
+            registry: registry,
             safeRetry: safeRetry
           )
       operation.safeRetry = safeRetry
@@ -563,6 +568,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -720,6 +726,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry
@@ -882,6 +889,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
       operation.safeRetry = safeRetry

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops.loadbalancer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -45,6 +46,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
 
   @Shared GoogleHealthCheck hc
   @Shared def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared def registry = new DefaultRegistry()
   @Shared SafeRetry safeRetry
 
   def setupSpec() {
@@ -127,6 +129,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
     operation.safeRetry = safeRetry
@@ -231,6 +234,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
     operation.safeRetry = safeRetry
@@ -335,6 +339,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
     operation.safeRetry = safeRetry

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -30,6 +30,7 @@ import com.google.api.services.compute.model.Region
 import com.google.api.services.compute.model.RegionList
 import com.google.api.services.compute.model.TargetPool
 import com.google.api.services.compute.model.TargetPoolList
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -73,6 +74,8 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
 
   @Shared
   def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared
+  def registry = new DefaultRegistry()
   @Shared
   SafeRetry safeRetry
 
@@ -128,6 +131,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
 
@@ -217,6 +221,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
 
@@ -287,6 +292,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
 
@@ -347,6 +353,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
 
@@ -691,6 +698,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
 
@@ -783,6 +791,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
 
@@ -882,6 +891,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
           threadSleeper: threadSleeperMock,
+          registry: registry,
           safeRetry: safeRetry
         )
 

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
@@ -22,6 +22,7 @@ import com.google.api.services.compute.model.BackendService
 import com.google.api.services.compute.model.HTTPHealthCheck
 import com.google.api.services.compute.model.HealthCheck
 import com.google.api.services.compute.model.Operation
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -50,6 +51,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
 
   @Shared GoogleHealthCheck hc
   @Shared def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared def registry = new DefaultRegistry()
   @Shared SafeRetry safeRetry
 
   def setupSpec() {
@@ -138,6 +140,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
       new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
     operation.safeRetry = safeRetry
@@ -250,6 +253,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
       new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
     operation.safeRetry = safeRetry
@@ -362,6 +366,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
       new GoogleOperationPoller(
         googleConfigurationProperties: new GoogleConfigurationProperties(),
         threadSleeper: threadSleeperMock,
+        registry: registry,
         safeRetry: safeRetry
       )
     operation.safeRetry = safeRetry


### PR DESCRIPTION
Measures how long each of the polling requests takes to complete.

This change is encapsulated within GoogleOperationPoller however every operation test is affected because they need to provide Spring with an auto-wireable Spectator Registry.

@duftler