### PR TITLE
feat(provider/kubernetes): v2 on-demand manifest caching

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
@@ -39,7 +39,8 @@ public interface OnDemandAgent {
     SecurityGroup,
     LoadBalancer,
     Job,
-    TargetGroup;
+    TargetGroup,
+    Manifest;
 
     static OnDemandType fromString(String s) {
       return Arrays.stream(values())

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNetworkPolicyCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNetworkPolicyCachingAgent.java
@@ -80,11 +80,6 @@ public class KubernetesNetworkPolicyCachingAgent extends KubernetesV2OnDemandCac
   }
 
   @Override
-  protected OnDemandType onDemandType() {
-    return OnDemandType.SecurityGroup;
-  }
-
-  @Override
   protected KubernetesKind primaryKind() {
     return KubernetesKind.NETWORK_POLICY;
   }
@@ -92,19 +87,5 @@ public class KubernetesNetworkPolicyCachingAgent extends KubernetesV2OnDemandCac
   @Override
   protected KubernetesApiVersion primaryApiVersion() {
     return KubernetesApiVersion.EXTENSIONS_V1BETA1;
-  }
-
-  @Override
-  protected Map<String, String> mapKeyToOnDemandResult(Keys.InfrastructureCacheKey key) {
-    return new ImmutableMap.Builder<String, String>()
-        .put("securityGroup", key.getName())
-        .put("account", key.getAccount())
-        .put("region", key.getNamespace())
-        .build();
-  }
-
-  @Override
-  protected Optional<String> getResourceNameFromOnDemandRequest(Map<String, ?> request) {
-    return request.containsKey("securityGroup") ? Optional.of((String) request.get("securityGroup")) : Optional.empty();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
@@ -81,11 +81,6 @@ public class KubernetesReplicaSetCachingAgent extends KubernetesV2OnDemandCachin
   }
 
   @Override
-  protected OnDemandType onDemandType() {
-    return OnDemandType.ServerGroup;
-  }
-
-  @Override
   protected KubernetesKind primaryKind() {
     return KubernetesKind.REPLICA_SET;
   }
@@ -93,19 +88,5 @@ public class KubernetesReplicaSetCachingAgent extends KubernetesV2OnDemandCachin
   @Override
   protected KubernetesApiVersion primaryApiVersion() {
     return KubernetesApiVersion.EXTENSIONS_V1BETA1;
-  }
-
-  @Override
-  protected Map<String, String> mapKeyToOnDemandResult(Keys.InfrastructureCacheKey key) {
-    return new ImmutableMap.Builder<String, String>()
-        .put("serverGroup", key.getName())
-        .put("account", key.getAccount())
-        .put("region", key.getNamespace())
-        .build();
-  }
-
-  @Override
-  protected Optional<String> getResourceNameFromOnDemandRequest(Map<String, ?> request) {
-    return request.containsKey("serverGroup") ? Optional.of((String) request.get("serverGroup")) : Optional.empty();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -140,7 +140,11 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public String getFullResourceName() {
-    return String.join("|", getApiVersion().toString(), getKind().toString(), getName());
+    return getFullResourceName(getApiVersion(), getKind(), getName());
+  }
+
+  public static String getFullResourceName(KubernetesApiVersion apiVersion, KubernetesKind kind, String name) {
+    return String.join("|", apiVersion.toString(), kind.toString(), name);
   }
 
   public static Triple<KubernetesApiVersion, KubernetesKind, String> fromFullResourceName(String fullResourceName) {


### PR DESCRIPTION
Since manifest deployments have their own semantics, they are getting their own caching behavior too