### PR TITLE
fix(openstack): Fix to have the OpenstackImageV1Provider return all images when requested.

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackImageV1Provider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackImageV1Provider.groovy
@@ -29,14 +29,14 @@ class OpenstackImageV1Provider implements OpenstackImageProvider, OpenstackReque
   @Override
   List<Image> listImages(String region, Map<String, String> filters) {
     handleRequest {
-      getRegionClient(region).images().list(filters)
+      getRegionClient(region).images().listAll(filters)
     }
   }
 
   @Override
   List<Image> listImages(String region) {
     handleRequest {
-      getRegionClient(region).images().list(null)
+      getRegionClient(region).images().listAll(null)
     }
   }
 

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackImageV1ClientProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackImageV1ClientProviderSpec.groovy
@@ -36,7 +36,7 @@ class OpenstackImageV1ClientProviderSpec extends OpenstackClientProviderSpec {
 
     then:
     1 * mockClient.images() >> imageService
-    1 * imageService.list(filters) >> images
+    1 * imageService.listAll(filters) >> images
 
     and:
     result == images
@@ -54,7 +54,7 @@ class OpenstackImageV1ClientProviderSpec extends OpenstackClientProviderSpec {
 
     then:
     1 * mockClient.images() >> imageService
-    1 * imageService.list(filters) >> { throw throwable }
+    1 * imageService.listAll(filters) >> { throw throwable }
 
     and:
     OpenstackProviderException openstackProviderException = thrown(OpenstackProviderException)


### PR DESCRIPTION
This fix changes the behavior of the OpenstackImageV1Provider to return all images from Openstack rather than just the first page.

This is necessary for Openstack environments with greater than 25 images.