### PR TITLE
fix(dynomite): Skip cache op if no keys need to be set

### DIFF
--- a/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteCache.java
+++ b/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteCache.java
@@ -64,6 +64,10 @@ public class DynomiteCache extends AbstractRedisCache {
         MergeOp op = buildMergeOp(type, item, hashes);
         skippedWrites.addAndGet(op.skippedWrites);
 
+        if (op.keysToSet.isEmpty()) {
+          continue;
+        }
+
         try {
           client.sadd(allOfTypeReindex(type), item.getId());
           saddOperations.incrementAndGet();

--- a/cats/cats-dynomite/src/test/groovy/com/netflix/spinnaker/cat/dynomite/cache/DynomiteCacheSpec.groovy
+++ b/cats/cats-dynomite/src/test/groovy/com/netflix/spinnaker/cat/dynomite/cache/DynomiteCacheSpec.groovy
@@ -158,7 +158,7 @@ class DynomiteCacheSpec extends WriteableCacheSpec {
     ((WriteableCache) cache).merge('foo', data)
 
     then:
-    1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0)
+    1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0)
   }
 
   private static class Bean {


### PR DESCRIPTION
Would explain why writes shot through the roof with the latest refactor.

🤦‍♂️ 