### PR TITLE
(appengine) switched from app.yaml path to general config filepaths

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
@@ -31,7 +31,7 @@ class DeployAppengineDescription extends AbstractAppengineCredentialsDescription
   String repositoryUrl
   AppengineGitCredentialType gitCredentialType
   String branch
-  String appYamlPath
+  List<String> configFilepaths
   Boolean promote
   Boolean stopPreviousVersion
 }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
@@ -44,8 +44,8 @@ class DeployAppengineAtomicOperation implements AtomicOperation<DeploymentResult
     this.description = description
   }
   /**
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "createServerGroup": { "application": "myapp", "stack": "stack", "freeFormDetails": "details", "repositoryUrl": "https://github.com/organization/project.git", "branch": "feature-branch", "credentials": "my-appengine-account", "appYamlPath": "path/to/app.yaml" } } ]' "http://localhost:7002/appengine/ops"
-   * curl -X POST -H "Content-Type: application/json" -d '[ { "createServerGroup": { "application": "myapp", "stack": "stack", "freeFormDetails": "details", "repositoryUrl": "https://github.com/organization/project.git", "branch": "feature-branch", "credentials": "my-appengine-account", "appYamlPath": "path/to/app.yaml", "promote": true, "stopPreviousVersion": true } } ]' "http://localhost:7002/appengine/ops"
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "createServerGroup": { "application": "myapp", "stack": "stack", "freeFormDetails": "details", "repositoryUrl": "https://github.com/organization/project.git", "branch": "feature-branch", "credentials": "my-appengine-account", "configFilepaths": ["path/to/app.yaml"] } } ]' "http://localhost:7002/appengine/ops"
+   * curl -X POST -H "Content-Type: application/json" -d '[ { "createServerGroup": { "application": "myapp", "stack": "stack", "freeFormDetails": "details", "repositoryUrl": "https://github.com/organization/project.git", "branch": "feature-branch", "credentials": "my-appengine-account", "configFilepaths": ["path/to/app.yaml"], "promote": true, "stopPreviousVersion": true } } ]' "http://localhost:7002/appengine/ops"
    */
   @Override
   DeploymentResult operate(List priorOutputs) {
@@ -107,7 +107,8 @@ class DeployAppengineAtomicOperation implements AtomicOperation<DeploymentResult
                                                                          description.stack,
                                                                          description.freeFormDetails,
                                                                          false)
-    def deployCommand = ["gcloud", "app", "deploy", "$directoryPath/$description.appYamlPath"]
+    def fullyQualifiedConfigFilepaths = description.configFilepaths.collect { "$directoryPath/$it" }
+    def deployCommand = ["gcloud", "app", "deploy", *fullyQualifiedConfigFilepaths]
     deployCommand << "--version=$versionName"
     deployCommand << (description.promote ? "--promote" : "--no-promote")
     deployCommand << (description.stopPreviousVersion ? "--stop-previous-version": "--no-stop-previous-version")

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
@@ -51,6 +51,6 @@ class DeployAppengineDescriptionValidator extends DescriptionValidator<DeployApp
     helper.validateDetails(description.freeFormDetails, "freeFormDetails")
     helper.validateNotEmpty(description.repositoryUrl, "repositoryUrl")
     helper.validateNotEmpty(description.branch, "branch")
-    helper.validateNotEmpty(description.appYamlPath, "appYamlPath")
+    helper.validateNotEmpty(description.configFilepaths, "configFilepaths")
   }
 }

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineAtomicOperationConverterSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineAtomicOperationConverterSpec.groovy
@@ -29,7 +29,7 @@ class DeployAppengineAtomicOperationConverterSpec extends Specification {
   private static final APPLICATION = "myapp"
   private static final REPO_URL = "https://github.com/spinnaker/clouddriver.git"
   private static final BRANCH = "new-feature"
-  private static final APP_YAML_PATH = "/path/to/app.yaml"
+  private static final CONFIG_FILEPATHS = ["/path/to/app.yaml"]
 
   @Shared
   ObjectMapper mapper = new ObjectMapper()
@@ -52,7 +52,7 @@ class DeployAppengineAtomicOperationConverterSpec extends Specification {
         application: APPLICATION,
         repositoryUrl: REPO_URL,
         branch: BRANCH,
-        appYamlPath: APP_YAML_PATH
+        configFilepaths: CONFIG_FILEPATHS
       ]
 
     when:

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidatorSpec.groovy
@@ -34,7 +34,7 @@ class DeployAppengineDescriptionValidatorSpec extends Specification {
   private static final FREE_FORM_DETAILS = "details"
   private static final REPOSITORY_URL = "git@github.com:spinnaker/clouddriver.git"
   private static final BRANCH = "appengine"
-  private static final APP_YAML_PATH = "/path/to/app.yaml"
+  private static final CONFIG_FILEPATHS = ["/path/to/app.yaml"]
   private static final REGION = "us-central"
 
   @Shared
@@ -69,7 +69,7 @@ class DeployAppengineDescriptionValidatorSpec extends Specification {
         freeFormDetails: FREE_FORM_DETAILS,
         repositoryUrl: REPOSITORY_URL,
         branch: BRANCH,
-        appYamlPath: APP_YAML_PATH,
+        configFilepaths: CONFIG_FILEPATHS,
         promote: true,
         stopPreviousVersion: true,
         credentials: credentials,
@@ -90,7 +90,7 @@ class DeployAppengineDescriptionValidatorSpec extends Specification {
         application: APPLICATION_NAME,
         repositoryUrl: REPOSITORY_URL,
         branch: BRANCH,
-        appYamlPath: APP_YAML_PATH,
+        configFilepaths: CONFIG_FILEPATHS,
         credentials: credentials,
         gitCredentialType: AppengineGitCredentialType.NONE)
       def errors = Mock(Errors)


### PR DESCRIPTION
@lwander or @duftler please review.

Allows you to update top-level application config during a deploy operation. There seem to be good reasons for doing so, and I can't see any reason to stop people from doing it.