### PR TITLE
fix(elasticsearch): Force refresh when fetching entity tags from Front50

### DIFF
--- a/clouddriver-elasticsearch/elasticsearch_index_template.json
+++ b/clouddriver-elasticsearch/elasticsearch_index_template.json
@@ -1,0 +1,90 @@
+{
+  "order": 0,
+  "template": "tags_v*",
+  "settings": {
+    "index": {
+      "number_of_shards": "6",
+      "number_of_replicas": "2",
+      "refresh_interval": "1s"
+    }
+  },
+  "mappings": {
+    "_default_": {
+      "dynamic": "false",
+      "dynamic_templates": [
+        {
+          "tags_template": {
+            "path_match": "tagsMetadata",
+            "mapping": {
+              "index": "no"
+            }
+          }
+        },
+        {
+          "entityRef_template": {
+            "path_match": "entityRef.*",
+            "mapping": {
+              "index": "not_analyzed"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "entityRef": {
+          "properties": {
+            "accountId": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "application": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "entityType": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "cloudProvider": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "entityId": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "region": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "account": {
+              "index": "not_analyzed",
+              "type": "string"
+            }
+          }
+        },
+        "tags": {
+          "type": "nested",
+          "properties": {
+            "valueType": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "name": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "namespace": {
+              "index": "not_analyzed",
+              "type": "string"
+            },
+            "value": {
+              "index": "not_analyzed",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "aliases": {}
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProvider.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProvider.java
@@ -261,7 +261,7 @@ public class ElasticSearchEntityTagsProvider implements EntityTagsProvider {
       throw new ElasticSearchException("Unable to re-create index '" + activeElasticSearchIndex + "'");
     }
 
-    Collection<EntityTags> entityTags = front50Service.getAllEntityTags(false);
+    Collection<EntityTags> entityTags = front50Service.getAllEntityTags(true);
 
     log.info("Indexing {} entity tags", entityTags.size());
     bulkIndex(


### PR DESCRIPTION
`elasticsearch_index_template.json` is the index template that
should be applied in elastic search.
