### PR TITLE
fix(kubernetes): Set account in loaderBalancerDescription

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -69,13 +69,14 @@ class KubernetesApiConverter {
   }
 
 
-  static KubernetesLoadBalancerDescription fromService(Service service) {
+  static KubernetesLoadBalancerDescription fromService(Service service, String accountName) {
     if (!service) {
       return null
     }
 
     def loadBalancerDescription = new KubernetesLoadBalancerDescription()
 
+    loadBalancerDescription.account = accountName
     loadBalancerDescription.name = service.metadata.name
     def parse = Names.parseName(loadBalancerDescription.name)
     loadBalancerDescription.app = parse.app

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesLoadBalancer.groovy
@@ -57,7 +57,7 @@ class KubernetesLoadBalancer implements LoadBalancer, Serializable, LoadBalancer
     this.namespace = service.metadata.namespace
     this.securityGroups = securityGroups
     this.region = this.namespace
-    this.description = KubernetesApiConverter.fromService(service)
+    this.description = KubernetesApiConverter.fromService(service, accountName)
     this.account = accountName
     this.createdTime = KubernetesModelUtil.translateTime(service.metadata?.creationTimestamp)
     this.yaml = SerializationUtils.dumpWithoutRuntimeStateAsYaml(service)


### PR DESCRIPTION
If not set, account of loadBalancerDescription will be blank. That will be used in situations like updating load balancers.