### PR TITLE
feat(provider/kubernetes): runJob logs

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesJobStatus.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesJobStatus.groovy
@@ -40,6 +40,7 @@ class KubernetesJobStatus implements JobStatus, Serializable {
   Set<String> securityGroups
   @JsonIgnore
   Pod pod
+  String logs
 
   KubernetesJobStatus(Pod pod, String account) {
     this.name = pod.metadata.name


### PR DESCRIPTION
add support for capturing logs as part of `collectJob`. logs are added
to the job status. i'm not sure how well this scales as log size grows
so this may not be the best implementation, but it may work for the
short term. since execution details are persisted to volitile storage
storing them with the jobs status is best since the reference to the job
pod is also stored there.

spinnaker/spinnaker#1961
spinnaker/spinnaker#1832

@lwander PTAL. I'll submit a Deck PR once we settle on an implementation.