### PR TITLE
feat(request buffer): optional buffer to distribute api requests

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/RequestQueue.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/RequestQueue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.requestqueue.pooled.PooledRequestQueue;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RequestQueue.
+ */
+public interface RequestQueue {
+
+  long DEFAULT_TIMEOUT_MILLIS = 60000;
+
+  static RequestQueue noop() {
+    return new NOOP();
+  }
+
+  static RequestQueue pooled(Registry registry, int poolSize) {
+    return pooled(registry, DEFAULT_TIMEOUT_MILLIS, poolSize);
+  }
+
+  static RequestQueue pooled(Registry registry, long timeoutMillis, int poolSize) {
+    return new PooledRequestQueue(registry, timeoutMillis, poolSize);
+  }
+
+  default long getDefaultTimeoutMillis() {
+    return DEFAULT_TIMEOUT_MILLIS;
+  }
+
+  default <T> T execute(String partition, Callable<T> operation) throws Throwable {
+    return execute(partition, operation, getDefaultTimeoutMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  <T> T execute(String partition, Callable<T> operation, long timeout, TimeUnit unit) throws Throwable;
+
+  class NOOP implements RequestQueue {
+    @Override
+    public <T> T execute(String partition, Callable<T> operation, long timeout, TimeUnit unit) throws Throwable {
+      return operation.call();
+    }
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/RequestQueueConfiguration.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/RequestQueueConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("requestQueue")
+public class RequestQueueConfiguration {
+  private boolean enabled = false;
+  private long timeoutMillis = RequestQueue.DEFAULT_TIMEOUT_MILLIS;
+  private int poolSize = 10;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public long getTimeoutMillis() {
+    return timeoutMillis;
+  }
+
+  public void setTimeoutMillis(long timeoutMillis) {
+    this.timeoutMillis = timeoutMillis;
+  }
+
+  public int getPoolSize() {
+    return poolSize;
+  }
+
+  public void setPoolSize(int poolSize) {
+    this.poolSize = poolSize;
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PollCoordinator.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PollCoordinator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class PollCoordinator {
+  private final Object notifier = new Object();
+  private final AtomicBoolean itemsAdded = new AtomicBoolean();
+
+  void reset() {
+    itemsAdded.set(false);
+  }
+
+  void notifyItemsAdded() {
+    synchronized (notifier) {
+      itemsAdded.set(true);
+      notifier.notifyAll();
+    }
+  }
+
+  void waitForItems(boolean skipWait) {
+    if (skipWait) {
+      return;
+    }
+
+    if (itemsAdded.get()) {
+      return;
+    }
+
+    synchronized (notifier) {
+      if (!itemsAdded.get()) {
+        try {
+          notifier.wait(50);
+        } catch (InterruptedException ignored) {
+
+        }
+      }
+    }
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequest.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
+
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+
+class PooledRequest<T> implements Runnable {
+  private final Timer timer;
+  private final Promise<T> result;
+  private final Callable<T> work;
+  private final long startTime = System.nanoTime();
+
+  PooledRequest(Registry registry, String partition, Callable<T> work) {
+    this.timer = registry.timer(registry.createId("pooledRequest.execute.time", "partition", partition));
+    this.result = new Promise<>(registry, partition);
+    this.work = work;
+  }
+
+  Promise<T> getPromise() {
+    return result;
+  }
+
+  void cancel() {
+    result.completeWithException(new CancellationException());
+  }
+
+  @Override
+  public void run() {
+    timer.record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+    //request may have expired with a timeout prior to this point, lets not
+    // issue the work if that is the case as the caller has already moved on
+    if (!result.isComplete()) {
+      try {
+        result.complete(work.call());
+      } catch (Throwable t) {
+        result.completeWithException(t);
+      }
+    }
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueue.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueue.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
+
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue;
+
+import javax.annotation.PreDestroy;
+import java.util.Collection;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class PooledRequestQueue implements RequestQueue {
+  private final ConcurrentMap<String, Queue<PooledRequest<?>>> partitionedRequests = new ConcurrentHashMap<>();
+  private final PollCoordinator pollCoordinator = new PollCoordinator();
+
+  private final long defaultTimeout;
+  private final ExecutorService executorService;
+  private final BlockingQueue<Runnable> submittedRequests;
+  private final Collection<Queue<PooledRequest<?>>> requestQueues;
+  private final RequestDistributor requestDistributor;
+  private final Registry registry;
+
+  public PooledRequestQueue(Registry registry, long defaultTimeout, int requestPoolSize) {
+    if (defaultTimeout <= 0) {
+      throw new IllegalArgumentException("defaultTimeout");
+    }
+
+    if (requestPoolSize < 1) {
+      throw new IllegalArgumentException("requestPoolSize");
+    }
+    this.registry = registry;
+    this.defaultTimeout = defaultTimeout;
+    this.submittedRequests = new LinkedBlockingQueue<>();
+    registry.gauge("pooledRequestQueue.executorQueue.size", submittedRequests, Queue::size);
+    final int actualThreads = requestPoolSize + 1;
+    this.executorService = new ThreadPoolExecutor(actualThreads, actualThreads, 0, TimeUnit.MILLISECONDS, submittedRequests);
+    this.requestQueues = new CopyOnWriteArrayList<>();
+    this.requestDistributor = new RequestDistributor(registry, pollCoordinator, executorService, requestQueues);
+    executorService.submit(requestDistributor);
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    requestDistributor.shutdown();
+    executorService.shutdown();
+    PooledRequest<?> req;
+    while ((req = (PooledRequest<?>) submittedRequests.poll()) != null) {
+      req.cancel();
+    }
+  }
+
+  @Override
+  public long getDefaultTimeoutMillis() {
+    return defaultTimeout;
+  }
+
+  @Override
+  public <T> T execute(String partition, Callable<T> operation, long timeout, TimeUnit unit) throws Throwable {
+    final Queue<PooledRequest<?>> queue;
+    if (!partitionedRequests.containsKey(partition)) {
+      Queue<PooledRequest<?>> newQueue = new LinkedBlockingQueue<>();
+      Queue<PooledRequest<?>> existing = partitionedRequests.putIfAbsent(partition, newQueue);
+      if (existing == null) {
+        requestQueues.add(newQueue);
+        queue = newQueue;
+        registry.gauge(registry.createId("pooledRequestQueue.partition.size", "partition", partition), queue, Queue::size);
+      } else {
+        queue = existing;
+      }
+    } else {
+      queue = partitionedRequests.get(partition);
+    }
+
+    final PooledRequest<T> request = new PooledRequest<>(registry, partition, operation);
+
+    queue.offer(request);
+    pollCoordinator.notifyItemsAdded();
+
+    return request.getPromise().blockingGetOrThrow(timeout, unit);
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/Promise.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/Promise.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
+
+import com.netflix.spectator.api.Registry;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+class Promise<T> {
+  private static class Either<T> {
+    private final T result;
+    private final Throwable exception;
+
+    static <T> Either<T> forResult(T result) {
+      return new Either<>(result, null);
+    }
+
+    static <T> Either<T> forException(Throwable exception) {
+      return new Either<>(null, exception);
+    }
+
+    Either(T result, Throwable exception) {
+      this.result = result;
+      this.exception = exception;
+    }
+
+    T getOrThrow() throws Throwable {
+      if (exception != null) {
+        throw exception;
+      }
+
+      return result;
+    }
+  }
+  private final CountDownLatch latch = new CountDownLatch(1);
+  private final AtomicReference<Either<T>> result = new AtomicReference<>();
+  private final Registry registry;
+  private final String partition;
+
+  public Promise(Registry registry, String partition) {
+    this.registry = registry;
+    this.partition = partition;
+  }
+
+  boolean isComplete() {
+    return result.get() != null;
+  }
+
+  void complete(T result) {
+    registry.counter(registry.createId("pooledRequestQueue.promise.complete", "partition", partition)).increment();
+    this.result.compareAndSet(null, Either.forResult(result));
+    latch.countDown();
+  }
+
+  void completeWithException(Throwable exception) {
+    final String cause = Optional.ofNullable(exception).map(Throwable::getClass).map(Class::getSimpleName).orElse("unknown");
+    registry.counter(registry.createId("pooledRequestQueue.promise.exception", "partition", partition, "cause", cause)).increment();
+    this.result.compareAndSet(null, Either.forException(exception));
+    latch.countDown();
+  }
+
+  T blockingGetOrThrow(long timeout, TimeUnit unit) throws Throwable {
+    try {
+      if (!latch.await(timeout, unit)) {
+        registry.counter(registry.createId("pooledRequestQueue.promise.timeout", "partition", partition)).increment();
+        completeWithException(new TimeoutException());
+      }
+    } catch (Throwable t) {
+      completeWithException(t);
+    }
+    return this.result.get().getOrThrow();
+  }
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/RequestDistributor.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/RequestDistributor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class RequestDistributor implements Runnable {
+  private final AtomicBoolean continueRunning = new AtomicBoolean(true);
+  private final PollCoordinator pollCoordinator;
+  private final Executor executor;
+  private final Collection<Queue<PooledRequest<?>>> requestQueues;
+  private final Counter submissionCounter;
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  RequestDistributor(Registry registry, PollCoordinator pollCoordinator, Executor executor, Collection<Queue<PooledRequest<?>>> requestQueues) {
+    this.pollCoordinator = pollCoordinator;
+    this.executor = executor;
+    this.requestQueues = requestQueues;
+    this.submissionCounter = registry.counter("pooledRequestQueue.submitted");
+  }
+
+  void shutdown() {
+    continueRunning.set(false);
+  }
+
+  @Override
+  public void run() {
+    while (continueRunning.get()) {
+      processPartitions();
+    }
+  }
+
+  void processPartitions() {
+    try {
+      boolean hadItems = false;
+      pollCoordinator.reset();
+      for (Queue<PooledRequest<?>> queue : requestQueues) {
+        final PooledRequest<?> request = queue.poll();
+        if (request != null) {
+          hadItems = true;
+          submissionCounter.increment();
+          executor.execute(request);
+        }
+      }
+
+      pollCoordinator.waitForItems(hadItems);
+    } catch (Throwable t) {
+      log.warn("Throwable during processPartitions", t);
+    }
+  }
+}

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ApplicationControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ApplicationControllerSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.model.Cluster
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonApplication
+import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -31,7 +32,7 @@ class ApplicationControllerSpec extends Specification {
   ApplicationsController applicationsController
 
   def setup() {
-    applicationsController = new ApplicationsController()
+    applicationsController = new ApplicationsController(requestQueue: RequestQueue.noop())
   }
 
   def "call all application providers on listing"() {

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.model.Cluster
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
 import com.netflix.spinnaker.clouddriver.model.Instance
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -32,7 +33,7 @@ class ClusterControllerSpec extends Specification {
   ClusterController clusterController
 
   def setup() {
-    clusterController = new ClusterController()
+    clusterController = new ClusterController(requestQueue: RequestQueue.noop())
   }
 
   void "should call all application providers to get and merge the cluster names"() {

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueueSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueueSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue.pooled
+
+import com.netflix.spectator.api.NoopRegistry
+import spock.lang.Specification
+
+import java.util.concurrent.TimeoutException
+
+class PooledRequestQueueSpec extends Specification {
+  def "should execute requests"() {
+    given:
+    def queue = new PooledRequestQueue(new NoopRegistry(), 10, 1)
+
+    when:
+    Long result = queue.execute("foo", { return 12345L })
+
+    then:
+    result == 12345L
+  }
+
+  def "should time out if request does not complete"() {
+    given:
+    def queue = new PooledRequestQueue(new NoopRegistry(), 10, 1)
+
+    when:
+    Long result = queue.execute("foo", { Thread.sleep(20); return 12345L })
+
+    then:
+    thrown(TimeoutException)
+  }
+}

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/RequestDistributorSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/RequestDistributorSpec.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue.pooled
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import spock.lang.Specification
+
+import java.util.concurrent.Executor
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+class RequestDistributorSpec extends Specification {
+
+  def "should pop and dispatch one item per queue"() {
+    given:
+    Registry registry = new NoopRegistry()
+    Collection<Queue<PooledRequest>> queues = [new LinkedBlockingQueue<>(), new LinkedBlockingQueue<>(), new LinkedBlockingQueue<>()]
+    queues[0].add(new PooledRequest<Integer>(registry, "appA", {return 0}))
+    queues[0].add(new PooledRequest<Integer>(registry, "appA", {return 1}))
+    queues[2].add(new PooledRequest<Integer>(registry, "appC", {return 2}))
+    def coord = Mock(PollCoordinator)
+    List<PooledRequest<Integer>> reqs = []
+    def exec = Stub(Executor) {
+      execute(_) >> { Runnable r ->
+        reqs.add(r)
+        r.run()
+      }
+    }
+
+    RequestDistributor dist = new RequestDistributor(registry, coord, exec, queues)
+
+    when:
+    dist.processPartitions()
+
+    then:
+    1 * coord.reset()
+    1 * coord.waitForItems(true)
+    0 * _
+
+    reqs.size() == 2
+    reqs[0].getPromise().blockingGetOrThrow(1, TimeUnit.MILLISECONDS) == 0
+    reqs[1].getPromise().blockingGetOrThrow(1, TimeUnit.MILLISECONDS) == 2
+
+  }
+}


### PR DESCRIPTION
When enabled submitted API requests are first queued by application. Requests are popped
one at a time from each application queue and submitted for execution. This should mitigate
one particular application user hammering the API and degrading service for others.

In addition the requests are executed on a fixed size thread pool so no matter how many requests
are submitted only a bounded number will be executed at any time.

The request thread is blocked until the request is serviced from the threadpool or times out.