### PR TITLE
fix(kubernetes): allow configMaps to have no items

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/KubernetesVolumeSourceValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/KubernetesVolumeSourceValidator.groovy
@@ -56,8 +56,7 @@ class KubernetesVolumeSourceValidator {
         break
 
       case KubernetesVolumeSourceType.ConfigMap:
-        if (!(helper.validateNotEmpty(source.configMap, "${prefix}.configMap") &&
-            helper.validateNotEmpty(source.configMap.items, "${prefix}.configMap.items"))) {
+        if (! helper.validateNotEmpty(source.configMap, "${prefix}.configMap")) {
           break
         }
         helper.validateNotEmpty(source.configMap.configMapName, "${prefix}.configMap.configMapName")


### PR DESCRIPTION
Having a configMap volume source with zero key/path pairs is allowed by kubernetes, but is rejected by the clouddriver pipeline validator. Having no items in a configMap already works fine if you manually create a server group, presumably b/c server group validation is implemented separately. However if you take this manually created server group and import it as your server group template in a pipeline, the resulting pipeline does not execute b/c of the strict validation that is loosened by this PR.

Addresses https://github.com/spinnaker/spinnaker/issues/1622