### PR TITLE
fix(aws) : region default resolution does not have to be statically initialized

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicator.groovy
@@ -65,8 +65,7 @@ class AmazonHealthIndicator implements HealthIndicator {
       } as Set<NetflixAmazonCredentials>
       for (NetflixAmazonCredentials credentials in amazonCredentials) {
         try {
-          def region = AmazonClientProvider.DEFAULT_REGION ?: credentials.getRegions().get(0).name
-          def ec2 = amazonClientProvider.getAmazonEC2(credentials, region, true)
+          def ec2 = amazonClientProvider.getAmazonEC2(credentials, AmazonClientProvider.DEFAULT_REGION, true)
           if (!ec2) {
             throw new AmazonClientException("Could not create Amazon client for ${credentials.name}")
           }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -16,13 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.security;
 
-import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.handlers.RequestHandler2;
-import com.amazonaws.regions.AwsRegionProvider;
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.autoscaling.AmazonAutoScaling;
@@ -55,6 +50,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.AmazonClientInvo
 import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.AwsSdkClientSupplier;
 import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.ProxyHandlerBuilder;
 import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.RateLimiterSupplier;
+import com.netflix.spinnaker.clouddriver.aws.security.sdkclient.SpinnakerAwsRegionProvider;
 import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration;
 import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfigurationBuilder;
 import org.apache.http.client.HttpClient;
@@ -70,23 +66,15 @@ import java.util.List;
  */
 public class AmazonClientProvider {
 
-  public static final String DEFAULT_REGION;
-
-  static {
-    final AwsRegionProvider defaultRegionProvider = new DefaultAwsRegionProviderChain();
-    String region;
-    try {
-      region = defaultRegionProvider.getRegion();
-    } catch (AmazonClientException _e) {
-      region = null;
-    }
-    if (region == null) {
-      final Region currentRegion = Regions.getCurrentRegion();
-      DEFAULT_REGION = currentRegion == null ? null : currentRegion.getName();
-    } else {
-      DEFAULT_REGION = region;
-    }
-  }
+  /**
+   * This constant (as null) indicates that whatever the current region from the
+   * AWS SDKs perspective should be used.
+   *
+   * The region to use will be resolved dynamically by {@link SpinnakerAwsRegionProvider}
+   * which supports all the standard SDK means of explicitly specifying the current region,
+   * (environment variable, instance profile, instance metadata).
+   */
+  public static final String DEFAULT_REGION = null;
 
   private final AwsSdkClientSupplier awsSdkClientSupplier;
   private final ProxyHandlerBuilder proxyHandlerBuilder;


### PR DESCRIPTION
This undoes some changes that were introduced in #1239 

The DEFAULT_REGION constant in AmazonClientProvider is there as an indicator that the region should be resolved to the current region, and that happens in AwsClientSupplier via SpinnakerAwsRegionProvider.

@qqshfox Can you confirm that this still works for you, provided you are running on an EC2 instance within cn-north-1 (to get the region from instance metadata) or you have set the AWS_REGION environment variable to cn-north-1 ?