### PR TITLE
feat(aws): Allow termination lifecycle hooks to target SQS directly

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentSpec.groovy
@@ -101,7 +101,7 @@ class InstanceTerminationLifecycleAgentSpec extends Specification {
 
   def 'should create queue if it does not exist'() {
     when:
-    def queueId = InstanceTerminationLifecycleAgent.ensureQueueExists(amazonSQS, queueARN, topicARN)
+    def queueId = InstanceTerminationLifecycleAgent.ensureQueueExists(amazonSQS, queueARN, topicARN, ['1234'])
 
     then:
     queueId == "my-queue-url"
@@ -109,7 +109,7 @@ class InstanceTerminationLifecycleAgentSpec extends Specification {
     1 * amazonSQS.createQueue(queueARN.name) >> { new CreateQueueResult().withQueueUrl("my-queue-url") }
 
     1 * amazonSQS.setQueueAttributes("my-queue-url", [
-      "Policy": InstanceTerminationLifecycleAgent.buildSQSPolicy(queueARN, topicARN).toJson()
+      "Policy": InstanceTerminationLifecycleAgent.buildSQSPolicy(queueARN, topicARN, ['1234']).toJson()
     ])
     0 * _
   }


### PR DESCRIPTION
With this update, people will be able to choose between sending to SNS and fanning out to SQS queues (current behavior) or sending lifecycle events directly to an SQS queue. I'm hoping that cutting out SNS from the equation will allow us to squeeze out more performance.

@spinnaker/netflix-reviewers PTAL