### PR TITLE
fix(provider/dcos): Use createApp instead of updateApp for deploy

### DIFF
--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosSpectatorHandler.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosSpectatorHandler.groovy
@@ -55,7 +55,7 @@ class DcosSpectatorHandler implements InvocationHandler {
         }
 
         if (failure != null) {
-            throw new Throwable(method.name, failure)
+            throw failure
         } else {
             return result
         }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DeployDcosServerGroupAtomicOperation.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DeployDcosServerGroupAtomicOperation.groovy
@@ -69,7 +69,7 @@ class DeployDcosServerGroupAtomicOperation implements AtomicOperation<Deployment
     task.updateStatus BASE_PHASE, "Marathon ID chosen to be $dcosPathId."
     task.updateStatus BASE_PHASE, "Building application..."
 
-    dcosClient.updateApp(dcosPathId.toString(), descriptionToAppMapper.map(dcosPathId.toString(), description), description.forceDeployment)
+    dcosClient.createApp(descriptionToAppMapper.map(dcosPathId.toString(), description))
 
     task.updateStatus BASE_PHASE, "Deployed service ${resolvedServerGroupName}"
 

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/mapper/DeployDcosServerGroupDescriptionToAppMapper.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/mapper/DeployDcosServerGroupDescriptionToAppMapper.groovy
@@ -65,7 +65,7 @@ class DeployDcosServerGroupDescriptionToAppMapper {
           it
         } : null
         volumes = parseVolumes(description.persistentVolumes, description.dockerVolumes, description.externalVolumes)
-        type = volumes ? "DOCKER" : null
+        type = docker ? "DOCKER" : null
 
         it
       }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/security/DcosCredentialsInitializer.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/security/DcosCredentialsInitializer.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.dcos.DcosConfigurationProperties
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils
+import feign.FeignException
 import groovy.util.logging.Slf4j
 import mesosphere.dcos.client.DCOS
 import mesosphere.dcos.client.DCOSException
@@ -113,7 +114,7 @@ class DcosCredentialsInitializer implements CredentialsInitializerSynchronizable
           DCOS client = clientProvider.getDcosClient(clusterCredentials)
           try {
             client.getServerInfo()
-          } catch (DCOSException e) {
+          } catch (DCOSException | FeignException e) {
             LOGGER.error("[account={}] There was a problem trying to connect to the cluster with url=[{}] using uid=[{}]. Details: ", account.name, cluster.dcosUrl, clusterConfig.uid, e)
           }
 


### PR DESCRIPTION
Uses the correct DC/OS API call for creating a new marathon application, due to "Bad Request" issues with certain marathon application definitions when using updateApp.

Also corrects a small issue with the exceptions being thrown out of the spectator proxy for the DC/OS client, such that now the correct exception flows are hit.
