### PR TITLE
fix(aws): Do not do stale key evictions of amazon load balancers

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
@@ -48,13 +48,6 @@ class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAg
   }
 
   @Override
-  Optional<Map<String, String>> getCacheKeyPatterns() {
-    return [
-      (LOAD_BALANCERS.ns): Keys.getLoadBalancerKey('*', account.name, region, '*', null)
-    ]
-  }
-
-  @Override
   OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data) {
     if (!data.containsKey("loadBalancerName")) {
       return null


### PR DESCRIPTION
Seeing some mixed results when application/network and classic load
balancers are being used.
