### PR TITLE
fix(provider/kubernetes): fix v1 credentials init

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -31,6 +31,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Scope
+import org.springframework.context.annotation.DependsOn
 
 @Slf4j
 @Configuration
@@ -58,6 +59,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
 
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @Bean
+  @DependsOn("dockerRegistryNamedAccountCredentials")
   List<? extends KubernetesNamedAccountCredentials> synchronizeKubernetesAccounts(
     String clouddriverUserAgentApplicationName,
     KubernetesConfigurationProperties kubernetesConfigurationProperties,


### PR DESCRIPTION
without depending on docker credentials, initialization fails because
KubernetesV1Credentials depends on them being present. this leads to
inability to deploy images properly.

@lwander PTAL. if you can think of another solution, let me know. `KubernetesV1Credentials` _does_ have a hard dependency on `dockerRegistryNamedAccountCredentials`. The credential initialization _does not_ get fixed on the next cycle.
