### PR TITLE
fix(provider/amazon): throw better exception on invalid cluster name

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AWSServerGroupNameResolver.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AWSServerGroupNameResolver.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy
 
+import com.netflix.frigga.NameConstants
+import com.netflix.frigga.NameValidation
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.helpers.AbstractServerGroupNameResolver
 import com.netflix.spinnaker.clouddriver.aws.services.AsgService
@@ -76,9 +78,15 @@ class AWSServerGroupNameResolver extends AbstractServerGroupNameResolver {
 
   @Override
   String resolveNextServerGroupName(String application, String stack, String details, Boolean ignoreSequence) {
+    def clusterName = combineAppStackDetail(application, stack, details)
+
+    if (!NameValidation.checkNameWithHyphen(clusterName)) {
+      throw new IllegalArgumentException("Invalid cluster name: '${clusterName}'. Cluster names can only contain " +
+        "characters in the following range: ${NameConstants.NAME_HYPHEN_CHARS}")
+    }
+
     def originalNextServerGroupName = super.resolveNextServerGroupName(application, stack, details, ignoreSequence)
     def nextServerGroupName = originalNextServerGroupName
-    def clusterName = combineAppStackDetail(application, stack, details)
 
     if (nextServerGroupName) {
       def hasNextServerGroup = false

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AWSServerGroupNameResolverSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AWSServerGroupNameResolverSpec.groovy
@@ -141,6 +141,18 @@ class AWSServerGroupNameResolverSpec extends Specification {
     thrown(IllegalArgumentException)
   }
 
+  void "should raise IllegalArgumentException in cluster name is invalid"() {
+    given:
+    def clusterProviders = [amazonClusterProvider]
+    def resolver = new AWSServerGroupNameResolver(account, region, asgService, clusterProviders, 1)
+
+    when:
+    resolver.resolveNextServerGroupName('application', 'stack', 'details with spaces', false)
+
+    then:
+    thrown(IllegalArgumentException)
+  }
+
   static ServerGroup sG(String name, Long createdTime, String region) {
     return new SimpleServerGroup(name: name, createdTime: createdTime, region: region)
   }


### PR DESCRIPTION
Right now, we end up throwing a NPE trying to parse the keys, which is understandably cryptic to users.

Happy to move this validation further up the stack, but this should be sufficient to get a cleaner error message to folks in the UI.