### PR TITLE
fix(perf): Restrict the recent ClusterController-focused perf changes…

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppengineClusterProvider.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppengineClusterProvider.groovy
@@ -121,6 +121,11 @@ class AppengineClusterProvider implements ClusterProvider<AppengineCluster> {
     AppengineCloudProvider.ID
   }
 
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
+  }
+
   Collection<AppengineCluster> translateClusters(Collection<CacheData> clusterData, boolean includeDetails) {
     if (!clusterData) {
       return []

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -106,6 +106,11 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster> {
     return amazonCloudProvider.id
   }
 
+  @Override
+  boolean supportsMinimalClusters() {
+    return true
+  }
+
   private static Map<String, Set<AmazonCluster>> mapResponse(Collection<AmazonCluster> clusters) {
     clusters.groupBy { it.accountName }.collectEntries { k, v -> [k, new HashSet(v)] }
   }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/cluster/view/AzureClusterProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/cluster/view/AzureClusterProvider.groovy
@@ -127,6 +127,11 @@ class AzureClusterProvider implements ClusterProvider<AzureCluster> {
     return azureCloudProvider.id
   }
 
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
+  }
+
   private Collection<AzureCluster> translateClusters(Collection<CacheData> clusterData, boolean includeDetails) {
     Map<String, AzureLoadBalancer> loadBalancers
     Map<String, AzureServerGroupDescription> serverGroups

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/view/CloudFoundryClusterProvider.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/view/CloudFoundryClusterProvider.groovy
@@ -113,6 +113,11 @@ class CloudFoundryClusterProvider implements ClusterProvider<CloudFoundryCluster
     return cloudFoundryCloudProvider.id
   }
 
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
+  }
+
   private Map<String, Set<CloudFoundryCluster>> getClusters0(String applicationName, boolean includeDetails) {
     CacheData application = cacheView.get(APPLICATIONS.ns, Keys.getApplicationKey(applicationName))
     if (application == null) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ClusterProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ClusterProvider.groovy
@@ -95,4 +95,11 @@ interface ClusterProvider<T extends Cluster> {
    * @return the identifier of the backing cloud provider
    */
   String getCloudProviderId()
+
+  /**
+   * Determines whether or not optimizations can be made by retrieving minimal or unexpanded clusters.
+   *
+   * This primarily affects how server groups are loaded for a cluster (@see com.netflix.spinnaker.clouddriver.controllers.ClusterController}.
+   */
+  boolean supportsMinimalClusters()
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopClusterProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopClusterProvider.groovy
@@ -57,4 +57,9 @@ class NoopClusterProvider implements ClusterProvider<Cluster> {
   String getCloudProviderId() {
     return "noop"
   }
+
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
+  }
 }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/view/DcosClusterProvider.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/view/DcosClusterProvider.groovy
@@ -126,6 +126,11 @@ class DcosClusterProvider implements ClusterProvider<DcosCluster> {
     return dcosCloudProvider.id
   }
 
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
+  }
+
   private static Map<String, Set<DcosCluster>> mapResponse(Collection<DcosCluster> clusters) {
     clusters.groupBy { it.accountName }.collectEntries { k, v -> [k, new HashSet(v)] }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -146,6 +146,11 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
     return googleCloudProvider.id
   }
 
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
+  }
+
   GoogleCluster.View clusterFromCacheData(CacheData cacheData, boolean includeInstanceDetails) {
     GoogleCluster.View clusterView = objectMapper.convertValue(cacheData.attributes, GoogleCluster)?.view
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesClusterProvider.groovy
@@ -80,9 +80,7 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
   KubernetesCluster getCluster(String application, String account, String name, boolean includeDetails) {
     CacheData serverGroupCluster = cacheView.get(Keys.Namespace.CLUSTERS.ns, Keys.getClusterKey(account, application, "serverGroup", name))
     List<CacheData> clusters = [serverGroupCluster] - null
-    // Opting to always include details due to some bugs trying to optimize server group performance
-    // Proper fix should include an audit of what server group details are needed when.
-    return clusters ? translateClusters(clusters, true /*includeDetails*/).inject(new KubernetesCluster()) { KubernetesCluster acc, KubernetesCluster val ->
+    return clusters ? translateClusters(clusters, includeDetails).inject(new KubernetesCluster()) { KubernetesCluster acc, KubernetesCluster val ->
       acc.name = acc.name ?: val.name
       acc.accountName = acc.accountName ?: val.accountName
       acc.loadBalancers.addAll(val.loadBalancers)
@@ -238,5 +236,10 @@ class KubernetesClusterProvider implements ClusterProvider<KubernetesCluster> {
   @Override
   String getCloudProviderId() {
     return kubernetesCloudProvider.id
+  }
+
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
   }
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackClusterProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackClusterProvider.groovy
@@ -116,6 +116,11 @@ class OpenstackClusterProvider implements ClusterProvider<OpenstackCluster.View>
     return openstackCloudProvider.id
   }
 
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
+  }
+
   protected Map<String, Set<OpenstackCluster.View>> getClustersInternal(
     final String applicationName, final boolean includeInstanceDetails) {
     Map<String, Set<OpenstackCluster.View>> result = null

--- a/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/view/OracleBMCSClusterProvider.groovy
+++ b/clouddriver-oracle-bmcs/src/main/groovy/com/netflix/spinnaker/clouddriver/oraclebmcs/provider/view/OracleBMCSClusterProvider.groovy
@@ -93,6 +93,11 @@ class OracleBMCSClusterProvider implements ClusterProvider<OracleBMCSCluster.Vie
     return serverGroups.iterator().next().getView()
   }
 
+  @Override
+  boolean supportsMinimalClusters() {
+    return false
+  }
+
   private OracleBMCSServerGroup restoreCreds(OracleBMCSServerGroup partial, String identifier) {
     def account = Keys.parse(identifier)?.get("account")
     partial.credentials = accountCredentialsProvider.getCredentials(account)

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
@@ -91,6 +91,8 @@ class ClusterControllerSpec extends Specification {
       def result = clusterController.getServerGroup("app", "account", "clusterName", "type", "clusterName-v001", null)
 
     then:
+      1 * clusterProvider1.getCloudProviderId() >> { return "type" }
+      1 * clusterProvider1.supportsMinimalClusters() >> { return true }
       1 * clusterProvider1.getCluster("app", "account", "clusterName", false) >> {
         def cluster = Mock(Cluster)
         cluster.getType() >> "type"
@@ -100,29 +102,6 @@ class ClusterControllerSpec extends Specification {
       1 * serverGroupController.getServerGroup("app", "account", "us-west-2", "clusterName-v001") >> serverGroup
       0 * _
       result == [serverGroup]
-  }
-
-  void "should delegate to ServerGroupController when region is provided"() {
-    given:
-    def serverGroupController = Mock(ServerGroupController)
-    clusterController.serverGroupController = serverGroupController
-
-    and:
-    def serverGroup = new AmazonServerGroup(type: "aws")
-
-    when:
-    def result = clusterController.getServerGroup("app", "test", "mycluster", "aws", "mycluster-v001", "us-west-2")
-
-    then:
-    1 * serverGroupController.getServerGroup("app", "test", "us-west-2", "mycluster-v001") >> { return serverGroup }
-    result == serverGroup
-
-    when:
-    clusterController.getServerGroup("app", "test", "mycluster", "google", "mycluster-v001", "us-west-2")
-
-    then:
-    1 * serverGroupController.getServerGroup("app", "test", "us-west-2", "mycluster-v001") >> { return serverGroup }
-    thrown(NotFoundException)
   }
 
   void "should throw exception when no clusters are found for an account"() {
@@ -197,6 +176,8 @@ class ClusterControllerSpec extends Specification {
         getInstances() >> [Mock(Instance), Mock(Instance)]
       }
 
+      clusterProvider1.getCloudProviderId() >> { return "cloudProvider" }
+      clusterProvider1.supportsMinimalClusters() >> { return false }
       clusterProvider1.getCluster(*_) >> {
         def cluster = Mock(Cluster)
         with(cluster) {
@@ -278,6 +259,8 @@ class ClusterControllerSpec extends Specification {
         getImageSummary() >> mockImageSummary
       }
 
+      clusterProvider1.getCloudProviderId() >> { return "cloudProvider" }
+      clusterProvider1.supportsMinimalClusters() >> { return true }
       clusterProvider1.getCluster(*_) >> {
         def cluster = Mock(Cluster)
         with(cluster) {


### PR DESCRIPTION
… to aws

Unfortunately there were some issues / inconsistencies with what an
unexpanded server group means to different cloud providers.

Any cloud provider looking to implement supportsMinimalClusters() will need
to verify the behavior of `ClusterController.getServerGroup()` and
`ClusterController.getTargetServerGroup()` as they have expectations of what
data is available in a 'minimal' cluster.