### PR TITLE
fix(cats): Get bytes in consistent chatset during decompress

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/compression/GZipCompression.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/compression/GZipCompression.java
@@ -88,8 +88,8 @@ public class GZipCompression implements CompressionStrategy {
 
     byte[] bytes;
     try {
-      bytes = Base64.getDecoder().decode(compressed);
-    } catch (IllegalArgumentException e) {
+      bytes = Base64.getDecoder().decode(compressed.getBytes(CHARSET));
+    } catch (IllegalArgumentException|UnsupportedEncodingException e) {
       return compressed;
     }
 


### PR DESCRIPTION
The migration to compression from uncompressed values failed in some cases due to charset issues.