### PR TITLE
fix(provider/kubernetes): allows dots in secretNames

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/KubernetesVolumeSourceValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/KubernetesVolumeSourceValidator.groovy
@@ -48,7 +48,7 @@ class KubernetesVolumeSourceValidator {
         if (!helper.validateNotEmpty(source.secret, "${prefix}.secret")) {
           break
         }
-        helper.validateName(source.secret.secretName, "${prefix}.secret.secretName")
+        helper.validateSecretName(source.secret.secretName, "${prefix}.secret.secretName")
 
         break
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidator.groovy
@@ -23,6 +23,7 @@ import org.springframework.validation.Errors
 
 class StandardKubernetesAttributeValidator {
   static final namePattern = /^[a-z0-9]+([-a-z0-9]*[a-z0-9])?$/
+  static final dnsSubdomainPattern = /^[a-z0-9]+([-\.a-z0-9]*[a-z0-9])?$/
   static final credentialsPattern = /^[a-z0-9]+([-a-z0-9_]*[a-z0-9])?$/
   static final prefixPattern = /^[a-z0-9]+$/
   static final pathPattern = /^\/.*$/
@@ -82,6 +83,14 @@ class StandardKubernetesAttributeValidator {
   def validateName(String value, String attribute) {
     if (validateNotEmpty(value, attribute)) {
       return validateByRegex(value, attribute, namePattern)
+    } else {
+      return false
+    }
+  }
+
+  def validateSecretName(String value, String attribute) {
+    if (validateNotEmpty(value, attribute)) {
+      return validateByRegex(value, attribute, dnsSubdomainPattern)
     } else {
       return false
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
@@ -359,6 +359,65 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       0 * errorsMock._
   }
 
+  void "secretName accept"() {
+    setup:
+    def errorsMock = Mock(Errors)
+    def validator = new StandardKubernetesAttributeValidator(DECORATOR, errorsMock)
+    def label = "label"
+
+    when:
+    validator.validateSecretName("valid", label)
+    then:
+    0 * errorsMock._
+
+    when:
+    validator.validateSecretName("mega-valid-name", label)
+    then:
+    0 * errorsMock._
+
+    when:
+    validator.validateSecretName("call-me-123-456-7890", label)
+    then:
+    0 * errorsMock._
+
+    when:
+    validator.validateSecretName("dots.are.valid-too", label)
+    then:
+    0 * errorsMock._
+  }
+
+  void "secretName reject"() {
+    setup:
+    def errorsMock = Mock(Errors)
+    def validator = new StandardKubernetesAttributeValidator(DECORATOR, errorsMock)
+    def label = "label"
+
+    when:
+    validator.validateSecretName("-", label)
+    then:
+    1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.dnsSubdomainPattern})")
+    0 * errorsMock._
+
+    when:
+    validator.validateSecretName("an_underscore", label)
+    then:
+    1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.dnsSubdomainPattern})")
+    0 * errorsMock._
+
+    when:
+    validator.validateSecretName("?name", label)
+    then:
+    1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.invalid (Must match ${StandardKubernetesAttributeValidator.dnsSubdomainPattern})")
+    0 * errorsMock._
+
+    when:
+    validator.validateSecretName("", label)
+    then:
+    1 * errorsMock.rejectValue("${DECORATOR}.${label}", "${DECORATOR}.${label}.empty")
+    0 * errorsMock._
+  }
+
+
   void "application accept"() {
     setup:
       def errorsMock = Mock(Errors)


### PR DESCRIPTION
We have some secrets in our cluster that have dots in the name and have deployed manually using them as volume sources. The next logical step was to set up a spinnaker pipeline but doing so resulted in:

    deployKubernetesAtomicOperationDescription.volumeSources[1].secret.secretName.invalid (Must match ^[a-z0-9]+([-a-z0-9]*[a-z0-9])?$)

Upon further investigation, the kubernetes api allows dots in secret names:
https://github.com/kubernetes/kubernetes/blob/e5ac41331119bb8c67004b8efaa0c3d942b31d3a/pkg/api/validation/validation.go#L160-L162
https://github.com/kubernetes/kubernetes/blob/8d7d7a5e0d4d7e75f5a860574346944b8cc0fc43/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L126-L142
https://github.com/kubernetes/kubernetes/blob/e5ac41331119bb8c67004b8efaa0c3d942b31d3a/pkg/api/validation/validation.go#L1488

It seems that spinnaker should line up with the kubernetes api in the validation it does on secret names, so I brewed up this code. 


