### PR TITLE
Adding instance termination lifecycle to pull apps out of Eureka faster

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/ARN.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/ARN.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class ARN {
+
+  static final Pattern PATTERN = Pattern.compile("arn:aws:.*:(.*):(\\d+):(.*)");
+
+  String arn;
+  String region;
+  String name;
+
+  NetflixAmazonCredentials account;
+
+  ARN(Collection<? extends AccountCredentials> accountCredentials, String arn) {
+    this.arn = arn;
+
+    Matcher sqsMatcher = PATTERN.matcher(arn);
+    if (!sqsMatcher.matches()) {
+      throw new IllegalArgumentException(arn + " is not a valid SNS or SQS ARN");
+    }
+
+    this.region = sqsMatcher.group(1);
+    this.name = sqsMatcher.group(3);
+
+    String accountId = sqsMatcher.group(2);
+    this.account = (NetflixAmazonCredentials) accountCredentials.stream()
+      .filter(c -> accountId.equals(c.getAccountId()))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("No account credentials found for " + accountId));
+
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.lifecycle
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("aws.lifecycleSubscribers.instanceTermination")
+class InstanceTerminationConfigurationProperties {
+  String accountName
+  String queueARN
+  String sourceARN
+
+  int maxMessagesPerCycle = 1000
+  int visibilityTimeout = 30
+  int waitTimeSeconds = 5
+
+  InstanceTerminationConfigurationProperties() {
+    // default constructor
+  }
+
+  InstanceTerminationConfigurationProperties(String accountName,
+                                             String queueARN,
+                                             String sourceARN,
+                                             int maxMessagesPerCycle,
+                                             int visibilityTimeout,
+                                             int waitTimeSeconds) {
+    this.accountName = accountName
+    this.queueARN = queueARN
+    this.sourceARN = sourceARN
+    this.maxMessagesPerCycle = maxMessagesPerCycle
+    this.visibilityTimeout = visibilityTimeout
+    this.waitTimeSeconds = waitTimeSeconds
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgent.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.amazonaws.auth.policy.Condition;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Principal;
+import com.amazonaws.auth.policy.Resource;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.actions.SQSActions;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiptHandleIsInvalidException;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.RunnableAgent;
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableInstanceDiscoveryDescription;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent;
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTask;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport.DiscoveryStatus;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Provider;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class InstanceTerminationLifecycleAgent implements RunnableAgent, CustomScheduledAgent {
+
+  private static final Logger log = LoggerFactory.getLogger(InstanceTerminationLifecycleAgent.class);
+
+  private static final int AWS_MAX_NUMBER_OF_MESSAGES = 10;
+  private static final String SUPPORTED_LIFECYCLE_TRANSITION = "autoscaling:EC2_INSTANCE_TERMINATING";
+
+  ObjectMapper objectMapper;
+  AmazonClientProvider amazonClientProvider;
+  AccountCredentialsProvider accountCredentialsProvider;
+  InstanceTerminationConfigurationProperties properties;
+  Provider<AwsEurekaSupport> discoverySupport;
+
+  private final ARN queueARN;
+
+  private String queueId = null;
+
+  public InstanceTerminationLifecycleAgent(ObjectMapper objectMapper,
+                                           AmazonClientProvider amazonClientProvider,
+                                           AccountCredentialsProvider accountCredentialsProvider,
+                                           InstanceTerminationConfigurationProperties properties,
+                                           Provider<AwsEurekaSupport> discoverySupport) {
+    this.objectMapper = objectMapper;
+    this.amazonClientProvider = amazonClientProvider;
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.properties = properties;
+    this.discoverySupport = discoverySupport;
+
+    Set<? extends AccountCredentials> accountCredentials = accountCredentialsProvider.getAll();
+    this.queueARN = new ARN(accountCredentials, properties.getQueueARN());
+  }
+
+  @Override
+  public String getAgentType() {
+    return queueARN.account.getName() + "/" + queueARN.region + "/" + InstanceTerminationLifecycleAgent.class.getSimpleName();
+  }
+
+  @Override
+  public String getProviderName() {
+    return AwsProvider.PROVIDER_NAME;
+  }
+
+  @Override
+  public long getPollIntervalMillis() {
+    return TimeUnit.SECONDS.toMillis(30);
+  }
+
+  @Override
+  public long getTimeoutMillis() {
+    return -1;
+  }
+
+  @Override
+  public void run() {
+    AmazonSQS amazonSQS = amazonClientProvider.getAmazonSQS(queueARN.account, queueARN.region);
+
+    Set<String> allAccountIds = accountCredentialsProvider.getAll()
+      .stream()
+      .map(AccountCredentials::getAccountId)
+      .filter(a -> a != null)
+      .collect(Collectors.toSet());
+
+    this.queueId = ensureQueueExists(amazonSQS, queueARN, properties.getSourceARN(), allAccountIds);
+
+    AtomicInteger messagesProcessed = new AtomicInteger(0);
+    while (messagesProcessed.get() < properties.getMaxMessagesPerCycle()) {
+      ReceiveMessageResult receiveMessageResult = amazonSQS.receiveMessage(
+        new ReceiveMessageRequest(queueId)
+          .withMaxNumberOfMessages(AWS_MAX_NUMBER_OF_MESSAGES)
+          .withVisibilityTimeout(properties.getVisibilityTimeout())
+          .withWaitTimeSeconds(properties.getWaitTimeSeconds())
+      );
+
+      if (receiveMessageResult.getMessages().isEmpty()) {
+        // No messages
+        break;
+      }
+
+      receiveMessageResult.getMessages().forEach(message -> {
+        try {
+          LifecycleMessage lifecycleMessage = objectMapper.readValue(message.getBody(), LifecycleMessage.class);
+
+          if (SUPPORTED_LIFECYCLE_TRANSITION.equalsIgnoreCase(lifecycleMessage.lifecycleTransition)) {
+            Task originalTask = TaskRepository.threadLocalTask.get();
+            try {
+              TaskRepository.threadLocalTask.set(
+                Optional.ofNullable(originalTask).orElse(new DefaultTask(InstanceTerminationLifecycleAgent.class.getSimpleName()))
+              );
+              handleMessage(lifecycleMessage, TaskRepository.threadLocalTask.get());
+            } finally {
+              TaskRepository.threadLocalTask.set(originalTask);
+            }
+          }
+        } catch (IOException e) {
+          log.error("Unable to convert NotificationMessage (body: {})", message.getBody(), e);
+        }
+
+        deleteMessage(amazonSQS, queueId, message);
+        messagesProcessed.incrementAndGet();
+      });
+    }
+
+    log.info("Processed {} messages (queueARN: {})", messagesProcessed.get(), queueARN.arn);
+  }
+
+  private void handleMessage(LifecycleMessage message, Task task) {
+    List<String> instanceIds = Collections.singletonList(message.ec2InstanceId);
+
+    EnableDisableInstanceDiscoveryDescription description = new EnableDisableInstanceDiscoveryDescription();
+    description.setCredentials(getAccountCredentialsById(message.accountId));
+    description.setRegion(queueARN.region);
+    description.setAsgName(message.autoScalingGroupName);
+    description.setInstanceIds(instanceIds);
+
+    discoverySupport.get().updateDiscoveryStatusForInstances(
+      description, task, "handleLifecycleMessage", DiscoveryStatus.Disable, instanceIds
+    );
+  }
+
+  private static void deleteMessage(AmazonSQS amazonSQS, String queueUrl, Message message) {
+    try {
+      amazonSQS.deleteMessage(queueUrl, message.getReceiptHandle());
+    } catch (ReceiptHandleIsInvalidException e) {
+      log.warn("Error deleting lifecycle message, reason: {} (receiptHandle: {})", e.getMessage(), message.getReceiptHandle());
+    }
+  }
+
+  private NetflixAmazonCredentials getAccountCredentialsById(String accountId) {
+    return (NetflixAmazonCredentials) accountCredentialsProvider.getAll()
+      .stream()
+      .filter(c -> c.getAccountId().equals(accountId))
+      .findFirst()
+      .orElseThrow((Supplier<RuntimeException>) () -> {
+        return new RuntimeException(String.format("Unable to find AmazonCredentials by id (id: %s)", accountId));
+      });
+  }
+
+  private static String ensureQueueExists(AmazonSQS amazonSQS, ARN queueARN, String sourceARN, Set<String> allAccountIds) {
+    String queueUrl = amazonSQS.createQueue(queueARN.name).getQueueUrl();
+    amazonSQS.setQueueAttributes(
+      queueUrl, Collections.singletonMap("Policy", buildSQSPolicy(queueARN, sourceARN, allAccountIds).toJson())
+    );
+
+    return queueUrl;
+  }
+
+  private static Policy buildSQSPolicy(ARN queue, String sourceARN, Set<String> allAccountIds) {
+    Statement statement = new Statement(Statement.Effect.Allow).withActions(SQSActions.SendMessage);
+    statement.setPrincipals(allAccountIds.stream().map(Principal::new).collect(Collectors.toList()));
+    statement.setResources(Collections.singletonList(new Resource(queue.arn)));
+
+    statement.setConditions(Collections.singletonList(
+      new Condition().withType("ArnLike").withConditionKey("aws:SourceArn").withValues(sourceARN)
+    ));
+
+    return new Policy("allow-remote-account-send", Collections.singletonList(statement));
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.Agent;
+import com.netflix.spinnaker.cats.agent.AgentProvider;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+
+import javax.inject.Provider;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class InstanceTerminationLifecycleAgentProvider implements AgentProvider {
+  private final static String REGION_TEMPLATE_PATTERN = Pattern.quote("{{region}}");
+  private final static String ACCOUNT_ID_TEMPLATE_PATTERN = Pattern.quote("{{accountId}}");
+
+  private final ObjectMapper objectMapper;
+  private final AmazonClientProvider amazonClientProvider;
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final InstanceTerminationConfigurationProperties properties;
+  private final Provider<AwsEurekaSupport> discoverySupport;
+
+  InstanceTerminationLifecycleAgentProvider(ObjectMapper objectMapper,
+                                            AmazonClientProvider amazonClientProvider,
+                                            AccountCredentialsProvider accountCredentialsProvider,
+                                            InstanceTerminationConfigurationProperties properties,
+                                            Provider<AwsEurekaSupport> discoverySupport) {
+    this.objectMapper = objectMapper;
+    this.amazonClientProvider = amazonClientProvider;
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.properties = properties;
+    this.discoverySupport = discoverySupport;
+  }
+
+  @Override
+  public boolean supports(String providerName) {
+    return providerName.equalsIgnoreCase(AwsProvider.PROVIDER_NAME);
+  }
+
+  @Override
+  public Collection<Agent> agents() {
+    NetflixAmazonCredentials credentials = (NetflixAmazonCredentials) accountCredentialsProvider.getCredentials(
+      properties.getAccountName()
+    );
+
+    // an agent for each region in the specified account
+    return credentials.getRegions().stream()
+      .map(region -> new InstanceTerminationLifecycleAgent(
+        objectMapper,
+        amazonClientProvider,
+        accountCredentialsProvider,
+        new InstanceTerminationConfigurationProperties(
+          properties.getAccountName(),
+          properties
+            .getQueueARN()
+            .replaceAll(REGION_TEMPLATE_PATTERN, region.getName())
+            .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
+          properties.getSourceARN()
+            .replaceAll(REGION_TEMPLATE_PATTERN, region.getName())
+            .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
+          properties.getMaxMessagesPerCycle(),
+          properties.getVisibilityTimeout(),
+          properties.getWaitTimeSeconds()
+        ),
+        discoverySupport
+      ))
+      .collect(Collectors.toList());
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LifecycleMessage.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LifecycleMessage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.lifecycle;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LifecycleMessage {
+  @JsonProperty("LifecycleActionToken")
+  String lifecycleActionToken;
+
+  @JsonProperty("AccountId")
+  String accountId;
+
+  @JsonProperty("AutoScalingGroupName")
+  String autoScalingGroupName;
+
+  @JsonProperty("LifecycleHookName")
+  String lifecycleHookName;
+
+  @JsonProperty("EC2InstanceId")
+  String ec2InstanceId;
+
+  @JsonProperty("LifecycleTransition")
+  String lifecycleTransition;
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LifecycleSubscriberConfiguration.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LifecycleSubscriberConfiguration.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.lifecycle;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import com.netflix.spinnaker.clouddriver.tags.ServerGroupTagger;
@@ -25,9 +26,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import javax.inject.Provider;
+
 @Configuration
-@EnableConfigurationProperties(LaunchFailureConfigurationProperties.class)
+@EnableConfigurationProperties({LaunchFailureConfigurationProperties.class, InstanceTerminationConfigurationProperties.class})
 class LifecycleSubscriberConfiguration {
+
   @Bean
   @ConditionalOnProperty("aws.lifecycleSubscribers.launchFailure.enabled")
   LaunchFailureNotificationAgentProvider launchFailureNotificationAgentProvider(ObjectMapper objectMapper,
@@ -37,6 +41,18 @@ class LifecycleSubscriberConfiguration {
                                                                                 ServerGroupTagger serverGroupTagger) {
     return new LaunchFailureNotificationAgentProvider(
       objectMapper, amazonClientProvider, accountCredentialsProvider, properties, serverGroupTagger
+    );
+  }
+
+  @Bean
+  @ConditionalOnProperty("aws.lifecycleSubscribers.instanceTermination.enabled")
+  InstanceTerminationLifecycleAgentProvider instanceTerminationNotificationAgentProvider(ObjectMapper objectMapper,
+                                                                                         AmazonClientProvider amazonClientProvider,
+                                                                                         AccountCredentialsProvider accountCredentialsProvider,
+                                                                                         InstanceTerminationConfigurationProperties properties,
+                                                                                         Provider<AwsEurekaSupport> discoverySupport) {
+    return new InstanceTerminationLifecycleAgentProvider(
+      objectMapper, amazonClientProvider, accountCredentialsProvider, properties, discoverySupport
     );
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/ARNSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/ARNSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.lifecycle
+
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ARNSpec extends Specification {
+
+  def mgmtCredentials = Mock(NetflixAmazonCredentials) {
+    getAccountId() >> { return "100" }
+    getName() >> { return "mgmt" }
+  }
+
+  @Unroll
+  void "should extract accountId, region and name from SQS or SNS ARN"() {
+    when:
+    def parsedARN = new ARN(
+      [mgmtCredentials],
+      arn,
+    )
+
+    then:
+    parsedARN.account == mgmtCredentials
+    parsedARN.region == expectedRegion
+    parsedARN.name == expectedName
+
+    when:
+    new ARN([mgmtCredentials], "invalid-arn")
+
+    then:
+    def e1 = thrown(IllegalArgumentException)
+    e1.message == "invalid-arn is not a valid SNS or SQS ARN"
+
+    when:
+    new ARN([], arn)
+
+    then:
+    def e2 = thrown(IllegalArgumentException)
+    e2.message == "No account credentials found for 100"
+
+    where:
+    arn                                   || expectedRegion || expectedName
+    "arn:aws:sqs:us-west-2:100:queueName" || "us-west-2"    || "queueName"
+    "arn:aws:sns:us-west-2:100:topicName" || "us-west-2"    || "topicName"
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProviderSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.lifecycle
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+import spock.lang.Subject
+
+import javax.inject.Provider
+
+class InstanceTerminationLifecycleAgentProviderSpec extends Specification {
+
+  ObjectMapper objectMapper = Mock()
+  AmazonClientProvider amazonClientProvider = Mock()
+  AccountCredentialsProvider accountCredentialsProvider = Mock()
+  Provider<AwsEurekaSupport> awsEurekaSupport = Mock()
+
+  InstanceTerminationConfigurationProperties properties = new InstanceTerminationConfigurationProperties(
+    'mgmt',
+    'arn:aws:sqs:{{region}}:{{accountId}}:{{environment}}-queueName',
+    'arn:aws:iam::*:sourceArn',
+    -1,
+    -1,
+    -1
+  )
+
+  @Subject
+  def subject = new InstanceTerminationLifecycleAgentProvider(
+    objectMapper,
+    amazonClientProvider,
+    accountCredentialsProvider,
+    properties,
+    awsEurekaSupport
+  )
+
+  def 'should support AwsProvider'() {
+    expect:
+    subject.supports(AwsProvider.PROVIDER_NAME)
+    !subject.supports(AwsCleanupProvider.PROVIDER_NAME)
+  }
+
+  def 'should return an agent per region in specified account'() {
+    given:
+    def regions = ['us-west-1', 'us-west-2', 'us-east-1']
+    def mgmtCredentials = Mock(NetflixAmazonCredentials) {
+      getRegions() >> {
+        return regions.collect { new AmazonCredentials.AWSRegion(it, []) }
+      }
+      getAccountId() >> "100"
+      getName() >> "mgmt"
+    }
+
+    when:
+    def agents = subject.agents()
+
+    then:
+    regions.each { String region ->
+      assert agents.find { it.agentType == "mgmt/${region}/InstanceTerminationLifecycleAgent".toString() } != null
+    }
+    1 * accountCredentialsProvider.getCredentials("mgmt") >> mgmtCredentials
+    3 * accountCredentialsProvider.getAll() >> [mgmtCredentials]
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentSpec.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.lifecycle
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.CreateQueueResult
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableInstanceDiscoveryDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTask
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport.DiscoveryStatus
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+import spock.lang.Subject
+
+import javax.inject.Provider
+
+class InstanceTerminationLifecycleAgentSpec extends Specification {
+
+  NetflixAmazonCredentials mgmtCredentials = Mock() {
+    getAccountId() >> { return "100" }
+    getName() >> { return "mgmt" }
+  }
+  NetflixAmazonCredentials testCredentials = Mock() {
+    getAccountId() >> { return "200" }
+    getName() >> { return "test" }
+  }
+
+  AmazonSQS amazonSQS = Mock()
+  AccountCredentialsProvider accountCredentialsProvider = Mock() {
+    getAll() >>[mgmtCredentials, testCredentials]
+  }
+  Provider<AwsEurekaSupport> awsEurekaSupportProvider = Mock()
+  AwsEurekaSupport awsEurekaSupport = Mock()
+
+  def queueARN = new ARN([mgmtCredentials, testCredentials], "arn:aws:sqs:us-west-2:100:queueName")
+
+  @Subject
+  def subject = new InstanceTerminationLifecycleAgent(
+    Mock(ObjectMapper),
+    Mock(AmazonClientProvider),
+    accountCredentialsProvider,
+    new InstanceTerminationConfigurationProperties(
+      'mgmt',
+      queueARN.arn,
+      'aws:arn:iam::*:role/sourceArn',
+      -1,
+      -1,
+      -1
+    ),
+    awsEurekaSupportProvider
+  )
+
+  def 'should create queue if it does not exist'() {
+    when:
+    def queueId = InstanceTerminationLifecycleAgent.ensureQueueExists(amazonSQS, queueARN, 'sourceArn', ['100', '200'] as Set)
+
+    then:
+    queueId == "my-queue-url"
+
+    1 * amazonSQS.createQueue(queueARN.name) >> { new CreateQueueResult().withQueueUrl("my-queue-url") }
+
+    1 * amazonSQS.setQueueAttributes("my-queue-url", [
+      "Policy": InstanceTerminationLifecycleAgent.buildSQSPolicy(queueARN, 'sourceArn', ['100', '200'] as Set).toJson()
+    ])
+    0 * _
+  }
+
+  def 'should get update discovery with notification'() {
+    given:
+    LifecycleMessage message = new LifecycleMessage(
+      accountId: '200',
+      autoScalingGroupName: 'clouddriver-main-v000',
+      ec2InstanceId: 'i-1234',
+      lifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING'
+    )
+
+    when:
+    subject.handleMessage(message, Mock(DefaultTask))
+
+    then:
+    1 * accountCredentialsProvider.getAll() >> [mgmtCredentials, testCredentials]
+    1 * awsEurekaSupportProvider.get() >> awsEurekaSupport
+    1 * awsEurekaSupport.updateDiscoveryStatusForInstances(
+      { EnableDisableInstanceDiscoveryDescription arg ->
+        arg.credentials == testCredentials
+        arg.region == 'us-west-2'
+        arg.asgName == 'clouddriver-main-v000'
+        arg.instanceIds == ['i-1234']
+      },
+      _ as Task,
+      'handleLifecycleMessage',
+      DiscoveryStatus.Disable,
+      ['i-1234']
+    )
+  }
+}


### PR DESCRIPTION
Porting the code that I added into Eureka to update application service states on termination faster. The agent will create an SQS queue in a single account and every region that spinnaker knows about.

@spinnaker/netflix-reviewers PTAL