### PR TITLE
fix(provider/kubernetes): fixed the issue to support for nodeSelector…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
@@ -31,6 +31,7 @@ class RunKubernetesJobDescription extends KubernetesAtomicOperationDescription {
   String freeFormDetails
   String namespace
   Boolean hostNetwork=false
+  Map<String, String> nodeSelector
   KubernetesContainerDescription container
   List<KubernetesVolumeSource> volumeSources
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -80,6 +80,11 @@ class RunKubernetesJobAtomicOperation implements AtomicOperation<DeploymentResul
     if (description.hostNetwork) {
         podBuilder = podBuilder.withHostNetwork(description.hostNetwork)
     }
+
+    if (description.nodeSelector){
+     podBuilder = podBuilder.withNodeSelector(description.nodeSelector)
+    }
+
     description.container.name = description.container.name ?: "job"
     def container = KubernetesApiConverter.toContainer(description.container)
 


### PR DESCRIPTION
… property in RunJob stage in pipeline , nodeselector is provided through edit as JSON  option

When RunJob is edited as  JSON , there we can give the nodeSelector  key-value pair  , and fix is being added to support the nodeSelector which is the label to select the node from multi node kubernetes setup.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](http://www.spinnaker.io/docs/contributing-to-spinnaker).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
