### PR TITLE
chore(consul) add debug log for consul checks

### DIFF
--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/provider/ConsulProviderUtils.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/provider/ConsulProviderUtils.groovy
@@ -23,8 +23,10 @@ import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulHealth
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulNode
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulService
+import groovy.util.logging.Slf4j
 import retrofit.RetrofitError
 
+@Slf4j
 class ConsulProviderUtils {
   static ConsulNode getHealths(ConsulConfig config, String agent) {
     def healths = []
@@ -39,6 +41,8 @@ class ConsulProviderUtils {
       } ?: []
       running = true
     } catch (RetrofitError e) {
+      // Instance can't be connected to on hostname:port/v1/agent/checks
+      log.debug(e)
     }
     return new ConsulNode(healths: healths, running: running, services: services)
   }


### PR DESCRIPTION
@lwander PTAL

It'll be helpful to not swallow this error when debugging. It will print for every instance that spinnaker manages that doesn't have consul running. 