### PR TITLE
fix(provider/kubernetes): v2 cache clusters for workloads only

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesDaemonSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesDaemonSetCachingAgent.java
@@ -56,6 +56,11 @@ public class KubernetesDaemonSetCachingAgent extends KubernetesV2OnDemandCaching
   );
 
   @Override
+  protected boolean hasClusterRelationship() {
+    return true;
+  }
+
+  @Override
   protected KubernetesKind primaryKind() {
     return KubernetesKind.DAEMON_SET;
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesDeploymentCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesDeploymentCachingAgent.java
@@ -55,6 +55,11 @@ public class KubernetesDeploymentCachingAgent extends KubernetesV2OnDemandCachin
   );
 
   @Override
+  protected boolean hasClusterRelationship() {
+    return true;
+  }
+
+  @Override
   protected KubernetesKind primaryKind() {
     return KubernetesKind.DEPLOYMENT;
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesPodCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesPodCachingAgent.java
@@ -54,10 +54,15 @@ public class KubernetesPodCachingAgent extends KubernetesV2CachingAgent {
   final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
           INFORMATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
-          INFORMATIVE.forType(Keys.LogicalKind.CLUSTERS.toString()),
+          AUTHORITATIVE.forType(Keys.LogicalKind.CLUSTERS.toString()),
           INFORMATIVE.forType(KubernetesKind.DEPLOYMENT.toString()),
           INFORMATIVE.forType(KubernetesKind.REPLICA_SET.toString()),
           AUTHORITATIVE.forType(KubernetesKind.POD.toString())
       ))
   );
+
+  @Override
+  protected boolean hasClusterRelationship() {
+    return true;
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
@@ -59,4 +59,9 @@ public class KubernetesReplicaSetCachingAgent extends KubernetesV2OnDemandCachin
   protected KubernetesKind primaryKind() {
     return KubernetesKind.REPLICA_SET;
   }
+
+  @Override
+  protected boolean hasClusterRelationship() {
+    return true;
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesStatefulSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesStatefulSetCachingAgent.java
@@ -88,4 +88,9 @@ public class KubernetesStatefulSetCachingAgent extends KubernetesV2OnDemandCachi
 
     return result;
   }
+
+  @Override
+  protected boolean hasClusterRelationship() {
+    return true;
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -58,6 +58,11 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
 
   protected abstract KubernetesKind primaryKind();
 
+  // Cache types can choose to have relationships with Spinnaker 'clusters'
+  protected boolean hasClusterRelationship() {
+    return false;
+  }
+
   protected List<KubernetesManifest> loadPrimaryResourceList() {
     return namespaces.stream()
         .map(n -> credentials.list(primaryKind(), n))
@@ -84,7 +89,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
     Map<KubernetesManifest, List<KubernetesManifest>> relationships = loadSecondaryResourceRelationships(resources);
 
     List<CacheData> resourceData = resources.stream()
-        .map(rs -> KubernetesCacheDataConverter.convertAsResource(accountName, rs, relationships.get(rs)))
+        .map(rs -> KubernetesCacheDataConverter.convertAsResource(accountName, rs, relationships.get(rs), hasClusterRelationship()))
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ApplicationProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ApplicationProvider.java
@@ -92,6 +92,10 @@ public class KubernetesV2ApplicationProvider implements ApplicationProvider {
         .map(k -> (ClusterCacheKey) k)
         .collect(Collectors.toList());
 
+    if (keys.isEmpty()) {
+      return null;
+    }
+
     return KubernetesV2Application.builder()
         .name(name)
         .clusterNames(groupClustersByAccount(keys))


### PR DESCRIPTION
This ensures that only workload based resources are associated with a
spinnaker cluster, reducing 'application' screen clutter
