### PR TITLE
fix(provider/kubernetes): handle exception to reduce noise for user(Issue no: 1989)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesClientApiAdapter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesClientApiAdapter.groovy
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Clock
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.exception.KubernetesClientOperationException
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesApiClientConfig
+import groovy.util.logging.Slf4j
 import io.kubernetes.client.ApiClient
 import io.kubernetes.client.ApiException
 import io.kubernetes.client.Configuration
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory
 
 import java.util.concurrent.TimeUnit
 
+@Slf4j
 class KubernetesClientApiAdapter {
   private static final Logger LOG = LoggerFactory.getLogger(KubernetesClientApiConverter)
 
@@ -144,14 +146,18 @@ class KubernetesClientApiAdapter {
       /*
        "fixme" and note this is k8s-client api issue and we are working this as workaround.
         */
-      V1beta1StatefulSetList list = apiInstance.listNamespacedStatefulSet(namespace, null, null, null, null, API_CALL_TIMEOUT_SECONDS, false)
-      String apiVersion = list.getApiVersion();
-      for (V1beta1StatefulSet item : list.getItems()) {
-        item.setApiVersion(apiVersion);
-        item.setKind("StatefulSet");
-      }
+      try {
+        V1beta1StatefulSetList list = apiInstance.listNamespacedStatefulSet(namespace, null, null, null, null, API_CALL_TIMEOUT_SECONDS, false)
+        String apiVersion = list.getApiVersion();
+        for (V1beta1StatefulSet item : list.getItems()) {
+          item.setApiVersion(apiVersion);
+          item.setKind("StatefulSet");
+        }
 
-      return list.items
+        return list.items
+      } catch (ApiException ex) {
+        log.debug("Cannot fetch Statefulsets Required Kubernetes VERSION>=1.6")
+      }
     }
   }
 
@@ -160,14 +166,18 @@ class KubernetesClientApiAdapter {
       /*
      "fixme" and note this is k8s-client api issue and we are working this as workaround.
       */
-      V1beta1DaemonSetList list = extApi.listNamespacedDaemonSet(namespace, null, null, null, null, API_CALL_TIMEOUT_SECONDS, null)
-      String apiVersion = list.getApiVersion();
-      for (V1beta1DaemonSet item : list.getItems()) {
-        item.setApiVersion(apiVersion);
-        item.setKind("DaemonSet");
-      }
+      try {
+        V1beta1DaemonSetList list = extApi.listNamespacedDaemonSet(namespace, null, null, null, null, API_CALL_TIMEOUT_SECONDS, null)
+        String apiVersion = list.getApiVersion();
+        for (V1beta1DaemonSet item : list.getItems()) {
+          item.setApiVersion(apiVersion);
+          item.setKind("DaemonSet");
+        }
 
-      return list.items
+        return list.items
+      } catch (ApiException ex) {
+        log.debug("Cannot fetch Daemonsets Required Kubernetes VERSION>=1.6")
+      }
     }
   }
 


### PR DESCRIPTION
@lwander 
Regarding issue spinnaker/spinnaker#1989

It was because of using the older version of Kubernates (1.4) that’s why that error coming , as we have written new cashing agent which is a part of framework that’s why its started automatically and try to fetch the StatefulSets list from Kubernates. Which older version does not supports.
We have surrounded the call with exception framework that’s why its printing the exception
So i have handled the exception and Printed the message " Cannot fetch Statefulsets [Required Kubernates VERSION>=1.6"
Please review it.
CC @chlung 
We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
