### PR TITLE
fix(provider/kubernetes): Advanced targetSize use case.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
@@ -810,7 +810,13 @@ class KubernetesApiConverter {
                                  DeployKubernetesAtomicOperationDescription description,
                                  String replicaSetName) {
 
-    def targetSize = description.targetSize ?: description.capacity?.desired
+    def targetSize
+    if (description.targetSize == 0) {
+      targetSize = description.targetSize
+    }
+    else {
+      targetSize = description.targetSize ?: description.capacity?.desired
+    }
 
     return serverGroupBuilder.withNewMetadata()
       .withName(replicaSetName)
@@ -830,8 +836,15 @@ class KubernetesApiConverter {
   static DeploymentFluentImpl toDeployment(DeploymentFluentImpl serverGroupBuilder,
                                         DeployKubernetesAtomicOperationDescription description,
                                         String replicaSetName) {
+
     def parsedName = Names.parseName(replicaSetName)
-    def targetSize = description.targetSize ?: description.capacity?.desired
+    def targetSize
+    if (description.targetSize == 0) {
+      targetSize = description.targetSize
+    }
+    else {
+      targetSize = description.targetSize ?: description.capacity?.desired
+    }
 
     def builder = serverGroupBuilder.withNewMetadata()
       .withName(parsedName.cluster)


### PR DESCRIPTION
The elvis operator before was not evaluating truthiness correctly for a value
of 0. A User could and may want to deploy an update ReplicaSet of 0 and Scale
it later. Or perhaps it's bundled in a Spinnaker Pipeline with multiple Server
Groups and one of the Server Groups is scaled to 0. If the User is implementing
'useSourceCapacity' we would want that 0 value respected and not overwritten
with a value of 1.

The proposal is that the desired capacity trumps targetSize.  It's
reasonable to assume that someone who wants a targetSize of 0 would also
have a desired capacity of 0.  However, we shouldn't use the targetSize
if the desired capacity is greater than its value.