### PR TITLE
fix(aws): Short-circuit failed describe instances if repeated

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -29,18 +29,15 @@ import com.amazonaws.services.elasticloadbalancingv2.model.InvalidTargetExceptio
 import com.amazonaws.services.elasticloadbalancingv2.model.RegisterTargetsRequest
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription
 import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
-import com.netflix.frigga.Names
-import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport
-import com.netflix.spinnaker.clouddriver.data.task.Task
-import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
-import com.netflix.spinnaker.clouddriver.eureka.model.EurekaInstance
-import com.netflix.spinnaker.clouddriver.helpers.EnableDisablePercentageCategorizer
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableInstanceDiscoveryDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -116,6 +113,7 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
         it.lifecycleState == "InService" || it.lifecycleState.startsWith("Pending")
       }*.instanceId
 
+      int failedAttempts = 0
       if (instanceIds) {
         DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(instanceIds)
         List<Reservation> reservations = []
@@ -129,7 +127,12 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
 
             describeInstancesRequest.setNextToken(describeInstancesResult.nextToken)
           } catch(Exception e) {
-           log.error("Failed to describe one of the instances in  {}", instanceIds, e)
+            failedAttempts++
+            log.error("Failed to describe one of the instances in  {}", instanceIds, e)
+            if (failedAttempts >= 10) {
+              task.updateStatus phaseName, "Failed to describe instances 10 times, aborting. This may happen if the server group has been disabled for a long period of time."
+              return false
+            }
           }
         }
 


### PR DESCRIPTION
This doesn't actually fix the root cause of the error, but does prevent this section of code from an infinite loop if the condition is encountered. Error condition is: A disabled server group, which has an instance terminated, will not have its list of instances refreshed; causing the EC2 describe instances call to permanently fail since the instance no longer exists.

I want to get this short-circuit in prior to figuring out a long-term fix for the actual behavior. Correct behavior was in tagged server groups, but was too slow for something. I suspect we can get everything we need from `DescribeAutoScalingGroupInstances`'s `HealthStatus` field:

```
    // The last reported health status of this instance. "Healthy" means that the
    // instance is healthy and should remain in service. "Unhealthy" means that
    // the instance is unhealthy and Auto Scaling should terminate and replace it.
```

@spinnaker/netflix-reviewers PTAL