### PR TITLE
feat(provider/kubernetes): add dns policy

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -658,6 +658,7 @@ class KubernetesApiConverter {
     deployDescription.serviceAccountName = replicaSet?.spec?.template?.spec?.serviceAccountName
 
     deployDescription.nodeSelector = replicaSet?.spec?.template?.spec?.nodeSelector
+    deployDescription.dnsPolicy = replicaSet?.spec?.template?.spec?.dnsPolicy
 
     return deployDescription
   }
@@ -713,6 +714,7 @@ class KubernetesApiConverter {
     deployDescription.serviceAccountName = replicationController.spec?.template?.spec?.serviceAccountName
 
     deployDescription.nodeSelector = replicationController?.spec?.template?.spec?.nodeSelector
+    deployDescription.dnsPolicy = replicationController?.spec?.template?.spec?.dnsPolicy
 
     return deployDescription
   }
@@ -928,6 +930,10 @@ class KubernetesApiConverter {
 
     if (description.restartPolicy) {
       podTemplateSpecBuilder.withRestartPolicy(description.restartPolicy)
+    }
+
+    if (description.dnsPolicy) {
+      podTemplateSpecBuilder.withDnsPolicy(description.dnsPolicy.name())
     }
 
     if (description.terminationGracePeriodSeconds) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/job/RunKubernetesJobDescription.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.Kubernete
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesContainerDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesImageDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesVolumeSource
+import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesDnsPolicy
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 
@@ -37,4 +38,6 @@ class RunKubernetesJobDescription extends KubernetesAtomicOperationDescription {
   Map<String, String> labels
   Map<String, String> annotations
   String serviceAccountName
+  KubernetesDnsPolicy dnsPolicy
+
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -48,6 +48,7 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesAtomicOperati
   String serviceAccountName
   Integer sequence
   KubernetesPodSpecDescription podSpec
+  KubernetesDnsPolicy dnsPolicy
 
   @JsonIgnore
   Set<String> imagePullSecrets
@@ -240,6 +241,17 @@ enum KubernetesVolumeSourceType {
 
   @JsonProperty("UNSUPPORTED")
   Unsupported,
+}
+
+enum KubernetesDnsPolicy {
+  @JsonProperty("ClusterFirst")
+  ClusterFirst,
+
+  @JsonProperty("Default")
+  Default,
+
+  @JsonProperty("ClusterFirstWithHostNet")
+  ClusterFirstWithHostNet,
 }
 
 enum KubernetesStorageMediumType {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -84,12 +84,16 @@ class RunKubernetesJobAtomicOperation implements AtomicOperation<DeploymentResul
       podBuilder = podBuilder.withServiceAccountName(description.serviceAccountName)
     }
 
+    if (description.dnsPolicy) {
+      podBuilder = podBuilder.withDnsPolicy(description.dnsPolicy.name())
+    }
+
     if (description.hostNetwork) {
-        podBuilder = podBuilder.withHostNetwork(description.hostNetwork)
+      podBuilder = podBuilder.withHostNetwork(description.hostNetwork)
     }
 
     if (description.nodeSelector){
-     podBuilder = podBuilder.withNodeSelector(description.nodeSelector)
+      podBuilder = podBuilder.withNodeSelector(description.nodeSelector)
     }
 
     description.container.name = description.container.name ?: "job"


### PR DESCRIPTION
adds support for dns policy on server group definition. 

https://kubernetes.io/docs/api-reference/v1.7/#pod-v1-core

@lwander PTAL.