### PR TITLE
(aws & titus) Deleting tags from server group upon creation

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -22,6 +22,7 @@ import com.amazonaws.services.autoscaling.model.LaunchConfiguration
 import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest
 import com.google.common.annotations.VisibleForTesting
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration.DeployDefaults
 import com.netflix.spinnaker.clouddriver.aws.deploy.AmiIdResolver
@@ -40,6 +41,9 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.deploy.DeployHandler
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.events.CreateServerGroupEvent
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import groovy.transform.PackageScope
 
@@ -60,6 +64,8 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
   private final RegionScopedProviderFactory regionScopedProviderFactory
   private final AccountCredentialsRepository accountCredentialsRepository
   private final AwsConfiguration.DeployDefaults deployDefaults
+
+  private List<OperationEvent> events = []
 
   BasicAmazonDeployHandler(RegionScopedProviderFactory regionScopedProviderFactory,
                            AccountCredentialsRepository accountCredentialsRepository,
@@ -270,9 +276,18 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
       }
 
       createLifecycleHooks(task, regionScopedProvider, account, description, asgName)
+
+      this.events << new CreateServerGroupEvent(
+        AmazonCloudProvider.ID, account.accountId, region, asgName
+      )
     }
 
     return deploymentResult
+  }
+
+  @Override
+  void preDeploy(AtomicOperation operation) {
+    this.events = operation.events
   }
 
   @VisibleForTesting

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployHandler.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployHandler.java
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.deploy
+package com.netflix.spinnaker.clouddriver.deploy;
+
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import java.util.List;
 
 /**
  * A DeployHandler takes a parameterized description object and performs some deployment operation based off of its
  * detail. These objects may most often be derived from a {@link DeployHandlerRegistry} implementation.
  *
- * @param < T >      the type of the {@link DeployDescription}
+ * @param <T>      the type of the {@link DeployDescription}
  * @see DeployDescription
  *
  */
@@ -30,10 +33,10 @@ public interface DeployHandler<T> {
    * implementation of {@link DeploymentResult}
    *
    * @param description
-   * @param outputs from prior operations
+   * @param priorOutputs from prior operations
    * @return deployment result object
    */
-  DeploymentResult handle(T description, List priorOutputs)
+  DeploymentResult handle(T description, List priorOutputs);
 
   /**
    * Used to determine if this handler is suitable for processing the supplied description object.
@@ -41,5 +44,9 @@ public interface DeployHandler<T> {
    * @param description
    * @return true/false
    */
-  boolean handles(DeployDescription description)
+  boolean handles(DeployDescription description);
+
+  default void preDeploy(AtomicOperation operation) {
+    return;
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/events/CreateServerGroupEvent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/events/CreateServerGroupEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.orchestration.events;
+
+public class CreateServerGroupEvent implements OperationEvent {
+  private final OperationEvent.Type type = OperationEvent.Type.SERVER_GROUP;
+  private final OperationEvent.Action action = OperationEvent.Action.CREATE;
+
+  private final String cloudProvider;
+
+  private final String accountId;
+  private final String region;
+  private final String name;
+
+  public CreateServerGroupEvent(String cloudProvider, String accountId, String region, String name) {
+    this.cloudProvider = cloudProvider;
+    this.accountId = accountId;
+    this.region = region;
+    this.name = name;
+  }
+
+  @Override
+  public OperationEvent.Type getType() {
+    return type;
+  }
+
+  @Override
+  public OperationEvent.Action getAction() {
+    return action;
+  }
+
+  @Override
+  public String getCloudProvider() {
+    return cloudProvider;
+  }
+
+  public String getAccountId() {
+    return accountId;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return "CreateServerGroupEvent{" +
+      "type=" + type +
+      ", action=" + action +
+      ", cloudProvider='" + cloudProvider + '\'' +
+      ", accountId='" + accountId + '\'' +
+      ", region='" + region + '\'' +
+      ", name='" + name + '\'' +
+      '}';
+  }
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/events/CreateServerGroupEventHandler.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/events/CreateServerGroupEventHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.events;
+
+import com.netflix.spinnaker.clouddriver.elasticsearch.ElasticSearchServerGroupTagger;
+import com.netflix.spinnaker.clouddriver.orchestration.events.CreateServerGroupEvent;
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEventHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CreateServerGroupEventHandler implements OperationEventHandler {
+  private final ElasticSearchServerGroupTagger serverGroupTagger;
+
+  @Autowired
+  public CreateServerGroupEventHandler(ElasticSearchServerGroupTagger serverGroupTagger) {
+    this.serverGroupTagger = serverGroupTagger;
+  }
+
+  @Override
+  public void handle(OperationEvent operationEvent) {
+    if (!(operationEvent instanceof CreateServerGroupEvent)) {
+      return;
+    }
+
+    CreateServerGroupEvent createServerGroupEvent = (CreateServerGroupEvent) operationEvent;
+    serverGroupTagger.deleteAll(
+      createServerGroupEvent.getCloudProvider(),
+      createServerGroupEvent.getAccountId(),
+      createServerGroupEvent.getRegion(),
+      createServerGroupEvent.getName()
+    );
+  }
+}

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/events/CreateServerGroupEventHandlerSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/events/CreateServerGroupEventHandlerSpec.groovy
@@ -1,0 +1,37 @@
+package com.netflix.spinnaker.clouddriver.elasticsearch.events
+
+import com.netflix.spinnaker.clouddriver.elasticsearch.ElasticSearchServerGroupTagger
+import com.netflix.spinnaker.clouddriver.orchestration.events.CreateServerGroupEvent
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class CreateServerGroupEventHandlerSpec extends Specification {
+  def serverGroupTagger = Mock(ElasticSearchServerGroupTagger)
+
+  @Subject
+  def eventHandler = new CreateServerGroupEventHandler(serverGroupTagger)
+
+  @Unroll
+  void "should only handle events of type CreateServerGroupEvent"() {
+    given:
+    def operationEvent = Mock(OperationEvent) {
+      getType() >> { return OperationEvent.Type.SERVER_GROUP }
+      getAction() >> { return OperationEvent.Action.CREATE }
+      getCloudProvider() >> { return "aws" }
+    }
+
+    when:
+    eventHandler.handle(operationEvent)
+
+    then:
+    0 * serverGroupTagger.deleteAll(_, _, _, _)
+
+    when:
+    eventHandler.handle(new CreateServerGroupEvent("aws", "accountId", "region", "serverGroup-v001"))
+
+    then:
+    1 * serverGroupTagger.deleteAll("aws", "accountId", "region", "serverGroup-v001")
+  }
+}


### PR DESCRIPTION
This PR has already been reviewed. had to revert to fix a javadoc compilation error

- Added a createServerGroupEventHandler to handle create server group events
- Deletes tags from servergroup name on deploy