### PR TITLE
Fix Eureka integration (delete override) 

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableAsgAtomicOperationUnitSpec.groovy
@@ -84,7 +84,7 @@ class EnableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnitS
                 app: "asg1"
             ]
         ]
-    1 * eureka.resetInstanceStatus('asg1', 'i1', AbstractEurekaSupport.DiscoveryStatus.Disable.value)
+    1 * eureka.resetInstanceStatus('asg1', 'i1', AbstractEurekaSupport.DiscoveryStatus.Enable.value)
   }
 
   def 'should skip discovery if not enabled for account'() {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/DiscoverySupportUnitSpec.groovy
@@ -181,7 +181,7 @@ class DiscoverySupportUnitSpec extends Specification {
 
     0 * task.fail()
     instanceIds.each {
-      1 * eureka.resetInstanceStatus(appName, it, AbstractEurekaSupport.DiscoveryStatus.Disable.value) >> response(200)
+      1 * eureka.resetInstanceStatus(appName, it, AbstractEurekaSupport.DiscoveryStatus.Enable.value) >> response(200)
     }
 
     where:
@@ -207,9 +207,9 @@ class DiscoverySupportUnitSpec extends Specification {
     task.getStatus() >> new DefaultTaskStatus(state: TaskState.STARTED)
     1 * task.fail()
     1 * eureka.getInstanceInfo(_) >> [ instance: [ app: appName ] ]
-    1 * eureka.resetInstanceStatus(appName, "bad", AbstractEurekaSupport.DiscoveryStatus.Disable.value) >> httpError(500)
-    1 * eureka.resetInstanceStatus(appName, "good", AbstractEurekaSupport.DiscoveryStatus.Disable.value) >> response(200)
-    1 * eureka.resetInstanceStatus(appName, "also-bad", AbstractEurekaSupport.DiscoveryStatus.Disable.value) >> httpError(500)
+    1 * eureka.resetInstanceStatus(appName, "bad", AbstractEurekaSupport.DiscoveryStatus.Enable.value) >> httpError(500)
+    1 * eureka.resetInstanceStatus(appName, "good", AbstractEurekaSupport.DiscoveryStatus.Enable.value) >> response(200)
+    1 * eureka.resetInstanceStatus(appName, "also-bad", AbstractEurekaSupport.DiscoveryStatus.Enable.value) >> httpError(500)
     1 * task.updateStatus("PHASE", { it.startsWith("Looking up discovery") })
     3 * task.updateStatus("PHASE", { it.startsWith("Attempting to mark") })
     1 * task.updateStatus("PHASE", { it.startsWith("Failed marking instances 'UP'")})
@@ -247,7 +247,7 @@ class DiscoverySupportUnitSpec extends Specification {
         ]
       ]
     instanceIds.each {
-      1 * eureka.resetInstanceStatus(appName, it, AbstractEurekaSupport.DiscoveryStatus.Disable.value) >> response(200)
+      1 * eureka.resetInstanceStatus(appName, it, AbstractEurekaSupport.DiscoveryStatus.Enable.value) >> response(200)
     }
 
     where:
@@ -306,7 +306,7 @@ class DiscoverySupportUnitSpec extends Specification {
           app: appName
         ]
       ]
-    3 * eureka.resetInstanceStatus(appName, 'i-123', AbstractEurekaSupport.DiscoveryStatus.Disable.value) >>> [response(302), response(201), response(200)]
+    3 * eureka.resetInstanceStatus(appName, 'i-123', AbstractEurekaSupport.DiscoveryStatus.Enable.value) >>> [response(302), response(201), response(200)]
     4 * task.getStatus() >> new DefaultTaskStatus(state: TaskState.STARTED)
     0 * task.fail()
 
@@ -366,7 +366,7 @@ class DiscoverySupportUnitSpec extends Specification {
       ]
     1 * task.fail()
     instanceIds.eachWithIndex { it, idx ->
-      1 * eureka.resetInstanceStatus(appName, it, AbstractEurekaSupport.DiscoveryStatus.Disable.value) >> {
+      1 * eureka.resetInstanceStatus(appName, it, AbstractEurekaSupport.DiscoveryStatus.Enable.value) >> {
         if (!result[idx]) {
           throw new RuntimeException("blammo")
         }

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
@@ -131,7 +131,7 @@ abstract class AbstractEurekaSupport {
           if(discoveryStatus == DiscoveryStatus.Disable) {
             resp = eureka.updateInstanceStatus(applicationName, instanceId, discoveryStatus.value)
           } else {
-            resp = eureka.resetInstanceStatus(applicationName, instanceId, DiscoveryStatus.Disable.value)
+            resp = eureka.resetInstanceStatus(applicationName, instanceId, discoveryStatus.value)
           }
 
           if (resp.status != 200) {


### PR DESCRIPTION
Currently clouddriver sends requests like 
DELETE /apps/{application}/{instanceId}/status?value=OUT_OF_SERVICE
to enable instance in eureka. 
Even though it seems like correct behaviour (remove previous disable state) but in reality such query deletes override and sets current status to OUT_OF_SERVICE effectively doing nothing with observable state.

To see real behaviour go to com.netflix.eureka.registry.AbstractInstanceRegistry::deleteStatusOverride

                    info.setOverriddenStatus(InstanceStatus.UNKNOWN);
                    info.setStatus(newStatus);