### PR TITLE
feat(search): enhance searching capabilities

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
@@ -16,10 +16,15 @@
 
 package com.netflix.spinnaker.clouddriver.aws.cache
 
+import com.google.common.base.CaseFormat
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.cache.KeyParser
+import org.springframework.stereotype.Component
+
 import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.ID
 
-class Keys {
+@Component("AmazonInfraKeys")
+class Keys implements KeyParser {
   static enum Namespace {
     CERTIFICATES,
     SECURITY_GROUPS,
@@ -33,14 +38,27 @@ class Keys {
     final String ns
 
     private Namespace() {
-      def parts = name().split('_')
-
-      ns = parts.tail().inject(new StringBuilder(parts.head().toLowerCase())) { val, next -> val.append(next.charAt(0)).append(next.substring(1).toLowerCase()) }
+      ns = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, name())
     }
 
     String toString() {
       ns
     }
+  }
+
+  @Override
+  String getCloudProvider() {
+    return ID
+  }
+
+  @Override
+  Map<String, String> parseKey(String key) {
+    return parse(key)
+  }
+
+  @Override
+  Boolean canParse(String type) {
+    return Namespace.values().any { it.ns == type }
   }
 
   static Map<String, String> parse(String key) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -16,13 +16,51 @@
 
 package com.netflix.spinnaker.clouddriver.aws.data
 
+import com.google.common.collect.ImmutableMap
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.cache.KeyParser
 import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
 import groovy.transform.CompileStatic
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.springframework.stereotype.Component
+
 import static com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider.ID
 
 @CompileStatic
-class Keys {
+@Component("AmazonKeys")
+class Keys implements KeyParser {
+
+  private static final Map<String, String> NAMESPACE_MAPPING =
+    ImmutableMap.builder()
+      .put(Namespace.SERVER_GROUPS.ns, "serverGroup")
+      .put(Namespace.INSTANCES.ns, "instanceId")
+      .put(Namespace.LOAD_BALANCERS.ns, "loadBalancer")
+      .put(Namespace.TARGET_GROUPS.ns, "targetGroup")
+      .put(Namespace.CLUSTERS.ns, "cluster")
+      .put(Namespace.APPLICATIONS.ns, "application")
+      .build()
+
+  @Override
+  String getNameMapping(String cache) {
+    return NAMESPACE_MAPPING.get(cache)
+  }
+
+  @Override
+  String getCloudProvider() {
+    return ID
+  }
+
+  @Override
+  Map<String, String> parseKey(String key) {
+    return parse(key)
+  }
+
+  @Override
+  @TypeChecked(value = TypeCheckingMode.SKIP)
+  Boolean canParse(String type) {
+    return Namespace.values().any { it.ns == type }
+  }
 
   static Map<String, String> parse(String key) {
     def parts = key.split(':')

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyParser.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyParser.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cache;
+
+import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace;
+
+import java.util.Map;
+
+public interface KeyParser {
+
+  /**
+   * Returns the parsed property name for the specified <code>cache</code> that represents the "name" of the item being
+   * parsed.
+   *
+   * For example,
+   *
+   * Given the AWS key <code>serverGroups:mycluster-stack-detail:some-account:some-region:myservergroup-stack-detail-v000</code>,
+   * we might store the server group name (the last part of the key) under a different property than <code>name</code>,
+   * e.g., <code>serverGroup</code>, in which case the mapping of {@link Namespace#SERVER_GROUPS#ns} ->
+   * "serverGroup" would be needed.
+   *
+   * @param cache the name of the cache (key type) being parsed
+   *
+   * @return the mapping of the key name to the actual key property name for the specified <code>cache</code> or
+   * <code>null</code> if no mapping exists or is required (e.g., if the parsed key already contains a <code>name</code>
+   * property and it maps correctly).
+   */
+  default String getNameMapping(String cache) {
+    return null;
+  }
+
+  /**
+   * Indicates which provider this particular parser handles
+   * @return the cloud provider ID
+   */
+  String getCloudProvider();
+
+  /**
+   * Parses the supplied key to an arbitrary Map of attributes
+   * @param key the full key
+   * @return a Map of the key attributes
+   */
+  Map<String, String> parseKey(String key);
+
+  /**
+   * indicates whether this parser can parse the supplied type
+   * @param type the entity type, typically corresponding to a value in the implementing class's Namespace
+   * @return true if it can parse this type
+   */
+  Boolean canParse(String type);
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/Namespace.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/Namespace.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.core.provider.agent
 
+import com.google.common.base.CaseFormat
 import groovy.transform.CompileStatic
 
 @CompileStatic
@@ -39,9 +40,7 @@ public enum Namespace {
   final String ns
 
   private Namespace() {
-    def parts = name().split('_')
-
-    ns = parts.tail().inject(new StringBuilder(parts.head().toLowerCase())) { val, next -> val.append(next.charAt(0)).append(next.substring(1).toLowerCase()) }
+    ns = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, name()) // FOO_BAR -> fooBar
   }
 
   String toString() {


### PR DESCRIPTION
* initial step at allowing more advanced searching by letting the
cloudproviders define their own key parsing implementations.  e.g., for
AWS, allows the ability to query by account and region:
`http://clouddriver/search?account=prod&region=us-east-1` (note that
`account` and `region` are valid namespace parts for certain keys.

