### PR TITLE
fix(kubenetesjob): Fixed missing updated hostNetwork option for job.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
@@ -30,6 +30,7 @@ class RunKubernetesJobDescription extends KubernetesAtomicOperationDescription {
   String stack
   String freeFormDetails
   String namespace
+  Boolean hostNetwork=false
   KubernetesContainerDescription container
   List<KubernetesVolumeSource> volumeSources
 }


### PR DESCRIPTION
Fixed missing hostNetwork filed for job which caused missing property exception during "Run a Job" deployment.