### PR TITLE
fix(provider/amazon):  add gov-cloud special case to arn patterns

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/ArnUtils.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/ArnUtils.groovy
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.clouddriver.aws.data
 import java.util.regex.Pattern
 
 class ArnUtils {
-  private static final Pattern ELBV2_ARN_PATTERN = Pattern.compile(/^arn:aws(?:-cn)?:elasticloadbalancing:[^:]+:[^:]+:loadbalancer\/([^:]+)\/([^\/]+)\/.+$/)
-  private static final Pattern TARGET_GROUP_ARN_PATTERN = Pattern.compile(/^arn:aws(?:-cn)?:elasticloadbalancing:[^:]+:[^:]+:targetgroup\/([^\/]+)\/.+$/)
+  private static final Pattern ELBV2_ARN_PATTERN = Pattern.compile(/^arn:aws(?:-cn|-us-gov)?:elasticloadbalancing:[^:]+:[^:]+:loadbalancer\/([^:]+)\/([^\/]+)\/.+$/)
+  private static final Pattern TARGET_GROUP_ARN_PATTERN = Pattern.compile(/^arn:aws(?:-cn|-us-gov)?:elasticloadbalancing:[^:]+:[^:]+:targetgroup\/([^\/]+)\/.+$/)
 
   static Optional<String> extractLoadBalancerName(String loadBalancerArn) {
     def m = ELBV2_ARN_PATTERN.matcher(loadBalancerArn)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/ARN.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/ARN.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 
 class ARN {
 
-  static final Pattern PATTERN = Pattern.compile("arn:aws(?:-cn)?:.*:(.*):(\\d+):(.*)");
+  static final Pattern PATTERN = Pattern.compile("arn:aws(?:-cn|-us-gov)?:.*:(.*):(\\d+):(.*)");
 
   String arn;
   String region;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/DefaultAWSAccountInfoLookup.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/DefaultAWSAccountInfoLookup.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
 
 public class DefaultAWSAccountInfoLookup implements AWSAccountInfoLookup {
     private static final String DEFAULT_SECURITY_GROUP_NAME = "default";
-    private static final Pattern IAM_ARN_PATTERN = Pattern.compile(".*?arn:aws(?:-cn)?:(?:iam|sts)::(\\d+):.*");
+    private static final Pattern IAM_ARN_PATTERN = Pattern.compile(".*?arn:aws(?:-cn|-us-gov)?:(?:iam|sts)::(\\d+):.*");
 
     private final AWSCredentialsProvider credentialsProvider;
     private final AmazonClientProvider amazonClientProvider;


### PR DESCRIPTION
GovCloud ARNs don't fit the standard model, much in the same way that the china region does.

This PR adds support for GovCloud Style Arns to fix spinnaker/spinnaker/issues/1698