### PR TITLE
fix(provider/kubernetes): Fix instance annotation (#1782)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesInstanceCachingAgent.groovy
@@ -88,7 +88,7 @@ class KubernetesInstanceCachingAgent extends KubernetesCachingAgent {
 
       def key = Keys.getInstanceKey(accountName, pod.metadata.namespace, pod.metadata.name)
       cachedInstances[key].with {
-        if (pod.metadata.annotations.containsKey(CACHE_TTL_ANNOTATION)) {
+        if (pod.metadata?.annotations?.containsKey(CACHE_TTL_ANNOTATION)) {
           attributes.cacheExpiry = pod.metadata.annotations[CACHE_TTL_ANNOTATION]
         }
         attributes.name = pod.metadata.name


### PR DESCRIPTION
Older versions of k8s have null annotations by default.
