### PR TITLE
perf(aws): Simplifying termination lifecyle to not lookup app info first

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationConfigurationProperties.groovy
@@ -27,7 +27,6 @@ class InstanceTerminationConfigurationProperties {
   int visibilityTimeout = 30
   int waitTimeSeconds = 5
   int sqsMessageRetentionPeriodSeconds = 120
-  int eurekaFindApplicationRetryMax = 3
   int eurekaUpdateStatusRetryMax = 3
 
   InstanceTerminationConfigurationProperties() {
@@ -40,7 +39,6 @@ class InstanceTerminationConfigurationProperties {
                                              int visibilityTimeout,
                                              int waitTimeSeconds,
                                              int sqsMessageRetentionPeriodSeconds,
-                                             int eurekaFindApplicationRetryMax,
                                              int eurekaUpdateStatusRetryMax) {
     this.accountName = accountName
     this.queueARN = queueARN
@@ -48,7 +46,6 @@ class InstanceTerminationConfigurationProperties {
     this.visibilityTimeout = visibilityTimeout
     this.waitTimeSeconds = waitTimeSeconds
     this.sqsMessageRetentionPeriodSeconds = sqsMessageRetentionPeriodSeconds
-    this.eurekaFindApplicationRetryMax = eurekaFindApplicationRetryMax
     this.eurekaUpdateStatusRetryMax = eurekaUpdateStatusRetryMax
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
@@ -88,7 +88,6 @@ public class InstanceTerminationLifecycleWorkerProvider {
           properties.getVisibilityTimeout(),
           properties.getWaitTimeSeconds(),
           properties.getSqsMessageRetentionPeriodSeconds(),
-          properties.getEurekaFindApplicationRetryMax(),
           properties.getEurekaUpdateStatusRetryMax()
         ),
         discoverySupport,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureConfigurationProperties.groovy
@@ -1,8 +1,6 @@
 package com.netflix.spinnaker.clouddriver.aws.lifecycle
 
-import groovy.transform.Canonical
 import org.springframework.boot.context.properties.ConfigurationProperties
-
 /*
  * Copyright 2017 Netflix, Inc.
  *


### PR DESCRIPTION
After talking to cloudperf, we're mostly interested in processing messages
as quick as possible. We don't really care if discovery knows about the
application or instance, so we'll only retry on network errors, otherwise,
we'll just move onto the next message.

@spinnaker/netflix-reviewers PTAL