### PR TITLE
feat(search): cull missing ASGs before returning

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/search/ServerGroupKeyProcessor.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/search/ServerGroupKeyProcessor.groovy
@@ -1,0 +1,35 @@
+package com.netflix.spinnaker.clouddriver.aws.search
+
+import com.netflix.spinnaker.clouddriver.aws.data.Keys
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonServerGroup
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonClusterProvider
+import com.netflix.spinnaker.clouddriver.cache.KeyProcessor
+import com.netflix.spinnaker.clouddriver.model.view.ServerGroupViewModelPostProcessor
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component("AmazonServerGroupKeyProcessor")
+class ServerGroupKeyProcessor implements KeyProcessor {
+
+  @Autowired
+  AmazonClusterProvider amazonClusterProvider
+
+  @Autowired(required = false)
+  ServerGroupViewModelPostProcessor serverGroupViewModelPostProcessor
+
+  @Override
+  Boolean canProcess(String type) {
+    return type == "serverGroups"
+  }
+
+  @Override
+  Boolean exists(String key) {
+
+    Map<String, String> parsed = Keys.parse(key)
+    String account = parsed['account']
+    String region = parsed['region']
+    String name = parsed['serverGroup']
+
+    return amazonClusterProvider.getServerGroup(account, region, name) != null
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyParser.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyParser.java
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.cache;
 
-import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace;
-
 import java.util.Map;
 
 public interface KeyParser {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyProcessor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyProcessor.java
@@ -1,0 +1,22 @@
+package com.netflix.spinnaker.clouddriver.cache;
+
+public interface KeyProcessor {
+
+  /**
+   * Indicates whether this processor can process the specified type
+   *
+   * @param type the cache type to process
+   *
+   * @return <code>true</code> if this processor can process the specified type and <code>false</code> otherwise.
+   */
+  Boolean canProcess(String type);
+
+  /**
+   * Determines whether the underlying object represented by this key exists.
+   *
+   * @param key the cache key to process
+   *
+   * @return <code>true</code> if the underlying object represented by this key exists and <code>false</code> otherwise.
+   */
+  Boolean exists(String key);
+}


### PR DESCRIPTION
* removes ASGs that show up in the search results from the redis cache
but don't actually exist.
