### PR TITLE
fix(provider/kubernetes): Allow None Cluster IP

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidator.groovy
@@ -58,7 +58,9 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidator extends DescriptionVa
       helper.validateIpv4(ip, "externalIps[$idx]")
     }
 
-    description.clusterIp ? helper.validateIpv4(description.clusterIp, "clusterIp")  : null
+    if (description.clusterIp && description.clusterIp != "None") {
+      helper.validateIpv4(description.clusterIp, "clusterIp")
+    }
 
     description.loadBalancerIp ? helper.validateIpv4(description.loadBalancerIp, "loadBalancerIp")  : null
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
@@ -42,6 +42,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
   final static String INVALID_NAME = "bad name ?"
   final static String VALID_IP = "127.0.0.1"
   final static String INVALID_IP = "0.127.0.0.1"
+  final static String VALID_CLUSTER_IP_NONE = "None"
   final static String VALID_ACCOUNT = "my-kubernetes-account"
 
   UpsertKubernetesLoadBalancerAtomicOperationValidator validator
@@ -112,6 +113,23 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     then:
       0 * errorsMock._
   }
+
+  void "validation accept (none cluster ip)"() {
+    setup:
+      def description = new KubernetesLoadBalancerDescription(name: VALID_NAME,
+        ports: [validPort],
+        externalIps: [VALID_IP],
+        account: VALID_ACCOUNT,
+        clusterIp: VALID_CLUSTER_IP_NONE)
+      def errorsMock = Mock(Errors)
+
+    when:
+      validator.validate([], description, errorsMock)
+
+    then:
+      0 * errorsMock._
+  }
+
   void "validation reject (bad protocol)"() {
     setup:
       def description = new KubernetesLoadBalancerDescription(name: VALID_NAME,


### PR DESCRIPTION
Kubernetes allows creation of "headless" services by setting
`spec.clusterIP` to `None`. This allows `None` as the only non-ip value
that could be accepted.

Addresses spinnaker/spinnaker#1836

@lwander PTAL