### PR TITLE
feat(provider/docker): add catalogFile option

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
@@ -53,6 +53,8 @@ class DockerRegistryConfigurationProperties {
     // or <library> for repositories like 'ubuntu'.
     List<String> repositories
     List<String> skip
+    // a file listing all repositories to index
+    String catalogFile
   }
 
   List<ManagedAccount> accounts = []

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
@@ -70,6 +70,7 @@ class DockerRegistryCredentialsInitializer implements CredentialsInitializerSync
           .username(managedAccount.username)
           .email(managedAccount.email)
           .passwordFile(managedAccount.passwordFile)
+          .catalogFile(managedAccount.catalogFile)
           .dockerconfigFile(managedAccount.dockerconfigFile)
           .cacheThreads(managedAccount.cacheThreads)
           .cacheIntervalSeconds(managedAccount.cacheIntervalSeconds)


### PR DESCRIPTION
adds the `catalogFile` option to the Docker Registry provider. This is
an attempt to make it easier to use registries that don't support
`v2/_catalog` (which happens to be a lot). This file can be managed by
an external process. Each caching cycle, Clouddriver reads this file to
determine the list of repositories it should cache tags for.

the format of the `configFile` is:
```
{
  "repositories":[
    "library/nginx",
    "library/busybox"
  ]
}
```

@lwander PTAL. This is the first iteration/POC for spinnaker/spinnaker#1909. We can implement more remote options (S3/GCS) when there's more precedence for it in Clouddriver. 