### PR TITLE
feat(appengine): Permit deployments from gs:// repositories

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
@@ -39,18 +39,20 @@ class DeployAppengineDescriptionValidator extends DescriptionValidator<DeployApp
       return
     }
 
-    if (!helper.validateGitCredentials(description.credentials.gitCredentials,
-                                       description.gitCredentialType,
-                                       description.credentials.name,
-                                       "gitCredentialType")) {
-      return
+    if (!description.repositoryUrl.startsWith("gs://")) {
+      if (!helper.validateGitCredentials(description.credentials.gitCredentials,
+                                         description.gitCredentialType,
+                                         description.credentials.name,
+                                         "gitCredentialType")) {
+         return
+      }
+      helper.validateNotEmpty(description.branch, "branch")
     }
 
     helper.validateApplication(description.application, "application")
     helper.validateStack(description.stack, "stack")
     helper.validateDetails(description.freeFormDetails, "freeFormDetails")
     helper.validateNotEmpty(description.repositoryUrl, "repositoryUrl")
-    helper.validateNotEmpty(description.branch, "branch")
     if (!(description.configFilepaths || description.configFiles)) {
       helper.validateNotEmpty(description.configFilepaths, "configFilepaths")
       helper.validateNotEmpty(description.configFiles, "configFiles")

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gcsClient/AppengineGcsRepositoryClient.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gcsClient/AppengineGcsRepositoryClient.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.gcsClient
+
+import com.netflix.spinnaker.clouddriver.appengine.AppengineJobExecutor
+import com.netflix.spinnaker.clouddriver.appengine.model.AppengineRepositoryClient
+
+import groovy.transform.TupleConstructor
+
+@TupleConstructor
+class AppengineGcsRepositoryClient implements AppengineRepositoryClient {
+  String repositoryUrl
+  String targetDirectory
+  String applicationDirectoryRoot
+  AppengineJobExecutor jobExecutor
+
+  void initializeLocalDirectory() {
+    rsync()
+  }
+
+  void updateLocalDirectoryWithVersion(String version) {
+    rsync()
+  }
+
+  void rsync() {
+    def dest = targetDirectory + '/' + applicationDirectoryRoot
+    new File(dest).mkdirs()  // ensure target root exists
+
+    def command  = ["gsutil", "-m", "rsync", "-d", "-r",
+                    repositoryUrl + '/' + applicationDirectoryRoot,
+                    dest]
+                    
+    jobExecutor.runCommand(command)
+  }
+}

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gitClient/AppengineGitRepositoryClient.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gitClient/AppengineGitRepositoryClient.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.appengine.gitClient
 
+import com.netflix.spinnaker.clouddriver.appengine.model.AppengineRepositoryClient
+
 import groovy.transform.TupleConstructor
 import org.eclipse.jgit.api.CloneCommand
 import org.eclipse.jgit.api.FetchCommand
@@ -25,13 +27,13 @@ import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 
 @TupleConstructor
-class AppengineGitRepositoryClient {
+class AppengineGitRepositoryClient implements AppengineRepositoryClient {
   String repositoryUrl
   String targetDirectory
   AppengineGitCredentialType credentialType
   AppengineGitCredentials config
 
-  void cloneRepository() {
+  void initializeLocalDirectory() {
     CloneCommand command = Git.cloneRepository()
       .setURI(repositoryUrl)
       .setDirectory(new File(targetDirectory))
@@ -39,6 +41,11 @@ class AppengineGitRepositoryClient {
     attachCredentials(command)
 
     command.call()
+  }
+
+  void updateLocalDirectoryWithVersion(String version) {
+    fetch();
+    checkout(version);
   }
 
   void fetch() {

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppengineRepositoryClient.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppengineRepositoryClient.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.model
+
+interface AppengineRepositoryClient {
+  void initializeLocalDirectory()
+  void updateLocalDirectoryWithVersion(String version)
+}


### PR DESCRIPTION
@danielpeach 

I refactored the old gitClient into an interface that can update a "version".

The gist is you specifiy the repositoryUrl as a gcs path rather than an github HTTP url.
I dont do anything with the "branch".