### PR TITLE
feat(provider/oraclebmcs): Add initial scaffolding for Oracle BMCS pr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ application.yml
 README.html
 *~
 es-tmp/
+clouddriver-oracle-bmcs/bmcs-sdk

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Pivotal, Inc <*@pivotal.io>
 Microsoft, Inc <*@microsoft.com>
 Veritas Technologies, LLC <*@veritas.com>
 Target, Inc <*@target.com>
+Oracle America, Inc <*@oracle.com>

--- a/clouddriver-oracle-bmcs/clouddriver-oracle-bmcs.gradle
+++ b/clouddriver-oracle-bmcs/clouddriver-oracle-bmcs.gradle
@@ -1,0 +1,59 @@
+// Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile/runtime deps
+def bmcsSDK = project.file('bmcs-sdk/lib/oracle-bmc-java-sdk-full-1.2.2.jar')
+def sdkDest = "bmcs-sdk"
+
+if (bmcsSDK.exists() == false) {
+  def sdkArchive = File.createTempFile("bmcsSDK","archive.zip")
+  sdkArchive << new URL("https://github.com/oracle/bmcs-java-sdk/releases/download/v1.2.2/oracle-bmcs-java-sdk.zip").openStream()
+
+  copy {
+    from zipTree(sdkArchive)
+    into sdkDest
+    include "**/*.jar"
+    exclude "**/*-sources.jar"
+    exclude "**/*-javadoc.jar"
+
+    // Scary but works. I think clouddriver deps in general need cleaning at some point
+    // Even without the oracle bmc sdk 3rd party deps there's still multiple javax.inject and commons-X JARs
+    exclude "**/*jackson*.jar"
+    exclude "**/*jersey*.jar"
+    exclude "**/hk2*.jar"
+    exclude "**/*guava*.jar"
+    exclude "**/commons*.jar"
+    exclude "**/javax*.jar"
+    exclude "**/aopalliance*.jar"
+    exclude "**/javassist*.jar"
+    exclude "**/slf*.jar"
+    exclude "**/osgi*.jar"
+    exclude "**/validation*.jar"
+    exclude "**/jsr305*.jar"
+    exclude "**/bcprov*.jar"
+
+  }
+}
+
+def bmcsSDKDeps = project.fileTree('bmcs-sdk/third-party/lib')
+
+task cleanSDK << {
+  project.file(sdkDest).deleteDir()
+}
+clean.dependsOn cleanSDK
+
+
+
+dependencies {
+  compile project(":clouddriver-core")
+  compile spinnaker.dependency('frigga')
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('bootWeb')
+  compile files(bmcsSDK)
+  runtime files(bmcsSDKDeps)
+}
+
+
+license {
+  header project.file('oracle-source-header')
+  includes(["**/*.groovy", "**/*.java", "**/*.properties"])
+  strictCheck true
+  skipExistingHeaders false
+}

