### PR TITLE
feat(provider/oraclebmcs): Adding initial loadbalancer support

### DIFF
--- a/clouddriver-oracle-bmcs/clouddriver-oracle-bmcs.gradle
+++ b/clouddriver-oracle-bmcs/clouddriver-oracle-bmcs.gradle
@@ -17,7 +17,7 @@ final File sdkLocation = project.file('build/bmcs-sdk')
 
 // Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile/runtime deps
 task fetchSdk(type: DownloadTask) {
-  sourceUrl = 'https://github.com/oracle/bmcs-java-sdk/releases/download/v1.2.2/oracle-bmcs-java-sdk.zip'
+  sourceUrl = 'https://github.com/oracle/bmcs-java-sdk/releases/download/v1.2.7/oracle-bmcs-java-sdk.zip'
   target = sdkDownloadLocation
 }
 

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/cache/Keys.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/cache/Keys.groovy
@@ -22,7 +22,8 @@ class Keys {
     SUBNETS,
     IMAGES,
     SECURITY_GROUPS,
-    INSTANCES
+    INSTANCES,
+    LOADBALANCERS
 
     static String provider = OracleBMCSCloudProvider.ID
 
@@ -107,6 +108,14 @@ class Keys {
           account    : parts[5]
         ]
         break
+      case Namespace.LOADBALANCERS.ns:
+        result << [
+          name   : parts[2],
+          id     : parts[3],
+          region : parts[4],
+          account: parts[5]
+        ]
+        break
       default:
         return null
         break
@@ -149,6 +158,13 @@ class Keys {
   static String getServerGroupKey(String account, String region, String serverGroupName) {
     Names names = Names.parseName(serverGroupName)
     "$OracleBMCSCloudProvider.ID:${Namespace.SERVER_GROUPS}:${names.cluster}:${account}:${region}:${serverGroupName}"
+  }
+
+  static String getLoadBalancerKey(String loadBalancerName,
+                              String loadBalancerId,
+                              String region,
+                              String account) {
+    "$OracleBMCSCloudProvider.ID:${Namespace.NETWORKS}:${loadBalancerName}:${loadBalancerId}:${region}:${account}"
   }
 
 }

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/OracleBMCSWorkRequestPoller.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/OracleBMCSWorkRequestPoller.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.oracle.bmc.loadbalancer.LoadBalancerClient
+import com.oracle.bmc.loadbalancer.model.WorkRequest
+import com.oracle.bmc.loadbalancer.requests.GetWorkRequestRequest
+
+class OracleBMCSWorkRequestPoller {
+
+  public static WorkRequest poll(String workRequestId, String phase, Task task, LoadBalancerClient loadBalancerClient) {
+    def wr = GetWorkRequestRequest.builder().workRequestId(workRequestId).build()
+
+    task.updateStatus(phase, "Waiting for WorkRequest to finish: $workRequestId")
+    def waiter = loadBalancerClient.waiters.forWorkRequest(wr)
+    def finalWorkRequestResult = waiter.execute().workRequest
+
+    if (finalWorkRequestResult.lifecycleState != WorkRequest.LifecycleState.Succeeded) {
+      task.updateStatus(phase, "WorkRequest finished: ${finalWorkRequestResult.lifecycleState} ${finalWorkRequestResult.message}")
+      for (def err : finalWorkRequestResult.errorDetails) {
+        task.updateStatus(phase, "Error Code: ${err.errorCode}, Message: ${err.message}")
+      }
+      task.fail()
+    } else {
+      task.updateStatus(phase, "WorkRequest finished: ${finalWorkRequestResult.lifecycleState}")
+    }
+    return finalWorkRequestResult
+  }
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/converter/CreateOracleBMCSLoadBalancerAtomicOperationConverter.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/converter/CreateOracleBMCSLoadBalancerAtomicOperationConverter.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.converter
+
+import com.netflix.spinnaker.clouddriver.oraclebmcs.OracleBMCSOperation
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.CreateLoadBalancerDescription
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.op.CreateOracleBMCSLoadBalancerAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+
+@Slf4j
+@OracleBMCSOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
+@Component("createOracleBMCSLoadBalancerDescription")
+class CreateOracleBMCSLoadBalancerAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  AtomicOperation convertOperation(Map input) {
+    new CreateOracleBMCSLoadBalancerAtomicOperation(convertDescription(input))
+  }
+
+  @Override
+  CreateLoadBalancerDescription convertDescription(Map input) {
+    OracleBMCSAtomicOperationConverterHelper.convertDescription(input, this, CreateLoadBalancerDescription)
+  }
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/description/CreateLoadBalancerDescription.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/description/CreateLoadBalancerDescription.groovy
@@ -8,21 +8,33 @@
  */
 package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description
 
-import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
-import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
-import groovy.transform.AutoClone
-import groovy.transform.Canonical
-import groovy.transform.ToString
 
-@AutoClone
-@Canonical
-@ToString(includeSuper = true, includeNames = true)
-class BasicOracleBMCSDeployDescription extends BaseOracleBMCSInstanceDescription implements DeployDescription, ApplicationNameable {
+class CreateLoadBalancerDescription extends AbstractOracleBMCSCredentialsDescription implements ApplicationNameable {
 
   String application
   String stack
-  String freeFormDetails
-  String loadBalancerId
-  ServerGroup.Capacity capacity
+  String shape
+  String policy
+  List<String> subnetIds
+  Listener listener
+  HealthCheck healthCheck
+
+  static class Listener {
+
+    Integer port
+    String protocol
+  }
+
+  static class HealthCheck {
+
+    String protocol
+    Integer port
+    Integer interval
+    Integer retries
+    Integer timeout
+    String url
+    Integer statusCode
+    String responseBodyRegex
+  }
 }

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/handler/BasicOracleBMCSDeployHandler.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/handler/BasicOracleBMCSDeployHandler.groovy
@@ -8,17 +8,33 @@
  */
 package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.handler
 
+import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.deploy.DeployHandler
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.OracleBMCSServerGroupNameResolver
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.OracleBMCSWorkRequestPoller
 import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.BasicOracleBMCSDeployDescription
+import com.netflix.spinnaker.clouddriver.oraclebmcs.model.OracleBMCSInstance
 import com.netflix.spinnaker.clouddriver.oraclebmcs.model.OracleBMCSServerGroup
+import com.netflix.spinnaker.clouddriver.oraclebmcs.provider.view.OracleBMCSClusterProvider
 import com.netflix.spinnaker.clouddriver.oraclebmcs.service.servergroup.OracleBMCSServerGroupService
+import com.oracle.bmc.core.requests.GetVnicRequest
+import com.oracle.bmc.core.requests.ListVnicAttachmentsRequest
+import com.oracle.bmc.loadbalancer.model.BackendDetails
+import com.oracle.bmc.loadbalancer.model.CreateBackendSetDetails
+import com.oracle.bmc.loadbalancer.model.HealthCheckerDetails
+import com.oracle.bmc.loadbalancer.model.UpdateListenerDetails
+import com.oracle.bmc.loadbalancer.requests.CreateBackendSetRequest
+import com.oracle.bmc.loadbalancer.requests.GetLoadBalancerRequest
+import com.oracle.bmc.loadbalancer.requests.UpdateListenerRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+
+import java.util.concurrent.TimeUnit
 
 @Component
 class BasicOracleBMCSDeployHandler implements DeployHandler<BasicOracleBMCSDeployDescription> {
@@ -27,6 +43,9 @@ class BasicOracleBMCSDeployHandler implements DeployHandler<BasicOracleBMCSDeplo
 
   @Autowired
   OracleBMCSServerGroupService oracleBMCSServerGroupService
+
+  @Autowired
+  OracleBMCSClusterProvider clusterProvider
 
   private static Task getTask() {
     TaskRepository.threadLocalTask.get()
@@ -69,12 +88,100 @@ class BasicOracleBMCSDeployHandler implements DeployHandler<BasicOracleBMCSDeplo
       zone: description.availabilityDomain,
       launchConfig: launchConfig,
       targetSize: description.capacity.desired,
-      credentials: description.credentials
+      credentials: description.credentials,
+      loadBalancerId: description.loadBalancerId
     )
 
     oracleBMCSServerGroupService.createServerGroup(sg)
 
     task.updateStatus BASE_PHASE, "Done creating server group $serverGroupName."
+
+    if (description.loadBalancerId) {
+      // wait for instances to go into running state
+      ServerGroup sgView
+      long finishBy = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(30)
+      boolean allUp = false
+      while (!allUp && System.currentTimeMillis() < finishBy) {
+        sgView = clusterProvider.getServerGroup(sg.credentials.name, sg.region, sg.name)
+        if (sgView && (sgView.instanceCounts.up == sgView.instanceCounts.total)) {
+          task.updateStatus BASE_PHASE, "All instances are Up"
+          allUp = true
+          break
+        }
+        task.updateStatus BASE_PHASE, "Waiting for server group instances to get to Up state"
+        Thread.sleep(5000)
+      }
+      if (!allUp) {
+        task.updateStatus(BASE_PHASE, "Timed out waiting for server group instances to get to Up state")
+        task.fail()
+        return
+      }
+
+      // get their ip addresses
+      task.updateStatus BASE_PHASE, "Looking up instance IP addresses"
+      List<String> ips = []
+      sgView.instances.each { instance ->
+        def vnicAttachRs = description.credentials.computeClient.listVnicAttachments(ListVnicAttachmentsRequest.builder()
+          .compartmentId(description.credentials.compartmentId)
+          .instanceId(((OracleBMCSInstance) instance).id)
+          .build())
+        vnicAttachRs.items.each { vnicAttach ->
+          def vnic = description.credentials.networkClient.getVnic(GetVnicRequest.builder()
+            .vnicId(vnicAttach.vnicId).build()).vnic
+          ips << vnic.privateIp
+        }
+      }
+
+      // get LB
+      task.updateStatus BASE_PHASE, "Getting loadbalancer details"
+      def lb = description.credentials.loadBalancerClient.getLoadBalancer(GetLoadBalancerRequest.builder().loadBalancerId(description.loadBalancerId).build()).loadBalancer
+
+      // use backend-template to add a new backend set
+      def names = Names.parseName(sg.name)
+      def backendTemplate = lb.backendSets.get(names.cluster + '-template')
+      def backend = CreateBackendSetDetails.builder()
+        .healthChecker(HealthCheckerDetails.builder()
+        .protocol(backendTemplate.healthChecker.protocol)
+        .port(backendTemplate.healthChecker.port)
+        .intervalInMillis(backendTemplate.healthChecker.intervalInMillis)
+        .retries(backendTemplate.healthChecker.retries)
+        .timeoutInMillis(backendTemplate.healthChecker.timeoutInMillis)
+        .urlPath(backendTemplate.healthChecker.urlPath)
+        .returnCode(backendTemplate.healthChecker.returnCode)
+        .responseBodyRegex(backendTemplate.healthChecker.responseBodyRegex)
+        .build())
+        .policy(backendTemplate.policy)
+        .backends(ips.collect { ip ->
+        BackendDetails.builder().ipAddress(ip).port(backendTemplate.healthChecker.port).build()
+      })
+        .name(sg.name)
+        .build()
+
+      // update lb to point to that backend set
+      task.updateStatus BASE_PHASE, "Creating backend set ${backend.name}"
+      def rs = description.credentials.loadBalancerClient.createBackendSet(CreateBackendSetRequest.builder()
+        .loadBalancerId(lb.id)
+        .createBackendSetDetails(backend).build())
+
+      // wait for backend set to be created
+      OracleBMCSWorkRequestPoller.poll(rs.getOpcWorkRequestId(), BASE_PHASE, task, description.credentials.loadBalancerClient)
+
+      // update listener
+      def currentListener = lb.listeners.get(names.cluster)
+      task.updateStatus BASE_PHASE, "Updating listener ${currentListener.name} to point to backend set ${backend.name}"
+      def ulrs = description.credentials.loadBalancerClient.updateListener(UpdateListenerRequest.builder()
+        .listenerName(currentListener.name)
+        .loadBalancerId(lb.id)
+        .updateListenerDetails(UpdateListenerDetails.builder()
+        .port(currentListener.port)
+        .defaultBackendSetName(backend.name)
+        .protocol(currentListener.protocol)
+        .build())
+        .build())
+
+      // wait for listener to be updated
+      OracleBMCSWorkRequestPoller.poll(ulrs.getOpcWorkRequestId(), BASE_PHASE, task, description.credentials.loadBalancerClient)
+    }
 
     DeploymentResult deploymentResult = new DeploymentResult()
     deploymentResult.serverGroupNames = ["$region:$serverGroupName".toString()]

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/AbstractEnableDisableAtomicOperation.groovy
@@ -9,11 +9,16 @@
 package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.op
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.OracleBMCSWorkRequestPoller
 import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.EnableDisableOracleBMCSServerGroupDescription
 import com.netflix.spinnaker.clouddriver.oraclebmcs.service.servergroup.OracleBMCSServerGroupService
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.oracle.bmc.loadbalancer.model.UpdateListenerDetails
+import com.oracle.bmc.loadbalancer.requests.GetLoadBalancerRequest
+import com.oracle.bmc.loadbalancer.requests.UpdateListenerRequest
 import org.springframework.beans.factory.annotation.Autowired
 
 abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<Void> {
@@ -42,15 +47,54 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
     task.updateStatus phaseName, "Initializing $verb server group operation for $description.serverGroupName in " +
       "$description.region..."
 
+    def sg = oracleBMCSServerGroupService.getServerGroup(description.credentials, description.application, description.serverGroupName)
+    def names = Names.parseName(description.serverGroupName)
+
     if (disable) {
       task.updateStatus phaseName, "$presentParticipling server group from Http(s) load balancers..."
 
       oracleBMCSServerGroupService.disableServerGroup(task, description.credentials, description.serverGroupName)
 
+      // SL: Make sure this sg is not pointed by the listener - otherwise replace with backend template
+
+      if (sg.loadBalancerId) {
+        def lb = description.credentials.loadBalancerClient.getLoadBalancer(GetLoadBalancerRequest.builder().loadBalancerId(sg.loadBalancerId).build())
+        def listener = lb.loadBalancer.listeners.get(names.cluster)
+        String backendSetTemplateName = "${names.cluster}-template"
+        if (listener.defaultBackendSetName == sg.name) {
+          def workResponse = description.credentials.loadBalancerClient.updateListener(UpdateListenerRequest.builder()
+            .listenerName(listener.name)
+            .loadBalancerId(lb.loadBalancer.id)
+            .updateListenerDetails(UpdateListenerDetails.builder()
+            .defaultBackendSetName(backendSetTemplateName)
+            .port(listener.port)
+            .protocol(listener.protocol)
+            .build())
+            .build())
+          OracleBMCSWorkRequestPoller.poll(workResponse.opcWorkRequestId, phaseName, task, description.credentials.loadBalancerClient)
+        }
+      }
+
     } else {
       task.updateStatus phaseName, "Registering server group with Http(s) load balancers..."
 
       oracleBMCSServerGroupService.enableServerGroup(task, description.credentials, description.serverGroupName)
+
+      // SL: update listener to point to this SGs backend set name
+      if (sg.loadBalancerId) {
+        def lb = description.credentials.loadBalancerClient.getLoadBalancer(GetLoadBalancerRequest.builder().loadBalancerId(sg.loadBalancerId).build())
+        def listener = lb.loadBalancer.listeners.get(names.getCluster())
+        if (listener.defaultBackendSetName != sg.name) {
+          def workResponse = description.credentials.loadBalancerClient.updateListener(UpdateListenerRequest.builder()
+            .listenerName(listener.name)
+            .loadBalancerId(lb.loadBalancer.id)
+            .updateListenerDetails(UpdateListenerDetails.builder()
+            .defaultBackendSetName(sg.name)
+            .build())
+            .build())
+          OracleBMCSWorkRequestPoller.poll(workResponse.opcWorkRequestId, phaseName, task, description.credentials.loadBalancerClient)
+        }
+      }
     }
 
     task.updateStatus phaseName, "$presentParticipling server group $description.serverGroupName in $description.region..."

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/CreateOracleBMCSLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/CreateOracleBMCSLoadBalancerAtomicOperation.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.op
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.OracleBMCSWorkRequestPoller
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.CreateLoadBalancerDescription
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.oracle.bmc.loadbalancer.model.BackendSetDetails
+import com.oracle.bmc.loadbalancer.model.CreateLoadBalancerDetails
+import com.oracle.bmc.loadbalancer.model.HealthCheckerDetails
+import com.oracle.bmc.loadbalancer.model.ListenerDetails
+import com.oracle.bmc.loadbalancer.requests.CreateLoadBalancerRequest
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class CreateOracleBMCSLoadBalancerAtomicOperation implements AtomicOperation<Void> {
+
+  private final CreateLoadBalancerDescription description
+
+  private static final String BASE_PHASE = "CREATE_LOADBALANCER"
+
+  private static Task getTask() {
+    TaskRepository.threadLocalTask.get()
+  }
+
+  CreateOracleBMCSLoadBalancerAtomicOperation(CreateLoadBalancerDescription description) {
+    this.description = description
+  }
+
+  @Override
+  Void operate(List priorOutputs) {
+    def task = getTask()
+    def clusterName = "${description.application}${description.stack ? '-' + description.stack : ''}"
+    def backendSetTemplateName = "$clusterName-template"
+    def dummyBackendSet = BackendSetDetails.builder()
+      .policy(description.policy)
+      .healthChecker(HealthCheckerDetails.builder()
+      .protocol(description.healthCheck.protocol)
+      .port(description.healthCheck.port)
+      .intervalInMillis(description.healthCheck.interval)
+      .retries(description.healthCheck.retries)
+      .timeoutInMillis(description.healthCheck.timeout)
+      .urlPath(description.healthCheck.url)
+      .returnCode(description.healthCheck.statusCode)
+      .responseBodyRegex(description.healthCheck.responseBodyRegex)
+      .build())
+      .build()
+
+    def rq = CreateLoadBalancerRequest.builder()
+      .createLoadBalancerDetails(CreateLoadBalancerDetails.builder()
+      .displayName(clusterName)
+      .compartmentId(description.credentials.compartmentId)
+      .shapeName(description.shape)
+      .subnetIds(description.subnetIds)
+      .backendSets([(backendSetTemplateName.toString()): dummyBackendSet])
+      .listeners([(clusterName.toString()): ListenerDetails.builder()
+      .port(description.listener.port)
+      .protocol(description.listener.protocol)
+      .defaultBackendSetName(backendSetTemplateName)
+      .build()])
+      .build()).build()
+
+    def rs = description.credentials.loadBalancerClient.createLoadBalancer(rq)
+    task.updateStatus(BASE_PHASE, "Create LB rq submitted - work request id: ${rs.getOpcWorkRequestId()}")
+
+    OracleBMCSWorkRequestPoller.poll(rs.getOpcWorkRequestId(), BASE_PHASE, task, description.credentials.loadBalancerClient)
+
+    return null
+  }
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/DestroyOracleBMCSServerGroupAtomicOperation.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/DestroyOracleBMCSServerGroupAtomicOperation.groovy
@@ -8,11 +8,16 @@
  */
 package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.op
 
+import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.OracleBMCSWorkRequestPoller
 import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.DestroyOracleBMCSServerGroupDescription
 import com.netflix.spinnaker.clouddriver.oraclebmcs.service.servergroup.OracleBMCSServerGroupService
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import com.oracle.bmc.loadbalancer.requests.DeleteBackendSetRequest
+import com.oracle.bmc.loadbalancer.requests.GetBackendSetRequest
+import com.oracle.bmc.model.BmcException
 import org.springframework.beans.factory.annotation.Autowired
 
 class DestroyOracleBMCSServerGroupAtomicOperation implements AtomicOperation<Void> {
@@ -34,8 +39,31 @@ class DestroyOracleBMCSServerGroupAtomicOperation implements AtomicOperation<Voi
 
   @Override
   Void operate(List priorOutputs) {
+    def sg = oracleBMCSServerGroupService.getServerGroup(description.credentials, Names.parseName(description.serverGroupName).app, description.serverGroupName)
+    if (sg.loadBalancerId) {
+      task.updateStatus BASE_PHASE, "Destroying server group backend set: " + description.serverGroupName
+      try {
+        description.credentials.loadBalancerClient.getBackendSet(GetBackendSetRequest.builder()
+          .backendSetName(description.serverGroupName)
+          .loadBalancerId(sg.loadBalancerId)
+          .build())
+        def workResponse = description.credentials.loadBalancerClient.deleteBackendSet(DeleteBackendSetRequest.builder()
+          .backendSetName(description.serverGroupName)
+          .loadBalancerId(sg.loadBalancerId)
+          .build())
+        OracleBMCSWorkRequestPoller.poll(workResponse.opcWorkRequestId, BASE_PHASE, task, description.credentials.loadBalancerClient)
+      } catch (BmcException e) {
+        if (e.statusCode == 404) {
+          task.updateStatus BASE_PHASE, "Backend set did not exist...continuing"
+        } else {
+          throw e
+        }
+      }
+    }
+
     task.updateStatus BASE_PHASE, "Destroying server group: " + description.serverGroupName
     oracleBMCSServerGroupService.destroyServerGroup(task, description.credentials, description.serverGroupName)
+
     task.updateStatus BASE_PHASE, "Completed server group destruction"
     return null
   }

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/model/OracleBMCSServerGroup.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/model/OracleBMCSServerGroup.groovy
@@ -32,6 +32,7 @@ class OracleBMCSServerGroup {
   Map buildInfo
   Boolean disabled = false
   Integer targetSize
+  String loadBalancerId
   OracleBMCSNamedAccountCredentials credentials
 
   @JsonIgnore
@@ -70,7 +71,7 @@ class OracleBMCSServerGroup {
 
     @Override
     Set<String> getLoadBalancers() {
-      return null
+      return [OracleBMCSServerGroup.this.loadBalancerId] as Set
     }
 
     @Override

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/OracleBMCSInfrastructureProvider.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/OracleBMCSInfrastructureProvider.groovy
@@ -25,7 +25,8 @@ class OracleBMCSInfrastructureProvider extends AgentSchedulerAware implements Se
     Namespace.IMAGES.ns,
     Namespace.INSTANCES.ns,
     Namespace.SECURITY_GROUPS.ns,
-    Namespace.SERVER_GROUPS.ns
+    Namespace.SERVER_GROUPS.ns,
+    Namespace.LOADBALANCERS.ns
   ].asImmutable()
 
   final Map<String, String> urlMappingTemplates = [:]

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/agent/OracleBMCSLoadBalancerCachingAgent.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/agent/OracleBMCSLoadBalancerCachingAgent.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.CacheResult
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.oraclebmcs.cache.Keys
+import com.netflix.spinnaker.clouddriver.oraclebmcs.security.OracleBMCSNamedAccountCredentials
+import com.oracle.bmc.loadbalancer.model.LoadBalancer
+import com.oracle.bmc.loadbalancer.requests.ListLoadBalancersRequest
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class OracleBMCSLoadBalancerCachingAgent extends AbstractOracleBMCSCachingAgent {
+
+  final Set<AgentDataType> providedDataTypes = [
+    AgentDataType.Authority.AUTHORITATIVE.forType(Keys.Namespace.LOADBALANCERS.ns)
+  ] as Set
+
+  OracleBMCSLoadBalancerCachingAgent(String clouddriverUserAgentApplicationName,
+                                     OracleBMCSNamedAccountCredentials credentials,
+                                     ObjectMapper objectMapper) {
+    super(objectMapper, credentials, clouddriverUserAgentApplicationName)
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    List<LoadBalancer> loadBalancers = loadLoadBalancers()
+    return buildCacheResult(loadBalancers)
+  }
+
+  List<LoadBalancer> loadLoadBalancers() {
+    def response = credentials.loadBalancerClient.listLoadBalancers(ListLoadBalancersRequest.builder()
+      .compartmentId(credentials.compartmentId)
+      .build())
+    return response.items
+  }
+
+  private CacheResult buildCacheResult(List<LoadBalancer> loadBalancers) {
+    log.info("Describing items in $agentType")
+
+    List<CacheData> data = loadBalancers.collect { LoadBalancer lb ->
+      if (lb.lifecycleState != LoadBalancer.LifecycleState.Active) {
+        return null
+      }
+      Map<String, Object> attributes = objectMapper.convertValue(lb, ATTRIBUTES)
+      new DefaultCacheData(
+        Keys.getLoadBalancerKey(lb.displayName, lb.id, credentials.region, credentials.name),
+        attributes,
+        [:]
+      )
+    }
+    data.removeAll { it == null }
+    def cacheData = [(Keys.Namespace.LOADBALANCERS.ns): data]
+    log.info("Caching ${data.size()} items in $agentType")
+    return new DefaultCacheResult(cacheData, [:])
+  }
+
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/config/OracleBMCSInfrastructureProviderConfig.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/config/OracleBMCSInfrastructureProviderConfig.groovy
@@ -112,6 +112,10 @@ class OracleBMCSInfrastructureProviderConfig {
           credentials,
           objectMapper)
 
+        newlyAddedAgents << new OracleBMCSLoadBalancerCachingAgent(clouddriverUserAgentApplicationName,
+          credentials,
+          objectMapper)
+
         // If there is an agent scheduler, then this provider has been through the AgentController in the past.
         // In that case, we need to do the scheduling here (because accounts have been added to a running system).
         if (oracleBMCSInfrastructureProvider.agentScheduler) {

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/view/OracleBMCSLoadBalancerProvider.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/view/OracleBMCSLoadBalancerProvider.groovy
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.provider.view
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
+import com.netflix.spinnaker.clouddriver.oraclebmcs.OracleBMCSCloudProvider
+import com.netflix.spinnaker.clouddriver.oraclebmcs.cache.Keys
+import com.oracle.bmc.loadbalancer.model.LoadBalancer
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Slf4j
+@Component
+class OracleBMCSLoadBalancerProvider implements LoadBalancerProvider<OBMCSLoadBalancerDetail> {
+
+  final Cache cacheView
+  final ObjectMapper objectMapper
+  final String cloudProvider = OracleBMCSCloudProvider.ID
+
+  @Autowired
+  OracleBMCSLoadBalancerProvider(Cache cacheView, ObjectMapper objectMapper) {
+    this.cacheView = cacheView
+    this.objectMapper = objectMapper
+  }
+
+  @Override
+  List<LoadBalancerProvider.Item> list() {
+    def results = []
+    getAll().each { lb ->
+      def summary = new OBMCSLoadBalancerSummary(name: lb.name)
+      summary.getOrCreateAccount(lb.account).getOrCreateRegion(lb.region).loadBalancers << lb
+      results << summary
+    }
+
+    return results
+  }
+
+  @Override
+  LoadBalancerProvider.Item get(String name) {
+    def summary = new OBMCSLoadBalancerSummary(name: name)
+    getAllMatchingKeyPattern(Keys.getLoadBalancerKey(name, '*', '*', '*')).each { lb ->
+      summary.getOrCreateAccount(lb.account).getOrCreateRegion(lb.region).loadBalancers << lb
+    }
+    return summary
+  }
+
+  @Override
+  List<LoadBalancerProvider.Details> byAccountAndRegionAndName(String account, String region, String name) {
+    return getAllMatchingKeyPattern(Keys.getLoadBalancerKey(name, '*', region, account))
+  }
+
+  @Override
+  Set<OBMCSLoadBalancerDetail> getApplicationLoadBalancers(String application) {
+    return getAllMatchingKeyPattern(Keys.getLoadBalancerKey("$application*", '*', '*', '*'))
+  }
+
+  Set<OBMCSLoadBalancerDetail> getAll() {
+    getAllMatchingKeyPattern(Keys.getLoadBalancerKey('*', '*', '*', '*'))
+  }
+
+  Set<OBMCSLoadBalancerDetail> getAllMatchingKeyPattern(String pattern) {
+    loadResults(cacheView.filterIdentifiers(Keys.Namespace.LOADBALANCERS.ns, pattern))
+  }
+
+  Set<OBMCSLoadBalancerDetail> loadResults(Collection<String> identifiers) {
+    def data = cacheView.getAll(Keys.Namespace.LOADBALANCERS.ns, identifiers, RelationshipCacheFilter.none())
+    def transformed = data.collect(this.&fromCacheData)
+
+    return transformed
+  }
+
+  OBMCSLoadBalancerDetail fromCacheData(CacheData cacheData) {
+    LoadBalancer loadBalancer = objectMapper.convertValue(cacheData.attributes, LoadBalancer)
+    Map<String, String> parts = Keys.parse(cacheData.id)
+
+    return new OBMCSLoadBalancerDetail(
+      id: loadBalancer.id,
+      name: loadBalancer.displayName,
+      account: parts.account,
+      region: parts.region,
+      serverGroups: [loadBalancer.listeners.values().first().defaultBackendSetName] as Set<String>
+    )
+  }
+
+  static class OBMCSLoadBalancerSummary implements LoadBalancerProvider.Item {
+
+    private Map<String, OBMCSLoadBalancerAccount> mappedAccounts = [:]
+    String name
+
+    OBMCSLoadBalancerAccount getOrCreateAccount(String name) {
+      if (!mappedAccounts.containsKey(name)) {
+        mappedAccounts.put(name, new OBMCSLoadBalancerAccount(name: name))
+      }
+      mappedAccounts[name]
+    }
+
+    @JsonProperty("accounts")
+    List<OBMCSLoadBalancerAccount> getByAccounts() {
+      mappedAccounts.values() as List
+    }
+  }
+
+  static class OBMCSLoadBalancerAccount implements LoadBalancerProvider.ByAccount {
+
+    private Map<String, OBMCSLoadBalancerAccountRegion> mappedRegions = [:]
+    String name
+
+    OBMCSLoadBalancerAccountRegion getOrCreateRegion(String name) {
+      if (!mappedRegions.containsKey(name)) {
+        mappedRegions.put(name, new OBMCSLoadBalancerAccountRegion(name: name, loadBalancers: []))
+      }
+      mappedRegions[name]
+    }
+
+    @JsonProperty("regions")
+    List<OBMCSLoadBalancerAccountRegion> getByRegions() {
+      mappedRegions.values() as List
+    }
+  }
+
+  static class OBMCSLoadBalancerAccountRegion implements LoadBalancerProvider.ByRegion {
+
+    String name
+    List<OBMCSLoadBalancerSummary> loadBalancers
+  }
+
+  static class OBMCSLoadBalancerDetail implements LoadBalancerProvider.Details, com.netflix.spinnaker.clouddriver.model.LoadBalancer {
+
+    String account
+    String region
+    String name
+    String type = 'oraclebmcs'
+    String cloudProvider = 'oraclebmcs'
+    String id
+    Set<String> serverGroups
+  }
+
+}

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/security/OracleBMCSNamedAccountCredentials.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/security/OracleBMCSNamedAccountCredentials.groovy
@@ -19,6 +19,7 @@ import com.oracle.bmc.core.ComputeClient
 import com.oracle.bmc.core.VirtualNetworkClient
 import com.oracle.bmc.identity.IdentityClient
 import com.oracle.bmc.identity.requests.ListAvailabilityDomainsRequest
+import com.oracle.bmc.loadbalancer.LoadBalancerClient
 import com.oracle.bmc.objectstorage.ObjectStorageClient
 
 class OracleBMCSNamedAccountCredentials implements AccountCredentials<Object> {
@@ -40,6 +41,7 @@ class OracleBMCSNamedAccountCredentials implements AccountCredentials<Object> {
   VirtualNetworkClient networkClient
   ObjectStorageClient objectStorageClient
   IdentityClient identityClient
+  LoadBalancerClient loadBalancerClient
 
   OracleBMCSNamedAccountCredentials(String name,
                                     String environment,
@@ -80,6 +82,8 @@ class OracleBMCSNamedAccountCredentials implements AccountCredentials<Object> {
     this.objectStorageClient.setRegion(desiredRegion)
     this.identityClient = new IdentityClient(provider)
     this.identityClient.setRegion(desiredRegion)
+    this.loadBalancerClient = new LoadBalancerClient(provider)
+    this.loadBalancerClient.setRegion(desiredRegion)
     this.regions = [new OracleBMCSRegion(name: desiredRegion.regionId,
       availabilityZones: this.identityClient.listAvailabilityDomains(ListAvailabilityDomainsRequest.builder()
         .compartmentId(this.compartmentId)

--- a/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/converter/CreateOracleBMCSLoadBalancerAtomicOperationConverterUnitSpec.groovy
+++ b/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/converter/CreateOracleBMCSLoadBalancerAtomicOperationConverterUnitSpec.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.converter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.CreateLoadBalancerDescription
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.op.CreateOracleBMCSLoadBalancerAtomicOperation
+import com.netflix.spinnaker.clouddriver.oraclebmcs.security.OracleBMCSNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CreateOracleBMCSLoadBalancerAtomicOperationConverterUnitSpec extends Specification {
+
+  @Shared
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Shared
+  CreateOracleBMCSLoadBalancerAtomicOperationConverter converter
+
+  def setupSpec() {
+    this.converter = new CreateOracleBMCSLoadBalancerAtomicOperationConverter(objectMapper: mapper)
+    def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+    def mockCredentials = Mock(OracleBMCSNamedAccountCredentials)
+    accountCredentialsProvider.getCredentials(_) >> mockCredentials
+    converter.accountCredentialsProvider = accountCredentialsProvider
+  }
+
+  def "return correct description and operation"() {
+    setup:
+    def input = [application: "foo",
+                 region     : "us-phoenix-1",
+                 accountName: "my-obmcs-acc",
+                 stack      : "bar",
+                 shape      : "100Mbps",
+                 policy     : "ROUND_ROBIN",
+                 subnetIds  : ["1", "2"],
+                 listener   : [
+                   port    : 80,
+                   protocol: "tcp"
+                 ],
+                 healthCheck: [
+                   protocol         : "http",
+                   port             : 8080,
+                   interval         : 10,
+                   retries          : 5,
+                   timeout          : 5,
+                   url              : "/healthz",
+                   statusCode       : 200,
+                   responseBodyRegex: ".*GOOD.*"
+                 ]]
+
+    when:
+    def description = converter.convertDescription(input)
+
+    then:
+    description instanceof CreateLoadBalancerDescription
+
+    when:
+    def operation = converter.convertOperation(input)
+
+    then:
+    operation instanceof CreateOracleBMCSLoadBalancerAtomicOperation
+  }
+}

--- a/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/handler/BasicOracleBMCSDeployHandlerSpec.groovy
+++ b/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/handler/BasicOracleBMCSDeployHandlerSpec.groovy
@@ -12,15 +12,24 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.OracleBMCSWorkRequestPoller
 import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.BasicOracleBMCSDeployDescription
 import com.netflix.spinnaker.clouddriver.oraclebmcs.model.OracleBMCSServerGroup
+import com.netflix.spinnaker.clouddriver.oraclebmcs.provider.view.OracleBMCSClusterProvider
 import com.netflix.spinnaker.clouddriver.oraclebmcs.security.OracleBMCSNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.oraclebmcs.service.servergroup.OracleBMCSServerGroupService
+import com.oracle.bmc.core.ComputeClient
+import com.oracle.bmc.core.VirtualNetworkClient
+import com.oracle.bmc.loadbalancer.LoadBalancerClient
+import com.oracle.bmc.loadbalancer.model.BackendSet
+import com.oracle.bmc.loadbalancer.model.HealthChecker
+import com.oracle.bmc.loadbalancer.model.Listener
+import com.oracle.bmc.loadbalancer.model.LoadBalancer
+import com.oracle.bmc.loadbalancer.responses.CreateBackendSetResponse
+import com.oracle.bmc.loadbalancer.responses.GetLoadBalancerResponse
+import com.oracle.bmc.loadbalancer.responses.UpdateListenerResponse
 import spock.lang.Specification
 
-/**
- * Created by slord on 18/04/2017.
- */
 class BasicOracleBMCSDeployHandlerSpec extends Specification {
 
   def "Handles correct description"(def desc, def result) {
@@ -47,10 +56,24 @@ class BasicOracleBMCSDeployHandlerSpec extends Specification {
     desc.application = "foo"
     desc.stack = "dev"
     desc.region = "us-phoenix-1"
+    desc.loadBalancerId = "ocid.lb.oc1..1918273"
+    def loadBalancerClient = Mock(LoadBalancerClient)
+    creds.loadBalancerClient >> loadBalancerClient
+    def computeClient = Mock(ComputeClient)
+    creds.computeClient >> computeClient
+    def networkClient = Mock(VirtualNetworkClient)
+    creds.networkClient >> networkClient
+    GroovySpy(OracleBMCSWorkRequestPoller, global: true)
     def sgService = Mock(OracleBMCSServerGroupService)
     def sg = new OracleBMCSServerGroup(launchConfig: ["createdTime": System.currentTimeMillis()])
     def handler = new BasicOracleBMCSDeployHandler()
     handler.oracleBMCSServerGroupService = sgService
+    def sgProvider = Mock(OracleBMCSClusterProvider)
+    handler.clusterProvider = sgProvider
+    def sgViewMock = Mock(ServerGroup)
+    def instanceCounts = new ServerGroup.InstanceCounts()
+    instanceCounts.setUp(3)
+    instanceCounts.setTotal(3)
 
     when:
     def res = handler.handle(desc, null)
@@ -61,5 +84,17 @@ class BasicOracleBMCSDeployHandlerSpec extends Specification {
     1 * sgService.createServerGroup(_)
     res != null
     res.serverGroupNames == ["us-phoenix-1:foo-dev-v002"]
+    1 * loadBalancerClient.getLoadBalancer(_) >> GetLoadBalancerResponse.builder()
+      .loadBalancer(LoadBalancer.builder()
+      .listeners(["foo-dev": Listener.builder()
+      .defaultBackendSetName("foo-dev-v001").build()])
+      .backendSets(["foo-dev-template": BackendSet.builder()
+      .healthChecker(HealthChecker.builder().build())
+      .build()]).build()).build()
+    1 * loadBalancerClient.createBackendSet(_) >> CreateBackendSetResponse.builder().build()
+    1 * loadBalancerClient.updateListener(_) >> UpdateListenerResponse.builder().opcWorkRequestId("wr1").build()
+    2 * OracleBMCSWorkRequestPoller.poll(_, _, _, loadBalancerClient) >> null
+    1 * sgProvider.getServerGroup(_, _, _) >> sgViewMock
+    sgViewMock.instanceCounts >> instanceCounts
   }
 }

--- a/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/DisableOracleBMCSServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/DisableOracleBMCSServerGroupAtomicOperationSpec.groovy
@@ -11,8 +11,16 @@ package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.op
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.OracleBMCSWorkRequestPoller
 import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.EnableDisableOracleBMCSServerGroupDescription
+import com.netflix.spinnaker.clouddriver.oraclebmcs.model.OracleBMCSServerGroup
+import com.netflix.spinnaker.clouddriver.oraclebmcs.security.OracleBMCSNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.oraclebmcs.service.servergroup.OracleBMCSServerGroupService
+import com.oracle.bmc.loadbalancer.LoadBalancerClient
+import com.oracle.bmc.loadbalancer.model.Listener
+import com.oracle.bmc.loadbalancer.model.LoadBalancer
+import com.oracle.bmc.loadbalancer.responses.GetLoadBalancerResponse
+import com.oracle.bmc.loadbalancer.responses.UpdateListenerResponse
 import spock.lang.Specification
 
 class DisableOracleBMCSServerGroupAtomicOperationSpec extends Specification {
@@ -21,6 +29,11 @@ class DisableOracleBMCSServerGroupAtomicOperationSpec extends Specification {
     setup:
     def disableDesc = new EnableDisableOracleBMCSServerGroupDescription()
     disableDesc.serverGroupName = "sg1"
+    def creds = Mock(OracleBMCSNamedAccountCredentials)
+    def loadBalancerClient = Mock(LoadBalancerClient)
+    creds.loadBalancerClient >> loadBalancerClient
+    disableDesc.credentials = creds
+    GroovySpy(OracleBMCSWorkRequestPoller, global: true)
 
     TaskRepository.threadLocalTask.set(Mock(Task))
     def sgService = Mock(OracleBMCSServerGroupService)
@@ -28,10 +41,15 @@ class DisableOracleBMCSServerGroupAtomicOperationSpec extends Specification {
     op.oracleBMCSServerGroupService = sgService
     op.objectMapper = new ObjectMapper()
 
+
     when:
     op.operate(null)
 
     then:
     1 * sgService.disableServerGroup(_, _, "sg1")
+    1 * sgService.getServerGroup(_, _, "sg1") >> new OracleBMCSServerGroup(loadBalancerId: "ocid.lb.oc1..12345")
+    1 * loadBalancerClient.getLoadBalancer(_) >> GetLoadBalancerResponse.builder().loadBalancer(LoadBalancer.builder().listeners(["sg1": Listener.builder().name("sg1").build()]).build()).build()
+    1 * loadBalancerClient.updateListener(_) >> UpdateListenerResponse.builder().opcWorkRequestId("wr1").build()
+    1 * OracleBMCSWorkRequestPoller.poll("wr1", _, _, loadBalancerClient) >> null
   }
 }

--- a/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/ResizeOracleBMCSServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/deploy/op/ResizeOracleBMCSServerGroupAtomicOperationSpec.groovy
@@ -11,8 +11,20 @@ package com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.op
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.OracleBMCSWorkRequestPoller
 import com.netflix.spinnaker.clouddriver.oraclebmcs.deploy.description.ResizeOracleBMCSServerGroupDescription
+import com.netflix.spinnaker.clouddriver.oraclebmcs.model.OracleBMCSServerGroup
+import com.netflix.spinnaker.clouddriver.oraclebmcs.provider.view.OracleBMCSClusterProvider
+import com.netflix.spinnaker.clouddriver.oraclebmcs.security.OracleBMCSNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.oraclebmcs.service.servergroup.OracleBMCSServerGroupService
+import com.oracle.bmc.core.ComputeClient
+import com.oracle.bmc.core.VirtualNetworkClient
+import com.oracle.bmc.loadbalancer.LoadBalancerClient
+import com.oracle.bmc.loadbalancer.model.BackendSet
+import com.oracle.bmc.loadbalancer.model.HealthChecker
+import com.oracle.bmc.loadbalancer.model.LoadBalancer
+import com.oracle.bmc.loadbalancer.responses.GetLoadBalancerResponse
+import com.oracle.bmc.loadbalancer.responses.UpdateBackendSetResponse
 import spock.lang.Specification
 
 class ResizeOracleBMCSServerGroupAtomicOperationSpec extends Specification {
@@ -22,16 +34,43 @@ class ResizeOracleBMCSServerGroupAtomicOperationSpec extends Specification {
     def resizeDesc = new ResizeOracleBMCSServerGroupDescription()
     resizeDesc.serverGroupName = "sg1"
     resizeDesc.capacity = new ServerGroup.Capacity(desired: 3)
+    def creds = Mock(OracleBMCSNamedAccountCredentials)
+    def loadBalancerClient = Mock(LoadBalancerClient)
+    creds.loadBalancerClient >> loadBalancerClient
+    def computeClient = Mock(ComputeClient)
+    creds.computeClient >> computeClient
+    def networkClient = Mock(VirtualNetworkClient)
+    creds.networkClient >> networkClient
+    resizeDesc.credentials = creds
+    GroovySpy(OracleBMCSWorkRequestPoller, global: true)
 
     TaskRepository.threadLocalTask.set(Mock(Task))
     def sgService = Mock(OracleBMCSServerGroupService)
     ResizeOracleBMCSServerGroupAtomicOperation op = new ResizeOracleBMCSServerGroupAtomicOperation(resizeDesc)
     op.oracleBMCSServerGroupService = sgService
 
+
+    def sgProvider = Mock(OracleBMCSClusterProvider)
+    op.clusterProvider = sgProvider
+    def sgViewMock = Mock(ServerGroup)
+    def instanceCounts = new ServerGroup.InstanceCounts()
+    instanceCounts.setUp(3)
+    instanceCounts.setTotal(3)
+
     when:
     op.operate(null)
 
     then:
     1 * sgService.resizeServerGroup(_, _, "sg1", 3)
+    1 * sgService.getServerGroup(_, _, "sg1") >> new OracleBMCSServerGroup(loadBalancerId: "ocid.lb.oc1..12345", name: "sg1", credentials: creds)
+    1 * loadBalancerClient.getLoadBalancer(_) >> GetLoadBalancerResponse.builder()
+      .loadBalancer(LoadBalancer.builder()
+      .backendSets(["sg1-template": BackendSet.builder()
+      .healthChecker(HealthChecker.builder().build())
+      .build()]).build()).build()
+    1 * loadBalancerClient.updateBackendSet(_) >> UpdateBackendSetResponse.builder().opcWorkRequestId("wr1").build()
+    1 * OracleBMCSWorkRequestPoller.poll("wr1", _, _, loadBalancerClient) >> null
+    1 * sgProvider.getServerGroup(_, _, _) >> sgViewMock
+    sgViewMock.instanceCounts >> instanceCounts
   }
 }

--- a/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/agent/OracleBMCSNetworkCachingAgentSpec.groovy
+++ b/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/agent/OracleBMCSNetworkCachingAgentSpec.groovy
@@ -63,12 +63,12 @@ class OracleBMCSNetworkCachingAgentSpec extends Specification {
     def networkClient = Mock(VirtualNetworkClient)
     def vcnId = "ocid.vcn.123"
     def vcnDisplayName = "My Network"
-    def vcn = new Vcn(null, null, null, null, null, vcnDisplayName, vcnId, Vcn.LifecycleState.Available, null)
+    def vcn = new Vcn(null, null, null, null, null, vcnDisplayName, null, vcnId, Vcn.LifecycleState.Available, null, null)
     def vcns = [
       vcn,
-      new Vcn(null, null, null, null, null, "Another network", "ocid.vcn.321", Vcn.LifecycleState.Terminated, null),
-      new Vcn(null, null, null, null, null, "Yet Another network", "ocid.vcn.531", Vcn.LifecycleState.Terminating, null),
-      new Vcn(null, null, null, null, null, "Coming soon network", "ocid.vcn.878", Vcn.LifecycleState.Provisioning, null)
+      new Vcn(null, null, null, null, null, "Another network", null,"ocid.vcn.321", Vcn.LifecycleState.Terminated, null, null),
+      new Vcn(null, null, null, null, null, "Yet Another network", null, "ocid.vcn.531", Vcn.LifecycleState.Terminating, null, null),
+      new Vcn(null, null, null, null, null, "Coming soon network", null, "ocid.vcn.878", Vcn.LifecycleState.Provisioning, null, null)
     ]
 
     networkClient.listVcns(_) >> ListVcnsResponse.builder().items(vcns).build()

--- a/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/agent/OracleBMCSSecurityGroupCachingAgentSpec.groovy
+++ b/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/agent/OracleBMCSSecurityGroupCachingAgentSpec.groovy
@@ -69,7 +69,7 @@ class OracleBMCSSecurityGroupCachingAgentSpec extends Specification {
     def networkClient = Mock(VirtualNetworkClient)
     def vcnId = "ocid.vcn.123"
     def vcns = [
-      new Vcn(null, null, null, null, null, "My Network", vcnId, Vcn.LifecycleState.Available, null)
+      new Vcn(null, null, null, null, null, "My Network", null, vcnId, Vcn.LifecycleState.Available, null, null)
     ]
     def secLists = [
       new SecurityList(null, "My Frontend SecList", null, "ocid.seclist.123", null, SecurityList.LifecycleState.Available, null, vcnId),

--- a/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/agent/OracleBMCSSubnetCachingAgentSpec.groovy
+++ b/clouddriver-oracle-bmcs/src/test/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/agent/OracleBMCSSubnetCachingAgentSpec.groovy
@@ -66,12 +66,12 @@ class OracleBMCSSubnetCachingAgentSpec extends Specification {
     creds.region = Region.US_PHOENIX_1.regionId
     def networkClient = Mock(VirtualNetworkClient)
     def vcnId = "ocid.vcn.123"
-    def vcn = new Vcn(null, null, null, null, null, "My Network", vcnId, Vcn.LifecycleState.Available, null)
-    def subnet = new Subnet("AD1", null, null, null, "My Subnet", "ocid.subnet.123", Subnet.LifecycleState.Available, null, null, null, vcnId, null, null)
+    def vcn = new Vcn(null, null, null, null, null, "My Network", null, vcnId, Vcn.LifecycleState.Available, null, null)
+    def subnet = new Subnet("AD1", null, null, null, "My Subnet", null, "ocid.subnet.123", Subnet.LifecycleState.Available, null, null, null, null, vcnId, null, null)
     def subnets = [
       subnet,
-      new Subnet("AD1", null, null, null, "My Subnet 2", "ocid.subnet.234", Subnet.LifecycleState.Terminated, null, null, null, vcnId, null, null),
-      new Subnet("AD1", null, null, null, "My Subnet 3", "ocid.subnet.567", Subnet.LifecycleState.Provisioning, null, null, null, vcnId, null, null)
+      new Subnet("AD1", null, null, null, "My Subnet 2", null, "ocid.subnet.234", Subnet.LifecycleState.Terminated, null, null, null, null, vcnId, null, null),
+      new Subnet("AD1", null, null, null, "My Subnet 3", null, "ocid.subnet.567", Subnet.LifecycleState.Provisioning, null, null, null, null, vcnId, null, null)
     ]
 
     networkClient.listVcns(_) >> ListVcnsResponse.builder().items([vcn]).build()


### PR DESCRIPTION
You can create an LB with health check and listener.

You can deploy a servergroup and have it attach to the loadbalancer.

Integrates with:
  - Deploy
  - Disable
  - Enabled
  - Resize
