### PR TITLE
fix(elasticsearch): Fix NPE generated when an entity tag type is null

### DIFF
--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProvider.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProvider.java
@@ -267,7 +267,7 @@ public class ElasticSearchEntityTagsProvider implements EntityTagsProvider {
     OperationPoller.retryWithBackoff(o -> {
         // verify that the indexed document can be retrieved (accounts for index lag)
         Map<String, Object> entityTagsCriteria = new HashMap<>();
-        entityTags.getTags().forEach(entityTag -> {
+        entityTags.getTags().stream().filter(entityTag -> entityTag != null && entityTag.getValueType() != null).forEach(entityTag -> {
           switch(entityTag.getValueType()) {
             case object:
               entityTagsCriteria.put(entityTag.getName(), "*");


### PR DESCRIPTION
Encountered an issue in test where entity tags was returning a value with a null value type. Filtering out these values.

@ajordens FYI
@spinnaker/netflix-reviewers PTAL