### PR TITLE
feat(cats): Adding cache gzip compression

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/compression/CompressionStrategy.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/compression/CompressionStrategy.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.cats.compression;
+
+public interface CompressionStrategy {
+  String compress(final String str);
+  String decompress(final String compressed);
+}

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/compression/GZipCompression.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/compression/GZipCompression.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.cats.compression;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class GZipCompression implements CompressionStrategy {
+
+  private final static Logger log = LoggerFactory.getLogger(GZipCompression.class);
+
+  private final static String CHARSET = "UTF-8";
+
+  private final long thresholdBytesSize;
+  private final boolean enabled;
+
+  public GZipCompression(long thresholdBytesSize, boolean enabled) {
+    log.info("Cats using gzip compression: {} bytes threshold, compress enabled: {}", thresholdBytesSize, enabled);
+    this.thresholdBytesSize = thresholdBytesSize;
+    this.enabled = enabled;
+  }
+
+  @Override
+  public String compress(final String str) {
+    if (str == null) {
+      return null;
+    }
+
+    byte[] bytes;
+    try {
+      bytes = str.getBytes(CHARSET);
+    } catch (UnsupportedEncodingException e) {
+      log.error("Failed to compress string: {}", str, e);
+      return str;
+    }
+
+    if (!enabled || bytes.length < thresholdBytesSize) {
+      return str;
+    }
+
+    ByteArrayOutputStream obj = new ByteArrayOutputStream();
+    try {
+      GZIPOutputStream gzip = new GZIPOutputStream(obj);
+      gzip.write(bytes);
+      gzip.flush();
+      gzip.close();
+    } catch (IOException e) {
+      log.error("Failed to compress string: {}", str, e);
+      return str;
+    }
+
+    try {
+      return new String(Base64.getEncoder().encode(obj.toByteArray()), CHARSET);
+    } catch (UnsupportedEncodingException e) {
+      log.error("Failed to compress string: {}", str, e);
+      return str;
+    }
+  }
+
+  @Override
+  public String decompress(final String compressed) {
+    if (compressed == null) {
+      return null;
+    }
+
+    byte[] bytes;
+    try {
+      bytes = Base64.getDecoder().decode(compressed);
+    } catch (IllegalArgumentException e) {
+      return compressed;
+    }
+
+    if (bytes.length == 0 || !isCompressed(bytes)) {
+      return compressed;
+    }
+
+    final StringBuilder outStr = new StringBuilder();
+    try {
+      final GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(bytes));
+      final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(gis, CHARSET));
+
+      String line;
+      while ((line = bufferedReader.readLine()) != null) {
+        outStr.append(line);
+      }
+    } catch (IOException e) {
+      log.error("Failed to decompress string: {}", compressed, e);
+      return compressed;
+    }
+
+    return outStr.toString();
+  }
+
+  private static boolean isCompressed(final byte[] compressed) {
+    return compressed[0] == (byte) (GZIPInputStream.GZIP_MAGIC) && compressed[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8);
+  }
+}

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/compression/NoopCompression.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/compression/NoopCompression.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.cats.compression;
+
+public class NoopCompression implements CompressionStrategy {
+
+  @Override
+  public String compress(String str) {
+    return str;
+  }
+
+  @Override
+  public String decompress(String compressed) {
+    return compressed;
+  }
+}

--- a/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/compression/GZipCompressionStrategySpec.groovy
+++ b/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/compression/GZipCompressionStrategySpec.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.cats.compression
+
+import spock.lang.Specification
+
+class GZipCompressionStrategySpec extends Specification {
+
+  def 'should compress and decompress values'() {
+    given:
+    def subject = new GZipCompression(16, true)
+
+    when:
+    def result = subject.compress(data)
+
+    then:
+    if (shouldCompress) {
+      result != data
+    } else {
+      result == data
+    }
+    subject.decompress(result) == data
+
+    where:
+    data          || shouldCompress
+    'hello world' || true
+    'foo bar baz' || true
+    'a'           || false
+  }
+}

--- a/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteNamedCacheFactory.java
+++ b/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteNamedCacheFactory.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.cats.dynomite.cache;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory;
 import com.netflix.spinnaker.cats.cache.WriteableCache;
+import com.netflix.spinnaker.cats.compression.CompressionStrategy;
 import com.netflix.spinnaker.cats.dynomite.DynomiteClientDelegate;
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache.CacheMetrics;
 import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions;
