### PR TITLE
feat(provider/aws): Support specifying explicit subnet ids for deploy

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -32,6 +32,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   String freeFormDetails
   String instanceType
   String subnetType
+  List<String> subnetIds
   String iamRole
   String keyPair
   Boolean associatePublicIpAddress
@@ -64,6 +65,11 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
    * If false, the newly created server group will not pick up block device mapping customizations from an ancestor group
    */
   boolean copySourceCustomBlockDeviceMappings = true
+
+  /**
+   * If false, the newly created server group will not pick up overridden subnet ids from an ancestor group
+   */
+  boolean copySourceSubnetIdOverrides = true
 
   String classicLinkVpcId
   List<String> classicLinkVpcSecurityGroups


### PR DESCRIPTION
Expectation is that a `subnetType` will still be provided and that
`subnetIds` will be a subnet of those valid for `subnetType`.

When explicit subnet ids are provided (or inherited), the newly created
server group will be tagged with:

`SPINNAKER_SUBNET_ID_OVERRIDE`: `"comma-separated list of subnet ids"`
