### PR TITLE
Ensure that `EntityTags.tags` is always a modifiable list

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
@@ -35,6 +35,13 @@ class EntityTags {
   Collection<EntityTagMetadata> tagsMetadata = []
   EntityRef entityRef
 
+  void setTags(Collection<EntityTag> tags) {
+    Objects.requireNonNull(tags)
+
+    // tag collection must be mutable (see putEntityTagIfAbsent())
+    this.tags = new ArrayList<>(tags)
+  }
+
   @JsonIgnore
   void putEntityTagMetadata(EntityTagMetadata updatedEntityTagMetadata) {
     def existingTagsMetadata = tagsMetadata.find { it.name.equalsIgnoreCase(updatedEntityTagMetadata.name) }

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperationSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperationSpec.groovy
@@ -172,7 +172,10 @@ class BulkUpsertEntityTagsAtomicOperationSpec extends Specification {
 
   void 'should preserve existing tags when merging'() {
     given:
-    def tag = new UpsertEntityTagsDescription()
+    def tag = new UpsertEntityTagsDescription(
+      tags: Collections.singletonList(buildTags(["tag1": "updated tag"])[0])
+    )
+
     description.entityTags = [tag]
     EntityTags current = new EntityTags(
       tags: buildTags([tag1: "old tag", tag2: "unchanged tag"]),
@@ -186,7 +189,6 @@ class BulkUpsertEntityTagsAtomicOperationSpec extends Specification {
       entityId: "orca-v001",
       attributes: [account: "test", region: "us-east-1"]
     )
-    tag.tags = buildTags(["tag1": "updated tag"])
 
     def now = new Date()
 


### PR DESCRIPTION
ElasticSearchServerGroupTagger supplies a singletonList(entityTag) which
causes an issue when updated tags are merged over existing tags.

Opt'd for a generic fix in `EntityTags.setTags()` rather than a point
fix in `ElasticSearchServerGroupTagger` to prevent a future recurrence.
