### PR TITLE
fix(provider/kubernetes): Get node selector from ReplicaSet/Replicati…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -619,6 +619,8 @@ class KubernetesApiConverter {
 
     deployDescription.terminationGracePeriodSeconds = replicaSet?.spec?.template?.spec?.terminationGracePeriodSeconds
 
+    deployDescription.nodeSelector = replicaSet?.spec?.template?.spec?.nodeSelector
+
     return deployDescription
   }
 
@@ -672,6 +674,8 @@ class KubernetesApiConverter {
     } ?: []
 
     deployDescription.terminationGracePeriodSeconds = replicationController?.spec?.template?.spec?.terminationGracePeriodSeconds
+
+    deployDescription.nodeSelector = replicationController?.spec?.template?.spec?.nodeSelector
 
     return deployDescription
   }


### PR DESCRIPTION
The Server Group Information panel (Deck) contains section that is responsible for displaying Node Selectors settings, but it is always hidden as node selector is not being retrieved from the ReplicaSet/ReplicationController. This fixes the issue https://github.com/spinnaker/spinnaker/issues/1264

@spinnaker/reviewers