### PR TITLE
feat(provider/ecs): Introduced atomic operation stubs

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/CloneServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/CloneServiceAtomicOperationConverter.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.deploy.DeployAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.BasicEcsDeployDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.CLONE_SERVER_GROUP)
+@Component("ecsCloneLastService")
+public class CloneServiceAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new CloneServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public CloneServiceDescription convertDescription(Map input) {
+    CloneServiceDescription converted = getObjectMapper().convertValue(input, CloneServiceDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DeleteScalingPolicyAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DeleteScalingPolicyAtomicOperationConverter.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DeleteScalingPolicyDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.DeleteScalingPolicyAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.DELETE_SCALING_POLICY)
+@Component("ecsDeleteScalingPolicy")
+public class DeleteScalingPolicyAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new DeleteScalingPolicyAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public DeleteScalingPolicyDescription convertDescription(Map input) {
+    DeleteScalingPolicyDescription converted = getObjectMapper().convertValue(input, DeleteScalingPolicyDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverter.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.DestroyServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.DESTROY_SERVER_GROUP)
+@Component("ecsDestroyServerGroup")
+public class DestroyServiceAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new DestroyServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public DestroyServiceDescription convertDescription(Map input) {
+    DestroyServiceDescription converted = getObjectMapper().convertValue(input, DestroyServiceDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DisableServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DisableServiceAtomicOperationConverter.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DisableServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.DisableServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.DISABLE_SERVER_GROUP)
+@Component("ecsDisableServerGroup")
+public class DisableServiceAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new DisableServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public DisableServiceDescription convertDescription(Map input) {
+    DisableServiceDescription converted = getObjectMapper().convertValue(input, DisableServiceDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/EnableServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/EnableServiceAtomicOperationConverter.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.EnableServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.EnableServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.ENABLE_SERVER_GROUP)
+@Component("ecsEnableServerGroup")
+public class EnableServiceAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new EnableServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public EnableServiceDescription convertDescription(Map input) {
+    EnableServiceDescription converted = getObjectMapper().convertValue(input, EnableServiceDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/ResizeServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/ResizeServiceAtomicOperationConverter.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ResizeServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.ResizeServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.RESIZE_SERVER_GROUP)
+@Component("ecsResizeServerGroup")
+public class ResizeServiceAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new ResizeServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public ResizeServiceDescription convertDescription(Map input) {
+    ResizeServiceDescription converted = getObjectMapper().convertValue(input, ResizeServiceDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/StartServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/StartServiceAtomicOperationConverter.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.StartServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.StartServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.START_SERVER_GROUP)
+@Component("ecsStartServerGroup")
+public class StartServiceAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new StartServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public StartServiceDescription convertDescription(Map input) {
+    StartServiceDescription converted = getObjectMapper().convertValue(input, StartServiceDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/StopServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/StopServiceAtomicOperationConverter.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.StopServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.StopServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.STOP_SERVER_GROUP)
+@Component("ecsStopServerGroup")
+public class StopServiceAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new StopServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public StopServiceDescription convertDescription(Map input) {
+    StopServiceDescription converted = getObjectMapper().convertValue(input, StopServiceDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/UpdateServiceAndTaskConfigAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/UpdateServiceAndTaskConfigAtomicOperationConverter.java
@@ -1,0 +1,30 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.UpdateServiceAndTaskConfigDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.UpdateServiceAndTaskConfigAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.UPDATE_LAUNCH_CONFIG)
+@Component("ecsUpdateServiceAndTaskConfig")
+public class UpdateServiceAndTaskConfigAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new UpdateServiceAndTaskConfigAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public UpdateServiceAndTaskConfigDescription convertDescription(Map input) {
+    UpdateServiceAndTaskConfigDescription converted = getObjectMapper().convertValue(input, UpdateServiceAndTaskConfigDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/UpsertScalingPolicyAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/UpsertScalingPolicyAtomicOperationConverter.java
@@ -1,0 +1,33 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAlarmDescription;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.UpsertScalingPolicyDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.UpsertScalingPolicyAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.UPSERT_SCALING_POLICY)
+@Component("ecsUpsertScalingPolicy")
+public class UpsertScalingPolicyAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new UpsertScalingPolicyAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public UpsertScalingPolicyDescription convertDescription(Map input) {
+    UpsertScalingPolicyDescription converted = getObjectMapper().convertValue(input, UpsertScalingPolicyDescription.class);
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+
+    return converted;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CloneServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CloneServiceDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class CloneServiceDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DeleteScalingPolicyDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DeleteScalingPolicyDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class DeleteScalingPolicyDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DestroyServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DestroyServiceDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class DestroyServiceDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DisableServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DisableServiceDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class DisableServiceDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/EnableServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/EnableServiceDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class EnableServiceDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/ResizeServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/ResizeServiceDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class ResizeServiceDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/StartServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/StartServiceDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class StartServiceDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/StopServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/StopServiceDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class StopServiceDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/UpdateServiceAndTaskConfigDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/UpdateServiceAndTaskConfigDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class UpdateServiceAndTaskConfigDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/UpsertScalingPolicyDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/UpsertScalingPolicyDescription.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+
+public class UpsertScalingPolicyDescription extends AbstractAmazonCredentialsDescription {
+
+  // TODO - implement this stub
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CloneServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CloneServiceAtomicOperation.java
@@ -1,0 +1,27 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CloneServiceAtomicOperation implements AtomicOperation<Void> {
+
+  CloneServiceDescription description;
+
+  public CloneServiceAtomicOperation(CloneServiceDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DeleteScalingPolicyAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DeleteScalingPolicyAtomicOperation.java
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DeleteScalingPolicyDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class DeleteScalingPolicyAtomicOperation implements AtomicOperation<Void> {
+
+  DeleteScalingPolicyDescription description;
+
+  public DeleteScalingPolicyAtomicOperation(DeleteScalingPolicyDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class DestroyServiceAtomicOperation implements AtomicOperation<Void> {
+
+  DestroyServiceDescription description;
+
+  public DestroyServiceAtomicOperation(DestroyServiceDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DisableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DisableServiceAtomicOperation.java
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DisableServiceDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class DisableServiceAtomicOperation implements AtomicOperation<Void> {
+
+  DisableServiceDescription description;
+
+  public DisableServiceAtomicOperation(DisableServiceDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.EnableServiceDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class EnableServiceAtomicOperation implements AtomicOperation<Void> {
+
+  EnableServiceDescription description;
+
+  public EnableServiceAtomicOperation(EnableServiceDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/ResizeServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/ResizeServiceAtomicOperation.java
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ResizeServiceDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class ResizeServiceAtomicOperation implements AtomicOperation<Void> {
+
+  ResizeServiceDescription description;
+
+  public ResizeServiceAtomicOperation(ResizeServiceDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StartServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StartServiceAtomicOperation.java
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ResizeServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.StartServiceDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class StartServiceAtomicOperation implements AtomicOperation<Void> {
+
+  StartServiceDescription description;
+
+  public StartServiceAtomicOperation(StartServiceDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StopServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StopServiceAtomicOperation.java
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.StopServiceDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class StopServiceAtomicOperation implements AtomicOperation<Void> {
+
+  StopServiceDescription description;
+
+  public StopServiceAtomicOperation(StopServiceDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpdateServiceAndTaskConfigAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpdateServiceAndTaskConfigAtomicOperation.java
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.UpdateServiceAndTaskConfigDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class UpdateServiceAndTaskConfigAtomicOperation implements AtomicOperation<Void> {
+
+  UpdateServiceAndTaskConfigDescription description;
+
+  public UpdateServiceAndTaskConfigAtomicOperation(UpdateServiceAndTaskConfigDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpsertScalingPolicyAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpsertScalingPolicyAtomicOperation.java
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.UpsertScalingPolicyDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+
+import java.util.List;
+
+public class UpsertScalingPolicyAtomicOperation implements AtomicOperation<Void> {
+
+  UpsertScalingPolicyDescription description;
+
+  public UpsertScalingPolicyAtomicOperation(UpsertScalingPolicyDescription description) {
+    this.description = description;
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+
+    // TODO - implement this stub
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CloneServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CloneServiceAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.CLONE_SERVER_GROUP)
+@Component("cloneServiceAtomicOperationValidator")
+public class CloneServiceAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DeleteScalingPolicyAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DeleteScalingPolicyAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.DELETE_SCALING_POLICY)
+@Component("deleteScalingPolicyAtomicOperationValidator")
+public class DeleteScalingPolicyAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DestroyServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DestroyServiceAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.DESTROY_SERVER_GROUP)
+@Component("destroyServiceAtomicOperationValidator")
+public class DestroyServiceAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DisableServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DisableServiceAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.DISABLE_SERVER_GROUP)
+@Component("disableServiceAtomicOperationValidator")
+public class DisableServiceAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EnableServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EnableServiceAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.ENABLE_SERVER_GROUP)
+@Component("enableServiceAtomicOperationValidator")
+public class EnableServiceAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ResizeServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ResizeServiceAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.RESIZE_SERVER_GROUP)
+@Component("resizeServiceAtomicOperationValidator")
+public class ResizeServiceAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StartServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StartServiceAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.START_SERVER_GROUP)
+@Component("startServiceAtomicOperationValidator")
+public class StartServiceAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StopServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StopServiceAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.STOP_SERVER_GROUP)
+@Component("stopServiceAtomicOperationValidator")
+public class StopServiceAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpdateServiceAndTaskConfigAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpdateServiceAndTaskConfigAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.UPDATE_LAUNCH_CONFIG)
+@Component("updateServiceAndTaskConfigAtomicOperationValidator")
+public class UpdateServiceAndTaskConfigAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpsertScalingPolicyAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpsertScalingPolicyAtomicOperationValidator.java
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.List;
+
+@EcsOperation(AtomicOperations.UPSERT_SCALING_POLICY)
+@Component("upsertScalingPolicyAtomicOperationValidator")
+public class UpsertScalingPolicyAtomicOperationValidator extends DescriptionValidator {
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+
+    // TODO - Implement this stub
+
+  }
+}


### PR DESCRIPTION
@robzienert  @tomaslin @ajordens @cfieber 
I created stubs for most server group atomic operations.  Although the number of files is quite high for a pull request, there is no code logic apart from the design of atomic operations, which is meant to mimic the design of the AWS module.  