### PR TITLE
Slims container by deleting compile-time requirements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ COPY . workdir/
 
 WORKDIR workdir
 
-RUN GRADLE_USER_HOME=cache ./gradlew buildDeb -x test
-
-RUN dpkg -i ./clouddriver-web/build/distributions/*.deb
+RUN GRADLE_USER_HOME=cache ./gradlew buildDeb -x test && \
+  dpkg -i ./clouddriver-web/build/distributions/*.deb && \
+  cd .. && \
+  rm -rf workdir
 
 CMD ["/opt/clouddriver/bin/clouddriver"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,12 @@
+FROM openjdk:8u111-jre-alpine
+
+MAINTAINER delivery-engineering@netflix.com
+
+COPY ./clouddriver-web/build/distributions/clouddriver.zip /opt/clouddriver.zip
+
+RUN apk add --update bash && \
+      unzip /opt/clouddriver.zip -d /opt && \
+      rm /opt/clouddriver.zip && \
+      rm -rf /var/cache/apk/*
+
+CMD ["/opt/clouddriver/bin/clouddriver"]

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,10 @@ buildscript {
   repositories {
     jcenter()
     maven { url "http://spinnaker.bintray.com/gradle" }
+    maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
-    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.10.0'
+    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.11.0'
     classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
   }
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+- name: 'gcr.io/cloud-builders/git'
+  args: ['fetch', '--unshallow']
+- name: 'java:8'
+  env: ["GRADLE_USER_HOME=cache"]
+  entrypoint: "bash"
+  args: [ "-c", "./gradlew clouddriver-web:distZip -x test"]
+- name: 'gcr.io/cloud-builders/docker'
+  args: ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA", "-f", "Dockerfile.slim", "."]
+images:
+- 'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'


### PR DESCRIPTION
This PR bumps the gradle project version (to get it working on Google Cloud Builder), and is the same process as https://github.com/spinnaker/fiat/pull/146

Currently, the built Docker container clocks in at a whopping 1GB. After this PR, Quay images should be ~427MB, and if built on GCB with the included `cloudbuild.yaml`, it is further reduced to a svelte 300MB.

@cfieber @tomaslin @duftler @lwander 

Tested by booting up in a K8 cluster.

cc: @leelasharma