### PR TITLE
perf(provider/gce): De-dupe getHealth() calls in LB caching agents.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleHttpLoadBalancerCachingAgent.groovy
@@ -29,11 +29,24 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
 import com.netflix.spinnaker.clouddriver.google.model.health.GoogleLoadBalancerHealth
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
+import com.netflix.spinnaker.clouddriver.google.provider.agent.util.GroupHealthRequest
+import com.netflix.spinnaker.clouddriver.google.provider.agent.util.LoadBalancerHealthResolution
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import groovy.util.logging.Slf4j
 
 @Slf4j
 class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachingAgent {
+
+  /**
+   * Local cache of BackendServiceGroupHealth keyed by BackendService name.
+   *
+   * It turns out that the types in the GCE Batch callbacks aren't the actual Compute
+   * types for some reason, which is why this map is String -> Object.
+   */
+  Map<String, List<Object>> bsNameToGroupHealthsMap = [:]
+  Set<GroupHealthRequest> queuedBsGroupHealthRequests = new HashSet<>()
+  List<LoadBalancerHealthResolution> resolutions = []
+
 
   GoogleHttpLoadBalancerCachingAgent(String clouddriverUserAgentApplicationName,
                                      GoogleNamedAccountCredentials credentials,
@@ -55,6 +68,11 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachi
     BatchRequest targetProxyRequest = buildBatchRequest()
     BatchRequest urlMapRequest = buildBatchRequest()
     BatchRequest groupHealthRequest = buildBatchRequest()
+
+    // Reset the local getHealth caches/queues each caching agent cycle.
+    bsNameToGroupHealthsMap = [:]
+    queuedBsGroupHealthRequests = new HashSet<>()
+    resolutions = []
 
     List<BackendService> projectBackendServices = GCEUtil.fetchBackendServices(this, compute, project)
     List<HttpHealthCheck> projectHttpHealthChecks = GCEUtil.fetchHttpHealthChecks(this, compute, project)
@@ -85,6 +103,12 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachi
     executeIfRequestsAreQueued(targetProxyRequest, "HttpLoadBalancerCaching.targetProxy")
     executeIfRequestsAreQueued(urlMapRequest, "HttpLoadBalancerCaching.urlMapRequest")
     executeIfRequestsAreQueued(groupHealthRequest, "HttpLoadBalancerCaching.groupHealth")
+
+    resolutions.each { LoadBalancerHealthResolution resolution ->
+      bsNameToGroupHealthsMap.get(resolution.getTarget()).each { groupHealth ->
+        GCEUtil.handleHealthObject(resolution.getGoogleLoadBalancer(), groupHealth)
+      }
+    }
 
     // Filter out all LBs that contain backend buckets, since we don't support them in our model.
     loadBalancers = loadBalancers.findAll { !it.containsBackendBucket }
@@ -349,10 +373,7 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachi
     if (!backendService) {
       return
     }
-    def groupHealthCallback = new GroupHealthCallback(
-      googleLoadBalancer: googleHttpLoadBalancer,
-      backendServiceName: backendService.name
-    )
+    def groupHealthCallback = new GroupHealthCallback(backendServiceName: backendService.name)
     Boolean isHttps = backendService.protocol == 'HTTPS'
 
     // We have to update the backend service objects we created from the UrlMapCallback.
@@ -379,9 +400,20 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachi
     backendService.backends?.findAll { Backend backend -> backend.group }?.each { Backend backend ->
       def resourceGroup = new ResourceGroupReference()
       resourceGroup.setGroup(backend.group)
-      compute.backendServices()
-        .getHealth(project, backendService.name, resourceGroup)
-        .queue(groupHealthRequest, groupHealthCallback)
+
+      // Make only the group health request calls we need to.
+      GroupHealthRequest ghr = new GroupHealthRequest(project, backendService.name as String, resourceGroup.getGroup())
+      if (!queuedBsGroupHealthRequests.contains(ghr)) {
+        // The groupHealthCallback updates the local cache.
+        log.debug("Queueing a batch call for getHealth(): {}", ghr)
+        queuedBsGroupHealthRequests.add(ghr)
+        compute.backendServices()
+          .getHealth(project, backendService.name, resourceGroup)
+          .queue(groupHealthRequest, groupHealthCallback)
+      } else {
+        log.debug("Passing, batch call result cached for getHealth(): {}", ghr)
+      }
+      resolutions.add(new LoadBalancerHealthResolution(googleHttpLoadBalancer, backendService.name))
     }
 
     backendService.healthChecks?.each { String healthCheckURL ->
@@ -486,7 +518,6 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachi
   }
 
   class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> {
-    GoogleHttpLoadBalancer googleLoadBalancer
     String backendServiceName
 
     /**
@@ -494,28 +525,16 @@ class GoogleHttpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachi
      * If healthStatus is null in the onSuccess() function, the same state is reported, so this shouldn't cause issues.
      */
     void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
-      log.debug("Failed backend service group health call for backend service ${backendServiceName} for Http load balancer ${googleLoadBalancer.name}." +
+      log.debug("Failed backend service group health call for backend service ${backendServiceName} for Http load balancer." +
         " The platform error message was:\n ${e.getMessage()}.")
     }
 
     @Override
     void onSuccess(BackendServiceGroupHealth backendServiceGroupHealth, HttpHeaders responseHeaders) throws IOException {
-      backendServiceGroupHealth.healthStatus?.each { HealthStatus status ->
-        def instanceName = Utils.getLocalName(status.instance)
-        def googleLBHealthStatus = GoogleLoadBalancerHealth.PlatformStatus.valueOf(status.healthState)
-
-        googleLoadBalancer.healths << new GoogleLoadBalancerHealth(
-          instanceName: instanceName,
-          instanceZone: Utils.getZoneFromInstanceUrl(status.instance),
-          status: googleLBHealthStatus,
-          lbHealthSummaries: [
-            new GoogleLoadBalancerHealth.LBHealthSummary(
-              loadBalancerName: googleLoadBalancer.name,
-              instanceId: instanceName,
-              state: googleLBHealthStatus.toServiceStatus(),
-            )
-          ]
-        )
+      if (!bsNameToGroupHealthsMap.containsKey(backendServiceName)) {
+        bsNameToGroupHealthsMap.put(backendServiceName, [backendServiceGroupHealth])
+      } else {
+        bsNameToGroupHealthsMap.get(backendServiceName) << backendServiceGroupHealth
       }
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -27,13 +27,24 @@ import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
-import com.netflix.spinnaker.clouddriver.google.model.health.GoogleLoadBalancerHealth
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
+import com.netflix.spinnaker.clouddriver.google.provider.agent.util.GroupHealthRequest
+import com.netflix.spinnaker.clouddriver.google.provider.agent.util.LoadBalancerHealthResolution
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import groovy.util.logging.Slf4j
 
 @Slf4j
 class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachingAgent {
+
+  /**
+   * Local cache of BackendServiceGroupHealth keyed by BackendService name.
+   *
+   * It turns out that the types in the GCE Batch callbacks aren't the actual Compute
+   * types for some reason, which is why this map is String -> Object.
+   */
+  Map<String, Object> bsNameToGroupHealthsMap = [:]
+  Set<GroupHealthRequest> queuedBsGroupHealthRequests = new HashSet<>()
+  List<LoadBalancerHealthResolution> resolutions = []
 
   GoogleSslLoadBalancerCachingAgent(String clouddriverUserAgentApplicationName,
                                     GoogleNamedAccountCredentials credentials,
@@ -61,6 +72,11 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
     BatchRequest targetSslProxyRequest = buildBatchRequest()
     BatchRequest groupHealthRequest = buildBatchRequest()
 
+    // Reset the local getHealth caches/queues each caching agent cycle.
+    bsNameToGroupHealthsMap = [:]
+    queuedBsGroupHealthRequests = new HashSet<>()
+    resolutions = []
+
     List<BackendService> projectBackendServices = GCEUtil.fetchBackendServices(this, compute, project)
     List<HealthCheck> projectHealthChecks = GCEUtil.fetchHealthChecks(this, compute, project)
 
@@ -84,6 +100,12 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
     executeIfRequestsAreQueued(forwardingRulesRequest, "SslLoadBalancerCaching.forwardingRules")
     executeIfRequestsAreQueued(targetSslProxyRequest, "SslLoadBalancerCaching.targetSslProxy")
     executeIfRequestsAreQueued(groupHealthRequest, "SslLoadBalancerCaching.groupHealthCheck")
+
+    resolutions.each { LoadBalancerHealthResolution resolution ->
+      bsNameToGroupHealthsMap.get(resolution.getTarget()).each { groupHealth ->
+        GCEUtil.handleHealthObject(resolution.getGoogleLoadBalancer(), groupHealth)
+      }
+    }
 
     return loadBalancers.findAll { !(it.name in failedLoadBalancers) }
   }
@@ -192,10 +214,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
       return
     }
 
-    def groupHealthCallback = new GroupHealthCallback(
-      googleLoadBalancer: googleLoadBalancer,
-      backendServiceName: backendService.name
-    )
+    def groupHealthCallback = new GroupHealthCallback(backendServiceName: backendService.name)
 
     GoogleBackendService newService = new GoogleBackendService(
       name: backendService.name,
@@ -216,9 +235,21 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
     backendService.backends?.findAll { Backend backend -> backend.group }?.each { Backend backend ->
       def resourceGroup = new ResourceGroupReference()
       resourceGroup.setGroup(backend.group as String)
-      compute.backendServices()
-        .getHealth(project, backendService.name, resourceGroup)
-        .queue(groupHealthRequest, groupHealthCallback)
+
+
+      // Make only the group health request calls we need to.
+      GroupHealthRequest ghr = new GroupHealthRequest(project, backendService.name as String, resourceGroup.getGroup())
+      if (!queuedBsGroupHealthRequests.contains(ghr)) {
+        // The groupHealthCallback updates the local cache.
+        log.debug("Queueing a batch call for getHealth(): {}", ghr)
+        queuedBsGroupHealthRequests.add(ghr)
+        compute.backendServices()
+          .getHealth(project, backendService.name, resourceGroup)
+          .queue(groupHealthRequest, groupHealthCallback)
+      } else {
+        log.debug("Passing, batch call result cached for getHealth(): {}", ghr)
+      }
+      resolutions.add(new LoadBalancerHealthResolution(googleLoadBalancer, backendService.name))
     }
 
     backendService.healthChecks?.each { String healthCheckURL ->
@@ -283,7 +314,6 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
   }
 
   class GroupHealthCallback<BackendServiceGroupHealth> extends JsonBatchCallback<BackendServiceGroupHealth> {
-    GoogleSslLoadBalancer googleLoadBalancer
     String backendServiceName
 
     /**
@@ -291,28 +321,16 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
      * If healthStatus is null in the onSuccess() function, the same state is reported, so this shouldn't cause issues.
      */
     void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
-      log.debug("Failed backend service group health call for backend service ${backendServiceName} for Http load balancer ${googleLoadBalancer.name}." +
+      log.debug("Failed backend service group health call for backend service ${backendServiceName} for Ssl load balancer." +
         " The platform error message was:\n ${e.getMessage()}.")
     }
 
     @Override
     void onSuccess(BackendServiceGroupHealth backendServiceGroupHealth, HttpHeaders responseHeaders) throws IOException {
-      backendServiceGroupHealth.healthStatus?.each { HealthStatus status ->
-        def instanceName = Utils.getLocalName(status.instance)
-        def googleLBHealthStatus = GoogleLoadBalancerHealth.PlatformStatus.valueOf(status.healthState)
-
-        googleLoadBalancer.healths << new GoogleLoadBalancerHealth(
-          instanceName: instanceName,
-          instanceZone: Utils.getZoneFromInstanceUrl(status.instance),
-          status: googleLBHealthStatus,
-          lbHealthSummaries: [
-            new GoogleLoadBalancerHealth.LBHealthSummary(
-              loadBalancerName: googleLoadBalancer.name,
-              instanceId: instanceName,
-              state: googleLBHealthStatus.toServiceStatus(),
-            )
-          ]
-        )
+      if (!bsNameToGroupHealthsMap.containsKey(backendServiceName)) {
+        bsNameToGroupHealthsMap.put(backendServiceName, [backendServiceGroupHealth])
+      } else {
+        bsNameToGroupHealthsMap.get(backendServiceName) << backendServiceGroupHealth
       }
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/GroupHealthRequest.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/GroupHealthRequest.java
@@ -1,0 +1,19 @@
+package com.netflix.spinnaker.clouddriver.google.provider.agent.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Helper class for locally resolving queued backend service group health requests.
+ */
+@Data
+@EqualsAndHashCode
+@AllArgsConstructor
+@ToString
+public class GroupHealthRequest {
+  private String project;
+  private String backendServiceName;
+  private String resourceGroup;
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/LoadBalancerHealthResolution.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/LoadBalancerHealthResolution.java
@@ -1,0 +1,15 @@
+package com.netflix.spinnaker.clouddriver.google.provider.agent.util;
+
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Helper class to resolve locally cached backend service get health call results.
+ */
+@Data
+@AllArgsConstructor
+public class LoadBalancerHealthResolution {
+  private GoogleLoadBalancer googleLoadBalancer;
+  private String target;
+}

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/TargetPoolHealthRequest.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/TargetPoolHealthRequest.java
@@ -1,0 +1,20 @@
+package com.netflix.spinnaker.clouddriver.google.provider.agent.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Helper class for locally resolving queued target pool health requests.
+ */
+@Data
+@EqualsAndHashCode
+@AllArgsConstructor
+@ToString
+public class TargetPoolHealthRequest {
+  private String project;
+  private String region;
+  private String targetPoolName;
+  private String instance;
+}


### PR DESCRIPTION
Refactors LB caching agents so that only one get health call is made per backendService -> serverGroup and targetPool -> instance pair per caching cycle.