### PR TITLE
feat(provider/kubernetes): cache controller revisions

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesControllerRevisionCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesControllerRevisionCachingAgent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+
+@Slf4j
+public class KubernetesControllerRevisionCachingAgent extends KubernetesV2OnDemandCachingAgent {
+  KubernetesControllerRevisionCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+      ObjectMapper objectMapper,
+      Registry registry,
+      int agentIndex,
+      int agentCount) {
+    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+  }
+
+  @Getter
+  final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          AUTHORITATIVE.forType(KubernetesKind.CONTROLLER_REVISION.toString())
+      ))
+  );
+
+  @Override
+  protected KubernetesKind primaryKind() {
+    return KubernetesKind.CONTROLLER_REVISION;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 public class KubernetesKind {
   public static KubernetesKind CONFIG_MAP = new KubernetesKind("configMap", "cm");
+  public static KubernetesKind CONTROLLER_REVISION = new KubernetesKind("controllerRevision");
   public static KubernetesKind DAEMON_SET = new KubernetesKind("daemonSet", "ds");
   public static KubernetesKind DEPLOYMENT = new KubernetesKind("deployment", "deploy");
   public static KubernetesKind INGRESS = new KubernetesKind("ingress", "ing");

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesControllerRevisionHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesControllerRevisionHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesControllerRevisionCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KubernetesControllerRevisionHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.CONTROLLER_REVISION;
+  }
+
+  @Override
+  public boolean versioned() {
+    return false;
+  }
+
+  @Override
+  public SpinnakerKind spinnakerKind() {
+    return SpinnakerKind.UNCLASSIFIED;
+  }
+
+  @Override
+  public Status status(KubernetesManifest manifest) {
+    return new Status();
+  }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return KubernetesControllerRevisionCachingAgent.class;
+  }
+}


### PR DESCRIPTION
This is how k8s surfaces what you can rollback to.