### PR TITLE
fix(provider/google): Use port from frontend when upserting SSL Proxy

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleSslLoadBalancerAtomicOperation.groovy
@@ -287,7 +287,7 @@ class UpsertGoogleSslLoadBalancerAtomicOperation extends UpsertGoogleLoadBalance
         loadBalancingScheme: 'EXTERNAL',
         IPProtocol: description.ipProtocol,
         IPAddress: description.ipAddress,
-        portRange: description.certificate ? "443" : description.portRange,
+        portRange: description.portRange,
         target: targetProxyUrl,
       )
       Operation ruleOp = safeRetry.doRetry(

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleTcpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleTcpLoadBalancerAtomicOperation.groovy
@@ -278,7 +278,7 @@ class UpsertGoogleTcpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalance
         loadBalancingScheme: 'EXTERNAL',
         IPProtocol: description.ipProtocol,
         IPAddress: description.ipAddress,
-        portRange: description.certificate ? "443" : description.portRange,
+        portRange: description.portRange,
         target: targetProxyUrl,
       )
       Operation ruleOp = safeRetry.doRetry(


### PR DESCRIPTION
This addresses the following issue found in review [1]:
> Changing the port on an SSL load balancer in the UI has no effect

[1] https://github.com/spinnaker/deck/pull/3894#pullrequestreview-49475804