### PR TITLE
fix(provider/gce): Tolerate named port values as Doubles.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/BasicGoogleDeployAtomicOperationConverter.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/converters/BasicGoogleDeployAtomicOperationConverter.groovy
@@ -22,16 +22,33 @@ import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDe
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
 @GoogleOperation(AtomicOperations.CREATE_SERVER_GROUP)
 @Component("basicGoogleDeployDescription")
+@Slf4j
 class BasicGoogleDeployAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
   AtomicOperation convertOperation(Map input) {
     new DeployAtomicOperation(convertDescription(input))
   }
 
   BasicGoogleDeployDescription convertDescription(Map input) {
+    // Note: Deploy descriptions are stored in pipelines such that namedPort ports are cast to doubles. This is a bug.
+    // As a result, pipelines in the wild have namedPort ports stored as doubles.
+    // If a pipeline containing a deploy is executed with a trigger (e.g. a cron trigger), the description converter
+    // chokes and the pipeline fails. The next block handles double ports for namedPorts gracefully.
+    def namedPorts = input?.loadBalancingPolicy?.namedPorts
+    if (namedPorts && namedPorts.any { np -> np.port instanceof Double }) {
+      log.warn("Deploy description contained named ports with ports of type Double." +
+        " Converting Double port value to Integer and continuing deploy.")
+      namedPorts.each { np ->
+        if (np.port instanceof Double) {
+          np.port = new Integer((np.port as Double).intValue())
+        }
+      }
+    }
+
     GoogleAtomicOperationConverterHelper.convertDescription(input, this, BasicGoogleDeployDescription)
   }
 }


### PR DESCRIPTION
Pipelines are being persisted with 'port' values of NamedPorts as
Doubles. This is an issue. This change tolerates that behavior in deploys
since users will have pipelines with Double ports in the wild.

This is an issue in 1.5.0, so we should cherry-pick and cut a patch release.

https://github.com/spinnaker/spinnaker/issues/2096