### PR TITLE
Changing autoscaling lifecycle agent to publish to sns instead of sqs

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 class InstanceTerminationConfigurationProperties {
   String accountName
   String queueARN
-  String sourceARN
+  String topicARN
 
   int maxMessagesPerCycle = 1000
   int visibilityTimeout = 30
@@ -34,13 +34,13 @@ class InstanceTerminationConfigurationProperties {
 
   InstanceTerminationConfigurationProperties(String accountName,
                                              String queueARN,
-                                             String sourceARN,
+                                             String topicARN,
                                              int maxMessagesPerCycle,
                                              int visibilityTimeout,
                                              int waitTimeSeconds) {
     this.accountName = accountName
     this.queueARN = queueARN
-    this.sourceARN = sourceARN
+    this.topicARN = topicARN
     this.maxMessagesPerCycle = maxMessagesPerCycle
     this.visibilityTimeout = visibilityTimeout
     this.waitTimeSeconds = waitTimeSeconds

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProvider.java
@@ -74,7 +74,7 @@ public class InstanceTerminationLifecycleAgentProvider implements AgentProvider 
             .getQueueARN()
             .replaceAll(REGION_TEMPLATE_PATTERN, region.getName())
             .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
-          properties.getSourceARN()
+          properties.getTopicARN()
             .replaceAll(REGION_TEMPLATE_PATTERN, region.getName())
             .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
           properties.getMaxMessagesPerCycle(),

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProviderSpec.groovy
@@ -37,8 +37,8 @@ class InstanceTerminationLifecycleAgentProviderSpec extends Specification {
 
   InstanceTerminationConfigurationProperties properties = new InstanceTerminationConfigurationProperties(
     'mgmt',
-    'arn:aws:sqs:{{region}}:{{accountId}}:{{environment}}-queueName',
-    'arn:aws:iam::*:sourceArn',
+    'arn:aws:sqs:{{region}}:{{accountId}}:queueName',
+    'arn:aws:sqs:{{region}}:{{accountId}}:topicName',
     -1,
     -1,
     -1


### PR DESCRIPTION
Altering the autoscaling lifecycle agent to have AutoScaling publish messages to SNS for fanout, rather than directly to a single queue.

@spinnaker/netflix-reviewers PTAL