### PR TITLE
refactor(provider/oraclebmcs): Take auth parameters from yaml instead…

### DIFF
--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/config/OracleBMCSConfigurationProperties.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/config/OracleBMCSConfigurationProperties.groovy
@@ -21,6 +21,11 @@ class OracleBMCSConfigurationProperties {
     String accountType
     List<String> requiredGroupMembership = []
     String compartmentId
+    String userId
+    String fingerprint
+    String sshPrivateKeyFilePath
+    String tenancyId
+    String region
   }
 
   List<ManagedAccount> accounts = []

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/security/OracleBMCSCredentialsInitializer.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/security/OracleBMCSCredentialsInitializer.groovy
@@ -55,12 +55,17 @@ class OracleBMCSCredentialsInitializer implements CredentialsInitializerSynchron
           environment(managedAccount.environment ?: managedAccount.name).
           accountType(managedAccount.accountType ?: managedAccount.name).
           requiredGroupMembership(managedAccount.requiredGroupMembership).
-          compartmentID(managedAccount.compartmentId).
+          compartmentId(managedAccount.compartmentId).
+          userId(managedAccount.userId).
+          fingerprint(managedAccount.fingerprint).
+          sshPrivateKeyFilePath(managedAccount.sshPrivateKeyFilePath).
+          tenancyId(managedAccount.tenancyId).
+          region(managedAccount.region).
           build()
 
         accountCredentialsRepository.save(managedAccount.name, oracleBMCSAccount)
       } catch (e) {
-        log.info("Could not load account $managedAccount.name for OracleBMCS", e)
+        log.warn("Could not load account $managedAccount.name for OracleBMCS", e)
       }
     }
 


### PR DESCRIPTION
… of oracle config file

This is being done to make the setup of Oracle BMCS from Halyard a nice experience.

i.e., Having Halyard CLI switches and descriptions for each required auth/config param including the path to the ssh private key.

Previously we assumed ~/.oraclebmc/config would magically exist (created by user via some setup doc).
