### PR TITLE
fix(aws): Raise an exception when a lifecycle hook specifies an invalid transition

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -387,13 +387,13 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
                             BasicAmazonDeployDescription description,
                             String targetAsgName) {
 
-    List<AmazonAsgLifecycleHook> lifecycleHooks = getLifecycleHooks(targetCredentials, description)
-    if (lifecycleHooks.size() > 0) {
-      try {
+    try {
+      List<AmazonAsgLifecycleHook> lifecycleHooks = getLifecycleHooks(targetCredentials, description)
+      if (lifecycleHooks.size() > 0) {
         targetRegionScopedProvider.asgLifecycleHookWorker.attach(task, lifecycleHooks, targetAsgName)
-      } catch (AmazonServiceException ase) {
-        task.updateStatus(BASE_PHASE, "Unable to attach lifecycle hooks to ASG ($targetAsgName): ${ase.message}")
       }
+    } catch (Exception e) {
+      task.updateStatus(BASE_PHASE, "Unable to attach lifecycle hooks to ASG ($targetAsgName): ${e.message}")
     }
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonAsgLifecycleHook.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonAsgLifecycleHook.groovy
@@ -52,7 +52,12 @@ class AmazonAsgLifecycleHook {
     }
 
     static Transition valueOfName(String name) {
-      values().find { it.value == name }
+      def transition = values().find { it.value == name }
+      if (!transition) {
+        throw new IllegalArgumentException("${name} is an unsupported Transition (valid values: ${values().join(",")})")
+      }
+
+      return transition
     }
   }
 


### PR DESCRIPTION
With this PR, failure to attach lifecycle hooks will not fail the task.

`catch (Exception) vs catch (AmazonServiceException)`