### PR TITLE
feat(provider/kubernetes): support envFrom

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -105,6 +105,7 @@ class KubernetesContainerDescription {
 
   List<KubernetesVolumeMount> volumeMounts
   List<KubernetesEnvVar> envVars
+  List<KubernetesEnvFromSource> envFrom
 
   List<String> command
   List<String> args
@@ -166,6 +167,28 @@ class KubernetesEnvVar {
   String name
   String value
   KubernetesEnvVarSource envSource
+}
+
+@AutoClone
+@Canonical
+class KubernetesEnvFromSource {
+  String prefix
+  KubernetesConfigMapEnvSource configMapRef
+  KubernetesSecretEnvSource secretRef
+}
+
+@AutoClone
+@Canonical
+class KubernetesConfigMapEnvSource {
+  String name
+  boolean optional
+}
+
+@AutoClone
+@Canonical
+class KubernetesSecretEnvSource {
+  String name
+  boolean optional
 }
 
 @AutoClone


### PR DESCRIPTION
adds support for envFrom for the v1 provider. envFrom can be either a
secret or config map reference and will be injected into the pod as
environment variables.

@lwander PTAL

spinnaker/spinnaker#2120
