### PR TITLE
feat(provider/aws): Remove ability to automatically remove dependencies when deleting a security group

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeleteSecurityGroupDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeleteSecurityGroupDescription.groovy
@@ -19,5 +19,4 @@ class DeleteSecurityGroupDescription extends AbstractAmazonCredentialsDescriptio
     String securityGroupName
     String vpcId
     Set<String> regions
-    Boolean removeDependencies
 }


### PR DESCRIPTION
The `removeDependencies` flag is a little too powerful, especially when trying to run automated cleanup.

FYI @ajordens