### PR TITLE
perf(aws): termination lifecycle eureka perf improvements

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
@@ -27,6 +27,8 @@ class InstanceTerminationConfigurationProperties {
   int visibilityTimeout = 30
   int waitTimeSeconds = 5
   int sqsMessageRetentionPeriodSeconds = 120
+  int eurekaFindApplicationRetryMax = 3
+  int eurekaUpdateStatusRetryMax = 3
 
   InstanceTerminationConfigurationProperties() {
     // default constructor
@@ -37,12 +39,16 @@ class InstanceTerminationConfigurationProperties {
                                              String topicARN,
                                              int visibilityTimeout,
                                              int waitTimeSeconds,
-                                             int sqsMessageRetentionPeriodSeconds) {
+                                             int sqsMessageRetentionPeriodSeconds,
+                                             int eurekaFindApplicationRetryMax,
+                                             int eurekaUpdateStatusRetryMax) {
     this.accountName = accountName
     this.queueARN = queueARN
     this.topicARN = topicARN
     this.visibilityTimeout = visibilityTimeout
     this.waitTimeSeconds = waitTimeSeconds
     this.sqsMessageRetentionPeriodSeconds = sqsMessageRetentionPeriodSeconds
+    this.eurekaFindApplicationRetryMax = eurekaFindApplicationRetryMax
+    this.eurekaUpdateStatusRetryMax = eurekaUpdateStatusRetryMax
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorker.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorker.java
@@ -212,7 +212,8 @@ public class InstanceTerminationLifecycleWorker implements Runnable {
     description.setInstanceIds(instanceIds);
 
     discoverySupport.get().updateDiscoveryStatusForInstances(
-      description, task, "handleLifecycleMessage", DiscoveryStatus.Disable, instanceIds
+      description, task, "handleLifecycleMessage", DiscoveryStatus.Disable, instanceIds,
+      properties.getEurekaFindApplicationRetryMax(), properties.getEurekaUpdateStatusRetryMax()
     );
 
     recordLag(message.time, queueARN.region, message.accountId, message.autoScalingGroupName, message.ec2InstanceId);

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -35,7 +35,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.regex.Pattern;
 
 @Component
-@ConditionalOnProperty("aws.lifecycleSubscribers.instanceTermination.enabled")
+@ConditionalOnExpression("${aws.lifecycleSubscribers.instanceTermination.enabled:false} && ${caching.writeEnabled:true}")
 public class InstanceTerminationLifecycleWorkerProvider {
   private final static String REGION_TEMPLATE_PATTERN = Pattern.quote("{{region}}");
   private final static String ACCOUNT_ID_TEMPLATE_PATTERN = Pattern.quote("{{accountId}}");
@@ -87,7 +87,9 @@ public class InstanceTerminationLifecycleWorkerProvider {
             .replaceAll(ACCOUNT_ID_TEMPLATE_PATTERN, credentials.getAccountId()),
           properties.getVisibilityTimeout(),
           properties.getWaitTimeSeconds(),
-          properties.getSqsMessageRetentionPeriodSeconds()
+          properties.getSqsMessageRetentionPeriodSeconds(),
+          properties.getEurekaFindApplicationRetryMax(),
+          properties.getEurekaUpdateStatusRetryMax()
         ),
         discoverySupport,
         registry

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerSpec.groovy
@@ -73,6 +73,8 @@ class InstanceTerminationLifecycleWorkerSpec extends Specification {
       topicARN.arn,
       -1,
       -1,
+      -1,
+      -1,
       -1
     ),
     awsEurekaSupportProvider,
@@ -140,7 +142,9 @@ class InstanceTerminationLifecycleWorkerSpec extends Specification {
       _ as Task,
       'handleLifecycleMessage',
       DiscoveryStatus.Disable,
-      ['i-1234']
+      ['i-1234'],
+      -1,
+      -1
     )
   }
 


### PR DESCRIPTION
A couple items in here:

1. Allow setting specific eureka maximum retry settings when calling from termination lifecycle worker (reducing defaults from 10 retries to 3).
2. Updating worker to only run on caching instances
3. Short-circuit eureka calls if the application name cannot be found from an ASG and if the ASG/instance no longer exists. This can happen when processing stale messages. Rather than waste cycles attempting to remove it from discovery, move on with life.

@ajordens PTAL