### PR TITLE
feat(provider/amazon): Use edda views if available for TargetGroup* and Listener caching

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/edda/EddaApi.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/edda/EddaApi.groovy
@@ -16,10 +16,23 @@
 
 package com.netflix.spinnaker.clouddriver.aws.edda
 
+import com.amazonaws.services.elasticloadbalancingv2.model.Listener
 import com.netflix.spinnaker.clouddriver.aws.model.edda.LoadBalancerInstanceState
+import com.netflix.spinnaker.clouddriver.aws.model.edda.TargetGroupAttributes
+import com.netflix.spinnaker.clouddriver.aws.model.edda.TargetGroupHealth
 import retrofit.http.GET
+import retrofit.http.Path
 
 interface EddaApi {
   @GET('/REST/v2/view/loadBalancerInstances;_expand')
   List<LoadBalancerInstanceState> loadBalancerInstances()
+
+  @GET('/REST/v2/view/targetGroupHealth;_expand')
+  List<TargetGroupHealth> targetGroupHealth()
+
+  @GET('/REST/v2/view/targetGroupAttributes;_expand')
+  List<TargetGroupAttributes> targetGroupAttributes()
+
+  @GET('/REST/v2/view/appLoadBalancerListeners/{loadBalancerName}')
+  List<Listener> listeners(@Path("loadBalancerName") String loadBalancerName)
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/edda/TargetGroupAttributes.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/edda/TargetGroupAttributes.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model.edda;
+
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupAttribute;
+
+import java.util.List;
+
+public class TargetGroupAttributes {
+  private String targetGroupArn;
+  private List<TargetGroupAttribute> attributes;
+
+  public String getTargetGroupArn() {
+    return targetGroupArn;
+  }
+
+  public void setTargetGroupArn(String targetGroupArn) {
+    this.targetGroupArn = targetGroupArn;
+  }
+
+  public List<TargetGroupAttribute> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(List<TargetGroupAttribute> attributes) {
+    this.attributes = attributes;
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/edda/TargetGroupHealth.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/edda/TargetGroupHealth.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.model.edda;
+
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription;
+
+import java.util.List;
+
+public class TargetGroupHealth {
+  private List<TargetHealthDescription> health;
+  private String targetGroupArn;
+
+  public List<TargetHealthDescription> getHealth() {
+    return health;
+  }
+
+  public void setHealth(List<TargetHealthDescription> health) {
+    this.health = health;
+  }
+
+  public String getTargetGroupArn() {
+    return targetGroupArn;
+  }
+
+  public void setTargetGroupArn(String targetGroupArn) {
+    this.targetGroupArn = targetGroupArn;
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -142,8 +142,8 @@ class AwsProviderConfig {
           }
           newlyAddedAgents << new InstanceCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
           newlyAddedAgents << new AmazonLoadBalancerCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, objectMapper, registry)
-          newlyAddedAgents << new AmazonApplicationLoadBalancerCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, objectMapper, registry)
-          newlyAddedAgents << new AmazonTargetGroupCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, objectMapper, registry)
+          newlyAddedAgents << new AmazonApplicationLoadBalancerCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, eddaApiFactory.createApi(credentials.edda, region.name), objectMapper, registry, eddaTimeoutConfig)
+          newlyAddedAgents << new AmazonTargetGroupCachingAgent(amazonCloudProvider, amazonClientProvider, credentials, region.name, eddaApiFactory.createApi(credentials.edda, region.name), objectMapper, eddaTimeoutConfig)
           newlyAddedAgents << new ReservedInstancesCachingAgent(amazonClientProvider, credentials, region.name, objectMapper, registry)
 
           if (credentials.eddaEnabled && !eddaTimeoutConfig.disabledRegions.contains(region.name)) {
@@ -168,7 +168,7 @@ class AwsProviderConfig {
     }
 
     agentProviders.findAll { it.supports(AwsProvider.PROVIDER_NAME) }.each {
-      newlyAddedAgents.addAll(it.agents());
+      newlyAddedAgents.addAll(it.agents())
     }
 
     awsProvider.agents.addAll(newlyAddedAgents)


### PR DESCRIPTION
When available, use edda for TargetGroupAttributes, TargetHealth, and Listeners.