### PR TITLE
feat(provider/kubernetes): automatically configure caching agents

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesArtifactConverter.java
@@ -22,12 +22,13 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 
 import java.util.Arrays;
 
 public abstract class KubernetesArtifactConverter {
-  abstract public Artifact toArtifact(KubernetesManifest manifest);
+  abstract public Artifact toArtifact(ArtifactProvider artifactProvider, KubernetesManifest manifest);
   abstract public KubernetesCoordinates toCoordinates(Artifact artifact);
   abstract public String getDeployedName(Artifact artifact);
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverter.java
@@ -19,13 +19,14 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KubernetesUnversionedArtifactConverter extends KubernetesArtifactConverter {
   @Override
-  public Artifact toArtifact(KubernetesManifest manifest) {
+  public Artifact toArtifact(ArtifactProvider provider, KubernetesManifest manifest) {
     String type = getType(manifest);
     String name = manifest.getName();
     String location = manifest.getNamespace();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverter.java
@@ -17,11 +17,10 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact;
 
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.KubernetesV2ArtifactProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -30,15 +29,12 @@ import java.util.stream.Collectors;
 
 @Component
 public class KubernetesVersionedArtifactConverter extends KubernetesArtifactConverter {
-  @Autowired
-  KubernetesV2ArtifactProvider artifactProvider;
-
   @Override
-  public Artifact toArtifact(KubernetesManifest manifest) {
+  public Artifact toArtifact(ArtifactProvider provider, KubernetesManifest manifest) {
     String type = getType(manifest);
     String name = manifest.getName();
     String location = manifest.getNamespace();
-    String version = getVersion(type, name, location);
+    String version = getVersion(provider, type, name, location);
     return Artifact.builder()
         .type(type)
         .name(name)
@@ -62,8 +58,8 @@ public class KubernetesVersionedArtifactConverter extends KubernetesArtifactConv
     return artifact.getName() + "-" + artifact.getVersion();
   }
 
-  private String getVersion(String type, String name, String location) {
-    List<Artifact> priorVersions = artifactProvider.getArtifacts(type, name, location);
+  private String getVersion(ArtifactProvider provider, String type, String name, String location) {
+    List<Artifact> priorVersions = provider.getArtifacts(type, name, location);
 
     List<Integer> taken = priorVersions.stream()
         .map(Artifact::getVersion)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesServiceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesServiceCachingAgent.java
@@ -24,8 +24,8 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAcco
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesReplicaSetDeployer;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesServiceDeployer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesReplicaSetHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesServiceHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import lombok.Getter;
@@ -96,7 +96,7 @@ public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAg
   }
 
   private static Set<KubernetesManifest> intersectLabels(KubernetesManifest service, Map<String, Set<KubernetesManifest>> mapLabelToManifest) {
-    Map<String, String> selector = KubernetesServiceDeployer.getSelector(service);
+    Map<String, String> selector = KubernetesServiceHandler.getSelector(service);
     if (selector == null || selector.isEmpty()) {
       return new HashSet<>();
     }
@@ -120,7 +120,7 @@ public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAg
 
   private static void addAllReplicaSetLabels(Map<String, Set<KubernetesManifest>> entries, KubernetesManifest replicaSet) {
     String namespace = replicaSet.getNamespace();
-    Map<String, String> podLabels = KubernetesReplicaSetDeployer.getPodTemplateLabels(replicaSet);
+    Map<String, String> podLabels = KubernetesReplicaSetHandler.getPodTemplateLabels(replicaSet);
     if (podLabels == null) {
       return;
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.Kubern
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.model.ManifestProvider;
 import com.netflix.spinnaker.moniker.Moniker;
 import org.apache.commons.lang3.tuple.Pair;
@@ -67,9 +67,7 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
     }
 
     CacheData data = dataOptional.get();
-    KubernetesDeployer deployer = registry.lookup()
-        .withKind(kind)
-        .getDeployer();
+    KubernetesHandler deployer = registry.get(kind).getHandler();
 
     KubernetesManifest manifest = KubernetesCacheDataConverter.getManifest(data);
     Moniker moniker = KubernetesCacheDataConverter.getMoniker(data);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/converter/manifest/KubernetesDeployManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/converter/manifest/KubernetesDeployManifestConverter.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.converter.manifest;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.converters.KubernetesAtomicOperationConverterHelper;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.KubernetesV2ArtifactProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest.KubernetesDeployManifestOperation;
@@ -38,9 +39,12 @@ public class KubernetesDeployManifestConverter extends AbstractAtomicOperationsC
   @Autowired
   private KubernetesResourcePropertyRegistry registry;
 
+  @Autowired
+  private KubernetesV2ArtifactProvider artifactProvider;
+
   @Override
   public AtomicOperation convertOperation(Map input) {
-    return new KubernetesDeployManifestOperation(convertDescription(input), registry);
+    return new KubernetesDeployManifestOperation(convertDescription(input), registry, artifactProvider);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesArtifactConverter;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesHandler;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,6 +29,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class KubernetesResourceProperties {
-  KubernetesDeployer deployer;
+  KubernetesHandler handler;
   KubernetesArtifactConverter converter;
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentHandler.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
@@ -26,13 +27,12 @@ import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup.Capacity;
 import io.kubernetes.client.models.AppsV1beta1Deployment;
 import io.kubernetes.client.models.AppsV1beta1DeploymentStatus;
-import io.kubernetes.client.models.V1DeleteOptions;
 import io.kubernetes.client.models.V1beta2Deployment;
 import io.kubernetes.client.models.V1beta2DeploymentStatus;
 import org.springframework.stereotype.Component;
 
 @Component
-public class KubernetesDeploymentDeployer extends KubernetesDeployer implements CanResize, CanDelete {
+public class KubernetesDeploymentHandler extends KubernetesHandler implements CanResize, CanDelete {
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.DEPLOYMENT;
@@ -60,6 +60,11 @@ public class KubernetesDeploymentDeployer extends KubernetesDeployer implements 
       default:
         throw new UnsupportedVersionException(manifest);
     }
+  }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return null;
   }
 
   private Status status(AppsV1beta1Deployment deployment) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesHandler.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.KubernetesCacheUtils;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
@@ -33,12 +33,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 
-public abstract class KubernetesDeployer {
+public abstract class KubernetesHandler {
   @Autowired
   protected ObjectMapper objectMapper;
-
-  @Autowired
-  private KubernetesCacheUtils cacheUtils;
 
   @Getter
   @Autowired
@@ -58,6 +55,7 @@ public abstract class KubernetesDeployer {
   abstract public boolean versioned();
   abstract public SpinnakerKind spinnakerKind();
   abstract public Status status(KubernetesManifest manifest);
+  abstract public Class<? extends KubernetesV2CachingAgent> cachingAgentClass();
 
   void deploy(KubernetesV2Credentials credentials, KubernetesManifest manifest) {
     jobExecutor.deploy(credentials, manifest);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesIngressHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesIngressHandler.java
@@ -17,22 +17,18 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
-import io.kubernetes.client.models.V1Service;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
-
 @Component
-public class KubernetesServiceDeployer extends KubernetesDeployer implements CanDelete {
+public class KubernetesIngressHandler extends KubernetesHandler implements CanDelete {
   @Override
   public KubernetesKind kind() {
-    return KubernetesKind.SERVICE;
+    return KubernetesKind.INGRESS;
   }
 
   @Override
@@ -50,13 +46,8 @@ public class KubernetesServiceDeployer extends KubernetesDeployer implements Can
     return Status.stable();
   }
 
-  public static Map<String, String> getSelector(KubernetesManifest manifest) {
-    switch (manifest.getApiVersion()) {
-      case V1:
-        V1Service v1Service = KubernetesCacheDataConverter.getResource(manifest, V1Service.class);
-        return v1Service.getSpec().getSelector();
-      default:
-        throw new IllegalArgumentException("No services with version " + manifest.getApiVersion() + " supported");
-    }
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return null;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesReplicaSetHandler.java
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesReplicaSetCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
@@ -33,7 +35,7 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 
 @Component
-public class KubernetesReplicaSetDeployer extends KubernetesDeployer implements CanResize, CanDelete {
+public class KubernetesReplicaSetHandler extends KubernetesHandler implements CanResize, CanDelete {
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.REPLICA_SET;
@@ -47,6 +49,11 @@ public class KubernetesReplicaSetDeployer extends KubernetesDeployer implements 
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.SERVER_GROUP;
+  }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return KubernetesReplicaSetCachingAgent.class;
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesServiceHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesServiceHandler.java
@@ -17,17 +17,23 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesServiceCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import io.kubernetes.client.models.V1Service;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
-public class KubernetesIngressDeployer extends KubernetesDeployer implements CanDelete {
+public class KubernetesServiceHandler extends KubernetesHandler implements CanDelete {
   @Override
   public KubernetesKind kind() {
-    return KubernetesKind.INGRESS;
+    return KubernetesKind.SERVICE;
   }
 
   @Override
@@ -43,5 +49,20 @@ public class KubernetesIngressDeployer extends KubernetesDeployer implements Can
   @Override
   public Status status(KubernetesManifest manifest) {
     return Status.stable();
+  }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return KubernetesServiceCachingAgent.class;
+  }
+
+  public static Map<String, String> getSelector(KubernetesManifest manifest) {
+    switch (manifest.getApiVersion()) {
+      case V1:
+        V1Service v1Service = KubernetesCacheDataConverter.getResource(manifest, V1Service.class);
+        return v1Service.getSpec().getSelector();
+      default:
+        throw new IllegalArgumentException("No services with version " + manifest.getApiVersion() + " supported");
+    }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
@@ -25,12 +25,11 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesRes
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesDeleteManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.CanDelete;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 
 import java.util.List;
-import java.util.Map;
 
 public class KubernetesDeleteManifestOperation implements AtomicOperation<Void> {
   private final KubernetesDeleteManifestDescription description;
@@ -55,8 +54,8 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Void> 
     KubernetesCoordinates coordinates = description.getCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
-    KubernetesResourceProperties properties = registry.lookup(coordinates);
-    KubernetesDeployer deployer = properties.getDeployer();
+    KubernetesResourceProperties properties = registry.get(coordinates.getKind());
+    KubernetesHandler deployer = properties.getHandler();
 
     if (!(deployer instanceof CanDelete)) {
       throw new IllegalArgumentException("Resource with " + coordinates + " does not support delete");

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/servergroup/KubernetesResizeServerGroupOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/servergroup/KubernetesResizeServerGroupOperation.java
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesRes
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.servergroup.KubernetesResizeServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.CanResize;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesDeployer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 
@@ -52,8 +52,8 @@ public class KubernetesResizeServerGroupOperation implements AtomicOperation<Voi
     KubernetesCoordinates coordinates = description.getCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
-    KubernetesResourceProperties properties = registry.lookup(coordinates);
-    KubernetesDeployer deployer = properties.getDeployer();
+    KubernetesResourceProperties properties = registry.get(coordinates.getKind());
+    KubernetesHandler deployer = properties.getHandler();
 
     if (!(deployer instanceof CanResize)) {
       throw new IllegalArgumentException("Resource with " + coordinates + " does not support resize");

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
@@ -60,10 +60,9 @@ class KubernetesVersionedArtifactConverterSpec extends Specification {
     artifactProvider.getArtifacts(type, name, location) >> artifacts
 
     def converter = new KubernetesVersionedArtifactConverter()
-    converter.artifactProvider = artifactProvider
 
     then:
-    converter.getVersion(type, name, location) == expected
+    converter.getVersion(artifactProvider, type, name, location) == expected
 
     where:
     versions  | expected

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
@@ -32,7 +32,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestSpinnakerRelationships
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesReplicaSetDeployer
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesReplicaSetHandler
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest.KubernetesDeployManifestOperation
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials
@@ -91,14 +91,14 @@ metadata:
     def jobExecutorMock = Mock(KubectlJobExecutor)
     jobExecutorMock.deploy(_, _) >> null
 
-    def replicaSetDeployer = new KubernetesReplicaSetDeployer()
+    def replicaSetDeployer = new KubernetesReplicaSetHandler()
     replicaSetDeployer.objectMapper = new ObjectMapper()
     replicaSetDeployer.versioned() >> true
     replicaSetDeployer.kind() >> KIND
     replicaSetDeployer.jobExecutor = jobExecutorMock
     def versionedArtifactConverterMock = Mock(KubernetesVersionedArtifactConverter)
     versionedArtifactConverterMock.getDeployedName(_) >> "$NAME-$VERSION"
-    versionedArtifactConverterMock.toArtifact(_) >> new Artifact()
+    versionedArtifactConverterMock.toArtifact(_, _) >> new Artifact()
     def registry = new KubernetesResourcePropertyRegistry(Collections.singletonList(replicaSetDeployer),
         new KubernetesSpinnakerKindMap(),
         versionedArtifactConverterMock,
@@ -108,7 +108,7 @@ metadata:
       .withAccount(ACCOUNT)
       .setNamer(KubernetesManifest.class, new KubernetesManifestNamer())
     
-    def deployOp = new KubernetesDeployManifestOperation(deployDescription, registry)
+    def deployOp = new KubernetesDeployManifestOperation(deployDescription, registry, null)
 
     return deployOp
   }


### PR DESCRIPTION
This allows us to not hard-code a list of caching agent types, and have them be discovered based on the "Handler" for the resource that owns them.