### PR TITLE
fix(L4 caching): Ignore 'targetInstances' in regional forwarding rules.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleLoadBalancerCachingAgent.groovy
@@ -197,7 +197,8 @@ class GoogleLoadBalancerCachingAgent extends AbstractGoogleCachingAgent implemen
 
           def forwardingRuleTokens = forwardingRule.target.split("/")
 
-          if (forwardingRuleTokens[forwardingRuleTokens.size() - 2] != "targetVpnGateways") {
+          if (forwardingRuleTokens[forwardingRuleTokens.size() - 2] != "targetVpnGateways"
+              && forwardingRuleTokens[forwardingRuleTokens.size() - 2] != "targetInstances") {
             def targetPoolName = Utils.getLocalName(forwardingRule.target)
             def targetPoolsCallback = new TargetPoolCallback(googleLoadBalancer: newLoadBalancer,
                                                              httpHealthChecksRequest: httpHealthChecksRequest,


### PR DESCRIPTION
New features for GCP causing issues with out caching agents: https://cloud.google.com/compute/docs/protocol-forwarding/.