### PR TITLE
feature(kubernetes): add ability to specify sequence number when deploying kubernetes server group

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -45,6 +45,7 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesAtomicOperati
   KubernetesSecurityContext securityContext
   KubernetesDeployment deployment
   Long terminationGracePeriodSeconds
+  Integer sequence
 
   @JsonIgnore
   Set<String> imagePullSecrets

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
@@ -77,7 +77,14 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
     def clusterName = serverGroupNameResolver.combineAppStackDetail(description.application, description.stack, description.freeFormDetails)
 
     task.updateStatus BASE_PHASE, "Looking up next sequence index for cluster ${clusterName}..."
-    def replicaSetName = serverGroupNameResolver.resolveNextServerGroupName(description.application, description.stack, description.freeFormDetails, false)
+
+    String replicaSetName
+    if (description.sequence) {
+      replicaSetName = serverGroupNameResolver.generateServerGroupName(description.application, description.stack, description.freeFormDetails, description.sequence, false)
+    } else {
+      replicaSetName = serverGroupNameResolver.resolveNextServerGroupName(description.application, description.stack, description.freeFormDetails, false)
+    }
+
     task.updateStatus BASE_PHASE, "Replica set name chosen to be ${replicaSetName}."
 
     task.updateStatus BASE_PHASE, "Building replica set..."


### PR DESCRIPTION
This pull request adds the capability to specify the server group sequence during a kubernetes deployment. This matches the functionality in `clouddriver-aws`.