### PR TITLE
fix(provider/ecs): ECS Cloud Metric endpoint camel-cased

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsCloudMetricController.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsCloudMetricController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Collection;
 
 @RestController
-@RequestMapping("/ecs/cloudmetrics")
+@RequestMapping("/ecs/cloudMetrics")
 public class EcsCloudMetricController {
   private final EcsCloudMetricProvider provider;
 


### PR DESCRIPTION
Based on the discussion in the gate pull request - https://github.com/spinnaker/gate/pull/500 - updated the corresponding endpoint for clouddriver.

@cfieber @ajordens @robzienert @BrunoCarrier