### PR TITLE
feat(dynomite): hashtags & dynomite pipelines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.111.1'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.113.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/cats/cats-dynomite/cats-dynomite.gradle
+++ b/cats/cats-dynomite/cats-dynomite.gradle
@@ -1,6 +1,6 @@
 dependencies {
   compile project(':cats:cats-redis')
-  compile('com.netflix.dyno:dyno-jedis:1.5.9', {
+  compile('com.netflix.dyno:dyno-jedis:1.6.0-rc.2', {
     exclude group: 'joda-time'
     exclude group: 'org.apache.httpcomponents'
     exclude group: 'org.slf4j'

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/JedisClientDelegate.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/JedisClientDelegate.java
@@ -21,8 +21,8 @@ import redis.clients.jedis.JedisCommands;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.MultiKeyCommands;
 import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.RedisPipeline;
 import redis.clients.jedis.ScriptingCommands;
-import redis.clients.jedis.commands.RedisPipeline;
 
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/RedisClientDelegate.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/RedisClientDelegate.java
@@ -19,8 +19,8 @@ import redis.clients.jedis.BinaryJedisCommands;
 import redis.clients.jedis.JedisCommands;
 import redis.clients.jedis.MultiKeyCommands;
 import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.RedisPipeline;
 import redis.clients.jedis.ScriptingCommands;
-import redis.clients.jedis.commands.RedisPipeline;
 
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteCacheConfig.groovy
@@ -102,7 +102,7 @@ class DynomiteCacheConfig {
 
   @Bean
   NamedCacheFactory cacheFactory(
-    RedisClientDelegate dynomiteClientDelegate,
+    DynomiteClientDelegate dynomiteClientDelegate,
     ObjectMapper objectMapper,
     RedisCacheOptions redisCacheOptions,
     CacheMetrics cacheMetrics) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteConfigurationProperties.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteConfigurationProperties.groovy
@@ -56,10 +56,12 @@ class DynomiteConfigurationProperties {
     String datacenter = 'localrac'
 
     Long token = 1000000L
+
+    String hashtag
   }
 
   List<Host> getDynoHosts() {
-    return hosts.collect { new Host(it.hostname, it.ipAddress, it.port, it.rack, it.datacenter, it.status) }
+    return hosts.collect { new Host(it.hostname, it.ipAddress, it.port, it.rack, it.datacenter, it.status, it.hashtag) }
   }
 
   List<HostToken> getDynoHostTokens() {


### PR DESCRIPTION
The latest round of dyno changes dramatically improved perf across the board, but it's still slow enough to rustle up some race conditions.

The dyno client currently doesn't support hashtags, but I wanted to put this out here so I don't forget about the work. This will further cut down the RTT dynomite latency. All keys for a provider's caching agent will get pinned to a single node, allowing most ops to get pipelined in `DynomiteCache`.