### PR TITLE
provider/amazon: clean lifecycle hook names

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgLifecycleHookWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AsgLifecycleHookWorker.groovy
@@ -55,7 +55,7 @@ class AsgLifecycleHookWorker {
         case AmazonAsgLifecycleHook.TransitionType.LIFECYCLE:
           def request = new PutLifecycleHookRequest(
             autoScalingGroupName: targetAsgName,
-            lifecycleHookName: lifecycleHookName,
+            lifecycleHookName: cleanLifecycleHookName(lifecycleHookName),
             roleARN: arnTemplater(lifecycleHook.roleARN, targetRegion, targetAccountId),
             notificationTargetARN: arnTemplater(lifecycleHook.notificationTargetARN, targetRegion, targetAccountId),
             notificationMetadata: lifecycleHook.notificationMetadata,
@@ -83,5 +83,9 @@ class AsgLifecycleHookWorker {
 
   private static String arnTemplater(String arnTemplate, String region, String accountId) {
     arnTemplate.replaceAll(REGION_TEMPLATE_PATTERN, region).replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, accountId)
+  }
+
+  public static String cleanLifecycleHookName(String name) {
+    return name.replaceAll("[^A-Za-z0-9\\-_/]", "_")
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperation.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.autoscaling.model.PutLifecycleHookRequest
+import com.netflix.spinnaker.clouddriver.aws.deploy.AsgLifecycleHookWorker
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgLifecycleHookDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.services.IdGenerator
@@ -42,7 +43,7 @@ class UpsertAsgLifecycleHookAtomicOperation implements AtomicOperation<Void> {
   Void operate(List priorOutputs) {
     final lifecycleHookName = description.name ?: "${description.serverGroupName}-lifecycle-${idGenerator.nextId()}"
     final request = new PutLifecycleHookRequest(
-      lifecycleHookName: lifecycleHookName,
+      lifecycleHookName: AsgLifecycleHookWorker.cleanLifecycleHookName(lifecycleHookName),
       autoScalingGroupName: description.serverGroupName,
       lifecycleTransition: description.lifecycleTransition.toString(),
       roleARN: description.roleARN,

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperationUnitSpec.groovy
@@ -72,6 +72,24 @@ class UpsertAsgLifecycleHookAtomicOperationUnitSpec extends Specification {
     0 * _
   }
 
+  def 'removes invalid characters from lifecycle hook name'() {
+    when:
+    description.serverGroupName = 'a+b=c!d@e#f$g%h&i*j(k)l_m-n{o}p[q]r\\s<t>u,v.w?x/y|z-v001' // this is a valid ASG name
+    op.operate([])
+
+    then:
+    1 * autoScaling.putLifecycleHook(new PutLifecycleHookRequest(
+      lifecycleHookName: 'a_b_c_d_e_f_g_h_i_j_k_l_m-n_o_p_q_r_s_t_u_v_w_x/y_z-v001-lifecycle-1',
+      autoScalingGroupName: 'a+b=c!d@e#f$g%h&i*j(k)l_m-n{o}p[q]r\\s<t>u,v.w?x/y|z-v001',
+      lifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING',
+      roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
+      notificationTargetARN: 'arn:aws:sns:us-west-1:123456789012:my-sns-topic',
+      heartbeatTimeout: 3600,
+      defaultResult: 'ABANDON'
+    ))
+    0 * _
+  }
+
   def 'creates named lifecycle hook'() {
     given:
     description.name = 'fancyHook'


### PR DESCRIPTION
Amazon doesn't like dots in lifecycle hook names.

@robzienert or @cfieber PTAL