### PR TITLE
refactor(dynomite): Merge now caches a single item at a time

### DIFF
--- a/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteCache.java
+++ b/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteCache.java
@@ -16,7 +16,6 @@
 package com.netflix.spinnaker.cats.dynomite.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.netflix.dyno.connectionpool.exception.DynoException;
 import com.netflix.spinnaker.cats.cache.CacheData;
@@ -30,23 +29,13 @@ import redis.clients.jedis.exceptions.JedisException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NavigableMap;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 public class DynomiteCache extends AbstractRedisCache {
-
-  // Arbitrary selection of hash expiration TTL. While the try/catches in a mergeItems call should catch cache drift
-  // caused by exceptions, this will ensure that any missed stale caches are no older than a few hours.
-  private final static int HASH_EXPIRY_SECONDS = (int) Duration.ofHours(3).getSeconds();
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -60,112 +49,83 @@ public class DynomiteCache extends AbstractRedisCache {
       return;
     }
 
-    final Set<String> relationshipNames = new HashSet<>();
-    final List<String> keysToSet = new LinkedList<>();
-    final Set<String> idSet = new HashSet<>();
-
-    final Map<String, Integer> ttlSecondsByKey = new HashMap<>();
-    int skippedWrites = 0;
-
-    final Map<String, String> hashes = getHashes(type, items);
-
-    final NavigableMap<String, String> updatedHashes = new TreeMap<>();
-
-    for (CacheData item : items) {
-      MergeOp op = buildMergeOp(type, item, hashes);
-      relationshipNames.addAll(op.relNames);
-      keysToSet.addAll(op.keysToSet);
-      idSet.add(item.getId());
-      updatedHashes.putAll(op.hashesToSet);
-      skippedWrites += op.skippedWrites;
-
-      if (item.getTtlSeconds() > 0) {
-        for (String key : op.keysToSet) {
-          ttlSecondsByKey.put(key, item.getTtlSeconds());
-        }
-      }
-    }
-
+    AtomicInteger keysWritten = new AtomicInteger();
+    AtomicInteger relationships = new AtomicInteger();
     AtomicInteger saddOperations = new AtomicInteger();
     AtomicInteger setOperations = new AtomicInteger();
-    AtomicInteger msetOperations = new AtomicInteger();
-    AtomicInteger hmsetOperations = new AtomicInteger();
     AtomicInteger expireOperations = new AtomicInteger();
-    if (!keysToSet.isEmpty()) {
-      final Set<String> failedKeys = new HashSet<>();
-      redisClientDelegate.withCommandsClient(client -> {
-        for (List<String> idPart : Iterables.partition(idSet, options.getMaxSaddSize())) {
-          final String[] ids = idPart.toArray(new String[idPart.size()]);
-          client.sadd(allOfTypeReindex(type), ids);
-          saddOperations.incrementAndGet();
-          client.sadd(allOfTypeId(type), ids);
-          saddOperations.incrementAndGet();
-        }
+    AtomicInteger delOperations = new AtomicInteger();
+    AtomicInteger skippedWrites = new AtomicInteger();
+    AtomicInteger hashesUpdated = new AtomicInteger();
 
-        for (int i = 0; i < keysToSet.size(); i = i + 2) {
-          try {
-            client.set(keysToSet.get(i), keysToSet.get(i+1));
+    final Map<String, String> hashes = getHashes(type, items);
+    redisClientDelegate.withCommandsClient(client -> {
+      for (CacheData item : items) {
+        MergeOp op = buildMergeOp(type, item, hashes);
+        skippedWrites.addAndGet(op.skippedWrites);
+
+        try {
+          client.sadd(allOfTypeReindex(type), item.getId());
+          saddOperations.incrementAndGet();
+          client.sadd(allOfTypeId(type), item.getId());
+          saddOperations.incrementAndGet();
+
+          for (int i = 0; i < op.keysToSet.size(); i = i + 2) {
+            client.set(op.keysToSet.get(i), op.keysToSet.get(i + 1));
             setOperations.incrementAndGet();
-          } catch (JedisException|DynoException e) {
-            log.error(type + " encountered Redis exception while setting cache data, marking item as failed", e);
-            failedKeys.add(keysToSet.get(i));
+            keysWritten.incrementAndGet();
           }
-        }
 
-        if (!relationshipNames.isEmpty()) {
-          for (List<String> relNamesPart : Iterables.partition(relationshipNames, options.getMaxSaddSize())) {
-            try {
-              client.sadd(allRelationshipsId(type), relNamesPart.toArray(new String[relNamesPart.size()]));
-              saddOperations.incrementAndGet();
-            } catch (JedisException|DynoException e) {
-              log.error(type + " encountered Redis exception while adding a relationship, marking " + relNamesPart.size() + " relationships as failed", e);
-              failedKeys.add(allRelationshipsId(type));
+          if (!op.relNames.isEmpty()) {
+            client.sadd(allRelationshipsId(type), op.relNames.toArray(new String[op.relNames.size()]));
+            saddOperations.incrementAndGet();
+            relationships.addAndGet(op.relNames.size());
+          }
+
+          if (!op.hashesToSet.isEmpty()) {
+            for (Entry<String, String> hashEntry : op.hashesToSet.entrySet()) {
+              client.setex(hashKey(hashesId(type), hashEntry.getKey()), getHashExpiry(), hashEntry.getValue());
+              setOperations.incrementAndGet();
+              hashesUpdated.incrementAndGet();
             }
           }
-        }
 
-        if (!updatedHashes.isEmpty()) {
-          // Prune all hashes that might be associated with failed cache writes
-          if (!failedKeys.isEmpty()) {
-            log.info(type + " failed writing caches for ~" + failedKeys.size() + " items, pruning their associated hashes");
-            Set<String> invalidHashIds = updatedHashes.entrySet().stream()
-              .filter(it -> failedKeys.contains(it.getKey()))
-              .map(Entry::getKey)
-              .collect(Collectors.toSet());
-
-            invalidHashIds.forEach(it -> {
-              updatedHashes.remove(it);
-              client.del(hashKey(hashesId(type), it));
-            });
+          if (item.getTtlSeconds() > 0) {
+            for (String key : op.keysToSet) {
+              client.expire(key, item.getTtlSeconds());
+              expireOperations.incrementAndGet();
+            }
           }
-
-          for (Entry<String, String> hashEntry : updatedHashes.entrySet()) {
-            client.setex(hashKey(hashesId(type), hashEntry.getKey()), HASH_EXPIRY_SECONDS, hashEntry.getValue());
-            setOperations.incrementAndGet();
-          }
+        } catch (JedisException|DynoException e) {
+          log.error(type + " encountered Redis exception while setting cache data for " + item.getId() + ", clearing all its related hashes");
+          op.hashesToSet.keySet().forEach(it -> {
+            String hashKey = hashKey(hashesId(type), it);
+            try {
+              client.del(hashKey);
+              delOperations.incrementAndGet();
+            } catch (JedisException|DynoException ne) {
+              log.error(type + " failed to cleanup hash " + hashKey, e);
+            }
+          });
         }
-
-        for (Map.Entry<String, Integer> ttlEntry : ttlSecondsByKey.entrySet()) {
-          client.expire(ttlEntry.getKey(), ttlEntry.getValue());
-        }
-        expireOperations.addAndGet(ttlSecondsByKey.size());
-      });
-    }
+      }
+    });
 
     cacheMetrics.merge(
       prefix,
       type,
       items.size(),
-      keysToSet.size() / 2,
-      relationshipNames.size(),
-      skippedWrites,
-      updatedHashes.size(),
+      keysWritten.get(),
+      relationships.get(),
+      skippedWrites.get(),
+      hashesUpdated.get(),
       saddOperations.get(),
       setOperations.get(),
-      msetOperations.get(),
-      hmsetOperations.get(),
       0,
-      expireOperations.get()
+      0,
+      0,
+      expireOperations.get(),
+      delOperations.get()
     );
   }
 
@@ -180,15 +140,14 @@ public class DynomiteCache extends AbstractRedisCache {
     }
 
     AtomicInteger delOperations = new AtomicInteger();
-    AtomicInteger hdelOperations = new AtomicInteger();
     AtomicInteger sremOperations = new AtomicInteger();
 
     redisClientDelegate.withCommandsClient(client -> {
       for (String key : delKeys) {
         client.del(key);
         delOperations.incrementAndGet();
-        client.hdel(hashesId(type), key);
-        hdelOperations.incrementAndGet();
+        client.del(hashKey(hashesId(type), key));
+        delOperations.incrementAndGet();
       }
 
       for (List<String> idPartition : Lists.partition(identifiers, options.getMaxDelSize())) {
@@ -207,7 +166,7 @@ public class DynomiteCache extends AbstractRedisCache {
       delKeys.size(),
       delKeys.size(),
       delOperations.get(),
-      hdelOperations.get(),
+      0,
       sremOperations.get()
     );
   }
@@ -226,5 +185,10 @@ public class DynomiteCache extends AbstractRedisCache {
 
   private String hashKey(String hashesId, String key) {
     return hashesId + ":" + key;
+  }
+
+  private int getHashExpiry() {
+    // between 1 and 3 hours; boundary is exclusive
+    return (int) Duration.ofMinutes(ThreadLocalRandom.current().nextInt(60, 4 * 60)).getSeconds();
   }
 }

--- a/cats/cats-dynomite/src/test/groovy/com/netflix/spinnaker/cat/dynomite/cache/DynomiteCacheSpec.groovy
+++ b/cats/cats-dynomite/src/test/groovy/com/netflix/spinnaker/cat/dynomite/cache/DynomiteCacheSpec.groovy
@@ -152,13 +152,13 @@ class DynomiteCacheSpec extends WriteableCacheSpec {
     ((WriteableCache) cache).merge('foo', data)
 
     then:
-    1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 1, 0, 1, 0, 0)
+    1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 2, 0, 0, 0, 0, 0)
 
     when:
     ((WriteableCache) cache).merge('foo', data)
 
     then:
-    1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0)
+    1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0)
   }
 
   private static class Bean {

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
@@ -61,7 +61,8 @@ public abstract class AbstractRedisCache implements WriteableCache {
                        int msetOperations,
                        int hmsetOperations,
                        int pipelineOperations,
-                       int expireOperations) {
+                       int expireOperations,
+                       int delOperations) {
       //noop
     }
 

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
@@ -132,7 +132,8 @@ public class RedisCache extends AbstractRedisCache {
       msetOperations.get(),
       hmsetOperations.get(),
       pipelineOperations.get(),
-      expireOperations.get()
+      expireOperations.get(),
+      0
     );
   }
 

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
@@ -136,20 +136,20 @@ class RedisCacheSpec extends WriteableCacheSpec {
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0, 0)
 
         when: //second write, hash matches
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0)
 
         when: //third write, disable hashing
         pool.resource.withCloseable { Jedis j -> j.set('test:foo:hashes.disabled', 'true')}
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0, 0)
     }
 
     def 'should not write an item if it is unchanged'() {
@@ -160,13 +160,13 @@ class RedisCacheSpec extends WriteableCacheSpec {
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0, 0)
 
         when:
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0)
     }
 
     def 'should merge #mergeCount items at a time'() {
@@ -183,8 +183,8 @@ class RedisCacheSpec extends WriteableCacheSpec {
 
         then:
 
-        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0, 2, 0, 1, 0, 1, 0)
-        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0, 2, 0, 1, 0, 1, 0)
+        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0, 2, 0, 1, 0, 1, 0, 0)
+        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0, 2, 0, 1, 0, 1, 0, 0)
 
         where:
         mergeCount << [ 1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 100, 101, 131 ]

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SpectatorRedisCacheMetrics.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SpectatorRedisCacheMetrics.groovy
@@ -33,7 +33,7 @@ class SpectatorRedisCacheMetrics implements AbstractRedisCache.CacheMetrics {
   void merge(String prefix, String type,
              int itemCount, int keysWritten, int relationshipCount, int hashMatches,
              int hashUpdates, int saddOperations, int setOperations, int msetOperations, int hmsetOperations,
-             int pipelineOperations, int expireOperations) {
+             int pipelineOperations, int expireOperations, int delOperations) {
     final Iterable<Tag> tags = tags(prefix, type)
     registry.counter(id("cats.redisCache.merge", "itemCount", tags)).increment(itemCount)
     registry.counter(id("cats.redisCache.merge", "keysWritten", tags)).increment(keysWritten)
@@ -46,6 +46,7 @@ class SpectatorRedisCacheMetrics implements AbstractRedisCache.CacheMetrics {
     registry.counter(id("cats.redisCache.merge", "hmsetOperations", tags)).increment(hmsetOperations)
     registry.counter(id("cats.redisCache.merge", "pipelineOperations", tags)).increment(pipelineOperations)
     registry.counter(id("cats.redisCache.merge", "expireOperations", tags)).increment(expireOperations)
+    registry.counter(id("cats.redisCache.merge", "delOperations", tags)).increment(delOperations)
   }
 
   @Override


### PR DESCRIPTION
Refactored `DynomiteCache` to handle merge ops more naturally instead of reusing the `RedisCache` batching logic. This also affords us much better control with hashes invalidation. Lastly, jittering hash TTLs to avoid the write spikes we were seeing.