### PR TITLE
feat(provider/kubernetes): v2 Cache lb & scg relationships

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpinnakerRelationships.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpinnakerRelationships.java
@@ -19,12 +19,13 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import lombok.Data;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
 public class KubernetesManifestSpinnakerRelationships {
   String application;
   String cluster;
-  List<String> loadBalancers;
-  List<String> securityGroups;
+  List<String> loadBalancers = new ArrayList<>();
+  List<String> securityGroups = new ArrayList<>();
 }


### PR DESCRIPTION
Caching load balancer and security group relationships like this allows us to support multiple kinds of each spinnaker resource (service vs ingress for example). 