### PR TITLE
Instrumented remaining google deploy operations.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbandonAndDecrementGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbandonAndDecrementGoogleServerGroupAtomicOperation.groovy
@@ -34,7 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired
  *
  * @see TerminateAndDecrementGoogleServerGroupAtomicOperation
  */
-class AbandonAndDecrementGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
+class AbandonAndDecrementGoogleServerGroupAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "ABANDON_AND_DEC_INSTANCES"
 
   private static Task getTask() {
@@ -77,12 +77,18 @@ class AbandonAndDecrementGoogleServerGroupAtomicOperation implements AtomicOpera
       def instanceGroupManagers = compute.regionInstanceGroupManagers()
       def abandonRequest = new RegionInstanceGroupManagersAbandonInstancesRequest().setInstances(instanceUrls)
 
-      instanceGroupManagers.abandonInstances(project, region, serverGroupName, abandonRequest).execute()
+      timeExecute(
+          instanceGroupManagers.abandonInstances(project, region, serverGroupName, abandonRequest),
+          "compute.regionInstanceGroupManagers.abandonInstances",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     } else {
       def instanceGroupManagers = compute.instanceGroupManagers()
       def abandonRequest = new InstanceGroupManagersAbandonInstancesRequest().setInstances(instanceUrls)
 
-      instanceGroupManagers.abandonInstances(project, zone, serverGroupName, abandonRequest).execute()
+      timeExecute(
+          instanceGroupManagers.abandonInstances(project, zone, serverGroupName, abandonRequest),
+          "compute.instanceGroupManagers.abandonInstances",
+          TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
     }
 
     task.updateStatus BASE_PHASE, "Done abandoning and decrementing instances " +

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
@@ -26,10 +26,9 @@ import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.CreateGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleNetworkProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleSubnetProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
-class CreateGoogleInstanceAtomicOperation implements AtomicOperation<DeploymentResult> {
+class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<DeploymentResult> {
   private static final String BASE_PHASE = "DEPLOY"
 
   // TODO(duftler): These should be exposed/configurable.
@@ -135,7 +134,9 @@ class CreateGoogleInstanceAtomicOperation implements AtomicOperation<DeploymentR
                                 serviceAccounts: serviceAccount)
 
     task.updateStatus BASE_PHASE, "Creating instance $description.instanceName..."
-    compute.instances().insert(project, zone, instance).execute()
+    timeExecute(compute.instances().insert(project, zone, instance),
+        "compute.instances.insert",
+        TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
 
     task.updateStatus BASE_PHASE, "Done creating instance $description.instanceName in $description.zone."
     new DeploymentResult(serverGroupNames: [description.instanceName])

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleSecurityGroupAtomicOperation.groovy
@@ -19,14 +19,13 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleSecurityGroupDescription
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 
 /**
  * Delete a firewall rule from the specified project.
  *
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/firewalls/delete}
  */
-class DeleteGoogleSecurityGroupAtomicOperation implements AtomicOperation<Void> {
+class DeleteGoogleSecurityGroupAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "DELETE_SECURITY_GROUP"
 
   private static Task getTask() {
@@ -50,7 +49,8 @@ class DeleteGoogleSecurityGroupAtomicOperation implements AtomicOperation<Void> 
     def project = description.credentials.project
     def firewallRuleName = description.securityGroupName
 
-    compute.firewalls().delete(project, firewallRuleName).execute()
+    timeExecute(compute.firewalls().delete(project, firewallRuleName),
+                "compute.firewalls.delete", TAG_SCOPE, SCOPE_GLOBAL)
 
     task.updateStatus BASE_PHASE, "Done deleting security group $firewallRuleName."
     null

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RebootGoogleInstancesAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RebootGoogleInstancesAtomicOperation.groovy
@@ -19,14 +19,13 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RebootGoogleInstancesDescription
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 
 /**
  * Resets each specified instance back to the initial state of its underlying virtual machine.
  *
  * @see https://cloud.google.com/compute/docs/instances/restarting-an-instance
  */
-class RebootGoogleInstancesAtomicOperation implements AtomicOperation<Void> {
+class RebootGoogleInstancesAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "REBOOT_INSTANCES"
 
   private static Task getTask() {
@@ -63,7 +62,10 @@ class RebootGoogleInstancesAtomicOperation implements AtomicOperation<Void> {
       task.updateStatus BASE_PHASE, "Attempting to reset instance $instanceId in $zone..."
 
       try {
-        compute.instances().reset(project, zone, instanceId).execute()
+        timeExecute(
+            compute.instances().reset(project, zone, instanceId),
+            "compute.instances.reset",
+            TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
         okIds.add(instanceId)
       } catch (Exception e) {
         task.updateStatus BASE_PHASE, "Failed to reset instance $instanceId in $zone: $e.message."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/TerminateAndDecrementGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/TerminateAndDecrementGoogleServerGroupAtomicOperation.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.TerminateAndDecrementGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
@@ -42,7 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired
  *
  * @see TerminateGoogleInstancesAtomicOperation
  */
-class TerminateAndDecrementGoogleServerGroupAtomicOperation implements AtomicOperation<Void> {
+class TerminateAndDecrementGoogleServerGroupAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "TERMINATE_AND_DEC_INSTANCES"
 
   private static Task getTask() {
@@ -85,12 +84,18 @@ class TerminateAndDecrementGoogleServerGroupAtomicOperation implements AtomicOpe
       def instanceGroupManagers = compute.regionInstanceGroupManagers()
       def deleteRequest = new RegionInstanceGroupManagersDeleteInstancesRequest().setInstances(instanceUrls)
 
-      instanceGroupManagers.deleteInstances(project, region, serverGroupName, deleteRequest).execute()
+      timeExecute(
+          instanceGroupManagers.deleteInstances(project, region, serverGroupName, deleteRequest),
+          "compute.regionInstanceGroupManagers.deleteInstances",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     } else {
       def instanceGroupManagers = compute.instanceGroupManagers()
       def deleteRequest = new InstanceGroupManagersDeleteInstancesRequest().setInstances(instanceUrls)
 
-      instanceGroupManagers.deleteInstances(project, zone, serverGroupName, deleteRequest).execute()
+      timeExecute(
+          instanceGroupManagers.deleteInstances(project, zone, serverGroupName, deleteRequest),
+          "compute.instanceGroupManagers.deleteInstances",
+          TAG_SCOPE, SCOPE_ZONAL, TAG_ZONE, zone)
     }
 
     task.updateStatus BASE_PHASE, "Done terminating and decrementing instances " +

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleImageTagsAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleImageTagsAtomicOperation.groovy
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired
  *
  * Uses {@link https://cloud.google.com/compute/docs/reference/beta/images/setLabels}
  */
-class UpsertGoogleImageTagsAtomicOperation implements AtomicOperation<Void> {
+class UpsertGoogleImageTagsAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "UPSERT_IMAGE_TAGS"
 
   private static Task getTask() {
@@ -90,7 +90,9 @@ class UpsertGoogleImageTagsAtomicOperation implements AtomicOperation<Void> {
       GlobalSetLabelsRequest setLabelsRequest = new GlobalSetLabelsRequest(labels: newLabels,
                                                                            labelFingerprint: image.getLabelFingerprint())
 
-      compute.images().setLabels(imageProject, imageName, setLabelsRequest).execute()
+      timeExecute(
+          compute.images().setLabels(imageProject, imageName, setLabelsRequest),
+          "compute.images.setLabels", TAG_SCOPE, SCOPE_GLOBAL)
     }
 
     task.updateStatus BASE_PHASE, "Done tagging image $imageName."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleSecurityGroupAtomicOperation.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleNetworkProvider
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
@@ -31,7 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/firewalls/update}
  * Uses {@link https://cloud.google.com/compute/docs/reference/latest/firewalls/insert}
  */
-class UpsertGoogleSecurityGroupAtomicOperation implements AtomicOperation<Void> {
+class UpsertGoogleSecurityGroupAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "UPSERT_SECURITY_GROUP"
 
   @Autowired
@@ -66,7 +65,10 @@ class UpsertGoogleSecurityGroupAtomicOperation implements AtomicOperation<Void> 
       task.updateStatus BASE_PHASE, "Attempting to retrieve existing firewall rule $firewallRuleName for network " +
         "$description.network..."
 
-      def origFirewall = compute.firewalls().get(project, firewallRuleName).execute()
+      def origFirewall = timeExecute(
+          compute.firewalls().get(project, firewallRuleName),
+          "compute.firewalls.get",
+          TAG_SCOPE, SCOPE_GLOBAL)
 
       task.updateStatus BASE_PHASE, "Updating existing firewall rule $firewallRuleName..."
 
@@ -75,7 +77,10 @@ class UpsertGoogleSecurityGroupAtomicOperation implements AtomicOperation<Void> 
       }
 
       // If the firewall rule already exists, update it.
-      compute.firewalls().update(project, firewallRuleName, firewall).execute()
+      timeExecute(
+          compute.firewalls().update(project, firewallRuleName, firewall),
+          "compute.firewalls.update",
+          TAG_SCOPE, SCOPE_GLOBAL)
     } catch (GoogleJsonResponseException e) {
       if (e.getStatusCode() == 404) {
         // If the firewall rule does not exist, insert a new one.
@@ -88,7 +93,10 @@ class UpsertGoogleSecurityGroupAtomicOperation implements AtomicOperation<Void> 
           firewall.targetTags = ["$firewallRuleName-${System.currentTimeMillis()}".toString()]
         }
 
-        compute.firewalls().insert(project, firewall).execute()
+        timeExecute(
+            compute.firewalls().insert(project, firewall),
+            "compute.firewalls.insert",
+            TAG_SCOPE, SCOPE_GLOBAL)
       } else {
         throw e;
       }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperation.groovy
@@ -26,10 +26,10 @@ import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.GoogleAtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
-class DeleteGoogleLoadBalancerAtomicOperation implements AtomicOperation<Void> {
+class DeleteGoogleLoadBalancerAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final String BASE_PHASE = "DELETE_LOAD_BALANCER"
 
   static class HealthCheckAsyncDeleteOperation {
@@ -78,7 +78,10 @@ class DeleteGoogleLoadBalancerAtomicOperation implements AtomicOperation<Void> {
     task.updateStatus BASE_PHASE, "Retrieving forwarding rule $forwardingRuleName in $region..."
 
     ForwardingRule forwardingRule = safeRetry.doRetry(
-      { compute.forwardingRules().get(project, region, forwardingRuleName).execute() },
+      { timeExecute(
+            compute.forwardingRules().get(project, region, forwardingRuleName),
+            "compute.forwardingRules.get",
+            TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       'Get',
       "Regional forwarding rule $forwardingRuleName",
       task,
@@ -95,7 +98,10 @@ class DeleteGoogleLoadBalancerAtomicOperation implements AtomicOperation<Void> {
     task.updateStatus BASE_PHASE, "Retrieving target pool $targetPoolName in $region..."
 
     TargetPool targetPool = safeRetry.doRetry(
-      { compute.targetPools().get(project, region, targetPoolName).execute() },
+      { timeExecute(
+            compute.targetPools().get(project, region, targetPoolName),
+            "compute.targetPools.get",
+            TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       'Get',
       "Target pool $targetPoolName",
       task,
@@ -120,7 +126,10 @@ class DeleteGoogleLoadBalancerAtomicOperation implements AtomicOperation<Void> {
     // delete its dependencies.
     task.updateStatus BASE_PHASE, "Deleting forwarding rule $forwardingRuleName in $region..."
     Operation deleteForwardingRuleOperation = safeRetry.doRetry(
-      { compute.forwardingRules().delete(project, region, forwardingRuleName).execute() },
+      { timeExecute(
+            compute.forwardingRules().delete(project, region, forwardingRuleName),
+            "compute.forwardingRules.delete",
+            TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       'Delete',
       "Regional forwarding rule $forwardingRuleName",
       task,
@@ -134,7 +143,10 @@ class DeleteGoogleLoadBalancerAtomicOperation implements AtomicOperation<Void> {
 
     task.updateStatus BASE_PHASE, "Deleting target pool $targetPoolName in $region..."
     Operation deleteTargetPoolOperation = safeRetry.doRetry(
-      { compute.targetPools().delete(project, region, targetPoolName).execute() },
+      { timeExecute(
+            compute.targetPools().delete(project, region, targetPoolName),
+            "compute.targetPools.delete",
+            TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       'Delete',
       "Target pool $targetPoolName",
       task,
@@ -153,7 +165,10 @@ class DeleteGoogleLoadBalancerAtomicOperation implements AtomicOperation<Void> {
       for (String healthCheckUrl : healthCheckUrls) {
         def healthCheckName = GCEUtil.getLocalName(healthCheckUrl)
         Operation deleteHealthCheckOp = GCEUtil.deleteIfNotInUse(
-          { compute.httpHealthChecks().delete(project, healthCheckName).execute() },
+          { timeExecute(
+                compute.httpHealthChecks().delete(project, healthCheckName),
+                "compute.httpHealthChecks.delete",
+                TAG_SCOPE, SCOPE_GLOBAL) },
           "Http health check $healthCheckName",
           project,
           task,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperation.groovy
@@ -27,13 +27,14 @@ import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.GoogleAtomicOperation
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleSessionAffinity
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+
 import org.springframework.beans.factory.annotation.Autowired
 
-class UpsertGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation<Map> {
+class UpsertGoogleInternalLoadBalancerAtomicOperation extends GoogleAtomicOperation<Map> {
   private static final String BASE_PHASE = "UPSERT_INTERNAL_LOAD_BALANCER"
 
   @Autowired
@@ -98,7 +99,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
     }
 
     existingBackendService = safeRetry.doRetry(
-      { compute.regionBackendServices().get(project, region, backendServiceName).execute() },
+      { timeExecute(
+            compute.regionBackendServices().get(project, region, backendServiceName),
+            "compute.regionBackendServices.get",
+            TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
       'Get',
       "Region backend service $backendServiceName",
       task,
@@ -118,7 +122,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
     // is nested in a field inside the HealthCheck object. This is different from all previous ways we used health checks,
     // and uses a separate endpoint from Http(s)HealthChecks.
     existingHealthCheck = safeRetry.doRetry(
-      { compute.healthChecks().get(project, healthCheckName).execute() },
+      { timeExecute(
+            compute.healthChecks().get(project, healthCheckName),
+            "compute.healthChecks.get",
+            TAG_SCOPE, SCOPE_GLOBAL) },
       'Get',
       "Health check $healthCheckName",
       task,
@@ -135,7 +142,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
       task.updateStatus BASE_PHASE, "Creating health check $healthCheckName..."
       def newHealthCheck = GCEUtil.createNewHealthCheck(descriptionHealthCheck)
       healthCheckOp = safeRetry.doRetry(
-        { compute.healthChecks().insert(project, newHealthCheck as HealthCheck).execute() },
+        { timeExecute(
+              compute.healthChecks().insert(project, newHealthCheck as HealthCheck),
+              "compute.healthChecks.insert",
+              TAG_SCOPE, SCOPE_GLOBAL) },
         'Insert',
         "Health check $healthCheckName",
         task,
@@ -147,7 +157,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
       task.updateStatus BASE_PHASE, "Updating health check $healthCheckName..."
       GCEUtil.updateExistingHealthCheck(existingHealthCheck, descriptionHealthCheck)
       healthCheckOp = safeRetry.doRetry(
-        { compute.healthChecks().update(project, healthCheckName, existingHealthCheck as HealthCheck).execute() },
+        { timeExecute(
+              compute.healthChecks().update(project, healthCheckName, existingHealthCheck as HealthCheck),
+              "compute.healthChecks.update",
+              TAG_SCOPE, SCOPE_GLOBAL) },
         'Update',
         "Health check $healthCheckName",
         task,
@@ -172,7 +185,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
         protocol: description.ipProtocol
       )
       backendServiceOp = safeRetry.doRetry(
-        { compute.regionBackendServices().insert(project, region, bs).execute() },
+        { timeExecute(
+              compute.regionBackendServices().insert(project, region, bs),
+              "compute.regionBackendServices.insert",
+              TAG_SCOPE, SCOPE_GLOBAL) },
         'Insert',
         "Backend service $description.backendService.name",
         task,
@@ -187,7 +203,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
       existingBackendService.loadBalancingScheme = 'INTERNAL'
       existingBackendService.protocol = description.ipProtocol
       backendServiceOp = safeRetry.doRetry(
-        { compute.regionBackendServices().update(project, region, existingBackendService.getName(), existingBackendService).execute() },
+        { timeExecute(
+              compute.regionBackendServices().update(project, region, existingBackendService.getName(), existingBackendService),
+              "compute.regionBackendServices.update",
+              TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
         'Update',
         "Backend service $description.backendService.name",
         task,
@@ -214,7 +233,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation implements AtomicOperation
         ports: description.ports
       )
       safeRetry.doRetry(
-        { compute.forwardingRules().insert(project, region, forwardingRule).execute() },
+        { timeExecute(
+              compute.forwardingRules().insert(project, region, forwardingRule),
+              "compute.forwardingRules.insert",
+              TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region) },
         'Insert',
         "Regional forwarding rule ${description.loadBalancerName}",
         task,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleLoadBalancerAtomicOperation.groovy
@@ -33,10 +33,10 @@ import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.google.deploy.ops.GoogleAtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
-class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
+class UpsertGoogleLoadBalancerAtomicOperation extends GoogleAtomicOperation<Map> {
   private static final String BASE_PHASE = "UPSERT_LOAD_BALANCER"
 
   private static Task getTask() {
@@ -253,7 +253,10 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
 
     def httpHealthCheck = GCEUtil.buildHttpHealthCheck(healthCheckName, description.healthCheck)
     // We won't block on this operation since nothing else depends on its completion.
-    compute.httpHealthChecks().update(project, healthCheckName, httpHealthCheck).execute()
+    timeExecute(
+        compute.httpHealthChecks().update(project, healthCheckName, httpHealthCheck),
+        "compute.httpHealthChecks.update",
+        TAG_SCOPE, SCOPE_GLOBAL)
   }
 
   private void createNewHttpHealthCheck(List<String> httpHealthChecksResourceLinks, Compute compute, String project) {
@@ -262,8 +265,10 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
     task.updateStatus BASE_PHASE, "Creating health check $healthCheckName..."
 
     def httpHealthCheck = GCEUtil.buildHttpHealthCheck(healthCheckName, description.healthCheck)
-    def httpHealthCheckResourceOperation =
-      compute.httpHealthChecks().insert(project, httpHealthCheck).execute()
+    def httpHealthCheckResourceOperation = timeExecute(
+        compute.httpHealthChecks().insert(project, httpHealthCheck),
+        "compute.httpHealthChecks.insert",
+        TAG_SCOPE, SCOPE_GLOBAL)
     def httpHealthCheckResourceLink = httpHealthCheckResourceOperation.targetLink
 
     httpHealthChecksResourceLinks << httpHealthCheckResourceLink
@@ -287,7 +292,10 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
         new InstanceReference(instance: instanceUrl)
       }
       // We won't block on this operation since nothing else depends on its completion.
-      compute.targetPools().addInstance(project, region, targetPoolName, targetPoolsAddInstanceRequest).execute()
+      timeExecute(
+          compute.targetPools().addInstance(project, region, targetPoolName, targetPoolsAddInstanceRequest),
+          "compute.targetPools.addInstance",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     }
   }
 
@@ -305,7 +313,10 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
         new InstanceReference(instance: instanceUrl)
       }
       // We won't block on this operation since nothing else depends on its completion.
-      compute.targetPools().removeInstance(project, region, targetPoolName, targetPoolsRemoveInstanceRequest).execute()
+      timeExecute(
+          compute.targetPools().removeInstance(project, region, targetPoolName, targetPoolsRemoveInstanceRequest),
+          "compute.targetPools.removeInstance",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     }
   }
 
@@ -321,9 +332,11 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
       [new HealthCheckReference(healthCheck: existingTargetPool.healthChecks[0])]
 
     // The http health check will be deleted down below, once this operation has completed.
-    targetPoolResourceOperation =
-      compute.targetPools().removeHealthCheck(
-        project, region, targetPoolName, targetPoolsRemoveHealthCheckRequest).execute()
+    targetPoolResourceOperation = timeExecute(
+        compute.targetPools().removeHealthCheck(project, region, targetPoolName, targetPoolsRemoveHealthCheckRequest),
+        "compute.targetPools.removeHealthCheck",
+        TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
+                   
     targetPoolResourceOperation
   }
 
@@ -337,8 +350,10 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
     targetPoolsAddHealthCheckRequest.healthChecks =
       [new HealthCheckReference(healthCheck: httpHealthChecksResourceLinks[0])]
 
-    targetPoolResourceOperation =
-      compute.targetPools().addHealthCheck(project, region, targetPoolName, targetPoolsAddHealthCheckRequest).execute()
+    targetPoolResourceOperation = timeExecute(
+        compute.targetPools().addHealthCheck(project, region, targetPoolName, targetPoolsAddHealthCheckRequest),
+        "compute.targetPools.addHealthCheck",
+        TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     targetPoolResourceOperation
   }
 
@@ -355,7 +370,10 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
       instances: description.instances
     )
 
-    targetPoolResourceOperation = compute.targetPools().insert(project, region, targetPool).execute()
+    targetPoolResourceOperation = timeExecute(
+        compute.targetPools().insert(project, region, targetPool),
+        "compute.tagetPools.insert",
+        TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     [targetPoolResourceOperation, targetPoolName]
   }
 
@@ -366,7 +384,9 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
       task.updateStatus BASE_PHASE, "Deleting health check $healthCheckName..."
 
       // We won't block on this operation since nothing else depends on its completion.
-      compute.httpHealthChecks().delete(project, healthCheckName).execute()
+      timeExecute(compute.httpHealthChecks().delete(project, healthCheckName),
+                  "compute.httpHealthChecks.delete",
+                  TAG_SCOPE, SCOPE_GLOBAL)
     }
   }
 
@@ -377,8 +397,10 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
       // These properties of the forwarding rule can't be updated, so we must do a delete and create.
       task.updateStatus BASE_PHASE, "Deleting forwarding rule $description.loadBalancerName..."
 
-      def forwardingRuleResourceOperation =
-        compute.forwardingRules().delete(project, region, description.loadBalancerName).execute()
+      def forwardingRuleResourceOperation = timeExecute(
+              compute.forwardingRules().delete(project, region, description.loadBalancerName),
+              "compute.forwardingRules.delete",
+              TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
       def forwardingRuleResourceLink = forwardingRuleResourceOperation.targetLink
 
       googleOperationPoller.waitForRegionalOperation(compute, project, region, forwardingRuleResourceOperation.getName(),
@@ -404,7 +426,10 @@ class UpsertGoogleLoadBalancerAtomicOperation implements AtomicOperation<Map> {
       )
 
       // We won't block on this operation since nothing else depends on its completion.
-      compute.forwardingRules().insert(project, region, forwardingRule).execute()
+      timeExecute(
+          compute.forwardingRules().insert(project, region, forwardingRule),
+          "compute.forwardingRules.insert",
+          TAG_SCOPE, SCOPE_REGIONAL, TAG_REGION, region)
     }
   }
 }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbandonAndDecrementGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbandonAndDecrementGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.InstanceGroupManagersAbandonInstancesRequest
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
@@ -41,6 +42,8 @@ class AbandonAndDecrementGoogleServerGroupAtomicOperationUnitSpec extends Specif
     "https://www.googleapis.com/compute/v1/projects/shared-spinnaker/zones/us-central1-f/instances/my-app7-dev-v000-1",
     "https://www.googleapis.com/compute/v1/projects/shared-spinnaker/zones/us-central1-f/instances/my-app7-dev-v000-2"
   ]
+
+  def registry = new DefaultRegistry()
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -74,6 +77,7 @@ class AbandonAndDecrementGoogleServerGroupAtomicOperationUnitSpec extends Specif
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new AbandonAndDecrementGoogleServerGroupAtomicOperation(description)
+      operation.registry = registry
       operation.googleClusterProvider = googleClusterProviderMock
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleSecurityGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleSecurityGroupAtomicOperationUnitSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.google.api.services.compute.Compute
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleSecurityGroupDescription
@@ -35,6 +36,7 @@ class DeleteGoogleSecurityGroupAtomicOperationUnitSpec extends Specification {
 
   void "should delete firewall rule"() {
     setup:
+      def registry = new DefaultRegistry()
       def computeMock = Mock(Compute)
       def firewallsMock = Mock(Compute.Firewalls)
       def firewallsDelete = Mock(Compute.Firewalls.Delete)
@@ -43,6 +45,7 @@ class DeleteGoogleSecurityGroupAtomicOperationUnitSpec extends Specification {
                                                                  accountName: ACCOUNT_NAME,
                                                                  credentials: credentials)
       @Subject def operation = new DeleteGoogleSecurityGroupAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -24,6 +24,7 @@ import com.google.api.services.compute.model.InstanceAggregatedList
 import com.google.api.services.compute.model.InstanceReference
 import com.google.api.services.compute.model.InstancesScopedList
 import com.google.api.services.compute.model.TargetPoolsRemoveInstanceRequest
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
@@ -54,6 +55,7 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec extends S
   private static final INSTANCE_URLS = [INSTANCE_URL1, INSTANCE_URL2]
 
   @Shared SafeRetry safeRetry
+  @Shared DefaultRegistry registry = new DefaultRegistry()
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -94,6 +96,7 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec extends S
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeregisterInstancesFromGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
       def request = new TargetPoolsRemoveInstanceRequest()
@@ -140,6 +143,7 @@ class DeregisterInstancesFromGoogleLoadBalancerAtomicOperationUnitSpec extends S
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeregisterInstancesFromGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
       def request = new TargetPoolsRemoveInstanceRequest()

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec.groovy
@@ -72,10 +72,9 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
   private static final SET_INSTANCE_TEMPLATE_OP_NAME = "set-instance-template-op"
   private static final DONE = "DONE"
 
-  @Shared
-  def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
-  @Shared
-  SafeRetry safeRetry
+  @Shared def threadSleeperMock = Mock(GoogleOperationPoller.ThreadSleeper)
+  @Shared def registry = new DefaultRegistry()
+  @Shared SafeRetry safeRetry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -123,6 +122,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
             safeRetry: safeRetry
           )
       operation.googleClusterProvider = googleClusterProviderMock
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -197,6 +197,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
             safeRetry: safeRetry
           )
       operation.googleClusterProvider = googleClusterProviderMock
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -264,6 +265,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
             safeRetry: safeRetry
           )
       operation.googleClusterProvider = googleClusterProviderMock
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -325,6 +327,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
             safeRetry: safeRetry
           )
       operation.googleClusterProvider = googleClusterProviderMock
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -388,6 +391,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperationUnitSpec extends Spe
             safeRetry: safeRetry
           )
       operation.googleClusterProvider = googleClusterProviderMock
+      operation.registry = registry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RebootGoogleInstancesAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RebootGoogleInstancesAtomicOperationUnitSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.google.api.services.compute.Compute
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RebootGoogleInstancesDescription
@@ -34,6 +35,7 @@ class RebootGoogleInstancesAtomicOperationUnitSpec extends Specification {
   private static final BAD_INSTANCE_IDS = ["${ID_BAD_PREFIX}1", "${ID_BAD_PREFIX}2"]
   private static final ALL_INSTANCE_IDS = ["${ID_GOOD_PREFIX}1", "${ID_BAD_PREFIX}1",
                                            "${ID_GOOD_PREFIX}2", "${ID_BAD_PREFIX}2"]
+  def registry = new DefaultRegistry()
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -50,6 +52,7 @@ class RebootGoogleInstancesAtomicOperationUnitSpec extends Specification {
                                                             accountName: ACCOUNT_NAME,
                                                             credentials: credentials)
       @Subject def operation = new RebootGoogleInstancesAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -74,6 +77,7 @@ class RebootGoogleInstancesAtomicOperationUnitSpec extends Specification {
                                                             accountName: ACCOUNT_NAME,
                                                             credentials: credentials)
       @Subject def operation = new RebootGoogleInstancesAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RegisterInstancesWithGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/RegisterInstancesWithGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -24,6 +24,7 @@ import com.google.api.services.compute.model.InstanceAggregatedList
 import com.google.api.services.compute.model.InstanceReference
 import com.google.api.services.compute.model.InstancesScopedList
 import com.google.api.services.compute.model.TargetPoolsAddInstanceRequest
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
@@ -53,6 +54,7 @@ class RegisterInstancesWithGoogleLoadBalancerAtomicOperationUnitSpec extends Spe
   private static final INSTANCE_IDS = [INSTANCE_ID1, INSTANCE_ID2]
   private static final INSTANCE_URLS = [INSTANCE_URL1, INSTANCE_URL2]
 
+  def registry = new DefaultRegistry()
   @Shared SafeRetry safeRetry
 
   def setupSpec() {
@@ -94,6 +96,7 @@ class RegisterInstancesWithGoogleLoadBalancerAtomicOperationUnitSpec extends Spe
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new RegisterInstancesWithGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
       def request = new TargetPoolsAddInstanceRequest()
@@ -140,6 +143,7 @@ class RegisterInstancesWithGoogleLoadBalancerAtomicOperationUnitSpec extends Spe
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new RegisterInstancesWithGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
       def request = new TargetPoolsAddInstanceRequest()

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/TerminateAndDecrementGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/TerminateAndDecrementGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.InstanceGroupManagersDeleteInstancesRequest
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
@@ -51,6 +52,7 @@ class TerminateAndDecrementGoogleServerGroupAtomicOperationUnitSpec extends Spec
   @Unroll
   void "should terminate instances"() {
     setup:
+      def registry = new DefaultRegistry()
       def googleClusterProviderMock = Mock(GoogleClusterProvider)
       def serverGroup = new GoogleServerGroup(
         regional: isRegional,
@@ -76,6 +78,7 @@ class TerminateAndDecrementGoogleServerGroupAtomicOperationUnitSpec extends Spec
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new TerminateAndDecrementGoogleServerGroupAtomicOperation(description)
+      operation.registry = registry
       operation.googleClusterProvider = googleClusterProviderMock
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleImageTagsAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleImageTagsAtomicOperationUnitSpec.groovy
@@ -24,6 +24,7 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Image
 import com.google.api.services.compute.model.ImageList
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
@@ -43,6 +44,8 @@ class UpsertGoogleImageTagsAtomicOperationUnitSpec extends Specification impleme
   private static final BASE_IMAGE_PROJECTS = ["centos-cloud", "ubuntu-os-cloud"]
   private static final TAGS = ['some-key-1': 'some-val-2']
   private static final LABELS = ['some-existing-key-1': 'some-existing-val-2']
+
+  def registry = new DefaultRegistry()
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -104,6 +107,7 @@ class UpsertGoogleImageTagsAtomicOperationUnitSpec extends Specification impleme
                                                                    accountName: ACCOUNT_NAME,
                                                                    credentials: credentials)
             @Subject def operation = new UpsertGoogleImageTagsAtomicOperation(description)
+            operation.registry = registry
             operation.googleConfigurationProperties = new GoogleConfigurationProperties(baseImageProjects: BASE_IMAGE_PROJECTS)
             operation.operate([])
           }
@@ -172,6 +176,7 @@ class UpsertGoogleImageTagsAtomicOperationUnitSpec extends Specification impleme
                                                                    accountName: ACCOUNT_NAME,
                                                                    credentials: credentials)
             @Subject def operation = new UpsertGoogleImageTagsAtomicOperation(description)
+            operation.registry = registry
             operation.googleConfigurationProperties = new GoogleConfigurationProperties(baseImageProjects: BASE_IMAGE_PROJECTS)
             operation.operate([])
           }
@@ -229,6 +234,7 @@ class UpsertGoogleImageTagsAtomicOperationUnitSpec extends Specification impleme
                                                                    accountName: ACCOUNT_NAME,
                                                                    credentials: credentials)
             @Subject def operation = new UpsertGoogleImageTagsAtomicOperation(description)
+            operation.registry = registry
             operation.googleConfigurationProperties = new GoogleConfigurationProperties(baseImageProjects: BASE_IMAGE_PROJECTS)
             operation.operate([])
           }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleSecurityGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleSecurityGroupAtomicOperationUnitSpec.groovy
@@ -21,6 +21,7 @@ import com.google.api.client.googleapis.testing.json.GoogleJsonResponseException
 import com.google.api.client.testing.json.MockJsonFactory
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.Firewall
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleSecurityGroupDescription
@@ -42,6 +43,8 @@ class UpsertGoogleSecurityGroupAtomicOperationUnitSpec extends Specification {
   private static final ORIG_TARGET_TAG = "some-other-target-tag"
   private static final ACCOUNT_NAME = "auto"
   private static final PROJECT_NAME = "my_project"
+
+  def registry = new DefaultRegistry()
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -74,6 +77,7 @@ class UpsertGoogleSecurityGroupAtomicOperationUnitSpec extends Specification {
           credentials: credentials
       )
       @Subject def operation = new UpsertGoogleSecurityGroupAtomicOperation(description)
+      operation.registry = registry
       operation.googleNetworkProvider = googleNetworkProviderMock
 
     when:
@@ -125,6 +129,7 @@ class UpsertGoogleSecurityGroupAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new UpsertGoogleSecurityGroupAtomicOperation(description)
+      operation.registry = registry
       operation.googleNetworkProvider = googleNetworkProviderMock
 
     when:
@@ -172,6 +177,7 @@ class UpsertGoogleSecurityGroupAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new UpsertGoogleSecurityGroupAtomicOperation(description)
+      operation.registry = registry
       operation.googleNetworkProvider = googleNetworkProviderMock
 
     when:
@@ -220,6 +226,7 @@ class UpsertGoogleSecurityGroupAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleSecurityGroupAtomicOperation(description)
+      operation.registry = registry
       operation.googleNetworkProvider = googleNetworkProviderMock
 
     when:
@@ -268,6 +275,7 @@ class UpsertGoogleSecurityGroupAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleSecurityGroupAtomicOperation(description)
+      operation.registry = registry
       operation.googleNetworkProvider = googleNetworkProviderMock
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleServerGroupTagsAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleServerGroupTagsAtomicOperationUnitSpec.groovy
@@ -130,6 +130,7 @@ class UpsertGoogleServerGroupTagsAtomicOperationUnitSpec extends Specification {
                                                                    accountName: ACCOUNT_NAME,
                                                                    credentials: credentials)
       @Subject def operation = new UpsertGoogleServerGroupTagsAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
           new GoogleOperationPoller(
             googleConfigurationProperties: new GoogleConfigurationProperties(),
@@ -243,6 +244,7 @@ class UpsertGoogleServerGroupTagsAtomicOperationUnitSpec extends Specification {
                                                                    accountName: ACCOUNT_NAME,
                                                                    credentials: credentials)
       @Subject def operation = new UpsertGoogleServerGroupTagsAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
           new GoogleOperationPoller(
             googleConfigurationProperties: new GoogleConfigurationProperties(),

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -124,6 +124,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -253,6 +254,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -328,6 +330,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleHttpLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -401,6 +404,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -486,6 +490,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -579,6 +584,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -679,6 +685,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -750,6 +757,7 @@ class DeleteGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
@@ -113,6 +113,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
           registry: registry,
           safeRetry: safeRetry
       )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -198,6 +199,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         registry: registry,
         safeRetry: safeRetry
       )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -283,6 +285,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         registry: registry,
         safeRetry: safeRetry
       )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -379,6 +382,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         registry: registry,
         safeRetry: safeRetry
       )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -470,6 +474,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         registry: registry,
         safeRetry: safeRetry
       )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -520,6 +525,7 @@ class DeleteGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         registry: registry,
         safeRetry: safeRetry
       )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -105,6 +105,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -168,6 +169,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -204,6 +206,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new DeleteGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -249,6 +252,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -299,6 +303,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -356,6 +361,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -438,6 +444,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -526,6 +533,7 @@ class DeleteGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
@@ -118,6 +118,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -185,6 +186,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
           threadSleeper: threadSleeperMock,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -245,6 +247,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -310,6 +313,7 @@ class DeleteGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
           threadSleeper: threadSleeperMock,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -172,6 +172,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -295,6 +296,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
             registry: registry,
             safeRetry: safeRetry
           )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -418,6 +420,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
             registry: registry,
             safeRetry: safeRetry
           )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -571,6 +574,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -729,6 +733,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:
@@ -892,6 +897,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
           registry: registry,
           safeRetry: safeRetry
         )
+      operation.registry = registry
       operation.safeRetry = safeRetry
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
@@ -132,6 +132,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         registry: registry,
         safeRetry: safeRetry
       )
+    operation.registry = registry
     operation.safeRetry = safeRetry
 
     when:
@@ -237,6 +238,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         registry: registry,
         safeRetry: safeRetry
       )
+    operation.registry = registry
     operation.safeRetry = safeRetry
 
     when:
@@ -342,6 +344,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
         registry: registry,
         safeRetry: safeRetry
       )
+    operation.registry = registry
     operation.safeRetry = safeRetry
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleLoadBalancerAtomicOperationUnitSpec.groovy
@@ -127,6 +127,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
@@ -217,6 +218,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
@@ -288,6 +290,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
@@ -349,6 +352,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
@@ -415,6 +419,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -455,6 +460,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
           accountName: ACCOUNT_NAME,
           credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -528,6 +534,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -610,6 +617,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -694,6 +702,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
@@ -787,6 +796,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
@@ -887,6 +897,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
       operation.googleOperationPoller =
         new GoogleOperationPoller(
           googleConfigurationProperties: new GoogleConfigurationProperties(),
@@ -991,6 +1002,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -1086,6 +1098,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -1182,6 +1195,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])
@@ -1280,6 +1294,7 @@ class UpsertGoogleLoadBalancerAtomicOperationUnitSpec extends Specification {
         accountName: ACCOUNT_NAME,
         credentials: credentials)
       @Subject def operation = new UpsertGoogleLoadBalancerAtomicOperation(description)
+      operation.registry = registry
 
     when:
       operation.operate([])

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec.groovy
@@ -143,6 +143,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         registry: registry,
         safeRetry: safeRetry
       )
+    operation.registry = registry
     operation.safeRetry = safeRetry
 
     when:
@@ -256,6 +257,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         registry: registry,
         safeRetry: safeRetry
       )
+    operation.registry = registry
     operation.safeRetry = safeRetry
 
     when:
@@ -369,6 +371,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperationUnitSpec extends Specification {
         registry: registry,
         safeRetry: safeRetry
       )
+    operation.registry = registry
     operation.safeRetry = safeRetry
 
     when:


### PR DESCRIPTION
@duftler 

I made these changes yesterday before your note about formatting. I chose to format the changes this way because I thought it was the most readable given the surrounding context. I dont mind going back and changing it since it is mechanical and have been through twice already and hasnt been a big deal.

The tests are slightly inconsistent. Sometimes I test for metrics and sometimes not. Where I dont, the registry scope doesnt really matter other than it needs to be defined. Where I do, I scope the registry to the test methods so that it wont be influenced elsewhere. I typically only test the main metric and typically only on success. I didnt want to make the tests too brittle because the metric lookup needs to have exact tags. But I wanted to call out differences between regional, zonal, global where the metric names differ. The successCode is "0" in the tests, even though that value doesnt make sense. That is a defincincy in the google client libraries. The runtime does give the right values (I tested this manually). I documented why each test was using "0".