### PR TITLE
feat(provider/aws): Enable optional AWS Shield protection on ELB & ALBs

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmazonLoadBalancerDescription.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmazonLoadBalancerDescription.java
@@ -33,6 +33,8 @@ public class UpsertAmazonLoadBalancerDescription extends AbstractAmazonCredentia
   private List<String> securityGroups;
   private Map<String, List<String>> availabilityZones;
 
+  private boolean shieldProtectionEnabled = true;
+
   public AmazonLoadBalancerType getLoadBalancerType() {
     return loadBalancerType;
   }
@@ -95,5 +97,13 @@ public class UpsertAmazonLoadBalancerDescription extends AbstractAmazonCredentia
 
   public void setAvailabilityZones(Map<String, List<String>> availabilityZones) {
     this.availabilityZones = availabilityZones;
+  }
+
+  public boolean getShieldProtectionEnabled() {
+    return shieldProtectionEnabled;
+  }
+
+  public void setShieldProtectionEnabled(boolean shieldProtectionEnabled) {
+    this.shieldProtectionEnabled = shieldProtectionEnabled;
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/LoadBalancerV2UpsertHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/LoadBalancerV2UpsertHandler.groovy
@@ -18,8 +18,31 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.handlers
 
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
-import com.amazonaws.services.elasticloadbalancingv2.model.*
-import com.netflix.spinnaker.clouddriver.aws.data.ArnUtils
+import com.amazonaws.services.elasticloadbalancingv2.model.Action
+import com.amazonaws.services.elasticloadbalancingv2.model.CreateListenerRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.CreateListenerResult
+import com.amazonaws.services.elasticloadbalancingv2.model.CreateLoadBalancerRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.CreateRuleRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.CreateTargetGroupRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.CreateTargetGroupResult
+import com.amazonaws.services.elasticloadbalancingv2.model.DeleteListenerRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.DeleteTargetGroupRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeListenersRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeRulesRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetGroupsRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.Listener
+import com.amazonaws.services.elasticloadbalancingv2.model.ListenerNotFoundException
+import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancer
+import com.amazonaws.services.elasticloadbalancingv2.model.Matcher
+import com.amazonaws.services.elasticloadbalancingv2.model.ModifyTargetGroupAttributesRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.ModifyTargetGroupRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.ResourceInUseException
+import com.amazonaws.services.elasticloadbalancingv2.model.Rule
+import com.amazonaws.services.elasticloadbalancingv2.model.RuleCondition
+import com.amazonaws.services.elasticloadbalancingv2.model.SetSecurityGroupsRequest
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroup
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupAttribute
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetGroupNotFoundException
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerV2Description
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -326,7 +349,7 @@ class LoadBalancerV2UpsertHandler {
     }
   }
 
