### PR TITLE
provider/google: Adds ability to set/change named ports.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -376,19 +376,19 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
           log.warn("Could not locate source server group ${sourceGroupName} to update named port.")
         }
         namedPort = new NamedPort(
-            name: GoogleHttpLoadBalancingPolicy.HTTP_PORT_NAME,
-            port: sourceServerGroup?.namedPorts[(GoogleHttpLoadBalancingPolicy.HTTP_PORT_NAME)] ?: GoogleHttpLoadBalancingPolicy.HTTP_DEFAULT_PORT,
+            name: GoogleHttpLoadBalancingPolicy.HTTP_DEFAULT_PORT_NAME,
+            port: sourceServerGroup?.namedPorts[(GoogleHttpLoadBalancingPolicy.HTTP_DEFAULT_PORT_NAME)] ?: GoogleHttpLoadBalancingPolicy.HTTP_DEFAULT_PORT,
         )
       } else {
         namedPort = new NamedPort(
-            name: GoogleHttpLoadBalancingPolicy.HTTP_PORT_NAME,
+            name: GoogleHttpLoadBalancingPolicy.HTTP_DEFAULT_PORT_NAME,
             port: description?.loadBalancingPolicy?.listeningPort ?: GoogleHttpLoadBalancingPolicy.HTTP_DEFAULT_PORT
         )
       }
       if (!namedPort) {
         log.warn("Could not locate named port on either load balancing policy or source server group. Setting default named port.")
         namedPort = new NamedPort(
-            name: GoogleHttpLoadBalancingPolicy.HTTP_PORT_NAME,
+            name: GoogleHttpLoadBalancingPolicy.HTTP_DEFAULT_PORT_NAME,
             port: GoogleHttpLoadBalancingPolicy.HTTP_DEFAULT_PORT,
         )
       }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleBackendService.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleBackendService.groovy
@@ -42,6 +42,11 @@ class GoogleBackendService {
   GoogleSessionAffinity sessionAffinity
   Integer affinityCookieTtlSec
   GoogleLoadBalancingScheme loadBalancingScheme
+  /**
+   * Named port this backend service will forward traffic to. Server groups that join
+   * this backend service are responsible for defining the port this name maps to.
+   */
+  String namedPort
 
   /**
    * Specifies whether edge caching is enabled or not. Only applicable for Https LBs.

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleHttpLoadBalancingPolicy.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/loadbalancing/GoogleHttpLoadBalancingPolicy.groovy
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
  */
 class GoogleHttpLoadBalancingPolicy extends GoogleLoadBalancingPolicy {
   @JsonIgnore
-  static final String HTTP_PORT_NAME = 'http'
+  static final String HTTP_DEFAULT_PORT_NAME = 'http'
 
   @JsonIgnore
   static final Integer HTTP_DEFAULT_PORT = 80

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleBackendServiceCachingAgent.groovy
@@ -95,6 +95,7 @@ class GoogleBackendServiceCachingAgent extends AbstractGoogleCachingAgent {
         attributes.name = backendService.name
         attributes.kind = backendService.kind
         attributes.healthCheckLink = backendService.healthCheckLink
+        attributes.namedPort = backendService.namedPort
         attributes.sessionAffinity = backendService.sessionAffinity
         attributes.affinityCookieTtlSec = backendService.affinityCookieTtlSec
         attributes.region = backendService.region
@@ -113,6 +114,7 @@ class GoogleBackendServiceCachingAgent extends AbstractGoogleCachingAgent {
       kind: kind,
       healthCheckLink: bs.healthChecks[0],
       sessionAffinity: bs.sessionAffinity,
+      namedPort: bs.namedPort,
       affinityCookieTtlSec: bs.affinityCookieTtlSec,
       enableCDN: bs.enableCDN,
       region: bs.region ?: 'global'

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -394,6 +394,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleCachingAgent impl
       List<GoogleBackendService> backendServicesInMap = Utils.getBackendServicesFromHttpLoadBalancerView(googleLoadBalancer.view)
       def backendServicesToUpdate = backendServicesInMap.findAll { it && it.name == backendService.name }
       backendServicesToUpdate.each { GoogleBackendService service ->
+        service.namedPort = backendService.portName
         service.sessionAffinity = GoogleSessionAffinity.valueOf(backendService.sessionAffinity)
         service.affinityCookieTtlSec = backendService.affinityCookieTtlSec
         service.enableCDN = backendService.enableCDN

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -238,6 +238,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleCachingAgent imple
 
       GoogleBackendService newService = new GoogleBackendService(
         name: backendService.name,
+        namedPort: backendService.portName,
         loadBalancingScheme: backendService.loadBalancingScheme,
         sessionAffinity: backendService.sessionAffinity,
         affinityCookieTtlSec: backendService.affinityCookieTtlSec,


### PR DESCRIPTION
Backend services have a `portName` field that is modifiable. We initially were opinionated about the name of this port (set it to `http` only), but this means you cannot direct traffic to two different ports on the same instance. This PR lets you set the named port on a BS. A following PR will let you set the named ports on a server group when deploying.