### PR TITLE
provider/appengine switch to jgit in deploy operation

### DIFF
--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -7,4 +7,5 @@ dependencies {
 
   // TODO(dpeach): move to spinnaker/spinnaker-dependencies.
   compile "com.google.apis:google-api-services-appengine:v1-rev4-1.22.0"
+  compile "org.eclipse.jgit:org.eclipse.jgit:4.5.0.201609210915-r"
 }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppEngineConfigurationProperties.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppEngineConfigurationProperties.groovy
@@ -34,6 +34,12 @@ class AppEngineConfigurationProperties {
     static final String metadataUrl = "http://metadata.google.internal/computeMetadata/v1"
 
     String serviceAccountEmail
+    String localRepositoryDirectory
+    String gitHttpsUsername
+    String gitHttpsPassword
+    String githubOAuthAccessToken
+    String sshPrivateKeyFilePath
+    String sshPrivateKeyPassword
 
     void initialize(AppEngineJobExecutor jobExecutor) {
       if (this.jsonPath) {

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppEngineDescription.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppEngineDescription.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.appengine.deploy.description
 
+import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppEngineGitCredentialType
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
@@ -28,6 +29,7 @@ class DeployAppEngineDescription extends AbstractAppEngineCredentialsDescription
   String stack
   String freeFormDetails
   String repositoryUrl
+  AppEngineGitCredentialType gitCredentialType
   String branch
   String appYamlPath
   Boolean promote

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppEngineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppEngineDescriptionValidator.groovy
@@ -39,6 +39,13 @@ class DeployAppEngineDescriptionValidator extends DescriptionValidator<DeployApp
       return
     }
 
+    if (!helper.validateGitCredentials(description.credentials.gitCredentials,
+                                       description.gitCredentialType,
+                                       description.credentials.name,
+                                       "gitCredentialType")) {
+      return
+    }
+
     helper.validateApplication(description.application, "application")
     helper.validateStack(description.stack, "stack")
     helper.validateDetails(description.freeFormDetails, "freeFormDetails")

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StandardAppEngineAttributeValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StandardAppEngineAttributeValidator.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppEngineGitCredentialType
+import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppEngineGitCredentials
 import com.netflix.spinnaker.clouddriver.appengine.model.AppEngineInstance
 import com.netflix.spinnaker.clouddriver.appengine.model.AppEngineServerGroup
 import com.netflix.spinnaker.clouddriver.appengine.model.AppEngineTrafficSplit
@@ -50,6 +52,25 @@ class StandardAppEngineAttributeValidator {
       }
     }
     result
+  }
+
+  def validateGitCredentials(AppEngineGitCredentials gitCredentials,
+                             AppEngineGitCredentialType gitCredentialType,
+                             String accountName,
+                             String attribute) {
+    if (validateNotEmpty(gitCredentialType, attribute)) {
+      def supportedCredentialTypes = gitCredentials.getSupportedCredentialTypes()
+      def credentialTypeSupported = supportedCredentialTypes.contains(gitCredentialType)
+      if (credentialTypeSupported) {
+        return true
+      } else {
+        errors.rejectValue("${context}.${attribute}",  "${context}.${attribute}.invalid" +
+                           " (Account ${accountName} supports only the following git credential types: ${supportedCredentialTypes.join(", ")}")
+        return false
+      }
+    } else {
+      return false
+    }
   }
 
   def validateNotEmpty(Object value, String attribute) {

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gitClient/AppEngineGitCredentialType.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gitClient/AppEngineGitCredentialType.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.gitClient
+
+enum AppEngineGitCredentialType {
+  NONE,
+  HTTPS_USERNAME_PASSWORD,
+  HTTPS_GITHUB_OAUTH_TOKEN,
+  SSH,
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gitClient/AppEngineGitCredentials.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gitClient/AppEngineGitCredentials.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.gitClient
+
+import com.jcraft.jsch.JSch
+import com.jcraft.jsch.JSchException
+import com.jcraft.jsch.Session
+import org.eclipse.jgit.api.TransportConfigCallback
+import org.eclipse.jgit.transport.JschConfigSessionFactory
+import org.eclipse.jgit.transport.OpenSshConfig
+import org.eclipse.jgit.transport.SshSessionFactory
+import org.eclipse.jgit.transport.SshTransport
+import org.eclipse.jgit.transport.Transport
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
+import org.eclipse.jgit.util.FS
+
+// Taken from http://www.codeaffine.com/2014/12/09/jgit-authentication/
+
+class AppEngineGitCredentials {
+  UsernamePasswordCredentialsProvider httpsUsernamePasswordCredentialsProvider
+  UsernamePasswordCredentialsProvider httpsOAuthCredentialsProvider
+  TransportConfigCallback sshTransportConfigCallback
+
+  AppEngineGitCredentials() {}
+
+  AppEngineGitCredentials(String gitHttpsUsername,
+                          String gitHttpsPassword,
+                          String githubOAuthAccessToken,
+                          String sshPrivateKeyFilePath,
+                          String sshPrivateKeyPassword) {
+    setHttpsUsernamePasswordCredentialsProvider(gitHttpsUsername, gitHttpsPassword)
+    setHttpsOAuthCredentialsProvider(githubOAuthAccessToken)
+    setSshPrivateKeyTransportConfigCallback(sshPrivateKeyFilePath, sshPrivateKeyPassword)
+  }
+
+  AppEngineGitRepositoryClient buildRepositoryClient(String repositoryUrl,
+                                                     String targetDirectory,
+                                                     AppEngineGitCredentialType credentialType) {
+    new AppEngineGitRepositoryClient(repositoryUrl, targetDirectory, credentialType, this)
+  }
+
+  List<AppEngineGitCredentialType> getSupportedCredentialTypes() {
+    def supportedTypes = [AppEngineGitCredentialType.NONE]
+
+    if (httpsUsernamePasswordCredentialsProvider) {
+      supportedTypes << AppEngineGitCredentialType.HTTPS_USERNAME_PASSWORD
+    }
+
+    if (httpsOAuthCredentialsProvider) {
+      supportedTypes << AppEngineGitCredentialType.HTTPS_GITHUB_OAUTH_TOKEN
+    }
+
+    if (sshTransportConfigCallback) {
+      supportedTypes << AppEngineGitCredentialType.SSH
+    }
+
+    return supportedTypes
+  }
+
+  void setHttpsUsernamePasswordCredentialsProvider(String gitHttpsUsername, String gitHttpsPassword) {
+    if (gitHttpsUsername && gitHttpsPassword) {
+      httpsUsernamePasswordCredentialsProvider = new UsernamePasswordCredentialsProvider(gitHttpsUsername, gitHttpsPassword)
+    }
+  }
+
+  void setHttpsOAuthCredentialsProvider(String githubOAuthAccessToken) {
+    if (githubOAuthAccessToken) {
+      httpsOAuthCredentialsProvider = new UsernamePasswordCredentialsProvider(githubOAuthAccessToken, "")
+    }
+  }
+
+  void setSshPrivateKeyTransportConfigCallback(String sshPrivateKeyFilePath, String sshPrivateKeyPassword) {
+    if (sshPrivateKeyPassword && sshPrivateKeyPassword) {
+      SshSessionFactory sshSessionFactory = new JschConfigSessionFactory() {
+        @Override
+        protected void configure(OpenSshConfig.Host hc, Session session) { }
+
+        @Override
+        protected JSch createDefaultJSch(FS fs) throws JSchException {
+          JSch defaultJSch = super.createDefaultJSch(fs)
+          defaultJSch.addIdentity(sshPrivateKeyFilePath, sshPrivateKeyPassword)
+          return defaultJSch
+        }
+      }
+
+      sshTransportConfigCallback = new TransportConfigCallback() {
+        @Override
+        void configure(Transport transport) {
+          SshTransport sshTransport = (SshTransport) transport
+          sshTransport.setSshSessionFactory(sshSessionFactory)
+        }
+      }
+    }
+  }
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gitClient/AppEngineGitRepositoryClient.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gitClient/AppEngineGitRepositoryClient.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.gitClient
+
+import groovy.transform.TupleConstructor
+import org.eclipse.jgit.api.CloneCommand
+import org.eclipse.jgit.api.FetchCommand
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.TransportCommand
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+
+@TupleConstructor
+class AppEngineGitRepositoryClient {
+  String repositoryUrl
+  String targetDirectory
+  AppEngineGitCredentialType credentialType
+  AppEngineGitCredentials config
+
+  void cloneRepository() {
+    CloneCommand command = Git.cloneRepository()
+      .setURI(repositoryUrl)
+      .setDirectory(new File(targetDirectory))
+
+    attachCredentials(command)
+
+    command.call()
+  }
+
+  void fetch() {
+    Repository repo = FileRepositoryBuilder.create(new File(targetDirectory, ".git"))
+    FetchCommand command = new Git(repo).fetch()
+
+    attachCredentials(command)
+
+    command.call()
+  }
+
+  void checkout(String branch) {
+    Repository repo = FileRepositoryBuilder.create(new File(targetDirectory, ".git"))
+    new Git(repo).checkout().setName("origin/$branch").call()
+  }
+
+  private <T extends TransportCommand> void attachCredentials(T command) {
+    switch (credentialType) {
+      case AppEngineGitCredentialType.HTTPS_USERNAME_PASSWORD:
+        command.setCredentialsProvider(config.httpsUsernamePasswordCredentialsProvider)
+        break
+      case AppEngineGitCredentialType.HTTPS_GITHUB_OAUTH_TOKEN:
+        command.setCredentialsProvider(config.httpsOAuthCredentialsProvider)
+        break
+      case AppEngineGitCredentialType.SSH:
+        command.setTransportConfigCallback(config.sshTransportConfigCallback)
+        break
+      case AppEngineGitCredentialType.NONE:
+      default:
+        break
+    }
+  }
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppEngineCredentialsInitializer.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppEngineCredentialsInitializer.groovy
@@ -75,6 +75,12 @@ class AppEngineCredentialsInitializer implements CredentialsInitializerSynchroni
           .jsonPath(managedAccount.jsonPath)
           .requiredGroupMembership(managedAccount.requiredGroupMembership)
           .serviceAccountEmail(managedAccount.serviceAccountEmail)
+          .localRepositoryDirectory(managedAccount.localRepositoryDirectory)
+          .gitHttpsUsername(managedAccount.gitHttpsUsername)
+          .gitHttpsPassword(managedAccount.gitHttpsPassword)
+          .githubOAuthAccessToken(managedAccount.githubOAuthAccessToken)
+          .sshPrivateKeyFilePath(managedAccount.sshPrivateKeyFilePath)
+          .sshPrivateKeyPassword(managedAccount.sshPrivateKeyPassword)
           .build()
 
         accountCredentialsRepository.save(managedAccount.name, appEngineAccount)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppEngineNamedAccountCredentials.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppEngineNamedAccountCredentials.groovy
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.appengine.security
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.google.api.services.appengine.v1.Appengine
 import com.netflix.spinnaker.clouddriver.appengine.AppEngineCloudProvider
+import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppEngineGitCredentialType
+import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppEngineGitCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import groovy.transform.TupleConstructor
 
@@ -37,8 +39,15 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
   final String jsonPath
   final AppEngineCredentials credentials
   final String applicationName
+  @JsonIgnore
   final Appengine appengine
+  @JsonIgnore
   final String serviceAccountEmail
+  @JsonIgnore
+  final String localRepositoryDirectory
+  @JsonIgnore
+  final AppEngineGitCredentials gitCredentials
+  final List<AppEngineGitCredentialType> supportedGitCredentialTypes
 
   static class Builder {
     String name
@@ -54,6 +63,13 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
     String applicationName
     Appengine appengine
     String serviceAccountEmail
+    String localRepositoryDirectory
+    String gitHttpsUsername
+    String gitHttpsPassword
+    String githubOAuthAccessToken
+    String sshPrivateKeyFilePath
+    String sshPrivateKeyPassword
+    AppEngineGitCredentials gitCredentials
 
     /*
     * If true, the builder will overwrite region with a value from the platform.
@@ -121,6 +137,41 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
       return this
     }
 
+    Builder localRepositoryDirectory(String localRepositoryDirectory) {
+      this.localRepositoryDirectory = localRepositoryDirectory
+      return this
+    }
+
+    Builder gitHttpsUsername(String gitHttpsUsername) {
+      this.gitHttpsUsername = gitHttpsUsername
+      return this
+    }
+
+    Builder gitHttpsPassword(String gitHttpsPassword) {
+      this.gitHttpsPassword = gitHttpsPassword
+      return this
+    }
+
+    Builder githubOAuthAccessToken(String githubOAuthAccessToken) {
+      this.githubOAuthAccessToken = githubOAuthAccessToken
+      return this
+    }
+
+    Builder sshPrivateKeyFilePath(String sshPrivateKeyFilePath) {
+      this.sshPrivateKeyFilePath = sshPrivateKeyFilePath
+      return this
+    }
+
+    Builder sshPrivateKeyPassword(String sshPrivateKeyPassword) {
+      this.sshPrivateKeyPassword = sshPrivateKeyPassword
+      return this
+    }
+
+    Builder gitCredentials(AppEngineGitCredentials gitCredentials) {
+      this.gitCredentials = gitCredentials
+      return this
+    }
+
     AppEngineNamedAccountCredentials build() {
       credentials = credentials ?:
         jsonKey ?
@@ -132,6 +183,14 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
       if (liveLookupsEnabled) {
         region = appengine.apps().get(project).execute().getLocationId()
       }
+
+      gitCredentials = gitCredentials ?: new AppEngineGitCredentials(
+        gitHttpsUsername,
+        gitHttpsPassword,
+        githubOAuthAccessToken,
+        sshPrivateKeyFilePath,
+        sshPrivateKeyPassword
+      )
 
       return new AppEngineNamedAccountCredentials(name,
                                                   environment,
@@ -145,7 +204,10 @@ class AppEngineNamedAccountCredentials implements AccountCredentials<AppEngineCr
                                                   credentials,
                                                   applicationName,
                                                   appengine,
-                                                  serviceAccountEmail)
+                                                  serviceAccountEmail,
+                                                  localRepositoryDirectory,
+                                                  gitCredentials,
+                                                  gitCredentials.getSupportedCredentialTypes())
     }
   }
 }

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppEngineDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppEngineDescriptionValidatorSpec.groovy
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.DeployAppEngineDescription
+import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppEngineGitCredentialType
+import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppEngineGitCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppEngineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppEngineNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
@@ -38,18 +40,22 @@ class DeployAppEngineDescriptionValidatorSpec extends Specification {
   @Shared
   DeployAppEngineDescriptionValidator validator
 
+  @Shared
+  AppEngineNamedAccountCredentials credentials
+
   void setupSpec() {
     validator = new DeployAppEngineDescriptionValidator()
 
     def credentialsRepo = new MapBackedAccountCredentialsRepository()
     def mockCredentials = Mock(AppEngineCredentials)
-    def namedAccountCredentials = new AppEngineNamedAccountCredentials.Builder()
+    credentials = new AppEngineNamedAccountCredentials.Builder()
       .name(ACCOUNT_NAME)
       .region(REGION)
       .applicationName(APPLICATION_NAME)
       .credentials(mockCredentials)
+      .gitCredentials(new AppEngineGitCredentials())
       .build()
-    credentialsRepo.save(ACCOUNT_NAME, namedAccountCredentials)
+    credentialsRepo.save(ACCOUNT_NAME, credentials)
 
     validator.accountCredentialsProvider = new DefaultAccountCredentialsProvider(credentialsRepo)
   }
@@ -65,7 +71,9 @@ class DeployAppEngineDescriptionValidatorSpec extends Specification {
         branch: BRANCH,
         appYamlPath: APP_YAML_PATH,
         promote: true,
-        stopPreviousVersion: true)
+        stopPreviousVersion: true,
+        credentials: credentials,
+        gitCredentialType: AppEngineGitCredentialType.NONE)
       def errors = Mock(Errors)
 
     when:
@@ -82,7 +90,9 @@ class DeployAppEngineDescriptionValidatorSpec extends Specification {
         application: APPLICATION_NAME,
         repositoryUrl: REPOSITORY_URL,
         branch: BRANCH,
-        appYamlPath: APP_YAML_PATH)
+        appYamlPath: APP_YAML_PATH,
+        credentials: credentials,
+        gitCredentialType: AppEngineGitCredentialType.NONE)
       def errors = Mock(Errors)
 
     when:


### PR DESCRIPTION
@duftler or @lwander please review.

- Removes git CLI / adds JGit.
- Adds support for configurable HTTPS/SSH authentication for git repositories.
- Allows configurable parent directory for local repositories.

There will be a corresponding Deck PR that will allow the user to specify the git credential type on the deploy description.