### PR TITLE
fix(provider/gce): Tolerate failed backend service getHealth() calls.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -170,7 +170,6 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
 
   class TargetSslProxyCallback<TargetSslProxy> extends JsonBatchCallback<TargetSslProxy> implements FailedSubjectChronicler {
     GoogleSslLoadBalancer googleLoadBalancer
-    BatchRequest backendServiceRequest
     List<BackendService> projectBackendServices
     List<HealthCheck> projectHealthChecks
     BatchRequest groupHealthRequest
@@ -181,12 +180,11 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
 
       String backendServiceName = GCEUtil.getLocalName(targetSslProxy.service)
       BackendService backendService = projectBackendServices?.find { BackendService bs -> bs.getName() == backendServiceName }
-      handleBackendService(backendService, failedSubjects, googleLoadBalancer, projectHealthChecks, groupHealthRequest)
+      handleBackendService(backendService, googleLoadBalancer, projectHealthChecks, groupHealthRequest)
     }
   }
 
   private void handleBackendService(BackendService backendService,
-                                    List<String> failedSubjects,
                                     GoogleSslLoadBalancer googleLoadBalancer,
                                     List<HealthCheck> healthChecks,
                                     BatchRequest groupHealthRequest) {
@@ -196,8 +194,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
 
     def groupHealthCallback = new GroupHealthCallback(
       googleLoadBalancer: googleLoadBalancer,
-      subject: googleLoadBalancer.name,
-      failedSubjects: failedSubjects
+      backendServiceName: backendService.name
     )
 
     GoogleBackendService newService = new GoogleBackendService(
@@ -285,8 +282,18 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
     }
   }
 
-  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> implements FailedSubjectChronicler {
+  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> {
     GoogleSslLoadBalancer googleLoadBalancer
+    String backendServiceName
+
+    /**
+     * Tolerate of the group health calls failing. Spinnaker reports empty load balancer healths as 'unknown'.
+     * If healthStatus is null in the onSuccess() function, the same state is reported, so this shouldn't cause issues.
+     */
+    void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
+      log.debug("Failed backend service group health call for backend service ${backendServiceName} for Http load balancer ${googleLoadBalancer.name}." +
+        " The platform error message was:\n ${e.getMessage()}.")
+    }
 
     @Override
     void onSuccess(BackendServiceGroupHealth backendServiceGroupHealth, HttpHeaders responseHeaders) throws IOException {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleTcpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleTcpLoadBalancerCachingAgent.groovy
@@ -177,12 +177,11 @@ class GoogleTcpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
     void onSuccess(TargetTcpProxy targetTcpProxy, HttpHeaders responseHeaders) throws IOException {
       String backendServiceName = GCEUtil.getLocalName(targetTcpProxy.service)
       BackendService backendService = projectBackendServices?.find { BackendService bs -> bs.getName() == backendServiceName }
-      handleBackendService(backendService, failedSubjects, googleLoadBalancer, projectHealthChecks, groupHealthRequest)
+      handleBackendService(backendService, googleLoadBalancer, projectHealthChecks, groupHealthRequest)
     }
   }
 
   private void handleBackendService(BackendService backendService,
-                                    List<String> failedSubjects,
                                     GoogleTcpLoadBalancer googleLoadBalancer,
                                     List<HealthCheck> healthChecks,
                                     BatchRequest groupHealthRequest) {
@@ -192,8 +191,7 @@ class GoogleTcpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
 
     def groupHealthCallback = new GroupHealthCallback(
       googleLoadBalancer: googleLoadBalancer,
-      subject: googleLoadBalancer.name,
-      failedSubjects: failedSubjects
+      backendServiceName: backendService.name
     )
 
     GoogleBackendService newService = new GoogleBackendService(
@@ -278,8 +276,18 @@ class GoogleTcpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
     }
   }
 
-  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> implements FailedSubjectChronicler {
+  class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> {
     GoogleTcpLoadBalancer googleLoadBalancer
+    String backendServiceName
+
+    /**
+     * Tolerate of the group health calls failing. Spinnaker reports empty load balancer healths as 'unknown'.
+     * If healthStatus is null in the onSuccess() function, the same state is reported, so this shouldn't cause issues.
+     */
+    void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
+      log.debug("Failed backend service group health call for backend service ${backendServiceName} for Http load balancer ${googleLoadBalancer.name}." +
+        " The platform error message was:\n ${e.getMessage()}.")
+    }
 
     @Override
     void onSuccess(BackendServiceGroupHealth backendServiceGroupHealth, HttpHeaders responseHeaders) throws IOException {


### PR DESCRIPTION
Currently, if the backend service getHealth() calls fail, we fail to cache the whole load balancer. This was fine using backend service get()s, since the platform seemed to always return fully-formed and ready backend services. Since we are using one backend service list() at the beginning of the cache cycle, it seems like resources _can be partially-formed_.

Rather than fail the whole LB if a getHealth() fails, we should be tolerant of that failure, mark the health state as unknown, log it, and retry next cycle. The health states are the leaves of the LB configuration, and an unknown health state is an acceptable configuration to Spinnaker (blue health check).