### PR TITLE
fix(provider/azure): Default environment and accountType to accountName

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsInitializer.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsInitializer.groovy
@@ -38,8 +38,8 @@ class AzureCredentialsInitializer {
       try {
         def azureAccount = new AzureNamedAccountCredentials(
           managedAccount.name,
-          managedAccount.environment,
-          managedAccount.accountType,
+          managedAccount.environment ?: managedAccount.name,
+          managedAccount.accountType ?: managedAccount.name,
           managedAccount.clientId,
           managedAccount.appKey,
           managedAccount.tenantId,


### PR DESCRIPTION
I was testing out some account behavior in deck (primary vs. secondary accounts) when I noticed Azure behaved differently than all other providers. Now the primary Azure credential will show up as a primary account by default.