### PR TITLE
feat(aws/auth): optionally include spinnaker authenticated user in aws requests

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -107,6 +107,7 @@ class AwsConfiguration {
       .useGzip(awsConfigurationProperties.client.useGzip)
       .serviceLimitConfiguration(serviceLimitConfiguration)
       .registry(registry)
+      .addSpinnakerUserToUserAgent(awsConfigurationProperties.client.addSpinnakerUserToUserAgent)
       .build()
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
@@ -30,6 +30,7 @@ class AwsConfigurationProperties {
     int maxConnections = 200
     int maxConnectionsPerRoute = 20
     boolean useGzip = true
+    boolean addSpinnakerUserToUserAgent = false
   }
 
   @Canonical

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AddSpinnakerUserToUserAgentRequestHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AddSpinnakerUserToUserAgentRequestHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.handlers.RequestHandler2;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+
+public class AddSpinnakerUserToUserAgentRequestHandler extends RequestHandler2 {
+  @Override
+  public AmazonWebServiceRequest beforeMarshalling(AmazonWebServiceRequest request) {
+    final String userAgent = "spinnaker-user/" + AuthenticatedRequest.getSpinnakerUser().orElse("unknown");
+    final AmazonWebServiceRequest cloned = request.clone();
+
+    cloned.getRequestClientOptions().appendUserAgent(userAgent);
+    return super.beforeMarshalling(cloned);
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -92,6 +92,7 @@ public class AmazonClientProvider {
     private int maxConnections = 200;
     private int maxConnectionsPerRoute = 20;
     private boolean uzeGzip = true;
+    private boolean addSpinnakerUserToUserAgent = false;
     private ServiceLimitConfiguration serviceLimitConfiguration = new ServiceLimitConfigurationBuilder().build();
     private Registry registry = new NoopRegistry();
 
@@ -165,6 +166,11 @@ public class AmazonClientProvider {
       return this;
     }
 
+    public Builder addSpinnakerUserToUserAgent(boolean addSpinnakerUserToUserAgent) {
+      this.addSpinnakerUserToUserAgent = addSpinnakerUserToUserAgent;
+      return this;
+    }
+
     public AmazonClientProvider build() {
       HttpClient client = this.httpClient;
       if (client == null) {
@@ -179,6 +185,15 @@ public class AmazonClientProvider {
       RetryPolicy policy = buildPolicy();
       AWSProxy proxy = this.proxy;
       EddaTimeoutConfig eddaTimeoutConfig = this.eddaTimeoutConfig == null ? EddaTimeoutConfig.DEFAULT : this.eddaTimeoutConfig;
+
+      final List<RequestHandler2> requestHandlers;
+      if (addSpinnakerUserToUserAgent) {
+        requestHandlers = new ArrayList<>(this.requestHandlers.size() + 1);
+        requestHandlers.addAll(this.requestHandlers);
+        requestHandlers.add(new AddSpinnakerUserToUserAgentRequestHandler());
+      } else {
+        requestHandlers = this.requestHandlers;
+      }
 
       return new AmazonClientProvider(client, mapper, templater, policy, requestHandlers, proxy, eddaTimeoutConfig, uzeGzip, serviceLimitConfiguration, registry);
     }


### PR DESCRIPTION
Adds `aws.client.addSpinnakerUserToUserAgent` configuration option that, if enabled, will include the currently authenticated Spinnaker user in the user agent string that is sent with all AWS requests.  This string is present in CloudTrail logs and can be used to correlate end user actions to AWS modifications.

This is off by default.