### PR TITLE
fix(requestQueue): differentiate timeout in queue vs in processing.

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
@@ -70,11 +70,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 
   @Bean
   RequestQueue requestQueue(RequestQueueConfiguration requestQueueConfiguration, Registry registry) {
-    if (!requestQueueConfiguration.enabled) {
-      return RequestQueue.noop()
-    }
-
-    return RequestQueue.pooled(registry, requestQueueConfiguration.timeoutMillis, requestQueueConfiguration.poolSize)
+    return RequestQueue.forConfig(registry, requestQueueConfiguration);
   }
 
   @Bean

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/QueuedRequestException.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/QueuedRequestException.java
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
+package com.netflix.spinnaker.clouddriver.requestqueue;
 
-import com.netflix.spinnaker.clouddriver.requestqueue.QueuedRequestException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-class PromiseTimeoutException extends QueuedRequestException {
-  PromiseTimeoutException() {
+@ResponseStatus(value = HttpStatus.TOO_MANY_REQUESTS)
+public class QueuedRequestException extends RuntimeException {
+  public QueuedRequestException() {
     super();
   }
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/RequestQueueConfiguration.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/RequestQueueConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("requestQueue")
 public class RequestQueueConfiguration {
   private boolean enabled = false;
+  private long startWorkTimeoutMillis = RequestQueue.DEFAULT_START_WORK_TIMEOUT_MILLIS;
   private long timeoutMillis = RequestQueue.DEFAULT_TIMEOUT_MILLIS;
   private int poolSize = 10;
 
@@ -30,6 +31,14 @@ public class RequestQueueConfiguration {
 
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
+  }
+
+  public long getStartWorkTimeoutMillis() {
+    return startWorkTimeoutMillis;
+  }
+
+  public void setStartWorkTimeoutMillis(long startWorkTimeoutMillis) {
+    this.startWorkTimeoutMillis = startWorkTimeoutMillis;
   }
 
   public long getTimeoutMillis() {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequest.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequest.java
@@ -48,7 +48,7 @@ class PooledRequest<T> implements Runnable {
     timer.record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
     //request may have expired with a timeout prior to this point, lets not
     // issue the work if that is the case as the caller has already moved on
-    if (!result.isComplete()) {
+    if (result.shouldStart()) {
       try {
         result.complete(work.call());
       } catch (Throwable t) {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PromiseNotStartedException.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PromiseNotStartedException.java
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
 
 import com.netflix.spinnaker.clouddriver.requestqueue.QueuedRequestException;
 
-class PromiseTimeoutException extends QueuedRequestException {
-  PromiseTimeoutException() {
+class PromiseNotStartedException extends QueuedRequestException {
+  PromiseNotStartedException() {
     super();
   }
 }

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueueSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueueSpec.groovy
@@ -19,12 +19,14 @@ package com.netflix.spinnaker.clouddriver.requestqueue.pooled
 import com.netflix.spectator.api.NoopRegistry
 import spock.lang.Specification
 
-import java.util.concurrent.TimeoutException
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
 
 class PooledRequestQueueSpec extends Specification {
   def "should execute requests"() {
     given:
-    def queue = new PooledRequestQueue(new NoopRegistry(), 10, 1)
+    def queue = new PooledRequestQueue(new NoopRegistry(), 10, 10, 1)
 
     when:
     Long result = queue.execute("foo", { return 12345L })
@@ -35,12 +37,44 @@ class PooledRequestQueueSpec extends Specification {
 
   def "should time out if request does not complete"() {
     given:
-    def queue = new PooledRequestQueue(new NoopRegistry(), 10, 1)
+    def queue = new PooledRequestQueue(new NoopRegistry(), 5000, 10, 1)
 
     when:
-    Long result = queue.execute("foo", { Thread.sleep(20); return 12345L })
+    queue.execute("foo", { Thread.sleep(20); return 12345L })
 
     then:
     thrown(PromiseTimeoutException)
+  }
+
+  def "should time out if request does not start in time"() {
+    given: "a queue with one worker thread"
+    def queue = new PooledRequestQueue(new NoopRegistry(), 10, 10, 1)
+    AtomicBoolean itRan = new AtomicBoolean(false)
+    Callable<Void> didItRun = {
+      itRan.set(true)
+    }
+
+    when: "we start up a thread that blocks the pool"
+    def latch = new CountDownLatch(1)
+    Callable<Void> jerkThread = {
+      latch.countDown()
+      Thread.sleep(40)
+    }
+
+    Thread.start {
+      try {
+        queue.execute("foo", jerkThread)
+      } catch (PromiseTimeoutException) {
+        //expected
+      }
+    }
+
+    and: "try to start another"
+    latch.await()
+    queue.execute("foo", didItRun)
+
+    then: "the second work is never started"
+    thrown(PromiseNotStartedException)
+    !itRan.get()
   }
 }

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/RequestDistributorSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/RequestDistributorSpec.groovy
@@ -53,8 +53,8 @@ class RequestDistributorSpec extends Specification {
     0 * _
 
     reqs.size() == 2
-    reqs[0].getPromise().blockingGetOrThrow(1, TimeUnit.MILLISECONDS) == 0
-    reqs[1].getPromise().blockingGetOrThrow(1, TimeUnit.MILLISECONDS) == 2
+    reqs[0].getPromise().blockingGetOrThrow(1, 1, TimeUnit.MILLISECONDS) == 0
+    reqs[1].getPromise().blockingGetOrThrow(1, 1, TimeUnit.MILLISECONDS) == 2
 
   }
 }


### PR DESCRIPTION
Allows a separate (shorter) timeout for how long a message can queue up before being rejected.

Requests that time out from the request queue fail with HTTP 429