### PR TITLE
fix(provider/aws): Remove invalid `spinnaker:` tags

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -588,12 +588,22 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
 
     if (description.application) {
       description.tags["spinnaker:application"] = description.application
+    } else {
+      description.tags.remove("spinnaker:application")
     }
+
+
     if (description.stack) {
       description.tags["spinnaker:stack"] = description.stack
+    } else {
+      description.tags.remove("spinnaker:stack")
     }
+
+
     if (description.freeFormDetails) {
       description.tags["spinnaker:details"] = description.freeFormDetails
+    } else {
+      description.tags.remove("spinnaker:details")
     }
 
     return description

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -778,13 +778,15 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     updatedDescription.tags == expectedTags
 
     where:
-    addAppStackDetailTags | application | stack   | details   | initialTags              || expectedTags
-    false                 | "app"       | "stack" | "details" | [foo: "bar"]             || ["foo": "bar"]
-    true                  | "app"       | "stack" | "details" | [foo: "bar"]             || [foo: "bar"] + buildTags("app", "stack", "details")
-    true                  | "app"       | "stack" | "details" | buildTags("1", "2", "3") || buildTags("app", "stack", "details")    // override any previous app/stack/details tags
-    true                  | "app"       | null    | "details" | [:]                      || buildTags("app", null, "details")       // avoid creating tags with null values
-    true                  | "app"       | null    | null      | [:]                      || buildTags("app", null, null)
-    true                  | null        | null    | null      | null                     || buildTags(null, null, null)
+    addAppStackDetailTags | application | stack   | details   | initialTags                          || expectedTags
+    false                 | "app"       | "stack" | "details" | [foo: "bar"]                         || ["foo": "bar"]
+    true                  | "app"       | "stack" | "details" | [foo: "bar"]                         || [foo: "bar"] + buildTags("app", "stack", "details")
+    true                  | "app"       | "stack" | "details" | buildTags("1", "2", "3")             || buildTags("app", "stack", "details")    // override any previous app/stack/details tags
+    true                  | "app"       | null    | "details" | [:]                                  || buildTags("app", null, "details")       // avoid creating tags with null values
+    true                  | "app"       | null    | "details" | buildTags("app", "stack", "details") || buildTags("app", null, "details")       // should remove pre-existing tags if invalid
+    true                  | null        | null    | null      | buildTags("app", "stack", "details") || [:]                                     // should remove pre-existing tags if invalid
+    true                  | "app"       | null    | null      | [:]                                  || buildTags("app", null, null)
+    true                  | null        | null    | null      | null                                 || buildTags(null, null, null)
   }
 
   private static Map buildTags(String application, String stack, String details) {


### PR DESCRIPTION
Remove any `spinnaker:*` tags that are no longer valid (ie. cloning
across stacks and `spinnaker:stack` no longer points at the correct
stack).

This is necessary as `deck` will _now_ supply existing tags when cloning.
