### PR TITLE
fix(provider/kubernetes): read namespace as region (#2123)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/KubernetesServerGroupDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/KubernetesServerGroupDescription.groovy
@@ -21,4 +21,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.Kubern
 class KubernetesServerGroupDescription extends KubernetesKindAtomicOperationDescription {
   String serverGroupName
   String namespace
+  String region
+
+  String getNamespace() {
+    namespace ?: region
+  }
 }


### PR DESCRIPTION
Patch for 1.5.x - will likely need https://github.com/spinnaker/orca/pull/1805/ merged & patched into 1.5.x as well