### PR TITLE
feat(kubernetes): Provides ability to drive pod cache TTL via metadata attribute

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
@@ -34,7 +34,7 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 
 @Slf4j
 class KubernetesInstanceCachingAgent extends KubernetesCachingAgent {
-  static final String CACHE_TTL_ANNOTATION = "spinnaker.cache-ttl"
+  static final String CACHE_TTL_ANNOTATION = "cache.spinnaker.io/ttl"
 
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
       AUTHORITATIVE.forType(Keys.Namespace.INSTANCES.ns),

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
@@ -34,6 +34,8 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 
 @Slf4j
 class KubernetesInstanceCachingAgent extends KubernetesCachingAgent {
+  static final String CACHE_TTL_ANNOTATION = "spinnaker.cache-ttl"
+
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
       AUTHORITATIVE.forType(Keys.Namespace.INSTANCES.ns),
   ] as Set)
@@ -86,6 +88,9 @@ class KubernetesInstanceCachingAgent extends KubernetesCachingAgent {
 
       def key = Keys.getInstanceKey(accountName, pod.metadata.namespace, pod.metadata.name)
       cachedInstances[key].with {
+        if (pod.metadata.annotations.containsKey(CACHE_TTL_ANNOTATION)) {
+          attributes.cacheExpiry = pod.metadata.annotations[CACHE_TTL_ANNOTATION]
+        }
         attributes.name = pod.metadata.name
         attributes.instance = new KubernetesInstance(pod, events)
       }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgentSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesApiAdaptor
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import io.fabric8.kubernetes.api.model.ObjectMeta
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.PodSpec
+import io.fabric8.kubernetes.api.model.PodStatus
+import spock.lang.Specification
+
+class KubernetesInstanceCachingAgentSpec extends Specification {
+  static final String accountName = "account"
+  static final String namespace = "namespace"
+  static final ObjectMapper mapper = new ObjectMapper()
+
+  KubernetesCredentials credentials
+  KubernetesApiAdaptor apiAdaptor
+  ProviderCache providerCache
+  KubernetesInstanceCachingAgent agent
+
+  def setup() {
+    apiAdaptor = Mock(KubernetesApiAdaptor)
+    credentials = Mock(KubernetesCredentials) {
+      getApiAdaptor() >> apiAdaptor
+    }
+    providerCache = Mock(ProviderCache)
+    agent = new KubernetesInstanceCachingAgent(accountName, credentials, mapper, 1, 1)
+  }
+
+  void "should apply cache-ttl annotation to pod"() {
+    setup:
+    def cacheExpiry = "1000"
+    def metadata = new ObjectMeta()
+    metadata.annotations = [(KubernetesInstanceCachingAgent.CACHE_TTL_ANNOTATION): cacheExpiry]
+    def pod = new Pod("v1", "Pod", metadata, new PodSpec(), new PodStatus())
+
+    when:
+    def data = agent.loadData(providerCache)
+
+    then:
+    1 * credentials.getNamespaces() >> [namespace]
+    1 * apiAdaptor.getPods(namespace) >> [pod]
+    data.cacheResults[Keys.Namespace.INSTANCES.ns].size() == 1
+    data.cacheResults[Keys.Namespace.INSTANCES.ns][0].attributes.containsKey("cacheExpiry")
+    data.cacheResults[Keys.Namespace.INSTANCES.ns][0].attributes["cacheExpiry"] == cacheExpiry
+  }
+}


### PR DESCRIPTION
This PR provides the ability to control the CATS cache TTL of a `KubernetesInstance` by adding a metadata annotation, `cache.spinnaker.io/ttl`, to the `Pod`.