### PR TITLE
fix(titus): okhttp doesn't properly url encode the ^ in the query string

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
@@ -29,12 +29,14 @@ import okhttp3.RequestBody;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.util.UriUtils;
 import retrofit2.Call;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
@@ -162,7 +164,11 @@ public class RegionScopedTitusClient implements TitusClient {
 
     @Override
     public Job findJobByName(String jobName) {
-        List<Job> jobs = execute("getJobsByLabel", titusRestAdapter.getJobsByLabel("name=" + jobName));
+        String query = "name=" + jobName;
+        try {
+            query = UriUtils.encodeQuery(query, "UTF-8");
+        } catch( UnsupportedEncodingException e ) {}
+        List<Job> jobs = execute("getJobsByLabel", titusRestAdapter.getJobsByLabel(query));
         if (jobs.isEmpty()) {
             return null;
         }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusRestAdapter.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusRestAdapter.java
@@ -45,7 +45,7 @@ public interface TitusRestAdapter {
     Call<List<Job>> getJobsByType(@Query("type") String type);
 
     @GET("/api/v2/jobs")
-    Call<List<Job>> getJobsByLabel(@Query("labels") String labels);
+    Call<List<Job>> getJobsByLabel(@Query(value="labels", encoded=true) String labels);
 
     @GET("/api/v2/jobs")
     Call<List<Job>> getJobsByApplication(@Query("appName") String application);

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
@@ -35,7 +35,7 @@ class RegionScopedTitusClientSpec extends Specification {
     setup:
     Logger logger = LoggerFactory.getLogger(TitusClient)
     TitusRegion titusRegion = new TitusRegion(
-      "us-east-1", "test", "http://titusapi.mainvpc.us-east-1.dyntest.netflix.net:7101/"
+      "us-east-1", "test", "http://titusapi.mainvpc.us-east-1.dyntest.netflix.net:7001/"
     );
     TitusClient titusClient = new RegionScopedTitusClient(titusRegion, new NoopRegistry(), Collections.emptyList());
 


### PR DESCRIPTION
It seems that OkHttp3 doesn’t think that the ^ needs to be escaped as part of the query string.

```
@Grapes(
    @Grab(group='com.squareup.okhttp3', module='okhttp', version='3.6.0')
)

import okhttp3.HttpUrl

println new HttpUrl.Builder()
       .scheme("http")
       .host("www.google.com")
       .addQueryParameter("q", " titustestapp-clony-^1.0.0-v000")
       .build()
```

gives `http://www.google.com/?q=%20titustestapp-clony-^1.0.0-v000`

Looking at the code, it looks like they don't consider ^ to be something that needs to be encoded
https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/HttpUrl.java#L292

The titus API requires this values to be encoded, this fix changes that behavior so that query components are encoded according to the Titus API