### PR TITLE
Reducing the amount of times we repopulate the docker registry secret…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -79,10 +79,9 @@ public class KubernetesCredentials {
 
       List<String> resultNamespaces = new ArrayList<>(addedNamespaces);
 
-      // Find the namespaces that were added, and add docker secrets to them. No need to track deleted
+      // Find the namespaces that were added. No need to track deleted
       // namespaces since they delete their secrets automatically.
       addedNamespaces.removeAll(oldNamespaces);
-      reconfigureRegistries(addedNamespaces, resultNamespaces);
       oldNamespaces = resultNamespaces;
 
       return resultNamespaces;


### PR DESCRIPTION
Currently we are seeing problems related to the aggressive repopulation of k8s secrets in our clusters. The result is that accounts will be unavailable in Spinnaker whenever a repopulation has failed, which it does many times each day. Probably due to a race condition between the CloudDriver instances. 

This is an attempt to reduce the number of repopulations. If we need to repopulate this often, I'd argue that a more explicit approach outside of `getNamespaces` would be more appropriate, and we would also need some sort of locking when acting upon a namespace. WDYT? 