### PR TITLE
fix(provider/amazon): do not try to create reserved tags

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -365,7 +365,9 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
       description.tags[SUBNET_ID_OVERRIDE_TAG] = description.subnetIds.join(",")
     }
 
-    //skip a couple of AWS calls if we won't use any of the data
+    description.tags = cleanTags(description.tags)
+
+    // skip a couple of AWS calls if we won't use any of the data
     if (!(useSourceCapacity || description.copySourceCustomBlockDeviceMappings)) {
       return description
     }
@@ -572,6 +574,12 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
     return convertBlockDevices(sourceLaunchConfiguration.blockDeviceMappings)
   }
 
+  @VisibleForTesting
+  @PackageScope
+  static Map<String, String> cleanTags(Map<String, String> tags) {
+    return tags ? tags.findAll { !it.key.startsWith("aws:") } : [:]
+  }
+
   /**
    * Add tags for application/stack/details iff `deployDefaults.addAppStackDetailTags` is true.
    */
@@ -584,7 +592,6 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
     }
 
     description = description.clone()
-    description.tags = description.tags ?: [:]
 
     if (description.application) {
       description.tags["spinnaker:application"] = description.application

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -786,7 +786,19 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     true                  | "app"       | null    | "details" | buildTags("app", "stack", "details") || buildTags("app", null, "details")       // should remove pre-existing tags if invalid
     true                  | null        | null    | null      | buildTags("app", "stack", "details") || [:]                                     // should remove pre-existing tags if invalid
     true                  | "app"       | null    | null      | [:]                                  || buildTags("app", null, null)
-    true                  | null        | null    | null      | null                                 || buildTags(null, null, null)
+    true                  | null        | null    | null      | [:]                                  || buildTags(null, null, null)
+  }
+
+  void "should not copy reserved aws tags"() {
+    expect:
+    BasicAmazonDeployHandler.cleanTags(tags) == expected
+
+    where:
+    tags                       || expected
+    null                       || [:]
+    [:]                        || [:]
+    ["a": "a"]                 || ["a": "a"]
+    ["a": "a", "aws:foo": "3"] || ["a": "a"]
   }
 
   private static Map buildTags(String application, String stack, String details) {


### PR DESCRIPTION
Per http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions, Spinnaker should not be copying tags over that have the `aws:` prefix, as they are generated by Amazon and an exception will be thrown when trying to create them. This can be a problem when a user tries to clone a server group that was created by Cloud Formation.

There are probably other scenarios where these tags could be present; this one was just pointed out by a user in Slack.

This is likely fallout from recent fixes to tag copying in the UI.

@ajordens or @cfieber PTAL