### PR TITLE
fix(requestqueue): adds additional instrumentation.

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequest.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequest.java
@@ -30,7 +30,7 @@ class PooledRequest<T> implements Runnable {
   private final long startTime = System.nanoTime();
 
   PooledRequest(Registry registry, String partition, Callable<T> work) {
-    this.timer = registry.timer(registry.createId("pooledRequest.execute.time", "partition", partition));
+    this.timer = registry.timer(registry.createId("pooledRequestQueue.enqueueTime", "partition", partition));
     this.result = new Promise<>(registry, partition);
     this.work = work;
   }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/Promise.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/Promise.java
@@ -81,7 +81,7 @@ class Promise<T> {
     try {
       if (!latch.await(timeout, unit)) {
         registry.counter(registry.createId("pooledRequestQueue.promise.timeout", "partition", partition)).increment();
-        completeWithException(new TimeoutException());
+        completeWithException(new PromiseTimeoutException());
       }
     } catch (Throwable t) {
       completeWithException(t);

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PromiseTimeoutException.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PromiseTimeoutException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
+
+import java.util.concurrent.TimeoutException;
+
+class PromiseTimeoutException extends TimeoutException {
+  PromiseTimeoutException() {
+    super();
+  }
+}

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueueSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueueSpec.groovy
@@ -41,6 +41,6 @@ class PooledRequestQueueSpec extends Specification {
     Long result = queue.execute("foo", { Thread.sleep(20); return 12345L })
 
     then:
-    thrown(TimeoutException)
+    thrown(PromiseTimeoutException)
   }
 }


### PR DESCRIPTION
* renames pooledRequest.execute.time to pooledRequestQueue.enqueueTime to reflect the time spent waiting for a thread to run on
* adds pooledRequestQueue.totalTime to capture the total time from submission to completion (either result, exception or timeout)
* adds a specific exception with the request times out to differentiate between timeout in the queue vs a timeout as part of normal processing.
