### PR TITLE
refactor(provider/kubernetes): v2 include api version in resource id

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -130,19 +130,20 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public String getFullResourceName() {
-    return getKind() + "/" + getName();
+    return String.join("|", getApiVersion().toString(), getKind().toString(), getName());
   }
 
-  public static Pair<KubernetesKind, String> fromFullResourceName(String fullResourceName) {
-    String[] split = fullResourceName.split("/");
-    if (split.length != 2) {
-      throw new IllegalArgumentException("Expected a full resource name of the form <kind>/<name>");
+  public static Triple<KubernetesApiVersion, KubernetesKind, String> fromFullResourceName(String fullResourceName) {
+    String[] split = fullResourceName.split("\\|");
+    if (split.length != 3) {
+      throw new IllegalArgumentException("Expected a full resource name of the form <version>|<kind>|<name>");
     }
 
-    KubernetesKind kind = KubernetesKind.fromString(split[0]);
-    String name = split[1];
+    KubernetesApiVersion apiVersion = KubernetesApiVersion.fromString(split[0]);
+    KubernetesKind kind = KubernetesKind.fromString(split[1]);
+    String name = split[2];
 
-    return new ImmutablePair<>(kind, name);
+    return new ImmutableTriple<>(apiVersion, kind, name);
   }
 
   @Data

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -65,15 +65,16 @@ spec:
   @Unroll
   void "correctly parses a fully qualified resource name #kind/#name"() {
     expect:
-    def pair = KubernetesManifest.fromFullResourceName(fullResourceName)
-    pair.getLeft() == kind
-    pair.getRight() == name
+    def triple = KubernetesManifest.fromFullResourceName(fullResourceName)
+    triple.getRight() == name
+    triple.getLeft() == apiVersion
+    triple.getMiddle() == kind
 
     where:
-    fullResourceName || kind                       | name
-    "replicaSet/abc" || KubernetesKind.REPLICA_SET | "abc"
-    "service/abc"    || KubernetesKind.SERVICE     | "abc"
-    "SERVICE/abc"    || KubernetesKind.SERVICE     | "abc"
-    "ingress/abc"    || KubernetesKind.INGRESS     | "abc"
+    fullResourceName                    || apiVersion                              | kind                       | name
+    "extensions/v1beta1|replicaSet|abc" || KubernetesApiVersion.EXTENSIONS_V1BETA1 | KubernetesKind.REPLICA_SET | "abc"
+    "v1|service|abc"                    || KubernetesApiVersion.V1                 | KubernetesKind.SERVICE     | "abc"
+    "V1|SERVICE|abc"                    || KubernetesApiVersion.V1                 | KubernetesKind.SERVICE     | "abc"
+    "apps/v1beta1|ingress|abc"          || KubernetesApiVersion.APPS_V1BETA1       | KubernetesKind.INGRESS     | "abc"
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesManifestDeployerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesManifestDeployerSpec.groovy
@@ -97,7 +97,7 @@ metadata:
 
     then:
     1 * credentialsMock.createReplicaSet(_) >> null
-    result.serverGroupNames == ["$NAMESPACE:$KIND/$NAME"]
+    result.serverGroupNames == ["$NAMESPACE:$API_VERSION|$KIND|$NAME"]
   }
 
   void "replica set deployer uses backup namespace"() {
@@ -111,6 +111,6 @@ metadata:
 
     then:
     1 * credentialsMock.createReplicaSet(_) >> null
-    result.serverGroupNames == ["$BACKUP_NAMESPACE:$KIND/$NAME"]
+    result.serverGroupNames == ["$BACKUP_NAMESPACE:$API_VERSION|$KIND|$NAME"]
   }
 }


### PR DESCRIPTION
Since in many cases these identifiers will be our only way to lookup objects, we need to disambiguate across api versions.