### PR TITLE
feat(provider/kubernetes): Support EBS Volumes

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -154,6 +154,17 @@ class KubernetesApiConverter {
         volume.configMap = res.build()
         break
 
+      case KubernetesVolumeSourceType.AwsElasticBlockStore:
+        def res = new AWSElasticBlockStoreVolumeSourceBuilder().withVolumeID(volumeSource.awsElasticBlockStore.volumeId)
+        res = res.withFsType(volumeSource.awsElasticBlockStore.fsType)
+
+        if (volumeSource.awsElasticBlockStore.partition) {
+          res = res.withPartition(volumeSource.awsElasticBlockStore.partition)
+        }
+
+        volume.awsElasticBlockStore = res.build()
+        break
+
       default:
         return null
     }
@@ -606,6 +617,12 @@ class KubernetesApiConverter {
         new KubernetesKeyToPath(key: item.key, path: item.path)
       }
       res.configMap = new KubernetesConfigMapVolumeSource(configMapName: volume.configMap.name, items: items)
+    } else if (volume.awsElasticBlockStore) {
+      res.type = KubernetesVolumeSourceType.AwsElasticBlockStore
+      def ebs = volume.awsElasticBlockStore
+      res.awsElasticBlockStore = new KubernetesAwsElasticBlockStoreVolumeSource(volumeId: ebs.volumeID,
+                                                                                fsType: ebs.fsType,
+                                                                                partition: ebs.partition)
     } else {
       res.type = KubernetesVolumeSourceType.Unsupported
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -235,6 +235,9 @@ enum KubernetesVolumeSourceType {
   @JsonProperty("CONFIGMAP")
   ConfigMap,
 
+  @JsonProperty("AWSELASTICBLOCKSTORE")
+  AwsElasticBlockStore,
+
   @JsonProperty("UNSUPPORTED")
   Unsupported,
 }
@@ -257,6 +260,7 @@ class KubernetesVolumeSource {
   KubernetesPersistentVolumeClaim persistentVolumeClaim
   KubernetesSecretVolumeSource secret
   KubernetesConfigMapVolumeSource configMap
+  KubernetesAwsElasticBlockStoreVolumeSource awsElasticBlockStore
 }
 
 @AutoClone
@@ -265,6 +269,14 @@ class KubernetesConfigMapVolumeSource {
   String configMapName
   List<KubernetesKeyToPath> items
   Integer defaultMode
+}
+
+@AutoClone
+@Canonical
+class KubernetesAwsElasticBlockStoreVolumeSource {
+  String volumeId
+  String fsType
+  Integer partition
 }
 
 @AutoClone


### PR DESCRIPTION
Adds support for AWS Elastic Block Store volumes. Can serve as a good
example for further supporting other volume source types.

Note: EBS Volumes cannot be mounted ReadOnly even though the client library says it can be. When I attempted to add support for ReadOnly, Kubernetes failed to mount the volume with an error saying as much. Thus, it was left out.

Partially addresses spinnaker/spinnaker#1826

@lwander PTAL