### PR TITLE
fix(provider/aws): updating edda API base URL to use /api/v2

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/edda/EddaApi.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/edda/EddaApi.groovy
@@ -25,18 +25,18 @@ import retrofit.http.GET
 import retrofit.http.Path
 
 interface EddaApi {
-  @GET('/REST/v2/view/loadBalancerInstances;_expand')
+  @GET('/api/v2/view/loadBalancerInstances;_expand')
   List<LoadBalancerInstanceState> loadBalancerInstances()
 
-  @GET('/REST/v2/view/targetGroupHealth;_expand')
+  @GET('/api/v2/view/targetGroupHealth;_expand')
   List<TargetGroupHealth> targetGroupHealth()
 
-  @GET('/REST/v2/view/targetGroupAttributes;_expand')
+  @GET('/api/v2/view/targetGroupAttributes;_expand')
   List<TargetGroupAttributes> targetGroupAttributes()
 
-  @GET('/REST/v2/view/appLoadBalancerListeners/{loadBalancerName}')
+  @GET('/api/v2/view/appLoadBalancerListeners/{loadBalancerName}')
   List<Listener> listeners(@Path("loadBalancerName") String loadBalancerName)
 
-  @GET('/REST/v2/view/appLoadBalancerRules/{loadBalancerName}')
+  @GET('/api/v2/view/appLoadBalancerRules/{loadBalancerName}')
   List<EddaRule> rules(@Path("loadBalancerName") String loadBalancerName)
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
@@ -373,7 +373,7 @@ public class AmazonClientInvocationHandler implements InvocationHandler {
   }
 
   private HttpEntity getHttpEntity(Map<String, String> metricTags, String objectName, String key) throws IOException {
-    final String url = edda + "/REST/v2/aws/" + objectName + (key == null ? ";_expand" : "/" + key) + ";_meta";
+    final String url = edda + "/api/v2/aws/" + objectName + (key == null ? ";_expand" : "/" + key) + ";_meta";
     final HttpGet get = new HttpGet(url);
     get.setConfig(
       RequestConfig


### PR DESCRIPTION
Edda's API base URL seems to have /api/v2/ at the beginning now, rather than /rest/v2/. With the prior configuration, any calls to edda from clouddriver resulted in 404s. I think this covers what needs to be updated in clouddriver to match, but there could be other areas as well. 

FWIW, /api/v2 is shown in the Edda wiki, here: https://github.com/Netflix/edda/wiki/REST