### PR TITLE
fix(provider/kubernetes): Cross Account Clone

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverter.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.ops.servergroup.Clone
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import org.springframework.stereotype.Component
 
 @KubernetesOperation(AtomicOperations.CLONE_SERVER_GROUP)
@@ -33,6 +34,9 @@ class CloneKubernetesAtomicOperationConverter extends AbstractAtomicOperationsCr
   }
 
   CloneKubernetesAtomicOperationDescription convertDescription(Map input) {
-    KubernetesAtomicOperationConverterHelper.convertDescription(input, this, CloneKubernetesAtomicOperationDescription)
+    def converted = KubernetesAtomicOperationConverterHelper.convertDescription(input, this, CloneKubernetesAtomicOperationDescription)
+    converted.sourceCredentials = (KubernetesNamedAccountCredentials) this.getCredentialsObject(converted.source.account)
+    return converted
+
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/CloneKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/CloneKubernetesAtomicOperationDescription.groovy
@@ -15,11 +15,13 @@
  */
 
 package com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 
 import groovy.transform.Canonical
 
 class CloneKubernetesAtomicOperationDescription extends DeployKubernetesAtomicOperationDescription {
   KubernetesCloneServerGroupSource source
+  KubernetesNamedAccountCredentials sourceCredentials
 }
 
 @Canonical

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperation.groovy
@@ -72,7 +72,7 @@ class CloneKubernetesAtomicOperation implements AtomicOperation<DeploymentResult
 
     task.updateStatus BASE_PHASE, "Reading ancestor server group ${description.source.serverGroupName}..."
 
-    def credentials = description.credentials.credentials
+    def credentials = description.sourceCredentials.credentials
 
     description.source.namespace = description.source.namespace ?: "default"
     def ancestorServerGroup = credentials.apiAdaptor.getReplicationController(description.source.namespace, description.source.serverGroupName)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/servergroup/CloneKubernetesAtomicOperationConverterSpec.groovy
@@ -52,19 +52,22 @@ class CloneKubernetesAtomicOperationConverterSpec extends Specification {
       def input = [app: APPLICATION,
                    stack: STACK,
                    freeFormDetails: DETAILS,
-                   account: ACCOUNT]
+                   account: ACCOUNT,
+                   source: [
+                     account: ACCOUNT
+                   ]]
     when:
       def description = converter.convertDescription(input)
 
     then:
-      1 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
+      2 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
       description instanceof CloneKubernetesAtomicOperationDescription
 
     when:
       def operation = converter.convertOperation(input)
 
     then:
-      1 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
+      2 * converter.accountCredentialsProvider.getCredentials(_) >> mockCredentials
       operation instanceof CloneKubernetesAtomicOperation
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -66,6 +66,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
   def dockerRegistries
   def credentials
   def namedAccountCredentials
+  def sourceNamedAccountCredentials
   def accountCredentialsRepositoryMock
   def spectatorRegistry
 
@@ -119,6 +120,13 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
         .credentials(credentials)
         .build()
 
+    sourceNamedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
+        .name("name")
+        .dockerRegistries(dockerRegistries)
+        .spectatorRegistry(spectatorRegistry)
+        .credentials(credentials)
+        .build()
+
     objectMetadata.setLabels(LABELS)
     podTemplateSpec.setMetadata(objectMetadata)
     replicationControllerSpec.setTemplate(podTemplateSpec)
@@ -153,7 +161,8 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
     setup:
       def inputDescription = new CloneKubernetesAtomicOperationDescription(
         source: [serverGroupName: ANCESTOR_SERVER_GROUP_NAME, namespace: NAMESPACE1],
-        credentials: namedAccountCredentials
+        credentials: namedAccountCredentials,
+        sourceCredentials: sourceNamedAccountCredentials
       )
 
       @Subject def operation = new CloneKubernetesAtomicOperation(inputDescription)
@@ -193,6 +202,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
         loadBalancers: LOAD_BALANCER_NAMES,
         containers: containers,
         credentials: namedAccountCredentials,
+        sourceCredentials: sourceNamedAccountCredentials,
         source: [serverGroupName: ANCESTOR_SERVER_GROUP_NAME, namespace: NAMESPACE2]
       )
 


### PR DESCRIPTION
Fixes cloning Server Groups across accounts. The previous implementation
was relying on the credentials of the target account which meant
cloning server groups that didn't exist in the target account failed.
This adds a `sourceCredentials` field to the Clone description that is
used to verify the source server group against the correct account.

Fixes spinnaker/spinnaker#1829

@lwander PTAL