### PR TITLE
fix(provider/kubernetes): fix registry init

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
@@ -132,6 +132,7 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
   public List<String> getDeclaredNamespaces() {
     if (namespaces != null && !namespaces.isEmpty()) {
       // If namespaces are provided, used them
+      reconfigureRegistries(namespaces);
       return namespaces;
     } else {
       try {


### PR DESCRIPTION
if using the `namespaces` key for kubernetes accounts, reconfigure
registries using those namespaces.

@lwander PTAL