### PR TITLE
EntityTags: batch bulk operations in groups of 50

### DIFF
--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperationSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperationSpec.groovy
@@ -56,19 +56,19 @@ class BulkUpsertEntityTagsAtomicOperationSpec extends Specification {
 
   void "should perform bulk operation"() {
     given:
-    (1..11).each { addTag(it) }
+    (1..1000).each { addTag(it) }
 
     when:
     operation.operate([])
 
     then:
-    11 * accountCredentialsProvider.getAll() >> { return [testCredentials] }
-    1 * front50Service.getAllEntityTagsById(_) >> []
-    1 * front50Service.batchUpdate(_) >> {
+    1000 * accountCredentialsProvider.getAll() >> { return [testCredentials] }
+    20 * front50Service.getAllEntityTagsById(_) >> []
+    20 * front50Service.batchUpdate(_) >> {
       description.entityTags.findResults { new EntityTags(id: it.id, lastModified: 123, lastModifiedBy: "unknown")}
     }
-    1 * entityTagsProvider.bulkIndex(description.entityTags)
-    11 * entityTagsProvider.verifyIndex(_)
+    20 * entityTagsProvider.bulkIndex(_)
+    1000 * entityTagsProvider.verifyIndex(_)
   }
 
   void 'should set id and pattern to default if none supplied'() {


### PR DESCRIPTION
While it's great that we're allowing users to submit batches of 1000 tags in the bulk upsert operation, it doesn't actually work unless Front50 is configured to handle GET requests for URLs that have 1000 tag ids in them, which...it almost certainly won't.

So: let's perform the upserts in batches of 50. I considered removing the 1000 tag limit because of this, but, considering we're storing the results and returning them to Orca, I'm a little concerned about the payload size and the pain Orca will feel when marshalling/unmarshalling the JSON of, e.g. 25,000 tags.

If any @spinnaker/reviewers know anything about Rx, I'd appreciate some eyes on this.