### PR TITLE
refactor(provider/kubernetes): refactor artifact/deployment boundary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.110.5'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.111.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesArtifactConverter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+
+import java.util.Arrays;
+
+public abstract class KubernetesArtifactConverter {
+  abstract public Artifact toArtifact(KubernetesManifest manifest);
+  abstract public KubernetesCoordinates toCoordinates(Artifact artifact);
+  abstract public String getDeployedName(Artifact artifact);
+
+  protected String getType(KubernetesManifest manifest) {
+    return String.join("/",
+        KubernetesCloudProvider.getID(),
+        manifest.getApiVersion().toString() + ":" + manifest.getKind().toString()
+    );
+  }
+
+  private String[] getLatterType(Artifact artifact) {
+    String[] split = artifact.getType().split("/", -1);
+    if (split.length < 2) {
+      throw new IllegalArgumentException("Not a kubernetes artifact: " + artifact);
+    }
+
+    if (!split[0].equals(KubernetesCloudProvider.getID())) {
+      throw new IllegalArgumentException("Not a kubernetes artifact: " + artifact);
+    }
+
+    split = String.join("/", Arrays.copyOfRange(split, 1, split.length)).split(":");
+
+    if (split.length != 2) {
+      throw new IllegalArgumentException("Not a kubernetes artifact: " + artifact);
+    }
+
+    return split;
+  }
+
+  protected KubernetesApiVersion getApiVersion(Artifact artifact) {
+    return KubernetesApiVersion.fromString(getLatterType(artifact)[0]);
+  }
+
+  protected KubernetesKind getKind(Artifact artifact) {
+    return KubernetesKind.fromString(getLatterType(artifact)[1]);
+  }
+
+  protected String getNamespace(Artifact artifact) {
+    return artifact.getLocation();
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverter.java
@@ -17,20 +17,35 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import org.apache.commons.lang.RandomStringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ManifestToUnversionedArtifact implements ManifestToArtifact {
+public class KubernetesUnversionedArtifactConverter extends KubernetesArtifactConverter {
   @Override
-  public Artifact convert(KubernetesManifest manifest) {
-    String type = manifest.getKind().toString();
+  public Artifact toArtifact(KubernetesManifest manifest) {
+    String type = getType(manifest);
     String name = manifest.getName();
     return Artifact.builder()
         .type(type)
         .name(name)
         .build();
+  }
+
+  @Override
+  public KubernetesCoordinates toCoordinates(Artifact artifact) {
+    return KubernetesCoordinates.builder()
+        .apiVersion(getApiVersion(artifact))
+        .kind(getKind(artifact))
+        .namespace(getNamespace(artifact))
+        .name(artifact.getName())
+        .build();
+  }
+
+  @Override
+  public String getDeployedName(Artifact artifact) {
+    return artifact.getName();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesCoordinates.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesCoordinates.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class KubernetesCoordinates {
+  KubernetesApiVersion apiVersion;
+  KubernetesKind kind;
+  String namespace;
+  String name;
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
-import org.joda.time.DateTime;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
@@ -15,11 +15,20 @@
  *
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact;
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
-import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesArtifactConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public interface ManifestToArtifact {
-  Artifact convert(KubernetesManifest manifest);
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KubernetesResourceProperties {
+  KubernetesDeployer deployer;
+  KubernetesArtifactConverter converter;
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourcePropertyRegistry.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesUnversionedArtifactConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class KubernetesResourcePropertyRegistry {
+  @Autowired
+  public KubernetesResourcePropertyRegistry(List<KubernetesDeployer> deployers,
+      KubernetesVersionedArtifactConverter versionedArtifactConverter,
+      KubernetesUnversionedArtifactConverter unversionedArtifactConverter) {
+    for (KubernetesDeployer deployer : deployers) {
+      KubernetesResourceProperties properties = KubernetesResourceProperties.builder()
+          .deployer(deployer)
+          .converter(deployer.versioned() ? versionedArtifactConverter : unversionedArtifactConverter)
+          .build();
+
+      apiVersionLookup.withApiVersion(deployer.apiVersion()).setProperties(deployer.kind(), properties);
+    }
+  }
+
+  public ApiVersionLookup lookup() {
+    return apiVersionLookup;
+  }
+
+  private ApiVersionLookup apiVersionLookup = new ApiVersionLookup();
+
+  public static class KindLookup {
+    private ConcurrentHashMap<KubernetesKind, KubernetesResourceProperties> map = new ConcurrentHashMap<>();
+
+    public KubernetesResourceProperties withKind(KubernetesKind kind) {
+      if (!map.containsKey(kind)) {
+        throw new IllegalArgumentException("No resource properties registered for " + kind);
+      } else {
+        return map.get(kind);
+      }
+    }
+
+    public void setProperties(KubernetesKind kind, KubernetesResourceProperties properties) {
+      map.put(kind, properties);
+    }
+  }
+
+  public static class ApiVersionLookup {
+    private ConcurrentHashMap<KubernetesApiVersion, KindLookup> map = new ConcurrentHashMap<>();
+
+    public KindLookup withApiVersion(KubernetesApiVersion apiVersion) {
+      if (!map.containsKey(apiVersion)) {
+        KindLookup result = new KindLookup();
+        map.put(apiVersion, result);
+        return result;
+      } else {
+        return map.get(apiVersion);
+      }
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesManifestDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesManifestDeployer.java
@@ -20,19 +20,20 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.op;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ManifestToArtifact;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ManifestToUnversionedArtifact;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ManifestToVersionedArtifact;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesArtifactConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesAugmentedManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifestAnnotater;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifestOperationDescription;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeploymentDeployer;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesIngressDeployer;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesReplicaSetDeployer;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesServiceDeployer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifestSpinnakerRelationships;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
@@ -43,22 +44,7 @@ public class KubernetesManifestDeployer implements AtomicOperation<DeploymentRes
   private static final String OP_NAME = "DEPLOY_KUBERNETES_MANIFESTS";
 
   @Autowired
-  private KubernetesReplicaSetDeployer replicaSetDeployer;
-
-  @Autowired
-  private KubernetesServiceDeployer serviceDeployer;
-
-  @Autowired
-  private KubernetesIngressDeployer ingressDeployer;
-
-  @Autowired
-  private KubernetesDeploymentDeployer deploymentDeployer;
-
-  @Autowired
-  private ManifestToVersionedArtifact manifestToVersionedArtifact;
-
-  @Autowired
-  private ManifestToUnversionedArtifact manifestToUnversionedArtifact;
+  private KubernetesResourcePropertyRegistry registry;
 
   public KubernetesManifestDeployer(KubernetesManifestOperationDescription description) {
     this.description = description;
@@ -83,31 +69,55 @@ public class KubernetesManifestDeployer implements AtomicOperation<DeploymentRes
         }).orElseThrow(() -> new IllegalArgumentException("Expected at least one manifest to deploy"));
   }
 
-  private KubernetesDeployer findDeployer(KubernetesKind kind) {
-    switch (kind) {
-      case REPLICA_SET:
-        return replicaSetDeployer;
-      case SERVICE:
-        return serviceDeployer;
-      case INGRESS:
-        return ingressDeployer;
-      case DEPLOYMENT:
-        return deploymentDeployer;
-      default:
-        throw new IllegalArgumentException("Kind " + kind + " is not supported yet");
+  private KubernetesResourceProperties findResourceProperties(KubernetesManifest manifest) {
+    KubernetesApiVersion apiVersion = manifest.getApiVersion();
+    KubernetesKind kind = manifest.getKind();
+    getTask().updateStatus(OP_NAME, "Finding deployer for " + apiVersion + "/" + kind);
+    return registry.lookup().withApiVersion(apiVersion).withKind(kind);
+  }
+
+  private void ensureMetadata(KubernetesResourceProperties properties, KubernetesAugmentedManifest augmentedManifest) {
+    KubernetesManifest manifest = augmentedManifest.getManifest();
+    KubernetesAugmentedManifest.Metadata metadata = augmentedManifest.getMetadata();
+
+    if (metadata.getMoniker() == null) {
+      throw new IllegalStateException("Every resource must be deployed with a moniker.");
+    }
+
+    if (metadata.getRelationships() == null) {
+      metadata.setRelationships(new KubernetesManifestSpinnakerRelationships());
+    }
+
+    if (metadata.getArtifact() == null) {
+      metadata.setArtifact(properties.getConverter().toArtifact(manifest));
+    }
+
+    if (StringUtils.isEmpty(manifest.getNamespace())) {
+      manifest.setNamespace(credentials.getDefaultNamespace());
     }
   }
 
-  private ManifestToArtifact findTranslator(KubernetesDeployer deployer) {
-    return deployer.isVersionedResource() ? manifestToVersionedArtifact : manifestToUnversionedArtifact;
+  private void annotateUsingMetadata(KubernetesAugmentedManifest augmentedManifest) {
+    KubernetesManifestAnnotater.annotateManifest(augmentedManifest.getManifest(), augmentedManifest.getMetadata());
+  }
+
+  private void versionResource(KubernetesResourceProperties properties, KubernetesAugmentedManifest augmentedManifest) {
+    KubernetesManifest manifest = augmentedManifest.getManifest();
+    KubernetesAugmentedManifest.Metadata metadata = augmentedManifest.getMetadata();
+    Artifact artifact = metadata.getArtifact();
+    KubernetesArtifactConverter converter = properties.getConverter();
+
+    manifest.setName(converter.getDeployedName(artifact));
   }
 
   private DeploymentResult dispatchDeployer(KubernetesAugmentedManifest augmentedManifest) {
-    KubernetesKind kind = augmentedManifest.getManifest().getKind();
-    getTask().updateStatus(OP_NAME, "Finding deployer for " + kind);
-    KubernetesDeployer deployer = findDeployer(kind);
-    ManifestToArtifact translator = findTranslator(deployer);
-    augmentedManifest.getMetadata().setArtifact(translator.convert(augmentedManifest.getManifest()));
-    return deployer.deployManifestPair(credentials, augmentedManifest);
+    KubernetesResourceProperties properties = findResourceProperties(augmentedManifest.getManifest());
+    KubernetesManifest manifest = augmentedManifest.getManifest();
+
+    ensureMetadata(properties, augmentedManifest);
+    annotateUsingMetadata(augmentedManifest);
+    versionResource(properties, augmentedManifest);
+
+    return properties.getDeployer().deployAugmentedManifest(credentials, manifest);
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentDeployer.java
@@ -17,6 +17,8 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import io.kubernetes.client.models.AppsV1beta1Deployment;
 import org.springframework.stereotype.Component;
@@ -26,6 +28,16 @@ public class KubernetesDeploymentDeployer extends KubernetesDeployer<AppsV1beta1
   @Override
   Class<AppsV1beta1Deployment> getDeployedClass() {
     return AppsV1beta1Deployment.class;
+  }
+
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.DEPLOYMENT;
+  }
+
+  @Override
+  public KubernetesApiVersion apiVersion() {
+    return KubernetesApiVersion.APPS_V1BETA1;
   }
 
   @Override
@@ -41,7 +53,7 @@ public class KubernetesDeploymentDeployer extends KubernetesDeployer<AppsV1beta1
   }
 
   @Override
-  public boolean isVersionedResource() {
+  public boolean versioned() {
     return false;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesIngressDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesIngressDeployer.java
@@ -17,12 +17,24 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import io.kubernetes.client.models.V1beta1Ingress;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KubernetesIngressDeployer extends KubernetesDeployer<V1beta1Ingress> {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.INGRESS;
+  }
+
+  @Override
+  public KubernetesApiVersion apiVersion() {
+    return KubernetesApiVersion.EXTENSIONS_V1BETA1;
+  }
+
   @Override
   Class<V1beta1Ingress> getDeployedClass() {
     return V1beta1Ingress.class;
@@ -34,7 +46,7 @@ public class KubernetesIngressDeployer extends KubernetesDeployer<V1beta1Ingress
   }
 
   @Override
-  public boolean isVersionedResource() {
+  public boolean versioned() {
     return false;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesReplicaSetDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesReplicaSetDeployer.java
@@ -17,12 +17,24 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import io.kubernetes.client.models.V1beta1ReplicaSet;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KubernetesReplicaSetDeployer extends KubernetesDeployer<V1beta1ReplicaSet> {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.REPLICA_SET;
+  }
+
+  @Override
+  public KubernetesApiVersion apiVersion() {
+    return KubernetesApiVersion.EXTENSIONS_V1BETA1;
+  }
+
   @Override
   Class<V1beta1ReplicaSet> getDeployedClass() {
     return V1beta1ReplicaSet.class;
@@ -34,7 +46,7 @@ public class KubernetesReplicaSetDeployer extends KubernetesDeployer<V1beta1Repl
   }
 
   @Override
-  public boolean isVersionedResource() {
+  public boolean versioned() {
     return true;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesServiceDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesServiceDeployer.java
@@ -17,12 +17,24 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import io.kubernetes.client.models.V1Service;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KubernetesServiceDeployer extends KubernetesDeployer<V1Service> {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.SERVICE;
+  }
+
+  @Override
+  public KubernetesApiVersion apiVersion() {
+    return KubernetesApiVersion.V1;
+  }
+
   @Override
   Class<V1Service> getDeployedClass() {
     return V1Service.class;
@@ -34,7 +46,7 @@ public class KubernetesServiceDeployer extends KubernetesDeployer<V1Service> {
   }
 
   @Override
-  public boolean isVersionedResource() {
+  public boolean versioned() {
     return false;
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverterSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Unversion 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import spock.lang.Specification
+
+class KubernetesUnversionedArtifactConverterSpec extends Specification {
+  def "correctly infer unversioned artifact properties"() {
+    expect:
+    def type = "kubernetes/$apiVersion:$kind"
+
+    def artifact = Artifact.builder()
+      .type(type)
+      .name(name)
+      .build()
+
+    def converter = new KubernetesUnversionedArtifactConverter()
+    converter.getApiVersion(artifact) == apiVersion
+    converter.getKind(artifact) == kind
+    converter.getDeployedName(artifact) == "$name"
+
+
+    where:
+    apiVersion                        | kind                      | name
+    KubernetesApiVersion.APPS_V1BETA1 | KubernetesKind.DEPLOYMENT | "my-deploy"
+    KubernetesApiVersion.V1           | KubernetesKind.SERVICE    | "my-other-rs-_-"
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import spock.lang.Specification
+
+class KubernetesVersionedArtifactConverterSpec extends Specification {
+  def "correctly infer versioned artifact properties"() {
+    expect:
+    def type = "kubernetes/$apiVersion:$kind"
+
+    def artifact = Artifact.builder()
+      .type(type)
+      .name(name)
+      .version(version)
+      .build()
+
+    def converter = new KubernetesVersionedArtifactConverter()
+    converter.getApiVersion(artifact) == apiVersion
+    converter.getKind(artifact) == kind
+    converter.getDeployedName(artifact) == "$name-$version"
+
+
+    where:
+    apiVersion                              | kind                       | name             | version
+    KubernetesApiVersion.EXTENSIONS_V1BETA1 | KubernetesKind.REPLICA_SET | "my-rs"          | "v000"
+    KubernetesApiVersion.EXTENSIONS_V1BETA1 | KubernetesKind.REPLICA_SET | "my-other-rs-_-" | "v010"
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesManifestDeployerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesManifestDeployerSpec.groovy
@@ -21,17 +21,17 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ManifestToArtifact
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ManifestToVersionedArtifact
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesUnversionedArtifactConverter
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiVersion
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesAugmentedManifest
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifest
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifestOperationDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesManifestSpinnakerRelationships
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesReplicaSetDeployer
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials
-import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.moniker.Moniker
 import org.yaml.snakeyaml.Yaml
 import spock.lang.Specification
@@ -86,10 +86,15 @@ metadata:
 
     def replicaSetDeployer = new KubernetesReplicaSetDeployer()
     replicaSetDeployer.objectMapper = new ObjectMapper()
+    replicaSetDeployer.versioned() >> true
+    replicaSetDeployer.apiVersion() >> API_VERSION
+    replicaSetDeployer.kind() >> KIND
+    def registry = new KubernetesResourcePropertyRegistry(Collections.singletonList(replicaSetDeployer),
+        new KubernetesVersionedArtifactConverter(),
+        new KubernetesUnversionedArtifactConverter())
 
     def deployOp = new KubernetesManifestDeployer(deployDescription)
-    deployOp.replicaSetDeployer = replicaSetDeployer
-    deployOp.manifestToVersionedArtifact = new ManifestToVersionedArtifact()
+    deployOp.registry = registry
 
     return deployOp
   }


### PR DESCRIPTION
Will roll up into a coming PR that uses prior "versions" of a resource, e.g. replicaSet to determine what to deploy. This enables version numbers like vNNN on versioned resources (replicaSet, configMap, ...)