### PR TITLE
feat(aws) Support enabling/disabling Auto Scaling Group metrics

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -36,6 +36,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   String keyPair
   Boolean associatePublicIpAddress
   Integer cooldown
+  Collection<String> enabledMetrics
   Integer healthCheckGracePeriod
   String healthCheckType
   String spotPrice

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyAsgDescription.groovy
@@ -22,6 +22,7 @@ class ModifyAsgDescription extends AbstractAmazonCredentialsDescription {
   Integer cooldown
   Integer healthCheckGracePeriod
   String healthCheckType
+  List<String> enabledMetrics
   List<String> terminationPolicies
 
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -255,6 +255,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         classicLoadBalancers: loadBalancers.classicLoadBalancers,
         targetGroupArns: loadBalancers.targetGroupArns,
         cooldown: description.cooldown,
+        enabledMetrics: description.enabledMetrics,
         healthCheckGracePeriod: description.healthCheckGracePeriod,
         healthCheckType: description.healthCheckType,
         terminationPolicies: description.terminationPolicies,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -165,6 +165,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
         newDescription.keyPair = description.keyPair ?: (sourceIsTarget ? ancestorLaunchConfiguration.keyName : description.credentials.defaultKeyPair)
         newDescription.associatePublicIpAddress = description.associatePublicIpAddress != null ? description.associatePublicIpAddress : ancestorLaunchConfiguration.associatePublicIpAddress
         newDescription.cooldown = description.cooldown != null ? description.cooldown : ancestorAsg.defaultCooldown
+        newDescription.enabledMetrics = description.enabledMetrics != null ? description.enabledMetrics : ancestorAsg.enabledMetrics*.metric
         newDescription.healthCheckGracePeriod = description.healthCheckGracePeriod != null ? description.healthCheckGracePeriod : ancestorAsg.healthCheckGracePeriod
         newDescription.healthCheckType = description.healthCheckType ?: ancestorAsg.healthCheckType
         newDescription.suspendedProcesses = description.suspendedProcesses != null ? description.suspendedProcesses : ancestorAsg.suspendedProcesses*.processName


### PR DESCRIPTION
Add clouddriver support for spinnaker/spinnaker#1548.

This introduces two new fields for the ASG server groups: `disabledGroupMetrics` and `enabledGroupMetrics`.

Each list is sent as the `metrics` flag to the appropriate `disable-metrics-collection`/`enable-metrics-collection` API.

These API calls can be made idempotently. For example `disable-metrics-collection` against previously disabled metric(s) will return in success.

If a user specifies a metric in both groups then the `enable` call will take precedence.