### PR TITLE
fix(provider/aws): handle spotPrice ==  in rollingpush

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgLaunchConfigurationOperation.groovy
@@ -78,6 +78,10 @@ class ModifyAsgLaunchConfigurationOperation implements AtomicOperation<Void> {
     props = props + description.properties.findResults { k, v -> (v != null && settingsKeys.contains(k)) ? [k, v] : null }.collectEntries()
     props.remove('class')
 
+    if (props.spotPrice == "") {
+      // a spotPrice of "" indicates that it should be removed regardless of value on source launch configuration
+      props.spotPrice = null
+    }
 
     if (description.amiName) {
       def amazonEC2 = regionScopedProvider.amazonEC2


### PR DESCRIPTION
Correctly handling spotPrice in a rollingpush strategy. @duftler is there any reason why you left out validation logic in this class? Want to make sure I'm not breaking anything around spotPrice!