### PR TITLE
chore(build): fix build config for oracle bmcs cloudprovider

### DIFF
--- a/clouddriver-oracle-bmcs/clouddriver-oracle-bmcs.gradle
+++ b/clouddriver-oracle-bmcs/clouddriver-oracle-bmcs.gradle
@@ -1,55 +1,67 @@
-// Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile/runtime deps
-def bmcsSDK = project.file('bmcs-sdk/lib/oracle-bmc-java-sdk-full-1.2.2.jar')
-def sdkDest = "bmcs-sdk"
 
-if (bmcsSDK.exists() == false) {
-  def sdkArchive = File.createTempFile("bmcsSDK","archive.zip")
-  sdkArchive << new URL("https://github.com/oracle/bmcs-java-sdk/releases/download/v1.2.2/oracle-bmcs-java-sdk.zip").openStream()
+class DownloadTask extends DefaultTask {
+  @Input
+  String sourceUrl
 
-  copy {
-    from zipTree(sdkArchive)
-    into sdkDest
-    include "**/*.jar"
-    exclude "**/*-sources.jar"
-    exclude "**/*-javadoc.jar"
+  @OutputFile
+  File target
 
-    // Scary but works. I think clouddriver deps in general need cleaning at some point
-    // Even without the oracle bmc sdk 3rd party deps there's still multiple javax.inject and commons-X JARs
-    exclude "**/*jackson*.jar"
-    exclude "**/*jersey*.jar"
-    exclude "**/hk2*.jar"
-    exclude "**/*guava*.jar"
-    exclude "**/commons*.jar"
-    exclude "**/javax*.jar"
-    exclude "**/aopalliance*.jar"
-    exclude "**/javassist*.jar"
-    exclude "**/slf*.jar"
-    exclude "**/osgi*.jar"
-    exclude "**/validation*.jar"
-    exclude "**/jsr305*.jar"
-    exclude "**/bcprov*.jar"
-
+  @TaskAction
+  void download() {
+    ant.get(src: sourceUrl, dest: target)
   }
 }
 
-def bmcsSDKDeps = project.fileTree('bmcs-sdk/third-party/lib')
+final File sdkDownloadLocation = project.file('build/sdkdownload')
+final File sdkLocation = project.file('build/bmcs-sdk')
 
-task cleanSDK << {
-  project.file(sdkDest).deleteDir()
+// Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile/runtime deps
+task fetchSdk(type: DownloadTask) {
+  sourceUrl = 'https://github.com/oracle/bmcs-java-sdk/releases/download/v1.2.2/oracle-bmcs-java-sdk.zip'
+  target = sdkDownloadLocation
 }
-clean.dependsOn cleanSDK
 
+task unpackSdk(type: Sync) {
+  dependsOn('fetchSdk')
+  from zipTree(tasks.fetchSdk.target)
+  into sdkLocation
+  include "**/*.jar"
+  exclude "**/*-sources.jar"
+  exclude "**/*-javadoc.jar"
+  exclude "apidocs/**"
+  exclude "examples/**"
 
+  // Scary but works. I think clouddriver deps in general need cleaning at some point
+  // Even without the oracle bmc sdk 3rd party deps there's still multiple javax.inject and commons-X JARs
+  exclude "**/*jackson*.jar"
+  exclude "**/*jersey*.jar"
+  exclude "**/hk2*.jar"
+  exclude "**/*guava*.jar"
+  exclude "**/commons*.jar"
+  exclude "**/javax*.jar"
+  exclude "**/aopalliance*.jar"
+  exclude "**/javassist*.jar"
+  exclude "**/slf*.jar"
+  exclude "**/osgi*.jar"
+  exclude "**/validation*.jar"
+  exclude "**/jsr305*.jar"
+  exclude "**/bcprov*.jar"
+}
+
+task cleanSdk(type: Delete) {
+  delete sdkLocation, sdkDownloadLocation
+}
+
+tasks.clean.dependsOn('cleanSdk')
+tasks.compileJava.dependsOn('unpackSdk')
 
 dependencies {
   compile project(":clouddriver-core")
   compile spinnaker.dependency('frigga')
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
-  compile files(bmcsSDK)
-  runtime files(bmcsSDKDeps)
+  compile fileTree(sdkLocation)
 }
-
 
 def allSourceSets = sourceSets
 license {


### PR DESCRIPTION
moves logic out of inline gradle script and into tasks wired into the task graph

The previous config suffered from an evaluation order problem where the SDK unzipping would happen as the build script was interpreted while the clean task would happen during task execution so doing a `./gradlew clean build` would extract the SDK then clean it up then try to do the build

@simonlord PTAL