### PR TITLE
fix(provider/openstack): Added OFFLINE status in LB Health enum

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackLoadBalancerHealth.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackLoadBalancerHealth.groovy
@@ -30,6 +30,7 @@ class OpenstackLoadBalancerHealth {
 
   enum PlatformStatus {
     ONLINE,
+    OFFLINE,
     DISABLED
 
     HealthState toHealthState() {


### PR DESCRIPTION
The current enumeration does not support the offline state. This results in an exception when the openstack provider is attempting to read the current status.

Fixed issue spinnaker/spinnaker#1556