### PR TITLE
fix(provider/kubernetes): v2 Replace artifact only if target found

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
@@ -153,7 +153,7 @@ public class ArtifactReplacer {
       String jsonPath = processPath(replacePath, artifact);
 
       Object get = obj.read(jsonPath);
-      if (get == null) {
+      if (get == null || (get instanceof ArrayNode && ((ArrayNode) get).size() == 0)) {
         return false;
       }
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentHandlerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesDeploymentHandlerSpec.groovy
@@ -76,6 +76,8 @@ spec:
 
     then:
     result.manifest.spec.template.spec.containers[0].image == target
+    result.boundArtifacts.size() == 1
+    result.boundArtifacts.contains(artifact) == true
   }
 
   void "check that image isn't replaced by the artifact replacer"() {
@@ -91,6 +93,7 @@ spec:
 
     then:
     result.manifest.spec.template.spec.containers[0].image == IMAGE
+    result.boundArtifacts.isEmpty() == true
   }
 
   void "check that image is found"() {


### PR DESCRIPTION
Do not attempt artifact replacement if no target was found. Reading a non-existing path can return an empty `ArrayNode` object, in which case we should not attempt any replacement.
Add checks for bound artifacts in artifact replacement tests.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
