### PR TITLE
fix(provider/kubernetes): Deployment scaling

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -628,10 +628,12 @@ class KubernetesApiConverter {
     description.scalingPolicy = new KubernetesScalingPolicy(cpuUtilization: cpuUtilization)
   }
 
-  static HorizontalPodAutoscaler toAutoscaler(KubernetesAutoscalerDescription description) {
+  static HorizontalPodAutoscaler toAutoscaler(KubernetesAutoscalerDescription description,
+                                              String resourceName,
+                                              String resourceKind) {
     def autoscalerBuilder = new HorizontalPodAutoscalerBuilder()
     autoscalerBuilder.withNewMetadata()
-      .withName(description.serverGroupName)
+      .withName(resourceName)
       .withNamespace(description.namespace)
       .endMetadata()
       .withNewSpec()
@@ -641,8 +643,8 @@ class KubernetesApiConverter {
       .withTargetPercentage(description.scalingPolicy.cpuUtilization.target)
       .endCpuUtilization()
       .withNewScaleRef()
-      .withKind(KubernetesUtil.SERVER_GROUP_KIND)
-      .withName(description.serverGroupName)
+      .withKind(resourceKind)
+      .withName(resourceName)
       .endScaleRef()
       .endSpec().build()
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -32,6 +32,7 @@ class KubernetesUtil {
   static String LOAD_BALANCER_LABEL_PREFIX = "load-balancer-"
   static String SERVER_GROUP_LABEL = "replication-controller"
   static String SERVER_GROUP_KIND = "replicaSet"
+  static String DEPLOYMENT_KIND = "deployment"
   static String JOB_LABEL = "job"
   @Value("kubernetes.defaultRegistry:gcr.io")
   static String DEFAULT_REGISTRY

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DestroyKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DestroyKubernetesAtomicOperation.groovy
@@ -42,23 +42,18 @@ class DestroyKubernetesAtomicOperation implements AtomicOperation<Void> {
    */
   @Override
   Void operate(List priorOutputs) {
-    task.updateStatus BASE_PHASE, "Initializing destroy of replication controller."
+    task.updateStatus BASE_PHASE, "Initializing destroy of server group."
     task.updateStatus BASE_PHASE, "Looking up provided namespace..."
 
     def credentials = description.credentials.credentials
     def namespace = KubernetesUtil.validateNamespace(credentials, description.namespace)
 
-    if (credentials.apiAdaptor.getAutoscaler(namespace, description.serverGroupName)) {
-      task.updateStatus BASE_PHASE, "Destroying autoscaler..."
-      if (!credentials.apiAdaptor.deleteAutoscaler(namespace, description.serverGroupName)) {
-        throw new KubernetesOperationException("Failed to delete associated autoscaler $description.serverGroupName in $namespace.")
-      }
-    }
-
+    def autoscalerName = description.serverGroupName
     def parsedName = Names.parseName(description.serverGroupName)
     def deploymentName = parsedName.cluster
     def deployment = credentials.apiAdaptor.getDeployment(namespace, deploymentName)
     def replicaSet = credentials.apiAdaptor.getReplicaSet(namespace, description.serverGroupName)
+    def destroyAutoscalerIfExists = true
 
     if (deployment && replicaSet) {
       task.updateStatus BASE_PHASE, "Checking if deployment ${deploymentName} needs to be destroyed..."
@@ -67,26 +62,31 @@ class DestroyKubernetesAtomicOperation implements AtomicOperation<Void> {
         task.updateStatus BASE_PHASE, "Destroying deployment ${deploymentName}..."
         if (!credentials.apiAdaptor.deleteDeployment(namespace, deploymentName)) {
           throw new KubernetesOperationException("Failed to delete deployment ${deploymentName} in $namespace")
-        } else {
-          // At this point we can safely return, since destroying the deployment destroys the constituent replica sets as well.
-          task.updateStatus BASE_PHASE, "Successfully destroyed deployment ${deploymentName}..."
-          return
         }
+
+        task.updateStatus BASE_PHASE, "Successfully destroyed deployment ${deploymentName}..."
+      } else {
+        destroyAutoscalerIfExists = false
+      }
+    }
+
+    if (credentials.apiAdaptor.getAutoscaler(namespace, autoscalerName) && destroyAutoscalerIfExists) {
+      task.updateStatus BASE_PHASE, "Destroying autoscaler..."
+      if (!credentials.apiAdaptor.deleteAutoscaler(namespace, autoscalerName)) {
+        throw new KubernetesOperationException("Failed to delete associated autoscaler $autoscalerName in $namespace.")
       }
     }
 
     task.updateStatus BASE_PHASE, "Destroying server group..."
 
     if (credentials.apiAdaptor.getReplicationController(namespace, description.serverGroupName)) {
+      task.updateStatus BASE_PHASE, "Underlying kind is 'ReplicationController'..."
       if (!credentials.apiAdaptor.hardDestroyReplicationController(namespace, description.serverGroupName)) {
         throw new KubernetesOperationException("Failed to delete $description.serverGroupName in $namespace.")
       }
     } else if (replicaSet) {
-      if (!credentials.apiAdaptor.hardDestroyReplicaSet(namespace, description.serverGroupName)) {
-        throw new KubernetesOperationException("Failed to delete $description.serverGroupName in $namespace.")
-      }
-    } else {
-      throw new KubernetesOperationException("Failed to find replication controller or replica set $description in $namespace.")
+      task.updateStatus BASE_PHASE, "Underlying kind is 'ReplicaSet'..."
+      credentials.apiAdaptor.hardDestroyReplicaSet(namespace, description.serverGroupName)
     }
 
     task.updateStatus BASE_PHASE, "Successfully destroyed server group $description.serverGroupName."


### PR DESCRIPTION
Before this fix, all scaling activities were applied to replica sets, even when a corresponding deployment existed. This caused the replica set & deployments to fight over the number of pods.