### PR TITLE
fix(provider/kubernetes): fixes ClassCastException on resize operations

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/servergroup/KubernetesResizeServerGroupValidator.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/servergroup/KubernetesResizeServerGroupValidator.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.servergroup.KubernetesResizeServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -45,4 +46,11 @@ public class KubernetesResizeServerGroupValidator extends DescriptionValidator<K
 
     util.validateNotEmpty("capacity", description.getCapacity());
   }
+
+  @Override
+  public boolean acceptsVersion(ProviderVersion version) {
+    return version == ProviderVersion.v2;
+  }
 }
+
+


### PR DESCRIPTION
Deployed the latest clouddriver to test out and some of our existing pipelines failed on resize operations. Did some poking around and if I'm reading things right, In what appears to be the absence of another v1 resize validator,
KubernetesResizeServerGroupValidator was being picked up which wasn't correctly
declaring its support for v2 only.

This resulted in stack traces like this in the log:

    java.lang.ClassCastException: com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.servergroup.ResizeKubernetesAtomicOperationDescription cannot be cast to com.netflix.spinnaker.clouddriver.kubernetes.v2.description.servergroup.KubernetesResizeServerGroupDescription
    at com.netflix.spinnaker.clouddriver.kubernetes.v2.validator.servergroup.KubernetesResizeServerGroupValidator.validate(KubernetesResizeServerGroupValidator.java:33) ~[clouddriver-kubernetes-1.690.1.jar:1.690.1]
    at com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator$validate$1.call(Unknown Source) ~[na:na]
    at com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.validators.servergroup.DisableKubernetesAtomicOperationValidator$validate.call(Unknown Source) ~[na:na]


Adding this acceptsVersion method to the Validator made things happy again.
