### PR TITLE
fix(provider/kubernetes): fix k8s client configuration and image id p…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesApiClientConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesApiClientConfig.groovy
@@ -66,7 +66,7 @@ public class KubernetesApiClientConfig extends Config {
 
     //TODO: Need to validate cluster and user when client library exposes these api.
     if (StringUtils.isEmpty(context) && !configMap.get("current-context")) {
-      throw new RuntimeException("Missing required field ${context} in kubeconfig file and clouddriver configuration.")
+      throw new RuntimeException("Missing required field context in kubeconfig file and clouddriver configuration.")
     }
 
     if (!StringUtils.isEmpty(context)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesClientApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesClientApiConverter.groovy
@@ -555,7 +555,7 @@ class KubernetesClientApiConverter {
     def imageId = KubernetesUtil.getImageId(container.imageDescription)
     def v1container = new V1Container()
 
-    v1container.image = container.imageDescription.repository
+    v1container.image = imageId
 
     if (container.imagePullPolicy) {
       v1container.imagePullPolicy = container.imagePullPolicy.toString()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
@@ -79,8 +79,6 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
 
     KubernetesApiClientConfig configClient = new KubernetesApiClientConfig(kubeconfigFile, context, cluster, user, userAgent);
 
-
-
     this.apiAdaptor = new KubernetesApiAdaptor(name, config, spectatorRegistry);
     this.apiClientAdaptor = new KubernetesClientApiAdapter(name, configClient, spectatorRegistry);
     this.namespaces = namespaces != null ? namespaces : new ArrayList<>();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
@@ -77,7 +77,9 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
     Config config = KubernetesConfigParser.parse(kubeconfigFile, context, cluster, user, namespaces, serviceAccount);
     config.setUserAgent(userAgent);
 
-    KubernetesApiClientConfig configClient = new KubernetesApiClientConfig(kubeconfigFile);
+    KubernetesApiClientConfig configClient = new KubernetesApiClientConfig(kubeconfigFile, context, cluster, user, userAgent);
+
+
 
     this.apiAdaptor = new KubernetesApiAdaptor(name, config, spectatorRegistry);
     this.apiClientAdaptor = new KubernetesClientApiAdapter(name, configClient, spectatorRegistry);


### PR DESCRIPTION
About this PR,

Fix the problem when context does not present in k8s configuration file and incorrect image id assignment. Port the code(https://github.com/spinnaker/clouddriver/pull/1933) from master into 1.4.x branch.

…roblem.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
