### PR TITLE
feat(aws): termination lifecycle worker config; cleaner SQS IAM

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
@@ -26,6 +26,7 @@ class InstanceTerminationConfigurationProperties {
 
   int visibilityTimeout = 30
   int waitTimeSeconds = 5
+  int sqsMessageRetentionPeriodSeconds = 120
 
   InstanceTerminationConfigurationProperties() {
     // default constructor
@@ -35,11 +36,13 @@ class InstanceTerminationConfigurationProperties {
                                              String queueARN,
                                              String topicARN,
                                              int visibilityTimeout,
-                                             int waitTimeSeconds) {
+                                             int waitTimeSeconds,
+                                             int sqsMessageRetentionPeriodSeconds) {
     this.accountName = accountName
     this.queueARN = queueARN
     this.topicARN = topicARN
     this.visibilityTimeout = visibilityTimeout
     this.waitTimeSeconds = waitTimeSeconds
+    this.sqsMessageRetentionPeriodSeconds = sqsMessageRetentionPeriodSeconds
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
@@ -86,7 +86,8 @@ public class InstanceTerminationLifecycleWorkerProvider {
             .replaceAll(REGION_TEMPLATE_PATTERN, region.getName())
             .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
           properties.getVisibilityTimeout(),
-          properties.getWaitTimeSeconds()
+          properties.getWaitTimeSeconds(),
+          properties.getSqsMessageRetentionPeriodSeconds()
         ),
         discoverySupport,
         registry


### PR DESCRIPTION
Two changes:

1. Add configuration for message retention period for SQS queues. The default value is 4 days, which is way too long for the purposes of this worker. New default is 2 minutes.
2. Cleaned up the SQS permission IAM based on feedback from cloud sec. The policy it generates is now a lot simpler.

@spinnaker/netflix-reviewers PTAL