### PR TITLE
fix(google): Add statusCode tag to google API metrics

### DIFF
--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/GoogleApiTestUtils.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/GoogleApiTestUtils.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.google
+
+import com.google.api.client.http.HttpHeaders
+import com.google.api.client.http.HttpResponseException
+
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import java.util.concurrent.TimeUnit
+
+
+public class GoogleApiTestUtils {
+  static public HttpResponseException makeHttpResponseException(int statusCode) {
+    def errorMessage = "there was an error"
+    def builder = new HttpResponseException.Builder(
+        statusCode,
+        "Injected Error",
+        new HttpHeaders()).setMessage(statusCode.toString() + " Injected Error")
+    return new HttpResponseException(builder)
+  }
+
+  static public Map makeTraitsTagMap(String method, int statusCode, Map extra) {
+    String statusString = statusCode.toString()
+    String series = statusString[0]
+    // See note in GoogleExecutorTraitsSpec as to why 0 is success in tests
+    String ok = (series == "2" || series == "0") ? "true" : "false"
+    return [api: method, success: ok, statusCode: statusString, status: series + "xx"] + extra
+  }
+
+  static public Id makeOkId(Registry registry, String method, Map extra) {
+    // See GoogleExecutorTraitsSpec as to why the statusCode is 0
+    return registry.createId("google.api", makeTraitsTagMap(method, 0, extra))
+  }
+
+  static public Id makeId(Registry registry, String method, int statusCode, Map extra) {
+    return registry.createId("google.api", makeTraitsTagMap(method, statusCode, extra))
+  }
+
+  /**
+   * Creates a timer, records a 0 time on it, and returns the id.
+   * This is so that tests can check the timer for a count
+   */
+  static public Id seedTimer(Registry registry, String method, Map extra) {
+    Id id = makeOkId(registry, method, extra)
+    print "INITIAL " + registry.timer(id).count()
+    print "BEFORE " + registry.timer(id).count()
+    registry.timer(id).record(0, TimeUnit.NANOSECONDS)
+    print "FINAL " + registry.timer(id).count()
+  }
+
+}

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperationUnitSpec.groovy
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleNetwork
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleNetworkProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.google.security.TestDefaults
+import com.netflix.spinnaker.clouddriver.google.GoogleApiTestUtils
 import groovy.mock.interceptor.MockFor
 import spock.lang.Specification
 import spock.lang.Subject
@@ -131,10 +132,9 @@ class CreateGoogleInstanceAtomicOperationUnitSpec extends Specification implemen
       1 * instancesMock.insert(PROJECT_NAME, ZONE, _) >> instancesInsertMock
       1 * instancesInsertMock.execute()
       registry.timer(
-          registry.createId("google.api",
-                [api: "compute.instances.insert",
-                 scope: "zonal", zone: ZONE,
-                 success: "true", statusCode: "0"])  // See GoogleExecutorTraitsSpec
+          GoogleApiTestUtils.makeOkId(
+            registry, "compute.instances.insert",
+            [scope: "zonal", zone: ZONE])
       ).count() == 1
   }
 

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DisableGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DisableGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.google.GoogleApiTestUtils
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -152,10 +153,9 @@ class DisableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       1 * forwardingRulesList.execute() >> new ForwardingRuleList(items: [])
 
       registry.timer(
-          registry.createId("google.api",
-                [api: "compute.targetPools.removeInstance",
-                 scope: "regional", region: REGION,
-                 success: "true", statusCode: "0"])  // See GoogleExecutorTraitsSpec
+          GoogleApiTestUtils.makeOkId(
+            registry, "compute.targetPools.removeInstance",
+            [scope: "regional", region: REGION])
       ).count() == 2
   }
 }

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/EnableGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/EnableGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.google.GoogleApiTestUtils
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -184,10 +185,9 @@ class EnableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       3 * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList
       3 * globalForwardingRulesList.execute() >> new ForwardingRuleList(items: [])
       registry.timer(
-          registry.createId("google.api",
-                [api: "compute.targetPools.addInstance",
-                 scope: "regional", region: REGION,
-                 success: "true", statusCode: "0"])  // See GoogleExecutorTraitsSpec
+          GoogleApiTestUtils.makeOkId(
+            registry, "compute.targetPools.addInstance",
+            [scope: "regional", region: REGION])
       ).count() == 2
   }
 


### PR DESCRIPTION
@duftler 
Turns out that getLastStatusCode on a response is only set for successful responses, not on errors. So this was always populating statusCode with -1 on errors.
