### PR TITLE
refactor(dynomite): Consolidating cache & hash structs into hashsets

### DIFF
--- a/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteNamedCacheFactory.java
+++ b/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteNamedCacheFactory.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory;
 import com.netflix.spinnaker.cats.cache.WriteableCache;
 import com.netflix.spinnaker.cats.dynomite.DynomiteClientDelegate;
-import com.netflix.spinnaker.cats.redis.cache.AbstractRedisCache.CacheMetrics;
+import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache.CacheMetrics;
 import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions;
 
 public class DynomiteNamedCacheFactory implements NamedCacheFactory {

--- a/cats/cats-dynomite/src/test/groovy/com/netflix/spinnaker/cat/dynomite/cache/DynomiteCacheSpec.groovy
+++ b/cats/cats-dynomite/src/test/groovy/com/netflix/spinnaker/cat/dynomite/cache/DynomiteCacheSpec.groovy
@@ -30,7 +30,7 @@ import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.cache.WriteableCacheSpec
 import com.netflix.spinnaker.cats.dynomite.DynomiteClientDelegate
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache
-import com.netflix.spinnaker.cats.redis.cache.AbstractRedisCache.CacheMetrics
+import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache.CacheMetrics
 import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import redis.clients.jedis.Jedis
@@ -58,11 +58,7 @@ class DynomiteCacheSpec extends WriteableCacheSpec {
 
   @Override
   Cache getSubject() {
-//    if (System.getProperty('dyno.hostname') == null) {
-//      initEmbeddedRedisClient()
-//    } else {
-      initLocalDynoClusterClient()
-//    }
+    initLocalDynoClusterClient()
 
     def delegate = new DynomiteClientDelegate(client)
 
@@ -152,13 +148,13 @@ class DynomiteCacheSpec extends WriteableCacheSpec {
     ((WriteableCache) cache).merge('foo', data)
 
     then:
-    1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 2, 0, 0, 0, 0, 0)
+    1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 2, 2, 1, 0)
 
     when:
     ((WriteableCache) cache).merge('foo', data)
 
     then:
-    1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0)
+    1 * cacheMetrics.merge('test', 'foo', 1, 0, 1, 0, 0, 0, 0, 0)
   }
 
   private static class Bean {

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
@@ -15,104 +15,52 @@
  */
 package com.netflix.spinnaker.cats.redis.cache;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.hash.Hashing;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.CacheFilter;
-import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.cache.WriteableCache;
 import com.netflix.spinnaker.cats.redis.RedisClientDelegate;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 public abstract class AbstractRedisCache implements WriteableCache {
 
-  public interface CacheMetrics {
-    default void merge(String prefix,
-                       String type,
-                       int itemCount,
-                       int keysWritten,
-                       int relationshipCount,
-                       int hashMatches,
-                       int hashUpdates,
-                       int saddOperations,
-                       int setOperations,
-                       int msetOperations,
-                       int hmsetOperations,
-                       int pipelineOperations,
-                       int expireOperations,
-                       int delOperations) {
-      //noop
-    }
-
-    default void evict(String prefix,
-                       String type,
-                       int itemCount,
-                       int keysDeleted,
-                       int hashesDeleted,
-                       int delOperations,
-                       int hdelOperations,
-                       int sremOperations) {
-      //noop
-    }
-
-    default void get(String prefix,
-                     String type,
-                     int itemCount,
-                     int requestedSize,
-                     int keysRequested,
-                     int relationshipsRequested,
-                     int mgetOperations) {
-      //noop
-    }
-
-    class NOOP implements CacheMetrics {
-    }
-  }
-
-  private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {
+  protected static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {
   };
-  private static final TypeReference<List<String>> RELATIONSHIPS = new TypeReference<List<String>>() {
+  protected static final TypeReference<List<String>> RELATIONSHIPS = new TypeReference<List<String>>() {
   };
 
   protected final String prefix;
   protected final RedisClientDelegate redisClientDelegate;
   protected final ObjectMapper objectMapper;
   protected final RedisCacheOptions options;
-  protected final CacheMetrics cacheMetrics;
 
-  public AbstractRedisCache(String prefix, RedisClientDelegate redisClientDelegate, ObjectMapper objectMapper, RedisCacheOptions options, CacheMetrics cacheMetrics) {
+  protected AbstractRedisCache(String prefix, RedisClientDelegate redisClientDelegate, ObjectMapper objectMapper, RedisCacheOptions options) {
     this.prefix = prefix;
     this.redisClientDelegate = redisClientDelegate;
     this.objectMapper = objectMapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
     this.options = options;
-    this.cacheMetrics = cacheMetrics == null ? new CacheMetrics.NOOP() : cacheMetrics;
   }
 
   abstract protected void mergeItems(String type, Collection<CacheData> items);
 
   abstract protected void evictItems(String type, List<String> identifiers, Collection<String> allRelationships);
+
+  abstract protected Collection<CacheData> getItems(String type, List<String> ids, List<String> knownRels);
 
   @Override
   public void merge(String type, CacheData item) {
@@ -149,7 +97,7 @@ public abstract class AbstractRedisCache implements WriteableCache {
 
   @Override
   public CacheData get(String type, String id, CacheFilter cacheFilter) {
-    Collection<CacheData> result = getAll(type, Arrays.asList(id), cacheFilter);
+    Collection<CacheData> result = getAll(type, Collections.singletonList(id), cacheFilter);
     if (result.isEmpty()) {
       return null;
     }
@@ -233,135 +181,7 @@ public abstract class AbstractRedisCache implements WriteableCache {
     });
   }
 
-  protected static class MergeOp {
-    public final Set<String> relNames;
-    public final List<String> keysToSet;
-    public final Map<String, String> hashesToSet;
-    public final int skippedWrites;
-
-    public MergeOp(Set<String> relNames, List<String> keysToSet, Map<String, String> hashesToSet, int skippedWrites) {
-      this.relNames = relNames;
-      this.keysToSet = keysToSet;
-      this.hashesToSet = hashesToSet;
-      this.skippedWrites = skippedWrites;
-    }
-  }
-
-  /**
-   * Compares the hash of serializedValue against an existing hash, if they do not match adds
-   * serializedValue to keys and the new hash to updatedHashes.
-   *
-   * @param hashes          the existing hash values
-   * @param id              the id of the item
-   * @param serializedValue the serialized value
-   * @param keys            values to persist - if the hash does not match id and serializedValue are appended
-   * @param updatedHashes   hashes to persist - if the hash does not match adds an entry of id -> computed hash
-   * @return true if the hash matched, false otherwise
-   */
-  private boolean hashCheck(Map<String, String> hashes, String id, String serializedValue, List<String> keys, Map<String, String> updatedHashes) {
-    if (options.isHashingEnabled()) {
-      final String hash = Hashing.sha1().newHasher().putString(serializedValue, UTF_8).hash().toString();
-      final String existingHash = hashes.get(id);
-      if (hash.equals(existingHash)) {
-        return true;
-      }
-      updatedHashes.put(id, hash);
-    }
-
-    keys.add(id);
-    keys.add(serializedValue);
-    return false;
-  }
-
-  protected MergeOp buildMergeOp(String type, CacheData cacheData, Map<String, String> hashes) {
-    int skippedWrites = 0;
-    final String serializedAttributes;
-    try {
-      if (cacheData.getAttributes().isEmpty()) {
-        serializedAttributes = null;
-      } else {
-        serializedAttributes = objectMapper.writeValueAsString(cacheData.getAttributes());
-      }
-    } catch (JsonProcessingException serializationException) {
-      throw new RuntimeException("Attribute serialization failed", serializationException);
-    }
-
-    final Map<String, String> hashesToSet = new HashMap<>();
-    final List<String> keysToSet = new ArrayList<>((cacheData.getRelationships().size() + 1) * 2);
-    if (serializedAttributes != null &&
-      hashCheck(hashes, attributesId(type, cacheData.getId()), serializedAttributes, keysToSet, hashesToSet)) {
-      skippedWrites++;
-    }
-
-    if (!cacheData.getRelationships().isEmpty()) {
-      for (Map.Entry<String, Collection<String>> relationship : cacheData.getRelationships().entrySet()) {
-        final String relationshipValue;
-        try {
-          relationshipValue = objectMapper.writeValueAsString(new LinkedHashSet<>(relationship.getValue()));
-        } catch (JsonProcessingException serializationException) {
-          throw new RuntimeException("Relationship serialization failed", serializationException);
-        }
-        if (hashCheck(hashes, relationshipId(type, cacheData.getId(), relationship.getKey()), relationshipValue, keysToSet, hashesToSet)) {
-          skippedWrites++;
-        }
-      }
-    }
-
-    return new MergeOp(cacheData.getRelationships().keySet(), keysToSet, hashesToSet, skippedWrites);
-  }
-
-  private List<String> getKeys(String type, Collection<CacheData> cacheDatas) {
-    final Collection<String> keys = new HashSet<>();
-    for (CacheData cacheData : cacheDatas) {
-      if (!cacheData.getAttributes().isEmpty()) {
-        keys.add(attributesId(type, cacheData.getId()));
-      }
-      if (!cacheData.getRelationships().isEmpty()) {
-        for (String relationship : cacheData.getRelationships().keySet()) {
-          keys.add(relationshipId(type, cacheData.getId(), relationship));
-        }
-      }
-    }
-    return new ArrayList<>(keys);
-  }
-
-  protected List<String> getHashValues(List<String> hashKeys, String hashesId) {
-    final List<String> hashValues = new ArrayList<>(hashKeys.size());
-    redisClientDelegate.withCommandsClient(c -> {
-      for (List<String> hashPart : Lists.partition(hashKeys, options.getMaxHmgetSize())) {
-        hashValues.addAll(c.hmget(hashesId, Arrays.copyOf(hashPart.toArray(), hashPart.size(), String[].class)));
-      }
-    });
-    return hashValues;
-  }
-
-  protected Map<String, String> getHashes(String type, Collection<CacheData> items) {
-    if (isHashingDisabled(type)) {
-      return Collections.emptyMap();
-    }
-
-    final List<String> hashKeys = getKeys(type, items);
-    if (hashKeys.isEmpty()) {
-      return Collections.emptyMap();
-    }
-
-    final List<String> hashValues = getHashValues(hashKeys, hashesId(type));
-    if (hashValues.size() != hashKeys.size()) {
-      throw new RuntimeException("Expected same size result as request");
-    }
-
-    final Map<String, String> hashes = new HashMap<>(hashKeys.size());
-    for (int i = 0; i < hashValues.size(); i++) {
-      final String hashValue = hashValues.get(i);
-      if (hashValue != null) {
-        hashes.put(hashKeys.get(i), hashValue);
-      }
-    }
-
-    return isHashingDisabled(type) ? Collections.emptyMap() : hashes;
-  }
-
-  private boolean isHashingDisabled(String type) {
+  protected boolean isHashingDisabled(String type) {
      if (!options.isHashingEnabled()) {
         return true;
      }
@@ -370,79 +190,12 @@ public abstract class AbstractRedisCache implements WriteableCache {
      });
    }
 
-  private Collection<CacheData> getItems(String type, List<String> ids, List<String> knownRels) {
-    final int singleResultSize = knownRels.size() + 1;
-
-    final List<String> keysToGet = new ArrayList<>(singleResultSize * ids.size());
-    for (String id : ids) {
-      keysToGet.add(attributesId(type, id));
-      for (String rel : knownRels) {
-        keysToGet.add(relationshipId(type, id, rel));
-      }
-    }
-
-    final List<String> keyResult = new ArrayList<>(keysToGet.size());
-
-    int mgetOperations = redisClientDelegate.withMultiClient(c -> {
-      int ops = 0;
-      for (List<String> part : Lists.partition(keysToGet, options.getMaxMgetSize())) {
-        ops++;
-        keyResult.addAll(c.mget(part.toArray(new String[part.size()])));
-      }
-      return ops;
-    });
-
-    if (keyResult.size() != keysToGet.size()) {
-      throw new RuntimeException("Expected same size result as request");
-    }
-
-    Collection<CacheData> results = new ArrayList<>(ids.size());
-    Iterator<String> idIterator = ids.iterator();
-    for (int ofs = 0; ofs < keyResult.size(); ofs += singleResultSize) {
-      CacheData item = extractItem(idIterator.next(), keyResult.subList(ofs, ofs + singleResultSize), knownRels);
-      if (item != null) {
-        results.add(item);
-      }
-    }
-
-    cacheMetrics.get(prefix, type, results.size(), ids.size(), keysToGet.size(), knownRels.size(), mgetOperations);
-    return results;
-  }
-
-  private CacheData extractItem(String id, List<String> keyResult, List<String> knownRels) {
-    if (keyResult.get(0) == null) {
-      return null;
-    }
-
-    try {
-      final Map<String, Object> attributes = objectMapper.readValue(keyResult.get(0), ATTRIBUTES);
-      final Map<String, Collection<String>> relationships = new HashMap<>(keyResult.size() - 1);
-      for (int relIdx = 1; relIdx < keyResult.size(); relIdx++) {
-        String rel = keyResult.get(relIdx);
-        if (rel != null) {
-          String relType = knownRels.get(relIdx - 1);
-          Collection<String> deserializedRel = objectMapper.readValue(rel, RELATIONSHIPS);
-          relationships.put(relType, deserializedRel);
-        }
-      }
-
-      return new DefaultCacheData(id, attributes, relationships);
-
-    } catch (IOException deserializationException) {
-      throw new RuntimeException("Deserialization failed", deserializationException);
-    }
-  }
-
   protected String attributesId(String type, String id) {
     return String.format("%s:%s:attributes:%s", prefix, type, id);
   }
 
   protected String relationshipId(String type, String id, String relationship) {
     return String.format("%s:%s:relationships:%s:%s", prefix, type, id, relationship);
-  }
-
-  protected String hashesId(String type) {
-    return String.format("%s:%s:hashes", prefix, type);
   }
 
   private String hashesDisabled(String type) {

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
@@ -15,16 +15,24 @@
  */
 package com.netflix.spinnaker.cats.redis.cache;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.hash.Hashing;
 import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.redis.RedisClientDelegate;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -33,10 +41,56 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class RedisCache extends AbstractRedisCache {
 
+  public interface CacheMetrics {
+    default void merge(String prefix,
+                       String type,
+                       int itemCount,
+                       int keysWritten,
+                       int relationshipCount,
+                       int hashMatches,
+                       int hashUpdates,
+                       int saddOperations,
+                       int msetOperations,
+                       int hmsetOperations,
+                       int pipelineOperations,
+                       int expireOperations) {
+      //noop
+    }
+
+    default void evict(String prefix,
+                       String type,
+                       int itemCount,
+                       int keysDeleted,
+                       int hashesDeleted,
+                       int delOperations,
+                       int hdelOperations,
+                       int sremOperations) {
+      //noop
+    }
+
+    default void get(String prefix,
+                     String type,
+                     int itemCount,
+                     int requestedSize,
+                     int keysRequested,
+                     int relationshipsRequested,
+                     int mgetOperations) {
+      //noop
+    }
+
+    class NOOP implements CacheMetrics {
+    }
+  }
+
+  private final CacheMetrics cacheMetrics;
+
   public RedisCache(String prefix, RedisClientDelegate redisClientDelegate, ObjectMapper objectMapper, RedisCacheOptions options, CacheMetrics cacheMetrics) {
-    super(prefix, redisClientDelegate, objectMapper, options, cacheMetrics);
+    super(prefix, redisClientDelegate, objectMapper, options);
+    this.cacheMetrics = cacheMetrics == null ? new CacheMetrics.NOOP() : cacheMetrics;
   }
 
   @Override
@@ -128,12 +182,10 @@ public class RedisCache extends AbstractRedisCache {
       skippedWrites,
       updatedHashes.size(),
       saddOperations.get(),
-      0,
       msetOperations.get(),
       hmsetOperations.get(),
       pipelineOperations.get(),
-      expireOperations.get(),
-      0
+      expireOperations.get()
     );
   }
 
@@ -179,5 +231,201 @@ public class RedisCache extends AbstractRedisCache {
       hdelOperations.get(),
       sremOperations.get()
     );
+  }
+
+  @Override
+  protected Collection<CacheData> getItems(String type, List<String> ids, List<String> knownRels) {
+    final int singleResultSize = knownRels.size() + 1;
+
+    final List<String> keysToGet = new ArrayList<>(singleResultSize * ids.size());
+    for (String id : ids) {
+      keysToGet.add(attributesId(type, id));
+      for (String rel : knownRels) {
+        keysToGet.add(relationshipId(type, id, rel));
+      }
+    }
+
+    final List<String> keyResult = new ArrayList<>(keysToGet.size());
+
+    int mgetOperations = redisClientDelegate.withMultiClient(c -> {
+      int ops = 0;
+      for (List<String> part : Lists.partition(keysToGet, options.getMaxMgetSize())) {
+        ops++;
+        keyResult.addAll(c.mget(part.toArray(new String[part.size()])));
+      }
+      return ops;
+    });
+
+    if (keyResult.size() != keysToGet.size()) {
+      throw new RuntimeException("Expected same size result as request");
+    }
+
+    Collection<CacheData> results = new ArrayList<>(ids.size());
+    Iterator<String> idIterator = ids.iterator();
+    for (int ofs = 0; ofs < keyResult.size(); ofs += singleResultSize) {
+      CacheData item = extractItem(idIterator.next(), keyResult.subList(ofs, ofs + singleResultSize), knownRels);
+      if (item != null) {
+        results.add(item);
+      }
+    }
+
+    cacheMetrics.get(prefix, type, results.size(), ids.size(), keysToGet.size(), knownRels.size(), mgetOperations);
+    return results;
+  }
+
+  private CacheData extractItem(String id, List<String> keyResult, List<String> knownRels) {
+    if (keyResult.get(0) == null) {
+      return null;
+    }
+
+    try {
+      final Map<String, Object> attributes = objectMapper.readValue(keyResult.get(0), ATTRIBUTES);
+      final Map<String, Collection<String>> relationships = new HashMap<>(keyResult.size() - 1);
+      for (int relIdx = 1; relIdx < keyResult.size(); relIdx++) {
+        String rel = keyResult.get(relIdx);
+        if (rel != null) {
+          String relType = knownRels.get(relIdx - 1);
+          Collection<String> deserializedRel = objectMapper.readValue(rel, RELATIONSHIPS);
+          relationships.put(relType, deserializedRel);
+        }
+      }
+
+      return new DefaultCacheData(id, attributes, relationships);
+
+    } catch (IOException deserializationException) {
+      throw new RuntimeException("Deserialization failed", deserializationException);
+    }
+  }
+
+  private static class MergeOp {
+    public final Set<String> relNames;
+    public final List<String> keysToSet;
+    public final Map<String, String> hashesToSet;
+    public final int skippedWrites;
+
+    MergeOp(Set<String> relNames, List<String> keysToSet, Map<String, String> hashesToSet, int skippedWrites) {
+      this.relNames = relNames;
+      this.keysToSet = keysToSet;
+      this.hashesToSet = hashesToSet;
+      this.skippedWrites = skippedWrites;
+    }
+  }
+
+  private MergeOp buildMergeOp(String type, CacheData cacheData, Map<String, String> hashes) {
+    int skippedWrites = 0;
+    final String serializedAttributes;
+    try {
+      if (cacheData.getAttributes().isEmpty()) {
+        serializedAttributes = null;
+      } else {
+        serializedAttributes = objectMapper.writeValueAsString(cacheData.getAttributes());
+      }
+    } catch (JsonProcessingException serializationException) {
+      throw new RuntimeException("Attribute serialization failed", serializationException);
+    }
+
+    final Map<String, String> hashesToSet = new HashMap<>();
+    final List<String> keysToSet = new ArrayList<>((cacheData.getRelationships().size() + 1) * 2);
+    if (serializedAttributes != null &&
+      hashCheck(hashes, attributesId(type, cacheData.getId()), serializedAttributes, keysToSet, hashesToSet)) {
+      skippedWrites++;
+    }
+
+    if (!cacheData.getRelationships().isEmpty()) {
+      for (Map.Entry<String, Collection<String>> relationship : cacheData.getRelationships().entrySet()) {
+        final String relationshipValue;
+        try {
+          relationshipValue = objectMapper.writeValueAsString(new LinkedHashSet<>(relationship.getValue()));
+        } catch (JsonProcessingException serializationException) {
+          throw new RuntimeException("Relationship serialization failed", serializationException);
+        }
+        if (hashCheck(hashes, relationshipId(type, cacheData.getId(), relationship.getKey()), relationshipValue, keysToSet, hashesToSet)) {
+          skippedWrites++;
+        }
+      }
+    }
+
+    return new MergeOp(cacheData.getRelationships().keySet(), keysToSet, hashesToSet, skippedWrites);
+  }
+
+  private List<String> getKeys(String type, Collection<CacheData> cacheDatas) {
+    final Collection<String> keys = new HashSet<>();
+    for (CacheData cacheData : cacheDatas) {
+      if (!cacheData.getAttributes().isEmpty()) {
+        keys.add(attributesId(type, cacheData.getId()));
+      }
+      if (!cacheData.getRelationships().isEmpty()) {
+        for (String relationship : cacheData.getRelationships().keySet()) {
+          keys.add(relationshipId(type, cacheData.getId(), relationship));
+        }
+      }
+    }
+    return new ArrayList<>(keys);
+  }
+
+  private List<String> getHashValues(List<String> hashKeys, String hashesId) {
+    final List<String> hashValues = new ArrayList<>(hashKeys.size());
+    redisClientDelegate.withCommandsClient(c -> {
+      for (List<String> hashPart : Lists.partition(hashKeys, options.getMaxHmgetSize())) {
+        hashValues.addAll(c.hmget(hashesId, Arrays.copyOf(hashPart.toArray(), hashPart.size(), String[].class)));
+      }
+    });
+    return hashValues;
+  }
+
+  /**
+   * Compares the hash of serializedValue against an existing hash, if they do not match adds
+   * serializedValue to keys and the new hash to updatedHashes.
+   *
+   * @param hashes          the existing hash values
+   * @param id              the id of the item
+   * @param serializedValue the serialized value
+   * @param keys            values to persist - if the hash does not match id and serializedValue are appended
+   * @param updatedHashes   hashes to persist - if the hash does not match adds an entry of id -> computed hash
+   * @return true if the hash matched, false otherwise
+   */
+  private boolean hashCheck(Map<String, String> hashes, String id, String serializedValue, List<String> keys, Map<String, String> updatedHashes) {
+    if (options.isHashingEnabled()) {
+      final String hash = Hashing.sha1().newHasher().putString(serializedValue, UTF_8).hash().toString();
+      final String existingHash = hashes.get(id);
+      if (hash.equals(existingHash)) {
+        return true;
+      }
+      updatedHashes.put(id, hash);
+    }
+
+    keys.add(id);
+    keys.add(serializedValue);
+    return false;
+  }
+
+  private Map<String, String> getHashes(String type, Collection<CacheData> items) {
+    if (isHashingDisabled(type)) {
+      return Collections.emptyMap();
+    }
+
+    final List<String> hashKeys = getKeys(type, items);
+    if (hashKeys.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    final List<String> hashValues = getHashValues(hashKeys, hashesId(type));
+    if (hashValues.size() != hashKeys.size()) {
+      throw new RuntimeException("Expected same size result as request");
+    }
+
+    final Map<String, String> hashes = new HashMap<>(hashKeys.size());
+    for (int i = 0; i < hashValues.size(); i++) {
+      final String hashValue = hashValues.get(i);
+      if (hashValue != null) {
+        hashes.put(hashKeys.get(i), hashValue);
+      }
+    }
+
+    return hashes;
+  }
+
+  private String hashesId(String type) {
+    return String.format("%s:%s:hashes", prefix, type);
   }
 }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactory.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactory.java
@@ -20,15 +20,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory;
 import com.netflix.spinnaker.cats.cache.WriteableCache;
 import com.netflix.spinnaker.cats.redis.RedisClientDelegate;
+import com.netflix.spinnaker.cats.redis.cache.RedisCache.CacheMetrics;
 
 public class RedisNamedCacheFactory implements NamedCacheFactory {
 
     private final RedisClientDelegate redisClientDelegate;
     private final ObjectMapper objectMapper;
     private final RedisCacheOptions options;
-    private final AbstractRedisCache.CacheMetrics cacheMetrics;
+    private final CacheMetrics cacheMetrics;
 
-    public RedisNamedCacheFactory(RedisClientDelegate redisClientDelegate, ObjectMapper objectMapper, RedisCacheOptions options, AbstractRedisCache.CacheMetrics cacheMetrics) {
+    public RedisNamedCacheFactory(RedisClientDelegate redisClientDelegate, ObjectMapper objectMapper, RedisCacheOptions options, CacheMetrics cacheMetrics) {
         this.redisClientDelegate = redisClientDelegate;
         this.objectMapper = objectMapper;
         this.options = options;

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.cache.WriteableCacheSpec
 import com.netflix.spinnaker.cats.redis.JedisClientDelegate
-import com.netflix.spinnaker.cats.redis.cache.AbstractRedisCache.CacheMetrics
+import com.netflix.spinnaker.cats.redis.cache.RedisCache.CacheMetrics
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
@@ -136,20 +136,20 @@ class RedisCacheSpec extends WriteableCacheSpec {
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 1, 1, 1, 0, )
 
         when: //second write, hash matches
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0)
 
         when: //third write, disable hashing
         pool.resource.withCloseable { Jedis j -> j.set('test:foo:hashes.disabled', 'true')}
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 1, 1, 1, 0)
     }
 
     def 'should not write an item if it is unchanged'() {
@@ -160,13 +160,13 @@ class RedisCacheSpec extends WriteableCacheSpec {
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 0, 1, 1, 1, 0, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 1, 1, 1, 0)
 
         when:
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 0, 0, 1, 0, 0, 0, 0, 0, 0)
     }
 
     def 'should merge #mergeCount items at a time'() {
@@ -183,8 +183,8 @@ class RedisCacheSpec extends WriteableCacheSpec {
 
         then:
 
-        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0, 2, 0, 1, 0, 1, 0, 0)
-        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0, 2, 0, 1, 0, 1, 0, 0)
+        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0, 2, 1, 0, 1, 0)
+        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0, 2, 1, 0, 1, 0)
 
         where:
         mergeCount << [ 1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 100, 101, 131 ]

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteCacheConfig.groovy
@@ -27,11 +27,10 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.AgentScheduler
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory
 import com.netflix.spinnaker.cats.dynomite.DynomiteClientDelegate
+import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache.CacheMetrics
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteNamedCacheFactory
 import com.netflix.spinnaker.cats.dynomite.cluster.DynoClusteredAgentScheduler
 import com.netflix.spinnaker.cats.redis.RedisClientDelegate
-import com.netflix.spinnaker.cats.redis.cache.AbstractRedisCache
-import com.netflix.spinnaker.cats.redis.cache.AbstractRedisCache.CacheMetrics
 import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions
 import com.netflix.spinnaker.cats.redis.cluster.AgentIntervalProvider
 import com.netflix.spinnaker.cats.redis.cluster.DefaultNodeIdentity
@@ -54,8 +53,8 @@ import java.util.concurrent.TimeUnit
 class DynomiteCacheConfig {
 
   @Bean
-  AbstractRedisCache.CacheMetrics cacheMetrics(Registry registry) {
-    new SpectatorRedisCacheMetrics(registry)
+  CacheMetrics cacheMetrics(Registry registry) {
+    new SpectatorDynomiteCacheMetrics(registry)
   }
 
   @Bean

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/JedisCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/JedisCacheConfig.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.cats.agent.AgentScheduler
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory
 import com.netflix.spinnaker.cats.redis.JedisClientDelegate
 import com.netflix.spinnaker.cats.redis.RedisClientDelegate
-import com.netflix.spinnaker.cats.redis.cache.AbstractRedisCache
+import com.netflix.spinnaker.cats.redis.cache.RedisCache.CacheMetrics
 import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions
 import com.netflix.spinnaker.cats.redis.cache.RedisNamedCacheFactory
 import com.netflix.spinnaker.cats.redis.cluster.AgentIntervalProvider
@@ -51,7 +51,7 @@ class JedisCacheConfig {
     RedisClientDelegate redisClientDelegate,
     ObjectMapper objectMapper,
     RedisCacheOptions redisCacheOptions,
-    AbstractRedisCache.CacheMetrics cacheMetrics) {
+    CacheMetrics cacheMetrics) {
     new RedisNamedCacheFactory(redisClientDelegate, objectMapper, redisCacheOptions, cacheMetrics)
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/RedisCacheConfig.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.cache
 
 import com.netflix.discovery.DiscoveryClient
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.cats.redis.cache.AbstractRedisCache
+import com.netflix.spinnaker.cats.redis.cache.RedisCache.CacheMetrics
 import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions
 import com.netflix.spinnaker.cats.redis.cluster.AgentIntervalProvider
 import com.netflix.spinnaker.cats.redis.cluster.DefaultNodeStatusProvider
@@ -51,7 +51,7 @@ class RedisCacheConfig {
   }
 
   @Bean
-  AbstractRedisCache.CacheMetrics cacheMetrics(Registry registry) {
+  CacheMetrics cacheMetrics(Registry registry) {
     new SpectatorRedisCacheMetrics(registry)
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SpectatorDynomiteCacheMetrics.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SpectatorDynomiteCacheMetrics.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.cache;
+
+import com.netflix.spectator.api.BasicTag;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache.CacheMetrics;
+
+import java.util.Arrays;
+
+public class SpectatorDynomiteCacheMetrics implements CacheMetrics {
+
+  private final Registry registry;
+
+  SpectatorDynomiteCacheMetrics(Registry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public void merge(String prefix, String type, int itemCount, int relationshipCount, int hashMatches, int hashUpdates, int saddOperations, int hmsetOperations, int expireOperations, int delOperations) {
+    final Iterable<Tag> tags = tags(prefix, type);
+    registry.counter(id("cats.dynomiteCache.merge", "itemCount", tags)).increment(itemCount);
+    registry.counter(id("cats.dynomiteCache.merge", "relationshipCount", tags)).increment(relationshipCount);
+    registry.counter(id("cats.dynomiteCache.merge", "hashMatches", tags)).increment(hashMatches);
+    registry.counter(id("cats.dynomiteCache.merge", "hashUpdates", tags)).increment(hashUpdates);
+    registry.counter(id("cats.dynomiteCache.merge", "saddOperations", tags)).increment(saddOperations);
+    registry.counter(id("cats.dynomiteCache.merge", "hmsetOperations", tags)).increment(hmsetOperations);
+    registry.counter(id("cats.dynomiteCache.merge", "expireOperations", tags)).increment(expireOperations);
+    registry.counter(id("cats.dynomiteCache.merge", "delOperations", tags)).increment(delOperations);
+  }
+
+  @Override
+  public void evict(String prefix, String type, int itemCount, int delOperations, int sremOperations) {
+    final Iterable<Tag> tags = tags(prefix, type);
+    registry.counter(id("cats.dynomiteCache.evict", "itemCount", tags)).increment(itemCount);
+    registry.counter(id("cats.dynomiteCache.evict", "delOperations", tags)).increment(delOperations);
+    registry.counter(id("cats.dynomiteCache.evict", "sremOperations", tags)).increment(sremOperations);
+  }
+
+  @Override
+  public void get(String prefix, String type, int itemCount, int requestedSize, int relationshipsRequested, int hmgetAllOperations) {
+    final Iterable<Tag> tags = tags(prefix, type);
+    registry.counter(id("cats.dynomiteCache.get", "itemCount", tags)).increment(itemCount);
+    registry.counter(id("cats.dynomiteCache.get", "requestedSize", tags)).increment(requestedSize);
+    registry.counter(id("cats.dynomiteCache.get", "relationshipsRequested", tags)).increment(relationshipsRequested);
+    registry.counter(id("cats.dynomiteCache.get", "hmgetAllOperations", tags)).increment(hmgetAllOperations);
+  }
+
+  private Id id(String metricGroup, String metric, Iterable<Tag> tags) {
+    return registry.createId(metricGroup + '.' + metric, tags);
+  }
+
+  private Iterable<Tag> tags(String prefix, String type) {
+    return Arrays.asList(new BasicTag("prefix", prefix), new BasicTag("type", type));
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SpectatorRedisCacheMetrics.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SpectatorRedisCacheMetrics.groovy
@@ -20,9 +20,9 @@ import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Tag
-import com.netflix.spinnaker.cats.redis.cache.AbstractRedisCache
+import com.netflix.spinnaker.cats.redis.cache.RedisCache.CacheMetrics
 
-class SpectatorRedisCacheMetrics implements AbstractRedisCache.CacheMetrics {
+class SpectatorRedisCacheMetrics implements CacheMetrics {
   private final Registry registry
 
   SpectatorRedisCacheMetrics(Registry registry) {
@@ -32,8 +32,8 @@ class SpectatorRedisCacheMetrics implements AbstractRedisCache.CacheMetrics {
   @Override
   void merge(String prefix, String type,
              int itemCount, int keysWritten, int relationshipCount, int hashMatches,
-             int hashUpdates, int saddOperations, int setOperations, int msetOperations, int hmsetOperations,
-             int pipelineOperations, int expireOperations, int delOperations) {
+             int hashUpdates, int saddOperations, int msetOperations, int hmsetOperations,
+             int pipelineOperations, int expireOperations) {
     final Iterable<Tag> tags = tags(prefix, type)
     registry.counter(id("cats.redisCache.merge", "itemCount", tags)).increment(itemCount)
     registry.counter(id("cats.redisCache.merge", "keysWritten", tags)).increment(keysWritten)
@@ -41,12 +41,10 @@ class SpectatorRedisCacheMetrics implements AbstractRedisCache.CacheMetrics {
     registry.counter(id("cats.redisCache.merge", "hashMatches", tags)).increment(hashMatches)
     registry.counter(id("cats.redisCache.merge", "hashUpdates", tags)).increment(hashUpdates)
     registry.counter(id("cats.redisCache.merge", "saddOperations", tags)).increment(saddOperations)
-    registry.counter(id("cats.redisCache.merge", "setOperations", tags)).increment(setOperations)
     registry.counter(id("cats.redisCache.merge", "msetOperations", tags)).increment(msetOperations)
     registry.counter(id("cats.redisCache.merge", "hmsetOperations", tags)).increment(hmsetOperations)
     registry.counter(id("cats.redisCache.merge", "pipelineOperations", tags)).increment(pipelineOperations)
     registry.counter(id("cats.redisCache.merge", "expireOperations", tags)).increment(expireOperations)
-    registry.counter(id("cats.redisCache.merge", "delOperations", tags)).increment(delOperations)
   }
 
   @Override


### PR DESCRIPTION
Now that we're running Dynomite in staging and performing loadtests,
we've been seeing dramatically reduced performance due, in part, to
the aggregate overhead of performing individual network calls for
each key, whereas in vanilla Redis, we were able to multi-key op and
pipeline requests.

This is a swing back in the direction of larger keys, in an effort
to reduce the overhead of network call volume.

@spinnaker/netflix-reviewers PTAL / FYI