### PR TITLE
feat(provider/amazon): Optionally tag server groups w/ app/stack/details

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -194,6 +194,7 @@ class AwsConfiguration {
     boolean addAppGroupsToClassicLink = false
     int maxClassicLinkSecurityGroups = 5
     boolean addAppGroupToServerGroup = false
+    boolean addAppStackDetailTags = false
     boolean createLoadBalancerIngressPermissions = false
     int maxSecurityGroups = 5
     ReconcileMode reconcileClassicLinkSecurityGroups = ReconcileMode.NONE

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -291,7 +291,8 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         regionScopedProvider: regionScopedProvider,
         base64UserData: description.base64UserData,
         legacyUdf: description.legacyUdf,
-        tags: description.tags)
+        tags: applyAppStackDetailTags(deployDefaults, description).tags
+      )
 
       def asgName = autoScalingWorker.deploy()
 
@@ -569,5 +570,32 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
     }
 
     return convertBlockDevices(sourceLaunchConfiguration.blockDeviceMappings)
+  }
+
+  /**
+   * Add tags for application/stack/details iff `deployDefaults.addAppStackDetailTags` is true.
+   */
+  @VisibleForTesting
+  @PackageScope
+  static BasicAmazonDeployDescription applyAppStackDetailTags(DeployDefaults deployDefaults,
+                                                              BasicAmazonDeployDescription description) {
+    if (!deployDefaults.addAppStackDetailTags) {
+      return description
+    }
+
+    description = description.clone()
+    description.tags = description.tags ?: [:]
+
+    if (description.application) {
+      description.tags["spinnaker:application"] = description.application
+    }
+    if (description.stack) {
+      description.tags["spinnaker:stack"] = description.stack
+    }
+    if (description.freeFormDetails) {
+      description.tags["spinnaker:details"] = description.freeFormDetails
+    }
+
+    return description
   }
 }


### PR DESCRIPTION
Set `aws.defaults.addAppStackDetailTags: true` to enable.

When enabled, all created server groups will be tagged with:
- `spinnaker:application`
- `spinnaker:stack`
- `spinnaker:details`

The tag will only be created if the value is non-null.

By default, these tags will be propagated to launched instances.
