### PR TITLE
fix(amazon): do not tag/share public images on AllowLaunch

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolver.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolver.groovy
@@ -41,7 +41,7 @@ class AmiIdResolver {
     }
     Image resolvedImage = amazonEC2.describeImages(req)?.images?.getAt(0)
     if (resolvedImage) {
-      return new ResolvedAmiResult(nameOrId, region, resolvedImage.imageId, resolvedImage.virtualizationType, resolvedImage.ownerId, resolvedImage.blockDeviceMappings)
+      return new ResolvedAmiResult(nameOrId, region, resolvedImage.imageId, resolvedImage.virtualizationType, resolvedImage.ownerId, resolvedImage.blockDeviceMappings, resolvedImage.public)
     }
 
     return null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ResolvedAmiResult.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ResolvedAmiResult.groovy
@@ -30,4 +30,5 @@ class ResolvedAmiResult {
   String virtualizationType
   String ownerId
   List<BlockDeviceMapping> blockDeviceMappings
+  Boolean isPublic
 }


### PR DESCRIPTION
We don't really need (and probably can't?) tag or modify launch permissions on a public AMI when performing an AllowLaunchOperation.

@cfieber PTAL