### PR TITLE
feat(provider/kubernetes): Allow op to override versioning

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
@@ -17,7 +17,8 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesArtifactConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesUnversionedArtifactConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesHandler;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,5 +31,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class KubernetesResourceProperties {
   KubernetesHandler handler;
-  KubernetesArtifactConverter converter;
+  boolean versioned;
+  KubernetesVersionedArtifactConverter versionedConverter;
+  KubernetesUnversionedArtifactConverter unversionedConverter;
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourcePropertyRegistry.java
@@ -38,7 +38,9 @@ public class KubernetesResourcePropertyRegistry {
     for (KubernetesHandler handler : handlers) {
       KubernetesResourceProperties properties = KubernetesResourceProperties.builder()
           .handler(handler)
-          .converter(handler.versioned() ? versionedArtifactConverter : unversionedArtifactConverter)
+          .versioned(handler.versioned())
+          .versionedConverter(versionedArtifactConverter)
+          .unversionedConverter(unversionedArtifactConverter)
           .build();
 
       kindMap.addRelationship(handler.spinnakerKind(), handler.kind());

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
@@ -32,4 +32,5 @@ public class KubernetesDeployManifestDescription extends KubernetesAtomicOperati
   Moniker moniker;
   KubernetesManifestSpinnakerRelationships relationships;
   List<Artifact> artifacts;
+  Boolean versioned;
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -79,10 +79,11 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Deploy
     }
 
     KubernetesResourceProperties properties = findResourceProperties(manifest);
+    boolean versioned = description.getVersioned() == null ? properties.isVersioned() : description.getVersioned();
+    KubernetesArtifactConverter converter = versioned ? properties.getVersionedConverter() : properties.getUnversionedConverter();
     KubernetesHandler deployer = properties.getHandler();
-    KubernetesArtifactConverter converter = properties.getConverter();
 
-    Artifact artifact = properties.getConverter().toArtifact(provider, manifest);
+    Artifact artifact = converter.toArtifact(provider, manifest);
     Moniker moniker = description.getMoniker();
     KubernetesManifestSpinnakerRelationships relationships = description.getRelationships();
 


### PR DESCRIPTION
Needed for operations that are strictly interpreted as an "edit", or explicit calls to avoid versioning things like configMaps