### PR TITLE
fix(provider/kubernetes): fix envvar source

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
@@ -432,10 +432,10 @@ class KubernetesApiConverter {
           res = res.withNewValueFrom()
           if (envVar.envSource.configMapSource) {
             def configMap = envVar.envSource.configMapSource
-            res = res.withNewConfigMapKeyRef(configMap.key, configMap.configMapName)
+            res = res.withNewConfigMapKeyRef(configMap.key, configMap.configMapName, configMap.optional)
           } else if (envVar.envSource.secretSource) {
             def secret = envVar.envSource.secretSource
-            res = res.withNewSecretKeyRef(secret.key, secret.secretName)
+            res = res.withNewSecretKeyRef(secret.key, secret.secretName, secret.optional)
           } else if (envVar.envSource.fieldRef) {
             def fieldPath = envVar.envSource.fieldRef.fieldPath
             res = res.withNewFieldRef().withFieldPath(fieldPath).endFieldRef()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -219,6 +219,7 @@ class KubernetesFieldRefSource {
 class KubernetesSecretSource {
   String secretName
   String key
+  Boolean optional = true
 }
 
 @AutoClone
@@ -226,6 +227,7 @@ class KubernetesSecretSource {
 class KubernetesConfigMapSource {
   String configMapName
   String key
+  Boolean optional = true
 }
 
 @AutoClone


### PR DESCRIPTION
the bump in client library broke the API for configMap and secret envvar
sources. adds an extra property for optional. defaults to true to
preserve backwards compatibility. shoutout major version bumps.

@lwander PTAL.