### PR TITLE
feat(provider/ecs): ECS Loadbalancer cache client and tests.

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsLoadbalancerCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsLoadbalancerCacheClient.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.cache.Cache;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter;
+import com.netflix.spinnaker.clouddriver.aws.data.Keys;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsLoadBalancerCache;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.LOAD_BALANCERS;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.TARGET_GROUPS;
+
+@Component
+public class EcsLoadbalancerCacheClient {
+
+  private final Cache cacheView;
+  private final ObjectMapper objectMapper;
+
+  public EcsLoadbalancerCacheClient(Cache cacheView, ObjectMapper objectMapper) {
+    this.cacheView = cacheView;
+    this.objectMapper = objectMapper;
+  }
+
+  public List<EcsLoadBalancerCache> findAll() {
+    String searchKey = Keys.getLoadBalancerKey("*", "*", "*", "*", "*") + "*";
+    Collection<String> loadbalancerKeys = cacheView.filterIdentifiers(LOAD_BALANCERS.getNs(), searchKey);
+
+    Set<Map<String, Object>> loadbalancerAttributes = fetchLoadBalancerAttributes(loadbalancerKeys);
+
+    return convertToLoadbalancer(loadbalancerAttributes);
+  }
+
+  public Set<EcsLoadBalancerCache> findWithTargetGroups(Set<String> targetGroups) {
+    return findAll().stream()
+      .filter(ecsLoadBalancerCache -> targetGroups.containsAll(ecsLoadBalancerCache.getTargetGroups()))
+      .collect(Collectors.toSet());
+  }
+
+  private EcsLoadBalancerCache convertToLoadBalancer(Map<String, Object> targetGroupAttributes) {
+    return objectMapper.convertValue(targetGroupAttributes, EcsLoadBalancerCache.class);
+  }
+
+  private List<EcsLoadBalancerCache> convertToLoadbalancer(Collection<Map<String, Object>> targetGroupAttributes) {
+    List<EcsLoadBalancerCache> ecsTargetGroups = new ArrayList<>();
+
+    for (Map<String, Object> attributes : targetGroupAttributes) {
+      ecsTargetGroups.add(convertToLoadBalancer(attributes));
+    }
+
+    return ecsTargetGroups;
+  }
+
+
+  private Set<Map<String, Object>> fetchLoadBalancerAttributes(Collection<String> targetGroupKeys) {
+    Set<CacheData> loadBalancers = fetchLoadBalancers(targetGroupKeys);
+
+    Set<CacheData> targetGroupsWithAtLeastOneLoadBalancer = loadBalancers
+      .stream()
+      .filter(loadbalancer -> loadbalancer.getRelationships().get("targetGroups") != null
+        && loadbalancer.getRelationships().get("targetGroups").size() > 0)
+      .collect(Collectors.toSet());
+
+    return targetGroupsWithAtLeastOneLoadBalancer.stream()
+      .map(lb -> {
+        Map<String, String> parts = Keys.parse(lb.getId());
+        lb.getAttributes().put("region", parts.get("region"));
+        lb.getAttributes().put("account", parts.get("account"));
+        lb.getAttributes().put("loadBalancerType", parts.get("loadBalancerType"));
+        lb.getAttributes().put("targetGroups", lb.getRelationships().get("targetGroups").stream()
+          .map(id -> Keys.parse(id).get("targetGroup"))
+          .collect(Collectors.toSet())
+        );
+        return lb.getAttributes();
+      })
+      .collect(Collectors.toSet());
+  }
+
+
+  private Set<Map<String, Object>> retrieveLoadbalancers(Set<String> loadbalancersAssociatedWithTargetGroups) {
+    Collection<CacheData> loadbalancers = cacheView.getAll(LOAD_BALANCERS.getNs(), loadbalancersAssociatedWithTargetGroups);
+    return loadbalancers.stream()
+      .map(CacheData::getAttributes)
+      .collect(Collectors.toSet());
+  }
+
+
+  private Set<String> inferAssociatedLoadBalancers(Set<CacheData> targetGroups) {
+    Set<String> loadbalancersAssociatedWithTargetGroups = new HashSet<>();
+
+    for (CacheData targetGroup : targetGroups) {
+      Collection<String> relatedLoadbalancer = targetGroup.getRelationships().get("loadbalancer");
+      if (relatedLoadbalancer != null && relatedLoadbalancer.size() > 0) {
+        for (String loadbalancerArn : relatedLoadbalancer) {
+          loadbalancersAssociatedWithTargetGroups.add(loadbalancerArn);
+        }
+      }
+    }
+    return loadbalancersAssociatedWithTargetGroups;
+  }
+
+  private Set<CacheData> fetchLoadBalancers(Collection<String> loadBalancerKeys) {
+    return cacheView
+      .getAll(LOAD_BALANCERS.getNs(), loadBalancerKeys, RelationshipCacheFilter.include(TARGET_GROUPS.getNs()))
+      .stream()
+      .collect(Collectors.toSet());
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/EcsLoadBalancerCache.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/EcsLoadBalancerCache.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache.model;
+
+import com.amazonaws.services.elasticloadbalancingv2.model.Listener;
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Set;
+
+@Data
+public class EcsLoadBalancerCache implements LoadBalancer {
+
+  private String account;
+  private String region;
+  private String loadBalancerArn;
+  private String loadBalancerType;
+  private String cloudProvider = EcsCloudProvider.ID;
+  private List<Listener> listeners;
+  private String scheme;
+  private List<String> availabilityZones;
+  private String ipAddressType;
+  private String loadBalancerName;
+  private String canonicalHostedZoneId;
+  private String vpcId;
+  private String dnsname;
+  private Long createdTime;
+  private List<String> subnets;
+  private List<String> securityGroups;
+  private List<String> targetGroups;
+  //private List<Object> state;
+  private Set<LoadBalancerServerGroup> serverGroups;
+
+  @Override
+  public String getName() {
+    return loadBalancerName;
+  }
+
+  @Override
+  public String getType() {
+    return loadBalancerType;
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsLoadbalancerCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsLoadbalancerCacheClientSpec.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"):
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.cache
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.clouddriver.aws.data.Keys
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsLoadbalancerCacheClient
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsLoadBalancerCache
+import spock.lang.Specification
+import spock.lang.Subject
+
+class EcsLoadbalancerCacheClientSpec extends Specification {
+  def cacheView = Mock(Cache)
+  def objectMapper = new ObjectMapper()
+
+  @Subject
+  EcsLoadbalancerCacheClient client = new EcsLoadbalancerCacheClient(cacheView, objectMapper)
+
+  def 'should convert cache data into object'() {
+    given:
+    def loadBalancerName = 'test-name'
+    def account = 'test-account'
+    def region = 'us-west-1'
+    def vpcId = 'vpc-id'
+    def loadBalancerType = 'classic'
+    def targetGroupName = 'test-target-group'
+
+    def loadbalancerKey = Keys.getLoadBalancerKey(loadBalancerName, account, region, vpcId, loadBalancerType)
+    def targetGroupKey = Keys.getTargetGroupKey(targetGroupName, account, region, vpcId)
+
+    def givenEcsLoadbalancer = new EcsLoadBalancerCache(
+      account: account,
+      region: region,
+      loadBalancerArn: 'arn',
+      loadBalancerType: loadBalancerType,
+      cloudProvider: EcsCloudProvider.ID,
+      listeners: [],
+      scheme: 'scheme',
+      availabilityZones: [],
+      ipAddressType: 'ipv4',
+      loadBalancerName: loadBalancerName,
+      canonicalHostedZoneId: 'zone-id',
+      vpcId: vpcId,
+      dnsname: 'dns-name',
+      createdTime: System.currentTimeMillis(),
+      subnets: [],
+      securityGroups: [],
+      targetGroups: [targetGroupName],
+      serverGroups: []
+    )
+
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    def attributes = objectMapper.convertValue(givenEcsLoadbalancer, Map)
+    def relations = [targetGroups: [targetGroupKey]]
+
+    when:
+    def retrievedLoadbalancers = client.findAll()
+
+    then:
+    cacheView.filterIdentifiers(_, _) >> Collections.singleton(loadbalancerKey)
+    cacheView.getAll(_, _, _) >> Collections.singleton(new DefaultCacheData(loadbalancerKey, attributes, relations))
+    retrievedLoadbalancers.size() == 1
+    retrievedLoadbalancers.get(0) == givenEcsLoadbalancer
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsLoadbalancerCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsLoadbalancerCacheClientSpec.groovy
@@ -30,6 +30,7 @@ import spock.lang.Subject
 class EcsLoadbalancerCacheClientSpec extends Specification {
   def cacheView = Mock(Cache)
   def objectMapper = new ObjectMapper()
+                          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
   @Subject
   EcsLoadbalancerCacheClient client = new EcsLoadbalancerCacheClient(cacheView, objectMapper)
@@ -66,8 +67,6 @@ class EcsLoadbalancerCacheClientSpec extends Specification {
       targetGroups: [targetGroupName],
       serverGroups: []
     )
-
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     def attributes = objectMapper.convertValue(givenEcsLoadbalancer, Map)
     def relations = [targetGroups: [targetGroupKey]]


### PR DESCRIPTION
Adds an EcsLoadbalancerCacheClient which  allows providers/services to interface more easily with the already existing AWS loadbalancer cache.

@cfieber @ajordens @robzienert @BrunoCarrier 