### PR TITLE
fix(provider/kubernetes): v2 Set default namespace dynamically

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -86,7 +86,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   public String getNamespace() {
     String namespace = (String) getMetadata().get("namespace");
-    return StringUtils.isEmpty(namespace) ? "default" : namespace;
+    return StringUtils.isEmpty(namespace) ? "" : namespace;
   }
 
   @JsonIgnore


### PR DESCRIPTION
Set the default namespace according to the `kubectl` rules defined in
https://github.com/kubernetes/kubernetes/blob/bd4d511a40e142ee65edff3b286e57de502aa790/pkg/kubectl/cmd/util/factory_client_access.go#L127

In short, the default namespace is set in this way:

- If `/var/run/secrets/kubernetes.io/serviceaccount/namespace` exists,
  assume we are running in a Kubernetes container, and set the default
  namespace to the contents of this file.
- Set the default namespace to the namespace of current `kubectl`
  config context, if it exists. `kubectl config view` is used to get
  this namespace, which takes care of the complicated merges and
  overrides.
- Otherwise, set the default namespace to "default".

This fixes the issue of manifests without a namespace specification
being deployed in the namespace of clouddriver when Spinnaker has been
deployed in Kubernetes.

Previously manifests without a namespace were assumed to belong to the
"default" namespace, but clouddriver would deploy them in the
"spinnaker" namespace, where it is deployed by default by Halyard.
Deploying such manifests would cause Spinnaker to get stuck waiting
for a deployment to show up in the "default" namespace, since
clouddriver would instead have created a deployment in the "spinnaker"
namespace.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
