### PR TITLE
feat(cats): Support for selectively enabling agents

### DIFF
--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
@@ -48,7 +48,15 @@ class ClusteredAgentSchedulerSpec extends Specification {
         }
         lockPollingScheduler = new ManualRunnableScheduler()
         agentExecutionScheduler = new ManualRunnableScheduler()
-        scheduler = new ClusteredAgentScheduler(new JedisClientDelegate(jedisPool), new DefaultNodeIdentity(), interval, new DefaultNodeStatusProvider(), lockPollingScheduler, agentExecutionScheduler)
+        scheduler = new ClusteredAgentScheduler(
+          new JedisClientDelegate(jedisPool),
+          new DefaultNodeIdentity(),
+          interval,
+          new DefaultNodeStatusProvider(),
+          lockPollingScheduler,
+          agentExecutionScheduler,
+          ".*"
+        )
     }
 
     def 'cache run aborted if agent doesnt acquire execution token'() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/JedisCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/JedisCacheConfig.groovy
@@ -57,7 +57,11 @@ class JedisCacheConfig {
 
   @Bean
   @ConditionalOnProperty(value = "caching.writeEnabled", matchIfMissing = true)
-  AgentScheduler agentScheduler(RedisConfigurationProperties redisConfigurationProperties, RedisClientDelegate redisClientDelegate, JedisPool jedisPool, AgentIntervalProvider agentIntervalProvider, NodeStatusProvider nodeStatusProvider) {
+  AgentScheduler agentScheduler(RedisConfigurationProperties redisConfigurationProperties,
+                                RedisClientDelegate redisClientDelegate,
+                                JedisPool jedisPool,
+                                AgentIntervalProvider agentIntervalProvider,
+                                NodeStatusProvider nodeStatusProvider) {
     if (redisConfigurationProperties.scheduler.equalsIgnoreCase("default")) {
       URI redisUri = URI.create(redisConfigurationProperties.connection)
       String redisHost = redisUri.host
@@ -65,7 +69,13 @@ class JedisCacheConfig {
       if (redisPort == -1) {
         redisPort = 6379
       }
-      new ClusteredAgentScheduler(redisClientDelegate, new DefaultNodeIdentity(redisHost, redisPort), agentIntervalProvider, nodeStatusProvider);
+      new ClusteredAgentScheduler(
+        redisClientDelegate,
+        new DefaultNodeIdentity(redisHost, redisPort),
+        agentIntervalProvider,
+        nodeStatusProvider,
+        redisConfigurationProperties.agent.enabledPattern
+      );
     } else if (redisConfigurationProperties.scheduler.equalsIgnoreCase("sort")) {
       new ClusteredSortAgentScheduler(jedisPool, nodeStatusProvider, agentIntervalProvider, redisConfigurationProperties.parallelism ?: -1);
     } else {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfigurationProperties.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfigurationProperties.groovy
@@ -31,8 +31,16 @@ class RedisConfigurationProperties {
     int timeoutSeconds = 300
   }
 
+  @Canonical
+  static class AgentConfiguration {
+    String enabledPattern = ".*"
+  }
+
   @NestedConfigurationProperty
   final PollConfiguration poll = new PollConfiguration()
+
+  @NestedConfigurationProperty
+  final AgentConfiguration agent = new AgentConfiguration()
 
   String connection = "redis://localhost:6379"
   String connectionPrevious = null


### PR DESCRIPTION
This is an assist to local development when you do not want _all_
agents to run by default.

```
redis:
  agent:
    enabledPattern: .*reservation.*
```

By default `enabledPattern` is `.*` and all agents will be scheduled.