### PR TITLE
Propagate 401 error for basic auth docker registry

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
@@ -92,17 +92,10 @@ class DockerBearerTokenService {
    * Parsed according to http://www.ietf.org/rfc/rfc2617.txt
    */
   public AuthenticateDetails parseBearerAuthenticateHeader(String header) {
-    String bearerPrefix = "bearer "
     String realmKey = "realm"
     String serviceKey = "service"
     String scopeKey = "scope"
     AuthenticateDetails result = new AuthenticateDetails()
-
-    if (!bearerPrefix.equalsIgnoreCase(header.substring(0, bearerPrefix.length()))) {
-      throw new DockerRegistryAuthenticationException("Docker registry must support 'Bearer' authentication.")
-    } else {
-      header = header.substring(bearerPrefix.length())
-    }
 
     // Each parameter has the form <token>=(<token>|<quoted-string>).
     while (header.length() > 0) {
@@ -191,22 +184,10 @@ class DockerBearerTokenService {
     return cachedTokens[repository]
   }
 
-  public DockerBearerToken getToken(String repository, List<Header> headers) {
-    String authenticate = null
-
-    headers.forEach { header ->
-      if (header.name.equalsIgnoreCase("www-authenticate")) {
-        authenticate = header.value
-      }
-    }
-
-    if (!authenticate) {
-      return null
-    }
-
+  public DockerBearerToken getToken(String repository, String authenticateHeader) {
     def authenticateDetails
     try {
-      authenticateDetails = parseBearerAuthenticateHeader(authenticate)
+      authenticateDetails = parseBearerAuthenticateHeader(authenticateHeader)
     } catch (Exception e) {
       throw new DockerRegistryAuthenticationException("Failed to parse www-authenticate header: ${e.message}")
     }

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenServiceSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenServiceSpec.groovy
@@ -39,7 +39,7 @@ class DockerBearerTokenServiceSpec extends Specification {
 
   void "should parse Www-Authenticate header with full privileges and path."() {
     setup:
-      def input = "Bearer realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE1}\""
+      def input = "realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE1}\""
     when:
       def result = tokenService.parseBearerAuthenticateHeader(input)
 
@@ -52,7 +52,7 @@ class DockerBearerTokenServiceSpec extends Specification {
 
   void "should parse Www-Authenticate header with some privileges and path."() {
     setup:
-      def input = "Bearer realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE2}\""
+      def input = "realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE2}\""
     when:
       def result = tokenService.parseBearerAuthenticateHeader(input)
 
@@ -65,7 +65,7 @@ class DockerBearerTokenServiceSpec extends Specification {
 
   void "should parse Www-Authenticate header with some privileges and no path."() {
     setup:
-      def input = "Bearer realm=\"${REALM1}\",service=\"${SERVICE1}\",scope=\"${SCOPE2}\""
+      def input = "realm=\"${REALM1}\",service=\"${SERVICE1}\",scope=\"${SCOPE2}\""
     when:
       def result = tokenService.parseBearerAuthenticateHeader(input)
 
@@ -78,7 +78,7 @@ class DockerBearerTokenServiceSpec extends Specification {
 
   void "should parse unquoted Www-Authenticate header with some privileges and path."() {
     setup:
-      def input = "Bearer realm=${REALM1}/${PATH1},service=${SERVICE1},scope=${SCOPE2}"
+      def input = "realm=${REALM1}/${PATH1},service=${SERVICE1},scope=${SCOPE2}"
     when:
       def result = tokenService.parseBearerAuthenticateHeader(input)
 
@@ -91,12 +91,9 @@ class DockerBearerTokenServiceSpec extends Specification {
 
   void "should request a real token from Dockerhub's token registry."() {
     setup:
-      def header = [:]
-      header.value = "Bearer realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE1}\""
-      header.name = "Www-Authenticate"
-      def headers = [header]
+      def authenticateHeader = "realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE1}\""
     when:
-      DockerBearerToken token = tokenService.getToken(REPOSITORY1, headers)
+      DockerBearerToken token = tokenService.getToken(REPOSITORY1, authenticateHeader)
 
     then:
       token.token.length() > 0
@@ -104,19 +101,16 @@ class DockerBearerTokenServiceSpec extends Specification {
 
   void "should request a real token from Dockerhub's token registry, and supply a cached one."() {
     setup:
-      def header = [:]
-      header.value = "Bearer realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE1}\""
-      header.name = "Www-Authenticate"
-      def headers = [header]
+      def authenticateHeader = "realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE1}\""
     when:
-      tokenService.getToken(REPOSITORY1, headers)
+      tokenService.getToken(REPOSITORY1, authenticateHeader)
       DockerBearerToken token = tokenService.getToken(REPOSITORY1)
 
     then:
       token.token.length() > 0
   }
 
-  void "should read a password from a file, and correctely prepare the basic auth string."() {
+  void "should read a password from a file, and correctly prepare the basic auth string."() {
     setup:
       def passwordFile = new File("src/test/resources/password.txt")
       def username = "username"
@@ -126,6 +120,5 @@ class DockerBearerTokenServiceSpec extends Specification {
 
     then:
       new String(Base64.decoder.decode(fileTokenService.getBasicAuth().bytes)) == "$username:$passwordContents"
-
   }
 }


### PR DESCRIPTION
There are two cases where a DockerRegistryAuthenticationException stating "Docker registry must support 'Bearer' authentication." was propagated instead of a 401, causing issues:
1. checkV2Availability always fails for a registry that only supports basic auth
2. If user specifies an incorrect password, the error thrown is the DockerRegistryAuthenticationException instead of the more accurate "401 Unauthorized" error