### PR TITLE
Fix issue 1632: not able to find AMI with encrypted snapshots in target account

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
@@ -61,7 +61,15 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
     def sourceAmazonEC2 = amazonClientProvider.getAmazonEC2(description.credentials, description.region, true)
     def targetAmazonEC2 = amazonClientProvider.getAmazonEC2(targetCredentials, description.region, true)
 
+    task.updateStatus BASE_PHASE, "Looking up AMI imageId '$description.amiName' in source accountId='$description.credentials.accountId'"
     ResolvedAmiResult resolvedAmi = AmiIdResolver.resolveAmiIdFromAllSources(sourceAmazonEC2, description.region, description.amiName, description.credentials.accountId)
+
+    if (!resolvedAmi) {
+      // Let's try looking for the AMI using target account
+      task.updateStatus BASE_PHASE, "Looking up AMI imageId '$description.amiName' in target accountId='$targetCredentials.accountId'"
+      resolvedAmi = AmiIdResolver.resolveAmiIdFromAllSources(targetAmazonEC2, description.region, description.amiName, targetCredentials.accountId)  
+    }
+
     if (!resolvedAmi && targetCredentials.allowPrivateThirdPartyImages) {
       resolvedAmi = AmiIdResolver.resolveAmiId(targetAmazonEC2, description.region, description.amiName)
       if (resolvedAmi) {
@@ -69,6 +77,7 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
         return resolvedAmi
       }
     }
+
     if (!resolvedAmi) {
       throw new IllegalArgumentException("unable to resolve AMI imageId from '$description.amiName': If this is a private AMI owned by a third-party, you will need to contact them to share the AMI to your desired account(s)")
     }
@@ -76,6 +85,12 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
     // If the AMI is public, this is a no-op
     if (resolvedAmi.isPublic) {
       task.updateStatus BASE_PHASE, "AMI is public, no need to allow launch"
+      return resolvedAmi
+    }
+
+    // If the AMI was create/owned by the target account, it is a no-op
+    if (resolvedAmi.ownerId == targetCredentials.accountId) {
+      task.updateStatus BASE_PHASE, "AMI ownerId '$resolvedAmi.ownerId' is the same as target account Id '$targetCredentials.accountId'"
       return resolvedAmi
     }
 


### PR DESCRIPTION
This is a proposed fix for issue: [https://github.com/spinnaker/spinnaker/issues/1632](url)

During the allow atomic launch process, it was only looking for AMI using the source account. Normally it works fine as the AMIs can be shared between accounts. However, when using EBS backed AMI, AWS doesn't allow sharing. The proposed fix is to also make an attempt to look for the AMI in the target account where we are doing the deployment (as in the EBS case, the AMI will have to be in the same account where the deployment happens anyway, due to the limitation of not allowing sharing). Also, for EBS AMI, AWS gives error when you make any permission modifications on the AMI, even to add the same accountId as the owner of AMI.  Since the launch will happen in the same account, there's no need to do the permission update either anyway. Thus, added condition to just return AMI when ownerId and target accounts are the same.

