### PR TITLE
chore(gradle): Bump spinnaker-gradle-project version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
-    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.11.0'
+    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:3.12.0'
     classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
   }
 }


### PR DESCRIPTION
@duftler @cfieber @ewiseblatt FYI. Updating just Clouddriver overnight in case something goes wrong -- it's 10x faster to roll back 1 thing instead of 10 :)