### PR TITLE
fix(provider/kubernetes): registry init fix

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
@@ -131,11 +131,8 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
 
   public List<String> getDeclaredNamespaces() {
     if (namespaces != null && !namespaces.isEmpty()) {
-      List<String> toInitialize = new ArrayList<>(namespaces);
-      List<String> initializedNamespaces = new ArrayList<>(imagePullSecrets.keySet());
-      toInitialize.removeAll(initializedNamespaces);
-      reconfigureRegistries(toInitialize);
       // If namespaces are provided, used them
+      reconfigureRegistries(namespaces);
       return namespaces;
     } else {
       try {
@@ -163,6 +160,10 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
     if (!configureImagePullSecrets) {
       return;
     }
+
+    // only initialize namespaces that haven't been initialized yet.
+    List<String> initializedNamespaces = new ArrayList<>(imagePullSecrets.keySet());
+    affectedNamespaces.removeAll(initializedNamespaces);
 
     for (int i = 0; i < dockerRegistries.size(); i++) {
       LinkedDockerRegistryConfiguration registry = dockerRegistries.get(i);


### PR DESCRIPTION
for real this time. the previous fix caused registry namespaces to get
set to an empty list the second time the initialization occurred. moving
it down into this method allows us to still use the full list of
namespaces (`allNamespaces`) and setup the affected ones to be
initialized. This would occur if a new namespace was added, for
instance.

@lwander PTAL.