### PR TITLE
K8s client staging

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -27,7 +27,7 @@ import io.fabric8.kubernetes.api.model.extensions.*
 import io.fabric8.kubernetes.client.DefaultKubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientException
-
+import io.kubernetes.client.models.V1beta1StatefulSet
 import java.util.concurrent.TimeUnit
 
 @Slf4j
@@ -115,8 +115,8 @@ class KubernetesApiAdaptor {
       }
 
       spectatorRegistry.timer(
-              spectatorRegistry.createId("kubernetes.api", tags))
-              .record(spectatorClock.monotonicTime() - startTime, TimeUnit.NANOSECONDS)
+        spectatorRegistry.createId("kubernetes.api", tags))
+        .record(spectatorClock.monotonicTime() - startTime, TimeUnit.NANOSECONDS)
 
       if (failure) {
         throw failure
@@ -381,7 +381,7 @@ class KubernetesApiAdaptor {
   }
 
   List<ConfigMap> getConfigMaps(String namespace) {
-   exceptionWrapper("configMaps.list", "Get Config Maps", namespace) {
+    exceptionWrapper("configMaps.list", "Get Config Maps", namespace) {
       client.configMaps().inNamespace(namespace).list().items
     }
   }
@@ -509,5 +509,8 @@ class KubernetesApiAdaptor {
 
   static String getDeploymentRevision(ReplicaSet replicaSet) {
     return replicaSet?.metadata?.annotations?.get("$DEPLOYMENT_ANNOTATION/revision".toString())
+  }
+  static String getDeploymentRevision(V1beta1StatefulSet statefulSet) {
+    return statefulSet?.metadata?.annotations?.get("$DEPLOYMENT_ANNOTATION/revision".toString())
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiAdaptor.groovy
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.api.model.extensions.*
 import io.fabric8.kubernetes.client.DefaultKubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientException
-import io.kubernetes.client.models.V1beta1StatefulSet
 import java.util.concurrent.TimeUnit
 
 @Slf4j
@@ -510,7 +509,5 @@ class KubernetesApiAdaptor {
   static String getDeploymentRevision(ReplicaSet replicaSet) {
     return replicaSet?.metadata?.annotations?.get("$DEPLOYMENT_ANNOTATION/revision".toString())
   }
-  static String getDeploymentRevision(V1beta1StatefulSet statefulSet) {
-    return statefulSet?.metadata?.annotations?.get("$DEPLOYMENT_ANNOTATION/revision".toString())
-  }
+
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesClientApiAdapter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesClientApiAdapter.groovy
@@ -25,7 +25,8 @@ import io.kubernetes.client.ApiException
 import io.kubernetes.client.Configuration
 import io.kubernetes.client.apis.AppsV1beta1Api
 import io.kubernetes.client.models.*
-
+import io.kubernetes.client.models.V1Pod
+import io.kubernetes.client.apis.CoreV1Api
 import java.util.concurrent.TimeUnit
 
 class KubernetesClientApiAdapter {
@@ -122,6 +123,19 @@ class KubernetesClientApiAdapter {
         return result
       }
     }
+  }
+  static String getDeploymentRevision(V1beta1StatefulSet statefulSet) {
+    return statefulSet?.metadata?.annotations?.get("$DEPLOYMENT_ANNOTATION/revision".toString())
+  }
+  static boolean hasDeployment(V1beta1StatefulSet statefulSet) {
+    return statefulSet?.metadata?.annotations?.any { k, v -> k.startsWith(DEPLOYMENT_ANNOTATION) }
+  }
+  V1PodList getPods(String namespace, Map<String, String> labels) {
+    CoreV1Api api = new CoreV1Api();
+     api.listNamespacedPod("default", null, null, null, null, 600, null);
+  }
+  V1beta1StatefulSet  getStatefulSet(String namespace, String serverGroupName) {
+    return this.apiInstance.readNamespacedStatefulSet(serverGroupName, namespace , null , false, false)
   }
 
   List<V1beta1StatefulSet> getStatefulSets(String namespace) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -26,7 +26,7 @@ import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.Job
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet
 import org.springframework.beans.factory.annotation.Value
-
+import io.kubernetes.client.models.V1beta1StatefulSet
 class KubernetesUtil {
   static String SECURITY_GROUP_LABEL_PREFIX = "security-group-"
   static String LOAD_BALANCER_LABEL_PREFIX = "load-balancer-"
@@ -161,7 +161,9 @@ class KubernetesUtil {
   static List<String> getLoadBalancers(ReplicaSet rs) {
     return getLoadBalancers(rs.spec?.template?.metadata?.labels ?: [:])
   }
-
+  static List<String> getLoadBalancers(V1beta1StatefulSet  rs) {
+    return getLoadBalancers(rs.spec?.template?.metadata?.labels ?: [:])
+  }
   static List<String> getLoadBalancers(ReplicationController rc) {
     return getLoadBalancers(rc.spec?.template?.metadata?.labels ?: [:])
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -33,6 +33,9 @@ import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet
 import io.fabric8.kubernetes.client.internal.SerializationUtils
 import io.kubernetes.client.models.V1beta1StatefulSet
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.netflix.spinnaker.clouddriver.kubernetes.api.KubernetesClientApiAdapter
 
 @CompileStatic
 @EqualsAndHashCode(includes = ["name", "namespace", "account"])
@@ -115,7 +118,9 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
     this.launchConfig = [:]
     this.labels = statefulSet.spec?.template?.metadata?.labels
     this.deployDescription = KubernetesApiConverter.fromStatefulSet(statefulSet)
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
     //this.yaml = SerializationUtils.dumpWithoutRuntimeStateAsYaml(statefulSet)
+    ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
     this.kind = statefulSet.kind
     this.events = events?.collect {
       new KubernetesEvent(it)
@@ -124,7 +129,7 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
       KubernetesApiConverter.attachAutoscaler(this.deployDescription, autoscaler)
       this.autoscalerStatus = new KubernetesAutoscalerStatus(autoscaler)
     }
-    this.revision = KubernetesApiAdaptor.getDeploymentRevision(statefulSet)
+    this.revision = KubernetesClientApiAdapter.getDeploymentRevision(statefulSet)
   }
 
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesServerGroup.groovy
@@ -32,6 +32,7 @@ import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSet
 import io.fabric8.kubernetes.client.internal.SerializationUtils
+import io.kubernetes.client.models.V1beta1StatefulSet
 
 @CompileStatic
 @EqualsAndHashCode(includes = ["name", "namespace", "account"])
@@ -101,6 +102,31 @@ class KubernetesServerGroup implements ServerGroup, Serializable {
     this.region = namespace
     this.namespace = namespace
   }
+  KubernetesServerGroup(V1beta1StatefulSet statefulSet, String account, List<Event> events, HorizontalPodAutoscaler autoscaler) {
+    this.name = statefulSet.metadata?.name
+    this.account = account
+    this.region = statefulSet.metadata?.namespace
+    this.namespace = this.region
+    this.createdTime = statefulSet.metadata?.creationTimestamp?.getMillis()
+    this.zones = [this.region] as Set
+    this.securityGroups = []
+    this.replicas = statefulSet.spec?.replicas ?: 0
+    this.loadBalancers = KubernetesUtil.getLoadBalancers(statefulSet) as Set
+    this.launchConfig = [:]
+    this.labels = statefulSet.spec?.template?.metadata?.labels
+    this.deployDescription = KubernetesApiConverter.fromStatefulSet(statefulSet)
+    //this.yaml = SerializationUtils.dumpWithoutRuntimeStateAsYaml(statefulSet)
+    this.kind = statefulSet.kind
+    this.events = events?.collect {
+      new KubernetesEvent(it)
+    }
+    if (autoscaler) {
+      KubernetesApiConverter.attachAutoscaler(this.deployDescription, autoscaler)
+      this.autoscalerStatus = new KubernetesAutoscalerStatus(autoscaler)
+    }
+    this.revision = KubernetesApiAdaptor.getDeploymentRevision(statefulSet)
+  }
+
 
   KubernetesServerGroup(ReplicaSet replicaSet, String account, List<Event> events, HorizontalPodAutoscaler autoscaler) {
     this.name = replicaSet.metadata?.name

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesControllersCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/agent/KubernetesControllersCachingAgent.groovy
@@ -1,0 +1,451 @@
+package com.netflix.spinnaker.clouddriver.kubernetes.provider.agent
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.frigga.Names
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.AgentDataType
+import com.netflix.spinnaker.cats.agent.CacheResult
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil
+import com.netflix.spinnaker.clouddriver.kubernetes.model.KubernetesServerGroup
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.view.MutableCacheData
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials
+import com.netflix.spinnaker.clouddriver.kubernetes.cache.Keys
+import groovy.util.logging.Slf4j
+import io.fabric8.kubernetes.api.model.Event
+import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler
+import io.fabric8.kubernetes.api.model.Pod
+import io.kubernetes.client.Configuration
+import io.kubernetes.client.apis.AppsV1beta1Api
+import io.kubernetes.client.models.V1beta1DaemonSet
+import io.kubernetes.client.models.V1beta1DaemonSetList
+import io.kubernetes.client.ApiClient
+import io.kubernetes.client.models.V1beta1StatefulSet
+import io.kubernetes.client.models.V1beta1StatefulSetList
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
+/**
+ * Created by spinnaker on 9/8/17.
+ */
+@Slf4j
+class KubernetesControllersCachingAgent extends KubernetesCachingAgent implements OnDemandAgent{
+  final OnDemandMetricsSupport metricsSupport
+  final AppsV1beta1Api appsV1beta1Api
+  final ApiClient newClient
+  static final String DEPLOYMENT_ANNOTATION = "deployment.kubernetes.io"
+  final String category = 'serverGroup'
+  static final Set<AgentDataType> types = Collections.unmodifiableSet([
+    AUTHORITATIVE.forType(Keys.Namespace.APPLICATIONS.ns),
+    AUTHORITATIVE.forType(Keys.Namespace.CLUSTERS.ns),
+    INFORMATIVE.forType(Keys.Namespace.LOAD_BALANCERS.ns),
+    AUTHORITATIVE.forType(Keys.Namespace.SERVER_GROUPS.ns),
+    INFORMATIVE.forType(Keys.Namespace.INSTANCES.ns),
+  ] as Set)
+
+  KubernetesControllersCachingAgent(String accountName, ObjectMapper objectMapper, KubernetesCredentials credentials, int agentIndex, int agentCount, Registry registry) {
+    super(accountName, objectMapper, credentials, agentIndex, agentCount)
+    this.metricsSupport = new OnDemandMetricsSupport(registry,
+      this,
+      "$kubernetesCloudProvider.id:$OnDemandAgent.OnDemandType.ServerGroup")
+    this.appsV1beta1Api = new AppsV1beta1Api()
+    this.newClient = io.kubernetes.client.util.Config.defaultClient()
+    Configuration.setDefaultApiClient(newClient)
+
+  }
+
+  @Override
+  String getOnDemandAgentType() {
+    return "${getAgentType()}-OnDemand"
+  }
+
+  @Override
+  OnDemandMetricsSupport getMetricsSupport() {
+    return null
+  }
+
+  /**
+   * @return the data types this Agent returns
+   * @see com.netflix.spinnaker.cats.agent.AgentDataType.Authority
+   */
+  @Override
+  Collection<AgentDataType> getProvidedDataTypes() {
+    return types
+  }
+
+  @Override
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+    OnDemandAgent.OnDemandType.ServerGroup == type && cloudProvider == kubernetesCloudProvider.id
+  }
+
+  /**
+   * Triggered by an AgentScheduler to tell this Agent to load its data.
+   *
+   * @param providerCache Cache associated with this Agent's provider
+   * @return the complete set of data for this Agent.
+   */
+  @Override
+  CacheResult loadData(ProviderCache providerCache) {
+    reloadNamespaces()
+    Long start = System.currentTimeMillis()
+    V1beta1StatefulSetList statefulSet = loadStatefulSets()
+
+
+
+    List<V1beta1StatefulSet> ss=statefulSet.getItems()
+
+
+    /*List<KubernetesController> serverGroups1 = (replicationControllerList.collect {
+      it ? new KubernetesController(controller: it) : null
+    } + replicaSetList.collect {
+      it ? new KubernetesController(controller: it) : null
+    } +   daemonSetList?.items.collect { it ? new KubernetesController(controller: it): null
+    } + statefulSetList?.items.collect { it ? new KubernetesController(controller: it): null
+    })- null*/
+
+
+    List<StateFulSet> serverGroups = (ss.collect {
+      it ? new StateFulSet(statefulSet: it) : null
+    }
+
+
+    ) - null
+
+    List<CacheData> evictFromOnDemand = []
+    List<CacheData> keepInOnDemand = []
+
+    providerCache.getAll(Keys.Namespace.ON_DEMAND.ns,
+      serverGroups.collect { serverGroup ->
+        Keys.getServerGroupKey(accountName, serverGroup.namespace, serverGroup.name)
+      })
+      .each { CacheData onDemandEntry ->
+      // Ensure that we don't overwrite data that was inserted by the `handle` method while we retrieved the
+      // replication controllers. Furthermore, cache data that hasn't been processed needs to be updated in the ON_DEMAND
+      // cache, so don't evict data without a processedCount > 0.
+      if (onDemandEntry.attributes.cacheTime < start && onDemandEntry.attributes.processedCount > 0) {
+        evictFromOnDemand << onDemandEntry
+      } else {
+        keepInOnDemand << onDemandEntry
+      }
+    }
+
+    def result = buildCacheResult(serverGroups, keepInOnDemand.collectEntries { CacheData onDemandEntry ->
+      [(onDemandEntry.id): onDemandEntry]
+    }, evictFromOnDemand*.id, start)
+
+    result.cacheResults[Keys.Namespace.ON_DEMAND.ns].each { CacheData onDemandEntry ->
+      onDemandEntry.attributes.processedTime = System.currentTimeMillis()
+      onDemandEntry.attributes.processedCount = (onDemandEntry.attributes.processedCount ?: 0) + 1
+    }
+
+    return result
+  }
+
+  @Override
+  OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ?extends Object> data) {
+
+
+    if (!data.containsKey("serverGroupName")) {
+      return null
+    }
+
+    if (data.account != accountName) {
+      return null
+    }
+
+    reloadNamespaces()
+    String namespace = data.region
+    if (!namespaces.contains(namespace)) {
+      return null
+    }
+
+    def serverGroupName = data.serverGroupName.toString()
+
+
+
+    V1beta1StatefulSet statefulSet = metricsSupport.readData {
+      loadStatefulSet(namespace, serverGroupName)
+    }
+
+    CacheResult result = metricsSupport.transformData {
+      buildCacheResult([new StateFulSet(statefulSet: statefulSet)], [:], [], Long.MAX_VALUE)
+    }
+    def jsonResult = objectMapper.writeValueAsString(result.cacheResults)
+
+    if (result.cacheResults.values().flatten().isEmpty()) {
+      // Avoid writing an empty onDemand cache record (instead delete any that may have previously existed).
+      providerCache.evictDeletedItems(Keys.Namespace.ON_DEMAND.ns, [Keys.getServerGroupKey(accountName, namespace, serverGroupName)])
+    } else {
+      metricsSupport.onDemandStore {
+        def cacheData = new DefaultCacheData(
+          Keys.getServerGroupKey(accountName, namespace, serverGroupName),
+          10 * 60, // ttl is 10 minutes
+          [
+            cacheTime: System.currentTimeMillis(),
+            cacheResults: jsonResult,
+            processedCount: 0,
+            processedTime: null
+          ],
+          [:]
+        )
+
+        providerCache.putCacheData(Keys.Namespace.ON_DEMAND.ns, cacheData)
+      }
+    }
+    // Evict this server group if it no longer exists.
+    Map<String, Collection<String>> evictions = statefulSet  ? [:] : [
+      (Keys.Namespace.SERVER_GROUPS.ns): [
+        Keys.getServerGroupKey(accountName, namespace, serverGroupName)
+      ]
+    ]
+    log.info("On demand cache refresh (data: ${data}) succeeded.")
+
+    return new OnDemandAgent.OnDemandResult(
+      sourceAgentType: getOnDemandAgentType(),
+      cacheResult: result,
+      evictions: evictions
+    )
+  }
+
+  @Override
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    def keys = providerCache.getIdentifiers(Keys.Namespace.ON_DEMAND.ns)
+    keys = keys.findResults {
+      def parse = Keys.parse(it)
+      if (parse && namespaces.contains(parse.namespace) && parse.account == accountName) {
+        return it
+      } else {
+        return null
+      }
+    }
+
+    def keyCount = keys.size()
+    def be = keyCount == 1 ? "is" : "are"
+    def pluralize = keyCount == 1 ? "" : "s"
+    log.info("There $be $keyCount pending on demand request$pluralize")
+
+    providerCache.getAll(Keys.Namespace.ON_DEMAND.ns, keys).collect {
+      [
+        details  : Keys.parse(it.id),
+        cacheTime: it.attributes.cacheTime,
+        processedCount: it.attributes.processedCount,
+        processedTime: it.attributes.processedTime
+      ]
+    }
+  }
+
+  @Override
+  String getSimpleName() {
+    return KubernetesControllersCachingAgent.getSimpleName()
+  }
+
+
+  V1beta1StatefulSet loadStatefulSet(String namespace, String name) {
+    getStatefulSet(namespace, name)
+  }
+  V1beta1StatefulSetList getStatefulSets(String namespace) {
+    return this.appsV1beta1Api.listNamespacedStatefulSet(namespace, null, null, null, null, 300, null)
+  }
+  V1beta1StatefulSetList getStatefulSetsForAllNamespace() {
+    return this.appsV1beta1Api.listStatefulSetForAllNamespaces(null,null,null,null,300,false)
+  }
+
+  V1beta1StatefulSet  getStatefulSet(String namespace, String serverGroupName) {
+    return this.appsV1beta1Api.readNamespacedStatefulSet(serverGroupName, namespace , null , false, false)
+  }
+  V1beta1StatefulSetList loadStatefulSets() {
+    getStatefulSetsForAllNamespace()
+  }
+
+
+  private CacheResult buildCacheResult(List<StateFulSet> serverGroups, Map<String, CacheData> onDemandKeep, List<String> onDemandEvict, Long start) {
+    log.info("Describing items in ${agentType}")
+
+    Map<String, MutableCacheData> cachedApplications = MutableCacheData.mutableCacheMap()
+    Map<String, MutableCacheData> cachedClusters = MutableCacheData.mutableCacheMap()
+    Map<String, MutableCacheData> cachedServerGroups = MutableCacheData.mutableCacheMap()
+    Map<String, MutableCacheData> cachedInstances = MutableCacheData.mutableCacheMap()
+    Map<String, MutableCacheData> cachedLoadBalancers = MutableCacheData.mutableCacheMap()
+
+    // Map namespace -> name -> event
+    Map<String, Map<String, Event>> rcEvents = [:].withDefault { _ -> [:] }
+    Map<String, Map<String, Event>> rsEvents = [:].withDefault { _ -> [:] }
+    try {
+      namespaces.each { String namespace ->
+        rcEvents[namespace] = credentials.apiAdaptor.getEvents(namespace, KubernetesUtil.DEPRECATED_SERVER_GROUP_KIND)
+        rsEvents[namespace] = credentials.apiAdaptor.getEvents(namespace, KubernetesUtil.SERVER_GROUP_KIND)
+      }
+    } catch (Exception e) {
+      log.warn "Failure fetching events for all server groups in $namespaces", e
+    }
+
+    // Map namespace -> name -> autoscaler
+    Map<String, Map<String, HorizontalPodAutoscaler>> rcAutoscalers = [:].withDefault { _ -> [:] }
+    Map<String, Map<String, HorizontalPodAutoscaler>> rsAutoscalers = [:].withDefault { _ -> [:] }
+    Map<String, Map<String, HorizontalPodAutoscaler>> deployAutoscalers = [:].withDefault { _ -> [:] }
+    try {
+      namespaces.each { String namespace ->
+        rcAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, KubernetesUtil.DEPRECATED_SERVER_GROUP_KIND)
+        rsAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, KubernetesUtil.SERVER_GROUP_KIND)
+        deployAutoscalers[namespace] = credentials.apiAdaptor.getAutoscalers(namespace, KubernetesUtil.DEPLOYMENT_KIND)
+      }
+    } catch (Exception e) {
+      log.warn "Failure fetching autoscalers for all server groups in $namespaces", e
+    }
+
+    for (StateFulSet serverGroup: serverGroups) {
+      if (!serverGroup.exists()) {
+        continue
+      }
+
+      def onDemandData = onDemandKeep ? onDemandKeep[Keys.getServerGroupKey(accountName, serverGroup.namespace, serverGroup.name)] : null
+
+      if (onDemandData && onDemandData.attributes.cacheTime >= start) {
+        Map<String, List<CacheData>> cacheResults = objectMapper.readValue(onDemandData.attributes.cacheResults as String,
+          new TypeReference<Map<String, List<MutableCacheData>>>() { })
+        cache(cacheResults, Keys.Namespace.APPLICATIONS.ns, cachedApplications)
+        cache(cacheResults, Keys.Namespace.CLUSTERS.ns, cachedClusters)
+        cache(cacheResults, Keys.Namespace.SERVER_GROUPS.ns, cachedServerGroups)
+        cache(cacheResults, Keys.Namespace.INSTANCES.ns, cachedInstances)
+      } else {
+        def serverGroupName = serverGroup.name
+        def pods = loadPods(serverGroup)
+        def names = Names.parseName(serverGroupName)
+        def applicationName = names.app
+        def clusterName = names.cluster
+
+        def serverGroupKey = Keys.getServerGroupKey(accountName, serverGroup.namespace, serverGroupName)
+        def applicationKey = Keys.getApplicationKey(applicationName)
+        def clusterKey = Keys.getClusterKey(accountName, applicationName, category, clusterName)
+        def instanceKeys = []
+        def loadBalancerKeys = serverGroup.loadBalancers.collect({
+          Keys.getLoadBalancerKey(accountName, serverGroup.namespace, it)
+        })
+
+        cachedApplications[applicationKey].with {
+          attributes.name = applicationName
+          relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
+          relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)
+          relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
+        }
+
+        cachedClusters[clusterKey].with {
+          attributes.name = clusterName
+          relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
+          relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)
+          relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
+        }
+
+        pods?.forEach { pod ->
+          def key = Keys.getInstanceKey(accountName, pod.metadata.namespace, pod.metadata.name)
+          instanceKeys << key
+          cachedInstances[key].with {
+            relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
+            relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
+            relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)
+            relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
+          }
+        }
+
+        loadBalancerKeys?.forEach { loadBalancerKey ->
+          cachedLoadBalancers[loadBalancerKey].with {
+            relationships[Keys.Namespace.SERVER_GROUPS.ns].add(serverGroupKey)
+            relationships[Keys.Namespace.INSTANCES.ns].addAll(instanceKeys)
+          }
+        }
+
+        cachedServerGroups[serverGroupKey].with {
+          def events = null
+          def autoscaler = null
+          attributes.name = serverGroupName
+
+          if (serverGroup.statefulSet) {
+            if (hasDeployment(serverGroup.statefulSet)) {
+              autoscaler = deployAutoscalers[serverGroup.namespace][clusterName]
+            } else {
+              autoscaler = rsAutoscalers[serverGroup.namespace][serverGroupName]
+            }
+            events = rsEvents[serverGroup.namespace][serverGroupName]
+          } else {
+            autoscaler = rcAutoscalers[serverGroup.namespace][serverGroupName]
+            events = rcEvents[serverGroup.namespace][serverGroupName]
+          }
+
+          attributes.serverGroup = new KubernetesServerGroup(serverGroup.statefulSet , accountName, events, autoscaler)
+          relationships[Keys.Namespace.APPLICATIONS.ns].add(applicationKey)
+          relationships[Keys.Namespace.CLUSTERS.ns].add(clusterKey)
+          relationships[Keys.Namespace.LOAD_BALANCERS.ns].addAll(loadBalancerKeys)
+          relationships[Keys.Namespace.INSTANCES.ns].addAll(instanceKeys)
+        }
+      }
+    }
+
+    log.info("Caching ${cachedApplications.size()} applications in ${agentType}")
+    log.info("Caching ${cachedClusters.size()} clusters in ${agentType}")
+    log.info("Caching ${cachedServerGroups.size()} server groups in ${agentType}")
+    log.info("Caching ${cachedInstances.size()} instances in ${agentType}")
+
+    new DefaultCacheResult([
+      (Keys.Namespace.APPLICATIONS.ns): cachedApplications.values(),
+      (Keys.Namespace.LOAD_BALANCERS.ns): cachedLoadBalancers.values(),
+      (Keys.Namespace.CLUSTERS.ns): cachedClusters.values(),
+      (Keys.Namespace.SERVER_GROUPS.ns): cachedServerGroups.values(),
+      (Keys.Namespace.INSTANCES.ns): cachedInstances.values(),
+      (Keys.Namespace.ON_DEMAND.ns): onDemandKeep.values()
+    ],[
+      (Keys.Namespace.ON_DEMAND.ns): onDemandEvict,
+    ])
+
+  }
+  static boolean hasDeployment(V1beta1StatefulSet statefulSet) {
+    return statefulSet?.metadata?.annotations?.any { k, v -> k.startsWith(DEPLOYMENT_ANNOTATION) }
+  }
+  List<Pod> loadPods(StateFulSet serverGroup) {
+    credentials.apiAdaptor.getPods(serverGroup.namespace, serverGroup.selector)
+  }
+  private static void cache(Map<String, List<CacheData>> cacheResults, String cacheNamespace, Map<String, CacheData> cacheDataById) {
+    cacheResults[cacheNamespace].each {
+      def existingCacheData = cacheDataById[it.id]
+      if (existingCacheData) {
+        existingCacheData.attributes.putAll(it.attributes)
+        it.relationships.each { String relationshipName, Collection<String> relationships ->
+          existingCacheData.relationships[relationshipName].addAll(relationships)
+        }
+      } else {
+        cacheDataById[it.id] = it
+      }
+    }
+  }
+
+  class StateFulSet{
+
+    V1beta1StatefulSet statefulSet
+    String getName() {
+      statefulSet.metadata.name
+    }
+
+    String getNamespace() {
+      statefulSet.metadata.namespace
+    }
+
+    Map<String, String> getSelector() {
+      statefulSet.spec.selector.matchLabels
+    }
+
+    boolean exists() {
+      statefulSet
+    }
+
+    List<String> getLoadBalancers() {
+      KubernetesUtil.getLoadBalancers(statefulSet)
+    }
+
+
+
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
@@ -102,6 +102,7 @@ class KubernetesProviderConfig implements Runnable {
         newlyAddedAgents << new KubernetesLoadBalancerCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads, registry)
         newlyAddedAgents << new KubernetesSecurityGroupCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads, registry)
         newlyAddedAgents << new KubernetesServerGroupCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads, registry)
+        newlyAddedAgents << new KubernetesControllersCachingAgent(credentials.name, objectMapper,credentials.credentials, index, credentials.cacheThreads,registry)
         newlyAddedAgents << new KubernetesInstanceCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)
         newlyAddedAgents << new KubernetesDeploymentCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)
         newlyAddedAgents << new KubernetesServiceAccountCachingAgent(credentials.name, credentials.credentials, objectMapper, index, credentials.cacheThreads)


### PR DESCRIPTION
feature(provider/kubernetes) : Adding support for Stateful set for new Caching agent using new java client library

1. Added new caching Agent to support StatefulSet
2. Statefull set controllers supported using new client java library (Only Get list function)
@lwander Please review the code
Regards
Prashant




We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
