### PR TITLE
feat(provider/kubernetes) - V2 Adds configMap replacer support for replicasets

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesReplicaSetHandler.java
@@ -52,6 +52,13 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler implements
             .type(ArtifactTypes.DOCKER_IMAGE)
             .build()
     );
+    registerReplacer(
+      Replacer.builder()
+        .replacePath("$.spec.template.spec.volumes.[?( @.configMap.name == \"{%name%}\" )].configMap.name")
+        .findPath("$.spec.template.spec.volumes.*.configMap.name")
+        .type(ArtifactTypes.KUBERNETES_CONFIG_MAP)
+        .build()
+    );
   }
 
   @Override


### PR DESCRIPTION
This adds support for replacing configMaps from artifacts in replicaset manifest deployments.