### PR TITLE
fix(userdata): Ensure whitespace is trimmed from userdata

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -131,7 +131,7 @@ class AutoScalingWorker {
       classicLinkVpcSecurityGroups: classicLinkVpcSecurityGroups,
       instanceType: instanceType,
       keyPair: keyPair,
-      base64UserData: base64UserData,
+      base64UserData: base64UserData?.trim(),
       associatePublicIpAddress: associatePublicIpAddress,
       kernelId: kernelId,
       ramdiskId: ramdiskId,


### PR DESCRIPTION
Reported in Slack (from multiple users) that userdata will transiently get a newline inserted at the beginning, causing cloud-init to fail.
