### PR TITLE
Addresses an issue wherein Spinnaker is incorrectly cleaning up tags …

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.description
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 
@@ -46,6 +47,8 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   Boolean ebsOptimized
   String base64UserData
   Boolean legacyUdf
+
+  Collection<OperationEvent> events = []
 
 
   //Default behaviour (legacy reasons) is to carry forward some settings (even on a deploy vs a cloneServerGroup) from an ancestor ASG

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -282,17 +282,12 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
 
       createLifecycleHooks(task, regionScopedProvider, account, description, asgName)
 
-      this.deployEvents << new CreateServerGroupEvent(
+      description.events << new CreateServerGroupEvent(
         AmazonCloudProvider.ID, account.accountId, region, asgName
       )
     }
 
     return deploymentResult
-  }
-
-  @Override
-  List<CreateServerGroupEvent> getDeployEvents() {
-    return new ArrayList<>(this.deployEvents)
   }
 
   @VisibleForTesting

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
@@ -30,7 +30,7 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult> {
   DeployHandlerRegistry deploymentHandlerRegistry
 
   private final DeployDescription description
-  private final Collection<CreateServerGroupEvent> events = []
+  private final Collection<OperationEvent> events = []
 
   DeployAtomicOperation(DeployDescription description) {
     this.description = description
@@ -59,7 +59,8 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult> {
     task.updateStatus TASK_PHASE, "Invoking Handler."
     def deploymentResult = deployHandler.handle(description, priorOutputs)
 
-    events.addAll(deployHandler.getDeployEvents())
+    def events = description.getEvents() ?: []
+    events.addAll(events)
 
     task.updateStatus TASK_PHASE, "Server Groups: ${deploymentResult.serverGroupNames} created."
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployDescription.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.deploy
+package com.netflix.spinnaker.clouddriver.deploy;
+
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * This is a marker interface for use by {@link DeployHandler} implementations.
  *
  * @see DeployHandler
- *
  */
 public interface DeployDescription {
-
+  default Collection<OperationEvent> getEvents() {
+    return Collections.emptyList();
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployHandler.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployHandler.java
@@ -46,8 +46,4 @@ public interface DeployHandler<T> {
    * @return true/false
    */
   boolean handles(DeployDescription description);
-
-  default List<CreateServerGroupEvent> getDeployEvents() {
-    return Collections.emptyList();
-  }
 }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperationUnitSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperationUnitSpec.groovy
@@ -38,7 +38,6 @@ class DeployAtomicOperationUnitSpec extends Specification {
 
     then:
     1 * deployHandlerRegistry.findHandler(_) >> testDeployHandler
-    1 * testDeployHandler.getDeployEvents() >> []
     1 * testDeployHandler.handle(_, _) >> { Mock(DeploymentResult) }
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
 import com.netflix.spinnaker.clouddriver.titus.client.model.Efs
 import groovy.transform.Canonical
 
@@ -45,6 +46,8 @@ class TitusDeployDescription extends AbstractTitusCredentialsDescription impleme
   int runtimeLimitSecs
   Boolean useApplicationDefaultSecurityGroup = true
   List<String> interestingHealthProviderNames
+
+  Collection<OperationEvent> events = []
 
   @Canonical
   static class Capacity {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
@@ -56,8 +56,6 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
 
   private final TitusClientProvider titusClientProvider
 
-  private final List<CreateServerGroupEvent> deployEvents = []
-
   TitusDeployHandler(TitusClientProvider titusClientProvider) {
     this.titusClientProvider = titusClientProvider
   }
@@ -187,7 +185,7 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
 
       deploymentResult.messages = task.history.collect { "${it.phase} : ${it.status}".toString() }
 
-      this.deployEvents << new CreateServerGroupEvent(
+      description.events << new CreateServerGroupEvent(
         TitusCloudProvider.ID, getAccountId(account), region, nextServerGroupName
       )
 
@@ -212,10 +210,5 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
   @Override
   boolean handles(DeployDescription description) {
     return description instanceof TitusDeployDescription
-  }
-
-  @Override
-  List<CreateServerGroupEvent> getDeployEvents() {
-    return new ArrayList<>(this.deployEvents)
   }
 }


### PR DESCRIPTION
…when server groups are created

BasicAmazonDeployHandler is a singleton and _cannot_ have local state.

This change moves the event state from BasicAmazonDeployHandler to the
underlying DeployDescription (which is _not_ a singleton).