### PR TITLE
fix(provider/oraclebmcs): Ignore unknown json properties for server g…

### DIFF
--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/model/OracleBMCSServerGroup.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/model/OracleBMCSServerGroup.groovy
@@ -9,6 +9,7 @@
 package com.netflix.spinnaker.clouddriver.oraclebmcs.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
@@ -18,6 +19,7 @@ import com.netflix.spinnaker.clouddriver.oraclebmcs.security.OracleBMCSNamedAcco
 import groovy.transform.Canonical
 
 @Canonical
+@JsonIgnoreProperties(ignoreUnknown = true)
 class OracleBMCSServerGroup {
 
   String name


### PR DESCRIPTION
Ignore unknown json properties for server groups.

Our server group model will be changing over time so need to support new properties appearing to older versions of code.