### PR TITLE
feat(aws): perform search filtering via Keys

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
@@ -17,9 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.cache
 
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.cache.KeyParser
+import org.springframework.stereotype.Component
+
 import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.ID
 
-class Keys {
+@Component("AmazonInfraKeys")
+class Keys implements KeyParser {
   static enum Namespace {
     CERTIFICATES,
     SECURITY_GROUPS,
@@ -41,6 +45,21 @@ class Keys {
     String toString() {
       ns
     }
+  }
+
+  @Override
+  String getCloudProvider() {
+    return ID
+  }
+
+  @Override
+  Map<String, String> parseKey(String key) {
+    return parse(key)
+  }
+
+  @Override
+  Boolean canParse(String type) {
+    return Namespace.values().any { it.ns == type }
   }
 
   static Map<String, String> parse(String key) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -17,12 +17,30 @@
 package com.netflix.spinnaker.clouddriver.aws.data
 
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.cache.KeyParser
 import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
 import groovy.transform.CompileStatic
+import org.springframework.stereotype.Component
+
 import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.ID
 
-@CompileStatic
-class Keys {
+@Component("AmazonKeys")
+class Keys implements KeyParser {
+
+  @Override
+  String getCloudProvider() {
+    return ID
+  }
+
+  @Override
+  Map<String, String> parseKey(String key) {
+    return parse(key)
+  }
+
+  @Override
+  Boolean canParse(String type) {
+    return Namespace.values().any { it.ns == type }
+  }
 
   static Map<String, String> parse(String key) {
     def parts = key.split(':')

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyParser.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyParser.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cache;
+
+import java.util.Map;
+
+public interface KeyParser {
+
+  /**
+   * Indicates which provider this particular parser handles
+   * @return the cloud provider ID
+   */
+  String getCloudProvider();
+
+  /**
+   * Parses the supplied key to an arbitrary Map of attributes
+   * @param key the full key
+   * @return a Map of the key attributes
+   */
+  Map<String, String> parseKey(String key);
+
+  /**
+   * indicates whether this parser can parse the supplied type
+   * @param type the entity type, typically corresponding to a value in the implementing class's Namespace
+   * @return true if it can parse this type
+   */
+  Boolean canParse(String type);
+}


### PR DESCRIPTION
**Do not merge, for discussion only**

Allows search filtering based on attributes found in a key, e.g. http://localhost:8081/search?q=int&type=serverGroups&filter[cloudProvider]=aws&filter[application]=api,apiproxy

@icfantv this is a rough idea of how you could accomplish ad-hoc filtering in Clouddriver with the existing Redis keys. It limits filtering to what's present in the keys themselves but would be roughly as fast as current search.