### PR TITLE
fix(provider/google): Don't NPE when machine types aren't returned. (…

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/security/GoogleNamedAccountCredentials.groovy
@@ -284,10 +284,17 @@ class GoogleNamedAccountCredentials implements AccountCredentials<GoogleCredenti
     def locationToInstanceTypesMap = instanceTypeList.items.collectEntries { zone, machineTypesScopedList ->
       zone = GCEUtil.getLocalName(zone)
 
-      return [(zone): [
-        instanceTypes: machineTypesScopedList.machineTypes.collect { it.name },
-        vCpuMax: machineTypesScopedList.machineTypes.max { it.guestCpus }.guestCpus
-      ]]
+      if (machineTypesScopedList.machineTypes) {
+        return [(zone): [
+          instanceTypes: machineTypesScopedList.machineTypes.collect { it.name },
+          vCpuMax      : machineTypesScopedList.machineTypes.max { it.guestCpus }.guestCpus
+        ]]
+      } else {
+        return [(zone): [
+          instanceTypes: [],
+          vCpuMax      : 0
+        ]]
+      }
     }
 
     // Populate region to instance types mappings.


### PR DESCRIPTION
…#1672)

Cherry-pick GCE NPE fix (https://github.com/spinnaker/clouddriver/pull/1672) into 1.0.x.