### PR TITLE
fix(provider/amazon): ignore description when upserting security grou…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
@@ -85,18 +85,21 @@ class SecurityGroupIngressConverter {
         it.groupName = null
         it.peeringStatus = null
         it.vpcPeeringConnectionId = null
+        it.description = null // not passed in via the UI
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)
           .withIpProtocol(ipPermission.ipProtocol)
           .withUserIdGroupPairs(it)
       } + ipPermission.ipv4Ranges.collect {
+        it.description = null // not passed in via the UI
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)
           .withIpProtocol(ipPermission.ipProtocol)
           .withIpv4Ranges(it)
       } + ipPermission.ipv6Ranges.collect {
+        it.description = null // not passed in via the UI
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)


### PR DESCRIPTION
…p rules

This is an edge case we haven't encountered (until this morning), but ingress rules have a `description` field. We do not pass that in via the UI, so, when we recreate the rules to determine if we need to add/remove them, we'll always consider a rule with a description as a new rule, and Amazon will throw an exception.
