### PR TITLE
feat(provider/aws): add executionId to user-agent for cloudtrail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.113.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.113.2'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AddSpinnakerUserToUserAgentRequestHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AddSpinnakerUserToUserAgentRequestHandler.java
@@ -23,7 +23,10 @@ import com.netflix.spinnaker.security.AuthenticatedRequest;
 public class AddSpinnakerUserToUserAgentRequestHandler extends RequestHandler2 {
   @Override
   public AmazonWebServiceRequest beforeMarshalling(AmazonWebServiceRequest request) {
-    final String userAgent = "spinnaker-user/" + AuthenticatedRequest.getSpinnakerUser().orElse("unknown");
+    final String userAgent = String.format("spinnaker-user/%s spinnaker-executionId/%s",
+      AuthenticatedRequest.getSpinnakerUser().orElse("unknown"),
+      AuthenticatedRequest.getSpinnakerExecutionId().orElse("unknown"));
+
     final AmazonWebServiceRequest cloned = request.clone();
 
     cloned.getRequestClientOptions().appendUserAgent(userAgent);


### PR DESCRIPTION
Verified aws cloudtrail logs contained i.e. "spinnaker-user/afeldman@netflix.com spinnaker-executionId/f17d557a-818f-459b-9ef0-97f53035810e"