### PR TITLE
feat(provider/kubernetes): Fix on demand caching

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgent.java
@@ -53,6 +53,8 @@ public abstract class KubernetesCachingAgent<C extends KubernetesCredentials> im
 
     this.agentIndex = agentIndex;
     this.agentCount = agentCount;
+
+    reloadNamespaces();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
@@ -158,7 +158,7 @@ class KubernetesLoadBalancerCachingAgent extends KubernetesCachingAgent<Kubernet
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    OnDemandAgent.OnDemandType.LoadBalancer == type && cloudProvider == kubernetesCloudProvider.id
+    OnDemandAgent.OnDemandType.LoadBalancer == type && cloudProvider == KubernetesCloudProvider.ID
   }
 
   List<Service> loadServices() {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesSecurityGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesSecurityGroupCachingAgent.groovy
@@ -159,7 +159,7 @@ class KubernetesSecurityGroupCachingAgent extends KubernetesCachingAgent<Kuberne
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    ON_DEMAND_TYPE == type && cloudProvider == kubernetesCloudProvider.id
+    ON_DEMAND_TYPE == type && cloudProvider == KubernetesCloudProvider.ID
   }
 
   List<Ingress> loadIngresses() {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -177,7 +177,7 @@ class KubernetesServerGroupCachingAgent extends KubernetesCachingAgent<Kubernete
 
   @Override
   boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
-    OnDemandAgent.OnDemandType.ServerGroup == type && cloudProvider == kubernetesCloudProvider.id
+    OnDemandAgent.OnDemandType.ServerGroup == type && cloudProvider == KubernetesCloudProvider.ID
   }
 
   List<ReplicationController> loadReplicationControllers() {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesInstanceCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesInstanceCachingAgentSpec.groovy
@@ -47,6 +47,7 @@ class KubernetesInstanceCachingAgentSpec extends Specification {
     namedCrededentialsMock.getCredentials() >> credentials
     namedCrededentialsMock.getName() >> accountName
     providerCache = Mock(ProviderCache)
+    credentials.getDeclaredNamespaces() >> [namespace]
     agent = new KubernetesInstanceCachingAgent(namedCrededentialsMock, mapper, null, 0, 1)
   }
 
@@ -61,7 +62,6 @@ class KubernetesInstanceCachingAgentSpec extends Specification {
     def data = agent.loadData(providerCache)
 
     then:
-    1 * credentials.getDeclaredNamespaces() >> [namespace]
     1 * apiAdaptor.getPods(namespace) >> [pod]
     data.cacheResults[Keys.Namespace.INSTANCES.ns].size() == 1
     data.cacheResults[Keys.Namespace.INSTANCES.ns][0].attributes.containsKey("cacheExpiry")


### PR DESCRIPTION
Looks like this also broke a number of other providers... The caching agents were moved out of the package where a package-private reference to kubernetesCloudProvider existed. 