### PR TITLE
fix(amazon): send correct source region when copying scaling policies

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.handlers
 
-import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.autoscaling.model.BlockDeviceMapping
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
 import com.amazonaws.services.autoscaling.model.LaunchConfiguration
@@ -286,7 +285,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
           task, sourceRegionScopedProvider,
           regionScopedProvider.amazonCredentials, description.credentials,
           description.source.asgName, asgName,
-          regionScopedProvider.region, region
+          description.source.region, region
         )
       }
 
@@ -379,7 +378,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
                                               NetflixAmazonCredentials targetCredentials,
                                               String sourceAsgName,
                                               String targetAsgName,
-                                              String sourceRegions,
+                                              String sourceRegion,
                                               String targetRegion) {
     if (!sourceRegionScopedProvider) {
       return
@@ -387,7 +386,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
 
     def asgReferenceCopier = sourceRegionScopedProvider.getAsgReferenceCopier(targetCredentials, targetRegion)
     scalingPolicyCopier.copyScalingPolicies(task, sourceAsgName, targetAsgName,
-      sourceCredentials, targetCredentials, sourceRegions, targetRegion)
+      sourceCredentials, targetCredentials, sourceRegion, targetRegion)
     asgReferenceCopier.copyScheduledActionsForAsg(task, sourceAsgName, targetAsgName)
   }
 


### PR DESCRIPTION
Fixes an issue when cloning an ASG across regions - we're currently trying to look up scaling policies from the target region instead of the source, which will cause the operation to either a) fail when it can't find the source ASG or b) copy potentially incorrect scaling policies if there is an ASG in the target region with the same name as the ASG in the source region.