### PR TITLE
feat(provider/openstack): consul enable/disable

### DIFF
--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/provider/ConsulProviderUtils.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/provider/ConsulProviderUtils.groovy
@@ -42,7 +42,7 @@ class ConsulProviderUtils {
       running = true
     } catch (RetrofitError e) {
       // Instance can't be connected to on hostname:port/v1/agent/checks
-      log.debug(e)
+      log.debug(e.message)
     }
     return new ConsulNode(healths: healths, running: running, services: services)
   }


### PR DESCRIPTION
Adding consul enable/disable for openstack provider modeled after the google implementation (https://github.com/spinnaker/clouddriver/blob/master/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbstractEnableDisableAtomicOperation.groovy#L83).

Adding try/catch for getHealths in OpenStack caching.

@lwander PTAL