### PR TITLE
feat(appengine): Deploy from Google Cloud Storage [accounts].

### DIFF
--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -8,4 +8,7 @@ dependencies {
   // TODO(dpeach): move to spinnaker/spinnaker-dependencies.
   compile "com.google.apis:google-api-services-appengine:v1-rev4-1.22.0"
   compile "org.eclipse.jgit:org.eclipse.jgit:4.5.0.201609210915-r"
+
+  compile spinnaker.dependency("googleStorage")
+  compile "org.apache.commons:commons-compress:1.14"
 }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
@@ -29,6 +29,7 @@ class DeployAppengineDescription extends AbstractAppengineCredentialsDescription
   String stack
   String freeFormDetails
   String repositoryUrl
+  String storageAccountName  // for GCS repositories only
   AppengineGitCredentialType gitCredentialType
   String branch
   String applicationDirectoryRoot

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/storage/GcsStorageService.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/storage/GcsStorageService.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.storage;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.StorageScopes;
+import com.google.api.services.storage.model.Objects;
+import com.google.api.services.storage.model.StorageObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class GcsStorageService {
+  private static final Logger log = LoggerFactory.getLogger(GcsStorageService.class);
+
+  public static interface VisitorOperation {
+    void visit(StorageObject storageObj) throws IOException;
+  };
+
+  static class Factory {
+    private String applicationName_;
+    private HttpTransport transport_;
+    private JsonFactory jsonFactory_;
+
+    public Factory(String applicationName) throws IOException, GeneralSecurityException {
+      applicationName_ = applicationName;
+      transport_ = GoogleNetHttpTransport.newTrustedTransport();
+      jsonFactory_ = JacksonFactory.getDefaultInstance();
+    }
+
+    public Factory(String applicationName, HttpTransport transport, JsonFactory jsonFactory) {
+      applicationName_ = applicationName;
+      transport_ = transport;
+      jsonFactory_ = jsonFactory;
+    }
+
+    public GcsStorageService newForCredentials(String credentialsPath) throws IOException {
+      GoogleCredential credential = loadCredential(credentialsPath);
+      Storage storage = new Storage.Builder(transport_, jsonFactory_, credential)
+        .setApplicationName(applicationName_)
+        .build();
+
+      return new GcsStorageService(storage);
+    }
+
+    private GoogleCredential loadCredential(String credentialsPath) throws IOException {
+      GoogleCredential credential;
+      if (!credentialsPath.isEmpty()) {
+        FileInputStream stream = new FileInputStream(credentialsPath);
+        credential = GoogleCredential.fromStream(stream, transport_, jsonFactory_)
+          .createScoped(Collections.singleton(StorageScopes.DEVSTORAGE_READ_ONLY));
+        log.info("Loaded credentials from " + credentialsPath);
+      } else {
+        log.info("spinnaker.gcs.enabled without spinnaker.gcs.jsonPath. " +
+          "Using default application credentials. Using default credentials.");
+        credential = GoogleCredential.getApplicationDefault();
+      }
+      return credential;
+    }
+  };
+
+  private Storage storage_;
+
+  public GcsStorageService(Storage storage) {
+    storage_ = storage;
+  }
+
+  public InputStream openObjectStream(String bucketName, String path) throws IOException {
+    Storage.Objects.Get get = storage_.objects().get(bucketName, path);
+    return get.executeMediaAsInputStream();
+  }
+
+  public void visitObjects(String bucketName, String pathPrefix, VisitorOperation op)
+      throws IOException {
+    Storage.Objects.List listMethod = storage_.objects().list(bucketName);
+    listMethod.setPrefix(pathPrefix);
+    Objects objects;
+    ExecutorService executor = Executors.newFixedThreadPool(8);
+
+    do {
+      objects = listMethod.execute();
+      List<StorageObject> items = objects.getItems();
+      if (items != null) {
+        for (StorageObject obj : items) {
+          executor.submit(() -> {
+              try {
+                op.visit(obj);
+              } catch (IOException ioex) {
+                throw new IllegalStateException(ioex);
+              }
+          });
+        }
+      }
+      listMethod.setPageToken(objects.getNextPageToken());
+    } while (objects.getNextPageToken() != null);
+    executor.shutdown();
+
+    try {
+      if (!executor.awaitTermination(10, TimeUnit.MINUTES)) {
+        throw new IllegalStateException("Timed out waiting to process StorageObjects.");
+      }
+    } catch (InterruptedException intex) {
+       throw new IllegalStateException(intex);
+    }
+  }
+
+  public void visitObjects(String bucketName, VisitorOperation op) throws IOException {
+    visitObjects(bucketName, "", op);
+  }
+
+  public void downloadStorageObjectRelative(StorageObject obj, String ignorePrefix, String baseDirectory)
+  throws IOException {
+    InputStream stream = openObjectStream(obj.getBucket(), obj.getName());
+    String objPath = obj.getName();
+    if (!ignorePrefix.isEmpty()) {
+      ignorePrefix += File.separator;
+      if (!objPath.startsWith(ignorePrefix)) {
+          throw new IllegalArgumentException(objPath + " does not start with '" + ignorePrefix + "'");
+      }
+      objPath = objPath.substring(ignorePrefix.length());
+    }
+
+    File target = new File(baseDirectory, objPath);
+    StorageUtils.writeStreamToFile(stream, target);
+    target.setLastModified(obj.getUpdated().getValue());
+    stream.close();
+  }
+
+  public void downloadStorageObject(StorageObject obj, String baseDirectory) throws IOException {
+    downloadStorageObjectRelative(obj, "", baseDirectory);
+  }
+}

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/storage/StorageConfiguration.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/storage/StorageConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.storage;
+
+import com.netflix.spinnaker.clouddriver.appengine.storage.config.StorageConfigurationProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+
+@Configuration
+@EnableConfigurationProperties
+@EnableScheduling
+@ConditionalOnProperty("storage.gcs.enabled")
+class StorageConfiguration {
+  @Autowired
+  StorageConfigurationProperties storageAccountInfo;
+
+  @Bean
+  @ConfigurationProperties("storage.gcs")
+  StorageConfigurationProperties storageConfigurationProperties() {
+    return new StorageConfigurationProperties();
+  }
+
+  @Bean
+  GcsStorageService.Factory storageServiceFactory(String clouddriverUserAgentApplicationName) {
+    try {
+      return new GcsStorageService.Factory(clouddriverUserAgentApplicationName);
+    } catch (IOException ioex) {
+      throw new IllegalStateException(ioex);
+    } catch (GeneralSecurityException secex) {
+      throw new IllegalStateException(secex);
+    }
+  }
+}

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/storage/StorageUtils.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/storage/StorageUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.storage;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.utils.IOUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.util.Stack;
+
+public class StorageUtils {
+  public static void untarStreamToPath(InputStream inputStream, String basePath) throws IOException {
+    class DirectoryTimestamp {
+      public DirectoryTimestamp(File d, long m) {
+          directory = d;
+          millis = m;
+      }
+      public File directory;
+      public long millis;
+    };
+    // Directories come in hierarchical order within the stream, but
+    // we need to set their timestamps after their children have been written.
+    Stack<DirectoryTimestamp> directoryStack = new Stack<DirectoryTimestamp>();
+
+    File baseDirectory = new File(basePath);
+    baseDirectory.mkdir();
+
+    TarArchiveInputStream tarStream = new TarArchiveInputStream(inputStream);
+    for (TarArchiveEntry entry = tarStream.getNextTarEntry();
+         entry != null;
+         entry = tarStream.getNextTarEntry()) {
+        File target = new File(baseDirectory, entry.getName());
+        if (entry.isDirectory()) {
+          directoryStack.push(new DirectoryTimestamp(target, entry.getModTime().getTime()));
+          continue;
+        }
+        writeStreamToFile(tarStream, target);
+        target.setLastModified(entry.getModTime().getTime());
+    }
+
+    while (!directoryStack.empty()) {
+      DirectoryTimestamp info = directoryStack.pop();
+      info.directory.setLastModified(info.millis);
+    }
+    tarStream.close();
+  }
+
+  public static void writeStreamToFile(InputStream sourceStream, File target) throws IOException {
+    File parent = target.getParentFile();
+    if (!parent.exists()) {
+        parent.mkdirs();
+    }
+    OutputStream targetStream = new FileOutputStream(target);
+    IOUtils.copy(sourceStream, targetStream);
+    targetStream.close();
+  }
+}

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/storage/config/StorageConfigurationProperties.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/storage/config/StorageConfigurationProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.storage.config;
+
+import groovy.transform.ToString;
+import retrofit.client.Response;
+import retrofit.mime.TypedByteArray;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import lombok.Data;
+
+@Data
+public class StorageConfigurationProperties {
+  @Data
+  @ToString(includeNames = true)
+  public static class ManagedAccount {
+    String name;
+    String jsonPath;
+
+    public static String responseToString(Response response) {
+      return new String(((TypedByteArray) response.getBody()).getBytes());
+    }
+  }
+
+  ManagedAccount getAccount(String name) {
+    for (ManagedAccount account : accounts) {
+      if (account.getName().equals(name)) {
+        return account;
+      }
+    }
+    throw new NoSuchElementException("Unknown storage account: " + name);
+  }
+
+  List<ManagedAccount> accounts = new ArrayList<ManagedAccount>();
+}

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesConfiguration
 import com.netflix.spinnaker.clouddriver.openstack.OpenstackConfiguration
 import com.netflix.spinnaker.clouddriver.oraclebmcs.OracleBMCSConfiguration
 import com.netflix.spinnaker.clouddriver.security.config.SecurityConfig
+import com.netflix.spinnaker.clouddriver.appengine.storage.StorageConfiguration
 import com.netflix.spinnaker.config.ErrorConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
@@ -65,6 +66,7 @@ import java.security.Security
   CloudFoundryConfig,
   AzureConfiguration,
   SecurityConfig,
+  StorageConfiguration,
   EurekaProviderConfiguration,
   DcosConfiguration,
   LocalJobConfig


### PR DESCRIPTION
@danielpeach please review
@duftler FYI

This works with the existing citest for gcs buckets (without passing a storage account).
I have another change for the test which does pass a storage account in with the deployment request.

I havent yet tested the tar file thing, but did test the extraction of tar files from buckets so believe it will work.

My only technical concern is that I do not preserve any file properties other than timestamps from GCS (e.g. mode bits, owner/group, etc). I dont think this matters for appengine, and that's the only scope at this time.

Note also that I load credentials on demand rather than on startup like other places seem to. It seems simpler this way. I dont think performance is a concenr, but for better or worse it means that a misconfiguration will be caught during request processing rather than startup (but on the positive side, failure will be scoped only to individual accounts rather than the whole server).
