### PR TITLE
fix(provider/kubernetes): Add missing credential props

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -133,6 +133,14 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     return cacheThreads;
   }
 
+  public List<LinkedDockerRegistryConfiguration> getDockerRegistries() {
+    return dockerRegistries;
+  }
+
+  public Permissions getPermissions() {
+    return permissions;
+  }
+
   @Override
   public List<String> getRequiredGroupMembership() {
     return requiredGroupMembership;


### PR DESCRIPTION
In the de-groovification these two were lost. Will also merge into 1.3 once closed.