### PR TITLE
feat(provider/gce): Support for RMIG zone selection.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -600,6 +600,10 @@ class GCEUtil {
     return GCE_API_PREFIX + "$projectName/regions/$region/instanceGroups/$serverGroupName"
   }
 
+  static String buildZoneUrl(String projectName, String zone) {
+    return GCE_API_PREFIX + "$projectName/zones/$zone"
+  }
+
   static List<AttachedDisk> buildAttachedDisks(BaseGoogleInstanceDescription description,
                                                String zone,
                                                boolean useDiskTypeUrl,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BasicGoogleDeployDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BasicGoogleDeployDescription.groovy
@@ -20,6 +20,7 @@ import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoHealingPolicy
+import com.netflix.spinnaker.clouddriver.google.model.GoogleDistributionPolicy
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleHttpLoadBalancingPolicy
 import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
 import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
@@ -39,6 +40,7 @@ class BasicGoogleDeployDescription extends BaseGoogleInstanceDescription impleme
   Integer targetSize
   String region
   Boolean regional
+  Boolean selectZones
   String zone
   List<String> loadBalancers
   Boolean disableTraffic
@@ -46,6 +48,10 @@ class BasicGoogleDeployDescription extends BaseGoogleInstanceDescription impleme
   GoogleAutoscalingPolicy autoscalingPolicy
   GoogleHttpLoadBalancingPolicy loadBalancingPolicy
   GoogleAutoHealingPolicy autoHealingPolicy
+  /**
+   * Optional explicit specification of zones for an RMIG.
+   */
+  GoogleDistributionPolicy distributionPolicy
   // Capacity is optional. If it is specified, capacity.desired takes precedence over targetSize.
   // If autoscalingPolicy is also specified, capacity.min and capacity.max take precedence over
   // autoscalingPolicy.minNumReplicas and autoscalingPolicy.maxNumReplicas.

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CopyLastGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CopyLastGoogleServerGroupAtomicOperation.groovy
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.clouddriver.google.deploy.handlers.BasicGoogleDeplo
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoHealingPolicy
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
 import com.netflix.spinnaker.clouddriver.google.model.GoogleDisk
+import com.netflix.spinnaker.clouddriver.google.model.GoogleDistributionPolicy
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import org.springframework.beans.factory.annotation.Autowired
@@ -128,6 +129,11 @@ class CopyLastGoogleServerGroupAtomicOperation extends GoogleAtomicOperation<Dep
         description.targetSize != null
         ? description.targetSize
         : ancestorServerGroup.capacity.desired
+    newDescription.distributionPolicy =
+      description.distributionPolicy != null ?
+        description.distributionPolicy :
+        ancestorServerGroup.distributionPolicy
+    newDescription.selectZones = description.selectZones ?: ancestorServerGroup.selectZones
 
     def ancestorInstanceTemplate = ancestorServerGroup.launchConfig.instanceTemplate
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleDistributionPolicy.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleDistributionPolicy.java
@@ -1,0 +1,17 @@
+package com.netflix.spinnaker.clouddriver.google.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Distribution policy for selecting zones in a regional MIG.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleDistributionPolicy {
+  List<String> zones;
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
@@ -52,6 +52,11 @@ class GoogleServerGroup {
   Map<String, String> instanceTemplateLabels = [:]
   String selfLink
   InstanceGroupManagerActionsSummary currentActions
+  /**
+   * Optional explicit specification of zones for an RMIG.
+   */
+  GoogleDistributionPolicy distributionPolicy
+  Boolean selectZones
 
   @JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.PROPERTY, property="class")
   AutoscalingPolicy autoscalingPolicy
@@ -79,6 +84,7 @@ class GoogleServerGroup {
     static final String GLOBAL_LOAD_BALANCER_NAMES = "global-load-balancer-names"
     static final String BACKEND_SERVICE_NAMES = "backend-service-names"
     static final String LOAD_BALANCING_POLICY = "load-balancing-policy"
+    static final String SELECT_ZONES = 'select-zones'
 
     String name = GoogleServerGroup.this.name
     String region = GoogleServerGroup.this.region
@@ -102,6 +108,8 @@ class GoogleServerGroup {
     AutoscalingPolicy autoscalingPolicy = GoogleServerGroup.this.autoscalingPolicy
     List<String> autoscalingMessages = GoogleServerGroup.this.autoscalingMessages
     InstanceGroupManagerAutoHealingPolicy autoHealingPolicy = GoogleServerGroup.this.autoHealingPolicy
+    GoogleDistributionPolicy distributionPolicy = GoogleServerGroup.this.distributionPolicy
+    Boolean selectZones = GoogleServerGroup.this.selectZones
 
     @Override
     Boolean isDisabled() { // Because groovy isn't smart enough to generate this method :-(


### PR DESCRIPTION
fyi @duftler as well.

Added a metadata entry to handle the case where users just want to use the default zones in a region since there is no flag indicating that in the platform. Removed the (possibly) brittle logic calculating default zones since the platform reports the zones it will use regardless of whether or not a user chose specific zones.