### PR TITLE
(entityTags) allow bulk update of entity tags

### DIFF
--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/BulkUpsertEntityTagsAtomicOperationConverter.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/BulkUpsertEntityTagsAtomicOperationConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.converters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.BulkUpsertEntityTagsDescription;
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
+import com.netflix.spinnaker.clouddriver.elasticsearch.ops.BulkUpsertEntityTagsAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component("bulkUpsertEntityTagsDescription")
+public class BulkUpsertEntityTagsAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  private final ObjectMapper objectMapper;
+  private final Front50Service front50Service;
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final ElasticSearchEntityTagsProvider entityTagsProvider;
+
+  @Autowired
+  public BulkUpsertEntityTagsAtomicOperationConverter(ObjectMapper objectMapper,
+                                                      Front50Service front50Service,
+                                                      AccountCredentialsProvider accountCredentialsProvider,
+                                                      ElasticSearchEntityTagsProvider entityTagsProvider) {
+    this.objectMapper = objectMapper;
+    this.front50Service = front50Service;
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.entityTagsProvider = entityTagsProvider;
+  }
+
+  public AtomicOperation convertOperation(Map input) {
+    return new BulkUpsertEntityTagsAtomicOperation(
+      front50Service, accountCredentialsProvider, entityTagsProvider, this.convertDescription(input)
+    );
+  }
+
+  public BulkUpsertEntityTagsDescription convertDescription(Map input) {
+    BulkUpsertEntityTagsDescription description = objectMapper.convertValue(input, BulkUpsertEntityTagsDescription.class);
+    description.entityTags.forEach(upsertEntityTagsDescription ->
+      upsertEntityTagsDescription.getTags().forEach(UpsertEntityTagsAtomicOperationConverter::setTagValueType)
+    );
+    return description;
+  }
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverter.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverter.java
@@ -62,13 +62,14 @@ public class UpsertEntityTagsAtomicOperationConverter extends AbstractAtomicOper
 
   public UpsertEntityTagsDescription convertDescription(Map input) {
     UpsertEntityTagsDescription upsertEntityTagsDescription = objectMapper.convertValue(input, UpsertEntityTagsDescription.class);
-    upsertEntityTagsDescription.getTags().forEach(entityTag -> {
-      if (entityTag.getValueType() == null) {
-        boolean isObject = entityTag.getValue() instanceof Map || entityTag.getValue() instanceof Collection;
-        entityTag.setValueType(isObject ? EntityTags.EntityTagValueType.object : EntityTags.EntityTagValueType.literal);
-      }
-    });
-
+    upsertEntityTagsDescription.getTags().forEach(UpsertEntityTagsAtomicOperationConverter::setTagValueType);
     return upsertEntityTagsDescription;
+  }
+
+  static void setTagValueType(EntityTags.EntityTag entityTag) {
+    if (entityTag.getValueType() == null) {
+      boolean isObject = entityTag.getValue() instanceof Map || entityTag.getValue() instanceof Collection;
+      entityTag.setValueType(isObject ? EntityTags.EntityTagValueType.object : EntityTags.EntityTagValueType.literal);
+    }
   }
 }

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/BulkUpsertEntityTagsDescription.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/descriptions/BulkUpsertEntityTagsDescription.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.descriptions;
+
+import com.netflix.spinnaker.clouddriver.security.resources.NonCredentialed;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BulkUpsertEntityTagsDescription implements NonCredentialed {
+  public List<UpsertEntityTagsDescription> entityTags = new ArrayList<>();
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperation.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperation.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.ops;
+
+import com.google.common.collect.Lists;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.BulkUpsertEntityTagsDescription;
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+
+import java.util.List;
+
+public class BulkUpsertEntityTagsAtomicOperation implements AtomicOperation<Void> {
+
+  private final Front50Service front50Service;
+  private final AccountCredentialsProvider accountCredentialsProvider;
+  private final ElasticSearchEntityTagsProvider entityTagsProvider;
+  private final BulkUpsertEntityTagsDescription bulkUpsertEntityTagsDescription;
+
+  public BulkUpsertEntityTagsAtomicOperation(Front50Service front50Service,
+                                             AccountCredentialsProvider accountCredentialsProvider,
+                                             ElasticSearchEntityTagsProvider entityTagsProvider,
+                                             BulkUpsertEntityTagsDescription bulkUpsertEntityTagsDescription) {
+    this.front50Service = front50Service;
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.entityTagsProvider = entityTagsProvider;
+    this.bulkUpsertEntityTagsDescription = bulkUpsertEntityTagsDescription;
+  }
+
+  public Void operate(List priorOutputs) {
+    bulkUpsertEntityTagsDescription.entityTags.forEach(tag ->
+      new UpsertEntityTagsAtomicOperation(front50Service, accountCredentialsProvider, entityTagsProvider, tag)
+        .operate(priorOutputs)
+    );
+    return null;
+  }
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/UpsertEntityTagsAtomicOperation.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/UpsertEntityTagsAtomicOperation.java
@@ -117,7 +117,7 @@ public class UpsertEntityTagsAtomicOperation implements AtomicOperation<Void> {
     return null;
   }
 
-  private static EntityRefIdBuilder.EntityRefId entityRefId(AccountCredentialsProvider accountCredentialsProvider,
+  public static EntityRefIdBuilder.EntityRefId entityRefId(AccountCredentialsProvider accountCredentialsProvider,
                                                             UpsertEntityTagsDescription description) {
     EntityTags.EntityRef entityRef = description.getEntityRef();
     String entityRefAccount = entityRef.getAccount();

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/validators/BulkUpsertEntityTagsDescriptionValidator.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/validators/BulkUpsertEntityTagsDescriptionValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.BulkUpsertEntityTagsDescription;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@Component("bulkUpsertEntityTagsDescriptionValidator")
+public class BulkUpsertEntityTagsDescriptionValidator extends DescriptionValidator<BulkUpsertEntityTagsDescription> {
+
+  @Value("${entityTags.maxConcurrentBulkTags:100}")
+  Integer maxConcurrentBulkTags;
+
+  @Override
+  public void validate(List priorDescriptions, BulkUpsertEntityTagsDescription description, Errors errors) {
+    if (description.entityTags != null && description.entityTags.size() > maxConcurrentBulkTags) {
+      errors.rejectValue("entityTags.length",
+        "Max number of entity tags that can be submitted at once is " + maxConcurrentBulkTags);
+    }
+  }
+}

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperationSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperationSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.ops
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.BulkUpsertEntityTagsDescription
+import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.UpsertEntityTagsDescription
+import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider
+import com.netflix.spinnaker.clouddriver.model.EntityTags
+import com.netflix.spinnaker.clouddriver.model.EntityTags.EntityRef
+import com.netflix.spinnaker.clouddriver.model.EntityTags.EntityTag
+import com.netflix.spinnaker.clouddriver.model.EntityTags.EntityTagValueType
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+
+class BulkUpsertEntityTagsAtomicOperationSpec extends Specification {
+
+  def testCredentials = Mock(AccountCredentials) {
+    getAccountId() >> { return "100" }
+    getName() >> { return "test" }
+  }
+
+  def front50Service = Mock(Front50Service)
+  def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+  def entityTagsProvider = Mock(ElasticSearchEntityTagsProvider)
+
+  BulkUpsertEntityTagsDescription description
+  BulkUpsertEntityTagsAtomicOperation operation
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+
+  def setup() {
+    description = new BulkUpsertEntityTagsDescription()
+    operation = new BulkUpsertEntityTagsAtomicOperation(front50Service, accountCredentialsProvider, entityTagsProvider, description)
+  }
+
+  void "should perform bulk operation"() {
+    given:
+    (1..11).each { addTag(it) }
+
+    when:
+    operation.operate([])
+
+    then:
+    11 * accountCredentialsProvider.getAll() >> { return [testCredentials] }
+    11 * front50Service.saveEntityTags(_) >> {
+      return new EntityTags(lastModified: 123, lastModifiedBy: "unknown")
+    }
+    11 * entityTagsProvider.index(_)
+    11 * entityTagsProvider.verifyIndex(_)
+  }
+
+  private void addTag(Integer index) {
+    def tag = new UpsertEntityTagsDescription()
+    tag.entityRef = new EntityRef(
+      cloudProvider: "aws", entityType: "servergroup", entityId: "orca-v001", accountId: "100", region: "us-east-1"
+    )
+    tag.tags = [new EntityTag(name: "tag-$index", value: "$index", valueType: EntityTagValueType.literal)]
+    description.entityTags.add(tag)
+  }
+
+}


### PR DESCRIPTION
Trying to do a bunch of concurrent operations against a single entity does not work, as you can easily get into a race condition (since the tagging operation could take up to a second).

This allows users to create multiple entity tags at once, using the same structure as they're using to create a single tag.

I tried to get fancy and parallelize operations, but that just re-introduced the same race condition, so...I just limited it to 100 tags at a time.

@cfieber PTAL