### PR TITLE
refactor(provider/appengine): artifact logic from orca

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
@@ -18,12 +18,14 @@ package com.netflix.spinnaker.clouddriver.appengine.deploy.description
 
 import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppengineGitCredentialType
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 
 @AutoClone
 @Canonical
 class DeployAppengineDescription extends AbstractAppengineCredentialsDescription implements DeployDescription {
+  Artifact artifact
   String accountName
   String application
   String stack

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/exception/AppengineDescriptionConversionException.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/exception/AppengineDescriptionConversionException.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.appengine.deploy.exception
+
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class AppengineDescriptionConversionException extends RuntimeException { }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
@@ -40,15 +40,23 @@ class DeployAppengineDescriptionValidator extends DescriptionValidator<DeployApp
     }
 
     boolean isContainerDeployment = description.containerImageUrl?.trim()
+    boolean usesGcs = description.repositoryUrl?.startsWith("gs://")
 
-    if (!isContainerDeployment && !description.repositoryUrl.startsWith("gs://")) {
-      if (!helper.validateGitCredentials(description.credentials.gitCredentials,
-                                         description.gitCredentialType,
-                                         description.credentials.name,
-                                         "gitCredentialType")) {
-         return
+    if (!description.artifact) {
+      if (isContainerDeployment) {
+        helper.validateNotEmpty(description.containerImageUrl, "containerImageUrl")
+      } else {
+        if (!usesGcs) {
+          if (!helper.validateGitCredentials(description.credentials.gitCredentials,
+                                             description.gitCredentialType,
+                                             description.credentials.name,
+                                             "gitCredentialType")) {
+             return
+          }
+          helper.validateNotEmpty(description.branch, "branch")
+        }
+        helper.validateNotEmpty(description.repositoryUrl, "repositoryUrl")
       }
-      helper.validateNotEmpty(description.branch, "branch")
     }
 
     if (isContainerDeployment) {

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineAtomicOperationConverterSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineAtomicOperationConverterSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.appengine.deploy.description.DeployAppe
 import com.netflix.spinnaker.clouddriver.appengine.deploy.ops.DeployAppengineAtomicOperation
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.appengine.deploy.exception.AppengineDescriptionConversionException
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -66,5 +67,26 @@ class DeployAppengineAtomicOperationConverterSpec extends Specification {
 
     then:
       operation instanceof DeployAppengineAtomicOperation
+  }
+
+  void "input with an unsupported artifact type throws an AppengineDescriptionConversionException"() {
+    setup:
+      def input = [
+        credentials: ACCOUNT_NAME,
+        application: APPLICATION,
+        repositoryUrl: REPO_URL,
+        branch: BRANCH,
+        configFilepaths: CONFIG_FILEPATHS,
+        artifact: [
+          type: 'foo/bar'
+        ]
+      ]
+
+    when:
+      def description = converter.convertDescription(input)
+
+    then:
+      AppengineDescriptionConversionException ex = thrown()
+      ex.message.contains('foo/bar')
   }
 }


### PR DESCRIPTION
Moves responsibility for artifact hydration during appengine deploys from orca into clouddriver.

This commit doesn't include any smarts around artifact typing, it's still just a `switch` statement on the artifact.type.  That is planned for a follow-up commit.