### PR TITLE
Introduce a new `namespace` attribute to `EntityTag`

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
@@ -105,11 +105,16 @@ class EntityTags {
 
   static class EntityTag {
     String name
+    String namespace
     Object value
     EntityTagValueType valueType
 
     String getName() {
       return name.toLowerCase()
+    }
+
+    String getNamespace() {
+      return (namespace ?: "default").toLowerCase()
     }
 
     @JsonIgnore


### PR DESCRIPTION
The idea being that tag name's could be re-used across namespaces, either
intentionally or accidentally.

Permissions / restrictions could also be applied to namespaces vs. individual
tag names.

Will need to sort out re-indexing and assign a proper namespace to all
existing tags.

Depends on spinnaker/front50#203