### PR TITLE
feat(provider/kubernetes): Infer relationships from ownerReference

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -82,7 +82,7 @@ public class Keys {
     return createKey(Kind.LOGICAL, LogicalKind.CLUSTER, account, application, name);
   }
 
-  public static String infrastructure(KubernetesKind kind, KubernetesApiVersion version, String account, String application, String namespace, String name) {
-    return createKey(Kind.INFRASTRUCTURE, kind, version, account, application, namespace, name);
+  public static String infrastructure(KubernetesKind kind, KubernetesApiVersion version, String account, String namespace, String name) {
+    return createKey(Kind.INFRASTRUCTURE, kind, version, account, namespace, name);
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -19,11 +19,16 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class Keys {
   /**
    * Keys are split into "logical" and "infrastructure" kinds. "logical" keys
@@ -78,11 +83,127 @@ public class Keys {
     return createKey(Kind.LOGICAL, LogicalKind.APPLICATION, name);
   }
 
-  public static String cluster(String account, String application, String name) {
-    return createKey(Kind.LOGICAL, LogicalKind.CLUSTER, account, application, name);
+  public static String cluster(String account, String name) {
+    return createKey(Kind.LOGICAL, LogicalKind.CLUSTER, account, name);
   }
 
   public static String infrastructure(KubernetesKind kind, KubernetesApiVersion version, String account, String namespace, String name) {
     return createKey(Kind.INFRASTRUCTURE, kind, version, account, namespace, name);
+  }
+
+  public static Optional<CacheKey> parseKey(String key) {
+    String[] parts = key.split(":", -1);
+
+    if (parts.length < 3 || !parts[0].equals(provider)) {
+      return Optional.empty();
+    }
+
+    try {
+      Kind kind = Kind.fromString(parts[1]);
+      switch (kind) {
+        case LOGICAL:
+          return Optional.of(parseLogicalKey(parts));
+        case INFRASTRUCTURE:
+          return Optional.of(new InfrastructureCacheKey(parts));
+        default:
+          throw new IllegalArgumentException("Unknown kind " + kind);
+      }
+    } catch (IllegalArgumentException e) {
+      log.warn("Kubernetes owned kind with unknown key structure '{}' (perhaps try flushing all clouddriver:* redis keys)", key, e);
+      return Optional.empty();
+    }
+  }
+
+  private static CacheKey parseLogicalKey(String[] parts) {
+    assert(parts.length >= 3);
+
+    LogicalKind logicalKind = LogicalKind.fromString(parts[2]);
+
+    switch (logicalKind) {
+      case APPLICATION:
+        return new ApplicationCacheKey(parts);
+      case CLUSTER:
+        return new ClusterCacheKey(parts);
+      default:
+        throw new IllegalArgumentException("Unknown kind " + logicalKind);
+    }
+  }
+
+  @Data
+  public static abstract class CacheKey {
+    private Kind kind;
+    public abstract String getGroup();
+  }
+
+  @EqualsAndHashCode(callSuper = true)
+  @Data
+  public static class ApplicationCacheKey extends CacheKey {
+    private Kind kind = Kind.LOGICAL;
+    private LogicalKind logicalKind = LogicalKind.APPLICATION;
+    private String name;
+
+    public ApplicationCacheKey(String[] parts) {
+      if (parts.length != 4) {
+        throw new IllegalArgumentException("Malformed application key" + Arrays.toString(parts));
+      }
+
+      name = parts[3];
+    }
+
+    @Override
+    public String getGroup() {
+      return logicalKind.toString();
+    }
+  }
+
+  @EqualsAndHashCode(callSuper = true)
+  @Data
+  public static class ClusterCacheKey extends CacheKey {
+    private Kind kind = Kind.LOGICAL;
+    private LogicalKind logicalKind = LogicalKind.CLUSTER;
+    private String account;
+    private String name;
+
+    public ClusterCacheKey(String[] parts) {
+      if (parts.length != 5) {
+        throw new IllegalArgumentException("Malformed cluster key " + Arrays.toString(parts));
+      }
+
+      account = parts[3];
+      name = parts[4];
+    }
+
+    @Override
+    public String getGroup() {
+      return logicalKind.toString();
+    }
+  }
+
+  @EqualsAndHashCode(callSuper = true)
+  @Data
+  public static class InfrastructureCacheKey extends CacheKey {
+    private Kind kind = Kind.INFRASTRUCTURE;
+    private KubernetesKind kubernetesKind;
+    private KubernetesApiVersion kubernetesApiVersion;
+    private String account;
+    private String namespace;
+    private String name;
+
+    public InfrastructureCacheKey(String[] parts) {
+      if (parts.length != 7) {
+        throw new IllegalArgumentException("Malformed infrastructure key " + Arrays.toString(parts));
+      }
+
+      kubernetesKind = KubernetesKind.fromString(parts[2]);
+      kubernetesApiVersion = KubernetesApiVersion.fromString(parts[3]);
+      account = parts[4];
+      namespace = parts[5];
+      name = parts[6];
+    }
+
+    @Override
+    public String getGroup() {
+      return kubernetesKind.toString();
+    }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import io.kubernetes.client.models.V1beta1ReplicaSet;
@@ -35,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
 
 @Slf4j
 public class KubernetesReplicaSetCachingAgent extends KubernetesCachingAgent<KubernetesV2Credentials> {
@@ -57,7 +58,10 @@ public class KubernetesReplicaSetCachingAgent extends KubernetesCachingAgent<Kub
   @Getter
   final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
-          AUTHORITATIVE.forType(KubernetesKind.REPLICA_SET.name)
+          INFORMATIVE.forType(Keys.LogicalKind.APPLICATION.toString()),
+          INFORMATIVE.forType(Keys.LogicalKind.CLUSTER.toString()),
+          INFORMATIVE.forType(KubernetesKind.DEPLOYMENT.toString()),
+          AUTHORITATIVE.forType(KubernetesKind.REPLICA_SET.toString())
       ))
   );
 
@@ -70,10 +74,15 @@ public class KubernetesReplicaSetCachingAgent extends KubernetesCachingAgent<Kub
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
 
-    log.info(getAgentType() + ": caching " + replicaSetData.size() + " replica sets");
+    List<CacheData> invertedRelationships = replicaSetData.stream()
+        .map(KubernetesCacheDataConverter::invertRelationships)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
 
-    Map<String, Collection<CacheData>> entries = new HashMap<>();
-    entries.put(KubernetesKind.REPLICA_SET.name, replicaSetData);
+    replicaSetData.addAll(invertedRelationships);
+
+    Map<String, Collection<CacheData>> entries = KubernetesCacheDataConverter.stratifyCacheDataByGroup(replicaSetData);
+    KubernetesCacheDataConverter.logStratifiedCacheData(getAgentType(), entries);
 
     return new DefaultCacheResult(entries);
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesApiVersion.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesApiVersion.java
@@ -17,6 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.util.Arrays;
 
 public enum KubernetesApiVersion {
@@ -24,19 +27,22 @@ public enum KubernetesApiVersion {
   EXTENSIONS_V1BETA1("extensions/v1beta1"),
   APPS_V1BETA1("apps/v1beta1");
 
-  public final String name;
+  private final String name;
+
   KubernetesApiVersion(String name) {
     this.name = name;
   }
 
   @Override
+  @JsonValue
   public String toString() {
     return name;
   }
 
+  @JsonCreator
   public static KubernetesApiVersion fromString(String name) {
     return Arrays.stream(values())
-        .filter(v -> v.name.equalsIgnoreCase(name))
+        .filter(v -> v.toString().equalsIgnoreCase(name))
         .findAny()
         .orElseThrow(() -> new IllegalArgumentException("API version " + name + " is not yet supported."));
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKind.java
@@ -17,6 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.util.Arrays;
 
 public enum KubernetesKind {
@@ -26,19 +29,22 @@ public enum KubernetesKind {
   NETWORK_POLICY("networkPolicy"),
   SERVICE("service");
 
-  public final String name;
+  private final String name;
+
   KubernetesKind(String name) {
     this.name = name;
   }
 
   @Override
+  @JsonValue
   public String toString() {
     return name;
   }
 
+  @JsonCreator
   public static KubernetesKind fromString(String name) {
     return Arrays.stream(values())
-        .filter(v -> v.name.equalsIgnoreCase(name))
+        .filter(v -> v.toString().equalsIgnoreCase(name))
         .findAny()
         .orElseThrow(() -> new IllegalArgumentException("Kubernetes kind '" + name + "' is not supported."));
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
@@ -18,10 +18,15 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class KubernetesManifest extends HashMap<String, Object> {
@@ -75,6 +80,17 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  public List<OwnerReference> getOwnerReferences(ObjectMapper mapper) {
+    Map<String, Object> metadata = getMetatdata();
+    Object ownerReferences = metadata.get("ownerReferences");
+    if (ownerReferences == null) {
+      return new ArrayList<>();
+    }
+
+    return mapper.convertValue(ownerReferences, new TypeReference<List<OwnerReference>>() {});
+  }
+
+  @JsonIgnore
   public Map<String, String> getAnnotations() {
     Map<String, String> result = (Map<String, String>) getMetatdata().get("annotations");
     if (result == null) {
@@ -100,5 +116,13 @@ public class KubernetesManifest extends HashMap<String, Object> {
     String name = split[1];
 
     return new ImmutablePair<>(kind, name);
+  }
+
+  @Data
+  public static class OwnerReference {
+    KubernetesApiVersion apiVersion;
+    KubernetesKind kind;
+    String name;
+    boolean controller;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
@@ -46,7 +46,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public void setKind(KubernetesKind kind) {
-    put("kind", kind.name);
+    put("kind", kind.toString());
   }
 
   @JsonIgnore
@@ -56,7 +56,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public void setApiVersion(KubernetesApiVersion apiVersion) {
-    put("apiVersion", apiVersion.name);
+    put("apiVersion", apiVersion.toString());
   }
 
   @JsonIgnore

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -255,8 +255,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   private static <T> T annotateMissingFields(T obj, Class<T> clazz, KubernetesApiVersion apiVersion, KubernetesKind kind) {
     try {
-      clazz.getMethod("setApiVersion", String.class).invoke(obj, apiVersion == null ? null : apiVersion.name);
-      clazz.getMethod("setKind", String.class).invoke(obj, kind == null ? null : kind.name);
+      clazz.getMethod("setApiVersion", String.class).invoke(obj, apiVersion == null ? null : apiVersion.toString());
+      clazz.getMethod("setKind", String.class).invoke(obj, kind == null ? null : kind.toString());
     } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       throw new RuntimeException("Unable to set missing fields on " + clazz.getSimpleName(), e);
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KeysSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KeysSpec.groovy
@@ -53,12 +53,12 @@ class KeysSpec extends Specification {
   @Unroll
   def "produces correct infra keys #key"() {
     expect:
-    Keys.infrastructure(kind, apiVersion, account, application, namespace, name) == key
+    Keys.infrastructure(kind, apiVersion, account, namespace, name) == key
 
     where:
-    kind                       | apiVersion                              | account | application | namespace   | name      || key
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "ac"    | "app"       | "namespace" | "v1-v000" || "kubernetes.v2:infrastructure:replicaSet:extensions/v1beta1:ac:app:namespace:v1-v000"
-    KubernetesKind.SERVICE     | KubernetesApiVersion.V1                 | "ac"    | "app"       | "namespace" | "v1"      || "kubernetes.v2:infrastructure:service:v1:ac:app:namespace:v1"
-    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.APPS_V1BETA1       | "ac"    | "app"       | "namespace" | "v1"      || "kubernetes.v2:infrastructure:deployment:apps/v1beta1:ac:app:namespace:v1"
+    kind                       | apiVersion                              | account | namespace   | name      || key
+    KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "ac"    | "namespace" | "v1-v000" || "kubernetes.v2:infrastructure:replicaSet:extensions/v1beta1:ac:namespace:v1-v000"
+    KubernetesKind.SERVICE     | KubernetesApiVersion.V1                 | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:service:v1:ac:namespace:v1"
+    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.APPS_V1BETA1       | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:deployment:apps/v1beta1:ac:namespace:v1"
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -69,7 +69,7 @@ metadata:
       cacheData.attributes.get("name") == name
       cacheData.attributes.get("namespace") == namespace
       cacheData.attributes.get("kind") == kind
-      cacheData.id == Keys.infrastructure(kind, apiVersion, account, application, namespace, name)
+      cacheData.id == Keys.infrastructure(kind, apiVersion, account, namespace, name)
     }
 
     where:
@@ -78,6 +78,24 @@ metadata:
     KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "my-account"      | "one-app"   | "the-cluster" | "some-namespace" | "a-name-v000"
     KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "my-account"      | "one-app"   | "the-cluster" | "some-namespace" | "a-name"
     KubernetesKind.SERVICE     | KubernetesApiVersion.V1                 | "another-account" | "your-app"  | null          | "some-namespace" | "what-name"
+  }
+
+  def "given a single owner reference, correctly build relationships"() {
+    setup:
+    def ownerRefs = [new KubernetesManifest.OwnerReference(kind: kind, apiVersion: apiVersion, name: name)]
+
+    when:
+    def result = KubernetesCacheDataConverter.ownerReferenceRelationships(account, namespace, ownerRefs)
+
+    then:
+    result.get(kind.toString()) == [Keys.infrastructure(kind, apiVersion, account, namespace, name)]
+
+    where:
+    kind                       | apiVersion                              | account           | cluster       | namespace        | name
+    KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "my-account"      | "another-clu" | "some-namespace" | "a-name-v000"
+    KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "my-account"      | "the-cluster" | "some-namespace" | "a-name-v000"
+    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "my-account"      | "the-cluster" | "some-namespace" | "a-name"
+    KubernetesKind.SERVICE     | KubernetesApiVersion.V1                 | "another-account" | "cluster"     | "some-namespace" | "what-name"
   }
 
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgentSpec.groovy
@@ -66,7 +66,7 @@ class KubernetesReplicaSetCachingAgentSpec extends Specification {
     then:
     result.cacheResults[KubernetesKind.REPLICA_SET.name].size() == 1
     def cacheData = result.cacheResults[KubernetesKind.REPLICA_SET.name].iterator().next()
-    cacheData.relationships.get(Keys.LogicalKind.CLUSTER.toString()) == [Keys.cluster(ACCOUNT, APPLICATION, CLUSTER)]
+    cacheData.relationships.get(Keys.LogicalKind.CLUSTER.toString()) == [Keys.cluster(ACCOUNT, CLUSTER)]
     cacheData.relationships.get(Keys.LogicalKind.APPLICATION.toString()) == [Keys.application(APPLICATION)]
     cacheData.attributes.get("name") == NAME
     cacheData.attributes.get("namespace") == NAMESPACE


### PR DESCRIPTION
The `ownerReferences` are a list of version/kind/name resources that created a particular resource. An example would be a replica set reference within a pod. This simplifies manually constructing relationships in the cache.