### PR TITLE
fix(provider/gce): Fix GCE destroy backend calls on LB cache misses.

### DIFF
--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DestroyGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -91,6 +91,10 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       def forwardingRulesList = Mock(Compute.ForwardingRules.List)
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+      def targetSslProxies = Mock(Compute.TargetSslProxies)
+      def targetSslProxiesList = Mock(Compute.TargetSslProxies.List)
+      def targetTcpProxies = Mock(Compute.TargetTcpProxies)
+      def targetTcpProxiesList = Mock(Compute.TargetTcpProxies.List)
 
       googleLoadBalancerProviderMock.getApplicationLoadBalancers(APPLICATION_NAME) >> []
       def credentials = new GoogleNamedAccountCredentials.Builder().project(PROJECT_NAME).compute(computeMock).build()
@@ -128,6 +132,14 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       1 * computeMock.instanceTemplates() >> instanceTemplatesMock
       1 * instanceTemplatesMock.delete(PROJECT_NAME, INSTANCE_TEMPLATE_NAME) >> instanceTemplatesDeleteMock
       1 * instanceTemplatesDeleteMock.execute()
+
+      1 * computeMock.targetSslProxies() >> targetSslProxies
+      1 * targetSslProxies.list(PROJECT_NAME) >> targetSslProxiesList
+      1 * targetSslProxiesList.execute() >> new TargetSslProxyList(items: [])
+
+      1 * computeMock.targetTcpProxies() >> targetTcpProxies
+      1 * targetTcpProxies.list(PROJECT_NAME) >> targetTcpProxiesList
+      1 * targetTcpProxiesList.execute() >> new TargetTcpProxyList(items: [])
 
       3 * computeMock.globalForwardingRules() >> globalForwardingRules
       3 * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList
@@ -186,6 +198,10 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       def forwardingRulesList = Mock(Compute.ForwardingRules.List)
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+      def targetSslProxies = Mock(Compute.TargetSslProxies)
+      def targetSslProxiesList = Mock(Compute.TargetSslProxies.List)
+      def targetTcpProxies = Mock(Compute.TargetTcpProxies)
+      def targetTcpProxiesList = Mock(Compute.TargetTcpProxies.List)
 
       def credentials = new GoogleNamedAccountCredentials.Builder().project(PROJECT_NAME).compute(computeMock).build()
       def description = new DestroyGoogleServerGroupDescription(serverGroupName: SERVER_GROUP_NAME,
@@ -216,6 +232,14 @@ class DestroyGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       3 * computeMock.globalForwardingRules() >> globalForwardingRules
       3 * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList
       3 * globalForwardingRulesList.execute() >> new ForwardingRuleList(items: [])
+
+      1 * computeMock.targetSslProxies() >> targetSslProxies
+      1 * targetSslProxies.list(PROJECT_NAME) >> targetSslProxiesList
+      1 * targetSslProxiesList.execute() >> new TargetSslProxyList(items: [])
+
+      1 * computeMock.targetTcpProxies() >> targetTcpProxies
+      1 * targetTcpProxies.list(PROJECT_NAME) >> targetTcpProxiesList
+      1 * targetTcpProxiesList.execute() >> new TargetTcpProxyList(items: [])
 
       1 * computeMock.forwardingRules() >> forwardingRules
       1 * forwardingRules.list(PROJECT_NAME, _) >> forwardingRulesList

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DisableGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DisableGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -21,6 +21,8 @@ import com.google.api.services.compute.model.ForwardingRuleList
 import com.google.api.services.compute.model.InstanceGroupManager
 import com.google.api.services.compute.model.InstanceGroupManagersSetTargetPoolsRequest
 import com.google.api.services.compute.model.TargetPool
+import com.google.api.services.compute.model.TargetSslProxyList
+import com.google.api.services.compute.model.TargetTcpProxyList
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -108,6 +110,10 @@ class DisableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
       def forwardingRulesList = Mock(Compute.ForwardingRules.List)
       def globalForwardingRules = Mock(Compute.GlobalForwardingRules)
       def globalForwardingRulesList = Mock(Compute.GlobalForwardingRules.List)
+      def targetSslProxies = Mock(Compute.TargetSslProxies)
+      def targetSslProxiesList = Mock(Compute.TargetSslProxies.List)
+      def targetTcpProxies = Mock(Compute.TargetTcpProxies)
+      def targetTcpProxiesList = Mock(Compute.TargetTcpProxies.List)
       @Subject def operation = new DisableGoogleServerGroupAtomicOperation(description)
       operation.registry = registry
       operation.googleClusterProvider = googleClusterProviderMock
@@ -143,6 +149,14 @@ class DisableGoogleServerGroupAtomicOperationUnitSpec extends Specification {
           SERVER_GROUP_NAME,
           new InstanceGroupManagersSetTargetPoolsRequest(targetPools: [])) >> instanceGroupManagersSetTargetPoolsMock
       1 * instanceGroupManagersSetTargetPoolsMock.execute()
+
+      1 * computeMock.targetSslProxies() >> targetSslProxies
+      1 * targetSslProxies.list(PROJECT_NAME) >> targetSslProxiesList
+      1 * targetSslProxiesList.execute() >> new TargetSslProxyList(items: [])
+
+      1 * computeMock.targetTcpProxies() >> targetTcpProxies
+      1 * targetTcpProxies.list(PROJECT_NAME) >> targetTcpProxiesList
+      1 * targetTcpProxiesList.execute() >> new TargetTcpProxyList(items: [])
 
       3 * computeMock.globalForwardingRules() >> globalForwardingRules
       3 * globalForwardingRules.list(PROJECT_NAME) >> globalForwardingRulesList


### PR DESCRIPTION
The GCE calls on cache misses were passing incorrectly typed arguments to the 'delete backends' closure, causing havoc.