### PR TITLE
feat(provider/kubernetes): Attach k8s annotation monikers to v2 resources

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/KubernetesV2Cluster.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/KubernetesV2Cluster.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.model.Cluster;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup;
+import com.netflix.spinnaker.moniker.Moniker;
 import lombok.Data;
 
 import java.util.HashSet;
@@ -29,6 +30,7 @@ import java.util.Set;
 @Data
 public class KubernetesV2Cluster implements Cluster {
   String name;
+  Moniker moniker;
   String type;
   String accountName;
   Set<ServerGroup> serverGroups = new HashSet<>();
@@ -37,5 +39,6 @@ public class KubernetesV2Cluster implements Cluster {
   public KubernetesV2Cluster(Keys.ClusterCacheKey key) {
     this.name = key.getName();
     this.accountName = key.getAccount();
+    this.moniker = Moniker.builder().cluster(name).build(); // TODO(lwander) if it turns out that cluster -> app is important, enforce constraints here.
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/KubernetesV2Instance.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/KubernetesV2Instance.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.view.model;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.HealthState;
 import com.netflix.spinnaker.clouddriver.model.Instance;
@@ -36,8 +37,10 @@ public class KubernetesV2Instance extends ManifestBasedModel implements Instance
   Long launchTime;
   List<Map<String, String>> health = new ArrayList<>();
   KubernetesManifest manifest;
+  Keys.InfrastructureCacheKey key;
 
-  public KubernetesV2Instance(KubernetesManifest manifest) {
+  public KubernetesV2Instance(KubernetesManifest manifest, String key) {
     this.manifest = manifest;
+    this.key = (Keys.InfrastructureCacheKey) Keys.parseKey(key).get();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/KubernetesV2LoadBalancer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/KubernetesV2LoadBalancer.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.view.model;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
@@ -32,8 +33,10 @@ public class KubernetesV2LoadBalancer extends ManifestBasedModel implements Load
   String account;
   Set<LoadBalancerServerGroup> serverGroups = new HashSet<>();
   KubernetesManifest manifest;
+  Keys.InfrastructureCacheKey key;
 
-  public KubernetesV2LoadBalancer(KubernetesManifest manifest) {
+  public KubernetesV2LoadBalancer(KubernetesManifest manifest, String key) {
     this.manifest = manifest;
+    this.key = (Keys.InfrastructureCacheKey) Keys.parseKey(key).get();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/KubernetesV2ServerGroup.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.view.model;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Instance;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup;
@@ -43,13 +44,15 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
   ImageSummary imageSummary;
   ImagesSummary imagesSummary;
   KubernetesManifest manifest;
+  Keys.InfrastructureCacheKey key;
 
   @Override
   public Boolean isDisabled() {
     return disabled;
   }
 
-  public KubernetesV2ServerGroup(KubernetesManifest manifest) {
+  public KubernetesV2ServerGroup(KubernetesManifest manifest, String key) {
     this.manifest = manifest;
+    this.key = (Keys.InfrastructureCacheKey) Keys.parseKey(key).get();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/ManifestBasedModel.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/view/model/ManifestBasedModel.java
@@ -18,7 +18,10 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.view.model;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
+import com.netflix.spinnaker.moniker.Moniker;
 
 abstract public class ManifestBasedModel {
   public String getName() {
@@ -47,5 +50,18 @@ abstract public class ManifestBasedModel {
     return KubernetesCloudProvider.getID();
   }
 
+  public Moniker getMoniker() {
+    return NamerRegistry.lookup()
+        .withProvider(KubernetesCloudProvider.getID())
+        .withAccount(getAccountName())
+        .withResource(KubernetesManifest.class)
+        .deriveMoniker(getManifest());
+  }
+
+  public String getAccountName() {
+    return getKey().getAccount();
+  }
+
   abstract protected KubernetesManifest getManifest();
+  abstract protected Keys.InfrastructureCacheKey getKey();
 }


### PR DESCRIPTION
Continuation of https://github.com/spinnaker/clouddriver/pull/1915