### PR TITLE
refactor(kubernetes): Update fabric8 client to 2.3.1 for StatefulSet

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -6,5 +6,5 @@ dependencies {
   compile spinnaker.dependency('bootWeb')
 
   // TODO (move to https://github.com/spinnaker/spinnaker-dependencies/blob/master/src/spinnaker-dependencies.yml)
-  compile 'io.fabric8:kubernetes-client:1.4.35'
+  compile 'io.fabric8:kubernetes-client:2.3.1'
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.exception.KubernetesI
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.ReplicationController
-import io.fabric8.kubernetes.api.model.extensions.Job
+import io.fabric8.kubernetes.api.model.Job
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet
 import org.springframework.beans.factory.annotation.Value
 


### PR DESCRIPTION
StatefulSet model is not available in the fabric8 client currently used.  This upgrades fabric8 to the latest client.  Also had to import the Job model class from a different location.