### PR TITLE
feat(artifact/decoration): Artifact decoration spinnaker/spinnaker#1348

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy
@@ -92,14 +92,26 @@ class DockerRegistryImageLookupController {
       } else {
         def parse = Keys.parse(it.id)
         return [
-          repository: (String) parse.repository,
-          tag       : (String) parse.tag,
-          account   : it.attributes.account,
-          registry  : credentials.registry,
-          digest    : it.attributes.digest,
+          repository: (String) parse.repository,  //TODO: Deprecate
+          tag       : (String) parse.tag,         //TODO: Deprecate
+          account   : it.attributes.account,      //TODO: Deprecate
+          registry  : credentials.registry,       //TODO: Deprecate
+          digest    : it.attributes.digest,       //TODO: Deprecate
+          artifact  : generateArtifact(credentials.registry, parse.repository, parse.tag)
         ]
       }
     }
+  }
+
+  Map generateArtifact( String registry,def repository, def tag) {
+    String reference = "${registry}/${repository}:${tag}"
+    [
+      name      : repository,
+      type      : "docker",
+      version   : tag,
+      reference : reference,
+      metadata  : [ registry: registry ]
+    ]
   }
 
   private List<Map> listAllImagesWithoutDigests(String key, LookupOptions lookupOptions) {
@@ -121,6 +133,7 @@ class DockerRegistryImageLookupController {
           tag       : (String) parse.tag,
           account   : (String) parse.account,
           registry  : credentials.registry,
+          artifact  : generateArtifact(credentials.registry, parse.repository, parse.tag)
         ]
       }
     }

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupControllerSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupControllerSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.controllers
+
+import spock.lang.Specification
+
+class DockerRegistryImageLookupControllerSpec extends Specification {
+  def "GenerateArtifact"() {
+    setup:
+    DockerRegistryImageLookupController dockerRegistryImageLookupController = new DockerRegistryImageLookupController();
+
+    when:
+    def result = dockerRegistryImageLookupController.generateArtifact("foo.registry", "my/app", "mytag")
+
+    then:
+    result.name              == "my/app"
+    result.version           == "mytag"
+    result.reference         == "foo.registry/my/app:mytag"
+    result.type              == "docker"
+    result.metadata.registry == "foo.registry"
+  }
+}


### PR DESCRIPTION
This PR makes clouddriver return decorated docker containers when using dockerRegistry/images/find.
    This is done so that we can start moving the handling of docker containers in spinnaker over to decorated artifacts.