### PR TITLE
fix(provider/kubernetes): Get node selector from ReplicaSet/Replicati…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -617,6 +617,8 @@ class KubernetesApiConverter {
       fromContainer(it)
     } ?: []
 
+    deployDescription.nodeSelector = replicaSet?.spec?.template?.spec?.nodeSelector
+
     return deployDescription
   }
 
@@ -666,6 +668,8 @@ class KubernetesApiConverter {
     deployDescription.containers = replicationController?.spec?.template?.spec?.containers?.collect {
       fromContainer(it)
     } ?: []
+
+    deployDescription.nodeSelector = replicationController?.spec?.template?.spec?.nodeSelector
 
     return deployDescription
   }


### PR DESCRIPTION
The Server Group Information panel (Deck) contains section that is responsible for displaying Node Selectors settings, but it is always hidden as node selector is not being retrieved from the ReplicaSet/ReplicationController. This fixes the issue https://github.com/spinnaker/spinnaker/issues/1264

@@spinnaker/reviewers