### PR TITLE
feat(kubernetes): cache additional resources

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -362,8 +362,26 @@ class KubernetesApiAdaptor {
   }
 
   Secret createSecret(String namespace, Secret secret) {
-    exceptionWrapper("secretes.create", "Create Secret $secret", namespace) {
+    exceptionWrapper("secrets.create", "Create Secret $secret", namespace) {
       client.secrets().inNamespace(namespace).create(secret)
+    }
+  }
+
+  List<Secret> getSecrets(String namespace) {
+    exceptionWrapper("secrets.list", "Get Secrets", namespace) {
+      client.secrets().inNamespace(namespace).list().items
+    }
+  }
+
+  List<ServiceAccount> getServiceAccounts(String namespace) {
+    exceptionWrapper("serviceAccounts.list", "Get Service Accounts", namespace) {
+      client.serviceAccounts().inNamespace(namespace).list().items
+    }
+  }
+
+  List<ConfigMap> getConfigMaps(String namespace) {
+   exceptionWrapper("configMaps.list", "Get Config Maps", namespace) {
+      client.configMaps().inNamespace(namespace).list().items
     }
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/cache/Keys.groovy
@@ -29,6 +29,9 @@ class Keys {
     EVENTS,
     DEPLOYMENTS,
     ON_DEMAND,
+    SERVICE_ACCOUNTS,
+    CONFIG_MAPS,
+    SECRETS,
 
     static String provider = "kubernetes"
 
@@ -138,11 +141,37 @@ class Keys {
           detail: names.detail,
         ]
         break
+      case Namespace.SERVICE_ACCOUNTS.ns:
+        result << [
+          account: parts[2],
+          namespace: parts[3],
+          region: parts[3],
+          name: parts[4],
+          serviceAccountName: parts[4],
+        ]
+        break
+      case Namespace.CONFIG_MAPS.ns:
+        result << [
+          account: parts[2],
+          namespace: parts[3],
+          region: parts[3],
+          name: parts[4],
+          configMapName: parts[4],
+        ]
+        break
+      case Namespace.SECRETS.ns:
+        result << [
+          account: parts[2],
+          namespace: parts[3],
+          region: parts[3],
+          name: parts[4],
+          secretName: parts[4],
+        ]
+        break
       default:
         return null
         break
     }
-
     result
   }
 
@@ -172,5 +201,17 @@ class Keys {
 
   static String getDeploymentKey(String account, String namespace, String deploymentName) {
     "${Namespace.provider}:${Namespace.DEPLOYMENTS}:${account}:${namespace}:${deploymentName}"
+  }
+
+  static String getServiceAccountKey(String account, String namespace, String serviceAccountName) {
+    "${Namespace.provider}:${Namespace.SERVICE_ACCOUNTS}:${account}:${namespace}:${serviceAccountName}"
+  }
+
+  static String getConfigMapKey(String account, String namespace, String configMapName) {
+    "${Namespace.provider}:${Namespace.CONFIG_MAPS}:${account}:${namespace}:${configMapName}"
+  }
+
+  static String getSecretKey(String account, String namespace, String secretName) {
+    "${Namespace.provider}:${Namespace.SECRETS}:${account}:${namespace}:${secretName}"
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesProvider.groovy
@@ -21,9 +21,13 @@ import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
 import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import groovy.util.logging.Slf4j
 
 import static com.netflix.spinnaker.clouddriver.cache.SearchableProvider.SearchableResource
 
+@Slf4j
 class KubernetesProvider extends AgentSchedulerAware implements SearchableProvider {
   public static final String PROVIDER_NAME = KubernetesProvider.name
 
@@ -42,7 +46,10 @@ class KubernetesProvider extends AgentSchedulerAware implements SearchableProvid
       Keys.Namespace.CLUSTERS.ns,
       Keys.Namespace.SERVER_GROUPS.ns,
       Keys.Namespace.INSTANCES.ns,
-      Keys.Namespace.SECURITY_GROUPS.ns
+      Keys.Namespace.SECURITY_GROUPS.ns,
+      Keys.Namespace.SERVICE_ACCOUNTS.ns,
+      Keys.Namespace.CONFIG_MAPS.ns,
+      Keys.Namespace.SECRETS.ns,
   ].asImmutable()
 
   @Override
@@ -50,10 +57,57 @@ class KubernetesProvider extends AgentSchedulerAware implements SearchableProvid
     return PROVIDER_NAME
   }
 
-  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = Collections.emptyMap()
+  final Map<SearchableResource, SearchableProvider.SearchResultHydrator> searchResultHydrators = [
+    (new KubernetesSearchableResource(Keys.Namespace.SERVICE_ACCOUNTS.ns)): new ServiceAccountResultHydrator(),
+    (new KubernetesSearchableResource(Keys.Namespace.CONFIG_MAPS.ns)): new ConfigMapResultHydrator(),
+    (new KubernetesSearchableResource(Keys.Namespace.SECRETS.ns)): new SecretResultHydrator(),
+  ]
 
   @Override
   Map<String, String> parseKey(String key) {
     return Keys.parse(key)
+  }
+
+  private static class KubernetesSearchableResource extends SearchableResource {
+    public KubernetesSearchableResource(String resourceType) {
+      this.resourceType = resourceType.toLowerCase()
+      this.platform = "kubernetes"
+    }
+  }
+
+  private static class ServiceAccountResultHydrator implements SearchableProvider.SearchResultHydrator {
+
+    @Override
+    Map<String,String> hydrateResult(Cache cacheView, Map<String,String> result, String id) {
+      CacheData sa = cacheView.get(Keys.Namespace.SERVICE_ACCOUNTS.ns, id)
+      return result + [
+        name: sa.attributes.name as String,
+        namespace: sa.attributes.namespace as String
+      ]
+    }
+  }
+
+  private static class ConfigMapResultHydrator implements SearchableProvider.SearchResultHydrator {
+
+    @Override
+    Map<String,String> hydrateResult(Cache cacheView, Map<String,String> result, String id) {
+      CacheData cm = cacheView.get(Keys.Namespace.CONFIG_MAPS.ns, id)
+      return result + [
+        name: cm.attributes.name as String,
+        namespace: cm.attributes.namespace as String
+      ]
+    }
+  }
+
+  private static class SecretResultHydrator implements SearchableProvider.SearchResultHydrator {
+
+    @Override
+    Map<String,String> hydrateResult(Cache cacheView, Map<String,String> result, String id) {
+      CacheData secret = cacheView.get(Keys.Namespace.SECRETS.ns, id)
+      return result + [
+        name: secret.attributes.name as String,
+        namespace: secret.attributes.namespace as String
+      ]
+    }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesConfigMapCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesConfigMapCachingAgent.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Skuid, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.*
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.view.MutableCacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import groovy.util.logging.Slf4j
+import io.fabric8.kubernetes.api.model.ConfigMap
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+
+@Slf4j
+class KubernetesConfigMapCachingAgent extends KubernetesCachingAgent {
+  static final Set<AgentDataType> types = Collections.unmodifiableSet([
+      AUTHORITATIVE.forType(Keys.Namespace.CONFIG_MAPS.ns),
+  ] as Set)
+
+  KubernetesConfigMapCachingAgent(String accountName,
+                                 KubernetesCredentials credentials,
+                                 ObjectMapper objectMapper,
+                                 int agentIndex,
+                                 int agentCount) {
+    super(accountName, objectMapper, credentials, agentIndex, agentCount)
+  }
+
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    return types
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    log.info("Loading config maps in $agentType")
+    reloadNamespaces()
+
+    def configMaps = namespaces.collect { String namespace ->
+      credentials.apiAdaptor.getConfigMaps(namespace)
+    }.flatten()
+
+    buildCacheResult(configMaps)
+  }
+
+  private CacheResult buildCacheResult(List<ConfigMap> configMaps) {
+    log.info("Describing items in ${agentType}")
+
+    Map<String, MutableCacheData> cachedConfigMaps = MutableCacheData.mutableCacheMap()
+
+    for (ConfigMap cm : configMaps) {
+      if (!cm) {
+        continue
+      }
+
+      def key = Keys.getConfigMapKey(accountName, cm.metadata.namespace, cm.metadata.name)
+
+      cachedConfigMaps[key].with {
+        attributes.name = cm.metadata.name
+        attributes.namespace = cm.metadata.namespace
+      }
+
+    }
+
+    log.info("Caching ${cachedConfigMaps.size()} configmaps in ${agentType}")
+
+    new DefaultCacheResult([
+        (Keys.Namespace.CONFIG_MAPS.ns): cachedConfigMaps.values(),
+    ], [:])
+  }
+
+  @Override
+  String getSimpleName() {
+    KubernetesConfigMapCachingAgent.simpleName
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesSecretCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesSecretCachingAgent.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Skuid, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.*
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.view.MutableCacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import groovy.util.logging.Slf4j
+import io.fabric8.kubernetes.api.model.Secret
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+
+@Slf4j
+class KubernetesSecretCachingAgent extends KubernetesCachingAgent {
+  static final Set<AgentDataType> types = Collections.unmodifiableSet([
+      AUTHORITATIVE.forType(Keys.Namespace.SECRETS.ns),
+  ] as Set)
+
+  KubernetesSecretCachingAgent(String accountName,
+                                 KubernetesCredentials credentials,
+                                 ObjectMapper objectMapper,
+                                 int agentIndex,
+                                 int agentCount) {
+    super(accountName, objectMapper, credentials, agentIndex, agentCount)
+  }
+
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    return types
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    log.info("Loading secrets in $agentType")
+    reloadNamespaces()
+
+    def secrets = namespaces.collect { String namespace ->
+      credentials.apiAdaptor.getSecrets(namespace)
+    }.flatten()
+
+    buildCacheResult(secrets)
+  }
+
+  private CacheResult buildCacheResult(List<Secret> secrets) {
+    log.info("Describing items in ${agentType}")
+
+    Map<String, MutableCacheData> cachedSecrets = MutableCacheData.mutableCacheMap()
+
+    for (Secret secret : secrets) {
+      if (!secret) {
+        continue
+      }
+
+      def key = Keys.getSecretKey(accountName, secret.metadata.namespace, secret.metadata.name)
+
+      cachedSecrets[key].with {
+        attributes.name = secret.metadata.name
+        attributes.namespace = secret.metadata.namespace
+      }
+
+    }
+
+    log.info("Caching ${cachedSecrets.size()} secrets in ${agentType}")
+
+    new DefaultCacheResult([
+        (Keys.Namespace.SECRETS.ns): cachedSecrets.values(),
+    ], [:])
+  }
+
+  @Override
+  String getSimpleName() {
+    KubernetesSecretCachingAgent.simpleName
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServiceAccountCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesServiceAccountCachingAgent.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Skuid, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.*
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.view.MutableCacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import groovy.util.logging.Slf4j
+import io.fabric8.kubernetes.api.model.ServiceAccount
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+
+@Slf4j
+class KubernetesServiceAccountCachingAgent extends KubernetesCachingAgent {
+  static final Set<AgentDataType> types = Collections.unmodifiableSet([
+      AUTHORITATIVE.forType(Keys.Namespace.SERVICE_ACCOUNTS.ns),
+  ] as Set)
+
+  KubernetesServiceAccountCachingAgent(String accountName,
+                                 KubernetesCredentials credentials,
+                                 ObjectMapper objectMapper,
+                                 int agentIndex,
+                                 int agentCount) {
+    super(accountName, objectMapper, credentials, agentIndex, agentCount)
+  }
+
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    return types
+  }
+
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    log.info("Loading service accounts in $agentType")
+    reloadNamespaces()
+
+    def serviceAccounts = namespaces.collect { String namespace ->
+      credentials.apiAdaptor.getServiceAccounts(namespace)
+    }.flatten()
+
+    buildCacheResult(serviceAccounts)
+  }
+
+  private CacheResult buildCacheResult(List<ServiceAccount> serviceAccounts) {
+    log.info("Describing items in ${agentType}")
+
+    Map<String, MutableCacheData> cachedServiceAccounts = MutableCacheData.mutableCacheMap()
+
+    for (ServiceAccount sa : serviceAccounts) {
+      if (!sa) {
+        continue
+      }
+
+      def key = Keys.getServiceAccountKey(accountName, sa.metadata.namespace, sa.metadata.name)
+
+      cachedServiceAccounts[key].with {
+        attributes.name = sa.metadata.name
+        attributes.namespace = sa.metadata.namespace
+      }
+
+    }
+
+    log.info("Caching ${cachedServiceAccounts.size()} service accounts in ${agentType}")
+
+    new DefaultCacheResult([
+        (Keys.Namespace.SERVICE_ACCOUNTS.ns): cachedServiceAccounts.values(),
+    ], [:])
+  }
+
+  @Override
+  String getSimpleName() {
+    KubernetesServiceAccountCachingAgent.simpleName
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
@@ -104,6 +104,9 @@ class KubernetesProviderConfig implements Runnable {
         newlyAddedAgents << new KubernetesServerGroupCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads, registry)
         newlyAddedAgents << new KubernetesInstanceCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)
         newlyAddedAgents << new KubernetesDeploymentCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)
+        newlyAddedAgents << new KubernetesServiceAccountCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)
+        newlyAddedAgents << new KubernetesConfigMapCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)
+        newlyAddedAgents << new KubernetesSecretCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)
       }
 
       // If there is an agent scheduler, then this provider has been through the AgentController in the past.


### PR DESCRIPTION
Makes ConfigMaps,Secrets & ServiceAccounts cacheable and searchable.
This will be used to populate dropdowns in Deck in the appropriate
places. Lots of repetative code throughout and I'm not sure I totally
understand the relationship between hydrators and keys, though there
probably isn't much of one in this case.

@lwander @danielpeach hopefully this isn't too cringe inducing.
