### PR TITLE
fix(provider/kubernetes): Use sanitized namespace in enable/disable.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
@@ -109,7 +109,7 @@ abstract class AbstractEnableDisableKubernetesAtomicOperation implements AtomicO
     if (!replicationController && !replicaSet )
       throw new KubernetesOperationException("No replication controller or replica set $description.serverGroupName in $namespace.")
 
-    KubernetesServerGroup serverGroup = clusterProviders.getServerGroup(description.account, description.namespace, description.serverGroupName)
+    KubernetesServerGroup serverGroup = clusterProviders.getServerGroup(description.account, namespace, description.serverGroupName)
     serverGroup.instances.forEach( { instance -> pods.add(instance.getPod())})
 
     if (!pods) {


### PR DESCRIPTION
`description.namespace` is null for the default namespace. `validateNamespace` sanitizes the description's namespace in this case, so we should use the sanitized namespace later on in this operation.