### PR TITLE
feat(provider/kubernetes): v2 version deployed manifests as resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.109.2'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.110.4'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -2,9 +2,10 @@ dependencies {
   spinnaker.group('kubernetes')
   compile project(":clouddriver-core")
   compile project(":clouddriver-docker")
-  compile spinnaker.dependency('frigga')
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
+  compile spinnaker.dependency('frigga')
+  compile spinnaker.dependency('korkArtifacts')
   compile spinnaker.dependency('lombok')
 
   // TODO(lwander) move to spinnaker-dependencies when library stabilizes

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ManifestToArtifact.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ManifestToArtifact.java
@@ -15,19 +15,11 @@
  *
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import lombok.Data;
 
-@Data
-public class KubernetesAugmentedManifest {
-  KubernetesManifest manifest;
-  Metadata metadata;
-
-  @Data
-  public class Metadata {
-    KubernetesManifestSpinnakerRelationships relationships;
-    Artifact artifact;
-  }
+public interface ManifestToArtifact {
+  Artifact convert(KubernetesManifest manifest);
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ManifestToUnversionedArtifact.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ManifestToUnversionedArtifact.java
@@ -15,19 +15,22 @@
  *
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import lombok.Data;
+import org.apache.commons.lang.RandomStringUtils;
+import org.springframework.stereotype.Component;
 
-@Data
-public class KubernetesAugmentedManifest {
-  KubernetesManifest manifest;
-  Metadata metadata;
-
-  @Data
-  public class Metadata {
-    KubernetesManifestSpinnakerRelationships relationships;
-    Artifact artifact;
+@Component
+public class ManifestToUnversionedArtifact implements ManifestToArtifact {
+  @Override
+  public Artifact convert(KubernetesManifest manifest) {
+    String type = manifest.getKind().toString();
+    String name = manifest.getName();
+    return Artifact.builder()
+        .type(type)
+        .name(name)
+        .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ManifestToVersionedArtifact.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ManifestToVersionedArtifact.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import org.apache.commons.lang.RandomStringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ManifestToVersionedArtifact implements ManifestToArtifact {
+  @Override
+  public Artifact convert(KubernetesManifest manifest) {
+    String type = manifest.getKind().toString();
+    String name = manifest.getName();
+    String version = RandomStringUtils.randomAlphanumeric(8).toLowerCase(); // TODO(lwander) rely on cache to get proper vNNN number in the future.
+    return Artifact.builder()
+        .type(type)
+        .name(name)
+        .version(version)
+        .build();
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.Data;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
@@ -68,6 +69,11 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   public String getName() {
     return (String) getMetatdata().get("name");
+  }
+
+  @JsonIgnore
+  public void setName(String name) {
+    getMetatdata().put("name", name);
   }
 
   @JsonIgnore

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestAnnotater.java
@@ -20,19 +20,26 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+@Slf4j
 public class KubernetesManifestAnnotater {
   private static final String SPINNAKER_ANNOTATION = "spinnaker.io";
   private static final String RELATIONSHIP_ANNOTATION_PREFIX = "relationships." + SPINNAKER_ANNOTATION;
+  private static final String ARTIFACT_ANNOTATION_PREFIX = "artifacts." + SPINNAKER_ANNOTATION;
   private static final String LOAD_BALANCERS = RELATIONSHIP_ANNOTATION_PREFIX + "/loadBalancers";
   private static final String SECURITY_GROUPS = RELATIONSHIP_ANNOTATION_PREFIX + "/securityGroups";
   private static final String CLUSTER = RELATIONSHIP_ANNOTATION_PREFIX + "/cluster";
   private static final String APPLICATION = RELATIONSHIP_ANNOTATION_PREFIX + "/application";
+  private static final String TYPE = ARTIFACT_ANNOTATION_PREFIX + "/type";
+  private static final String NAME = ARTIFACT_ANNOTATION_PREFIX + "/name";
+  private static final String VERSION = ARTIFACT_ANNOTATION_PREFIX + "/version";
 
   private static ObjectMapper objectMapper = new ObjectMapper();
 
@@ -61,21 +68,37 @@ public class KubernetesManifestAnnotater {
     }
   }
 
-  public static void annotateManifestWithRelationships(KubernetesManifest manifest, KubernetesManifestSpinnakerRelationships relationships) {
+  public static void annotateManifest(KubernetesManifest manifest, KubernetesAugmentedManifest.Metadata metadata) {
     Map<String, String> annotations = manifest.getAnnotations();
-    annotateManifestWithRelationships(annotations, relationships);
+    annotateManifest(annotations, metadata.getRelationships());
+    annotateManifest(annotations, metadata.getArtifact());
 
     manifest.getSpecTemplateAnnotations().flatMap(a -> {
-      annotateManifestWithRelationships(a, relationships);
+      annotateManifest(a, metadata.getRelationships());
       return Optional.empty();
     });
   }
 
-  private static void annotateManifestWithRelationships(Map<String, String> annotations, KubernetesManifestSpinnakerRelationships relationships) {
+  private static void annotateManifest(Map<String, String> annotations, KubernetesManifestSpinnakerRelationships relationships) {
+    if (relationships == null) {
+      throw new IllegalArgumentException("Every resource deployed via spinnaker must be assigned relationships");
+    }
+
     storeAnnotation(annotations, LOAD_BALANCERS, relationships.getLoadBalancers());
     storeAnnotation(annotations, SECURITY_GROUPS, relationships.getSecurityGroups());
     storeAnnotation(annotations, CLUSTER, relationships.getCluster());
     storeAnnotation(annotations, APPLICATION, relationships.getApplication());
+  }
+
+  private static void annotateManifest(Map<String, String> annotations, Artifact artifact) {
+    if (artifact == null) {
+      log.warn("Unknown artifact type & name");
+      return;
+    }
+
+    storeAnnotation(annotations, TYPE, artifact.getType());
+    storeAnnotation(annotations, NAME, artifact.getName());
+    storeAnnotation(annotations, VERSION, artifact.getVersion());
   }
 
   public static KubernetesManifestSpinnakerRelationships getManifestRelationships(KubernetesManifest manifest) {
@@ -86,5 +109,15 @@ public class KubernetesManifestAnnotater {
         .setSecurityGroups(getAnnotation(annotations, SECURITY_GROUPS, new TypeReference<List<String>>() {}))
         .setCluster(getAnnotation(annotations, CLUSTER, new TypeReference<String>() {}))
         .setApplication(getAnnotation(annotations, APPLICATION, new TypeReference<String>() {}));
+  }
+
+  public static Artifact getArtifact(KubernetesManifest manifest) {
+    Map<String, String> annotations = manifest.getAnnotations();
+
+    return Artifact.builder()
+        .type(getAnnotation(annotations, TYPE, new TypeReference<String>() {}))
+        .name(getAnnotation(annotations, NAME, new TypeReference<String>() {}))
+        .version(getAnnotation(annotations, VERSION, new TypeReference<String>() {}))
+        .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentDeployer.java
@@ -39,4 +39,9 @@ public class KubernetesDeploymentDeployer extends KubernetesDeployer<AppsV1beta1
       credentials.createDeployment(resource);
     }
   }
+
+  @Override
+  public boolean isVersionedResource() {
+    return false;
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesIngressDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesIngressDeployer.java
@@ -32,4 +32,9 @@ public class KubernetesIngressDeployer extends KubernetesDeployer<V1beta1Ingress
   void deploy(KubernetesV2Credentials credentials, V1beta1Ingress resource) {
     credentials.createIngress(resource);
   }
+
+  @Override
+  public boolean isVersionedResource() {
+    return false;
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesReplicaSetDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesReplicaSetDeployer.java
@@ -32,4 +32,9 @@ public class KubernetesReplicaSetDeployer extends KubernetesDeployer<V1beta1Repl
   void deploy(KubernetesV2Credentials credentials, V1beta1ReplicaSet resource) {
     credentials.createReplicaSet(resource);
   }
+
+  @Override
+  public boolean isVersionedResource() {
+    return true;
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesServiceDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesServiceDeployer.java
@@ -32,4 +32,9 @@ public class KubernetesServiceDeployer extends KubernetesDeployer<V1Service> {
   void deploy(KubernetesV2Credentials credentials, V1Service resource) {
     credentials.createService(resource);
   }
+
+  @Override
+  public boolean isVersionedResource() {
+    return false;
+  }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesAugmentedManifest
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifestAnnotater
@@ -54,9 +55,11 @@ metadata:
     def relationships = new KubernetesManifestSpinnakerRelationships()
         .setApplication(application)
         .setCluster(cluster)
+    def metadata = new KubernetesAugmentedManifest.Metadata()
+        .setRelationships(relationships)
 
     def manifest = stringToManifest(rawManifest)
-    KubernetesManifestAnnotater.annotateManifestWithRelationships(manifest, relationships)
+    KubernetesManifestAnnotater.annotateManifest(manifest, metadata)
     V1beta1ReplicaSet resource = mapper.convertValue(manifest, V1beta1ReplicaSet.class)
 
     when:

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestAnnotatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestAnnotatorSpec.groovy
@@ -40,7 +40,9 @@ class KubernetesManifestAnnotatorSpec extends Specification {
       .setCluster(cluster)
       .setApplication(application)
 
-    KubernetesManifestAnnotater.annotateManifestWithRelationships(manifest, input)
+    def metadata = new KubernetesAugmentedManifest.Metadata().setRelationships(input)
+
+    KubernetesManifestAnnotater.annotateManifest(manifest, metadata)
     input == KubernetesManifestAnnotater.getManifestRelationships(manifest)
 
     where:
@@ -64,7 +66,9 @@ class KubernetesManifestAnnotatorSpec extends Specification {
       .setCluster(cluster)
       .setApplication(application)
 
-    KubernetesManifestAnnotater.annotateManifestWithRelationships(manifest, relationships)
+    def metadata = new KubernetesAugmentedManifest.Metadata().setRelationships(relationships)
+
+    KubernetesManifestAnnotater.annotateManifest(manifest, metadata)
     manifest.getAnnotations().get(clusterKey) == '"' + cluster + '"'
     manifest.getAnnotations().get(applicationKey) == '"' + application + '"'
 


### PR DESCRIPTION
What's happening here is that every k8s resource is either "versioned" or "unversioned" which determines  how Spinnaker should create it. If it's versioned (e.g. replica set, configmap, secret, etc...) Spinnaker will get a new versioned name (`my-app-vasdf84` - will be suffixed with `vNNN` in the future) and deploy that. If it's unversioned (e.g. deployment, statefulset, service) it will be created as-is w/o modification to the name, forcing Spinnaker to patch the resource.