### PR TITLE
Revert " fix(provider/aws): ensure STSAssumeRoleSessionCredentialsPro…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
@@ -17,37 +17,20 @@
 package com.netflix.spinnaker.clouddriver.aws.security;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSSessionCredentials;
-import com.amazonaws.auth.AWSSessionCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
 
-public class NetflixSTSAssumeRoleSessionCredentialsProvider implements AWSSessionCredentialsProvider {
-  private final STSAssumeRoleSessionCredentialsProvider delegate;
+public class NetflixSTSAssumeRoleSessionCredentialsProvider extends STSAssumeRoleSessionCredentialsProvider {
   private final String accountId;
-
 
   public NetflixSTSAssumeRoleSessionCredentialsProvider(AWSCredentialsProvider longLivedCredentialsProvider,
                                                         String roleArn,
                                                         String roleSessionName,
                                                         String accountId) {
+    super(longLivedCredentialsProvider, roleArn, roleSessionName);
     this.accountId = accountId;
-    AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClient.builder().withCredentials(longLivedCredentialsProvider).build();
-    delegate = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName).withStsClient(stsClient).build();
   }
 
   public String getAccountId() {
     return accountId;
-  }
-
-  @Override
-  public AWSSessionCredentials getCredentials() {
-    return delegate.getCredentials();
-  }
-
-  @Override
-  public void refresh() {
-    delegate.refresh();
   }
 }


### PR DESCRIPTION
…vider get the right endpoint (#1888)"

This reverts commit 828fbb70fc5eb7d04617f2054c3135b45dee8040.

@robzienert 

@eisig this change broke our integration tests - looks like `AWSSecurityTokenServiceClient` needs to be provided a region.
