### PR TITLE
fix(provider/kubernetes): Dedup kind map

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java
@@ -21,6 +21,7 @@ import com.google.common.primitives.Ints;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.HealthState;
 import com.netflix.spinnaker.clouddriver.model.Instance;
@@ -32,7 +33,6 @@ import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
@@ -20,10 +20,10 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 @Component
 public class KubernetesSpinnakerKindMap {
@@ -36,13 +36,13 @@ public class KubernetesSpinnakerKindMap {
     UNCLASSIFIED
   }
 
-  private Map<SpinnakerKind, List<KubernetesKind>> spinnakerToKubernetes = new HashMap<>();
+  private Map<SpinnakerKind, Set<KubernetesKind>> spinnakerToKubernetes = new HashMap<>();
   private Map<KubernetesKind, SpinnakerKind> kubernetesToSpinnaker = new HashMap<>();
 
   void addRelationship(SpinnakerKind spinnakerKind, KubernetesKind kubernetesKind) {
-    List<KubernetesKind> kinds = spinnakerToKubernetes.get(spinnakerKind);
+    Set<KubernetesKind> kinds = spinnakerToKubernetes.get(spinnakerKind);
     if (kinds == null) {
-      kinds = new ArrayList<>();
+      kinds = new HashSet<>();
     }
 
     kinds.add(kubernetesKind);
@@ -50,15 +50,11 @@ public class KubernetesSpinnakerKindMap {
     kubernetesToSpinnaker.put(kubernetesKind, spinnakerKind);
   }
 
-  public KubernetesSpinnakerKindMap() {
-    addRelationship(SpinnakerKind.INSTANCE, KubernetesKind.POD);
-  }
-
   public SpinnakerKind translateKubernetesKind(KubernetesKind kubernetesKind) {
     return kubernetesToSpinnaker.get(kubernetesKind);
   }
 
-  public List<KubernetesKind> translateSpinnakerKind(SpinnakerKind spinnakerKind) {
+  public Set<KubernetesKind> translateSpinnakerKind(SpinnakerKind spinnakerKind) {
     return spinnakerToKubernetes.get(spinnakerKind);
   }
 }


### PR DESCRIPTION
Realized this bug when instances were being loaded from the cache twice since the PodHandler had just been registered. 