### PR TITLE
fix(provider/kubernetes): Kinds should be capitalized for k8s dashboard

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -31,8 +31,8 @@ class KubernetesUtil {
   static String SECURITY_GROUP_LABEL_PREFIX = "security-group-"
   static String LOAD_BALANCER_LABEL_PREFIX = "load-balancer-"
   static String SERVER_GROUP_LABEL = "replication-controller"
-  static String SERVER_GROUP_KIND = "replicaSet"
-  static String DEPLOYMENT_KIND = "deployment"
+  static String SERVER_GROUP_KIND = "ReplicaSet"
+  static String DEPLOYMENT_KIND = "Deployment"
   static String JOB_LABEL = "job"
   @Value("kubernetes.defaultRegistry:gcr.io")
   static String DEFAULT_REGISTRY


### PR DESCRIPTION
Seems the dashboard expects resource refs to have capitalized [kinds](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#types-kinds) even when the kubelet doesn't seem to mind