### PR TITLE
fix(amazon): explicitly declare volumeType for default block devices

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -75,6 +75,9 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
   )
 
   @Shared
+  BlockDeviceConfig blockDeviceConfig = new BlockDeviceConfig(deployDefaults)
+
+  @Shared
   Task task = Mock(Task)
 
   AmazonEC2 amazonEC2 = Mock(AmazonEC2)
@@ -99,7 +102,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     def defaults = new AwsConfiguration.DeployDefaults(iamRole: 'IamRole')
     def credsRepo = new MapBackedAccountCredentialsRepository()
     credsRepo.save('baz', TestCredential.named('baz'))
-    this.handler = new BasicAmazonDeployHandler(rspf, credsRepo, defaults, scalingPolicyCopier) {
+    this.handler = new BasicAmazonDeployHandler(rspf, credsRepo, defaults, scalingPolicyCopier, blockDeviceConfig) {
       @Override
       LoadBalancerLookupHelper loadBalancerLookupHelper() {
         return new LoadBalancerLookupHelper()
@@ -682,7 +685,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     })
 
     when:
-    def blockDeviceMappings = BasicAmazonDeployHandler.buildBlockDeviceMappings(deployDefaults, description, launchConfiguration)
+    def blockDeviceMappings = handler.buildBlockDeviceMappings(description, launchConfiguration)
 
     then:
     convertBlockDeviceMappings(blockDeviceMappings) == convertBlockDeviceMappings(expectedTargetBlockDevices)
@@ -715,7 +718,7 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
   }
 
   private Collection<AmazonBlockDevice> bD(String instanceType) {
-    return BlockDeviceConfig.getBlockDevicesForInstanceType(deployDefaults, instanceType)
+    return blockDeviceConfig.getBlockDevicesForInstanceType(instanceType)
   }
 
   private Collection<Map> convertBlockDeviceMappings(Collection<AmazonBlockDevice> blockDevices) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperationSpec.groovy
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.LaunchConfigurationBuilder
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyAsgLaunchConfigurationDescription
 import com.netflix.spinnaker.clouddriver.aws.services.AsgService
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -46,7 +47,11 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
 
   def description = new ModifyAsgLaunchConfigurationDescription()
 
+  @Shared
   def defaults = new AwsConfiguration.DeployDefaults(classicLinkSecurityGroupName: 'nf-classiclink')
+
+  @Shared
+  def blockDeviceConfig = new BlockDeviceConfig(defaults)
 
   @Subject op = new ModifyAsgLaunchConfigurationOperation(description)
 
@@ -79,6 +84,8 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
     }
 
     op.regionScopedProviderFactory = regionScopedProviderFactory
+
+    op.blockDeviceConfig = blockDeviceConfig
   }
 
   void 'should not modify launch configuration if no changes would result'() {
@@ -381,7 +388,7 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
       assert settings.suffix == null
       assert legacyUdf == null
       assert settings.instanceType == 'm4.xlarge'
-      assert settings.blockDevices == BlockDeviceConfig.getBlockDevicesForInstanceType(defaults, 'm4.xlarge')
+      assert settings.blockDevices == blockDeviceConfig.getBlockDevicesForInstanceType('m4.xlarge')
 
       return newLc
     }
@@ -410,7 +417,7 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
         ami: 'ami-f111f333',
         iamRole: 'BaseIAMRole',
         instanceType: 'm3.xlarge',
-        blockDevices: BlockDeviceConfig.getBlockDevicesForInstanceType(defaults, 'm3.xlarge'),
+        blockDevices: blockDeviceConfig.getBlockDevicesForInstanceType('m3.xlarge'),
         keyPair: 'sekret',
         associatePublicIpAddress: false,
         ebsOptimized: true,
@@ -513,7 +520,7 @@ class ModifyAsgLaunchConfigurationOperationSpec extends Specification {
       assert settings.suffix == null
       assert legacyUdf == null
       assert settings.instanceType == 'm4.xlarge'
-      assert settings.blockDevices == BlockDeviceConfig.getBlockDevicesForInstanceType(defaults, 'm4.xlarge')
+      assert settings.blockDevices == blockDeviceConfig.getBlockDevicesForInstanceType('m4.xlarge')
 
       return newLc
     }


### PR DESCRIPTION
**For review only - should not be merged yet**

`gp2` is going to be the default volume type at some point in the very near future, which will cause us grief at Netflix when we update our AWS client version.