### PR TITLE
(kubernetes) handle lack of load balancer relationship in cluster cache

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -129,7 +129,7 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
       cluster.accountName = clusterKey.account
       cluster.name = clusterKey.name
       if (includeDetails) {
-        cluster.loadBalancers = clusterDataEntry.relationships[Keys.Namespace.LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) }
+        cluster.loadBalancers = clusterDataEntry.relationships[Keys.Namespace.LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) } ?: []
         cluster.serverGroups = serverGroups[cluster.name]?.findAll { it.account == cluster.accountName } ?: []
       } else {
         cluster.loadBalancers = clusterDataEntry.relationships[Keys.Namespace.LOAD_BALANCERS.ns]?.collect { loadBalancerKey ->


### PR DESCRIPTION
It seems that groovy can't infer the type of a null `Set` object, and then crashes during dispatch. @leelasharma I think this fixes what you saw. @duftler PTAL