### PR TITLE
perf(aws): configurable termination lifecycle agent poll time

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
@@ -27,6 +27,7 @@ class InstanceTerminationConfigurationProperties {
   int maxMessagesPerCycle = 1000
   int visibilityTimeout = 30
   int waitTimeSeconds = 5
+  int pollIntervalSeconds = 30
 
   InstanceTerminationConfigurationProperties() {
     // default constructor
@@ -37,12 +38,14 @@ class InstanceTerminationConfigurationProperties {
                                              String topicARN,
                                              int maxMessagesPerCycle,
                                              int visibilityTimeout,
-                                             int waitTimeSeconds) {
+                                             int waitTimeSeconds,
+                                             int pollIntervalSeconds) {
     this.accountName = accountName
     this.queueARN = queueARN
     this.topicARN = topicARN
     this.maxMessagesPerCycle = maxMessagesPerCycle
     this.visibilityTimeout = visibilityTimeout
     this.waitTimeSeconds = waitTimeSeconds
+    this.pollIntervalSeconds = pollIntervalSeconds
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgent.java
@@ -112,7 +112,7 @@ public class InstanceTerminationLifecycleAgent implements RunnableAgent, CustomS
 
   @Override
   public long getPollIntervalMillis() {
-    return TimeUnit.SECONDS.toMillis(30);
+    return TimeUnit.SECONDS.toMillis(properties.getPollIntervalSeconds());
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProvider.java
@@ -83,7 +83,8 @@ public class InstanceTerminationLifecycleAgentProvider implements AgentProvider 
             .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
           properties.getMaxMessagesPerCycle(),
           properties.getVisibilityTimeout(),
-          properties.getWaitTimeSeconds()
+          properties.getWaitTimeSeconds(),
+          properties.getPollIntervalSeconds()
         ),
         discoverySupport,
         registry

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentProviderSpec.groovy
@@ -43,6 +43,7 @@ class InstanceTerminationLifecycleAgentProviderSpec extends Specification {
     'arn:aws:sqs:{{region}}:{{accountId}}:topicName',
     -1,
     -1,
+    -1,
     -1
   )
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleAgentSpec.groovy
@@ -73,6 +73,7 @@ class InstanceTerminationLifecycleAgentSpec extends Specification {
       topicARN.arn,
       -1,
       -1,
+      -1,
       -1
     ),
     awsEurekaSupportProvider,


### PR DESCRIPTION
Allows users to adjust the termination lifecycle agent poll time. We should see a huge gain in performance for our average hooks reducing this from the default.

@spinnaker/netflix-reviewers PTAL