### PR TITLE
fix(provider/kubernetes): Don't store-unowned artifacts

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesArtifactConverter.java
@@ -34,7 +34,7 @@ public abstract class KubernetesArtifactConverter {
   protected String getType(KubernetesManifest manifest) {
     return String.join("/",
         KubernetesCloudProvider.getID(),
-        manifest.getApiVersion().toString() + ":" + manifest.getKind().toString()
+        manifest.getApiVersion().toString() + "|" + manifest.getKind().toString()
     );
   }
 
@@ -48,7 +48,7 @@ public abstract class KubernetesArtifactConverter {
       throw new IllegalArgumentException("Not a kubernetes artifact: " + artifact);
     }
 
-    split = String.join("/", Arrays.copyOfRange(split, 1, split.length)).split(":");
+    split = String.join("/", Arrays.copyOfRange(split, 1, split.length)).split("\\|");
 
     if (split.length != 2) {
       throw new IllegalArgumentException("Not a kubernetes artifact: " + artifact);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -52,6 +52,10 @@ public class KubernetesCacheDataConverter {
   public static CacheData convertAsArtifact(String account, ObjectMapper mapper, Object resource) {
     KubernetesManifest manifest = mapper.convertValue(resource, KubernetesManifest.class);
     Artifact artifact = KubernetesManifestAnnotater.getArtifact(manifest);
+    if (artifact.getType() == null) {
+      log.info("No assigned artifact type for this resource.");
+      return null;
+    }
 
     Map<String, Object> attributes = new ImmutableMap.Builder<String, Object>()
         .put("artifact", artifact)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesManifestDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesManifestDeployer.java
@@ -66,6 +66,10 @@ public class KubernetesManifestDeployer implements AtomicOperation<DeploymentRes
     getTask().updateStatus(OP_NAME, "Beginning deployment of manifest...");
 
     KubernetesManifest manifest = description.getManifest();
+    if (StringUtils.isEmpty(manifest.getNamespace())) {
+      manifest.setNamespace(credentials.getDefaultNamespace());
+    }
+
     KubernetesResourceProperties properties = findResourceProperties(manifest);
     KubernetesDeployer deployer = properties.getDeployer();
     KubernetesArtifactConverter converter = properties.getConverter();
@@ -74,10 +78,6 @@ public class KubernetesManifestDeployer implements AtomicOperation<DeploymentRes
     Artifact artifact = properties.getConverter().toArtifact(manifest);
     Moniker moniker = description.getMoniker();
     KubernetesManifestSpinnakerRelationships relationships = description.getRelationships();
-
-    if (StringUtils.isEmpty(manifest.getNamespace())) {
-      manifest.setNamespace(credentials.getDefaultNamespace());
-    }
 
     getTask().updateStatus(OP_NAME, "Annotating manifest with artifact, relationships & moniker...");
     KubernetesManifestAnnotater.annotateManifest(manifest, artifact);

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverterSpec.groovy
@@ -27,7 +27,7 @@ class KubernetesUnversionedArtifactConverterSpec extends Specification {
   @Unroll
   def "correctly infer unversioned artifact properties"() {
     expect:
-    def type = "kubernetes/$apiVersion:$kind"
+    def type = "kubernetes/$apiVersion|$kind"
 
     def artifact = Artifact.builder()
       .type(type)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
@@ -28,7 +28,7 @@ class KubernetesVersionedArtifactConverterSpec extends Specification {
   @Unroll
   def "correctly infer versioned artifact properties"() {
     expect:
-    def type = "kubernetes/$apiVersion:$kind"
+    def type = "kubernetes/$apiVersion|$kind"
 
     def artifact = Artifact.builder()
       .type(type)


### PR DESCRIPTION
Improper handling of artifacts (wrong versions being assigned) prevented the same versioned manfiest from being deployed more than once in the UI