### PR TITLE
feat(provider/k8s): Prepare these new fileds or files for the statefu…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -641,7 +641,7 @@ class KubernetesApiConverter {
     deployDescription.namespace = replicaSet?.metadata?.namespace
     deployDescription.targetSize = replicaSet?.spec?.replicas
     deployDescription.securityGroups = []
-    deployDescription.controllerAnnotations = replicaSet?.metadata?.annotations
+    deployDescription.replicaSetAnnotations = replicaSet?.metadata?.annotations
     deployDescription.podAnnotations = replicaSet?.spec?.template?.metadata?.annotations
 
     deployDescription.volumeSources = replicaSet?.spec?.template?.spec?.volumes?.collect {
@@ -812,7 +812,7 @@ class KubernetesApiConverter {
 
     return serverGroupBuilder.withNewMetadata()
       .withName(replicaSetName)
-      .withAnnotations(description.controllerAnnotations)
+      .withAnnotations(description.replicaSetAnnotations)
       .endMetadata()
       .withNewSpec()
       .withNewSelector()
@@ -833,7 +833,7 @@ class KubernetesApiConverter {
 
     def builder = serverGroupBuilder.withNewMetadata()
       .withName(parsedName.cluster)
-      .withAnnotations(description.controllerAnnotations)
+      .withAnnotations(description.replicaSetAnnotations)
       .endMetadata()
       .withNewSpec()
       .withNewSelector()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesApiConverter.groovy
@@ -641,7 +641,7 @@ class KubernetesApiConverter {
     deployDescription.namespace = replicaSet?.metadata?.namespace
     deployDescription.targetSize = replicaSet?.spec?.replicas
     deployDescription.securityGroups = []
-    deployDescription.replicaSetAnnotations = replicaSet?.metadata?.annotations
+    deployDescription.controllerAnnotations = replicaSet?.metadata?.annotations
     deployDescription.podAnnotations = replicaSet?.spec?.template?.metadata?.annotations
 
     deployDescription.volumeSources = replicaSet?.spec?.template?.spec?.volumes?.collect {
@@ -812,7 +812,7 @@ class KubernetesApiConverter {
 
     return serverGroupBuilder.withNewMetadata()
       .withName(replicaSetName)
-      .withAnnotations(description.replicaSetAnnotations)
+      .withAnnotations(description.controllerAnnotations)
       .endMetadata()
       .withNewSpec()
       .withNewSelector()
@@ -833,7 +833,7 @@ class KubernetesApiConverter {
 
     def builder = serverGroupBuilder.withNewMetadata()
       .withName(parsedName.cluster)
-      .withAnnotations(description.replicaSetAnnotations)
+      .withAnnotations(description.controllerAnnotations)
       .endMetadata()
       .withNewSpec()
       .withNewSelector()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesClientApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/api/KubernetesClientApiConverter.groovy
@@ -73,7 +73,7 @@ class KubernetesClientApiConverter {
     deployDescription.namespace = statefulSet?.metadata?.namespace
     deployDescription.targetSize = statefulSet?.spec?.replicas
     deployDescription.securityGroups = []
-    deployDescription.replicaSetAnnotations = statefulSet?.metadata?.annotations
+    deployDescription.controllerAnnotations = statefulSet?.metadata?.annotations
     deployDescription.podAnnotations = statefulSet?.spec?.template?.metadata?.annotations
     deployDescription.volumeClaims = statefulSet?.spec?.getVolumeClaimTemplates()
     deployDescription.volumeSources = statefulSet?.spec?.template?.spec?.volumes?.collect {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/KubernetesUtil.groovy
@@ -34,6 +34,8 @@ class KubernetesUtil {
   static String DEPRECATED_SERVER_GROUP_KIND = "ReplicationController"
   static String SERVER_GROUP_KIND = "ReplicaSet"
   static String DEPLOYMENT_KIND = "Deployment"
+  static String CONTROLLERS_STATEFULSET_KIND = "StatefulSet"
+  static String CONTROLLERS_DAEMONSET_KIND = "DaemonSet"
   static String JOB_LABEL = "job"
   @Value("kubernetes.defaultRegistry:gcr.io")
   static String DEFAULT_REGISTRY

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/KubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/KubernetesAtomicOperationDescription.groovy
@@ -28,4 +28,6 @@ import groovy.transform.Canonical
 class KubernetesAtomicOperationDescription implements DeployDescription, CredentialsNameable {
   String account
   KubernetesNamedAccountCredentials credentials
+  String kind
+  String apiVersion
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -39,7 +39,7 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesAtomicOperati
   List<KubernetesVolumeSource> volumeSources
   Capacity capacity
   KubernetesScalingPolicy scalingPolicy
-  Map<String, String> replicaSetAnnotations
+  Map<String, String> controllerAnnotations
   Map<String, String> podAnnotations
   Map<String, String> volumeAnnotations
   Map<String, String> nodeSelector

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -39,6 +39,7 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesAtomicOperati
   List<KubernetesVolumeSource> volumeSources
   Capacity capacity
   KubernetesScalingPolicy scalingPolicy
+  Map<String, String> replicaSetAnnotations
   Map<String, String> controllerAnnotations
   Map<String, String> podAnnotations
   Map<String, String> volumeAnnotations

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -41,6 +41,7 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesAtomicOperati
   KubernetesScalingPolicy scalingPolicy
   Map<String, String> replicaSetAnnotations
   Map<String, String> podAnnotations
+  Map<String, String> volumeAnnotations
   Map<String, String> nodeSelector
   KubernetesSecurityContext securityContext
   KubernetesDeployment deployment

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/exception/KubernetesClientOperationException.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/deploy/exception/KubernetesClientOperationException.groovy
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.clouddriver.kubernetes.deploy.exception
+
+/**
+ * Created by chlung on 8/29/17.
+ */
+class KubernetesClientOperationException {
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesControllerConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesControllerConverter.groovy
@@ -32,10 +32,7 @@ class KubernetesControllerConverter implements HasMetadata {
     this.metadata = new ObjectMeta()
     this.metadata.name = metadata.name
     this.metadata.namespace = metadata.namespace
-    ObjectMeta mdata = new ObjectMeta()
-    mdata.name = metadata.name
-    mdata.namespace = metadata.namespace
-    setMetadata(mdata)
+    setMetadata(this.metadata)
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesControllerConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesControllerConverter.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Cisco, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model
+
+import io.fabric8.kubernetes.api.model.HasMetadata
+import io.fabric8.kubernetes.api.model.ObjectMeta
+import io.kubernetes.client.models.V1ObjectMeta
+
+class KubernetesControllerConverter implements HasMetadata {
+  String kind
+  String apiVersion
+  ObjectMeta metadata
+
+  KubernetesControllerConverter(String kind, String apiVersion, V1ObjectMeta metadata) {
+    this.kind = kind
+    this.apiVersion = apiVersion
+
+    this.metadata = new ObjectMeta()
+    this.metadata.name = metadata.name
+    this.metadata.namespace = metadata.namespace
+    ObjectMeta mdata = new ObjectMeta()
+    mdata.name = metadata.name
+    mdata.namespace = metadata.namespace
+    setMetadata(mdata)
+  }
+
+  @Override
+  ObjectMeta getMetadata() {
+    return this.metadata
+  }
+
+  @Override
+  void setMetadata(ObjectMeta metadata) {
+    this.metadata = metadata
+  }
+
+  @Override
+  String getKind() {
+    return this.kind
+  }
+
+  @Override
+  String getApiVersion() {
+    return this.apiVersion
+  }
+}
+


### PR DESCRIPTION
This PR will allow to deploy a new statefulset. In this commit, it mainly to update miscellaneous files for preparing for next commit deploy operation.

- Add a new file for transform between k8s client object to fabric8 object
- Add extra fields for supporting statefulset
- Add pre-defined string

***Note: this is re-submit due to my previous PR in wrong branch.

Thanks.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
