### PR TITLE
chore(jedis): Downgrade Jedis version because of runtime error

### DIFF
--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -1,4 +1,9 @@
 apply plugin: 'spring-boot'
+// Applying the spring-boot plugin pulls in a newer version of jedis that we can't use yet. The
+// other ways to override versions (namely the subprojects.configurations.all.resolutionStrategy in
+// build.gradle) didn't work.
+ext['jedis.version'] = spinnaker.version('jedis')
+
 apply plugin: 'spinnaker.package'
 
 ext {
@@ -33,15 +38,6 @@ dependencies {
   compile project(':clouddriver-elasticsearch')
   compile project(':clouddriver-oracle-bmcs')
   compile project(':clouddriver-dcos')
-
-//  Replace below with this line when fiat becomes stable.
-//  spinnaker.group "fiat"
-  compile "org.springframework.boot:spring-boot-starter-actuator:1.2.8.RELEASE"
-  compile "org.springframework.boot:spring-boot-starter-web:1.2.8.RELEASE"
-  compile "org.springframework.boot:spring-boot-starter-data-rest:1.2.8.RELEASE"
-  compile "org.springframework.security:spring-security-config:3.2.9.RELEASE"
-  compile "org.springframework.security:spring-security-core:3.2.9.RELEASE"
-  compile "org.springframework.security:spring-security-web:3.2.9.RELEASE"
 
   runtime spinnaker.dependency('kork')
   compile spinnaker.dependency('korkWeb')

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -12,6 +12,8 @@ services:
   front50:
     baseUrl: http://localhost:8080
 
+management.health.elasticsearch.enabled: false
+
 swagger:
   enabled: true
   title: clouddriver


### PR DESCRIPTION
Fighting this one sucked. Dunno why the `resolutionStrategy` way didn't work. Allegedly the spring boot gradle plugin for boot 2.0 won't automatically apply this dependency management plugin.