### PR TITLE
refactor(provider/kubernetes): ignore api versions

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.groovy
@@ -45,7 +45,7 @@ class JobExecutorLocal implements JobExecutor {
 
   @Override
   String startJob(JobRequest jobRequest, Map<String, String> environment, InputStream inputStream) {
-    log.info("Starting job: $jobRequest.tokenizedCommand...")
+    log.info("Starting job: '${String.join(' ', jobRequest.tokenizedCommand)}'...")
 
     String jobId = UUID.randomUUID().toString()
 
@@ -59,7 +59,7 @@ class JobExecutorLocal implements JobExecutor {
           CommandLine commandLine
 
           if (jobRequest.tokenizedCommand) {
-            log.info("Executing $jobId with tokenized command: $jobRequest.tokenizedCommand")
+            log.debug("Executing $jobId with tokenized command: $jobRequest.tokenizedCommand")
 
             // Grab the first element as the command.
             commandLine = new CommandLine(jobRequest.tokenizedCommand[0])
@@ -130,7 +130,7 @@ class JobExecutorLocal implements JobExecutor {
   @Override
   JobStatus updateJob(String jobId) {
     try {
-      log.info("Polling state for $jobId...")
+      log.debug("Polling state for $jobId...")
 
       if (jobIdToHandlerMap[jobId]) {
         JobStatus jobStatus = new JobStatus(id: jobId)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching;
 
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import lombok.Data;
@@ -97,12 +96,12 @@ public class Keys {
     return createKey(Kind.LOGICAL, LogicalKind.CLUSTER, account, application, name);
   }
 
-  public static String infrastructure(KubernetesApiVersion version, KubernetesKind kind, String account, String namespace, String name) {
-    return createKey(Kind.INFRASTRUCTURE, version, kind, account, namespace, name);
+  public static String infrastructure(KubernetesKind kind, String account, String namespace, String name) {
+    return createKey(Kind.INFRASTRUCTURE, kind, account, namespace, name);
   }
 
   public static String infrastructure(KubernetesManifest manifest, String account) {
-    return infrastructure(manifest.getApiVersion(), manifest.getKind(), account, manifest.getNamespace(), manifest.getName());
+    return infrastructure(manifest.getKind(), account, manifest.getNamespace(), manifest.getName());
   }
 
   public static Optional<CacheKey> parseKey(String key) {
@@ -244,26 +243,24 @@ public class Keys {
   public static class InfrastructureCacheKey extends CacheKey {
     private Kind kind = Kind.INFRASTRUCTURE;
     private KubernetesKind kubernetesKind;
-    private KubernetesApiVersion kubernetesApiVersion;
     private String account;
     private String namespace;
     private String name;
 
     public InfrastructureCacheKey(String[] parts) {
-      if (parts.length != 7) {
+      if (parts.length != 6) {
         throw new IllegalArgumentException("Malformed infrastructure key " + Arrays.toString(parts));
       }
 
-      kubernetesApiVersion = KubernetesApiVersion.fromString(parts[2]);
-      kubernetesKind = KubernetesKind.fromString(parts[3]);
-      account = parts[4];
-      namespace = parts[5];
-      name = parts[6];
+      kubernetesKind = KubernetesKind.fromString(parts[2]);
+      account = parts[3];
+      namespace = parts[4];
+      name = parts[5];
     }
 
     @Override
     public String toString() {
-      return createKey(kind, kubernetesKind, kubernetesApiVersion, account, namespace, name);
+      return createKey(kind, kubernetesKind, account, namespace, name);
     }
 
     @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNetworkPolicyCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNetworkPolicyCachingAgent.java
@@ -18,15 +18,13 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
-import io.kubernetes.client.models.V1beta1NetworkPolicy;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,22 +32,19 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
 
 @Slf4j
-public class KubernetesNetworkPolicyCachingAgent extends KubernetesV2OnDemandCachingAgent<V1beta1NetworkPolicy> {
+public class KubernetesNetworkPolicyCachingAgent extends KubernetesV2OnDemandCachingAgent {
   KubernetesNetworkPolicyCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+      KubectlJobExecutor jobExecutor,
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
       int agentCount) {
-    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+    super(namedAccountCredentials, jobExecutor, objectMapper, registry, agentIndex, agentCount);
   }
 
   @Getter
@@ -62,30 +57,7 @@ public class KubernetesNetworkPolicyCachingAgent extends KubernetesV2OnDemandCac
   );
 
   @Override
-  protected List<V1beta1NetworkPolicy> loadPrimaryResourceList() {
-    return namespaces.stream()
-        .map(credentials::listAllNetworkPolicies)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
-  }
-
-  @Override
-  protected V1beta1NetworkPolicy loadPrimaryResource(String namespace, String name) {
-    return credentials.readNetworkPolicy(namespace, name);
-  }
-
-  @Override
-  protected Class<V1beta1NetworkPolicy> primaryResourceClass() {
-    return V1beta1NetworkPolicy.class;
-  }
-
-  @Override
   protected KubernetesKind primaryKind() {
     return KubernetesKind.NETWORK_POLICY;
-  }
-
-  @Override
-  protected KubernetesApiVersion primaryApiVersion() {
-    return KubernetesApiVersion.EXTENSIONS_V1BETA1;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesPodCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesPodCachingAgent.java
@@ -23,8 +23,8 @@ import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
-import io.kubernetes.client.models.V1Pod;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,20 +32,24 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
 
 @Slf4j
-public class KubernetesPodCachingAgent extends KubernetesV2CachingAgent<V1Pod> {
+public class KubernetesPodCachingAgent extends KubernetesV2CachingAgent {
   KubernetesPodCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+      KubectlJobExecutor jobExecutor,
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
       int agentCount) {
-    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+    super(namedAccountCredentials, jobExecutor, objectMapper, registry, agentIndex, agentCount);
+  }
+
+  @Override
+  protected KubernetesKind primaryKind() {
+    return KubernetesKind.POD;
   }
 
   @Getter
@@ -58,12 +62,4 @@ public class KubernetesPodCachingAgent extends KubernetesV2CachingAgent<V1Pod> {
           AUTHORITATIVE.forType(KubernetesKind.POD.toString())
       ))
   );
-
-  @Override
-  protected List<V1Pod> loadPrimaryResourceList() {
-    return namespaces.stream()
-        .map(credentials::listAllPods)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
-  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
@@ -22,10 +22,9 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
-import io.kubernetes.client.models.V1beta1ReplicaSet;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,20 +32,19 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
 
 @Slf4j
-public class KubernetesReplicaSetCachingAgent extends KubernetesV2OnDemandCachingAgent<V1beta1ReplicaSet> {
+public class KubernetesReplicaSetCachingAgent extends KubernetesV2OnDemandCachingAgent {
   KubernetesReplicaSetCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+      KubectlJobExecutor jobExecutor,
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
       int agentCount) {
-    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+    super(namedAccountCredentials, jobExecutor, objectMapper, registry, agentIndex, agentCount);
   }
 
   @Getter
@@ -60,30 +58,7 @@ public class KubernetesReplicaSetCachingAgent extends KubernetesV2OnDemandCachin
   );
 
   @Override
-  protected List<V1beta1ReplicaSet> loadPrimaryResourceList() {
-    return namespaces.stream()
-        .map(credentials::listAllReplicaSets)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
-  }
-
-  @Override
-  protected V1beta1ReplicaSet loadPrimaryResource(String namespace, String name) {
-    return credentials.readReplicaSet(namespace, name);
-  }
-
-  @Override
-  protected Class<V1beta1ReplicaSet> primaryResourceClass() {
-    return V1beta1ReplicaSet.class;
-  }
-
-  @Override
   protected KubernetesKind primaryKind() {
     return KubernetesKind.REPLICA_SET;
-  }
-
-  @Override
-  protected KubernetesApiVersion primaryApiVersion() {
-    return KubernetesApiVersion.EXTENSIONS_V1BETA1;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesServiceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesServiceCachingAgent.java
@@ -22,13 +22,12 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesReplicaSetDeployer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesServiceDeployer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
-import io.kubernetes.client.models.V1Pod;
-import io.kubernetes.client.models.V1Service;
-import io.kubernetes.client.models.V1beta1ReplicaSet;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -45,13 +44,14 @@ import java.util.stream.Collectors;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
 
-public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAgent<V1Service> {
+public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAgent {
   protected KubernetesServiceCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+      KubectlJobExecutor jobExecutor,
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
       int agentCount) {
-    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+    super(namedAccountCredentials, jobExecutor, objectMapper, registry, agentIndex, agentCount);
   }
 
   @Getter
@@ -65,74 +65,45 @@ public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAg
   );
 
   @Override
-  protected List<V1Service> loadPrimaryResourceList() {
-    return namespaces.stream()
-        .map(credentials::listAllServices)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
-  }
-
-  @Override
-  protected V1Service loadPrimaryResource(String namespace, String name) {
-    return credentials.readService(namespace, name);
-  }
-
-  @Override
-  protected Class<V1Service> primaryResourceClass() {
-    return V1Service.class;
-  }
-
-  @Override
   protected KubernetesKind primaryKind() {
     return KubernetesKind.SERVICE;
   }
 
   @Override
-  protected KubernetesApiVersion primaryApiVersion() {
-    return KubernetesApiVersion.V1;
-  }
-
-  @Override
-  protected Map<V1Service, List<KubernetesManifest>> loadSecondaryResourceRelationships(List<V1Service> services) {
+  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(List<KubernetesManifest> services) {
     Map<String, Set<KubernetesManifest>> mapLabelToManifest = new HashMap<>();
 
     // TODO perf - this might be excessive when only a small number of services are specified. We could consider
     // reading from the cache here, or deciding how many pods to load ahead of time, or construct a fancy label
     // selector that merges all label selectors here.
     namespaces.stream()
-        .map(credentials::listAllPods)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList())
-        .forEach(p -> addAllPodLabels(mapLabelToManifest, p));
-
-    namespaces.stream()
-        .map(credentials::listAllReplicaSets)
+        .map(n -> jobExecutor.getAll(credentials, KubernetesKind.REPLICA_SET, n))
         .flatMap(Collection::stream)
         .collect(Collectors.toList())
         .forEach(r -> addAllReplicaSetLabels(mapLabelToManifest, r));
 
-    Map<V1Service, List<KubernetesManifest>> result = new HashMap<>();
+    Map<KubernetesManifest, List<KubernetesManifest>> result = new HashMap<>();
 
-    for (V1Service service : services) {
+    for (KubernetesManifest service : services) {
       result.put(service, getRelatedManifests(service, mapLabelToManifest));
     }
 
     return result;
   }
 
-  private static List<KubernetesManifest> getRelatedManifests(V1Service service, Map<String, Set<KubernetesManifest>> mapLabelToManifest) {
+  private static List<KubernetesManifest> getRelatedManifests(KubernetesManifest service, Map<String, Set<KubernetesManifest>> mapLabelToManifest) {
     return new ArrayList<>(intersectLabels(service, mapLabelToManifest));
   }
 
-  private static Set<KubernetesManifest> intersectLabels(V1Service service, Map<String, Set<KubernetesManifest>> mapLabelToManifest) {
-    Map<String, String> selector = service.getSpec().getSelector();
+  private static Set<KubernetesManifest> intersectLabels(KubernetesManifest service, Map<String, Set<KubernetesManifest>> mapLabelToManifest) {
+    Map<String, String> selector = KubernetesServiceDeployer.getSelector(service);
     if (selector == null || selector.isEmpty()) {
       return new HashSet<>();
     }
 
     Set<KubernetesManifest> result = null;
-    String namespace = service.getMetadata().getNamespace();
-    for (Map.Entry<String, String> label : service.getSpec().getSelector().entrySet())  {
+    String namespace = service.getNamespace();
+    for (Map.Entry<String, String> label : selector.entrySet())  {
       String labelKey = podLabelKey(namespace, label);
       Set<KubernetesManifest> manifests = mapLabelToManifest.get(labelKey);
       manifests = manifests == null ? new HashSet<>() : manifests;
@@ -147,9 +118,9 @@ public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAg
     return result;
   }
 
-  private static void addAllReplicaSetLabels(Map<String, Set<KubernetesManifest>> entries, V1beta1ReplicaSet replicaSet) {
-    String namespace = replicaSet.getMetadata().getNamespace();
-    Map<String, String> podLabels = replicaSet.getSpec().getTemplate().getMetadata().getLabels();
+  private static void addAllReplicaSetLabels(Map<String, Set<KubernetesManifest>> entries, KubernetesManifest replicaSet) {
+    String namespace = replicaSet.getNamespace();
+    Map<String, String> podLabels = KubernetesReplicaSetDeployer.getPodTemplateLabels(replicaSet);
     if (podLabels == null) {
       return;
     }
@@ -157,14 +128,6 @@ public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAg
     for (Map.Entry<String, String> label : podLabels.entrySet()) {
       String labelKey = podLabelKey(namespace, label);
       enterManifest(entries, labelKey, KubernetesCacheDataConverter.convertToManifest(replicaSet));
-    }
-  }
-
-  private static void addAllPodLabels(Map<String, Set<KubernetesManifest>> entries, V1Pod pod) {
-    String namespace = pod.getMetadata().getNamespace();
-    for (Map.Entry<String, String> label : pod.getMetadata().getLabels().entrySet()) {
-      String labelKey = podLabelKey(namespace, label);
-      enterManifest(entries, labelKey, KubernetesCacheDataConverter.convertToManifest(pod));
     }
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesCachingAgentDispatcher;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -40,15 +41,18 @@ public class KubernetesV2CachingAgentDispatcher implements KubernetesCachingAgen
   @Autowired
   private Registry registry;
 
+  @Autowired
+  private KubectlJobExecutor jobExecutor;
+
   @Override
   public List<KubernetesCachingAgent> buildAllCachingAgents(KubernetesNamedAccountCredentials credentials) {
     return IntStream.range(0, credentials.getCacheThreads())
         .boxed()
         .map(i -> new ArrayList<KubernetesCachingAgent>(Arrays.asList(
-            new KubernetesNetworkPolicyCachingAgent(credentials, objectMapper, registry, i, credentials.getCacheThreads()),
-            new KubernetesPodCachingAgent(credentials, objectMapper, registry, i, credentials.getCacheThreads()),
-            new KubernetesReplicaSetCachingAgent(credentials, objectMapper, registry, i, credentials.getCacheThreads()),
-            new KubernetesServiceCachingAgent(credentials, objectMapper, registry, i, credentials.getCacheThreads())
+            new KubernetesNetworkPolicyCachingAgent(credentials, jobExecutor, objectMapper, registry, i, credentials.getCacheThreads()),
+            new KubernetesPodCachingAgent(credentials, jobExecutor, objectMapper, registry, i, credentials.getCacheThreads()),
+            new KubernetesReplicaSetCachingAgent(credentials, jobExecutor, objectMapper, registry, i, credentials.getCacheThreads()),
+            new KubernetesServiceCachingAgent(credentials, jobExecutor, objectMapper, registry, i, credentials.getCacheThreads())
         )))
         .flatMap(Collection::stream)
         .collect(Collectors.toList());

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ClusterProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ClusterProvider.java
@@ -24,13 +24,12 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.ClusterCache
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Cluster;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2LoadBalancer;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2ServerGroup;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Triple;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -122,17 +121,16 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
 
   @Override
   public KubernetesV2ServerGroup getServerGroup(String account, String namespace, String name) {
-    Triple<KubernetesApiVersion, KubernetesKind, String> parsedName;
+    Pair<KubernetesKind, String> parsedName;
     try {
       parsedName = KubernetesManifest.fromFullResourceName(name);
     } catch (IllegalArgumentException e) {
       return null;
     }
 
-    KubernetesApiVersion apiVersion = parsedName.getLeft();
-    KubernetesKind kind = parsedName.getMiddle();
+    KubernetesKind kind = parsedName.getLeft();
     String shortName = parsedName.getRight();
-    String key = Keys.infrastructure(apiVersion, kind, account, namespace, shortName);
+    String key = Keys.infrastructure(kind, account, namespace, shortName);
     List<String> instanceGroups = kindMap.translateSpinnakerKind(INSTANCE)
         .stream()
         .map(KubernetesKind::toString)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -23,12 +23,11 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
 import com.netflix.spinnaker.clouddriver.model.ManifestProvider;
-import org.apache.commons.lang3.tuple.Triple;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,11 +48,9 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
 
   @Override
   public KubernetesV2Manifest getManifest(String account, String location, String name) {
-    Triple<KubernetesApiVersion, KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(name);
-    KubernetesApiVersion apiVersion = parsedName.getLeft();
-    KubernetesKind kind = parsedName.getMiddle();
+    Pair<KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(name);
+    KubernetesKind kind = parsedName.getLeft();
     String key = Keys.infrastructure(
-        apiVersion,
         kind,
         account,
         location,
@@ -67,7 +64,6 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
 
     CacheData data = dataOptional.get();
     KubernetesDeployer deployer = registry.lookup()
-        .withApiVersion(apiVersion)
         .withKind(kind)
         .getDeployer();
 
@@ -77,7 +73,7 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
         .account(account)
         .location(location)
         .manifest(manifest)
-        .stable(deployer.isStable(mapper.convertValue(manifest, deployer.getDeployedClass())))
+        .stable(deployer.isStable(manifest))
         .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourcePropertyRegistry.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesUnversionedArtifactConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,21 +41,20 @@ public class KubernetesResourcePropertyRegistry {
           .build();
 
       kindMap.addRelationship(deployer.spinnakerKind(), deployer.kind());
-      apiVersionLookup.withApiVersion(deployer.apiVersion()).setProperties(deployer.kind(), properties);
+      kindLookup.setProperties(deployer.kind(), properties);
     }
   }
 
-  public ApiVersionLookup lookup() {
-    return apiVersionLookup;
+  public KindLookup lookup() {
+    return kindLookup;
   }
+
+  private static KindLookup kindLookup = new KindLookup();
 
   public KubernetesResourceProperties lookup(KubernetesCoordinates coordinates) {
     return lookup()
-        .withApiVersion(coordinates.getApiVersion())
         .withKind(coordinates.getKind());
   }
-
-  private ApiVersionLookup apiVersionLookup = new ApiVersionLookup();
 
   public static class KindLookup {
     private ConcurrentHashMap<KubernetesKind, KubernetesResourceProperties> map = new ConcurrentHashMap<>();
@@ -71,20 +69,6 @@ public class KubernetesResourcePropertyRegistry {
 
     public void setProperties(KubernetesKind kind, KubernetesResourceProperties properties) {
       map.put(kind, properties);
-    }
-  }
-
-  public static class ApiVersionLookup {
-    private ConcurrentHashMap<KubernetesApiVersion, KindLookup> map = new ConcurrentHashMap<>();
-
-    public KindLookup withApiVersion(KubernetesApiVersion apiVersion) {
-      if (!map.containsKey(apiVersion)) {
-        KindLookup result = new KindLookup();
-        map.put(apiVersion, result);
-        return result;
-      } else {
-        return map.get(apiVersion);
-      }
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
@@ -25,7 +25,8 @@ import java.util.Arrays;
 public enum KubernetesApiVersion {
   V1("v1"),
   EXTENSIONS_V1BETA1("extensions.v1beta1"),
-  APPS_V1BETA1("apps.v1beta1");
+  APPS_V1BETA1("apps.v1beta1"),
+  APPS_V1BETA2("apps.v1beta2");
 
   private final String name;
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -23,17 +23,24 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
 
 public enum KubernetesKind {
-  DEPLOYMENT("deployment"),
-  INGRESS("ingress"),
-  POD("pod"),
-  REPLICA_SET("replicaSet"),
-  NETWORK_POLICY("networkPolicy"),
-  SERVICE("service");
+  DEPLOYMENT("deployment", "deploy"),
+  INGRESS("ingress", "ing"),
+  POD("pod", "po"),
+  REPLICA_SET("replicaSet", "rs"),
+  NETWORK_POLICY("networkPolicy", "netpol"),
+  SERVICE("service", "svc");
 
   private final String name;
+  private final String alias;
+
+  KubernetesKind(String name, String alias) {
+    this.name = name;
+    this.alias = alias;
+  }
 
   KubernetesKind(String name) {
     this.name = name;
+    this.alias = null;
   }
 
   @Override
@@ -45,7 +52,7 @@ public enum KubernetesKind {
   @JsonCreator
   public static KubernetesKind fromString(String name) {
     return Arrays.stream(values())
-        .filter(v -> v.toString().equalsIgnoreCase(name))
+        .filter(v -> v.name.equalsIgnoreCase(name) || (v.alias != null && v.alias.equalsIgnoreCase(name)))
         .findAny()
         .orElseThrow(() -> new IllegalArgumentException("Kubernetes kind '" + name + "' is not supported."));
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestList.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestList.java
@@ -18,12 +18,10 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
-import java.util.Map;
+import java.util.List;
 
-@EqualsAndHashCode(callSuper = true)
 @Data
-public class KubernetesDeleteManifestDescription extends KubernetesManifestOperationDescription {
-  Map deleteOptions;
+public class KubernetesManifestList {
+  private List<KubernetesManifest> items;
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestOperationDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestOperationDescription.java
@@ -21,8 +21,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import lombok.Data;
-import org.apache.commons.lang3.tuple.Triple;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.tuple.Pair;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 public class KubernetesManifestOperationDescription extends KubernetesAtomicOperationDescription {
   private String name;
@@ -30,14 +32,12 @@ public class KubernetesManifestOperationDescription extends KubernetesAtomicOper
 
   @JsonIgnore
   public KubernetesCoordinates getCoordinates() {
-    Triple<KubernetesApiVersion, KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(name);
+    Pair<KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(name);
 
     return KubernetesCoordinates.builder()
         .namespace(name)
-        .apiVersion(parsedName.getLeft())
-        .kind(parsedName.getMiddle())
+        .kind(parsedName.getLeft())
         .name(parsedName.getRight())
         .build();
   }
-
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/servergroup/KubernetesResizeServerGroupDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/servergroup/KubernetesResizeServerGroupDescription.java
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.servergroup;
 
 import com.netflix.spinnaker.clouddriver.model.ServerGroup.Capacity;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 public class KubernetesResizeServerGroupDescription extends KubernetesServerGroupOperationDescription {
   Capacity capacity;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/servergroup/KubernetesServerGroupOperationDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/servergroup/KubernetesServerGroupOperationDescription.java
@@ -20,12 +20,13 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.servergroup;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import lombok.Data;
-import org.apache.commons.lang3.tuple.Triple;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.tuple.Pair;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 public class KubernetesServerGroupOperationDescription extends KubernetesAtomicOperationDescription {
   private String serverGroupName;
@@ -33,12 +34,11 @@ public class KubernetesServerGroupOperationDescription extends KubernetesAtomicO
 
   @JsonIgnore
   public KubernetesCoordinates getCoordinates() {
-    Triple<KubernetesApiVersion, KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(serverGroupName);
+    Pair<KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(serverGroupName);
 
     return KubernetesCoordinates.builder()
         .namespace(region)
-        .apiVersion(parsedName.getLeft())
-        .kind(parsedName.getMiddle())
+        .kind(parsedName.getLeft())
         .name(parsedName.getRight())
         .build();
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentDeployer.java
@@ -18,30 +18,18 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
-import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup.Capacity;
-import io.kubernetes.client.models.AppsV1beta1Deployment;
 import io.kubernetes.client.models.V1DeleteOptions;
 import org.springframework.stereotype.Component;
 
 @Component
-public class KubernetesDeploymentDeployer extends KubernetesDeployer<AppsV1beta1Deployment> implements CanResize, CanDelete<V1DeleteOptions> {
-  @Override
-  public Class<AppsV1beta1Deployment> getDeployedClass() {
-    return AppsV1beta1Deployment.class;
-  }
-
+public class KubernetesDeploymentDeployer extends KubernetesDeployer implements CanResize, CanDelete<V1DeleteOptions> {
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.DEPLOYMENT;
-  }
-
-  @Override
-  public KubernetesApiVersion apiVersion() {
-    return KubernetesApiVersion.APPS_V1BETA1;
   }
 
   @Override
@@ -55,7 +43,7 @@ public class KubernetesDeploymentDeployer extends KubernetesDeployer<AppsV1beta1
   }
 
   @Override
-  public boolean isStable(AppsV1beta1Deployment resource) {
+  public boolean isStable(KubernetesManifest manifest) {
     return false;
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesIngressDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesIngressDeployer.java
@@ -18,28 +18,17 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import io.kubernetes.client.models.V1DeleteOptions;
-import io.kubernetes.client.models.V1beta1Ingress;
 import org.springframework.stereotype.Component;
 
 @Component
-public class KubernetesIngressDeployer extends KubernetesDeployer<V1beta1Ingress> implements CanDelete<V1DeleteOptions> {
+public class KubernetesIngressDeployer extends KubernetesDeployer implements CanDelete<V1DeleteOptions> {
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.INGRESS;
-  }
-
-  @Override
-  public KubernetesApiVersion apiVersion() {
-    return KubernetesApiVersion.EXTENSIONS_V1BETA1;
-  }
-
-  @Override
-  public Class<V1beta1Ingress> getDeployedClass() {
-    return V1beta1Ingress.class;
   }
 
   @Override
@@ -53,7 +42,7 @@ public class KubernetesIngressDeployer extends KubernetesDeployer<V1beta1Ingress
   }
 
   @Override
-  public boolean isStable(V1beta1Ingress resource) {
+  public boolean isStable(KubernetesManifest manifest) {
     return false;
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesServiceDeployer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesServiceDeployer.java
@@ -17,28 +17,21 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import io.kubernetes.client.models.V1Service;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
-public class KubernetesServiceDeployer extends KubernetesDeployer<V1Service> implements CanDelete<Void> {
+public class KubernetesServiceDeployer extends KubernetesDeployer implements CanDelete<Void> {
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.SERVICE;
-  }
-
-  @Override
-  public KubernetesApiVersion apiVersion() {
-    return KubernetesApiVersion.V1;
-  }
-
-  @Override
-  public Class<V1Service> getDeployedClass() {
-    return V1Service.class;
   }
 
   @Override
@@ -52,7 +45,7 @@ public class KubernetesServiceDeployer extends KubernetesDeployer<V1Service> imp
   }
 
   @Override
-  public boolean isStable(V1Service resource) {
+  public boolean isStable(KubernetesManifest manifest) {
     return false;
   }
 
@@ -64,5 +57,15 @@ public class KubernetesServiceDeployer extends KubernetesDeployer<V1Service> imp
   @Override
   public void delete(KubernetesV2Credentials credentials, String namespace, String name, Void deleteOptions) {
     credentials.deleteService(namespace, name);
+  }
+
+  public static Map<String, String> getSelector(KubernetesManifest manifest) {
+    switch (manifest.getApiVersion()) {
+      case V1:
+        V1Service v1Service = KubernetesCacheDataConverter.getResource(manifest, V1Service.class);
+        return v1Service.getSpec().getSelector();
+      default:
+        throw new IllegalArgumentException("No services with version " + manifest.getApiVersion() + " supported");
+    }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -24,11 +24,10 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesArtifactConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestAnnotater;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestSpinnakerRelationships;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
@@ -91,9 +90,8 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Deploy
   }
 
   private KubernetesResourceProperties findResourceProperties(KubernetesManifest manifest) {
-    KubernetesApiVersion apiVersion = manifest.getApiVersion();
     KubernetesKind kind = manifest.getKind();
-    getTask().updateStatus(OP_NAME, "Finding deployer for " + apiVersion + "/" + kind + "...");
-    return registry.lookup().withApiVersion(apiVersion).withKind(kind);
+    getTask().updateStatus(OP_NAME, "Finding deployer for " + kind + "...");
+    return registry.lookup().withKind(kind);
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.AppsV1beta1Api;
+import io.kubernetes.client.apis.AppsV1beta2Api;
 import io.kubernetes.client.apis.CoreV1Api;
 import io.kubernetes.client.apis.ExtensionsV1beta1Api;
 import io.kubernetes.client.models.AppsV1beta1Deployment;
@@ -64,6 +65,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final CoreV1Api coreV1Api;
   private final ExtensionsV1beta1Api extensionsV1beta1Api;
   private final AppsV1beta1Api appsV1beta1Api;
+  private final AppsV1beta2Api appsV1beta2Api;
   private final Registry registry;
   private final Clock clock;
   private final String accountName;
@@ -90,6 +92,9 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   @Getter
   private final String defaultNamespace = "default";
+
+  @Getter
+  private final boolean debug;
 
   public static class Builder {
     String accountName;
@@ -166,9 +171,17 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       namespaces = namespaces == null ? new ArrayList<>() : namespaces;
       omitNamespaces = omitNamespaces == null ? new ArrayList<>() : omitNamespaces;
       
-      return new KubernetesV2Credentials(accountName, client, namespaces, omitNamespaces, registry, kubeconfigFile, context, debug);
+      return new KubernetesV2Credentials(
+          accountName,
+          client,
+          namespaces,
+          omitNamespaces,
+          registry,
+          kubeconfigFile,
+          context,
+          debug
+      );
     }
-
   }
 
   private KubernetesV2Credentials(@NotNull String accountName,
@@ -186,9 +199,12 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.omitNamespaces = omitNamespaces;
     this.client = client;
     this.client.setDebugging(debug);
+    this.debug = debug;
+
     this.coreV1Api = new CoreV1Api(this.client);
     this.extensionsV1beta1Api = new ExtensionsV1beta1Api(this.client);
     this.appsV1beta1Api = new AppsV1beta1Api(this.client);
+    this.appsV1beta2Api = new AppsV1beta2Api(this.client);
 
     this.kubeconfigFile = kubeconfigFile;
     this.context = context;

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KeysSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KeysSpec.groovy
@@ -53,13 +53,13 @@ class KeysSpec extends Specification {
   @Unroll
   def "produces correct infra keys #key"() {
     expect:
-    Keys.infrastructure(apiVersion, kind, account, namespace, name) == key
+    Keys.infrastructure(kind, account, namespace, name) == key
 
     where:
     kind                       | apiVersion                              | account | namespace   | name      || key
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "ac"    | "namespace" | "v1-v000" || "kubernetes.v2:infrastructure:extensions.v1beta1:replicaSet:ac:namespace:v1-v000"
-    KubernetesKind.SERVICE     | KubernetesApiVersion.V1                 | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:v1:service:ac:namespace:v1"
-    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.APPS_V1BETA1       | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:apps.v1beta1:deployment:ac:namespace:v1"
+    KubernetesKind.REPLICA_SET | KubernetesApiVersion.EXTENSIONS_V1BETA1 | "ac"    | "namespace" | "v1-v000" || "kubernetes.v2:infrastructure:replicaSet:ac:namespace:v1-v000"
+    KubernetesKind.SERVICE     | KubernetesApiVersion.V1                 | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:service:ac:namespace:v1"
+    KubernetesKind.DEPLOYMENT  | KubernetesApiVersion.APPS_V1BETA1       | "ac"    | "namespace" | "v1"      || "kubernetes.v2:infrastructure:deployment:ac:namespace:v1"
   }
 
   @Unroll
@@ -103,14 +103,13 @@ class KeysSpec extends Specification {
   @Unroll
   def "unpacks infrastructure key for '#kind' and '#version'"() {
     when:
-    def key = "kubernetes.v2:infrastructure:$version:$kind:$account:$namespace:$name"
+    def key = "kubernetes.v2:infrastructure:$kind:$account:$namespace:$name"
     def parsed = Keys.parseKey(key).get()
 
     then:
     parsed instanceof Keys.InfrastructureCacheKey
     def parsedInfrastructureKey = (Keys.InfrastructureCacheKey) parsed
     parsedInfrastructureKey.kubernetesKind == kind
-    parsedInfrastructureKey.kubernetesApiVersion == version
     parsedInfrastructureKey.account == account
     parsedInfrastructureKey.namespace == namespace
     parsedInfrastructureKey.name == name

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesPodCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesPodCachingAgentSpec.groovy
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAcco
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials
 import io.kubernetes.client.models.V1ObjectMeta
 import io.kubernetes.client.models.V1Pod
@@ -56,13 +58,15 @@ class KubernetesPodCachingAgentSpec extends Specification {
 
     def credentials = Mock(KubernetesV2Credentials)
     credentials.getDeclaredNamespaces() >> [NAMESPACE]
-    credentials.listAllPods(NAMESPACE) >> [pod]
+
+    def jobExecutor = Mock(KubectlJobExecutor)
+    jobExecutor.getAll(credentials, KubernetesKind.POD, NAMESPACE) >> [new ObjectMapper().convertValue(pod, KubernetesManifest.class)]
 
     def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials)
     namedAccountCredentials.getCredentials() >> credentials
     namedAccountCredentials.getName() >> ACCOUNT
 
-    def cachingAgent = new KubernetesPodCachingAgent(namedAccountCredentials, new ObjectMapper(), null, 0, 1)
+    def cachingAgent = new KubernetesPodCachingAgent(namedAccountCredentials, jobExecutor, new ObjectMapper(), null, 0, 1)
 
     when:
     def result = cachingAgent.loadData(null)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -68,16 +68,16 @@ spec:
   @Unroll
   void "correctly parses a fully qualified resource name #kind/#name"() {
     expect:
-    def triple = KubernetesManifest.fromFullResourceName(fullResourceName)
-    triple.getRight() == name
-    triple.getLeft() == apiVersion
-    triple.getMiddle() == kind
+    def pair = KubernetesManifest.fromFullResourceName(fullResourceName)
+    pair.getRight() == name
+    pair.getLeft() == kind
 
     where:
-    fullResourceName                    || apiVersion                              | kind                       | name
-    "extensions/v1beta1|replicaSet|abc" || KubernetesApiVersion.EXTENSIONS_V1BETA1 | KubernetesKind.REPLICA_SET | "abc"
-    "v1|service|abc"                    || KubernetesApiVersion.V1                 | KubernetesKind.SERVICE     | "abc"
-    "V1|SERVICE|abc"                    || KubernetesApiVersion.V1                 | KubernetesKind.SERVICE     | "abc"
-    "apps/v1beta1|ingress|abc"          || KubernetesApiVersion.APPS_V1BETA1       | KubernetesKind.INGRESS     | "abc"
+    fullResourceName || kind                       | name
+    "replicaSet abc" || KubernetesKind.REPLICA_SET | "abc"
+    "rs abc"         || KubernetesKind.REPLICA_SET | "abc"
+    "service abc"    || KubernetesKind.SERVICE     | "abc"
+    "SERVICE abc"    || KubernetesKind.SERVICE     | "abc"
+    "ingress abc"    || KubernetesKind.INGRESS     | "abc"
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
@@ -89,12 +89,11 @@ metadata:
     deployDescription.setCredentials(namedCredentialsMock)
 
     def jobExecutorMock = Mock(KubectlJobExecutor)
-    jobExecutorMock.deployManifest(_, _) >> null
+    jobExecutorMock.deploy(_, _) >> null
 
     def replicaSetDeployer = new KubernetesReplicaSetDeployer()
     replicaSetDeployer.objectMapper = new ObjectMapper()
     replicaSetDeployer.versioned() >> true
-    replicaSetDeployer.apiVersion() >> API_VERSION
     replicaSetDeployer.kind() >> KIND
     replicaSetDeployer.jobExecutor = jobExecutorMock
     def versionedArtifactConverterMock = Mock(KubernetesVersionedArtifactConverter)
@@ -124,7 +123,7 @@ metadata:
     def result = deployOp.operate([])
     then:
     result.deployedNames.size == 1
-    result.deployedNames[0] == "$NAMESPACE:$API_VERSION|$KIND|$NAME-$VERSION"
+    result.deployedNames[0] == "$NAMESPACE:$KIND $NAME-$VERSION"
   }
 
   void "replica set deployer uses backup namespace"() {
@@ -138,6 +137,6 @@ metadata:
 
     then:
     result.deployedNames.size == 1
-    result.deployedNames[0] == "$BACKUP_NAMESPACE:$API_VERSION|$KIND|$NAME-$VERSION"
+    result.deployedNames[0] == "$BACKUP_NAMESPACE:$KIND $NAME-$VERSION"
   }
 }


### PR DESCRIPTION
I began to realize that having caching agents & deployers for every api version of a resource is difficult - it requires deciding which apis to use via service discovery, and puts extra burden on the user to decide what to version their resources with. To drop this requirement, I switched API calls to use kubectl (for now). This can easily be undone later with more clever use of the k8s apis, but is a fine solution for now.