-  static String createLoadBalancer(AmazonElasticLoadBalancing loadBalancing, String loadBalancerName, boolean isInternal,
+  static LoadBalancer createLoadBalancer(AmazonElasticLoadBalancing loadBalancing, String loadBalancerName, boolean isInternal,
                                           Collection<String> subnetIds, Collection<String> securityGroups,
                                           List<UpsertAmazonLoadBalancerV2Description.TargetGroup> targetGroups,
                                           List<UpsertAmazonLoadBalancerV2Description.Listener> listeners) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -40,6 +40,8 @@ import com.amazonaws.services.route53.AmazonRoute53;
 import com.amazonaws.services.route53.AmazonRoute53ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.shield.AWSShield;
+import com.amazonaws.services.shield.AWSShieldClientBuilder;
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
@@ -416,5 +418,13 @@ public class AmazonClientProvider {
 
   public AmazonIdentityManagement getAmazonIdentityManagement(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
     return awsSdkClientSupplier.getClient(AmazonIdentityManagementClientBuilder.class, AmazonIdentityManagement.class, accountName, awsCredentialsProvider, region);
+  }
+
+  public AWSShield getAmazonShield(NetflixAmazonCredentials amazonCredentials, String region) {
+    return proxyHandlerBuilder.getProxyHandler(AWSShield.class, AWSShieldClientBuilder.class, amazonCredentials, region, true);
+  }
+
+  public AWSShield getAmazonShield(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
+    return awsSdkClientSupplier.getClient(AWSShieldClientBuilder.class, AWSShield.class, accountName, awsCredentialsProvider, region);
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAmazonCredentials.java
@@ -34,6 +34,7 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
     private final boolean front50Enabled;
     private final String bastionHost;
     private final boolean bastionEnabled;
+    private final boolean shieldEnabled;
 
     public NetflixAmazonCredentials(@JsonProperty("name") String name,
                                     @JsonProperty("environment") String environment,
@@ -53,7 +54,8 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
                                     @JsonProperty("front50") String front50,
                                     @JsonProperty("front50Enabled") Boolean front50Enabled,
                                     @JsonProperty("bastionHost") String bastionHost,
-                                    @JsonProperty("bastionEnabled") Boolean bastionEnabled) {
+                                    @JsonProperty("bastionEnabled") Boolean bastionEnabled,
+                                    @JsonProperty("shieldEnabled") Boolean shieldEnabled) {
         this(name,
              environment,
              accountType,
@@ -73,7 +75,8 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
              front50,
              front50Enabled,
              bastionHost,
-             bastionEnabled);
+             bastionEnabled,
+             shieldEnabled);
     }
 
     private static boolean flagValue(String serviceUrl, Boolean flag) {
@@ -100,7 +103,8 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
              copy.getFront50(),
              copy.getFront50Enabled(),
              copy.getBastionHost(),
-             copy.getBastionEnabled());
+             copy.getBastionEnabled(),
+             copy.getShieldEnabled());
     }
 
     NetflixAmazonCredentials(String name,
@@ -122,7 +126,8 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
                              String front50,
                              Boolean front50Enabled,
                              String bastionHost,
-                             Boolean bastionEnabled) {
+                             Boolean bastionEnabled,
+                             Boolean shieldEnabled) {
         super(name,
               environment,
               accountType,
@@ -143,6 +148,7 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
         this.front50Enabled = flagValue(front50, front50Enabled);
         this.bastionHost = bastionHost;
         this.bastionEnabled = flagValue(bastionHost, bastionEnabled);
+        this.shieldEnabled = (shieldEnabled == null) ? false : shieldEnabled;
     }
 
     public String getEdda() {
@@ -175,5 +181,9 @@ public class NetflixAmazonCredentials extends AmazonCredentials {
 
     public boolean getBastionEnabled() {
         return bastionEnabled;
+    }
+
+    public boolean getShieldEnabled() {
+      return shieldEnabled;
     }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAssumeRoleAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixAssumeRoleAmazonCredentials.java
@@ -53,6 +53,7 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
                                               @JsonProperty("front50Enabled") Boolean front50Enabled,
                                               @JsonProperty("bastionHost") String bastionHost,
                                               @JsonProperty("bastionEnabled") Boolean bastionEnabled,
+                                              @JsonProperty("shieldEnabled") Boolean shieldEnabled,
                                               @JsonProperty("assumeRole") String assumeRole,
                                               @JsonProperty("sessionName") String sessionName) {
 
@@ -76,6 +77,7 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
              front50Enabled,
              bastionHost,
              bastionEnabled,
+             shieldEnabled,
              assumeRole,
              sessionName);
     }
@@ -101,6 +103,7 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
              copy.getFront50Enabled(),
              copy.getBastionHost(),
              copy.getBastionEnabled(),
+             copy.getShieldEnabled(),
              copy.getAssumeRole(),
              copy.getSessionName());
     }
@@ -125,6 +128,7 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
                                        Boolean front50Enabled,
                                        String bastionHost,
                                        Boolean bastionEnabled,
+                                       Boolean shieldEnabled,
                                        String assumeRole,
                                        String sessionName) {
         super(name,
@@ -149,7 +153,8 @@ public class NetflixAssumeRoleAmazonCredentials extends NetflixAmazonCredentials
               front50,
               front50Enabled,
               bastionHost,
-              bastionEnabled);
+              bastionEnabled,
+              shieldEnabled);
         this.assumeRole = assumeRole;
         this.sessionName = sessionName == null ? AssumeRoleAmazonCredentials.DEFAULT_SESSION_NAME : sessionName;
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/AwsProviderSpec.groovy
@@ -48,6 +48,7 @@ class AwsProviderSpec extends Specification {
             null,
             false,
             null,
+            false,
             false)
     def eurekaAccount2 = new NetflixAmazonCredentials("my-qa-account",
             "qa",
@@ -67,6 +68,7 @@ class AwsProviderSpec extends Specification {
             null,
             false,
             null,
+            false,
             false)
 
     def eurekaAccounts = [ eurekaAccount1, eurekaAccount2 ]
@@ -95,6 +97,7 @@ class AwsProviderSpec extends Specification {
             null,
             false,
             null,
+            false,
             false)
     def account2 = new NetflixAmazonCredentials("my-qa-account",
             "qa",
@@ -114,6 +117,7 @@ class AwsProviderSpec extends Specification {
             null,
             false,
             null,
+            false,
             false)
 
     def accounts = [ account1, account2 ]

--- a/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
+++ b/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
@@ -194,6 +194,7 @@ class ProviderUtilsSpec extends Specification {
                                  null,
                                  null,
                                  null,
+                                 null,
                                  null)
   }
 


### PR DESCRIPTION
We only want to enable protection on newly created, external ELBs & ALBs. By default, shield protection is disabled and can be enabled per-account, additionally exposed an opt-out field on the create ELB description in case we want to expose via the UI explicitly not attaching Shield protection.

