### PR TITLE
fix(provider/kubernetes): v2 Make workloads authoritative for apps

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesDaemonSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesDaemonSetCachingAgent.java
@@ -48,7 +48,7 @@ public class KubernetesDaemonSetCachingAgent extends KubernetesV2OnDemandCaching
   @Getter
   final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
-          INFORMATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
+          AUTHORITATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
           INFORMATIVE.forType(Keys.LogicalKind.CLUSTERS.toString()),
           INFORMATIVE.forType(KubernetesKind.DEPLOYMENT.toString()),
           AUTHORITATIVE.forType(KubernetesKind.DAEMON_SET.toString())

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesDeploymentCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesDeploymentCachingAgent.java
@@ -48,7 +48,7 @@ public class KubernetesDeploymentCachingAgent extends KubernetesV2OnDemandCachin
   @Getter
   final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
-          INFORMATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
+          AUTHORITATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
           INFORMATIVE.forType(Keys.LogicalKind.CLUSTERS.toString()),
           AUTHORITATIVE.forType(KubernetesKind.DEPLOYMENT.toString())
       ))

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgent.java
@@ -48,7 +48,7 @@ public class KubernetesReplicaSetCachingAgent extends KubernetesV2OnDemandCachin
   @Getter
   final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
-          INFORMATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
+          AUTHORITATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
           INFORMATIVE.forType(Keys.LogicalKind.CLUSTERS.toString()),
           INFORMATIVE.forType(KubernetesKind.DEPLOYMENT.toString()),
           AUTHORITATIVE.forType(KubernetesKind.REPLICA_SET.toString())

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesStatefulSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesStatefulSetCachingAgent.java
@@ -55,7 +55,7 @@ public class KubernetesStatefulSetCachingAgent extends KubernetesV2OnDemandCachi
   @Getter
   final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
-          INFORMATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
+          AUTHORITATIVE.forType(Keys.LogicalKind.APPLICATIONS.toString()),
           INFORMATIVE.forType(Keys.LogicalKind.CLUSTERS.toString()),
           INFORMATIVE.forType(KubernetesKind.SERVICE.toString()),
           AUTHORITATIVE.forType(KubernetesKind.STATEFUL_SET.toString())


### PR DESCRIPTION
Let workload deployments have full control over (generated) applications coming and going.

This is in line with https://github.com/spinnaker/clouddriver/pull/2303 and fixes https://github.com/spinnaker/spinnaker/issues/2259

In particular, applications will not be shown in the deck "Applications" view if the daemonset/deployment/statefulset of the application has the `caching.spinnaker.io/ignore="true"` annotation, and will be removed from the list if the annotation added to an existing workload.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
