### PR TITLE
fix(aws): Enable stale key evictions for amazon load balancers

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CachingAgent.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CachingAgent.java
@@ -112,7 +112,7 @@ public interface CachingAgent extends Agent {
                 Collection<String> evictionsForType = result.getEvictions().computeIfAbsent(type, evictableKeys -> new ArrayList<>());
                 evictionsForType.addAll(evictableIdentifiers);
 
-                log.info("Evicting stale identifiers: {}", evictableIdentifiers);
+                log.debug("Evicting stale identifiers: {}", evictableIdentifiers);
               }
             } catch (Exception e) {
               log.error("Failed to check for stale identifiers (type: {}, pattern: {}, agent: {})", type, cacheKeyPatternForType, agent, e);

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
@@ -67,6 +67,13 @@ class AmazonApplicationLoadBalancerCachingAgent extends AbstractAmazonLoadBalanc
   }
 
   @Override
+  Optional<Map<String, String>> getCacheKeyPatterns() {
+    return [
+      (LOAD_BALANCERS.ns): Keys.getLoadBalancerKey('*', account.name, region, 'vpc-????????', '*')
+    ]
+  }
+
+  @Override
   OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data) {
     if (!data.containsKey("loadBalancerName")) {
       return null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
@@ -48,6 +48,13 @@ class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAg
   }
 
   @Override
+  Optional<Map<String, String>> getCacheKeyPatterns() {
+    return [
+      (LOAD_BALANCERS.ns): Keys.getLoadBalancerKey('*', account.name, region, 'vpc-????????', null)
+    ]
+  }
+
+  @Override
   OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data) {
     if (!data.containsKey("loadBalancerName")) {
       return null


### PR DESCRIPTION
Key structures vary between classic and application/networking load
balancers.
