### PR TITLE
feat(provider/aws) Fetch image information based on image id

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonImage.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonImage.java
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.clouddriver.aws.model;
+
+public class AmazonImage {
+  public static final String AMAZON_IMAGE_TYPE = "aws/image";
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonImage.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonImage.java
@@ -16,6 +16,18 @@
 
 package com.netflix.spinnaker.clouddriver.aws.model;
 
-public class AmazonImage {
+import com.netflix.spinnaker.clouddriver.model.Image;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class AmazonImage extends com.amazonaws.services.ec2.model.Image implements Image {
   public static final String AMAZON_IMAGE_TYPE = "aws/image";
+  String id;
+  String region;
+  List<AmazonServerGroup> serverGroups = new ArrayList<>();
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonImage.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonImage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.aws.model;
 
 public class AmazonImage {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProvider.java
@@ -1,0 +1,82 @@
+package com.netflix.spinnaker.clouddriver.aws.provider.view;
+
+import com.netflix.spinnaker.cats.cache.Cache;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonImage;
+import com.netflix.spinnaker.clouddriver.model.ImageProvider;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IMAGES;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS;
+
+
+@Component
+public class AmazonImageProvider implements ImageProvider {
+
+  private final Cache cacheView;
+
+
+  @Autowired
+  AmazonImageProvider(Cache cacheView) {
+    this.cacheView = cacheView;
+  }
+
+  @Override
+  public Optional<Artifact> getImageById(String imageId) {
+
+    if (!imageId.startsWith("ami-")) {
+      throw new RuntimeException("Image Id provided (" + imageId + ") is not a valid id for the provider " + getCloudProvider());
+    }
+
+    List<String> imageIdList = new ArrayList<>(cacheView.filterIdentifiers(IMAGES.toString(), "*" + imageId));
+
+    if (imageIdList.isEmpty()) {
+      return Optional.empty();
+    } else if (imageIdList.size() > 1) {
+      throw new RuntimeException("Image id (" + imageId + ") didn't return an unique image for provider " + getCloudProvider());
+    }
+
+    String imageCacheId = imageIdList.get(0);
+    CacheData imageCache = cacheView.get(IMAGES.toString(), imageCacheId);
+
+    Artifact image = Artifact.builder()
+        .name((String) imageCache.getAttributes().get("name"))
+        .type(AmazonImage.AMAZON_IMAGE_TYPE)
+        .location(imageCacheId.split(":")[2] + "/" + imageCacheId.split(":")[3])
+        .reference((String) imageCache.getAttributes().get("imageId"))
+        .metadata(imageCache.getAttributes())
+        .build();
+
+    image.getMetadata().put(SERVER_GROUPS.toString(), getServerGroupsBasedOnInstances(imageCache.getRelationships().get(INSTANCES.toString())));
+    return Optional.of(image);
+  }
+
+  @Override
+  public String getCloudProvider() {
+    return AmazonCloudProvider.ID;
+  }
+
+  private List<Map<String, Object>> getServerGroupsBasedOnInstances(Collection<String> instancesIdList) {
+    if (instancesIdList == null) {
+      return new ArrayList<>();
+    }
+    return cacheView.getAll(INSTANCES.toString(), instancesIdList)
+        .stream()
+        .map(instanceCache -> instanceCache.getRelationships().get(SERVER_GROUPS.toString()))
+        .flatMap(Collection::stream)
+        .map(serverGroupId -> cacheView.get(SERVER_GROUPS.toString(), serverGroupId).getAttributes())
+        .collect(Collectors.toList());
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.aws.provider.view;
 
 import com.netflix.spinnaker.cats.cache.Cache;
@@ -10,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProvider.java
@@ -66,7 +66,7 @@ public class AmazonImageProvider implements ImageProvider {
     Artifact image = Artifact.builder()
         .name((String) imageCacheList.get(0).getAttributes().get("name"))
         .type(AmazonImage.AMAZON_IMAGE_TYPE)
-        .location(imageCacheList.get(0).getId().split(":")[2] + "/" + imageCacheList.get(0).getId().split(":")[3])
+        .location(imageCacheList.get(0).getAttributes().get("ownerId") + "/" + imageCacheList.get(0).getId().split(":")[3])
         .reference((String) imageCacheList.get(0).getAttributes().get("imageId"))
         .metadata(imageCacheList.get(0).getAttributes())
         .build();

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProviderSpec.groovy
@@ -42,8 +42,8 @@ class AmazonImageProviderSpec extends Specification {
     result == Optional.of(Artifact.builder()
             .name("some_ami")
             .type(AmazonImage.AMAZON_IMAGE_TYPE)
-            .location("test_account/eu-west-1")
-            .metadata("name": "some_ami", "serverGroups": [], "imageId": "ami-123321", "region": "eu-west-1", "account": "test_account")
+            .location("123456789/eu-west-1")
+            .metadata("name": "some_ami", ownerId: '123456789', "serverGroups": [], "imageId": "ami-123321", "region": "eu-west-1", "account": "test_account")
             .reference("ami-123321")
             .build())
 
@@ -57,6 +57,7 @@ class AmazonImageProviderSpec extends Specification {
                     account: 'test_account',
                     region : 'eu-west-1',
                     name   : 'some_ami',
+                    ownerId: '123456789',
                     imageId: 'ami-123321'])]
   }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProviderSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.aws.provider.view
 
 import com.netflix.spinnaker.cats.cache.Cache
@@ -12,72 +28,72 @@ import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IM
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 
 class AmazonImageProviderSpec extends Specification {
-    Cache cache = Mock(Cache)
+  Cache cache = Mock(Cache)
 
-    @Subject
-    AmazonImageProvider provider = new AmazonImageProvider(cache)
+  @Subject
+  AmazonImageProvider provider = new AmazonImageProvider(cache)
 
-    void "should return one image"() {
+  void "should return one image"() {
 
-        when:
-        def result = provider.getImageById("ami-123321")
+    when:
+    def result = provider.getImageById("ami-123321")
 
-        then:
-        result == Optional.of(Artifact.builder()
-                .name("some_ami")
-                .type(AmazonImage.AMAZON_IMAGE_TYPE)
-                .location("test_account/eu-west-1")
-                .metadata("name": "some_ami", "serverGroups": [], "imageId": "ami-123321", "region": "eu-west-1", "account": "test_account")
-                .reference("ami-123321")
-                .build())
+    then:
+    result == Optional.of(Artifact.builder()
+            .name("some_ami")
+            .type(AmazonImage.AMAZON_IMAGE_TYPE)
+            .location("test_account/eu-west-1")
+            .metadata("name": "some_ami", "serverGroups": [], "imageId": "ami-123321", "region": "eu-west-1", "account": "test_account")
+            .reference("ami-123321")
+            .build())
 
-        and:
-        1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> [
-                "aws:images:test_account:eu-west-1:ami-123321"
-        ]
+    and:
+    1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> [
+            "aws:images:test_account:eu-west-1:ami-123321"
+    ]
 
-        1 * cache.get(IMAGES.ns, "aws:images:test_account:eu-west-1:ami-123321") >>
-                imageCacheData('aws:images:test_account:eu-west-1:ami-123321', [
-                        account: 'test_account',
-                        region : 'eu-west-1',
-                        name   : 'some_ami',
-                        imageId: 'ami-123321'])
-    }
+    1 * cache.get(IMAGES.ns, "aws:images:test_account:eu-west-1:ami-123321") >>
+            imageCacheData('aws:images:test_account:eu-west-1:ami-123321', [
+                    account: 'test_account',
+                    region : 'eu-west-1',
+                    name   : 'some_ami',
+                    imageId: 'ami-123321'])
+  }
 
-    void "should return exception because of image not being unique"() {
-        when:
-        provider.getImageById("ami-123321")
+  void "should return exception because of image not being unique"() {
+    when:
+    provider.getImageById("ami-123321")
 
-        then:
-        thrown(RuntimeException)
+    then:
+    thrown(RuntimeException)
 
-        and:
-        1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> [
-                "aws:images:test_account:eu-west-1:ami-123321",
-                "aws:images:test_account:eu-west-1:ami-123321"
-        ]
-    }
+    and:
+    1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> [
+            "aws:images:test_account:eu-west-1:ami-123321",
+            "aws:images:test_account:eu-west-1:ami-123321"
+    ]
+  }
 
-    void "should not find any image"() {
-        when:
-        def result = provider.getImageById("ami-123321")
+  void "should not find any image"() {
+    when:
+    def result = provider.getImageById("ami-123321")
 
-        then:
-        result == Optional.empty()
+    then:
+    result == Optional.empty()
 
-        and:
-        1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> []
-    }
+    and:
+    1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> []
+  }
 
-    void "should throw exception of invalid ami name"() {
-        when:
-        provider.getImageById("amiz-123321")
+  void "should throw exception of invalid ami name"() {
+    when:
+    provider.getImageById("amiz-123321")
 
-        then:
-        thrown(RuntimeException)
-    }
+    then:
+    thrown(RuntimeException)
+  }
 
-    static private CacheData imageCacheData(String imageId, Map attributes) {
-        new DefaultCacheData(Keys.getImageKey(imageId, attributes.account, attributes.region), attributes, [:])
-    }
+  static private CacheData imageCacheData(String imageId, Map attributes) {
+    new DefaultCacheData(Keys.getImageKey(imageId, attributes.account, attributes.region), attributes, [:])
+  }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProviderSpec.groovy
@@ -1,0 +1,83 @@
+package com.netflix.spinnaker.clouddriver.aws.provider.view
+
+import com.netflix.spinnaker.cats.cache.Cache
+import com.netflix.spinnaker.cats.cache.CacheData
+import com.netflix.spinnaker.cats.cache.DefaultCacheData
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonImage
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IMAGES
+import com.netflix.spinnaker.clouddriver.aws.data.Keys
+
+class AmazonImageProviderSpec extends Specification {
+    Cache cache = Mock(Cache)
+
+    @Subject
+    AmazonImageProvider provider = new AmazonImageProvider(cache)
+
+    void "should return one image"() {
+
+        when:
+        def result = provider.getImageById("ami-123321")
+
+        then:
+        result == Optional.of(Artifact.builder()
+                .name("some_ami")
+                .type(AmazonImage.AMAZON_IMAGE_TYPE)
+                .location("test_account/eu-west-1")
+                .metadata("name": "some_ami", "serverGroups": [], "imageId": "ami-123321", "region": "eu-west-1", "account": "test_account")
+                .reference("ami-123321")
+                .build())
+
+        and:
+        1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> [
+                "aws:images:test_account:eu-west-1:ami-123321"
+        ]
+
+        1 * cache.get(IMAGES.ns, "aws:images:test_account:eu-west-1:ami-123321") >>
+                imageCacheData('aws:images:test_account:eu-west-1:ami-123321', [
+                        account: 'test_account',
+                        region : 'eu-west-1',
+                        name   : 'some_ami',
+                        imageId: 'ami-123321'])
+    }
+
+    void "should return exception because of image not being unique"() {
+        when:
+        provider.getImageById("ami-123321")
+
+        then:
+        thrown(RuntimeException)
+
+        and:
+        1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> [
+                "aws:images:test_account:eu-west-1:ami-123321",
+                "aws:images:test_account:eu-west-1:ami-123321"
+        ]
+    }
+
+    void "should not find any image"() {
+        when:
+        def result = provider.getImageById("ami-123321")
+
+        then:
+        result == Optional.empty()
+
+        and:
+        1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> []
+    }
+
+    void "should throw exception of invalid ami name"() {
+        when:
+        provider.getImageById("amiz-123321")
+
+        then:
+        thrown(RuntimeException)
+    }
+
+    static private CacheData imageCacheData(String imageId, Map attributes) {
+        new DefaultCacheData(Keys.getImageKey(imageId, attributes.account, attributes.region), attributes, [:])
+    }
+}

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonImageProviderSpec.groovy
@@ -52,26 +52,12 @@ class AmazonImageProviderSpec extends Specification {
             "aws:images:test_account:eu-west-1:ami-123321"
     ]
 
-    1 * cache.get(IMAGES.ns, "aws:images:test_account:eu-west-1:ami-123321") >>
-            imageCacheData('aws:images:test_account:eu-west-1:ami-123321', [
+    1 * cache.getAll(IMAGES.ns, ["aws:images:test_account:eu-west-1:ami-123321"]) >>
+            [imageCacheData('aws:images:test_account:eu-west-1:ami-123321', [
                     account: 'test_account',
                     region : 'eu-west-1',
                     name   : 'some_ami',
-                    imageId: 'ami-123321'])
-  }
-
-  void "should return exception because of image not being unique"() {
-    when:
-    provider.getImageById("ami-123321")
-
-    then:
-    thrown(RuntimeException)
-
-    and:
-    1 * cache.filterIdentifiers(IMAGES.ns, _ as String) >> [
-            "aws:images:test_account:eu-west-1:ami-123321",
-            "aws:images:test_account:eu-west-1:ami-123321"
-    ]
+                    imageId: 'ami-123321'])]
   }
 
   void "should not find any image"() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -211,7 +211,7 @@ class CloudDriverConfig {
 
   @Bean
   @ConditionalOnMissingBean(ImageProvider)
-  ImageProvider noopImageIdProvider() {
+  ImageProvider noopImageProvider() {
     new NoopImageProvider()
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/CloudDriverConfig.groovy
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.clouddriver.model.ApplicationProvider
 import com.netflix.spinnaker.clouddriver.model.CloudMetricProvider
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
 import com.netflix.spinnaker.clouddriver.model.ElasticIpProvider
+import com.netflix.spinnaker.clouddriver.model.ImageProvider
 import com.netflix.spinnaker.clouddriver.model.InstanceProvider
 import com.netflix.spinnaker.clouddriver.model.InstanceTypeProvider
 import com.netflix.spinnaker.clouddriver.model.KeyPairProvider
@@ -40,6 +41,7 @@ import com.netflix.spinnaker.clouddriver.model.NoopApplicationProvider
 import com.netflix.spinnaker.clouddriver.model.NoopCloudMetricProvider
 import com.netflix.spinnaker.clouddriver.model.NoopClusterProvider
 import com.netflix.spinnaker.clouddriver.model.NoopElasticIpProvider
+import com.netflix.spinnaker.clouddriver.model.NoopImageProvider
 import com.netflix.spinnaker.clouddriver.model.NoopInstanceProvider
 import com.netflix.spinnaker.clouddriver.model.NoopInstanceTypeProvider
 import com.netflix.spinnaker.clouddriver.model.NoopKeyPairProvider
@@ -205,6 +207,12 @@ class CloudDriverConfig {
   @ConditionalOnMissingBean(InstanceProvider)
   InstanceProvider noopInstanceProvider() {
     new NoopInstanceProvider()
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ImageProvider)
+  ImageProvider noopImageIdProvider() {
+    new NoopImageProvider()
   }
 
   @Bean

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ImageProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ImageProvider.java
@@ -16,12 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.model;
 
-import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-
 import java.util.Optional;
 
 public interface ImageProvider {
-  Optional<Artifact> getImageById(String imageId);
+  Optional<Image> getImageById(String imageId);
 
   String getCloudProvider();
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ImageProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ImageProvider.java
@@ -1,0 +1,11 @@
+package com.netflix.spinnaker.clouddriver.model;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+
+import java.util.Optional;
+
+public interface ImageProvider {
+  Optional<Artifact> getImageById(String imageId);
+
+  String getCloudProvider();
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ImageProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ImageProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.model;
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopImageProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopImageProvider.java
@@ -16,14 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.model;
 
-import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-
 import java.util.Optional;
 
 public class NoopImageProvider implements ImageProvider {
 
   @Override
-  public Optional<Artifact> getImageById(String imageId) {
+  public Optional<Image> getImageById(String imageId) {
     return Optional.empty();
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopImageProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopImageProvider.java
@@ -1,0 +1,20 @@
+
+
+package com.netflix.spinnaker.clouddriver.model;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+
+import java.util.Optional;
+
+public class NoopImageProvider implements ImageProvider {
+
+  @Override
+  public Optional<Artifact> getImageById(String imageId) {
+    return Optional.empty();
+  }
+
+  @Override
+  public String getCloudProvider() {
+    return "none";
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopImageProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopImageProvider.java
@@ -1,4 +1,18 @@
-
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.netflix.spinnaker.clouddriver.model;
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ImageController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ImageController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.controllers;
 
 import com.netflix.spinnaker.clouddriver.model.ImageProvider;

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ImageController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ImageController.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.controllers;
 
+import com.netflix.spinnaker.clouddriver.model.Image;
 import com.netflix.spinnaker.clouddriver.model.ImageProvider;
-import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,7 +37,7 @@ public class ImageController {
   List<ImageProvider> imageProviders;
 
   @RequestMapping(value = "/{provider}/{imageId}", method = RequestMethod.GET)
-  Artifact getImage(@PathVariable String provider, @PathVariable String imageId) {
+  Image getImage(@PathVariable String provider, @PathVariable String imageId) {
 
     List<ImageProvider> imageProviderList = imageProviders.stream()
         .filter(imageProvider -> imageProvider.getCloudProvider().equals(provider))
@@ -46,7 +46,7 @@ public class ImageController {
     if (imageProviderList.isEmpty()) {
       throw new UnsupportedOperationException("ImageProvider for provider " + provider + " not found.");
     } else if (imageProviderList.size() > 1) {
-      throw new UnsupportedOperationException("Found multiple ImageProviders for provider " + provider + ". Multiple ImageProviders for a single provider are not supported.");
+      throw new IllegalStateException("Found multiple ImageProviders for provider " + provider + ". Multiple ImageProviders for a single provider are not supported.");
     } else {
       return imageProviderList.get(0).getImageById(imageId).orElseThrow(() -> new NotFoundException("Image not found (id: " + imageId + ")"));
     }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ImageController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ImageController.java
@@ -1,0 +1,38 @@
+package com.netflix.spinnaker.clouddriver.controllers;
+
+import com.netflix.spinnaker.clouddriver.model.ImageProvider;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@RestController
+@RequestMapping("/images")
+public class ImageController {
+
+  @Autowired
+  List<ImageProvider> imageProviders;
+
+  @RequestMapping(value = "/{provider}/{imageId}", method = RequestMethod.GET)
+  Artifact getImage(@PathVariable String provider, @PathVariable String imageId) {
+
+    List<ImageProvider> imageProviderList = imageProviders.stream()
+        .filter(imageProvider -> imageProvider.getCloudProvider().equals(provider))
+        .collect(Collectors.toList());
+
+    if (imageProviderList.isEmpty()) {
+      throw new UnsupportedOperationException("ImageProvider for provider " + provider + " not found.");
+    } else if (imageProviderList.size() > 1) {
+      throw new UnsupportedOperationException("Found multiple ImageProviders for provider " + provider + ". Multiple ImageProviders for a single provider are not supported.");
+    } else {
+      return imageProviderList.get(0).getImageById(imageId).orElseThrow(() -> new NotFoundException("Image not found (id: " + imageId + ")"));
+    }
+  }
+}


### PR DESCRIPTION
This PR adds functionality to get an image based on the id of the image. Currently, only AWS provider is implemented.

Based on an image id (`ami-123321`), it would be possible to call `images/aws/ami-123321` and retrieve the information about such image - including the server groups and instances where the image might be used.

Usefulness of such endpoint:
- Cleaning up images. After using spinnaker for some time and baking a lot of images, these images start to pile up and increase costs and resource usage. Being able to know if a certain image is being used or not, is useful to make a decision on either delete it or not.
- Security. At some point, a certain image can be discovered to have been compromised - having a quick way to identify which server groups/instances are using such image might be useful.

For reference, here's a result of calling such endpoint:
```
{
  "artifactAccount" : null,
  "location" : "123456789/eu-west-1",
  "metadata" : {
    "architecture" : "x86_64",
    "blockDeviceMappings" : [ {
      "deviceName" : "/dev/sda1",
      "ebs" : {
        "deleteOnTermination" : true,
        "encrypted" : false,
        "snapshotId" : "snap-0ab7091111111e036",
        "volumeSize" : 8,
        "volumeType" : "gp2"
      }
    }, {
      "deviceName" : "/dev/sdb",
      "virtualName" : "ephemeral0"
    }, {
      "deviceName" : "/dev/sdc",
      "virtualName" : "ephemeral1"
    } ],
    "creationDate" : "2017-10-12T20:08:47.000Z",
    "enaSupport" : true,
    "hypervisor" : "xen",
    "imageId" : "ami-f531111c",
    "imageLocation" : "811111117767/my_app-amd64-20171012200143-xenial",
    "imageType" : "machine",
    "name" : "my_app-amd64-20171012200143-xenial",
    "ownerId" : "811111117767",
    "productCodes" : [ ],
    "public" : false,
    "rootDeviceName" : "/dev/sda1",
    "rootDeviceType" : "ebs",
    "serverGroups" : [ {
      "asg" : {
        "autoScalingGroupARN" : "arn:aws:autoscaling:eu-west-1:411111117094:autoScalingGroup:b23900e2-e127-1111-1111-38d16b970f81:autoScalingGroupName/my_app-v025",
        "autoScalingGroupName" : "my_app-v025",
        "availabilityZones" : [ "eu-west-1a" ],
        "createdTime" : 1507841610647,
        "defaultCooldown" : 10,
        "desiredCapacity" : 1,
        "enabledMetrics" : [ ],
        "healthCheckGracePeriod" : 600,
        "healthCheckType" : "EC2",
        "instances" : [ {
          "availabilityZone" : "eu-west-1a",
          "healthStatus" : "Healthy",
          "instanceId" : "i-04874711111111123",
          "launchConfigurationName" : "my_app-v025-10122017205329",
          "lifecycleState" : "InService",
          "protectedFromScaleIn" : false
        } ],
        "launchConfigurationName" : "my_app-v025-10122017205329",
        "loadBalancerNames" : [ "my_app-elb" ],
        "maxSize" : 1,
        "minSize" : 1,
        "newInstancesProtectedFromScaleIn" : false,
        "suspendedProcesses" : [ {
          "processName" : "AZRebalance",
          "suspensionReason" : "User suspended at 2017-10-12T20:53:30Z"
        } ],
        "tags" : [ ],
        "targetGroupARNs" : [ ],
        "terminationPolicies" : [ "Default" ],
        "vpczoneIdentifier" : "subnet-81111dd2"
      },
      "instances" : [ {
        "availabilityZone" : "eu-west-1a",
        "healthStatus" : "Healthy",
        "instanceId" : "i-04874711111111123",
        "launchConfigurationName" : "my_app-v025-10122017205329",
        "lifecycleState" : "InService",
        "protectedFromScaleIn" : false
      } ],
      "launchConfigName" : "my_app-v025-10122017205329",
      "name" : "my_app-v025",
      "region" : "eu-west-1",
      "scalingPolicies" : [ ],
      "scheduledActions" : [ ],
      "targetGroups" : [ ],
      "vpcId" : "vpc-c91111ad",
      "zones" : [ "eu-west-1a" ]
    } ],
    "sriovNetSupport" : "simple",
    "state" : "available",
    "tags" : [ {
      "key" : "build_host",
      "value" : "https://travis.company.io/"
    }, {
      "key" : "build_info_url",
      "value" : "https://travis.company.io/infrastructure/my_app/builds/2059959"
    }, {
      "key" : "appversion",
      "value" : "my_app-0.0.8-h92.b195a5f3d9dc6627e06f40779cdb3d3d36fe0ba0/infrastructure-my_app/92"
    } ],
    "virtualizationType" : "hvm"
  },
  "name" : "my_app-amd64-20171012200143-xenial",
  "provenance" : null,
  "reference" : "ami-f531111c",
  "type" : "aws/image",
  "uuid" : null,
  "version" : null
}
```

