### PR TITLE
fix(provider/google): Wait for forwarding rule creation in LB upserts.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperation.groovy
@@ -232,7 +232,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation extends GoogleAtomicOperat
         subnetwork: GCEUtil.buildSubnetworkUrl(project, region, description.subnet),
         ports: description.ports
       )
-      safeRetry.doRetry(
+      Operation forwardingRuleOp = safeRetry.doRetry(
         { timeExecute(
               compute.forwardingRules().insert(project, region, forwardingRule),
               "compute.forwardingRules.insert",
@@ -243,7 +243,16 @@ class UpsertGoogleInternalLoadBalancerAtomicOperation extends GoogleAtomicOperat
         [],
         [action: "insert", phase: BASE_PHASE, operation: "compute.forwardingRules.insert", (TAG_SCOPE): SCOPE_GLOBAL],
         registry
-      )
+      ) as Operation
+
+      // Orca's orchestration for upserting a Google load balancer does not contain a task
+      // to wait for the state of the platform to show that a load balancer was created (for good reason,
+      // that would be a complicated operation). Instead, Orca waits for Clouddriver to execute this operation
+      // and do a force cache refresh. We should wait for the whole load balancer to be created in the platform
+      // before we exit this upsert operation, so we wait for the forwarding rule to be created before continuing
+      // so we _know_ the state of the platform when we do a force cache refresh.
+      googleOperationPoller.waitForRegionalOperation(compute, project, region, forwardingRuleOp.getName(),
+          null, task, "forwarding rule " + description.loadBalancerName, BASE_PHASE)
     }
 
     task.updateStatus BASE_PHASE, "Done upserting load balancer $description.loadBalancerName in $region."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperation.groovy
@@ -302,6 +302,13 @@ class UpsertGoogleSslLoadBalancerAtomicOperation extends UpsertGoogleLoadBalance
         [action: "insert", phase: BASE_PHASE, operation: "compute.globalForwardingRules.insert", (TAG_SCOPE): SCOPE_GLOBAL],
         registry
       ) as Operation
+
+      // Orca's orchestration for upserting a Google load balancer does not contain a task
+      // to wait for the state of the platform to show that a load balancer was created (for good reason,
+      // that would be a complicated operation). Instead, Orca waits for Clouddriver to execute this operation
+      // and do a force cache refresh. We should wait for the whole load balancer to be created in the platform
+      // before we exit this upsert operation, so we wait for the forwarding rule to be created before continuing
+      // so we _know_ the state of the platform when we do a force cache refresh.
       googleOperationPoller.waitForGlobalOperation(compute, project, ruleOp.getName(),
         null, task, "forwarding rule " + description.loadBalancerName, BASE_PHASE)
     }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec.groovy
@@ -82,6 +82,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalBackendServiceOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalUrlMapOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalTargetHttpProxyOperationGet = Mock(Compute.GlobalOperations.Get)
+      def globalForwardingRuleOperationGet = Mock(Compute.GlobalOperations.Get)
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
@@ -119,7 +120,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesInsert = Mock(Compute.GlobalForwardingRules.Insert)
       def globalForwardingRulesGet = Mock(Compute.GlobalForwardingRules.Get)
