### PR TITLE
(openstack) bugfix: make credential build method public

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentials.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/security/OpenstackNamedAccountCredentials.groovy
@@ -201,7 +201,7 @@ class OpenstackNamedAccountCredentials implements AccountCredentials<OpenstackCr
       return this
     }
 
-    private OpenstackCredentials build() {
+    public OpenstackCredentials build() {
       return new OpenstackNamedAccountCredentials(name,
         environment,
         accountType,


### PR DESCRIPTION
Fixing accidental private method. @lwander PTAL