### PR TITLE
refactor(core): s/version/providerVersion

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -25,7 +25,7 @@ class KubernetesConfigurationProperties {
   @ToString(includeNames = true)
   static class ManagedAccount {
     String name
-    ProviderVersion version
+    ProviderVersion providerVersion
     String environment
     String accountType
     String context

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesProviderConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesProviderConfig.groovy
@@ -97,7 +97,7 @@ class KubernetesProviderConfig implements Runnable {
 
     for (KubernetesNamedAccountCredentials credentials : allAccounts) {
       KubernetesCachingAgentDispatcher dispatcher
-      switch (credentials.version) {
+      switch (credentials.providerVersion) {
         case ProviderVersion.v1:
           dispatcher = kubernetesV1CachingAgentDispatcher
           break
@@ -105,13 +105,13 @@ class KubernetesProviderConfig implements Runnable {
           dispatcher = kubernetesV2CachingAgentDispatcher
           break
         default:
-          log.warn "No support for caching accounts of $credentials.version"
+          log.warn "No support for caching accounts of $credentials.providerVersion"
           continue
       }
 
       def newlyAddedAgents = dispatcher.buildAllCachingAgents(credentials)
 
-      log.info "Adding ${newlyAddedAgents.size()} agents for account ${credentials.name} at version ${credentials.version}"
+      log.info "Adding ${newlyAddedAgents.size()} agents for account ${credentials.name} at version ${credentials.providerVersion}"
 
       // If there is an agent scheduler, then this provider has been through the AgentController in the past.
       // In that case, we need to do the scheduling here (because accounts have been added to a running system).

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -40,7 +40,7 @@ import static com.netflix.spinnaker.clouddriver.security.ProviderVersion.v1;
 public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> implements AccountCredentials<C> {
   final private String cloudProvider = "kubernetes";
   final private String name;
-  final private ProviderVersion version;
+  final private ProviderVersion providerVersion;
   final private String environment;
   final private String accountType;
   final private String context;
@@ -60,7 +60,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
   private final AccountCredentialsRepository accountCredentialsRepository;
 
   KubernetesNamedAccountCredentials(String name,
-                                    ProviderVersion version,
+                                    ProviderVersion providerVersion,
                                     AccountCredentialsRepository accountCredentialsRepository,
                                     String userAgent,
                                     String environment,
@@ -79,7 +79,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
                                     Registry spectatorRegistry,
                                     C credentials) {
     this.name = name;
-    this.version = version;
+    this.providerVersion = providerVersion;
     this.environment = environment;
     this.accountType = accountType;
     this.context = context;
@@ -109,8 +109,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
   }
 
   @Override
-  public ProviderVersion getVersion() {
-    return version;
+  public ProviderVersion getProviderVersion() {
+    return providerVersion;
   }
 
   @Override
@@ -152,7 +152,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
 
   static class Builder<C extends KubernetesCredentials> {
     String name;
-    ProviderVersion version;
+    ProviderVersion providerVersion;
     String environment;
     String accountType;
     String context;
@@ -176,8 +176,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       return this;
     }
 
-    Builder version(ProviderVersion version) {
-      this.version = version;
+    Builder providerVersion(ProviderVersion providerVersion) {
+      this.providerVersion = providerVersion;
       return this;
     }
 
@@ -270,7 +270,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     }
 
     private C buildCredentials() {
-      switch (version) {
+      switch (providerVersion) {
         case v1:
           return (C) new KubernetesV1Credentials(
               name,
@@ -293,7 +293,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
               .setNamer(KubernetesManifest.class, new KubernetesManifestNamer());
           return (C) new KubernetesV2Credentials(name, spectatorRegistry);
         default:
-          throw new IllegalArgumentException("Unknown provider type: " + version);
+          throw new IllegalArgumentException("Unknown provider type: " + providerVersion);
       }
     }
 
@@ -310,8 +310,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
         cacheThreads = 1;
       }
 
-      if (version == null) {
-        version = v1;
+      if (providerVersion == null) {
+        providerVersion = v1;
       }
 
       if (StringUtils.isEmpty(kubeconfigFile)) {
@@ -330,7 +330,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
 
       return new KubernetesNamedAccountCredentials(
           name,
-          version,
+          providerVersion,
           accountCredentialsRepository,
           userAgent,
           environment,

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -77,7 +77,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .accountCredentialsRepository(accountCredentialsRepository)
           .userAgent(clouddriverUserAgentApplicationName)
           .name(managedAccount.name)
-          .version(managedAccount.version)
+          .providerVersion(managedAccount.providerVersion)
           .environment(managedAccount.environment ?: managedAccount.name)
           .accountType(managedAccount.accountType ?: managedAccount.name)
           .context(managedAccount.context)

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AccountCredentials.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AccountCredentials.java
@@ -68,7 +68,7 @@ public interface AccountCredentials<T> {
    *
    * @return the account's version.
    */
-  default ProviderVersion getVersion() {
+  default ProviderVersion getProviderVersion() {
     return ProviderVersion.v1;
   }
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
@@ -129,7 +129,7 @@ class OperationsController {
       String accountName = operation.credentials ?: operation.accountName ?: operation.account
       if (accountName) {
         def credentials = accountCredentialsRepository.getOne(accountName)
-        providerVersion = credentials.getVersion()
+        providerVersion = credentials.getProviderVersion()
       } else {
         log.warn "Unable to get account name from operation: $inputs"
       }


### PR DESCRIPTION
Having the account property named 'version' was confusing the concept of
the version the provider was at, with the version the cloud environment
was at.

Should be a quicky