### PR TITLE
fix(provider/google): Handle empty xpn resources.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/callbacks/Utils.groovy
@@ -273,6 +273,9 @@ class Utils {
   }
 
   static String decorateXpnResourceIdIfNeeded(String managedProjectId, String xpnResource) {
+    if (!xpnResource) {
+      return xpnResource
+    }
     def xpnResourceProject = GCEUtil.deriveProjectId(xpnResource)
     def xpnResourceId = GCEUtil.getLocalName(xpnResource)
 


### PR DESCRIPTION
Avoids parsing xpn resources that are missing or empty. The immediate use case where this arises is cloning a server group that has `network = default`, and hence no `subnet` defined. The child deploy description will not have a `subnet` present, which we can't parse even though the description is valid.