--- a/clouddriver-oracle-bmcs/oracle-source-header
+++ b/clouddriver-oracle-bmcs/oracle-source-header
@@ -1,0 +1,6 @@
+Copyright (c) 2017 Oracle America, Inc.
+
+The contents of this file are subject to the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+If a copy of the Apache License Version 2.0 was not distributed with this file,
+You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/OracleBMCSCloudProvider.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/OracleBMCSCloudProvider.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs
+
+import com.netflix.spinnaker.clouddriver.core.CloudProvider
+import org.springframework.stereotype.Component
+
+import java.lang.annotation.Annotation
+
+/**
+ * OracleBMCS declaration as a {@link CloudProvider}.
+ */
+@Component
+class OracleBMCSCloudProvider implements CloudProvider {
+
+  static final String ID = "oraclebmcs"
+  final String id = ID
+  final String displayName = ID
+  final Class<Annotation> operationAnnotationType = OracleBMCSOperation
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/OracleBMCSConfiguration.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/OracleBMCSConfiguration.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs
+
+import com.netflix.spinnaker.clouddriver.oraclebmcs.config.OracleBMCSConfigurationProperties
+import com.netflix.spinnaker.clouddriver.oraclebmcs.health.OracleBMCSHealthIndicator
+import com.netflix.spinnaker.clouddriver.oraclebmcs.security.OracleBMCSCredentialsInitializer
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.*
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableConfigurationProperties
+@EnableScheduling
+@ConditionalOnProperty('oraclebmcs.enabled')
+@ComponentScan(["com.netflix.spinnaker.clouddriver.oraclebmcs"])
+@Import([ OracleBMCSCredentialsInitializer ])
+class OracleBMCSConfiguration {
+
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  @Bean
+  @ConfigurationProperties("oraclebmcs")
+  OracleBMCSConfigurationProperties oracleBMCSConfigurationProperties() {
+    new OracleBMCSConfigurationProperties()
+  }
+
+  @Bean
+  OracleBMCSHealthIndicator OracleBMCSHealthIndicator() {
+    new OracleBMCSHealthIndicator()
+  }
+
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/OracleBMCSOperation.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/OracleBMCSOperation.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * {@code OracleBMCSOperation}s specify implementation classes of Spinnaker AtomicOperations for OracleBMCS.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@interface OracleBMCSOperation {
+
+  String value()
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/config/OracleBMCSConfigurationProperties.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/config/OracleBMCSConfigurationProperties.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.config
+
+import groovy.transform.ToString
+
+@ToString(includeNames = true)
+class OracleBMCSConfigurationProperties {
+
+  @ToString(includeNames = true)
+  static class ManagedAccount {
+
+    String name
+    String environment
+    String accountType
+    List<String> requiredGroupMembership = []
+    String compartmentId
+  }
+
+  List<ManagedAccount> accounts = []
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/converter/NoOpOracleBMCSAtomicOperationConverter.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/converter/NoOpOracleBMCSAtomicOperationConverter.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.converter
+
+import com.netflix.spinnaker.clouddriver.oraclebmcs.OracleBMCSOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import org.springframework.stereotype.Component
+
+/**
+ * SL: Adding this for initial pull request to satisfy FeatureController requirement of at least
+ * one atomic operation enabled when starting clouddriver with just oraclebmcs enabled.
+ */
+@OracleBMCSOperation(AtomicOperations.DELETE_SECURITY_GROUP)
+@Component("noopOracleBMCSDescription")
+class NoOpOracleBMCSAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    return null
+  }
+
+  @Override
+  Object convertDescription(Map input) {
+    return null
+  }
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/health/OracleBMCSHealthIndicator.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/health/OracleBMCSHealthIndicator.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.health
+
+import com.netflix.spinnaker.clouddriver.oraclebmcs.security.OracleBMCSNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.oracle.bmc.identity.requests.ListAvailabilityDomainsRequest
+import groovy.transform.InheritConstructors
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.http.HttpStatus
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.ResponseStatus
+
+import java.util.concurrent.atomic.AtomicReference
+
+@Slf4j
+@Component
+class OracleBMCSHealthIndicator implements HealthIndicator {
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  private final AtomicReference<Exception> lastException = new AtomicReference<>(null)
+
+  @Override
+  Health health() {
+    def ex = lastException.get()
+
+    if (ex) {
+      throw ex
+    }
+
+    new Health.Builder().up().build()
+  }
+
+  @Scheduled(fixedDelay = 300000L)
+  void checkHealth() {
+    try {
+      Set<OracleBMCSNamedAccountCredentials> creds = accountCredentialsProvider.all.findAll {
+        it instanceof OracleBMCSNamedAccountCredentials
+      } as Set<OracleBMCSNamedAccountCredentials>
+
+      creds.each { OracleBMCSNamedAccountCredentials cred ->
+        try {
+          cred.identityClient.listAvailabilityDomains(ListAvailabilityDomainsRequest.builder().compartmentId(cred.compartmentId).build())
+        } catch(Exception ex) {
+          throw new OracleBMCSUnreachableException(ex)
+        }
+      }
+
+      lastException.set(null)
+    } catch (Exception ex) {
+      log.warn "Unhealthy", ex
+      lastException.set(ex)
+    }
+  }
+
+  @ResponseStatus(value = HttpStatus.SERVICE_UNAVAILABLE, reason = 'Could not reach the Oracle BMCS service.')
+  @InheritConstructors
+  static class OracleBMCSUnreachableException extends RuntimeException {}
+}
+

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/security/OracleBMCSCredentialsInitializer.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/security/OracleBMCSCredentialsInitializer.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.security
+
+import com.netflix.spinnaker.cats.module.CatsModule
+import com.netflix.spinnaker.clouddriver.oraclebmcs.config.OracleBMCSConfigurationProperties
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable
+import com.netflix.spinnaker.clouddriver.security.ProviderUtils
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Scope
+
+@Slf4j
+@Configuration
+class OracleBMCSCredentialsInitializer implements CredentialsInitializerSynchronizable {
+
+  @Bean
+  List<? extends OracleBMCSNamedAccountCredentials> oracleBMCSNamedAccountCredentials(
+    String clouddriverUserAgentApplicationName,
+    OracleBMCSConfigurationProperties oracleBMCSConfigurationProperties,
+    AccountCredentialsRepository accountCredentialsRepository
+  ) {
+    synchronizeOracleBMCSAccounts(clouddriverUserAgentApplicationName, oracleBMCSConfigurationProperties, null, accountCredentialsRepository)
+  }
+
+  @Override
+  String getCredentialsSynchronizationBeanName() {
+    return "synchronizeOracleBMCSAccounts"
+  }
+
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  @Bean
+  List<? extends OracleBMCSNamedAccountCredentials> synchronizeOracleBMCSAccounts(String clouddriverUserAgentApplicationName,
+                                                                                  OracleBMCSConfigurationProperties oracleBMCSConfigurationProperties,
+                                                                                  CatsModule catsModule,
+                                                                                  AccountCredentialsRepository accountCredentialsRepository) {
+
+    def (ArrayList<OracleBMCSConfigurationProperties.ManagedAccount> accountsToAdd, List<String> namesOfDeletedAccounts) =
+    ProviderUtils.calculateAccountDeltas(accountCredentialsRepository,
+      OracleBMCSNamedAccountCredentials.class,
+      oracleBMCSConfigurationProperties.accounts)
+
+    accountsToAdd.each { OracleBMCSConfigurationProperties.ManagedAccount managedAccount ->
+      try {
+        def oracleBMCSAccount = new OracleBMCSNamedAccountCredentials.Builder().name(managedAccount.name).
+          environment(managedAccount.environment ?: managedAccount.name).
+          accountType(managedAccount.accountType ?: managedAccount.name).
+          requiredGroupMembership(managedAccount.requiredGroupMembership).
+          compartmentID(managedAccount.compartmentId).
+          build()
+
+        accountCredentialsRepository.save(managedAccount.name, oracleBMCSAccount)
+      } catch (e) {
+        log.info("Could not load account $managedAccount.name for OracleBMCS", e)
+      }
+    }
+
+    ProviderUtils.unscheduleAndDeregisterAgents(namesOfDeletedAccounts, catsModule)
+
+    accountCredentialsRepository.all.findAll {
+      it instanceof OracleBMCSNamedAccountCredentials
+    } as List<OracleBMCSNamedAccountCredentials>
+  }
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/security/OracleBMCSNamedAccountCredentials.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/security/OracleBMCSNamedAccountCredentials.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.security
+
+import com.netflix.spinnaker.clouddriver.oraclebmcs.OracleBMCSCloudProvider
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials
+import com.oracle.bmc.Region
+import com.oracle.bmc.auth.AuthenticationDetailsProvider
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider
+import com.oracle.bmc.core.ComputeClient
+import com.oracle.bmc.core.VirtualNetworkClient
+import com.oracle.bmc.identity.IdentityClient
+import com.oracle.bmc.identity.requests.ListAvailabilityDomainsRequest
+import com.oracle.bmc.objectstorage.ObjectStorageClient
+
+class OracleBMCSNamedAccountCredentials implements AccountCredentials<Object> {
+
+  String cloudProvider = OracleBMCSCloudProvider.ID
+  String name
+  String environment
+  String accountType
+  String compartmentId
+  List<String> requiredGroupMembership = []
+  Object credentials
+  String region
+  List<OracleBMCSRegion> regions
+  ComputeClient computeClient
+  VirtualNetworkClient networkClient
+  ObjectStorageClient objectStorageClient
+  IdentityClient identityClient
+
+  OracleBMCSNamedAccountCredentials(String name, String environment, String accountType, List<String> requiredGroupMembership, String compartmentId) {
+    this.name = name
+    this.environment = environment
+    this.accountType = accountType
+    this.requiredGroupMembership = requiredGroupMembership
+    this.compartmentId = compartmentId
+
+    AuthenticationDetailsProvider provider = new ConfigFileAuthenticationDetailsProvider(this.name)
+    this.computeClient = new ComputeClient(provider)
+    this.computeClient.setRegion(Region.US_PHOENIX_1)
+    this.networkClient = new VirtualNetworkClient(provider)
+    this.networkClient.setRegion(Region.US_PHOENIX_1)
+    this.objectStorageClient = new ObjectStorageClient(provider)
+    this.objectStorageClient.setRegion(Region.US_PHOENIX_1)
+    this.identityClient = new IdentityClient(provider)
+    this.identityClient.setRegion(Region.US_PHOENIX_1)
+    this.region = Region.US_PHOENIX_1.regionId
+    this.regions = [new OracleBMCSRegion(name: Region.US_PHOENIX_1.regionId,
+      availabilityZones: this.identityClient.listAvailabilityDomains(ListAvailabilityDomainsRequest.builder()
+        .compartmentId(this.compartmentId)
+        .build()).items.collect { it.name })]
+  }
+
+  static class Builder {
+    String name
+    String environment
+    String accountType
+    List<String> requiredGroupMembership = []
+    String compartmentId
+
+    Builder name(String name) {
+      this.name = name
+      return this
+    }
+
+    Builder environment(String environment) {
+      this.environment = environment
+      return this
+    }
+
+    Builder accountType(String accountType) {
+      this.accountType = accountType
+      return this
+    }
+
+    Builder requiredGroupMembership(List<String> requiredGroupMembership) {
+      this.requiredGroupMembership = requiredGroupMembership
+      return this
+    }
+
+    Builder compartmentID(String compartmentID) {
+      this.compartmentId = compartmentID
+      return this
+    }
+
+    OracleBMCSNamedAccountCredentials build() {
+      return new OracleBMCSNamedAccountCredentials(this.name, this.environment, this.accountType, this.requiredGroupMembership, this.compartmentId)
+    }
+  }
+
+  class OracleBMCSRegion {
+    String name
+    List<String> availabilityZones
+  }
+}

--- a/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/OracleBMCSProviderSpec.groovy
+++ b/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/OracleBMCSProviderSpec.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+
+package com.netflix.spinnaker.clouddriver.oraclebmcs
+
+import spock.lang.Specification
+
+
+class OracleBMCSProviderSpec extends Specification {
+
+  def oracleBMCSProvider
+
+  def setup() {
+    oracleBMCSProvider = new OracleBMCSCloudProvider()
+  }
+
+  def "Testing default values of OracleBMCSCloudProvider"() {
+    expect:
+    oracleBMCSProvider.id == "oraclebmcs"
+  }
+}

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -32,6 +32,7 @@ dependencies {
   compile project(':clouddriver-docker')
   compile project(':clouddriver-eureka')
   compile project(':clouddriver-elasticsearch')
+  compile project(':clouddriver-oracle-bmcs')
 
 //  Replace below with this line when fiat becomes stable.
 //  spinnaker.group "fiat"

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -266,6 +266,9 @@ cf:
       artifactUsername: ${cf.repo.username}
       artifactPassword: ${cf.repo.password}
 
+oraclebmcs:
+  enabled: ${ORACLEBMCS_ENABLED:false}
+
 spring:
   jackson:
     mapper:

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.jobs.config.LocalJobConfig
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesConfiguration
 import com.netflix.spinnaker.clouddriver.openstack.OpenstackConfiguration
+import com.netflix.spinnaker.clouddriver.oraclebmcs.OracleBMCSConfiguration
 import com.netflix.spinnaker.clouddriver.security.config.SecurityConfig
 import com.netflix.spinnaker.clouddriver.titus.TitusConfiguration
 import com.netflix.spinnaker.config.ErrorConfiguration
@@ -56,6 +57,7 @@ import java.security.Security
   TitusConfiguration,
   AppengineConfiguration,
   GoogleConfiguration,
+  OracleBMCSConfiguration,
   KubernetesConfiguration,
   OpenstackConfiguration,
   DockerRegistryConfiguration,

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 rootProject.name="clouddriver"
 
-include 'clouddriver-core', 'clouddriver-security', 'clouddriver-web', 'clouddriver-aws', 'clouddriver-titus', 'clouddriver-google', 'clouddriver-google-common', 'clouddriver-cf', 'clouddriver-azure', 'clouddriver-kubernetes', 'clouddriver-docker', 'clouddriver-eureka', 'clouddriver-consul', 'clouddriver-elasticsearch', 'clouddriver-openstack', 'clouddriver-appengine', 'cats:cats-core', 'cats:cats-redis', 'cats:cats-test'
+include 'clouddriver-core', 'clouddriver-security', 'clouddriver-web', 'clouddriver-aws', 'clouddriver-titus', 'clouddriver-google', 'clouddriver-google-common', 'clouddriver-cf', 'clouddriver-azure', 'clouddriver-kubernetes', 'clouddriver-docker', 'clouddriver-eureka', 'clouddriver-consul', 'clouddriver-elasticsearch', 'clouddriver-openstack', 'clouddriver-appengine', 'cats:cats-core', 'cats:cats-redis', 'cats:cats-test', 'clouddriver-oracle-bmcs'
 
 def setBuildFile(project) {
   project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
Based on the discussions during the demo we gave last Wednesday here is the first PR for an Oracle BMCS provider. This is the smallest PR i felt i could create. 

It is essentially: 
- Gradle build script
- Credentials/config loading
- A no-op atomic operation (required by FeatureController - otherwise it won't start with just oraclebmcs enabled). This'll be removed as soon as the first real atomic operation gets added
- A health indicator
- Integration into clouddriver-web
- Added Oracle BMCS section to clouddriver.yaml


It passes './gradlew test', and when enabled with a valid account it will run the health indicator.

The only bit i know you're not going to like is the way we're adding the Oracle BMCS SDK dependency. At the moment it's only available via a zip file on the github releases area of the github repo. I didn't want to add the jars to git, so instead we're downloading on the fly, unzipping and adding to the gradle deps. This should be in a public maven repo soon.

We'll get a demo account setup for you to able to run this as soon as possible.