### PR TITLE
feat(provider/kubernetes): runJob multi-container

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/job/RunKubernetesJobDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/job/RunKubernetesJobDescription.groovy
@@ -32,7 +32,9 @@ class RunKubernetesJobDescription extends KubernetesKindAtomicOperationDescripti
   String namespace
   Boolean hostNetwork=false
   Map<String, String> nodeSelector
+  // this should be deprecated at some point
   KubernetesContainerDescription container
+  List<KubernetesContainerDescription> containers
   List<KubernetesVolumeSource> volumeSources
   Map<String, String> labels
   Map<String, String> annotations

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/job/RunKubernetesJobAtomicOperation.groovy
@@ -95,11 +95,18 @@ class RunKubernetesJobAtomicOperation implements AtomicOperation<DeploymentResul
     if (description.nodeSelector){
       podBuilder = podBuilder.withNodeSelector(description.nodeSelector)
     }
+    
+    // if the description is still using the single container, convert to a list first
+    if (description.container) {
+      description.containers = [description.container]
+    }
 
-    description.container.name = description.container.name ?: "job"
-    def container = KubernetesApiConverter.toContainer(description.container)
-
-    podBuilder = podBuilder.withContainers(container)
+    def containers = description.containers.collect { container ->
+      container.name = container.name ?: "job"
+      KubernetesApiConverter.toContainer(container)
+    }
+    
+    podBuilder = podBuilder.withContainers(containers)
 
     podBuilder = podBuilder.endSpec()
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/job/RunKubernetesJobAtomicOperationValidator.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/job/RunKubernetesJobAtomicOperationValidator.groovy
@@ -53,10 +53,17 @@ class RunKubernetesJobAtomicOperationValidator extends DescriptionValidator<RunK
     description.volumeSources.eachWithIndex { source, idx ->
       KubernetesVolumeSourceValidator.validate(source, helper, "volumeSources[${idx}]")
     }
+    
+    if (description.container) {
+      description.containers = [description.container]
+    }
 
-    helper.validateNotEmpty(description.container, "containers")
-    description.container.name = description.container.name ?: "job"
-    KubernetesContainerValidator.validate(description.container, helper, "container")
+    helper.validateNotEmpty(description.containers, "containers")
+
+    description.containers.eachWithIndex { container, idx ->
+      container.name = container.name ?: "job"
+      KubernetesContainerValidator.validate(container, helper, "containers[${idx}]")
+    }
   }
 }
 


### PR DESCRIPTION
support multiple containers in the run job description. we have to
support both `container` and `containers` until we can deprecate the
`container` field since the current defs are all using `container`.

@lwander PTAL. I'm not sure the validator changes are correct.

spinnaker/spinnaker#1961