### PR TITLE
feat(provider/kubernetes): Annotation config

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
@@ -35,4 +35,5 @@ class RunKubernetesJobDescription extends KubernetesAtomicOperationDescription {
   KubernetesContainerDescription container
   List<KubernetesVolumeSource> volumeSources
   Map<String, String> labels
+  Map<String, String> annotations
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -64,8 +64,9 @@ class RunKubernetesJobAtomicOperation implements AtomicOperation<DeploymentResul
     task.updateStatus BASE_PHASE, "JobStatus name chosen to be ${podName}."
 
     def podLabels = description?.labels ?: [:]
+    def podAnnotations = description?.annotations ?: [:]
 
-    def podBuilder = new PodBuilder().withNewMetadata().withNamespace(namespace).withName(podName).withLabels(podLabels).endMetadata().withNewSpec()
+    def podBuilder = new PodBuilder().withNewMetadata().withNamespace(namespace).withName(podName).withLabels(podLabels).withAnnotations(podAnnotations).endMetadata().withNewSpec()
     podBuilder.withRestartPolicy("Never")
     if (description.volumeSources) {
       List<Volume> volumeSources = description.volumeSources.findResults { volumeSource ->


### PR DESCRIPTION
Adds the ability to configure Pod annotations on the pod created by the
Run Job stage. Similar to #1683, this is useful for pin pointing pods
for logging purposes. There is a Deck PR which adds support for both
Labels and Pods.

@lwander very similar to the last one. PTAL.