### PR TITLE
feat(aws): Adding conditional scaling policy copy method

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/scalingpolicy/DefaultScalingPolicyCopier.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/scalingpolicy/DefaultScalingPolicyCopier.groovy
@@ -106,7 +106,7 @@ class DefaultScalingPolicyCopier implements ScalingPolicyCopier {
       }
       actions
     }
-    sourceAlarms.each { alarm ->
+    sourceAlarms.findAll{ shouldCopySourceAlarm(it) }.each { alarm ->
       List<Dimension> newDimensions = Lists.newArrayList(alarm.dimensions)
       Dimension asgDimension = newDimensions.find { it.name == DIMENSION_NAME_FOR_ASG }
       if (asgDimension) {
@@ -133,6 +133,10 @@ class DefaultScalingPolicyCopier implements ScalingPolicyCopier {
       )
       targetCloudWatch.putMetricAlarm(request)
     }
+  }
+
+  protected boolean shouldCopySourceAlarm(MetricAlarm metricAlarm) {
+    return true
   }
 
   @Canonical


### PR DESCRIPTION
Some components in Netflix code need to conditionally filter out scaling policies that are copied to a new ASG. For OSS, this has no effect.

@spinnaker/netflix-reviewers PTAL