### PR TITLE
feat(amazon): Support a generic proxy for static content stored in S3

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProvider.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.view;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.CacheStats;
+import com.google.common.cache.LoadingCache;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.model.DataProvider;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.*;
+
+@Component
+public class AmazonS3DataProvider implements DataProvider {
+  private final ObjectMapper objectMapper;
+  private final AmazonClientProvider amazonClientProvider;
+  private final AccountCredentialsRepository accountCredentialsRepository;
+  private final AmazonS3StaticDataProviderConfiguration configuration;
+
+  private final Set<String> supportedIdentifiers;
+
+  private final LoadingCache<String, Object> staticCache = CacheBuilder.newBuilder()
+    .expireAfterWrite(1, TimeUnit.MINUTES)
+    .recordStats()
+    .build(
+      new CacheLoader<String, Object>() {
+        public Object load(String id) throws IOException {
+          StaticRecord record = configuration.getStaticRecord(id);
+          S3Object s3Object = fetchObject(
+            record.getBucketAccount(), record.getBucketRegion(), record.getBucketName(), record.getId()
+          );
+
+          switch (record.getType()) {
+            case list:
+              return objectMapper.readValue(s3Object.getObjectContent(), List.class);
+            case object:
+              return objectMapper.readValue(s3Object.getObjectContent(), Map.class);
+          }
+
+          return IOUtils.toString(s3Object.getObjectContent());
+        }
+      });
+
+  @Autowired
+  public AmazonS3DataProvider(ObjectMapper objectMapper,
+                              AmazonClientProvider amazonClientProvider,
+                              AccountCredentialsRepository accountCredentialsRepository,
+                              AmazonS3StaticDataProviderConfiguration configuration) {
+    this.objectMapper = objectMapper;
+    this.amazonClientProvider = amazonClientProvider;
+    this.accountCredentialsRepository = accountCredentialsRepository;
+    this.configuration = configuration;
+
+    this.supportedIdentifiers = configuration.getStaticRecords()
+      .stream()
+      .map(r -> r.getId().toLowerCase())
+      .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Object getStaticData(String id, Map<String, Object> filters) {
+    try {
+      Object contents = staticCache.get(id);
+      if (filters.isEmpty() || !(contents instanceof List)) {
+        return contents;
+      }
+
+      return ((List<Map>) contents)
+        .stream()
+        .filter(r -> {
+          // currently only support filtering against first level attributes (TBD whether this is even necessary)
+          return filters.entrySet()
+            .stream()
+            .anyMatch(f -> r.get(f.getKey()).equals(f.getValue()));
+        })
+        .collect(Collectors.toList());
+    } catch (ExecutionException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public void getAdhocData(String groupId, String bucketId, String objectId, OutputStream outputStream) {
+    String[] bucketCoordinates = bucketId.split(":");
+    if (bucketCoordinates.length != 3) {
+      throw new IllegalArgumentException("'bucketId' must be of the form {account}:{region}:{name}");
+    }
+
+    String bucketAccount = getAccountName(bucketCoordinates[0]);
+    String bucketRegion = bucketCoordinates[1];
+    String bucketName = bucketCoordinates[2];
+
+    AdhocRecord record = configuration.getAdhocRecord(groupId);
+    Matcher bucketNameMatcher = record.getBucketNamePattern().matcher(bucketName);
+    Matcher objectKeyMatcher = record.getObjectKeyPattern().matcher(objectId);
+
+    if (!bucketNameMatcher.matches() || !objectKeyMatcher.matches()) {
+      throw new AccessDeniedException("Access denied (bucket: " + bucketName + ", object: " + objectId + ")");
+    }
+
+    try {
+      S3Object s3Object = fetchObject(bucketAccount, bucketRegion, bucketName, objectId);
+      IOUtils.copy(s3Object.getObjectContent(), outputStream);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String getAccountForIdentifier(IdentifierType identifierType, String id) {
+    switch (identifierType) {
+      case Static:
+        return configuration.getStaticRecord(id).getBucketAccount();
+      case Adhoc:
+        return getAccountName(id.split(":")[0]);
+    }
+
+    throw new IllegalArgumentException("Unsupported identifierType (" + identifierType + ")");
+  }
+
+  @Override
+  public boolean supportsIdentifier(IdentifierType identifierType, String id) {
+    switch (identifierType) {
+      case Static:
+        return supportedIdentifiers.contains(id.toLowerCase());
+      case Adhoc:
+        return configuration.getAdhocRecords()
+          .stream()
+          .anyMatch(r -> r.getId().equalsIgnoreCase(id));
+    }
+
+    throw new IllegalArgumentException("Unsupported identifierType (" + identifierType + ")");
+  }
+
+  CacheStats getStaticCacheStats() {
+    return staticCache.stats();
+  }
+
+  protected S3Object fetchObject(String bucketAccount, String bucketRegion, String bucketName, String objectId) {
+    NetflixAmazonCredentials account = (NetflixAmazonCredentials) accountCredentialsRepository.getOne(bucketAccount);
+
+    AmazonS3 amazonS3 = amazonClientProvider.getAmazonS3(account, bucketRegion);
+    return amazonS3.getObject(bucketName, objectId);
+  }
+
+  private String getAccountName(String accountIdOrName) {
+    return accountCredentialsRepository.getAll()
+      .stream()
+      .filter(c -> c.getAccountId().equalsIgnoreCase(accountIdOrName) || c.getName().equalsIgnoreCase(accountIdOrName))
+      .map(AccountCredentials::getName)
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("Unsupported account identifier (accountId: " + accountIdOrName + ")"));
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3StaticDataProviderConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3StaticDataProviderConfiguration.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.view
+
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+import java.util.regex.Pattern;
+
+@Component
+@ConfigurationProperties('data.s3')
+@Canonical
+class AmazonS3StaticDataProviderConfiguration {
+  enum StaticRecordType {
+    list,
+    object,
+    string
+  }
+
+  @Canonical
+  static class StaticRecord {
+    String id
+    StaticRecordType type
+    String bucketAccount
+    String bucketRegion
+    String bucketName
+    String bucketKey
+  }
+
+  @Canonical
+  static class AdhocRecord {
+    String id
+    Pattern bucketNamePattern
+    Pattern objectKeyPattern
+
+    void setBucketNamePattern(String bucketNamePattern) {
+      this.bucketNamePattern = Pattern.compile(bucketNamePattern)
+    }
+
+    void setObjectKeyPattern(String objectKeyPattern) {
+      this.objectKeyPattern = Pattern.compile(objectKeyPattern)
+    }
+  }
+
+  List<StaticRecord> staticRecords = []
+  List<AdhocRecord> adhocRecords = []
+
+  StaticRecord getStaticRecord(String id) {
+    def staticRecord = getStaticRecords().find { it.getId().equalsIgnoreCase(id) }
+    if (!staticRecord) {
+      throw new NotFoundException("No static data found (id: ${id})")
+    }
+
+    return staticRecord
+  }
+
+  AdhocRecord getAdhocRecord(String id) {
+    def adhocRecord = getAdhocRecords().find { it.getId().equalsIgnoreCase(id) }
+    if (!adhocRecord) {
+      throw new NotFoundException("No adhoc data found (id: ${id})")
+    }
+
+    return adhocRecord
+  }
+
+
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -38,6 +38,8 @@ import com.amazonaws.services.lambda.AWSLambdaAsyncClientBuilder;
 import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
 import com.amazonaws.services.route53.AmazonRoute53;
 import com.amazonaws.services.route53.AmazonRoute53ClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
@@ -297,6 +299,10 @@ public class AmazonClientProvider {
 
   public AWSLambdaAsync getAmazonLambdaAsync(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
     return awsSdkClientSupplier.getClient(AWSLambdaAsyncClientBuilder.class, AWSLambdaAsync.class, accountName, awsCredentialsProvider, region);
+  }
+
+  public AmazonS3 getAmazonS3(NetflixAmazonCredentials amazonCredentials, String region) {
+    return proxyHandlerBuilder.getProxyHandler(AmazonS3.class, AmazonS3ClientBuilder.class, amazonCredentials, region, true);
   }
 
   public AmazonAutoScaling getAutoScaling(NetflixAmazonCredentials amazonCredentials, String region) {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonS3DataProviderSpec.groovy
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.view
+
+import com.amazonaws.services.s3.model.S3Object
+import com.amazonaws.services.s3.model.S3ObjectInputStream
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import org.springframework.security.access.AccessDeniedException
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.util.regex.Pattern;
+
+import static com.netflix.spinnaker.clouddriver.model.DataProvider.IdentifierType.*
+import static com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3StaticDataProviderConfiguration.StaticRecordType.*
+
+class AmazonS3DataProviderSpec extends Specification {
+  def objectMapper = new ObjectMapper()
+  def amazonClientProvider = Mock(AmazonClientProvider)
+  def accountCredentialsRepository = Mock(AccountCredentialsRepository)
+  def configuration = new AmazonS3StaticDataProviderConfiguration([
+    new AmazonS3StaticDataProviderConfiguration.StaticRecord("staticId", string, "accountName", "bucket", "key"),
+    new AmazonS3StaticDataProviderConfiguration.StaticRecord("staticListId", list, "accountName", "bucket", "key")
+  ], [
+    new AmazonS3StaticDataProviderConfiguration.AdhocRecord(
+      id: "adhocId",
+      bucketNamePattern: Pattern.compile(".*restricted.*"),
+      objectKeyPattern: Pattern.compile(".*magic.*")
+    )
+  ])
+
+  def s3Object = Mock(S3Object)
+
+  @Subject
+  def dataProvider = new AmazonS3DataProvider(
+    objectMapper,
+    amazonClientProvider,
+    accountCredentialsRepository,
+    configuration
+  ) {
+    @Override
+    protected S3Object fetchObject(String bucketAccount, String bucketRegion, String bucketName, String objectId) {
+      return s3Object
+    }
+  }
+
+  void setup() {
+    accountCredentialsRepository.getAll() >> {
+      [
+        Mock(AccountCredentials) {
+          getAccountId() >> "12345678910"
+          getName() >> "accountName"
+        }
+      ]
+    }
+  }
+
+  def "supports account lookup by id or name"() {
+    expect:
+    dataProvider.getAccountForIdentifier(Adhoc, "accountName:us-east-1:my_bucket") == "accountName"
+    dataProvider.getAccountForIdentifier(Adhoc, "12345678910:us-east-1:my_bucket") == "accountName"
+    dataProvider.getAccountForIdentifier(Static, "staticId") == "accountName"
+  }
+
+  @Unroll
+  def "should raise exception if identifier is unsupported"() {
+    expect:
+    try {
+      dataProvider.getAccountForIdentifier(type, id)
+      assert !expectsException
+    } catch (Exception ignored) {
+      assert expectsException
+    }
+
+    where:
+    type   | id                                       || expectsException
+    Adhoc  | "invalidAccountName:us-east-1:my_bucket" || true
+    Adhoc  | "accountName:us-east-1:my_bucket"        || false
+    Static | "invalidId"                              || true
+    Static | "staticId"                               || false
+  }
+
+  @Unroll
+  def "should support identifier iff configuration exists"() {
+    expect:
+    dataProvider.supportsIdentifier(type, id) == supported
+
+    where:
+    type   | id         || supported
+    Adhoc  | "adhocId"  || true
+    Static | "staticId" || true
+    Adhoc  | "randomId" || false
+    Static | "randomId" || false
+  }
+
+  def "should stream adhoc results"() {
+    given:
+    def outputStream = new ByteArrayOutputStream()
+
+    when:
+    dataProvider.getAdhocData("adhocId", "accountName:us-east-1:my_restricted_bucket", "magic/my_object", outputStream)
+
+    then:
+    1 * s3Object.getObjectContent() >> {
+      return new S3ObjectInputStream(new ByteArrayInputStream("my example output!".bytes), null)
+    }
+    new String(outputStream.toByteArray(), "UTF-8") == "my example output!"
+  }
+
+  def "should deny requests to fetch adhoc results from non-whitelisted buckets or keys"() {
+    when: "the object key is not whitelisted"
+    dataProvider.getAdhocData("adhocId", "accountName:us-east-1:my_restricted_bucket", "my_object", null)
+
+    then:
+    thrown(AccessDeniedException)
+
+    when: "the bucket name is not whitelisted"
+    dataProvider.getAdhocData("adhocId", "accountName:us-east-1:my_bucket", "magic/my_object", null)
+
+    then:
+    thrown(AccessDeniedException)
+  }
+
+  def "should cache static results"() {
+    when:
+    def result = dataProvider.getStaticData("staticId", [:])
+
+    then:
+    1 * s3Object.getObjectContent() >> {
+      return new S3ObjectInputStream(new ByteArrayInputStream("my example output!".bytes), null)
+    }
+    dataProvider.getStaticCacheStats().hitCount() == 0
+    result == "my example output!"
+
+    when:
+    result = dataProvider.getStaticData("staticId", [:])
+
+    then:
+    0 * _
+    dataProvider.getStaticCacheStats().hitCount() == 1
+    result == "my example output!"
+  }
+
+  def "should support filters when static result is of type list"() {
+    given:
+    def resultsJson = objectMapper.writeValueAsString([
+      [name: "foo", id: 1],
+      [name: "bar", id: 2],
+      [name: "baz", id: 3]
+    ])
+
+    when:
+    def result = dataProvider.getStaticData("staticListId", [name: "bar"])
+
+    then:
+    1 * s3Object.getObjectContent() >> {
+      return new S3ObjectInputStream(
+        new ByteArrayInputStream(resultsJson.bytes), null
+      )
+    }
+    result == [
+      [name: "bar", id: 2]
+    ]
+
+    when:
+    result = dataProvider.getStaticData("staticId", [name: "bar"])
+
+    then:
+    1 * s3Object.getObjectContent() >> {
+      return new S3ObjectInputStream(
+        new ByteArrayInputStream(resultsJson.bytes), null
+      )
+    }
+
+    // if type != list than all results should be returned as-is w/o filtering
+    result == resultsJson
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/DataProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/DataProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model;
+
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Map;
+
+public interface DataProvider {
+  enum IdentifierType {
+    Static,
+    Adhoc
+  }
+
+  /**
+   * Fetch a specific object from a bucket that has been explicitly configured.
+   *
+   * Filters are supported if the configured object is of type `list`.
+   *
+   * @return string/list/map depending on type of configured object
+   */
+  Object getStaticData(String id, Map<String, Object> filters);
+
+  /**
+   * Stream a specified object from a bucket.
+   *
+   * Both the object key and bucket name must be whitelisted.
+   */
+  void getAdhocData(String groupId, String bucketId, String objectId, OutputStream outputStream);
+
+  /**
+   * @return true if this identifier is supported by the data provider
+   */
+  boolean supportsIdentifier(IdentifierType identifierType, String id);
+
+  /**
+   * @return the account name corresponding to the provided identifier
+   */
+  String getAccountForIdentifier(IdentifierType identifierType, String id);
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/DataController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/DataController.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers
+
+import com.netflix.spinnaker.clouddriver.model.DataProvider
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import com.netflix.spinnaker.security.AuthenticatedRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.util.AntPathMatcher
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.HandlerMapping
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+
+import javax.servlet.http.HttpServletRequest
+
+@RestController
+@RequestMapping("/v1/data")
+class DataController {
+  @Autowired(required = false)
+  List<DataProvider> dataProviders = []
+
+  @RequestMapping(value = "/static/{id}", method = RequestMethod.GET)
+  Object getStaticData(@PathVariable("id") String id, @RequestParam Map<String, String> filters) {
+    def dataProvider = dataProviders.find { it.supportsIdentifier(DataProvider.IdentifierType.Static, id) }
+    if (!dataProvider) {
+      throw new NotFoundException("No data available (id: ${id})")
+    }
+
+    def account = dataProvider.getAccountForIdentifier(DataProvider.IdentifierType.Static, id)
+    verifyAccessToAccount(account)
+
+    return dataProvider.getStaticData(id, filters)
+  }
+
+  @RequestMapping(value = "/adhoc/{groupId}/{bucketId}/**")
+  StreamingResponseBody getAdhocData(@PathVariable("groupId") String groupId,
+                                     @PathVariable("bucketId") String bucketId,
+                                     HttpServletRequest httpServletRequest) {
+    def dataProvider = dataProviders.find { it.supportsIdentifier(DataProvider.IdentifierType.Adhoc, groupId) }
+    if (!dataProvider) {
+      throw new NotFoundException("No data available (groupId: ${groupId})")
+    }
+
+    def account = dataProvider.getAccountForIdentifier(DataProvider.IdentifierType.Adhoc, bucketId)
+    verifyAccessToAccount(account)
+
+    String pattern = (String) httpServletRequest.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+    String objectId = new AntPathMatcher().extractPathWithinPattern(pattern, httpServletRequest.getServletPath());
+
+    return new StreamingResponseBody() {
+      @Override
+      void writeTo (OutputStream outputStream) throws IOException {
+        dataProvider.getAdhocData(groupId, bucketId, objectId, outputStream)
+      }
+    };
+  }
+
+  private static void verifyAccessToAccount(String account) {
+    def allowedAccounts = (AuthenticatedRequest.getSpinnakerAccounts().orElse(null)?.split(",") ?: []) as Set<String>
+    if (!allowedAccounts.contains(account)) {
+      throw new AccessDeniedException("Access denied (account: ${account})")
+    }
+  }
+}

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/DataControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/DataControllerSpec.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers
+
+import com.netflix.spinnaker.clouddriver.model.DataProvider
+import com.netflix.spinnaker.security.AuthenticatedRequest
+import org.slf4j.MDC
+import org.springframework.security.access.AccessDeniedException
+import spock.lang.Specification
+import spock.lang.Subject
+
+import javax.servlet.http.HttpServletRequest;
+
+class DataControllerSpec extends Specification {
+  def dataProvider = Mock(DataProvider) {
+    supportsIdentifier(_, _) >> { return true }
+    getAccountForIdentifier(_, _) >> { _, id -> return id }
+  }
+
+  @Subject
+  def dataController = new DataController(dataProviders: [dataProvider])
+
+  void setup() {
+    MDC.remove(AuthenticatedRequest.SPINNAKER_ACCOUNTS)
+  }
+
+
+  def "should verify access to account when fetching static data"() {
+    when:
+    dataController.getStaticData("restricted", [:])
+
+    then:
+    thrown(AccessDeniedException)
+
+    when:
+    MDC.put(AuthenticatedRequest.SPINNAKER_ACCOUNTS, "restricted")
+    dataController.getStaticData("restricted", [:])
+
+    then:
+    notThrown(AccessDeniedException)
+  }
+
+  def "should verify access to account when fetching adhoc data"() {
+    given:
+    def httpServletRequest = Mock(HttpServletRequest)
+
+    when:
+    dataController.getAdhocData("groupId", "restricted", httpServletRequest)
+
+    then:
+    thrown(AccessDeniedException)
+
+    when:
+    MDC.put(AuthenticatedRequest.SPINNAKER_ACCOUNTS, "restricted")
+    dataController.getAdhocData("groupId", "restricted", httpServletRequest)
+
+    then:
+    1 * httpServletRequest.getAttribute(_) >> { return "pattern" }
+    1 * httpServletRequest.getServletPath() >> { return "/servlet/path" }
+    notThrown(AccessDeniedException)
+  }
+}


### PR DESCRIPTION
In the short-term. this will allow a custom `deck` component to display
data that has been placed in an s3 bucket (in our case, by another team).

The proxy supports both static and adhoc configurations:
- `static`: A single bucket/object will be proxied (and temporarily cached)
-  `adhoc`: Any bucket/object will be proxied provided it matches a whitelist.
            The whitelist allows restriction on both bucket names and object keys.

Only buckets that Spinnaker has read access to are eligible for proxying.

The requesting user _must_ have access to the account containing the bucket/object
being proxied.