### PR TITLE
(kubernetes) Complete enable/disable early when there are no pods to operate on

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
@@ -102,6 +102,11 @@ abstract class AbstractEnableDisableKubernetesAtomicOperation implements AtomicO
       }
     }
 
+    if (!pods) {
+      task.updateStatus basePhase, "No pods to ${basePhase.toLowerCase()}. Operation finshed successfully."
+      return
+    }
+
     task.updateStatus basePhase, "Resetting service labels for each pod..."
 
     def pool = Executors.newWorkStealingPool((int) (pods.size() / 2) + 1)


### PR DESCRIPTION
@duftler 

In Kubernetes 1.5 pods are returned as a null object rather than an empty array.