### PR TITLE
fix(provider/docker): update bearer_token to access_token

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerToken.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerToken.groovy
@@ -20,9 +20,9 @@ import groovy.transform.ToString
 
 @ToString(includeNames = true)
 class DockerBearerToken {
-  // One of token or bearer_token will be filled by the request.
+  // One of token or access_token will be filled by the request.
   String token
-  String bearer_token
+  String access_token
   int expires_in
   String issued_at
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerToken.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerToken.groovy
@@ -20,9 +20,10 @@ import groovy.transform.ToString
 
 @ToString(includeNames = true)
 class DockerBearerToken {
-  // One of token or access_token will be filled by the request.
+  // One of token, access_token, or bearer_token will be filled by the request.
   String token
   String access_token
+  String bearer_token
   int expires_in
   String issued_at
 }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -391,7 +391,7 @@ class DockerRegistryClient {
       DockerBearerToken dockerToken = tokenService.getToken(target)
       String token
       if (dockerToken) {
-        token = "Bearer ${dockerToken.access_token ?: dockerToken.token}"
+        token = "Bearer ${(dockerToken.bearer_token ?: dockerToken.token) ?: dockerToken.access_token}"
       }
 
       Response response
@@ -423,7 +423,7 @@ class DockerRegistryClient {
           if (bearerPrefix.equalsIgnoreCase(authenticateHeader.substring(0, bearerPrefix.length()))) {
             // If we got a 401 and the request requires bearer auth, get a new token and try again
             dockerToken = tokenService.getToken(target, authenticateHeader.substring(bearerPrefix.length()))
-            token = "Bearer ${dockerToken.access_token ?: dockerToken.token}"
+            token = "Bearer ${(dockerToken.bearer_token ?: dockerToken.token) ?: dockerToken.access_token}"
             response = withToken(token)
           } else if (basicPrefix.equalsIgnoreCase(authenticateHeader.substring(0, basicPrefix.length()))) {
             // If we got a 401 and the request requires basic auth, there's no point in trying again

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/client/DockerRegistryClient.groovy
@@ -391,7 +391,7 @@ class DockerRegistryClient {
       DockerBearerToken dockerToken = tokenService.getToken(target)
       String token
       if (dockerToken) {
-        token = "Bearer ${dockerToken.bearer_token ?: dockerToken.token}"
+        token = "Bearer ${dockerToken.access_token ?: dockerToken.token}"
       }
 
       Response response
@@ -423,7 +423,7 @@ class DockerRegistryClient {
           if (bearerPrefix.equalsIgnoreCase(authenticateHeader.substring(0, bearerPrefix.length()))) {
             // If we got a 401 and the request requires bearer auth, get a new token and try again
             dockerToken = tokenService.getToken(target, authenticateHeader.substring(bearerPrefix.length()))
-            token = "Bearer ${dockerToken.bearer_token ?: dockerToken.token}"
+            token = "Bearer ${dockerToken.access_token ?: dockerToken.token}"
             response = withToken(token)
           } else if (basicPrefix.equalsIgnoreCase(authenticateHeader.substring(0, basicPrefix.length()))) {
             // If we got a 401 and the request requires basic auth, there's no point in trying again


### PR DESCRIPTION
Per https://docs.docker.com/registry/spec/auth/token/#requesting-a-token, the token response fields will either contain `token` or `access_token`.

In ACR, for example, only access_token is sent back as a response, meaning that the response from Spinnaker will fail to authenticate.