### PR TITLE
debug(provider/aws): Avoid thread pool when building reservation report

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
@@ -179,19 +179,11 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
     ConcurrentHashMap<String, OverallReservationDetail> reservations = new ConcurrentHashMap<>()
     ConcurrentHashMap<String, Collection<String>> errorsByRegion = new ConcurrentHashMap<>()
 
-    Map<NetflixAmazonCredentials, Future> tasks = accounts.collectEntries { NetflixAmazonCredentials credential ->
-      [
-        (credential) : reservationReportPool.submit {
-          extractReservations(reservations, errorsByRegion, credential)
-        }
-      ]
-    }
-
-    tasks.each {
+    accounts.each { NetflixAmazonCredentials credential ->
       try {
-        it.value.get()
+        extractReservations(reservations, errorsByRegion, credential)
       } catch (Exception e) {
-        recordError(registry, errorsByRegion, it.key, "*", e)
+        recordError(registry, errorsByRegion, credential, "*", e)
       }
     }
 
@@ -307,11 +299,11 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
           }
 
           startTime = System.currentTimeMillis()
-
           def fetchedInstanceCount = 0
           def describeInstancesRequest = new DescribeInstancesRequest().withMaxResults(500)
           def allowedStates = ["pending", "running"] as Set<String>
           while (true) {
+            log.debug("Describing instances for ${credentials.name}/${region.name}")
             def result = amazonEC2.describeInstances(describeInstancesRequest)
             result.reservations.each {
               it.getInstances().each {


### PR DESCRIPTION
Attempting to track down an issue wherein the reservation report caching
agents _stop_ and are never rescheduled after some period of time.

Will revisit and remove the thread pool configuration if this change
happens to improve the stop/reschedule situation.
