### PR TITLE
feat(provider/kubernetes): Run Job Pod Labels

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
@@ -34,4 +34,5 @@ class RunKubernetesJobDescription extends KubernetesAtomicOperationDescription {
   Map<String, String> nodeSelector
   KubernetesContainerDescription container
   List<KubernetesVolumeSource> volumeSources
+  Map<String, String> labels
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -63,7 +63,9 @@ class RunKubernetesJobAtomicOperation implements AtomicOperation<DeploymentResul
     def podName = (new KubernetesJobNameResolver()).createJobName(description.application, description.stack, description.freeFormDetails)
     task.updateStatus BASE_PHASE, "JobStatus name chosen to be ${podName}."
 
-    def podBuilder = new PodBuilder().withNewMetadata().withNamespace(namespace).withName(podName).withLabels([:]).endMetadata().withNewSpec()
+    def podLabels = description?.labels ?: [:]
+
+    def podBuilder = new PodBuilder().withNewMetadata().withNamespace(namespace).withName(podName).withLabels(podLabels).endMetadata().withNewSpec()
     podBuilder.withRestartPolicy("Never")
     if (description.volumeSources) {
       List<Volume> volumeSources = description.volumeSources.findResults { volumeSource ->


### PR DESCRIPTION
Provide a way to define a set of labels on a Run Job pod. Useful for
being able to pin point specific pods for logging purposes. Adds a Map
for labels in the Run Job description and applies them if they're set.
Does not impact current without a `labels` field.

Part of [#1683](https://github.com/spinnaker/spinnaker/issues/1683). Deck PR coming soon.

@lwander PTAL
