### PR TITLE
fix(provider/docker): fix client constructor

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -150,13 +150,13 @@ class DockerRegistryClient {
   }
 
   DockerRegistryClient(String address, String email, String username, String password, long clientTimeoutMillis, int paginateSize, String catalogFile) {
-    this(address, clientTimeoutMillis, paginateSize)
+    this(address, clientTimeoutMillis, paginateSize, catalogFile)
     this.tokenService = new DockerBearerTokenService(username, password)
     this.email = email
   }
 
   DockerRegistryClient(String address, String email, String username, File passwordFile, long clientTimeoutMillis, int paginateSize, String catalogFile) {
-    this(address, clientTimeoutMillis, paginateSize)
+    this(address, clientTimeoutMillis, paginateSize, catalogFile)
     this.tokenService = new DockerBearerTokenService(username, passwordFile)
     this.email = email
   }


### PR DESCRIPTION
Bug introduced in `f70d6ea`. I updated the constructor to include
`catalogFile` but didn't update the constructor for those using
`password` and `passwordFile` configurations. This fixes that potential
issue.

@lwander PTAL.
