### PR TITLE
fix(provider/kubernetes): Update HPA endpoint for k8s 1.6

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -6,5 +6,5 @@ dependencies {
   compile spinnaker.dependency('bootWeb')
 
   // TODO (move to https://github.com/spinnaker/spinnaker-dependencies/blob/master/src/spinnaker-dependencies.yml)
-  compile 'io.fabric8:kubernetes-client:2.3.1'
+  compile 'io.fabric8:kubernetes-client:2.4.1'
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -419,28 +419,28 @@ class KubernetesApiAdaptor {
 
   HorizontalPodAutoscaler createAutoscaler(String namespace, HorizontalPodAutoscaler autoscaler) {
     exceptionWrapper("horizontalPodAutoscalers.create", "Create Autoscaler ${autoscaler?.metadata?.name}", namespace) {
-      client.extensions().horizontalPodAutoscalers().inNamespace(namespace).create(autoscaler)
+      client.autoscaling().horizontalPodAutoscalers().inNamespace(namespace).create(autoscaler)
     }
   }
 
   HorizontalPodAutoscaler getAutoscaler(String namespace, String name) {
     exceptionWrapper("horizontalPodAutoscalers.get", "Get Autoscaler $name", namespace) {
-      client.extensions().horizontalPodAutoscalers().inNamespace(namespace).withName(name).get()
+      client.autoscaling().horizontalPodAutoscalers().inNamespace(namespace).withName(name).get()
     }
   }
 
   Map<String, HorizontalPodAutoscaler> getAutoscalers(String namespace, String kind) {
     exceptionWrapper("horizontalPodAutoscalers.list", "Get Autoscalers", namespace) {
-      def items = client.extensions().horizontalPodAutoscalers().inNamespace(namespace).list().items ?: []
+      def items = client.autoscaling().horizontalPodAutoscalers().inNamespace(namespace).list().items ?: []
       items.collectEntries { def autoscaler ->
-        autoscaler.spec.scaleRef.kind == kind ? [(autoscaler.metadata.name): autoscaler] : [:]
+        autoscaler.spec.scaleTargetRef.kind == kind ? [(autoscaler.metadata.name): autoscaler] : [:]
       }
     }
   }
 
   boolean deleteAutoscaler(String namespace, String name) {
     exceptionWrapper("horizontalPodAutoscalers.delete", "Destroy Autoscaler $name", namespace) {
-      client.extensions().horizontalPodAutoscalers().inNamespace(namespace).withName(name).delete()
+      client.autoscaling().horizontalPodAutoscalers().inNamespace(namespace).withName(name).delete()
     }
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -634,7 +634,7 @@ class KubernetesApiConverter {
     description.capacity = new Capacity(min: autoscaler.spec.minReplicas,
                                         max: autoscaler.spec.maxReplicas,
                                         desired: description.targetSize)
-    def cpuUtilization = new KubernetesCpuUtilization(target: autoscaler.spec.cpuUtilization.targetPercentage)
+    def cpuUtilization = new KubernetesCpuUtilization(target: autoscaler.spec.targetCPUUtilizationPercentage)
     description.scalingPolicy = new KubernetesScalingPolicy(cpuUtilization: cpuUtilization)
   }
 
@@ -649,13 +649,11 @@ class KubernetesApiConverter {
       .withNewSpec()
       .withMinReplicas(description.capacity.min)
       .withMaxReplicas(description.capacity.max)
-      .withNewCpuUtilization()
-      .withTargetPercentage(description.scalingPolicy.cpuUtilization.target)
-      .endCpuUtilization()
-      .withNewScaleRef()
+      .withTargetCPUUtilizationPercentage(description.scalingPolicy.cpuUtilization.target)
+      .withNewScaleTargetRef()
       .withKind(resourceKind)
       .withName(resourceName)
-      .endScaleRef()
+      .endScaleTargetRef()
       .endSpec().build()
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/autoscaler/UpsertKubernetesAutoscalerAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/autoscaler/UpsertKubernetesAutoscalerAtomicOperation.groovy
@@ -78,7 +78,7 @@ class UpsertKubernetesAutoscalerAtomicOperation implements AtomicOperation<Void>
       description.scalingPolicy.cpuUtilization = description.scalingPolicy.cpuUtilization ?: new KubernetesCpuUtilization()
       description.scalingPolicy.cpuUtilization.target = description.scalingPolicy.cpuUtilization.target != null ?
         description.scalingPolicy.cpuUtilization.target :
-        autoscaler.spec.cpuUtilization.targetPercentage
+        autoscaler.spec.targetCPUUtilizationPercentage
 
       task.updateStatus BASE_PHASE, "Deleting old autoscaler..."
       credentials.apiAdaptor.deleteAutoscaler(namespace, name)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesAutoscalerStatus.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesAutoscalerStatus.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.model
 
-import io.fabric8.kubernetes.api.model.extensions.HorizontalPodAutoscaler
+import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler
 
 class KubernetesAutoscalerStatus {
   Integer currentCpuUtilization

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -29,7 +29,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import io.fabric8.kubernetes.api.model.Event
 import io.fabric8.kubernetes.api.model.ReplicationController
-import io.fabric8.kubernetes.api.model.extensions.HorizontalPodAutoscaler
+import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet
 import io.fabric8.kubernetes.client.internal.SerializationUtils
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -37,7 +37,7 @@ import groovy.util.logging.Slf4j
 import io.fabric8.kubernetes.api.model.Event
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.ReplicationController
-import io.fabric8.kubernetes.api.model.extensions.HorizontalPodAutoscaler
+import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/1651

This updates kubernentes-client with this fix: https://github.com/fabric8io/kubernetes-client/pull/780

Changes between the two APIs:
> * Field CPUUtilization which was a nested structure CPUTargetUtilization in HorizontalPodAutoscalerSpec was replaced by TargetCPUUtilizationPercentage which is an integer.
> * ScaleRef of type SubresourceReference in HorizontalPodAutoscalerSpec which referred to scale subresource of the resource being scaled was replaced by ScaleTargetRef which points just to the resource being scaled.

This is necessary for supporting Kubernetes 1.6, but breaks support for Kubernetes 1.1. I'm not sure what the officially supported versions are.