### PR TITLE
feat(provider/kubernetes): Configure Service Acct

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -624,6 +624,7 @@ class KubernetesApiConverter {
     } ?: []
 
     deployDescription.terminationGracePeriodSeconds = replicaSet?.spec?.template?.spec?.terminationGracePeriodSeconds
+    deployDescription.serviceAccountName = replicaSet?.spec?.template?.spec?.serviceAccountName
 
     deployDescription.nodeSelector = replicaSet?.spec?.template?.spec?.nodeSelector
 
@@ -680,6 +681,7 @@ class KubernetesApiConverter {
     } ?: []
 
     deployDescription.terminationGracePeriodSeconds = replicationController?.spec?.template?.spec?.terminationGracePeriodSeconds
+    deployDescription.serviceAccountName = replicationController.spec?.template?.spec?.serviceAccountName
 
     deployDescription.nodeSelector = replicationController?.spec?.template?.spec?.nodeSelector
 
@@ -907,6 +909,10 @@ class KubernetesApiConverter {
 
     for (def imagePullSecret : description.imagePullSecrets) {
       podTemplateSpecBuilder = podTemplateSpecBuilder.addNewImagePullSecret(imagePullSecret)
+    }
+
+    if (description.serviceAccountName) {
+      podTemplateSpecBuilder = podTemplateSpecBuilder.withServiceAccountName(description.serviceAccountName)
     }
 
     podTemplateSpecBuilder = podTemplateSpecBuilder.withNodeSelector(description.nodeSelector)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
@@ -36,4 +36,5 @@ class RunKubernetesJobDescription extends KubernetesAtomicOperationDescription {
   List<KubernetesVolumeSource> volumeSources
   Map<String, String> labels
   Map<String, String> annotations
+  String serviceAccountName
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -45,6 +45,7 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesAtomicOperati
   KubernetesSecurityContext securityContext
   KubernetesDeployment deployment
   Long terminationGracePeriodSeconds
+  String serviceAccountName
   Integer sequence
   KubernetesPodSpecDescription podSpec
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -80,6 +80,10 @@ class RunKubernetesJobAtomicOperation implements AtomicOperation<DeploymentResul
       podBuilder = podBuilder.addNewImagePullSecret(imagePullSecret)
     }
 
+    if (description.serviceAccountName) {
+      podBuilder = podBuilder.withServiceAccountName(description.serviceAccountName)
+    }
+
     if (description.hostNetwork) {
         podBuilder = podBuilder.withHostNetwork(description.hostNetwork)
     }


### PR DESCRIPTION
Allows Service Account to be configured for both Server Group and Run
Job Pipeline stage. I also added it to the `fromReplicationController`
in the event that someone is using ReplicationControllers pre-Spinnaker.

@danielpeach PTAL
@lwander FYI