### PR TITLE
feat(provider/aws): Support expected capacity constraint when resizing

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
@@ -20,6 +20,7 @@ class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
 
   String serverGroupName
   String region
+
   Capacity capacity = new Capacity()
 
   List<AsgTargetDescription> asgs = []
@@ -41,8 +42,13 @@ class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
     }
   }
 
+  static class Constraints {
+    Capacity capacity
+  }
+
   static class AsgTargetDescription extends AsgDescription {
     Capacity capacity = new Capacity()
+    Constraints constraints = new Constraints()
 
     @Override
     String toString() {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/ResizeAsgDescriptionPreProcessor.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/ResizeAsgDescriptionPreProcessor.groovy
@@ -30,12 +30,17 @@ class ResizeAsgDescriptionPreProcessor implements AtomicOperationDescriptionPreP
   @Override
   Map process(Map description) {
     description.with {
+      def c = contraints ? [constraints: contraints] : [:]
+
       if (!asgs) {
         if (region) {
-          asgs = [[serverGroupName: serverGroupName ?: asgName, region: region, capacity: capacity]]
+          asgs = [
+            [serverGroupName: serverGroupName ?: asgName, region: region, capacity: capacity] + c
+          ]
         } else {
           asgs = regions.collect {
-            [serverGroupName: serverGroupName ?: asgName, region: it, capacity: capacity]
+            [serverGroupName: serverGroupName ?: asgName, region: it, capacity: capacity] + c
+
           }
         }
       }
@@ -46,6 +51,7 @@ class ResizeAsgDescriptionPreProcessor implements AtomicOperationDescriptionPreP
       description.remove("regions")
       description.remove("region")
       description.remove("capacity")
+      description.remove("constraints")
 
       return description
     }


### PR DESCRIPTION
Support a constraint wherein the server groups' current capacity must
match expected prior to a resize.

There are scenarios wherein a user initiates a resize via the UI at the
same time that an autoscaling event is happening behind the scenes. In
such a scenario, the resize via UI != autoscaling and some churn will
occur.

`deck` will be changed to supply the capacity constraint.
