### PR TITLE
feat(provider/kubernetes): init containers

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
@@ -693,6 +693,10 @@ class KubernetesApiConverter {
       fromContainer(it)
     } ?: []
 
+    deployDescription.initContainers = replicaSet?.spec?.template?.spec?.initContainers?.collect {
+      fromContainer(it)
+    } ?: []
+
     deployDescription.terminationGracePeriodSeconds = replicaSet?.spec?.template?.spec?.terminationGracePeriodSeconds
     deployDescription.serviceAccountName = replicaSet?.spec?.template?.spec?.serviceAccountName
 
@@ -746,6 +750,10 @@ class KubernetesApiConverter {
     } ?: []
 
     deployDescription.containers = replicationController?.spec?.template?.spec?.containers?.collect {
+      fromContainer(it)
+    } ?: []
+
+    deployDescription.initContainers = replicationController?.spec?.template?.spec?.initContainers?.collect {
       fromContainer(it)
     } ?: []
 
@@ -1019,6 +1027,12 @@ class KubernetesApiConverter {
     }
 
     podTemplateSpecBuilder = podTemplateSpecBuilder.withContainers(containers)
+
+    def initContainers = description.initContainers.collect { initContainer ->
+      toContainer(initContainer)
+    }
+
+    podTemplateSpecBuilder = podTemplateSpecBuilder.withInitContainers(initContainers)
 
     return podTemplateSpecBuilder.endSpec().build()
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -36,6 +36,7 @@ class DeployKubernetesAtomicOperationDescription extends KubernetesKindAtomicOpe
   List<String> loadBalancers
   List<String> securityGroups
   List<KubernetesContainerDescription> containers
+  List<KubernetesContainerDescription> initContainers
   List<KubernetesVolumeSource> volumeSources
   Capacity capacity
   KubernetesScalingPolicy scalingPolicy


### PR DESCRIPTION
adds support for initContainer property of the Pod spec

@lwander can i get some feedback on this? I went with a separate `KubernetesInitContainerDescription` because they don't support readiness/liveness probes or lifecycle hooks. i'm also not totally stoked on the `toInitContainer` method creating a new container and passing it on. I'd rather cast to a container if possible. Any thoughts?
