### PR TITLE
Fix issue 1632: not able to find AMI in target account during deploy

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperationUnitSpec.groovy
@@ -301,4 +301,42 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
   Closure<DescribeTagsResult> constructDescribeTagsResult = { Map tags ->
     new DescribeTagsResult(tags: tags.collect {new TagDescription(key: it.key, value: it.value) })
   }
+  
+  void "should return resolved target AMI without performing additional operations"() {  
+    setup:
+    def ownerCredentials = TestCredential.named('owner')
+    def targetCredentials = TestCredential.named('target')
+    def ownerAmazonEc2 = Mock(AmazonEC2)
+    def targetAmazonEc2 = Mock(AmazonEC2)
+
+    def description = new AllowLaunchDescription(account: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: ownerCredentials)
+    def op = new AllowLaunchAtomicOperation(description)
+    op.amazonClientProvider = Mock(AmazonClientProvider)
+    op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
+
+    when:
+    op.operate([])
+
+    then:
+    with(op.accountCredentialsProvider) {
+      1 * getCredentials('target') >> targetCredentials
+    }
+
+    with(op.amazonClientProvider) {
+      1 * getAmazonEC2(targetCredentials, _, true) >> targetAmazonEc2
+      1 * getAmazonEC2(ownerCredentials, _, true) >> ownerAmazonEc2
+    }
+    with(ownerAmazonEc2) {
+      3 * describeImages(_) >> new DescribeImagesResult()
+    }	
+    with(targetAmazonEc2) {
+      1 * describeImages(_) >> new DescribeImagesResult().withImages(
+        new Image()
+          .withImageId("ami-123456")
+          .withOwnerId(targetCredentials.accountId))	  
+    }
+    0 * _
+    
+  }
+  
 }


### PR DESCRIPTION
This is a proposed fix for [https://github.com/spinnaker/spinnaker/issues/1632](url)
During the allow atomic launch step, it was only looking for AMI using the source account. Normally it works fine as the AMIs can be shared between accounts. However, when using EBS backed AMI, AWS doesn't allow sharing. The proposed fix is to also make an attempt to look for the AMI in the target account where we are doing the deployment (as in the EBS case, the AMI will have to be in the same account where the deployment happens anyway, due to the limitation of not allowing sharing). If the AMI is found there, we can return with it as the rest is no-op.