@@ -28,16 +29,22 @@ public class DynomiteNamedCacheFactory implements NamedCacheFactory {
   private final ObjectMapper objectMapper;
   private final RedisCacheOptions options;
   private final CacheMetrics cacheMetrics;
+  private final CompressionStrategy compressionStrategy;
 
-  public DynomiteNamedCacheFactory(DynomiteClientDelegate dynomiteClientDelegate, ObjectMapper objectMapper, RedisCacheOptions options, CacheMetrics cacheMetrics) {
+  public DynomiteNamedCacheFactory(DynomiteClientDelegate dynomiteClientDelegate,
+                                   ObjectMapper objectMapper,
+                                   RedisCacheOptions options,
+                                   CacheMetrics cacheMetrics,
+                                   CompressionStrategy compressionStrategy) {
     this.dynomiteClientDelegate = dynomiteClientDelegate;
     this.objectMapper = objectMapper;
     this.options = options;
     this.cacheMetrics = cacheMetrics;
+    this.compressionStrategy = compressionStrategy;
   }
 
   @Override
   public WriteableCache getCache(String name) {
-    return new DynomiteCache(name, dynomiteClientDelegate, objectMapper, options, cacheMetrics);
+    return new DynomiteCache(name, dynomiteClientDelegate, objectMapper, options, cacheMetrics, compressionStrategy);
   }
 }

--- a/cats/cats-dynomite/src/test/groovy/com/netflix/spinnaker/cat/dynomite/cache/DynomiteCacheSpec.groovy
+++ b/cats/cats-dynomite/src/test/groovy/com/netflix/spinnaker/cat/dynomite/cache/DynomiteCacheSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.cache.WriteableCacheSpec
+import com.netflix.spinnaker.cats.compression.NoopCompression
 import com.netflix.spinnaker.cats.dynomite.DynomiteClientDelegate
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache.CacheMetrics
@@ -67,7 +68,8 @@ class DynomiteCacheSpec extends WriteableCacheSpec {
       delegate,
       new ObjectMapper(),
       RedisCacheOptions.builder().maxMset(MAX_MSET_SIZE).maxMergeBatch(MAX_MERGE_COUNT).build(),
-      cacheMetrics
+      cacheMetrics,
+      new NoopCompression()
     )
   }
 

--- a/cats/cats-redis/cats-redis.gradle
+++ b/cats/cats-redis/cats-redis.gradle
@@ -2,7 +2,6 @@ dependencies {
     compile project(':cats:cats-core')
     compile spinnaker.dependency('eurekaClient')
     compile spinnaker.dependency('guava')
-    compile spinnaker.dependency('slf4jApi')
     compile "redis.clients:jedis:${spinnaker.version('jedis')}"
     compile "com.fasterxml.jackson.core:jackson-databind:${spinnaker.version('jackson')}"
     testCompile project(':cats:cats-test')

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteCacheConfig.groovy
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.clouddriver.cache
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.discovery.DiscoveryClient
+import com.netflix.dyno.connectionpool.ConnectionPoolConfiguration
 import com.netflix.dyno.connectionpool.Host
 import com.netflix.dyno.connectionpool.HostSupplier
 import com.netflix.dyno.connectionpool.TokenMapSupplier
@@ -26,6 +27,9 @@ import com.netflix.dyno.jedis.DynoJedisClient
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.AgentScheduler
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory
+import com.netflix.spinnaker.cats.compression.CompressionStrategy
+import com.netflix.spinnaker.cats.compression.GZipCompression
+import com.netflix.spinnaker.cats.compression.NoopCompression
 import com.netflix.spinnaker.cats.dynomite.DynomiteClientDelegate
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache.CacheMetrics
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteNamedCacheFactory
@@ -49,7 +53,7 @@ import java.util.concurrent.TimeUnit
 
 @Configuration
 @ConditionalOnExpression('${dynomite.enabled:false}')
-@EnableConfigurationProperties([DynomiteConfigurationProperties, RedisConfigurationProperties])
+@EnableConfigurationProperties([DynomiteConfigurationProperties, RedisConfigurationProperties, GZipCompressionStrategyProperties])
 class DynomiteCacheConfig {
 
   @Bean
@@ -61,6 +65,18 @@ class DynomiteCacheConfig {
   @ConfigurationProperties("dynomite.connectionPool")
   ConnectionPoolConfigurationImpl connectionPoolConfiguration(DynomiteConfigurationProperties dynomiteConfigurationProperties) {
     new ConnectionPoolConfigurationImpl(dynomiteConfigurationProperties.applicationName)
+  }
+
+  @Bean
+  CompressionStrategy compressionStrategy(ConnectionPoolConfigurationImpl connectionPoolConfiguration,
+                                          GZipCompressionStrategyProperties properties) {
+    if (!properties.enabled) {
+      return new NoopCompression()
+    }
+    return new GZipCompression(
+      properties.thresholdBytesSize,
+      properties.compressEnabled && connectionPoolConfiguration.compressionStrategy != ConnectionPoolConfiguration.CompressionStrategy.THRESHOLD
+    )
   }
 
   @Bean(destroyMethod = "stopClient")
@@ -105,8 +121,9 @@ class DynomiteCacheConfig {
     DynomiteClientDelegate dynomiteClientDelegate,
     ObjectMapper objectMapper,
     RedisCacheOptions redisCacheOptions,
-    CacheMetrics cacheMetrics) {
-    new DynomiteNamedCacheFactory(dynomiteClientDelegate, objectMapper, redisCacheOptions, cacheMetrics)
+    CacheMetrics cacheMetrics,
+    CompressionStrategy compressionStrategy) {
+    new DynomiteNamedCacheFactory(dynomiteClientDelegate, objectMapper, redisCacheOptions, cacheMetrics, compressionStrategy)
   }
 
   @Bean

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/GZipCompressionStrategyProperties.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/GZipCompressionStrategyProperties.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.cache;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("caching.gzip")
+public class GZipCompressionStrategyProperties {
+
+  boolean enabled = true;
+  boolean compressEnabled = true;
+  long thresholdBytesSize = 1024;
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/DynomiteConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/DynomiteConfig.groovy
@@ -34,6 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.Protocol
 


### PR DESCRIPTION
There's currently a bug in 1.6.0-rc.2 of dyno that doesn't handle dynomite threshold caches correctly in hashset values. This gets some basic level of compression in place, and could also be put in place for Redis later on as well.

The gzip strategy will auto-disable compression if dynomite compression is enabled, but will continue checking values for decompression. Ideally, we won't have to run this forever.