### PR TITLE
fix(provider/aws): Remove copySourceSpotPrice property

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -65,11 +65,6 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
    */
   boolean copySourceCustomBlockDeviceMappings = true
 
-  /**
-   * If false, the newly created server group will not pick up a spot price from an ancestor group
-   */
-  boolean copySourceSpotPrice = true
-
   String classicLinkVpcId
   List<String> classicLinkVpcSecurityGroups
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -326,7 +326,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
                                                     BasicAmazonDeployDescription description) {
 
     //skip a couple of AWS calls if we won't use any of the data
-    if (!(useSourceCapacity || description.copySourceCustomBlockDeviceMappings || description.copySourceSpotPrice)) {
+    if (!(useSourceCapacity || description.copySourceCustomBlockDeviceMappings)) {
       return description
     }
 
@@ -359,7 +359,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
     }
 
     //skip a describeLaunchConfiguration if we won't use it for anything
-    if (!(description.copySourceSpotPrice || description.copySourceCustomBlockDeviceMappings)) {
+    if (!description.copySourceCustomBlockDeviceMappings) {
       return description
     }
 
@@ -369,10 +369,6 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
 
     if (description.copySourceCustomBlockDeviceMappings) {
       description.blockDevices = buildBlockDeviceMappings(description, sourceLaunchConfiguration)
-    }
-
-    if (description.copySourceSpotPrice) {
-      description.spotPrice = description.spotPrice ?: sourceLaunchConfiguration.spotPrice
     }
 
     return description


### PR DESCRIPTION
This property is no longer needed and was causing Spinnaker to deploy
serverGroups with spotPrices even though the spot price had been removed
(because a previous deployment had the spot price set)

Related to https://github.com/spinnaker/deck/pull/4043 and https://github.com/spinnaker/orca/pull/1572