### PR TITLE
fix(aws: enable/disable) faster instance lookup for enable/disable

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DisableAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DisableAsgAtomicOperationUnitSpec.groovy
@@ -42,6 +42,7 @@ class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnit
     def asg = Mock(AutoScalingGroup)
     asg.getAutoScalingGroupName() >> "asg1"
     asg.getLoadBalancerNames() >> ["lb1"]
+    asg.getInstances() >> [new com.amazonaws.services.autoscaling.model.Instance().withInstanceId("i1").withLifecycleState("InService") ]
 
     and:
     def instance = new Instance().withState(new InstanceState().withName("running")).withInstanceId("i1")
@@ -66,6 +67,7 @@ class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnit
     def asg = Mock(AutoScalingGroup)
     asg.getAutoScalingGroupName() >> "asg1"
     asg.getLoadBalancerNames() >> ["lb1"]
+    asg.getInstances() >> [new com.amazonaws.services.autoscaling.model.Instance().withInstanceId("i1").withLifecycleState("InService") ]
 
     and:
     def instance = new Instance().withState(new InstanceState().withName("running")).withInstanceId("i1")
@@ -94,6 +96,7 @@ class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnit
   def 'should disable instances for asg in discovery'() {
     given:
     def asg = Mock(AutoScalingGroup)
+    asg.getInstances() >> [new com.amazonaws.services.autoscaling.model.Instance().withInstanceId("i1").withLifecycleState("InService") ]
     def instance = new Instance().withState(new InstanceState().withName("running")).withInstanceId("i1")
     def describeInstanceResult = Mock(DescribeInstancesResult)
     describeInstanceResult.getReservations() >> [new Reservation().withInstances(instance)]
@@ -129,6 +132,7 @@ class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnit
 
     def asg = Mock(AutoScalingGroup)
     asg.getAutoScalingGroupName() >> "asg1"
+    asg.getInstances() >> [new com.amazonaws.services.autoscaling.model.Instance().withInstanceId("i1").withLifecycleState("InService") ]
 
     and:
     def instance = new Instance().withState(new InstanceState().withName("running")).withInstanceId("i1")

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableAsgAtomicOperationUnitSpec.groovy
@@ -41,6 +41,7 @@ class EnableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnitS
     def asg = Mock(AutoScalingGroup)
     asg.getAutoScalingGroupName() >> "asg1"
     asg.getLoadBalancerNames() >> ["lb1"]
+    asg.getInstances() >> [new com.amazonaws.services.autoscaling.model.Instance().withInstanceId("i1").withLifecycleState("InService") ]
 
     and:
     def instance = new Instance().withState(new InstanceState().withName("running")).withInstanceId("i1")
@@ -64,6 +65,7 @@ class EnableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnitS
     given:
     def asg = Mock(AutoScalingGroup)
     asg.getAutoScalingGroupName() >> "asg1"
+    asg.getInstances() >> [new com.amazonaws.services.autoscaling.model.Instance().withInstanceId("i1").withLifecycleState("InService") ]
 
     and:
     def instance1 = new Instance().withState(new InstanceState().withName("running")).withInstanceId("i1")
@@ -102,6 +104,7 @@ class EnableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnitS
 
     def asg = Mock(AutoScalingGroup)
     asg.getAutoScalingGroupName() >> "asg1"
+    asg.getInstances() >> [new com.amazonaws.services.autoscaling.model.Instance().withInstanceId("i1").withLifecycleState("InService") ]
 
     and:
     def instance = new Instance().withState(new InstanceState().withName("running")).withInstanceId("i1")


### PR DESCRIPTION
Reworks instance lookup logic in #1255 to prefer a query against known instance ids instead of a query with a tag filter.

The current implementation can time out with large instance counts in a region