### PR TITLE
fix(amazon): Support `ExtendedStatistic` parameter when copying ASG alarm

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/scalingpolicy/DefaultScalingPolicyCopier.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/scalingpolicy/DefaultScalingPolicyCopier.groovy
@@ -141,6 +141,7 @@ class DefaultScalingPolicyCopier implements ScalingPolicyCopier {
         metricName: alarm.metricName,
         namespace: alarm.namespace,
         statistic: alarm.statistic,
+        extendedStatistic: alarm.extendedStatistic,
         dimensions: newDimensions,
         period: alarm.period,
         unit: alarm.unit,


### PR DESCRIPTION
Spinnaker fails when copying ASG alarms if any existing alarms (created outside Spinnaker) are using percentile values.