### PR TITLE
Titus: link titus task to discovery instance with the instanceId

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProvider.groovy
@@ -42,7 +42,7 @@ class TitusCachingProvider implements Provider, EurekaAwareProvider {
 
   @Override
   Boolean isProviderForEurekaRecord(Map<String, Object> attributes) {
-    attributes.containsKey('titusTaskId') && attributes.get('titusTaskId') != null
+    attributes.containsKey('titusTaskId') && attributes.get('titusTaskId') != null && attributes.get('instanceId') != null
   }
 
   @Override
@@ -52,7 +52,7 @@ class TitusCachingProvider implements Provider, EurekaAwareProvider {
 
   @Override
   String getInstanceHealthKey(Map<String, Object> attributes,  String region, String healthId) {
-    Keys.getInstanceHealthKey(attributes.titusTaskId, healthId)
+    Keys.getInstanceHealthKey(attributes.instanceId, healthId)
   }
 
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
@@ -241,7 +241,7 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster> {
     instanceData.each { instanceEntry ->
       externalHealthProviders.each { externalHealthProvider ->
         externalHealthProvider.agents.each { externalHealthAgent ->
-          def key = Keys.getInstanceHealthKey(instanceEntry.attributes.task.id, externalHealthAgent.healthId)
+          def key = Keys.getInstanceHealthKey(instanceEntry.attributes.task.instanceId, externalHealthAgent.healthId)
           healthKeysToInstance.put(key, instanceEntry.id)
         }
       }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusInstanceProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusInstanceProvider.groovy
@@ -70,7 +70,7 @@ class TitusInstanceProvider implements InstanceProvider<TitusInstance> {
     externalHealthProviders.each { externalHealthProvider ->
       def healthKeys = []
       externalHealthProvider.agents.each { externalHealthAgent ->
-        healthKeys << Keys.getInstanceHealthKey(instance.name, externalHealthAgent.healthId)
+        healthKeys << Keys.getInstanceHealthKey(instance.instanceId, externalHealthAgent.healthId)
       }
       healthKeys.unique().each { key ->
         def externalHealth = cacheView.getAll(HEALTH.ns, key)


### PR DESCRIPTION
Given that instanceId is is the value needed to enable / disable via discovery API, it makes sense to link via this value instead of the titusTaskId in the metadata. This change will surface issues in discovery payload better at deploy time rather than at destroy time of the titus job.