### PR TITLE
feat(provider/ecs): ECS Metric Alarm caching classes and tests

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -32,7 +32,8 @@ public class Keys implements KeyParser {
     ECS_CLUSTERS,
     TASKS,
     CONTAINER_INSTANCES,
-    TASK_DEFINITIONS;
+    TASK_DEFINITIONS,
+    ALARMS;
 
     public final String ns;
 
@@ -102,6 +103,9 @@ public class Keys implements KeyParser {
       case TASK_DEFINITIONS:
         result.put("taskDefinitionArn", parts[4]);
         break;
+      case ALARMS:
+        result.put("alarmArn", parts[4]);
+        break;
       case IAM_ROLE:
         result.put("roleName", parts[3]);
       default:
@@ -138,6 +142,10 @@ public class Keys implements KeyParser {
 
   public static String getTaskDefinitionKey(String account, String region, String taskDefinitionArn) {
     return buildKey(Namespace.TASK_DEFINITIONS.ns, account, region, taskDefinitionArn);
+  }
+
+  public static String getAlarmKey(String account, String region, String alarmArn) {
+    return buildKey(Namespace.ALARMS.ns, account, region, alarmArn);
   }
 
   public static String getIamRoleKey(String account, String iamRoleName) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsCloudWatchAlarmCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsCloudWatchAlarmCacheClient.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache.client;
+
+import com.netflix.spinnaker.cats.cache.Cache;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsMetricAlarm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ALARMS;
+
+@Component
+public class EcsCloudWatchAlarmCacheClient extends AbstractCacheClient<EcsMetricAlarm> {
+
+  @Autowired
+  public EcsCloudWatchAlarmCacheClient(Cache cacheView) {
+    super(cacheView, ALARMS.toString());
+  }
+
+  @Override
+  protected EcsMetricAlarm convert(CacheData cacheData) {
+    EcsMetricAlarm metricAlarm = new EcsMetricAlarm();
+    Map<String, Object> attributes = cacheData.getAttributes();
+
+    metricAlarm.setAlarmArn((String) attributes.get("alarmArn"));
+    metricAlarm.setAlarmName((String) attributes.get("alarmName"));
+    metricAlarm.setAccountName((String) attributes.get("accountName"));
+    metricAlarm.setRegion((String) attributes.get("region"));
+
+    if (attributes.containsKey("alarmActions") && attributes.get("alarmActions") != null) {
+      metricAlarm.setAlarmActions((Collection<String>) attributes.get("alarmActions"));
+    } else {
+      metricAlarm.setAlarmActions(Collections.emptyList());
+    }
+
+    if (attributes.containsKey("okActions") && attributes.get("okActions") != null) {
+      metricAlarm.setOKActions((Collection<String>) attributes.get("okActions"));
+    } else {
+      metricAlarm.setOKActions(Collections.emptyList());
+    }
+
+    if (attributes.containsKey("insufficientDataActions") && attributes.get("insufficientDataActions") != null) {
+      metricAlarm.setInsufficientDataActions((Collection<String>) attributes.get("insufficientDataActions"));
+    } else {
+      metricAlarm.setInsufficientDataActions(Collections.emptyList());
+    }
+
+    return metricAlarm;
+  }
+
+  public List<EcsMetricAlarm> getMetricAlarms(String serviceName, String accountName, String region) {
+    List<EcsMetricAlarm> metricAlarms = new LinkedList<>();
+    Collection<EcsMetricAlarm> allMetricAlarms = getAll(accountName, region);
+
+    outLoop:
+    for (EcsMetricAlarm metricAlarm : allMetricAlarms) {
+      for (String action : metricAlarm.getAlarmActions()) {
+        if (action.contains(serviceName)) {
+          metricAlarms.add(metricAlarm);
+          continue outLoop;
+        }
+      }
+
+      for (String action : metricAlarm.getOKActions()) {
+        if (action.contains(serviceName)) {
+          metricAlarms.add(metricAlarm);
+          continue outLoop;
+        }
+      }
+
+      for (String action : metricAlarm.getInsufficientDataActions()) {
+        if (action.contains(serviceName)) {
+          metricAlarms.add(metricAlarm);
+          continue outLoop;
+        }
+      }
+    }
+
+    return metricAlarms;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/EcsMetricAlarm.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/EcsMetricAlarm.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache.model;
+
+import com.amazonaws.services.cloudwatch.model.MetricAlarm;
+import lombok.Data;
+
+@Data
+public class EcsMetricAlarm extends MetricAlarm {
+  private String accountName;
+  private String region;
+
+  public EcsMetricAlarm withAccountName(String accountName){
+    setAccountName(accountName);
+    return this;
+  }
+
+  public EcsMetricAlarm withRegion(String region){
+    setRegion(region);
+    return this;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.model.DescribeAlarmsRequest;
+import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult;
+import com.amazonaws.services.cloudwatch.model.MetricAlarm;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.agent.CacheResult;
+import com.netflix.spinnaker.cats.agent.CachingAgent;
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.DefaultCacheData;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
+import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ALARMS;
+
+public class EcsCloudMetricAlarmCachingAgent implements CachingAgent {
+  static final Collection<AgentDataType> types = Collections.unmodifiableCollection(Arrays.asList(
+    AUTHORITATIVE.forType(ALARMS.toString())
+  ));
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private AmazonClientProvider amazonClientProvider;
+  private AWSCredentialsProvider awsCredentialsProvider;
+  private String accountName;
+  private String region;
+
+  public EcsCloudMetricAlarmCachingAgent(String accountName, String region,
+                                         AmazonClientProvider amazonClientProvider,
+                                         AWSCredentialsProvider awsCredentialsProvider) {
+    this.region = region;
+    this.accountName = accountName;
+    this.amazonClientProvider = amazonClientProvider;
+    this.awsCredentialsProvider = awsCredentialsProvider;
+  }
+
+  public static Map<String, Object> convertMetricAlarmToAttributes(MetricAlarm metricAlarm, String accountName, String region) {
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("alarmArn", metricAlarm.getAlarmArn());
+    attributes.put("alarmName", metricAlarm.getAlarmName());
+    attributes.put("alarmActions", metricAlarm.getAlarmActions());
+    attributes.put("okActions", metricAlarm.getOKActions());
+    attributes.put("insufficientDataActions", metricAlarm.getInsufficientDataActions());
+    attributes.put("accountName", accountName);
+    attributes.put("region", region);
+    return attributes;
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return types;
+  }
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    AmazonCloudWatch cloudWatch = amazonClientProvider.getAmazonCloudWatch(accountName, awsCredentialsProvider, region);
+
+    Set<MetricAlarm> cacheableMetricAlarm = fetchMetricAlarms(cloudWatch);
+    Map<String, Collection<CacheData>> newDataMap = generateFreshData(cacheableMetricAlarm);
+    Collection<CacheData> newData = newDataMap.get(ALARMS.toString());
+
+    Set<String> oldKeys = providerCache.getAll(ALARMS.toString()).stream()
+      .map(CacheData::getId).collect(Collectors.toSet());
+    Map<String, Collection<String>> evictionsByKey = computeEvictableData(newData, oldKeys);
+
+    return new DefaultCacheResult(newDataMap, evictionsByKey);
+  }
+
+  private Map<String, Collection<String>> computeEvictableData(Collection<CacheData> newData, Collection<String> oldKeys) {
+    Set<String> newKeys = newData.stream().map(CacheData::getId).collect(Collectors.toSet());
+    Set<String> evictedKeys = oldKeys.stream().filter(oldKey -> !newKeys.contains(oldKey)).collect(Collectors.toSet());
+
+    Map<String, Collection<String>> evictionsByKey = new HashMap<>();
+    evictionsByKey.put(ALARMS.toString(), evictedKeys);
+    log.info("Evicting " + evictedKeys.size() + " cloud metrics alarms in " + getAgentType());
+    return evictionsByKey;
+  }
+
+  Map<String, Collection<CacheData>> generateFreshData(Set<MetricAlarm> cacheableMetricAlarm) {
+    Collection<CacheData> dataPoints = new HashSet<>();
+    Map<String, Collection<CacheData>> newDataMap = new HashMap<>();
+
+    for (MetricAlarm metricAlarm : cacheableMetricAlarm) {
+      String key = Keys.getAlarmKey(accountName, region, metricAlarm.getAlarmArn());
+      Map<String, Object> attributes = convertMetricAlarmToAttributes(metricAlarm, accountName, region);
+
+      CacheData data = new DefaultCacheData(key, attributes, Collections.emptyMap());
+      dataPoints.add(data);
+    }
+
+    log.info("Caching " + dataPoints.size() + " cloud metrics alarms in " + getAgentType());
+    newDataMap.put(ALARMS.toString(), dataPoints);
+    return newDataMap;
+  }
+
+  Set<MetricAlarm> fetchMetricAlarms(AmazonCloudWatch cloudWatch) {
+    Set<MetricAlarm> cacheableMetricAlarm = new HashSet<>();
+    String nextToken = null;
+    do {
+      DescribeAlarmsRequest request = new DescribeAlarmsRequest();
+      if (nextToken != null) {
+        request.setNextToken(nextToken);
+      }
+
+      DescribeAlarmsResult describeAlarmsResult = cloudWatch.describeAlarms(request);
+      cacheableMetricAlarm.addAll(describeAlarmsResult.getMetricAlarms());
+
+      nextToken = describeAlarmsResult.getNextToken();
+    } while (nextToken != null && nextToken.length() != 0);
+
+    return cacheableMetricAlarm;
+  }
+
+  @Override
+  public String getAgentType() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public String getProviderName() {
+    return EcsProvider.NAME;
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsCloudWatchAlarmCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsCloudWatchAlarmCacheClientSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache
+
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsCloudWatchAlarmCacheClient
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsMetricAlarm
+import com.netflix.spinnaker.clouddriver.ecs.provider.agent.EcsCloudMetricAlarmCachingAgent
+import spock.lang.Specification
+import spock.lang.Subject
+
+class EcsCloudWatchAlarmCacheClientSpec extends Specification {
+  def cacheView = Mock(Cache)
+  @Subject
+  EcsCloudWatchAlarmCacheClient client = new EcsCloudWatchAlarmCacheClient(cacheView)
+
+  def 'should convert cache data into object'() {
+    given:
+    def accountName = 'test-account-1'
+    def region = 'us-west-1'
+    def metricAlarm = new EcsMetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn").withRegion(region).withAccountName(accountName)
+    def key = Keys.getAlarmKey(accountName, region, metricAlarm.getAlarmArn())
+    def attributes = EcsCloudMetricAlarmCachingAgent.convertMetricAlarmToAttributes(metricAlarm, accountName, region)
+
+    when:
+    def returnedMetricAlarm = client.get(key)
+
+    then:
+    cacheView.get(Keys.Namespace.ALARMS.ns, key) >> new DefaultCacheData(key, attributes, [:])
+    returnedMetricAlarm == metricAlarm
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgentSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.agent
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsMetricAlarm
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class EcsCloudMetricAlarmCachingAgentSpec extends Specification {
+  @Shared
+  String ACCOUNT = 'test-account'
+  @Shared
+  String REGION = 'us-west-1'
+  AmazonCloudWatch cloudWatch
+  AmazonClientProvider clientProvider
+  ProviderCache providerCache
+  AWSCredentialsProvider credentialsProvider
+
+  @Subject
+  EcsCloudMetricAlarmCachingAgent agent = new EcsCloudMetricAlarmCachingAgent(ACCOUNT, REGION, clientProvider, credentialsProvider)
+
+  def setup() {
+    cloudWatch = Mock(AmazonCloudWatch)
+    clientProvider = Mock(AmazonClientProvider)
+    providerCache = Mock(ProviderCache)
+    credentialsProvider = Mock(AWSCredentialsProvider)
+  }
+
+  def 'should get a list of cloud watch alarms'() {
+    given:
+    def metricAlarm = new EcsMetricAlarm().withAlarmName("alarm-name").withAlarmArn("alarmArn")
+
+    when:
+    def alarms = agent.fetchMetricAlarms(cloudWatch)
+
+    then:
+    cloudWatch.describeAlarms(_) >> new DescribeAlarmsResult().withMetricAlarms(metricAlarm)
+    alarms.contains(metricAlarm)
+  }
+
+  def 'should generate fresh data'() {
+    given:
+    Set metricAlarms = [new EcsMetricAlarm().withAlarmName("alarm-name-1").withAlarmArn("alarmArn-1").withAccountName(ACCOUNT).withRegion(REGION),
+                        new EcsMetricAlarm().withAlarmName("alarm-name-2").withAlarmArn("alarmArn-2").withAccountName(ACCOUNT).withRegion(REGION)]
+    when:
+    def cacheData = agent.generateFreshData(metricAlarms)
+
+    then:
+    cacheData.size() == 1
+    cacheData.get(Keys.Namespace.ALARMS.ns).size() == metricAlarms.size()
+    metricAlarms*.alarmName.containsAll(cacheData.get(Keys.Namespace.ALARMS.ns)*.getAttributes().alarmName)
+    metricAlarms*.alarmArn.containsAll(cacheData.get(Keys.Namespace.ALARMS.ns)*.getAttributes().alarmArn)
+    metricAlarms*.accountName.containsAll(cacheData.get(Keys.Namespace.ALARMS.ns)*.getAttributes().accountName)
+    metricAlarms*.region.containsAll(cacheData.get(Keys.Namespace.ALARMS.ns)*.getAttributes().region)
+  }
+}


### PR DESCRIPTION
Adds an EcsCloudMetricAlarmCachingAgent which is responsible for caching cloud metric alarm information - used for scaling -, along with EcsCloudWatchAlarmCacheClient.
The client allows providers/services to interface more easily with the cache.

@cfieber @ajordens @robzienert @BrunoCarrier