### PR TITLE
fix(provider/kubernetes): Use setApiKey when using token from service account

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesApiClientConfig.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesApiClientConfig.groovy
@@ -70,7 +70,7 @@ public class KubernetesApiClientConfig extends Config {
     try {
       String serviceTokenCandidate = new String(Files.readAllBytes(new File(io.fabric8.kubernetes.client.Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH).toPath()))
       if (serviceTokenCandidate != null) {
-        client.setAccessToken(serviceTokenCandidate)
+        client.setApiKey("Bearer " + serviceTokenCandidate)
       } else {
         throw new IllegalStateException("Did not find service account token at $io.fabric8.kubernetes.client.Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH")
       }


### PR DESCRIPTION
This fixes the use of service accounts for getting credentials when Spinnaker is deployed inside a Kubernetes cluster.

Fix found via https://github.com/kubernetes-client/java/issues/74.
Issue found when testing https://github.com/kubernetes/charts/pull/2616