### PR TITLE
fix(provider/aws): block device config for missing instance types

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/BlockDeviceConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/BlockDeviceConfig.groovy
@@ -27,65 +27,136 @@ class BlockDeviceConfig {
   BlockDeviceConfig(DeployDefaults deployDefaults) {
     this.deployDefaults = deployDefaults
     blockDevicesByInstanceType = [
-      "c3.large": enumeratedBlockDevicesWithVirtualName(2),
-      "c3.xlarge": enumeratedBlockDevicesWithVirtualName(2),
-      "c3.2xlarge": enumeratedBlockDevicesWithVirtualName(2),
-      "c3.4xlarge": enumeratedBlockDevicesWithVirtualName(2),
-      "c3.8xlarge": enumeratedBlockDevicesWithVirtualName(2),
-      "c4.large" : defaultBlockDevicesForEbsOnly(),
-      "c4.xlarge" : defaultBlockDevicesForEbsOnly(),
-      "c4.2xlarge" : defaultBlockDevicesForEbsOnly(),
-      "c4.4xlarge" : defaultBlockDevicesForEbsOnly(),
-      "c4.8xlarge" : defaultBlockDevicesForEbsOnly(),
-      "c5.large" : defaultBlockDevicesForEbsOnly(),
-      "c5.xlarge" : defaultBlockDevicesForEbsOnly(),
-      "c5.2xlarge" : defaultBlockDevicesForEbsOnly(),
-      "c5.4xlarge" : defaultBlockDevicesForEbsOnly(),
-      "c5.9xlarge" : defaultBlockDevicesForEbsOnly(),
+      "c1.medium"   : enumeratedBlockDevicesWithVirtualName(1),
+      "c1.xlarge"   : enumeratedBlockDevicesWithVirtualName(4),
+
+      "c3.large"    : enumeratedBlockDevicesWithVirtualName(2),
+      "c3.xlarge"   : enumeratedBlockDevicesWithVirtualName(2),
+      "c3.2xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+      "c3.4xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+      "c3.8xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+
+      "c4.large"    : defaultBlockDevicesForEbsOnly(),
+      "c4.xlarge"   : defaultBlockDevicesForEbsOnly(),
+      "c4.2xlarge"  : defaultBlockDevicesForEbsOnly(),
+      "c4.4xlarge"  : defaultBlockDevicesForEbsOnly(),
+      "c4.8xlarge"  : defaultBlockDevicesForEbsOnly(),
+
+      "c5.large"    : defaultBlockDevicesForEbsOnly(),
+      "c5.xlarge"   : defaultBlockDevicesForEbsOnly(),
+      "c5.2xlarge"  : defaultBlockDevicesForEbsOnly(),
+      "c5.4xlarge"  : defaultBlockDevicesForEbsOnly(),
+      "c5.9xlarge"  : defaultBlockDevicesForEbsOnly(),
       "c5.18xlarge" : defaultBlockDevicesForEbsOnly(),
-      "d2.xlarge" : enumeratedBlockDevicesWithVirtualName(3),
-      "d2.2xlarge" : enumeratedBlockDevicesWithVirtualName(6),
-      "d2.4xlarge" : enumeratedBlockDevicesWithVirtualName(12),
-      "d2.8xlarge" : enumeratedBlockDevicesWithVirtualName(24),
-      "i2.2xlarge" : enumeratedBlockDevicesWithVirtualName(2),
-      "i2.xlarge" : enumeratedBlockDevicesWithVirtualName(1),
-      "i2.4xlarge" : enumeratedBlockDevicesWithVirtualName(4),
-      "i2.8xlarge" : enumeratedBlockDevicesWithVirtualName(8),
-      "m3.medium" : enumeratedBlockDevicesWithVirtualName(1),
-      "m3.large" : enumeratedBlockDevicesWithVirtualName(1),
-      "m3.xlarge" : enumeratedBlockDevicesWithVirtualName(2),
-      "m3.2xlarge" : enumeratedBlockDevicesWithVirtualName(2),
-      "m4.large" : sizedBlockDevicesForEbs(40),
-      "m4.xlarge" : sizedBlockDevicesForEbs(80),
-      "m4.2xlarge" : sizedBlockDevicesForEbs(80),
-      "m4.4xlarge" : sizedBlockDevicesForEbs(120),
+
+      "cc2.8xlarge" : enumeratedBlockDevicesWithVirtualName(4),
+
+      "cg1.4xlarge" : sizedBlockDevicesForEbs(120),
+
+      "cr1.8xlarge" : enumeratedBlockDevicesWithVirtualName(2),
+
+      "d2.xlarge"   : enumeratedBlockDevicesWithVirtualName(3),
+      "d2.2xlarge"  : enumeratedBlockDevicesWithVirtualName(6),
+      "d2.4xlarge"  : enumeratedBlockDevicesWithVirtualName(12),
+      "d2.8xlarge"  : enumeratedBlockDevicesWithVirtualName(24),
+
+      "f1.2xlarge"  : enumeratedBlockDevicesWithVirtualName(1),
+      "f1.16xlarge" : enumeratedBlockDevicesWithVirtualName(4),
+
+      "g2.2xlarge"  : enumeratedBlockDevicesWithVirtualName(1),
+      "g2.8xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+
+      "g3.4xlarge"  : sizedBlockDevicesForEbs(120),
+      "g3.8xlarge"  : sizedBlockDevicesForEbs(120),
+      "g3.16xlarge" : sizedBlockDevicesForEbs(120),
+
+      "h1.2xlarge"  : enumeratedBlockDevicesWithVirtualName(1),
+      "h1.4xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+      "h1.8xlarge"  : enumeratedBlockDevicesWithVirtualName(4),
+      "h1.16xlarge" : enumeratedBlockDevicesWithVirtualName(8),
+
+      "hs1.8xlarge" : enumeratedBlockDevicesWithVirtualName(24),
+
+      "i2.xlarge"   : enumeratedBlockDevicesWithVirtualName(1),
+      "i2.2xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+      "i2.4xlarge"  : enumeratedBlockDevicesWithVirtualName(4),
+      "i2.8xlarge"  : enumeratedBlockDevicesWithVirtualName(8),
+
+      "i3.large"    : enumeratedBlockDevicesWithVirtualName(1),
+      "i3.xlarge"   : enumeratedBlockDevicesWithVirtualName(1),
+      "i3.2xlarge"  : enumeratedBlockDevicesWithVirtualName(1),
+      "i3.4xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+      "i3.8xlarge"  : enumeratedBlockDevicesWithVirtualName(4),
+      "i3.16xlarge" : enumeratedBlockDevicesWithVirtualName(8),
+
+      "m1.small"    : enumeratedBlockDevicesWithVirtualName(1),
+      "m1.medium"   : enumeratedBlockDevicesWithVirtualName(1),
+      "m1.large"    : enumeratedBlockDevicesWithVirtualName(2),
+      "m1.xlarge"   : enumeratedBlockDevicesWithVirtualName(4),
+
+      "m2.xlarge"   : enumeratedBlockDevicesWithVirtualName(1),
+      "m2.2xlarge"  : enumeratedBlockDevicesWithVirtualName(1),
+      "m2.4xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+
+      "m3.medium"   : enumeratedBlockDevicesWithVirtualName(1),
+      "m3.large"    : enumeratedBlockDevicesWithVirtualName(1),
+      "m3.xlarge"   : enumeratedBlockDevicesWithVirtualName(2),
+      "m3.2xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+
+      "m4.large"    : sizedBlockDevicesForEbs(40),
+      "m4.xlarge"   : sizedBlockDevicesForEbs(80),
+      "m4.2xlarge"  : sizedBlockDevicesForEbs(80),
+      "m4.4xlarge"  : sizedBlockDevicesForEbs(120),
       "m4.10xlarge" : sizedBlockDevicesForEbs(120),
       "m4.16xlarge" : sizedBlockDevicesForEbs(120),
-      "r3.large": enumeratedBlockDevicesWithVirtualName(1),
-      "r3.xlarge": enumeratedBlockDevicesWithVirtualName(1),
-      "r3.2xlarge": enumeratedBlockDevicesWithVirtualName(1),
-      "r3.4xlarge": enumeratedBlockDevicesWithVirtualName(1),
-      "r3.8xlarge": enumeratedBlockDevicesWithVirtualName(2),
-      "r4.large" : sizedBlockDevicesForEbs(40),
-      "r4.xlarge" : sizedBlockDevicesForEbs(80),
-      "r4.2xlarge" : sizedBlockDevicesForEbs(80),
-      "r4.4xlarge" : sizedBlockDevicesForEbs(120),
-      "r4.8xlarge" : sizedBlockDevicesForEbs(120),
+
+      "m5.large"    : sizedBlockDevicesForEbs(40),
+      "m5.xlarge"   : sizedBlockDevicesForEbs(80),
+      "m5.2xlarge"  : sizedBlockDevicesForEbs(80),
+      "m5.4xlarge"  : sizedBlockDevicesForEbs(120),
+      "m5.12xlarge" : sizedBlockDevicesForEbs(120),
+      "m5.24xlarge" : sizedBlockDevicesForEbs(120),
+
+      "r3.large"    : enumeratedBlockDevicesWithVirtualName(1),
+      "r3.xlarge"   : enumeratedBlockDevicesWithVirtualName(1),
+      "r3.2xlarge"  : enumeratedBlockDevicesWithVirtualName(1),
+      "r3.4xlarge"  : enumeratedBlockDevicesWithVirtualName(1),
+      "r3.8xlarge"  : enumeratedBlockDevicesWithVirtualName(2),
+
+      "r4.large"    : sizedBlockDevicesForEbs(40),
+      "r4.xlarge"   : sizedBlockDevicesForEbs(80),
+      "r4.2xlarge"  : sizedBlockDevicesForEbs(80),
+      "r4.4xlarge"  : sizedBlockDevicesForEbs(120),
+      "r4.8xlarge"  : sizedBlockDevicesForEbs(120),
       "r4.16xlarge" : sizedBlockDevicesForEbs(120),
-      "i3.large" : enumeratedBlockDevicesWithVirtualName(1),
-      "i3.xlarge" : enumeratedBlockDevicesWithVirtualName(1),
-      "i3.2xlarge" : enumeratedBlockDevicesWithVirtualName(1),
-      "i3.4xlarge" : enumeratedBlockDevicesWithVirtualName(2),
-      "i3.8xlarge" : enumeratedBlockDevicesWithVirtualName(4),
-      "i3.16xlarge" : enumeratedBlockDevicesWithVirtualName(8),
-      "h1.2xlarge" : enumeratedBlockDevicesWithVirtualName(1),
-      "h1.4xlarge" : enumeratedBlockDevicesWithVirtualName(2),
-      "h1.8xlarge" : enumeratedBlockDevicesWithVirtualName(4),
-      "h1.16xlarge" : enumeratedBlockDevicesWithVirtualName(8),
-      "t2.micro" : [],
-      "t2.small" : [],
-      "t2.medium" : [],
-      "t2.large" : [],
+
+      "p2.xlarge"   : sizedBlockDevicesForEbs(80),
+      "p2.8xlarge"  : sizedBlockDevicesForEbs(120),
+      "p2.16xlarge" : sizedBlockDevicesForEbs(120),
+
+      "p3.2xlarge"  : sizedBlockDevicesForEbs(80),
+      "p3.8xlarge"  : sizedBlockDevicesForEbs(120),
+      "p3.16xlarge" : sizedBlockDevicesForEbs(120),
+
+      "t1.micro"    : [],
+
+      "t2.nano"     : [],
+      "t2.micro"    : [],
+      "t2.small"    : [],
+      "t2.medium"   : [],
+      "t2.large"    : [],
+      "t2.xlarge"   : [],
+      "t2.2xlarge"  : [],
+
+      "x1.16xlarge" : enumeratedBlockDevicesWithVirtualName(1),
+      "x1.32xlarge" : enumeratedBlockDevicesWithVirtualName(2),
+
+      "x1e.xlarge"  : enumeratedBlockDevicesWithVirtualName(1),
+      "x1e.2xlarge" : enumeratedBlockDevicesWithVirtualName(1),
+      "x1e.4xlarge" : enumeratedBlockDevicesWithVirtualName(1),
+      "x1e.8xlarge" : enumeratedBlockDevicesWithVirtualName(1),
+      "x1e.16xlarge": enumeratedBlockDevicesWithVirtualName(1),
+      "x1e.32xlarge": enumeratedBlockDevicesWithVirtualName(2),
     ].asImmutable()
   }
 
@@ -120,4 +191,7 @@ class BlockDeviceConfig {
     return blockDevices
   }
 
+  Set<String> getInstanceTypesWithBlockDeviceMappings() {
+    return blockDevicesByInstanceType.keySet()
+  }
 }


### PR DESCRIPTION
This should provide coverage for all currently available instance types.

Will look for better ways to manage this moving forward.
