### PR TITLE
fix(dynomite): Correctly handle lock TTLs while checking to self-heal

### DIFF
--- a/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cluster/DynoClusteredAgentScheduler.java
+++ b/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cluster/DynoClusteredAgentScheduler.java
@@ -132,11 +132,8 @@ public class DynoClusteredAgentScheduler extends CatsModuleAware implements Agen
         boolean purge = true;
         for (int i = 0; i <= 3; i++) {
           Long ttl = client.ttl(agentType);
-          if (ttl == -2) {
+          if (ttl > 0 || ttl == -2) {
             purge = false;
-            break;
-          }
-          if (ttl == -1) {
             break;
           }
           try {


### PR DESCRIPTION
Finally got local dyno working again, fixing self-heal logic that heals itself a lot too aggressively.