### PR TITLE
feat(core): Version provider accounts/operations

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.deploy
 
+import com.netflix.spinnaker.clouddriver.orchestration.VersionedCloudProviderOperation
 import com.netflix.spinnaker.clouddriver.security.resources.AccountNameable
 import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
 import com.netflix.spinnaker.clouddriver.security.resources.ResourcesNameable
@@ -25,7 +26,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Errors
 
-public abstract class DescriptionValidator<T> {
+public abstract class DescriptionValidator<T> implements VersionedCloudProviderOperation {
 
   static String getValidatorName(String description) {
     description + "Validator"

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistry.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistry.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.orchestration
 import com.netflix.spinnaker.clouddriver.core.CloudProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.exceptions.CloudProviderNotFoundException
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,10 +33,10 @@ class AnnotationsBasedAtomicOperationsRegistry extends ApplicationContextAtomicO
   List<CloudProvider> cloudProviders
 
   @Override
-  AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider) {
+  AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider, ProviderVersion version) {
     // Legacy naming convention which is not generic and description name is specific to cloud provider
     try {
-      AtomicOperationConverter converter = super.getAtomicOperationConverter(description, cloudProvider)
+      AtomicOperationConverter converter = super.getAtomicOperationConverter(description, cloudProvider, version)
       if (converter) return converter
     } catch (NoSuchBeanDefinitionException e) {
       /**
@@ -57,16 +58,18 @@ class AnnotationsBasedAtomicOperationsRegistry extends ApplicationContextAtomicO
       value instanceof AtomicOperationConverter
     }.values().toList()
 
+    converters = VersionedOperationHelper.findVersionMatches(version, converters)
+
     if (!converters) {
       throw new AtomicOperationConverterNotFoundException(
-        "No atomic operation converter found for description '${description}' and cloud provider '${cloudProvider}'"
+          "No atomic operation converter found for description '${description}' and cloud provider '${cloudProvider}' at version '${version}'"
       )
     }
 
     if (converters.size() > 1) {
       throw new RuntimeException(
         "More than one (${converters.size()}) atomic operation converters found for description '${description}' and cloud provider " +
-          "'${cloudProvider}'"
+          "'${cloudProvider}' at version '${version}'"
       )
     }
 
@@ -74,10 +77,10 @@ class AnnotationsBasedAtomicOperationsRegistry extends ApplicationContextAtomicO
   }
 
   @Override
-  DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider) {
+  DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider, ProviderVersion version) {
     // Legacy naming convention which is not generic and validator name is specific to cloud provider
     try {
-      DescriptionValidator descriptionValidator = super.getAtomicOperationDescriptionValidator(validator, cloudProvider)
+      DescriptionValidator descriptionValidator = super.getAtomicOperationDescriptionValidator(validator, cloudProvider, version)
       if (descriptionValidator) {
         return descriptionValidator
       }
@@ -91,6 +94,8 @@ class AnnotationsBasedAtomicOperationsRegistry extends ApplicationContextAtomicO
       DescriptionValidator.getValidatorName(value.getClass().getAnnotation(providerAnnotationType).value()) == validator &&
       value instanceof DescriptionValidator
     }.values().toList()
+
+    validators = VersionedOperationHelper.findVersionMatches(version, validators)
 
     return validators ? (DescriptionValidator) validators[0] : null
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/ApplicationContextAtomicOperationsRegistry.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/ApplicationContextAtomicOperationsRegistry.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.orchestration
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 
@@ -31,12 +32,22 @@ class ApplicationContextAtomicOperationsRegistry implements AtomicOperationsRegi
   ApplicationContext applicationContext
 
   @Override
-  AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider) {
-    (AtomicOperationConverter) applicationContext.getBean(description)
+  AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider, ProviderVersion version) {
+    def result = (AtomicOperationConverter) applicationContext.getBean(description)
+    if (!result.acceptsVersion(version)) {
+      throw new AtomicOperationConverterNotFoundException("Converter version mismatch. Converter '$description' not applicable for '$version'")
+    }
+
+    return result
   }
 
   @Override
-  DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider) {
-    (DescriptionValidator) applicationContext.getBean(validator)
+  DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider, ProviderVersion version) {
+    def result = (DescriptionValidator) applicationContext.getBean(validator)
+    if (!result.acceptsVersion(version)) {
+      throw new AtomicOperationConverterNotFoundException("Validator version mismatch. Validator '$validator' not applicable for '$version'")
+    }
+
+    return result
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverter.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverter.groovy
@@ -16,20 +16,20 @@
 
 package com.netflix.spinnaker.clouddriver.orchestration
 
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
+
 /**
- * Implementations of this interface will provide an object capable of converting a Map of input parameters to an
+ * Implementations of this trait will provide an object capable of converting a Map of input parameters to an
  * operation's description object and an {@link AtomicOperation} instance.
- *
- *
  */
-interface AtomicOperationConverter {
+trait AtomicOperationConverter implements VersionedCloudProviderOperation {
   /**
    * This method takes a Map input and converts it to an {@link AtomicOperation} instance.
    *
    * @param input
    * @return atomic operation
    */
-  AtomicOperation convertOperation(Map input)
+  abstract AtomicOperation convertOperation(Map input)
 
   /**
    * This method takes a Map input and creates a description object, that will often be used by an {@link AtomicOperation}.
@@ -37,5 +37,5 @@ interface AtomicOperationConverter {
    * @param input
    * @return instance of an operation description object
    */
-  Object convertDescription(Map input)
+  abstract Object convertDescription(Map input)
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationsRegistry.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationsRegistry.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.orchestration
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 
 /**
  * A registry which does a lookup of AtomicOperationConverters and DescriptionValidators based on their names and
@@ -29,15 +30,17 @@ interface AtomicOperationsRegistry {
    *
    * @param description
    * @param cloudProvider
+   * @param providerVersion
    * @return
    */
-  AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider)
+  AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider, ProviderVersion version)
 
   /**
    *
    * @param validator
    * @param cloudProvider
+   * @param providerVersion
    * @return
    */
-  DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider)
+  DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider, ProviderVersion version)
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/VersionedCloudProviderOperation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/VersionedCloudProviderOperation.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.orchestration
+
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
+
+trait VersionedCloudProviderOperation {
+  /**
+   * Various operations can satisfy different provider's versions. This operation will only be applicable to accounts
+   * at this version.
+   *
+   * @return true i.f.f. this operations works on accounts at this version
+   */
+  boolean acceptsVersion(ProviderVersion version) {
+    return version == ProviderVersion.v1
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/VersionedOperationHelper.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/VersionedOperationHelper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.orchestration;
+
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class VersionedOperationHelper {
+  static <T extends VersionedCloudProviderOperation> List<T> findVersionMatches(ProviderVersion version, List<T> operations) {
+    return operations.stream()
+        .filter(o -> o.acceptsVersion(version))
+        .collect(Collectors.toList());
+  }
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
 import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -594,7 +595,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
         ]
       }
 
-      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce')
+      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce', ProviderVersion.v1)
       AtomicOperation templateOp = converter.convertOperation(templateOpMap)
       orchestrationProcessor.process([templateOp], UUID.randomUUID().toString())
     }

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -5,6 +5,7 @@ dependencies {
   compile spinnaker.dependency('frigga')
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
+  compile spinnaker.dependency('lombok')
 
   // TODO(lwander) move to spinnaker-dependencies when library stabilizes
   compile 'io.kubernetes:client-java-util:0.1'

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.config
 
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import com.netflix.spinnaker.fiat.model.resources.Permissions
 import groovy.transform.ToString
 
@@ -24,7 +25,7 @@ class KubernetesConfigurationProperties {
   @ToString(includeNames = true)
   static class ManagedAccount {
     String name
-    KubernetesProviderVersion providerVersion
+    ProviderVersion version
     String environment
     String accountType
     String context
@@ -47,8 +48,4 @@ class KubernetesConfigurationProperties {
 class LinkedDockerRegistryConfiguration {
   String accountName
   List<String> namespaces
-}
-
-enum KubernetesProviderVersion {
-  v1, v2
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/config/KubernetesProviderConfig.groovy
@@ -22,12 +22,19 @@ import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.cats.thread.NamedThreadFactory
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
-import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesProviderVersion
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesProvider
-import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.*
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesConfigMapCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesDeploymentCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesInstanceCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesLoadBalancerCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesSecretCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesSecurityGroupCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServerGroupCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.agent.KubernetesServiceAccountCachingAgent
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -96,7 +103,7 @@ class KubernetesProviderConfig implements Runnable {
     kubernetesProvider.agents.clear()
 
     allAccounts.each { KubernetesNamedAccountCredentials credentials ->
-      if (credentials.providerVersion == KubernetesProviderVersion.v2) {
+      if (credentials.version == ProviderVersion.v2) {
         return
       }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -17,12 +17,12 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.security;
 
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesProviderVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import groovy.util.logging.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -30,13 +30,13 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Collections;
 import java.util.List;
 
-import static com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesProviderVersion.v1;
+import static com.netflix.spinnaker.clouddriver.security.ProviderVersion.v1;
 
 @Slf4j
 public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> implements AccountCredentials<C> {
   final private String cloudProvider = "kubernetes";
   final private String name;
-  final private KubernetesProviderVersion providerVersion;
+  final private ProviderVersion version;
   final private String environment;
   final private String accountType;
   final private String context;
@@ -56,7 +56,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
   private final AccountCredentialsRepository accountCredentialsRepository;
 
   KubernetesNamedAccountCredentials(String name,
-                                    KubernetesProviderVersion providerVersion,
+                                    ProviderVersion version,
                                     AccountCredentialsRepository accountCredentialsRepository,
                                     String userAgent,
                                     String environment,
@@ -75,7 +75,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
                                     Registry spectatorRegistry,
                                     C credentials) {
     this.name = name;
-    this.providerVersion = providerVersion;
+    this.version = version;
     this.environment = environment;
     this.accountType = accountType;
     this.context = context;
@@ -104,8 +104,9 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     return name;
   }
 
-  public KubernetesProviderVersion getProviderVersion() {
-    return providerVersion;
+  @Override
+  public ProviderVersion getVersion() {
+    return version;
   }
 
   @Override
@@ -135,7 +136,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
 
   static class Builder<C extends KubernetesCredentials> {
     String name;
-    KubernetesProviderVersion providerVersion;
+    ProviderVersion version;
     String environment;
     String accountType;
     String context;
@@ -159,8 +160,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       return this;
     }
 
-    Builder providerVersion(KubernetesProviderVersion providerVersion) {
-      this.providerVersion = providerVersion;
+    Builder version(ProviderVersion version) {
+      this.version = version;
       return this;
     }
 
@@ -253,7 +254,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     }
 
     private C buildCredentials() {
-      switch (providerVersion) {
+      switch (version) {
         case v1:
           return (C) new KubernetesV1Credentials(
               name,
@@ -272,7 +273,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
         case v2:
           return (C) new KubernetesV2Credentials();
         default:
-          throw new IllegalArgumentException("Unknown provider type: " + providerVersion);
+          throw new IllegalArgumentException("Unknown provider type: " + version);
       }
     }
 
@@ -285,8 +286,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
         throw new IllegalArgumentException("At most one of 'namespaces' and 'omitNamespaces' can be specified");
       }
 
-      if (providerVersion == null) {
-        providerVersion = v1;
+      if (version == null) {
+        version = v1;
       }
 
       if (StringUtils.isEmpty(kubeconfigFile)) {
@@ -306,7 +307,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
 
       return new KubernetesNamedAccountCredentials(
           name,
-          providerVersion,
+          version,
           accountCredentialsRepository,
           userAgent,
           environment,

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -77,7 +77,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .accountCredentialsRepository(accountCredentialsRepository)
           .userAgent(clouddriverUserAgentApplicationName)
           .name(managedAccount.name)
-          .providerVersion(managedAccount.providerVersion)
+          .version(managedAccount.version)
           .environment(managedAccount.environment ?: managedAccount.name)
           .accountType(managedAccount.accountType ?: managedAccount.name)
           .context(managedAccount.context)

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AccountCredentials.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AccountCredentials.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.security;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.fiat.model.resources.Permissions;
 
 import java.util.List;
 
@@ -29,39 +28,49 @@ import java.util.List;
  * @param <T> - type of credential object to be returned
  */
 public interface AccountCredentials<T> {
-    /**
-     * Provides the name of the account to be returned.
-     *
-     * Uniquely identifies the account.
-     *
-     * @return the name of the account
-     */
-    String getName();
+  /**
+   * Provides the name of the account to be returned.
+   *
+   * Uniquely identifies the account.
+   *
+   * @return the name of the account
+   */
+  String getName();
 
-    /**
-     * Provides the environment name for the account.
-     *
-     * Many accounts can share the same environment (e.g. dev, test, prod)
-     *
-     * @return the Environment name
-     */
-    String getEnvironment();
+  /**
+   * Provides the environment name for the account.
+   *
+   * Many accounts can share the same environment (e.g. dev, test, prod)
+   *
+   * @return the Environment name
+   */
+  String getEnvironment();
 
-    /**
-     * Provides the type for the account.
-     *
-     * Account type is typically consistent among the set of credentials that represent a related set of environments.
-     *
-     * e.g.:
-     * <ul>
-     *     <li>account name: maindev, environment: dev, accountType: main</li>
-     *     <li>account name: maintest, environment: test, accountType: main</li>
-     *     <li>account name: mainprod, environment: prod, accountType: main</li>
-     * </ul>
-     *
-     * @return the type for the account.
-     */
-    String getAccountType();
+  /**
+   * Provides the type for the account.
+   *
+   * Account type is typically consistent among the set of credentials that represent a related set of environments.
+   *
+   * e.g.:
+   * <ul>
+   *     <li>account name: maindev, environment: dev, accountType: main</li>
+   *     <li>account name: maintest, environment: test, accountType: main</li>
+   *     <li>account name: mainprod, environment: prod, accountType: main</li>
+   * </ul>
+   *
+   * @return the type for the account.
+   */
+  String getAccountType();
+
+  /**
+   * Provides the "version" of the account's provider. If an account has been configured at a particular version, it can
+   * be supported by different caching agents and operation converters. By default every account is at version v1.
+   *
+   * @return the account's version.
+   */
+  default ProviderVersion getVersion() {
+    return ProviderVersion.v1;
+  }
 
   /**
    * @return the id for the account (may be null if not supported by underlying cloud provider)

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/ProviderVersion.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/ProviderVersion.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.security;
+
+public enum ProviderVersion {
+  v1,
+  v2
+}

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+lombok.nonNull.exceptionType = IllegalArgumentException
+lombok.accessors.chain = true


### PR DESCRIPTION
This is intended for the v2 k8s provider.

The idea is that accounts can expose a "version" which converters,
validators, and (in the future) caching agents will use to determine
when to be run. This is also useful if we want to start moving features
into release tracks, as we can flag operations with a "beta" version
that requires accounts to be marked with that version.

Sorry for the half-finished k8s work, I wanted to submit this before the
PR got too big
