### PR TITLE
feat(amazon): A 'v3' reservation report that attempts to use regional…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReport.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReport.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.model
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.fasterxml.jackson.annotation.JsonView
 import com.netflix.spinnaker.clouddriver.model.ReservationReport
 
 import java.util.concurrent.ConcurrentHashMap
@@ -26,12 +27,22 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @JsonPropertyOrder(["reservations", "start", "end", "accounts", "type"])
 class AmazonReservationReport implements ReservationReport {
+  @JsonView(Views.V1.class)
   Date start
+
+  @JsonView(Views.V1.class)
   Date end
+
+  @JsonView(Views.V1.class)
   String type = "aws"
 
+  @JsonView(Views.V1.class)
   Collection<Map> accounts = []
+
+  @JsonView(Views.V1.class)
   Collection<OverallReservationDetail> reservations = []
+
+  @JsonView(Views.V1.class)
   Map<String, Collection<String>> errorsByRegion = [:]
 
   static enum OperatingSystemType {
@@ -52,31 +63,88 @@ class AmazonReservationReport implements ReservationReport {
     }
   }
 
+  static class Views {
+    static class V1 {
+
+    }
+
+    static class V2 extends V1 {
+
+    }
+
+    static class V3 extends V2 {
+
+    }
+  }
+
   @JsonPropertyOrder(["availabilityZone", "region", "availabilityZoneId", "instanceType", "os", "totalReserved", "totalUsed", "totalSurplus", "details", "accounts"])
   static class OverallReservationDetail {
     String availabilityZone
+
+    @JsonView(Views.V1.class)
     String instanceType
+
     // Support for region-scoped RIs
     String region
+
+    @JsonView(Views.V1.class)
     OperatingSystemType os
+
+    @JsonView(Views.V1.class)
     AtomicInteger totalReserved = new AtomicInteger(0)
+
+    @JsonView(Views.V1.class)
     AtomicInteger totalUsed = new AtomicInteger(0)
 
+    AtomicInteger totalAllocated = new AtomicInteger(0)
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonView(Views.V1.class)
     Map<String, AccountReservationDetail> accounts = new ConcurrentHashMap<>()
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonView(Views.V3.class)
+    List<Allocation> allocations = []
+
     @JsonProperty
+    @JsonView(Views.V3.class)
+    String id() {
+      return "${region}:${availabilityZoneId()}:${instanceType}:${os.name.toLowerCase()}"
+    }
+
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonView(Views.V3.class)
+    Integer totalAllocated() {
+      return totalAllocated.intValue()
+    }
+
+    @JsonProperty
+    @JsonView(Views.V1.class)
     int totalSurplus() {
-      return (totalReserved.intValue() - totalUsed.intValue())
+      return (totalReserved.intValue() + totalAllocated.intValue() - totalUsed.intValue())
     }
 
     @JsonProperty
+    @JsonView(Views.V1.class)
     String region() {
-      return availabilityZone == null ? region : availabilityZone[0..-2]
+      return (availabilityZone == null || availabilityZone == '*') ? region : availabilityZone[0..-2]
     }
 
     @JsonProperty
+    @JsonView(Views.V1.class)
     String availabilityZoneId() {
-      return availabilityZone == null ? '*' : availabilityZone[-1..-1]
+      return (availabilityZone == null || availabilityZone == '*') ? '*' : availabilityZone[-1..-1]
+    }
+
+    @JsonProperty
+    @JsonView(Views.V1.class)
+    String availabilityZone() {
+      return availabilityZone == null ? '*' : availabilityZone
+    }
+
+    String instanceFamily() {
+      return instanceType.substring(0, instanceType.indexOf('.'))
     }
 
     AccountReservationDetail getAccount(String accountName) {
@@ -93,23 +161,108 @@ class AmazonReservationReport implements ReservationReport {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   static class AccountReservationDetail {
+    @JsonView(Views.V1.class)
     AtomicInteger reserved = new AtomicInteger(0)
+
+    @JsonView(Views.V1.class)
     AtomicInteger used = new AtomicInteger(0)
+
+    @JsonView(Views.V1.class)
     AtomicInteger reservedVpc = new AtomicInteger(0)
+
+    @JsonView(Views.V1.class)
     AtomicInteger usedVpc = new AtomicInteger(0)
 
     @JsonProperty
+    @JsonView(Views.V1.class)
     int surplus() {
       return (reserved.intValue() - used.intValue())
     }
 
     @JsonProperty
+    @JsonView(Views.V1.class)
     Integer surplusVpc() {
       if (reservedVpc == null || usedVpc == null) {
         return null
       }
 
       return (reservedVpc.intValue() - usedVpc.intValue())
+    }
+  }
+
+  static class Allocation {
+    @JsonView(Views.V3.class)
+    String source
+
+    @JsonView(Views.V3.class)
+    String sourceInstanceType
+
+    @JsonView(Views.V3.class)
+    int sourceInstanceQuantity
+
+    @JsonView(Views.V3.class)
+    String target
+
+    @JsonView(Views.V3.class)
+    String targetInstanceType
+
+    @JsonView(Views.V3.class)
+    int targetInstanceQuantity
+
+    @JsonView(Views.V3.class)
+    int index
+  }
+
+  static class DescendingOverallReservationDetailComparator implements Comparator<OverallReservationDetail> {
+    @Override
+    int compare(OverallReservationDetail a, OverallReservationDetail b) {
+      def r = a.region <=> b.region
+
+      if (!r) {
+        r = a.availabilityZone <=> b.availabilityZone
+      }
+
+      if (!r) {
+        r = a.instanceFamily() <=> b.instanceFamily()
+      }
+
+      if (!r) {
+        r = normalizeInstanceType(a.instanceType) <=> normalizeInstanceType(b.instanceType)
+      }
+
+      if (!r) {
+        r = a.os.name <=> b.os.name
+      }
+
+      return -r
+    }
+
+    /**
+     * @return normalized instance type that can be lexicographically sorted
+     */
+    static String normalizeInstanceType(String instanceType) {
+      def instanceClassRankings = [
+        'xlarge': 6,
+        'large' : 5,
+        'medium': 4,
+        'small' : 3,
+        'micro' : 2,
+        'nano'  : 1,
+      ];
+
+      def instanceClassRanking = instanceClassRankings.find { instanceType.contains(it.key) }
+      if (!instanceClassRanking) {
+        return "0000"
+      }
+
+      // extract {{multiplier}} from {{family}}.{{multiplier}}{{size}}
+      def multiplier = instanceType.substring(instanceType.indexOf('.') + 1).replaceAll(instanceClassRanking.key, "")
+
+      if (multiplier.length() > 3) {
+        throw new IllegalArgumentException("Instance type '${instanceType}' has an unsupported multiplier, must be < 999")
+      }
+
+      return instanceClassRanking.value + multiplier.padLeft(3, "0")
     }
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReportBuilder.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReportBuilder.groovy
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model
+
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonReservationReport.OverallReservationDetail
+import groovy.util.logging.Slf4j
+
+import java.util.concurrent.atomic.AtomicInteger
+
+interface AmazonReservationReportBuilder {
+  AmazonReservationReport build(AmazonReservationReport source)
+
+  /**
+   * This version (v3) of the reservation report:
+   *
+   * - normalizes all regional reservations to `fxlarge` instance types
+   *   (fxlarge is equivalent to xlarge but kept separate to prevent confusion with normal xlarge instances)
+   * - attempts to cover all shortfalls with regional reservations (converting `xlarge` to the necessary instance types)
+   */
+  @Slf4j
+  class V3 implements AmazonReservationReportBuilder {
+    // relative multipliers for instance types < xlarge where the baseline is xlarge
+    // (would be nice if AWS had an API to derive this from)
+    Map<String, Double> instanceTypeMultipliers = [
+      "t2.nano" : 0.03125,
+      "t2.micro" : 0.0625,
+      "t2.small" : 0.125,
+      "t2.medium": 0.25,
+      "t2.large" : 0.5,
+
+      "m1.small" : 0.125,
+      "m1.medium": 0.25,
+      "m1.large" : 0.5,
+      "m3.medium": 0.25,
+      "m3.large" : 0.5,
+      "m4.large" : 0.5,
+
+      "c1.medium": 0.25,
+      "c3.large" : 0.5,
+      "c4.large" : 0.5,
+
+      "r3.large" : 0.5,
+      "r4.large" : 0.5,
+
+      "i3.large" : 0.5
+    ]
+
+    AmazonReservationReport build(AmazonReservationReport source) {
+      def reservations = source.reservations.sort(
+        false, new AmazonReservationReport.DescendingOverallReservationDetailComparator()
+      )
+
+      // aggregate all regional reservations for each instance family
+      def regionalReservations = aggregateRegionalReservations(reservations)
+
+      // remove any regional reservations that have been fully utilized (ie. they've all been converted to xlarge)
+      reservations.removeAll { it.availabilityZone == "*" && it.totalSurplus() == 0 }
+
+      // add the aggregated regional reservations
+      reservations.addAll(regionalReservations)
+
+      // used to track the order in which regional reservations are used to cover shortfalls
+      def allocationIndex = new AtomicInteger(0)
+
+      def shortfalls = reservations.findAll { it.totalSurplus() < 0 }
+      shortfalls.each { OverallReservationDetail shortfall ->
+        def regional = regionalReservations.find {
+          it.instanceFamily() == shortfall.instanceFamily() && shortfall.region == it.region && it.os == shortfall.os
+        }
+
+        if (!regional) {
+          // no regional reservation to cover shortfall from
+          return
+        }
+
+        coverShortfall(allocationIndex, regional, shortfall)
+      }
+
+      return new AmazonReservationReport(
+        start: source.start,
+        end: source.end,
+        accounts: source.accounts,
+        reservations: reservations,
+        errorsByRegion: source.errorsByRegion
+      )
+    }
+
+    private List<OverallReservationDetail> aggregateRegionalReservations(List<OverallReservationDetail> reservations) {
+      def regionalReservations = filterRegionalReservations(reservations)
+
+      regionalReservations.groupBy { "${it.region}-${it.instanceFamily()}-${it.os}" }.collect {
+        def overallRegionalReservationDetail = new OverallReservationDetail(
+          availabilityZone: "*",
+          instanceType: it.value[0].instanceFamily() + ".fxlarge",
+          os: it.value[0].os,
+          region: it.value[0].region,
+        )
+
+        // aggregate all reserved instances in the same family
+        it.value.each { OverallReservationDetail o ->
+          double multiplier = getMultiplier(o.instanceType)
+          if (!multiplier) {
+            log.warn("Unable to determine multiplier for instance type '${o.instanceType}'")
+            return
+          }
+
+          if (multiplier >= 1) {
+            overallRegionalReservationDetail.totalReserved.addAndGet(
+              (int) multiplier * o.totalSurplus()
+            )
+
+            o.totalUsed.set(o.totalSurplus())
+          } else {
+            // how many instances are required to make a single xlarge
+            int convertibleInstances = o.totalSurplus() * multiplier
+
+            overallRegionalReservationDetail.totalReserved.addAndGet(convertibleInstances)
+            o.totalUsed.addAndGet((int) (convertibleInstances / multiplier))
+          }
+
+          // provide some traceability around which accounts/instanceTypes were converted to xlarge
+          o.accounts.each {
+            def accountInstanceTypeKey = "${it.key}__${o.instanceType}".toString()
+            def accountReservationDetail = overallRegionalReservationDetail.accounts.get(accountInstanceTypeKey)
+            accountReservationDetail = accountReservationDetail ?: new AmazonReservationReport.AccountReservationDetail()
+
+            overallRegionalReservationDetail.accounts.put(accountInstanceTypeKey, accountReservationDetail)
+
+            // only consider vpc reservations
+            accountReservationDetail.reservedVpc.addAndGet(it.value.reservedVpc.get())
+          }
+        }
+
+        return overallRegionalReservationDetail
+      }
+    }
+
+    /**
+     * @return all regional reservations (availabilityZone == '*' and supported instance type)
+     */
+    private List<OverallReservationDetail> filterRegionalReservations(List<OverallReservationDetail> reservations) {
+      return reservations.findAll {
+        it.availabilityZone == '*' && (it.instanceType.endsWith("xlarge") || instanceTypeMultipliers.containsKey(it.instanceType))
+      }
+    }
+
+    /**
+     * @return the multiplier of a given instanceType related to an 'xlarge', or 0 if instanceType is not supported
+     */
+    private double getMultiplier(String instanceType) {
+      if (!instanceTypeMultipliers.containsKey(instanceType) && !instanceType.endsWith("xlarge")) {
+        // not an xlarge instance type (or no explicit multiplier if < xlarge)
+        return 0
+      }
+
+      if (instanceTypeMultipliers.containsKey(instanceType)) {
+        return instanceTypeMultipliers.get(instanceType)
+      }
+
+      String instanceFamily = instanceType.substring(0, instanceType.indexOf("."))
+      return Integer.valueOf(
+        instanceType.replaceAll("xlarge", "").replaceAll(instanceFamily + ".", "") ?: "1"
+      )
+    }
+
+    private void coverShortfall(AtomicInteger allocationIndex,
+                                OverallReservationDetail regional,
+                                OverallReservationDetail shortfall) {
+      def multiplier = getMultiplier(shortfall.instanceType)
+      if (!multiplier) {
+        // instance type is unsupported (some unknown variant smaller than an xlarge)
+        log.warn("Unable to determine multiplier for instance type '${shortfall.instanceType}'")
+        return
+      }
+
+      // Math.ceil() protects against fractional instances when going from xlarge -> large (0.5 multiplier)
+      int sourceInstancesNeeded = Math.ceil(Math.abs(shortfall.totalSurplus() * multiplier))
+
+      if (regional.totalSurplus() >= sourceInstancesNeeded) {
+        // we have more instances than necessary to cover the shortfall
+        int targetInstanceQuantity = sourceInstancesNeeded / multiplier
+
+        regional.totalAllocated.addAndGet(-1 * sourceInstancesNeeded)
+        shortfall.totalAllocated.addAndGet(targetInstanceQuantity)
+
+        def allocation = new AmazonReservationReport.Allocation(
+          source: regional.id(),
+          sourceInstanceQuantity: sourceInstancesNeeded,
+          sourceInstanceType: regional.instanceType,
+          target: shortfall.id(),
+          targetInstanceQuantity: targetInstanceQuantity,
+          targetInstanceType: shortfall.instanceType,
+          index: allocationIndex.incrementAndGet()
+        )
+
+        regional.allocations << allocation
+        shortfall.allocations << allocation
+      } else {
+        // determine how much shortfall can be covered as surplus not large enough to cover everything
+        // (may not be entirety of surplus depending on multiplier)
+        int targetInstanceQuantity = Math.floor(regional.totalSurplus() / multiplier)
+
+        if (targetInstanceQuantity > 0) {
+          regional.totalAllocated.addAndGet(-1 * (int) (targetInstanceQuantity * multiplier))
+          shortfall.totalAllocated.addAndGet(targetInstanceQuantity)
+
+          def allocation = new AmazonReservationReport.Allocation(
+            source: regional.id(),
+            sourceInstanceQuantity: targetInstanceQuantity * multiplier,
+            sourceInstanceType: regional.instanceType,
+            target: shortfall.id(),
+            targetInstanceQuantity: targetInstanceQuantity,
+            targetInstanceType: shortfall.instanceType,
+            index: allocationIndex.incrementAndGet()
+          )
+
+          regional.allocations << allocation
+          shortfall.allocations << allocation
+        }
+      }
+    }
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReportBuilderV3Spec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReportBuilderV3Spec.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model
+
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonReservationReport.OverallReservationDetail
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class AmazonReservationReportBuilderV3Spec extends Specification {
+  @Shared
+  def reportBuilder = new AmazonReservationReportBuilder.V3()
+
+  def allocationIndex = new AtomicInteger(0)
+
+  void "should partially cover a shortfall"() {
+    given:
+    def regional = overallReservationDetail("m4.xlarge", 5, 0)
+    def shortfall = overallReservationDetail("m4.4xlarge", 0, 2)
+
+    when:
+    reportBuilder.coverShortfall(allocationIndex, regional, shortfall)
+
+    then:
+    allocationIndex.get() == 1
+
+    // took 4 * xlarge to partially cover shortfall (4 * xlarge == 1 * 4xlarge)
+    regional.totalSurplus() == 1
+    regional.totalAllocated() == -4
+
+    shortfall.totalSurplus() == -1
+    shortfall.totalAllocated() == 1
+  }
+
+  void "should fully cover a shortfall"() {
+    given:
+    def regional = overallReservationDetail("m4.xlarge", 10, 0)
+    def shortfall = overallReservationDetail("m4.4xlarge", 0, 2)
+
+    when:
+    reportBuilder.coverShortfall(allocationIndex, regional, shortfall)
+
+    then:
+    allocationIndex.get() == 1
+
+    // took 8 * 4xlarge to fully cover shortfall (8 * xlarge == 2 * 4xlarge)
+    regional.totalSurplus() == 2
+    regional.totalAllocated() == -8
+
+    shortfall.totalSurplus() == 0
+    shortfall.totalAllocated() == 2
+  }
+
+  void "unable to cover any shortfall"() {
+    given:
+    def regional = overallReservationDetail("m4.xlarge", 1, 0)
+    def shortfall = overallReservationDetail("m4.4xlarge", 0, 2)
+
+    when:
+    reportBuilder.coverShortfall(allocationIndex, regional, shortfall)
+
+    then:
+    allocationIndex.get() == 0
+
+    // took 8 * 4xlarge to fully cover shortfall (8 * xlarge == 2 * 4xlarge)
+    regional.totalSurplus() == 1
+    regional.totalAllocated() == 0
+
+    shortfall.totalSurplus() == -2
+    shortfall.totalAllocated() == 0
+  }
+
+  @Unroll
+  void "should determine multiplier relative to 'xlarge'"() {
+    expect:
+    reportBuilder.getMultiplier(instanceType) == multiplier
+
+    where:
+    instanceType   || multiplier
+    "m4.16xlarge"  || 16
+    "m4.xlarge"    || 1
+    "m4.xwhoknows" || 0
+    "m4.large"     || 0.5
+  }
+
+  private OverallReservationDetail overallReservationDetail(String instanceType, int totalReserved, int totalUsed) {
+    return new OverallReservationDetail(
+      totalReserved: new AtomicInteger(totalReserved),
+      totalUsed: new AtomicInteger(totalUsed),
+      instanceType: instanceType,
+      os: AmazonReservationReport.OperatingSystemType.LINUX
+    )
+  }
+
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReportSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReportSpec.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model
+
+import spock.lang.Specification
+import spock.lang.Unroll;
+
+import static com.netflix.spinnaker.clouddriver.aws.model.AmazonReservationReport.OperatingSystemType.*
+import static com.netflix.spinnaker.clouddriver.aws.model.AmazonReservationReport.*
+
+class AmazonReservationReportSpec extends Specification {
+  @Unroll
+  def "should normalize instance types by size and multiplier"() {
+    given:
+    def comparator = new DescendingOverallReservationDetailComparator()
+
+    expect:
+    comparator.normalizeInstanceType(left) > comparator.normalizeInstanceType(right)
+
+    and:
+    comparator.normalizeInstanceType("m4.16xlarge") == "6016"
+    comparator.normalizeInstanceType("m4.16large") == "5016"
+    comparator.normalizeInstanceType("m4.10medium") == "4010"
+    comparator.normalizeInstanceType("m4.8small") == "3008"
+    comparator.normalizeInstanceType("m4.3micro") == "2003"
+    comparator.normalizeInstanceType("m4.999nano") == "1999"
+
+    // unknown size should always normalize to '0000'
+    comparator.normalizeInstanceType("m4.4unknown") == "0000"
+
+    try {
+      comparator.normalizeInstanceType("m4.1000nano")
+      assert false
+    } catch (IllegalArgumentException e) {
+      assert e.message.contains("must be < 999")
+    }
+
+    where:
+    left          | right         || _
+    "c4.16xlarge" | "c4.10xlarge" || _
+    "c4.10xlarge" | "c4.8xlarge"  || _
+    "c4.4xlarge"  | "c4.2xlarge"  || _
+    "c4.2xlarge"  | "c4.xlarge"   || _
+    "c4.xlarge"   | "c4.large"    || _
+    "c4.large"    | "c4.small"    || _
+    "c4.small"    | "c4.16nano"   || _
+    "c4.nano"     | "c4.unknown"  || _
+  }
+
+  def "should support regional reservations w/o availabilityZone"() {
+    given:
+    def report = new AmazonReservationReport(
+      reservations: [
+        new OverallReservationDetail(
+          instanceType: "m4.xlarge",
+          availabilityZone: "*",
+          region: "us-west-2",
+          os: LINUX
+        )
+      ]
+    )
+
+    expect:
+    report.reservations[0].availabilityZoneId() == "*"
+    report.reservations[0].availabilityZone() == "*"
+    report.reservations[0].region() == "us-west-2"
+  }
+
+  def "should sort reservations by normalized instance type ranking"() {
+    given:
+    def reservations = ["c4.small", "c4.4xlarge", "c4.large", "c4.16xlarge", "c4.8xlarge"].collect {
+      new OverallReservationDetail(
+        instanceType: it
+      )
+    }
+
+    when:
+    def sortedReservations = reservations.sort(false, new DescendingOverallReservationDetailComparator())
+
+    then:
+    sortedReservations*.instanceType == [
+      "c4.16xlarge", "c4.8xlarge", "c4.4xlarge", "c4.large", "c4.small"
+    ]
+  }
+
+  @Unroll
+  def "should compare by region, az, family, normalized instance type, os"() {
+    given:
+    def comparator = new DescendingOverallReservationDetailComparator()
+
+    def left = new AmazonReservationReport.OverallReservationDetail(
+      region: lRegion,
+      availabilityZone: lAvailabilityZone,
+      instanceType: lInstanceType,
+      os: lOs
+    )
+
+    def right = new AmazonReservationReport.OverallReservationDetail(
+      region: rRegion,
+      availabilityZone: rAvailabilityZone,
+      instanceType: rInstanceType,
+      os: rOs
+    )
+
+    expect:
+    comparator.compare(left, right) == expected
+
+    where:
+    lRegion     | lAvailabilityZone | lInstanceType | lOs   | rRegion     | rAvailabilityZone | rInstanceType | rOs     || expected
+    "us-west-1" | "us-west-1c"      | "c4.4xlarge"  | LINUX | "us-west-1" | "us-west-1c"      | "c4.4xlarge"  | LINUX   || 0
+    "us-west-1" | "us-west-1c"      | "c4.4xlarge"  | LINUX | "us-west-2" | "us-west-2a"      | "c4.4xlarge"  | LINUX   || 1    // us-west-2 > us-west-1
+    "us-west-1" | "us-west-1c"      | "c4.4xlarge"  | LINUX | "us-east-1" | "us-east-1c"      | "c4.4xlarge"  | LINUX   || -1   // us-west-1 > us-east-1
+    "us-west-1" | "us-west-1c"      | "c4.4xlarge"  | LINUX | "us-west-1" | "us-west-1d"      | "c4.4xlarge"  | LINUX   || 1    // us-west-1d > us-west-1c
+    "us-west-1" | "us-west-1c"      | "c4.16xlarge" | LINUX | "us-west-1" | "us-west-1c"      | "c4.4xlarge"  | LINUX   || -1   // c4.16xlarge > c4.4xlarge
+    "us-west-1" | "us-west-1c"      | "c4.4xlarge"  | LINUX | "us-west-1" | "us-west-1c"      | "c4.4xlarge"  | WINDOWS || 1    // windows > linux
+  }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgentSpec.groovy
@@ -20,9 +20,11 @@ package com.netflix.spinnaker.clouddriver.aws.provider.agent
 import com.netflix.spectator.api.Counter
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonReservationReport
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import java.util.concurrent.ConcurrentHashMap
 


### PR DESCRIPTION
… reserved instances to cover zonal shortfalls

It accomplishes this by:
- normalizing all regional reserved instances to `xlarge`
- using some number of `xlarge` reservations to cover each zonal shortfall

Shortfalls are covered in descending order:
- us-west-2c > us-west-2b : us-west-2a
- m4.16xlarge > m4.8xlarge > m4.xlarge > m4.large

Relies on the fact that AWS credits regional reserved instances towards a shortfall of any instance type.

Looking for feedback from @robzienert 