-      def insertOp = new Operation(targetLink: "link")
+      def forwardingRuleInsertOp = new Operation(
+          targetLink: "forwarding-rule",
+          name: LOAD_BALANCER_NAME,
+          status: DONE)
 
       def input = [
         accountName       : ACCOUNT_NAME,
@@ -204,10 +208,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.globalForwardingRules() >> globalForwardingRules
       1 * globalForwardingRules.insert(PROJECT_NAME, _) >> globalForwardingRulesInsert
       1 * globalForwardingRules.get(PROJECT_NAME, _) >> globalForwardingRulesGet
-      1 * globalForwardingRulesInsert.execute() >> insertOp
+      1 * globalForwardingRulesInsert.execute() >> forwardingRuleInsertOp
       1 * globalForwardingRulesGet.execute() >> null
 
-      6 * computeMock.globalOperations() >> globalOperations
+      7 * computeMock.globalOperations() >> globalOperations
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> httpHealthChecksInsertOp
       3 * globalOperations.get(PROJECT_NAME, BACKEND_SERVICE_OP_NAME) >> globalBackendServiceOperationGet
@@ -216,6 +220,8 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * globalUrlMapOperationGet.execute() >> httpHealthChecksInsertOp
       1 * globalOperations.get(PROJECT_NAME, TARGET_HTTP_PROXY_OP_NAME) >> globalTargetHttpProxyOperationGet
       1 * globalTargetHttpProxyOperationGet.execute() >> httpHealthChecksInsertOp
+      1 * globalOperations.get(PROJECT_NAME, LOAD_BALANCER_NAME) >> globalForwardingRuleOperationGet
+      1 * globalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 
   void "should create an HTTP Load Balancer with minimal description"() {
@@ -236,6 +242,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalBackendServiceOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalUrlMapOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalTargetHttpProxyOperationGet = Mock(Compute.GlobalOperations.Get)
+      def globalForwardingRuleOperationGet = Mock(Compute.GlobalOperations.Get)
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
@@ -273,7 +280,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesInsert = Mock(Compute.GlobalForwardingRules.Insert)
       def globalForwardingRulesGet = Mock(Compute.GlobalForwardingRules.Get)
-      def insertOp = new Operation(targetLink: "link")
+      def forwardingRuleInsertOp = new Operation(
+          targetLink: "forwarding-rule",
+          name: LOAD_BALANCER_NAME,
+          status: DONE)
       def input = [
         accountName       : ACCOUNT_NAME,
         "loadBalancerName": LOAD_BALANCER_NAME,
@@ -328,10 +338,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.globalForwardingRules() >> globalForwardingRules
       1 * globalForwardingRules.insert(PROJECT_NAME, _) >> globalForwardingRulesInsert
       1 * globalForwardingRules.get(PROJECT_NAME, _) >> globalForwardingRulesGet
-      1 * globalForwardingRulesInsert.execute() >> insertOp
+      1 * globalForwardingRulesInsert.execute() >> forwardingRuleInsertOp
       1 * globalForwardingRulesGet.execute() >> null
 
-      4 * computeMock.globalOperations() >> globalOperations
+      5 * computeMock.globalOperations() >> globalOperations
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> httpHealthChecksInsertOp
       1 * globalOperations.get(PROJECT_NAME, BACKEND_SERVICE_OP_NAME) >> globalBackendServiceOperationGet
@@ -340,6 +350,8 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * globalUrlMapOperationGet.execute() >> httpHealthChecksInsertOp
       1 * globalOperations.get(PROJECT_NAME, TARGET_HTTP_PROXY_OP_NAME) >> globalTargetHttpProxyOperationGet
       1 * globalTargetHttpProxyOperationGet.execute() >> httpHealthChecksInsertOp
+      1 * globalOperations.get(PROJECT_NAME, LOAD_BALANCER_NAME) >> globalForwardingRuleOperationGet
+      1 * globalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 
   void "should create an HTTPS Load Balancer when certificate specified"() {
@@ -360,6 +372,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalBackendServiceOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalUrlMapOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalTargetHttpsProxyOperationGet = Mock(Compute.GlobalOperations.Get)
+      def globalForwardingRuleOperationGet = Mock(Compute.GlobalOperations.Get)
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
@@ -397,7 +410,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesInsert = Mock(Compute.GlobalForwardingRules.Insert)
       def globalForwardingRulesGet = Mock(Compute.GlobalForwardingRules.Get)
-      def insertOp = new Operation(targetLink: "link")
+      def forwardingRuleInsertOp = new Operation(
+          targetLink: "forwarding-rule",
+          name: LOAD_BALANCER_NAME,
+          status: DONE)
       def input = [
         accountName       : ACCOUNT_NAME,
         "loadBalancerName": LOAD_BALANCER_NAME,
@@ -452,10 +468,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.globalForwardingRules() >> globalForwardingRules
       1 * globalForwardingRules.insert(PROJECT_NAME, _) >> globalForwardingRulesInsert
       1 * globalForwardingRules.get(PROJECT_NAME, _) >> globalForwardingRulesGet
-      1 * globalForwardingRulesInsert.execute() >> insertOp
+      1 * globalForwardingRulesInsert.execute() >> forwardingRuleInsertOp
       1 * globalForwardingRulesGet.execute() >> null
 
-      4 * computeMock.globalOperations() >> globalOperations
+      5 * computeMock.globalOperations() >> globalOperations
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> httpHealthChecksInsertOp
       1 * globalOperations.get(PROJECT_NAME, BACKEND_SERVICE_OP_NAME) >> globalBackendServiceOperationGet
@@ -464,6 +480,8 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * globalUrlMapOperationGet.execute() >> httpHealthChecksInsertOp
       1 * globalOperations.get(PROJECT_NAME, TARGET_HTTP_PROXY_OP_NAME) >> globalTargetHttpsProxyOperationGet
       1 * globalTargetHttpsProxyOperationGet.execute() >> httpHealthChecksInsertOp
+      1 * globalOperations.get(PROJECT_NAME, LOAD_BALANCER_NAME) >> globalForwardingRuleOperationGet
+      1 * globalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 
   void "should update health check when it exists and needs updated"() {
@@ -484,6 +502,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalBackendServiceOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalUrlMapOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalTargetHttpProxyOperationGet = Mock(Compute.GlobalOperations.Get)
+      def globalForwardingRuleOperationGet = Mock(Compute.GlobalOperations.Get)
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
@@ -521,7 +540,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesInsert = Mock(Compute.GlobalForwardingRules.Insert)
       def globalForwardingRulesGet = Mock(Compute.GlobalForwardingRules.Get)
-      def insertOp = new Operation(targetLink: "link")
+      def forwardingRuleInsertOp = new Operation(
+          targetLink: "forwarding-rule",
+          name: LOAD_BALANCER_NAME,
+          status: DONE)
 
       def input = [
         accountName       : ACCOUNT_NAME,
@@ -606,10 +628,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.globalForwardingRules() >> globalForwardingRules
       1 * globalForwardingRules.insert(PROJECT_NAME, _) >> globalForwardingRulesInsert
       1 * globalForwardingRules.get(PROJECT_NAME, _) >> globalForwardingRulesGet
-      1 * globalForwardingRulesInsert.execute() >> insertOp
+      1 * globalForwardingRulesInsert.execute() >> forwardingRuleInsertOp
       1 * globalForwardingRulesGet.execute() >> null
 
-      6 * computeMock.globalOperations() >> globalOperations
+      7 * computeMock.globalOperations() >> globalOperations
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> httpHealthChecksUpdateOp
       3 * globalOperations.get(PROJECT_NAME, BACKEND_SERVICE_OP_NAME) >> globalBackendServiceOperationGet
@@ -618,6 +640,8 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * globalUrlMapOperationGet.execute() >> urlMapsInsertOp
       1 * globalOperations.get(PROJECT_NAME, TARGET_HTTP_PROXY_OP_NAME) >> globalTargetHttpProxyOperationGet
       1 * globalTargetHttpProxyOperationGet.execute() >> targetHttpProxiesInsertOp
+      1 * globalOperations.get(PROJECT_NAME, LOAD_BALANCER_NAME) >> globalForwardingRuleOperationGet
+      1 * globalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 
   void "should update backend service if it exists and needs updated"() {
@@ -638,6 +662,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalBackendServiceOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalUrlMapOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalTargetHttpProxyOperationGet = Mock(Compute.GlobalOperations.Get)
+      def globalForwardingRuleOperationGet = Mock(Compute.GlobalOperations.Get)
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
@@ -680,7 +705,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesInsert = Mock(Compute.GlobalForwardingRules.Insert)
       def globalForwardingRulesGet = Mock(Compute.GlobalForwardingRules.Get)
-      def insertOp = new Operation(targetLink: "link")
+      def forwardingRuleInsertOp = new Operation(
+          targetLink: "forwarding-rule",
+          name: LOAD_BALANCER_NAME,
+          status: DONE)
 
       def input = [
         accountName       : ACCOUNT_NAME,
@@ -767,10 +795,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.globalForwardingRules() >> globalForwardingRules
       1 * globalForwardingRules.insert(PROJECT_NAME, _) >> globalForwardingRulesInsert
       1 * globalForwardingRules.get(PROJECT_NAME, _) >> globalForwardingRulesGet
-      1 * globalForwardingRulesInsert.execute() >> insertOp
+      1 * globalForwardingRulesInsert.execute() >> forwardingRuleInsertOp
       1 * globalForwardingRulesGet.execute() >> null
 
-      6 * computeMock.globalOperations() >> globalOperations
+      7 * computeMock.globalOperations() >> globalOperations
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> httpHealthChecksUpdateOp
       2 * globalOperations.get(PROJECT_NAME, BACKEND_SERVICE_OP_NAME) >> globalBackendServiceOperationGet
@@ -781,6 +809,8 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * globalUrlMapOperationGet.execute() >> urlMapsInsertOp
       1 * globalOperations.get(PROJECT_NAME, TARGET_HTTP_PROXY_OP_NAME) >> globalTargetHttpProxyOperationGet
       1 * globalTargetHttpProxyOperationGet.execute() >> targetHttpProxiesInsertOp
+      1 * globalOperations.get(PROJECT_NAME, LOAD_BALANCER_NAME) >> globalForwardingRuleOperationGet
+      1 * globalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 
   void "should update url map if it exists and needs updated"() {
@@ -801,6 +831,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalBackendServiceOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalUrlMapOperationGet = Mock(Compute.GlobalOperations.Get)
       def globalTargetHttpProxyOperationGet = Mock(Compute.GlobalOperations.Get)
+      def globalForwardingRuleOperationGet = Mock(Compute.GlobalOperations.Get)
 
       def httpHealthChecks = Mock(Compute.HttpHealthChecks)
       def httpHealthChecksList = Mock(Compute.HttpHealthChecks.List)
@@ -844,7 +875,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesInsert = Mock(Compute.GlobalForwardingRules.Insert)
       def globalForwardingRulesGet = Mock(Compute.GlobalForwardingRules.Get)
-      def insertOp = new Operation(targetLink: "link")
+      def forwardingRuleInsertOp = new Operation(
+          targetLink: "forwarding-rule",
+          name: LOAD_BALANCER_NAME,
+          status: DONE)
 
       def input = [
         accountName       : ACCOUNT_NAME,
@@ -931,10 +965,10 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       2 * computeMock.globalForwardingRules() >> globalForwardingRules
       1 * globalForwardingRules.insert(PROJECT_NAME, _) >> globalForwardingRulesInsert
       1 * globalForwardingRules.get(PROJECT_NAME, _) >> globalForwardingRulesGet
-      1 * globalForwardingRulesInsert.execute() >> insertOp
+      1 * globalForwardingRulesInsert.execute() >> forwardingRuleInsertOp
       1 * globalForwardingRulesGet.execute() >> null
 
-      6 * computeMock.globalOperations() >> globalOperations
+      7 * computeMock.globalOperations() >> globalOperations
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> httpHealthChecksUpdateOp
       2 * globalOperations.get(PROJECT_NAME, BACKEND_SERVICE_OP_NAME) >> globalBackendServiceOperationGet
@@ -945,5 +979,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperationUnitSpec extends Specification 
       1 * globalUrlMapOperationGet.execute() >> urlMapsUpdateOp
       1 * globalOperations.get(PROJECT_NAME, TARGET_HTTP_PROXY_OP_NAME) >> globalTargetHttpProxyOperationGet
       1 * globalTargetHttpProxyOperationGet.execute() >> targetHttpProxiesInsertOp
+      1 * globalOperations.get(PROJECT_NAME, LOAD_BALANCER_NAME) >> globalForwardingRuleOperationGet
+      1 * globalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec.groovy
@@ -82,6 +82,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
 
     def regionalOperations = Mock(Compute.RegionOperations)
     def regionalBackendServiceOperationGet = Mock(Compute.RegionOperations.Get)
+    def regionalForwardingRuleOperationGet = Mock(Compute.RegionOperations.Get)
 
     def regions = Mock(Compute.Regions)
     def regionsList = Mock(Compute.Regions.List)
@@ -90,6 +91,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
     def forwardingRules = Mock(Compute.ForwardingRules)
     def forwardingRulesGet = Mock(Compute.ForwardingRules.Get)
     def forwardingRulesInsert = Mock(Compute.ForwardingRules.Insert)
+    def forwardingRuleInsertOp = new Operation(
+        targetLink: "forwarding-rule",
+        name: LOAD_BALANCER_NAME,
+        status: DONE)
 
     def healthChecks = Mock(Compute.HealthChecks)
     def healthChecksGet = Mock(Compute.HealthChecks.Get)
@@ -147,7 +152,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       1 * forwardingRules.get(PROJECT_NAME, REGION, LOAD_BALANCER_NAME) >> forwardingRulesGet
       1 * forwardingRulesGet.execute() >> null
       1 * forwardingRules.insert(PROJECT_NAME, REGION, _) >> forwardingRulesInsert
-      1 * forwardingRulesInsert.execute()
+      1 * forwardingRulesInsert.execute() >> forwardingRuleInsertOp
 
       2 * computeMock.healthChecks() >> healthChecks
       1 * healthChecks.get(PROJECT_NAME, "basic-check") >> healthChecksGet
@@ -165,9 +170,11 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> healthChecksInsertOp
 
-      1 * computeMock.regionOperations() >> regionalOperations
+      2 * computeMock.regionOperations() >> regionalOperations
       1 * regionalOperations.get(PROJECT_NAME, REGION, BACKEND_SERVICE_OP_NAME) >> regionalBackendServiceOperationGet
       1 * regionalBackendServiceOperationGet.execute() >> backendServicesInsertOp
+      1 * regionalOperations.get(PROJECT_NAME, REGION, LOAD_BALANCER_NAME) >> regionalForwardingRuleOperationGet
+      1 * regionalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 
   void "should update backend service if it exists."() {
@@ -188,6 +195,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
 
     def regionalOperations = Mock(Compute.RegionOperations)
     def regionalBackendServiceOperationGet = Mock(Compute.RegionOperations.Get)
+    def regionalForwardingRuleOperationGet = Mock(Compute.RegionOperations.Get)
 
     def regions = Mock(Compute.Regions)
     def regionsList = Mock(Compute.Regions.List)
@@ -196,6 +204,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
     def forwardingRules = Mock(Compute.ForwardingRules)
     def forwardingRulesGet = Mock(Compute.ForwardingRules.Get)
     def forwardingRulesInsert = Mock(Compute.ForwardingRules.Insert)
+    def forwardingRuleInsertOp = new Operation(
+        targetLink: "forwarding-rule",
+        name: LOAD_BALANCER_NAME,
+        status: DONE)
 
     def healthChecks = Mock(Compute.HealthChecks)
     def healthChecksGet = Mock(Compute.HealthChecks.Get)
@@ -253,7 +265,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       1 * forwardingRules.get(PROJECT_NAME, REGION, LOAD_BALANCER_NAME) >> forwardingRulesGet
       1 * forwardingRulesGet.execute() >> null
       1 * forwardingRules.insert(PROJECT_NAME, REGION, _) >> forwardingRulesInsert
-      1 * forwardingRulesInsert.execute()
+      1 * forwardingRulesInsert.execute() >> forwardingRuleInsertOp
 
       2 * computeMock.healthChecks() >> healthChecks
       1 * healthChecks.get(PROJECT_NAME, "basic-check") >> healthChecksGet
@@ -271,9 +283,11 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> healthChecksInsertOp
 
-      1 * computeMock.regionOperations() >> regionalOperations
+      2 * computeMock.regionOperations() >> regionalOperations
       1 * regionalOperations.get(PROJECT_NAME, REGION, BACKEND_SERVICE_OP_NAME) >> regionalBackendServiceOperationGet
       1 * regionalBackendServiceOperationGet.execute() >> backendServicesInsertOp
+      1 * regionalOperations.get(PROJECT_NAME, REGION, LOAD_BALANCER_NAME) >> regionalForwardingRuleOperationGet
+      1 * regionalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 
   void "should update health check if it exists."() {
@@ -294,6 +308,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
 
     def regionalOperations = Mock(Compute.RegionOperations)
     def regionalBackendServiceOperationGet = Mock(Compute.RegionOperations.Get)
+    def regionalForwardingRuleOperationGet = Mock(Compute.RegionOperations.Get)
 
     def regions = Mock(Compute.Regions)
     def regionsList = Mock(Compute.Regions.List)
@@ -302,6 +317,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
     def forwardingRules = Mock(Compute.ForwardingRules)
     def forwardingRulesGet = Mock(Compute.ForwardingRules.Get)
     def forwardingRulesInsert = Mock(Compute.ForwardingRules.Insert)
+    def forwardingRuleInsertOp = new Operation(
+        targetLink: "forwarding-rule",
+        name: LOAD_BALANCER_NAME,
+        status: DONE)
 
     def healthChecks = Mock(Compute.HealthChecks)
     def healthChecksGet = Mock(Compute.HealthChecks.Get)
@@ -359,7 +378,7 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       1 * forwardingRules.get(PROJECT_NAME, REGION, LOAD_BALANCER_NAME) >> forwardingRulesGet
       1 * forwardingRulesGet.execute() >> null
       1 * forwardingRules.insert(PROJECT_NAME, REGION, _) >> forwardingRulesInsert
-      1 * forwardingRulesInsert.execute()
+      1 * forwardingRulesInsert.execute() >> forwardingRuleInsertOp
 
       2 * computeMock.healthChecks() >> healthChecks
       1 * healthChecks.get(PROJECT_NAME, "basic-check") >> healthChecksGet
@@ -377,8 +396,10 @@ class UpsertGoogleInternalLoadBalancerAtomicOperationUnitSpec extends Specificat
       1 * globalOperations.get(PROJECT_NAME, HEALTH_CHECK_OP_NAME) >> globalHealthCheckOperationGet
       1 * globalHealthCheckOperationGet.execute() >> healthChecksInsertOp
 
-      1 * computeMock.regionOperations() >> regionalOperations
+      2 * computeMock.regionOperations() >> regionalOperations
       1 * regionalOperations.get(PROJECT_NAME, REGION, BACKEND_SERVICE_OP_NAME) >> regionalBackendServiceOperationGet
       1 * regionalBackendServiceOperationGet.execute() >> backendServicesInsertOp
+      1 * regionalOperations.get(PROJECT_NAME, REGION, LOAD_BALANCER_NAME) >> regionalForwardingRuleOperationGet
+      1 * regionalForwardingRuleOperationGet.execute() >> forwardingRuleInsertOp
   }
 }


### PR DESCRIPTION
Orca's orchestration for upserting a Google load balancer does not contain a task to wait for the state of the platform to show that a load balancer was created (for good reason, that would be a complicated operation). Instead, Orca waits for Clouddriver to execute this operation and do a force cache refresh. We should wait for the whole load balancer to be created in the platform before we exit this upsert operation, so we wait for the forwarding rule to be created before continuing so we _know_ the state of the platform when we do a force cache refresh.