### PR TITLE
fix(core/search): Fix search query which matches non-conforming cache keys

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/search/ServerGroupKeyProcessor.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/search/ServerGroupKeyProcessor.groovy
@@ -1,9 +1,7 @@
 package com.netflix.spinnaker.clouddriver.aws.search
 
 import com.netflix.spinnaker.cats.cache.Cache
-import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
-import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.cache.KeyProcessor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -22,16 +20,7 @@ class ServerGroupKeyProcessor implements KeyProcessor {
   }
 
   @Override
-  Boolean exists(String key) {
-
-    Map<String, String> parsed = Keys.parse(key)
-    String account = parsed['account']
-    String region = parsed['region']
-    String name = parsed['serverGroup']
-
-    String serverGroupKey = Keys.getServerGroupKey(name, account, region)
-    CacheData serverGroupData = cacheView.get(SERVER_GROUPS.ns, serverGroupKey, RelationshipCacheFilter.none())
-
-    return serverGroupData != null;
+  Boolean exists(String serverGroupKey) {
+    return cacheView.get(SERVER_GROUPS.ns, serverGroupKey, RelationshipCacheFilter.none()) != null
   }
 }


### PR DESCRIPTION
Certain cache keys were failing due to `Keys.parse()` returning null.
Turns out there is no need to parse the cache key and then reconstruct it so stop doing that.