### PR TITLE
perf(cluster): Avoid prematurely fetching full server groups

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
@@ -223,29 +223,38 @@ class ClusterController {
       throw new NotFoundException("No server groups found (account: ${account}, cluster: ${clusterName}, type: ${cloudProvider})")
     }
 
-    if (!shouldExpand) {
-      sortedServerGroups = sortedServerGroups.collect {
-        serverGroupController.getServerGroupByApplication(application, account, it.region, it.name)
+    def expandServerGroup = { ServerGroup serverGroup ->
+      if (shouldExpand) {
+        // server group was already expanded on initial load
+        return serverGroup
       }
+
+      return serverGroupController.getServerGroupByApplication(
+        application, account, serverGroup.region, serverGroup.name
+      )
+    }
+
+    def expandServerGroups = { List<ServerGroup> serverGroups ->
+      return sortedServerGroups.collect { expandServerGroup(it) }
     }
 
     switch (tsg) {
       case TargetServerGroup.CURRENT:
-        return sortedServerGroups.get(0)
+        return expandServerGroup(sortedServerGroups.get(0))
       case TargetServerGroup.PREVIOUS:
         if (sortedServerGroups.size() == 1) {
           throw new NotFoundException("Target not found (target: ${target})")
         }
-        return sortedServerGroups.get(1)
+        return expandServerGroup(sortedServerGroups.get(1))
       case TargetServerGroup.OLDEST:
         // At least two expected, but some cases just want the oldest no matter what.
         if (Boolean.valueOf(validateOldest) && sortedServerGroups.size() == 1) {
           throw new NotFoundException("Target not found (target: ${target})")
         }
-        return sortedServerGroups.last()
+        return expandServerGroup(sortedServerGroups.last())
       case TargetServerGroup.LARGEST:
         // Choose the server group with the most instances, falling back to newest in the case of a tie.
-        return sortedServerGroups.sort { lhs, rhs ->
+        return expandServerGroups(sortedServerGroups).sort { lhs, rhs ->
           rhs.instances.size() <=> lhs.instances.size() ?:
               rhs.createdTime <=> lhs.createdTime
         }.get(0)
@@ -253,7 +262,7 @@ class ClusterController {
         if (sortedServerGroups.size() > 1) {
           throw new NotFoundException("More than one target found (scope: ${scope}, serverGroups: ${sortedServerGroups*.name})")
         }
-        return sortedServerGroups.get(0)
+        return expandServerGroup(sortedServerGroups.get(0))
     }
   }
 


### PR DESCRIPTION
This is an optimization for fetching target server groups by `CURRENT`,
`PREVIOUS`, `OLDEST` and `FAIL`.

For these strategies, the unexpanded server group is sufficient to
narrow down to a match.

Once a match is found, _only_ that server group will be expanded.

This only works for cluster providers that support loading both
expanded and unexpanded server groups (ie. aws). The behavior for other
providers should be unchanged.
