### PR TITLE
fix(request_queue): explicitly add http annotations to exception subclasses

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PromiseNotStartedException.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PromiseNotStartedException.java
@@ -17,7 +17,10 @@
 package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
 
 import com.netflix.spinnaker.clouddriver.requestqueue.QueuedRequestException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(value = HttpStatus.TOO_MANY_REQUESTS)
 class PromiseNotStartedException extends QueuedRequestException {
   PromiseNotStartedException() {
     super();

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PromiseTimeoutException.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PromiseTimeoutException.java
@@ -17,7 +17,10 @@
 package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
 
 import com.netflix.spinnaker.clouddriver.requestqueue.QueuedRequestException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(value = HttpStatus.TOO_MANY_REQUESTS)
 class PromiseTimeoutException extends QueuedRequestException {
   PromiseTimeoutException() {
     super();


### PR DESCRIPTION
quick workaround for GenericExceptionHandler