### PR TITLE
fix(cats): Remove lock key from Redis when agent is unscheduled.

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -147,6 +147,7 @@ public class ClusteredAgentScheduler extends CatsModuleAware implements AgentSch
 
     @Override
     public void unschedule(Agent agent) {
+        releaseRunKey(agent.getAgentType(), 0); // Delete lock key now.
         agents.remove(agent.getAgentType());
     }
 


### PR DESCRIPTION
I wanted a way for a single Fiat instance to come up (and resync) shortly after a previous one is taken down. Because Fiat's default timeout is significantly longer than Clouddrivers (10min vs 30s), I was having to wait for the whole timeout to elapse before a resync would occur. Deleting the lock key is the proper way to get around this.  I plan on using this within a shutdown hook in Fiat.

As for Clouddriver, `unschedule` is used when accounts are deleted, which should probably cleanup its keys during deletion anyway.