### PR TITLE
fix(core): Ensure CoreProvider/CleanupPendingOnDemandCachesAgent is c…

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -222,7 +222,6 @@ class CloudDriverConfig {
   }
 
   @Bean
-  @ConditionalOnExpression('${redis.connection != null || dynomite.enabled:false}')
   CoreProvider coreProvider(RedisClientDelegate redisClientDelegate, ApplicationContext applicationContext) {
     return new CoreProvider([
       new CleanupPendingOnDemandCachesAgent(redisClientDelegate, applicationContext)


### PR DESCRIPTION
…onsistently registered

The `@ConditionalOnExpression` should not be needed as redis/dynomite is
always going to be available.
