### PR TITLE
refactor(entitytags): Switch to using `refresh=false` when retrieving all entity tags from Front50

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/services/Front50Service.groovy
@@ -56,7 +56,7 @@ interface Front50Service {
   List<EntityTags> getAllEntityTagsById(@Query("ids") List<String> entityIds)
 
   @GET('/v2/tags?prefix=')
-  Collection<EntityTags> getAllEntityTags()
+  Collection<EntityTags> getAllEntityTags(@Query("refresh") boolean refresh)
 
   @DELETE('/v2/tags/{id}')
   Response deleteEntityTags(@Path('id') String id)

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProvider.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProvider.java
@@ -254,7 +254,7 @@ public class ElasticSearchEntityTagsProvider implements EntityTagsProvider {
       throw new ElasticSearchException("Unable to re-create index '" + activeElasticSearchIndex + "'");
     }
 
-    Collection<EntityTags> entityTags = front50Service.getAllEntityTags();
+    Collection<EntityTags> entityTags = front50Service.getAllEntityTags(false);
 
     log.info("Indexing {} entity tags", entityTags.size());
     bulkIndex(
@@ -268,7 +268,7 @@ public class ElasticSearchEntityTagsProvider implements EntityTagsProvider {
 
   @Override
   public Map metadata() {
-    Collection<EntityTags> allEntityTagsFront50 = front50Service.getAllEntityTags();
+    Collection<EntityTags> allEntityTagsFront50 = front50Service.getAllEntityTags(false);
     Map<String, List<EntityTags>> entityTagsByEntityTypeFront50 = allEntityTagsFront50
       .stream()
       .collect(Collectors.groupingBy(e ->


### PR DESCRIPTION
This affects the `/admin/tags/metadata` and `/admin/tags/reindex` endpoints.

A subsequent PR will introduce a `/repair` that will reindex _only_ the deltas
detected between Front50 and Elasticsearch.

These deltas can occur during a full flush + reindex operation as tags will
still arrive while the elastic search index is being re-created.
