### PR TITLE
feat(moniker): Adds moniker to pendingOnDemandResults

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineLoadBalancerCachingAgent.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineLoadBalancerCachingAgent.groovy
@@ -34,7 +34,6 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent.OnDemandResult
 import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.provider.view.MutableCacheData
-
 import groovy.util.logging.Slf4j
 
 import java.util.concurrent.TimeUnit
@@ -218,11 +217,13 @@ class AppengineLoadBalancerCachingAgent extends AbstractAppengineCachingAgent im
     }
 
     return providerCache.getAll(ON_DEMAND.ns, keys).collect {
-      [
-        details  : Keys.parse(it.id),
-        cacheTime: it.attributes.cacheTime,
-        processedCount: it.attributes.processedCount,
-        processedTime: it.attributes.processedTime
+      def details = Keys.parse(it.id)
+      return [
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          processedCount: it.attributes.processedCount,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineServerGroupCachingAgent.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineServerGroupCachingAgent.groovy
@@ -404,11 +404,14 @@ class AppengineServerGroupCachingAgent extends AbstractAppengineCachingAgent imp
     }
 
     providerCache.getAll(ON_DEMAND.ns, keys).collect {
-      [
-        details  : Keys.parse(it.id),
-        cacheTime: it.attributes.cacheTime,
-        processedCount: it.attributes.processedCount,
-        processedTime: it.attributes.processedTime
+      def details = Keys.parse(it.id)
+
+      return [
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          processedCount: it.attributes.processedCount,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -448,13 +448,16 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
       key.type == SERVER_GROUPS.ns && key.account == account.name && key.region == region
     }
     return providerCache.getAll(ON_DEMAND.ns, keys, RelationshipCacheFilter.none()).collect {
-      [
-        id: it.id,
-        details  : Keys.parse(it.id),
-        cacheTime: it.attributes.cacheTime,
-        cacheExpiry: it.attributes.cacheExpiry,
-        processedCount: it.attributes.processedCount,
-        processedTime: it.attributes.processedTime
+      def details = Keys.parse(it.id)
+
+      return [
+          id            : it.id,
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          cacheExpiry   : it.attributes.cacheExpiry,
+          processedCount: it.attributes.processedCount,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -144,12 +144,15 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
       key.type == AZURE_SERVER_GROUPS.ns && key.account == accountName && key.region == region
     }
     return providerCache.getAll(AZURE_ON_DEMAND.ns, keys, RelationshipCacheFilter.none()).collect {
-      [
-        id: it.id,
-        details  : Keys.parse(azureCloudProvider, it.id),
-        cacheTime: it.attributes.cacheTime,
-        processedCount: it.attributes.processedCount,
-        processedTime: it.attributes.processedTime
+      def details = Keys.parse(azureCloudProvider, it.id);
+
+      return [
+          id            : it.id,
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          processedCount: it.attributes.processedCount,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-cf/src/main/groovy/com/netflix/spinnaker/clouddriver/cf/provider/agent/ClusterCachingAgent.groovy
@@ -214,12 +214,15 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
   Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
     def keys = providerCache.getIdentifiers(ON_DEMAND.ns)
     providerCache.getAll(ON_DEMAND.ns, keys).collect {
-      [
-        id: it.id,
-        details: Keys.parse(it.id),
-        cacheTime: it.attributes.cacheTime,
-        processedCount: it.attributes.processedCount ?: 0,
-        processedTime: it.attributes.processedTime
+      def details = Keys.parse(it.id)
+
+      return [
+          id            : it.id,
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          processedCount: it.attributes.processedCount ?: 0,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.cache;
 
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.moniker.Moniker;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,6 +63,28 @@ public interface OnDemandAgent {
       this.sourceAgentType = sourceAgentType;
       this.cacheResult = cacheResult;
       this.evictions = evictions;
+    }
+  }
+
+  /*
+   * WARNING: this is an interim solution while cloud providers write their own ways to derive monikers.
+   */
+  default Moniker convertOnDemandDetails(Map<String, String> details) {
+    if (details == null || details.isEmpty()) {
+      return null;
+    }
+
+    try {
+      return Moniker.builder()
+          .app(details.get("application"))
+          .stack(details.get("stack"))
+          .detail(details.get("detail"))
+          .cluster(details.get("cluster"))
+          .sequence(Integer.valueOf(details.get("sequence")))
+          .build();
+    } catch (Exception e) {
+      e.printStackTrace();
+      return null;
     }
   }
 

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosLoadBalancerCachingAgent.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosLoadBalancerCachingAgent.groovy
@@ -174,11 +174,14 @@ class DcosLoadBalancerCachingAgent implements CachingAgent, AccountAware, OnDema
     }
 
     return providerCache.getAll(Keys.Namespace.ON_DEMAND.ns, keys).collect {
-      [
-        details       : Keys.parse(it.id),
-        cacheTime     : it.attributes.cacheTime,
-        processedCount: it.attributes.processedCount,
-        processedTime : it.attributes.processedTime
+      def details = Keys.parse(it.id)
+
+      return [
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          processedCount: it.attributes.processedCount,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosServerGroupCachingAgent.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosServerGroupCachingAgent.groovy
@@ -231,11 +231,14 @@ class DcosServerGroupCachingAgent implements CachingAgent, AccountAware, OnDeman
     }
 
     providerCache.getAll(Keys.Namespace.ON_DEMAND.ns, keys).collect {
-      [
-        details       : Keys.parse(it.id),
-        cacheTime     : it.attributes.cacheTime,
-        processedCount: it.attributes.processedCount,
-        processedTime : it.attributes.processedTime
+      def details = Keys.parse(it.id)
+
+      return [
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          processedCount: it.attributes.processedCount,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleLoadBalancerCachingAgent.groovy
@@ -163,11 +163,13 @@ abstract class AbstractGoogleLoadBalancerCachingAgent extends AbstractGoogleCach
     }
 
     return providerCache.getAll(ON_DEMAND.ns, keys).collect { CacheData cacheData ->
+      def details = Keys.parse(cacheData.id)
       [
-        details       : Keys.parse(cacheData.id),
-        cacheTime     : cacheData.attributes.cacheTime,
-        processedCount: cacheData.attributes.processedCount,
-        processedTime : cacheData.attributes.processedTime
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : cacheData.attributes.cacheTime,
+          processedCount: cacheData.attributes.processedCount,
+          processedTime : cacheData.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -233,8 +233,11 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
     }
 
     providerCache.getAll(ON_DEMAND.ns, keys).collect { CacheData cacheData ->
-      [
-          details       : Keys.parse(cacheData.id),
+      def details = Keys.parse(cacheData.id)
+
+      return [
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
           cacheTime     : cacheData.attributes.cacheTime,
           processedCount: cacheData.attributes.processedCount,
           processedTime : cacheData.attributes.processedTime

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -155,11 +155,14 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
     }
 
     return providerCache.getAll(ON_DEMAND.ns, keys).collect { CacheData cacheData ->
-      [
-        details       : Keys.parse(cacheData.id),
-        cacheTime     : cacheData.attributes.cacheTime,
-        processedCount: cacheData.attributes.processedCount,
-        processedTime : cacheData.attributes.processedTime
+      def details = Keys.parse(cacheData.id)
+
+      return [
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : cacheData.attributes.cacheTime,
+          processedCount: cacheData.attributes.processedCount,
+          processedTime : cacheData.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
@@ -242,8 +242,11 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
     }
 
     providerCache.getAll(ON_DEMAND.ns, keys).collect { CacheData cacheData ->
+      def details = Keys.parse(it.id)
+
       [
-          details       : Keys.parse(cacheData.id),
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
           cacheTime     : cacheData.attributes.cacheTime,
           processedCount: cacheData.attributes.processedCount,
           processedTime : cacheData.attributes.processedTime

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
@@ -147,11 +147,14 @@ class KubernetesLoadBalancerCachingAgent extends KubernetesCachingAgent<Kubernet
     }
 
     providerCache.getAll(Keys.Namespace.ON_DEMAND.ns, keys).collect {
+      def details = Keys.parse(it.id)
+
       [
-        details: Keys.parse(it.id),
-        cacheTime: it.attributes.cacheTime,
-        processedCount: it.attributes.processedCount,
-        processedTime: it.attributes.processedTime
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          processedCount: it.attributes.processedCount,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesSecurityGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesSecurityGroupCachingAgent.groovy
@@ -148,11 +148,14 @@ class KubernetesSecurityGroupCachingAgent extends KubernetesCachingAgent<Kuberne
     }
 
     providerCache.getAll(Keys.Namespace.ON_DEMAND.ns, keys).collect {
-      [
-          details  : Keys.parse(it.id),
-          cacheTime: it.attributes.cacheTime,
+      def details = Keys.parse(it.id)
+
+      return [
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
           processedCount: it.attributes.processedCount,
-          processedTime: it.attributes.processedTime
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -166,11 +166,14 @@ class KubernetesServerGroupCachingAgent extends KubernetesCachingAgent<Kubernete
     log.info("There $be $keyCount pending on demand request$pluralize")
 
     providerCache.getAll(Keys.Namespace.ON_DEMAND.ns, keys).collect {
-      [
-        details  : Keys.parse(it.id),
-        cacheTime: it.attributes.cacheTime,
-        processedCount: it.attributes.processedCount,
-        processedTime: it.attributes.processedTime
+      def details = Keys.parse(it.id)
+
+      return [
+          details       : details,
+          moniker       : convertOnDemandDetails(details),
+          cacheTime     : it.attributes.cacheTime,
+          processedCount: it.attributes.processedCount,
+          processedTime : it.attributes.processedTime
       ]
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNetworkPolicyCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNetworkPolicyCachingAgent.java
@@ -75,6 +75,11 @@ public class KubernetesNetworkPolicyCachingAgent extends KubernetesV2OnDemandCac
   }
 
   @Override
+  protected Class<V1beta1NetworkPolicy> primaryResourceClass() {
+    return V1beta1NetworkPolicy.class;
+  }
+
+  @Override
   protected OnDemandType onDemandType() {
     return OnDemandType.SecurityGroup;
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
@@ -76,6 +76,11 @@ public class KubernetesReplicaSetCachingAgent extends KubernetesV2OnDemandCachin
   }
 
   @Override
+  protected Class<V1beta1ReplicaSet> primaryResourceClass() {
+    return V1beta1ReplicaSet.class;
+  }
+
+  @Override
   protected OnDemandType onDemandType() {
     return OnDemandType.ServerGroup;
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -75,7 +75,6 @@ public abstract class KubernetesV2CachingAgent<T> extends KubernetesCachingAgent
     KubernetesCacheDataConverter.logStratifiedCacheData(getAgentType(), entries);
 
     return new DefaultCacheResult(entries);
-
   }
 
   protected abstract List<T> loadPrimaryResourceList();


### PR DESCRIPTION
See https://github.com/spinnaker/clouddriver/compare/master...lwander:moniker-on-demand?expand=1#diff-793a249c0692198d2557378d889e7285 for the "correct" long-term implementation, the "deriveMoniker" is more of a patch to get this working without proper support in each cloud provider.

@andrewbackes 