### PR TITLE
fix(kubernetes): Use 'kind' constants rather than strings

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -31,6 +31,7 @@ class KubernetesUtil {
   static String SECURITY_GROUP_LABEL_PREFIX = "security-group-"
   static String LOAD_BALANCER_LABEL_PREFIX = "load-balancer-"
   static String SERVER_GROUP_LABEL = "replication-controller"
+  static String DEPRECATED_SERVER_GROUP_KIND = "ReplicationController"
   static String SERVER_GROUP_KIND = "ReplicaSet"
   static String DEPLOYMENT_KIND = "Deployment"
   static String JOB_LABEL = "job"

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -279,8 +279,8 @@ class KubernetesServerGroupCachingAgent extends KubernetesCachingAgent implement
     Map<String, Map<String, Event>> rsEvents = [:].withDefault { _ -> [:] }
     try {
       namespaces.each { String namespace ->
-        rcEvents[namespace] = credentials.apiAdaptor.getEvents(namespace, "ReplicationController")
-        rsEvents[namespace] = credentials.apiAdaptor.getEvents(namespace, "ReplicaSet")
+        rcEvents[namespace] = credentials.apiAdaptor.getEvents(namespace, KubernetesUtil.DEPRECATED_SERVER_GROUP_KIND)
+        rsEvents[namespace] = credentials.apiAdaptor.getEvents(namespace, KubernetesUtil.SERVER_GROUP_KIND)
       }
     } catch (Exception e) {
       log.warn "Failure fetching events for all server groups in $namespaces", e
@@ -292,9 +292,9 @@ class KubernetesServerGroupCachingAgent extends KubernetesCachingAgent implement
     Map<String, Map<String, HorizontalPodAutoscaler>> deployAutoscalers = [:].withDefault { _ -> [:] }
     try {
       namespaces.each { String namespace ->
-        rcAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, "replicationController")
-        rsAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, "replicaSet")
-        deployAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, "deployment")
+        rcAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, KubernetesUtil.DEPRECATED_SERVER_GROUP_KIND)
+        rsAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, KubernetesUtil.SERVER_GROUP_KIND)
+        deployAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, KubernetesUtil.DEPLOYMENT_KIND)
       }
     } catch (Exception e) {
       log.warn "Failure fetching autoscalers for all server groups in $namespaces", e

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -95,8 +95,8 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
       podMetadataMock.getNamespace() >> NAMESPACE
       podMock.getMetadata() >> podMetadataMock
       apiMock.getReplicationControllers(NAMESPACE) >> [replicationControllerMock]
-      apiMock.getEvents(NAMESPACE, "ReplicationController") >> [:].withDefault { _ -> [] }
-      apiMock.getAutoscalers(NAMESPACE, "replicationController") >> [:]
+      apiMock.getEvents(NAMESPACE, KubernetesUtil.DEPRECATED_SERVER_GROUP_KIND) >> [:].withDefault { _ -> [] }
+      apiMock.getAutoscalers(NAMESPACE, KubernetesUtil.DEPRECATED_SERVER_GROUP_KIND) >> [:]
       apiMock.getPods(NAMESPACE, selector) >> [podMock]
 
       def providerCacheMock = Mock(ProviderCache)


### PR DESCRIPTION
This was causing a bug when loading autoscaler details