### PR TITLE
fix(dynomite): Retries and moving index ops to last step

### DIFF
--- a/cats/cats-dynomite/cats-dynomite.gradle
+++ b/cats/cats-dynomite/cats-dynomite.gradle
@@ -5,6 +5,7 @@ dependencies {
     exclude group: 'org.apache.httpcomponents'
     exclude group: 'org.slf4j'
   })
+  compile('net.jodah:failsafe:1.0.4')
 
   testCompile project(':cats:cats-test')
   testCompile spinnaker.dependency('korkJedisTest')


### PR DESCRIPTION
The transient errors in check preconditions appears to be related to cache invalidation. I've added some retry logic to both `merge` and `evict` options, hopefully that'll ensure a higher rate of success (although I'm not seeing many / any errors over a 12 hour period).

I've also re-ordered `merge` a little bit, so that hashes are set as the very last step, and then demoted updating the members index just before the hashes. This should reduce the risk of having a members index that is stale / inaccurate. Similarly, I moved updating the sets in `evict` to be the first operation.

@cfieber PTAL / WDYT?