### PR TITLE
feat(provider/kubernetes): Add hostNetwork option for pod creation.  …

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -6,5 +6,5 @@ dependencies {
   compile spinnaker.dependency('bootWeb')
 
   // TODO (move to https://github.com/spinnaker/spinnaker-dependencies/blob/master/src/spinnaker-dependencies.yml)
-  compile 'io.fabric8:kubernetes-api:2.2.184'
+  compile 'io.fabric8:kubernetes-client:1.4.35'
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -610,6 +610,8 @@ class KubernetesApiConverter {
       fromVolume(it)
     } ?: []
 
+    deployDescription.hostNetwork = replicaSet?.spec?.template?.spec?.hostNetwork
+
     deployDescription.containers = replicaSet?.spec?.template?.spec?.containers?.collect {
       fromContainer(it)
     } ?: []
@@ -640,6 +642,7 @@ class KubernetesApiConverter {
       .withNewScaleRef()
       .withKind(KubernetesUtil.SERVER_GROUP_KIND)
       .withName(description.serverGroupName)
+      .withHostName(description.hostName)
       .endScaleRef()
       .endSpec().build()
   }
@@ -895,6 +898,8 @@ class KubernetesApiConverter {
 
       podTemplateSpecBuilder = podTemplateSpecBuilder.withVolumes(volumeSources)
     }
+
+    podTemplateSpecBuilder = podTemplateSpecBuilder.withHostNetwork(description.hostNetwork)
 
     def containers = description.containers.collect { container ->
       toContainer(container)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -642,7 +642,6 @@ class KubernetesApiConverter {
       .withNewScaleRef()
       .withKind(KubernetesUtil.SERVER_GROUP_KIND)
       .withName(description.serverGroupName)
-      .withHostName(description.hostName)
       .endScaleRef()
       .endSpec().build()
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -32,6 +32,7 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesAtomicOperati
   String namespace
   String restartPolicy
   Integer targetSize
+  Boolean hostNetwork
   List<String> loadBalancers
   List<String> securityGroups
   List<KubernetesContainerDescription> containers

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -77,6 +77,9 @@ class RunKubernetesJobAtomicOperation implements AtomicOperation<DeploymentResul
       podBuilder = podBuilder.addNewImagePullSecret(imagePullSecret)
     }
 
+    if (description.hostNetwork) {
+        podBuilder = podBuilder.withHostNetwork(description.hostNetwork)
+    }
     description.container.name = description.container.name ?: "job"
     def container = KubernetesApiConverter.toContainer(description.container)
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
@@ -95,6 +95,7 @@ class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult
     newDescription.loadBalancers = description.loadBalancers != null ? description.loadBalancers : KubernetesUtil.getLoadBalancers(ancestorServerGroup)
     newDescription.restartPolicy = description.restartPolicy ?: ancestorServerGroup.spec?.template?.spec?.restartPolicy
     newDescription.nodeSelector = description.nodeSelector ?: ancestorServerGroup.spec?.template?.spec?.nodeSelector
+    newDescription.hostNetwork = description.hostNetwork ?: ancestorServerGroup.spec?.template?.spec?.hostNetwork
     if (!description.containers) {
       newDescription.containers = ancestorServerGroup.spec?.template?.spec?.containers?.collect { it ->
         KubernetesApiConverter.fromContainer(it)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -44,6 +44,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
   String account
   Long createdTime
   Integer replicas = 0
+  Boolean hostNetwork = false
   Set<String> zones
   Set<KubernetesInstance> instances
   Set<String> loadBalancers = [] as Set

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -97,8 +97,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
       targetSize: TARGET_SIZE,
       loadBalancers: LOAD_BALANCER_NAMES,
       containers: containers,
-      namespace: NAMESPACE1,
-      hostNetwork: false
+      namespace: NAMESPACE1
     )
 
     replicationController = new ReplicationController()

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup
 
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
@@ -66,6 +67,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
   def credentials
   def namedAccountCredentials
   def accountCredentialsRepositoryMock
+  def spectatorRegistry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -100,6 +102,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
       namespace: NAMESPACE1
     )
 
+    spectatorRegistry = new DefaultRegistry()
     replicationController = new ReplicationController()
     replicationControllerSpec = new ReplicationControllerSpec()
     podTemplateSpec= new PodTemplateSpec()
@@ -108,10 +111,11 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
     accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
-    credentials = new KubernetesCredentials(apiMock, [], [], accountCredentialsRepositoryMock)
+    credentials = new KubernetesCredentials(apiMock, [], [], [], accountCredentialsRepositoryMock)
     namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
         .name("name")
         .dockerRegistries(dockerRegistries)
+        .spectatorRegistry(spectatorRegistry)
         .credentials(credentials)
         .build()
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -98,7 +98,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
       loadBalancers: LOAD_BALANCER_NAMES,
       containers: containers,
       namespace: NAMESPACE1,
-      hostNetwor: false
+      hostNetwork: false
     )
 
     replicationController = new ReplicationController()

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup
 
-import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
@@ -67,7 +66,6 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
   def credentials
   def namedAccountCredentials
   def accountCredentialsRepositoryMock
-  def spectatorRegistry
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -99,10 +97,10 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
       targetSize: TARGET_SIZE,
       loadBalancers: LOAD_BALANCER_NAMES,
       containers: containers,
-      namespace: NAMESPACE1
+      namespace: NAMESPACE1,
+      hostNetwor: false
     )
 
-    spectatorRegistry = new DefaultRegistry()
     replicationController = new ReplicationController()
     replicationControllerSpec = new ReplicationControllerSpec()
     podTemplateSpec= new PodTemplateSpec()
@@ -111,11 +109,10 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
     accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
-    credentials = new KubernetesCredentials(apiMock, [], [], [], accountCredentialsRepositoryMock)
+    credentials = new KubernetesCredentials(apiMock, [], [], accountCredentialsRepositoryMock)
     namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
         .name("name")
         .dockerRegistries(dockerRegistries)
-        .spectatorRegistry(spectatorRegistry)
         .credentials(credentials)
         .build()
 


### PR DESCRIPTION
feat(provider/kubernetes): Add hostNetwork option for pod creation.

This is backend changes which will allow user to modify pipeline JSON file and add under stages -> clusters -> "hostNetowrk": true

When test it, the hostIP and podIP will match.  It still require UI work.  Per fabric8io suggestion, spinnaker should use io.fabric8:kubernetes-client jar not io.fabric8:kubernetes-api jar.  I don't observe any issue while testing, but it does need to further review.

