### PR TITLE
feat(provider/ecs): ECS Task Health caching classes and tests.

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskCacheClient.java
@@ -31,12 +31,12 @@ import java.util.Map;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
 
 public class TaskCacheClient extends AbstractCacheClient<Task> {
-  @Autowired
   private ObjectMapper mapper;
 
   @Autowired
   public TaskCacheClient(Cache cacheView, ObjectMapper mapper) {
     super(cacheView, TASKS.toString());
+    this.mapper = mapper;
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskHealthCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskHealthCacheClient.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache.client;
+
+import com.netflix.spinnaker.cats.cache.Cache;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.TaskHealth;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH;
+
+@Component
+public class TaskHealthCacheClient extends AbstractCacheClient<TaskHealth> {
+
+  @Autowired
+  public TaskHealthCacheClient(Cache cacheView) {
+    super(cacheView, HEALTH.toString());
+  }
+
+  @Override
+  protected TaskHealth convert(CacheData cacheData) {
+    TaskHealth taskHealth = new TaskHealth();
+
+    Map<String, Object> attributes = cacheData.getAttributes();
+    taskHealth.setState((String) attributes.get("state"));
+    taskHealth.setType((String) attributes.get("type"));
+    taskHealth.setServiceName((String) attributes.get("service"));
+    taskHealth.setTaskArn((String) attributes.get("taskArn"));
+    taskHealth.setInstanceId((String) attributes.get("instanceId"));
+    taskHealth.setTaskId((String) attributes.get("taskId"));
+
+    return taskHealth;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/TaskHealth.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/TaskHealth.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache.model;
+
+import lombok.Data;
+
+@Data
+public class TaskHealth {
+  String state;
+  String type;
+  String serviceName;
+  String taskArn;
+  String instanceId;
+  String taskId;
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ecs.AmazonECS;
+import com.amazonaws.services.ecs.model.LoadBalancer;
+import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing;
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult;
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.DefaultCacheData;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient;
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.ServiceCacheClient;
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskCacheClient;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.ContainerInstance;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.Service;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.Task;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.TaskHealth;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICES;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASK_DEFINITIONS;
+
+public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth> implements HealthProvidingCachingAgent {
+  private static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
+    AUTHORITATIVE.forType(HEALTH.toString())
+  ));
+  private final static String HEALTH_ID = "ecs-task-instance-health";
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private Collection<String> taskEvicitions;
+  private Collection<String> serviceEvicitions;
+  private Collection<String> taskDefEvicitions;
+  private ObjectMapper objectMapper;
+
+  public TaskHealthCachingAgent(String accountName, String region,
+                                AmazonClientProvider amazonClientProvider,
+                                AWSCredentialsProvider awsCredentialsProvider,
+                                ObjectMapper objectMapper) {
+    super(accountName, region, amazonClientProvider, awsCredentialsProvider);
+    this.objectMapper = objectMapper;
+  }
+
+  public static Map<String, Object> convertTaskHealthToAttributes(TaskHealth taskHealth) {
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("instanceId", taskHealth.getInstanceId());
+
+    attributes.put("state", taskHealth.getState());
+    attributes.put("type", taskHealth.getType());
+    attributes.put("service", taskHealth.getServiceName());
+    attributes.put("taskArn", taskHealth.getTaskArn());
+    attributes.put("taskId", taskHealth.getTaskId());
+    return attributes;
+  }
+
+  @Override
+  protected List<TaskHealth> getItems(AmazonECS ecs, ProviderCache providerCache) {
+    TaskCacheClient taskCacheClient = new TaskCacheClient(providerCache, objectMapper);
+    ServiceCacheClient serviceCacheClient = new ServiceCacheClient(providerCache, objectMapper);
+
+    AmazonElasticLoadBalancing amazonloadBalancing = amazonClientProvider.getAmazonElasticLoadBalancingV2(accountName, awsCredentialsProvider, region);
+
+    ContainerInstanceCacheClient containerInstanceCacheClient = new ContainerInstanceCacheClient(providerCache);
+
+    List<TaskHealth> taskHealthList = new LinkedList<>();
+    taskEvicitions = new LinkedList<>();
+    serviceEvicitions = new LinkedList<>();
+    taskDefEvicitions = new LinkedList<>();
+
+    Collection<Task> tasks = taskCacheClient.getAll();
+    if (tasks != null) {
+      for (Task task : tasks) {
+        String containerInstanceCacheKey = Keys.getContainerInstanceKey(accountName, region, task.getContainerInstanceArn());
+        ContainerInstance containerInstance = containerInstanceCacheClient.get(containerInstanceCacheKey);
+
+        String serviceName = StringUtils.substringAfter(task.getGroup(), "service:");
+        String serviceKey = Keys.getServiceKey(accountName, region, serviceName);
+        Service service = serviceCacheClient.get(serviceKey);
+        if (service == null) {
+          String taskEvictionKey = Keys.getTaskKey(accountName, region, task.getTaskId());
+          taskEvicitions.add(taskEvictionKey);
+          continue;
+        }
+
+        if (task.getContainers().size() == 0 ||
+          task.getContainers().get(0).getNetworkBindings() == null || task.getContainers().get(0).getNetworkBindings().size() == 0 ||
+          task.getContainers().get(0).getNetworkBindings().get(0) == null) {
+          continue;
+        }
+
+        int port = task.getContainers().get(0).getNetworkBindings().get(0).getHostPort();
+
+        List<LoadBalancer> loadBalancers = service.getLoadBalancers();
+
+        for (LoadBalancer loadBalancer : loadBalancers) {
+          if (loadBalancer.getTargetGroupArn() == null || containerInstance.getEc2InstanceId() == null) {
+            continue;
+          }
+
+          DescribeTargetHealthResult describeTargetHealthResult;
+          describeTargetHealthResult = amazonloadBalancing.describeTargetHealth(
+            new DescribeTargetHealthRequest().withTargetGroupArn(loadBalancer.getTargetGroupArn()).withTargets(
+              new TargetDescription().withId(containerInstance.getEc2InstanceId()).withPort(port)));
+
+          if (describeTargetHealthResult.getTargetHealthDescriptions().size() == 0) {
+            String serviceEvictionKey = Keys.getTaskDefinitionKey(accountName, region, service.getServiceName());
+            serviceEvicitions.add(serviceEvictionKey);
+            String taskEvictionKey = Keys.getTaskKey(accountName, region, task.getTaskId());
+            taskEvicitions.add(taskEvictionKey);
+
+            String taskDefArn = service.getTaskDefinition();
+            String taskDefKey = Keys.getTaskDefinitionKey(accountName, region, taskDefArn);
+            taskDefEvicitions.add(taskDefKey);
+            continue;
+          }
+
+          String targetHealth = describeTargetHealthResult.getTargetHealthDescriptions().get(0).getTargetHealth().getState();
+          // TODO - Return better values, and think of a better strategy at defining health
+          targetHealth = targetHealth.equals("healthy") ? "Up" : "Unknown";
+
+          TaskHealth taskHealth = new TaskHealth();
+          taskHealth.setType("loadBalancer");
+          taskHealth.setState(targetHealth);
+          taskHealth.setServiceName(serviceName);
+          taskHealth.setTaskId(task.getTaskId());
+          taskHealth.setTaskArn(task.getTaskArn());
+          taskHealth.setInstanceId(task.getTaskArn());
+
+          taskHealthList.add(taskHealth);
+        }
+      }
+    }
+
+    return taskHealthList;
+  }
+
+  @Override
+  protected Map<String, Collection<CacheData>> generateFreshData(Collection<TaskHealth> taskHealthList) {
+    Collection<CacheData> dataPoints = new LinkedList<>();
+
+    for (TaskHealth taskHealth : taskHealthList) {
+      Map<String, Object> attributes = convertTaskHealthToAttributes(taskHealth);
+
+      String key = Keys.getTaskHealthKey(accountName, region, taskHealth.getTaskId());
+      dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
+    }
+
+    log.info("Caching " + dataPoints.size() + " task health checks in " + getAgentType());
+    Map<String, Collection<CacheData>> dataMap = new HashMap<>();
+    dataMap.put(HEALTH.toString(), dataPoints);
+
+    return dataMap;
+  }
+
+  @Override
+  protected Map<String, Collection<String>> addExtraEvictions(Map<String, Collection<String>> evictions) {
+    if (taskEvicitions.size() != 0) {
+      if (evictions.containsKey(TASKS.toString())) {
+        evictions.get(TASKS.toString()).addAll(taskEvicitions);
+      } else {
+        evictions.put(TASKS.toString(), taskEvicitions);
+      }
+    }
+    if (serviceEvicitions.size() != 0) {
+      if (evictions.containsKey(SERVICES.toString())) {
+        evictions.get(SERVICES.toString()).addAll(serviceEvicitions);
+      } else {
+        evictions.put(SERVICES.toString(), serviceEvicitions);
+      }
+    }
+    if (taskDefEvicitions.size() != 0) {
+      if (evictions.containsKey(TASK_DEFINITIONS.toString())) {
+        evictions.get(TASK_DEFINITIONS.toString()).addAll(taskDefEvicitions);
+      } else {
+        evictions.put(TASK_DEFINITIONS.toString(), taskDefEvicitions);
+      }
+    }
+    return evictions;
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return types;
+  }
+
+  @Override
+  public String getAgentType() {
+    return TaskHealthCachingAgent.class.getSimpleName();
+  }
+
+  @Override
+  public String getHealthId() {
+    return HEALTH_ID;
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TaskHealthCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TaskHealthCacheClientSpec.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache
+
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskHealthCacheClient
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.TaskHealth
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.TaskHealthCachingAgent
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TaskHealthCacheClientSpec extends Specification {
+  def cacheView = Mock(Cache)
+  @Subject
+  private final TaskHealthCacheClient client = new TaskHealthCacheClient(cacheView)
+
+  def 'should convert'() {
+    given:
+    def taskId = '1dc5c17a-422b-4dc4-b493-371970c6c4d6'
+    def key = Keys.getTaskHealthKey('test-account', 'us-west-1', taskId)
+
+    def originalTaskHealth = new TaskHealth(
+      taskId: 'task-id',
+      type: 'type',
+      instanceId: 'i-deadbeef',
+      state: 'RUNNING',
+      taskArn: 'task-arn',
+      serviceName: 'service-name'
+    )
+
+    def attributes = TaskHealthCachingAgent.convertTaskHealthToAttributes(originalTaskHealth)
+    cacheView.get(Namespace.HEALTH.toString(), key) >> new DefaultCacheData(key, attributes, Collections.emptyMap())
+
+    when:
+    def retrievedTaskHealth = client.get(key)
+
+    then:
+    retrievedTaskHealth == originalTaskHealth
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCacheSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCacheSpec.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.agent
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.ecs.AmazonECS
+import com.amazonaws.services.ecs.model.Container
+import com.amazonaws.services.ecs.model.LoadBalancer
+import com.amazonaws.services.ecs.model.NetworkBinding
+import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealth
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthStateEnum
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskHealthCacheClient
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TaskHealthCacheSpec extends Specification {
+  def ecs = Mock(AmazonECS)
+  def clientProvider = Mock(AmazonClientProvider)
+  def providerCache = Mock(ProviderCache)
+  def credentialsProvider = Mock(AWSCredentialsProvider)
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Subject
+  TaskHealthCachingAgent agent = new TaskHealthCachingAgent(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, clientProvider, credentialsProvider, mapper)
+  TaskHealthCacheClient client = new TaskHealthCacheClient(providerCache)
+
+
+  def 'should retrieve from written cache'() {
+    given:
+    AmazonElasticLoadBalancing amazonloadBalancing = Mock(AmazonElasticLoadBalancing)
+    clientProvider.getAmazonElasticLoadBalancingV2(_, _, _) >> amazonloadBalancing
+
+    def targetGroupArn = 'arn:aws:elasticloadbalancing:' + CommonCachingAgent.REGION + ':769716316905:targetgroup/test-target-group/9e8997b7cff00c62'
+
+    def taskKey = Keys.getTaskKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_ID_1)
+    def healthKey = Keys.getTaskHealthKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_ID_1)
+    def serviceKey = Keys.getServiceKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.SERVICE_NAME_1)
+    def containerInstanceKey = Keys.getContainerInstanceKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.CONTAINER_INSTANCE_ARN_1)
+
+    ObjectMapper mapper = new ObjectMapper()
+    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(new NetworkBinding().withHostPort(1337)), Map.class)
+    Map<String, Object> loadbalancerMap = mapper.convertValue(new LoadBalancer().withTargetGroupArn(targetGroupArn), Map.class)
+
+    def taskAttributes = [
+      taskId              : CommonCachingAgent.TASK_ID_1,
+      taskArn             : CommonCachingAgent.TASK_ARN_1,
+      startedAt           : new Date().getTime(),
+      containerInstanceArn: CommonCachingAgent.CONTAINER_INSTANCE_ARN_1,
+      group               : 'service:' + CommonCachingAgent.SERVICE_NAME_1,
+      containers          : Collections.singletonList(containerMap)
+    ]
+    def taskCacheData = new DefaultCacheData(taskKey, taskAttributes, Collections.emptyMap())
+    providerCache.getAll(Keys.Namespace.TASKS.toString()) >> Collections.singletonList(taskCacheData)
+
+    def serviceAttributes = [
+      loadBalancers        : Collections.singletonList(loadbalancerMap),
+      taskDefinition       : CommonCachingAgent.TASK_DEFINITION_ARN_1,
+      desiredCount         : 1,
+      maximumPercent       : 1,
+      minimumHealthyPercent: 1,
+      createdAt            : new Date().getTime()
+    ]
+    def serviceCacheData = new DefaultCacheData(serviceKey, serviceAttributes, Collections.emptyMap())
+    providerCache.get(Keys.Namespace.SERVICES.toString(), serviceKey) >> serviceCacheData
+
+    def containerInstanceAttributes = [
+      ec2InstanceId: CommonCachingAgent.EC2_INSTANCE_ID_1
+    ]
+    def containerInstanceCache = new DefaultCacheData(containerInstanceKey, containerInstanceAttributes, Collections.emptyMap())
+    providerCache.get(Keys.Namespace.CONTAINER_INSTANCES.toString(), containerInstanceKey) >> containerInstanceCache
+
+    DescribeTargetHealthResult describeTargetHealthResult = new DescribeTargetHealthResult().withTargetHealthDescriptions(
+      new TargetHealthDescription().withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy))
+    )
+
+    amazonloadBalancing.describeTargetHealth(_) >> describeTargetHealthResult
+    providerCache.getAll(Namespace.HEALTH.toString()) >> []
+
+    when:
+    def cacheResult = agent.loadData(providerCache)
+    providerCache.get(Namespace.HEALTH.toString(), healthKey) >> cacheResult.getCacheResults().get(Namespace.HEALTH.toString()).iterator().next()
+
+    then:
+    def cacheData = cacheResult.getCacheResults().get(Namespace.HEALTH.toString())
+    def taskHealth = client.get(healthKey)
+
+    cacheData != null
+    cacheData.size() == 1
+
+    def retrievedKey = cacheData.iterator().next().getId()
+    retrievedKey == healthKey
+
+    taskHealth.getState() == 'Up'
+    taskHealth.getType() == 'loadBalancer'
+    taskHealth.getInstanceId() == CommonCachingAgent.TASK_ARN_1
+    taskHealth.getServiceName() == CommonCachingAgent.SERVICE_NAME_1
+    taskHealth.getTaskArn() == CommonCachingAgent.TASK_ARN_1
+    taskHealth.getTaskId() == CommonCachingAgent.TASK_ID_1
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.agent
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.ecs.AmazonECS
+import com.amazonaws.services.ecs.model.Container
+import com.amazonaws.services.ecs.model.LoadBalancer
+import com.amazonaws.services.ecs.model.NetworkBinding
+import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
+import com.amazonaws.services.elasticloadbalancingv2.model.DescribeTargetHealthResult
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealth
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthDescription
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetHealthStateEnum
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.TaskHealth
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TaskHealthCachingAgentSpec extends Specification {
+  def ecs = Mock(AmazonECS)
+  def clientProvider = Mock(AmazonClientProvider)
+  def providerCache = Mock(ProviderCache)
+  def credentialsProvider = Mock(AWSCredentialsProvider)
+  ObjectMapper mapper = new ObjectMapper()
+
+  @Subject
+  TaskHealthCachingAgent agent = new TaskHealthCachingAgent(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, clientProvider, credentialsProvider, mapper)
+
+
+  def 'should get a list of task definitions'() {
+    given:
+    AmazonElasticLoadBalancing amazonloadBalancing = Mock(AmazonElasticLoadBalancing)
+    clientProvider.getAmazonElasticLoadBalancingV2(_, _, _) >> amazonloadBalancing
+
+    def targetGroupArn = 'arn:aws:elasticloadbalancing:' + CommonCachingAgent.REGION + ':769716316905:targetgroup/test-target-group/9e8997b7cff00c62'
+
+    def taskKey = Keys.getTaskKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_ID_1)
+    def serviceKey = Keys.getServiceKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.SERVICE_NAME_1)
+    def containerInstanceKey = Keys.getContainerInstanceKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.CONTAINER_INSTANCE_ARN_1)
+
+    ObjectMapper mapper = new ObjectMapper()
+    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(new NetworkBinding().withHostPort(1337)), Map.class)
+    Map<String, Object> loadbalancerMap = mapper.convertValue(new LoadBalancer().withTargetGroupArn(targetGroupArn), Map.class)
+
+    def taskAttributes = [
+      taskId               : CommonCachingAgent.TASK_ID_1,
+      taskArn              : CommonCachingAgent.TASK_ARN_1,
+      startedAt            : new Date().getTime(),
+      containerInstanceArn: CommonCachingAgent.CONTAINER_INSTANCE_ARN_1,
+      group                : 'service:' + CommonCachingAgent.SERVICE_NAME_1,
+      containers           : Collections.singletonList(containerMap)
+    ]
+    def taskCacheData = new DefaultCacheData(taskKey, taskAttributes, Collections.emptyMap())
+    providerCache.getAll(Keys.Namespace.TASKS.toString()) >> Collections.singletonList(taskCacheData)
+
+    def serviceAttributes = [
+      loadBalancers        : Collections.singletonList(loadbalancerMap),
+      taskDefinition       : CommonCachingAgent.TASK_DEFINITION_ARN_1,
+      desiredCount         : 1,
+      maximumPercent       : 1,
+      minimumHealthyPercent: 1,
+      createdAt            : new Date().getTime()
+    ]
+    def serviceCacheData = new DefaultCacheData(serviceKey, serviceAttributes, Collections.emptyMap())
+    providerCache.get(Keys.Namespace.SERVICES.toString(), serviceKey) >> serviceCacheData
+
+    def containerInstanceAttributes = [
+      ec2InstanceId: CommonCachingAgent.EC2_INSTANCE_ID_1
+    ]
+    def containerInstanceCache = new DefaultCacheData(containerInstanceKey, containerInstanceAttributes, Collections.emptyMap())
+    providerCache.get(Keys.Namespace.CONTAINER_INSTANCES.toString(), containerInstanceKey) >> containerInstanceCache
+
+    DescribeTargetHealthResult describeTargetHealthResult = new DescribeTargetHealthResult().withTargetHealthDescriptions(
+      new TargetHealthDescription().withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy))
+    )
+
+    amazonloadBalancing.describeTargetHealth(_) >> describeTargetHealthResult
+
+    when:
+    def taskHealthList = agent.getItems(ecs, providerCache)
+
+    then:
+    taskHealthList.size() == 1
+    TaskHealth taskHealth = taskHealthList.get(0)
+    taskHealth.getState() == 'Up'
+    taskHealth.getType() == 'loadBalancer'
+    taskHealth.getInstanceId() == CommonCachingAgent.TASK_ARN_1
+    taskHealth.getServiceName() == CommonCachingAgent.SERVICE_NAME_1
+    taskHealth.getTaskArn() == CommonCachingAgent.TASK_ARN_1
+    taskHealth.getTaskId() == CommonCachingAgent.TASK_ID_1
+  }
+
+  def 'should generate fresh data'() {
+    given:
+    def taskIds = [CommonCachingAgent.TASK_ID_1, CommonCachingAgent.TASK_ID_2]
+
+    def taskHealthList = []
+    def keys = []
+
+    for (String taskId : taskIds) {
+      taskHealthList << new TaskHealth(
+        taskId: taskId,
+        type: 'loadBalancer',
+        state: 'Up',
+        instanceId: 'i-deadbeef',
+        taskArn: 'task-arn',
+        serviceName: 'service-name'
+      )
+
+      keys << Keys.getTaskHealthKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, taskId)
+    }
+
+    when:
+    def dataMap = agent.generateFreshData(taskHealthList)
+
+    then:
+    dataMap.keySet().size() == 1
+    dataMap.containsKey(Namespace.HEALTH.toString())
+    dataMap.get(Namespace.HEALTH.toString()).size() == taskIds.size()
+
+    for (CacheData cacheData : dataMap.get(Namespace.HEALTH.toString())) {
+      def attributes = cacheData.getAttributes()
+      keys.contains(cacheData.getId())
+      taskIds.contains(attributes.get('taskId'))
+      attributes.get('state') == 'Up'
+      attributes.get('service') == 'service-name'
+      attributes.get('taskArn') == 'task-arn'
+      attributes.get('type') == 'loadBalancer'
+      attributes.get('instanceId') == 'i-deadbeef'
+    }
+  }
+}


### PR DESCRIPTION
Adds an TaskHealthCachingAgent which is responsible for caching ECS Task health information, along with TaskHealthCacheClient.
The client allows providers/services to interface more easily with the cache.

@cfieber @ajordens @robzienert @BrunoCarrier