### PR TITLE
fix(provider/ecs): ECS Caching Agents - Account/Region awareness

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -61,6 +61,10 @@ public class Keys implements KeyParser {
 
   @Override
   public Boolean canParseType(String type) {
+    return canParse(type);
+  }
+
+  private static Boolean canParse(String type){
     for (Namespace key : Namespace.values()) {
       if (key.toString().equals(type)) {
         return true;
@@ -80,6 +84,12 @@ public class Keys implements KeyParser {
     result.put("provider", parts[0]);
     result.put("type", parts[1]);
     result.put("account", parts[2]);
+
+    if(!canParse(parts[1]) && parts[1].equals(HEALTH.getNs())){
+      result.put("region", parts[3]);
+      result.put("taskId", parts[4]);
+      return result;
+    }
 
 
     Namespace namespace = Namespace.valueOf(CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, parts[1]));

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/Keys.java
@@ -64,7 +64,7 @@ public class Keys implements KeyParser {
     return canParse(type);
   }
 
-  private static Boolean canParse(String type){
+  private static Boolean canParse(String type) {
     for (Namespace key : Namespace.values()) {
       if (key.toString().equals(type)) {
         return true;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsLoadbalancerCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsLoadbalancerCacheClient.java
@@ -46,13 +46,24 @@ public class EcsLoadbalancerCacheClient {
     this.objectMapper = objectMapper;
   }
 
+  public List<EcsLoadBalancerCache> find(String account, String region) {
+    Set<Map<String, Object>> loadbalancerAttributes = fetchFromCache(account, region);
+    return convertToLoadbalancer(loadbalancerAttributes);
+  }
+
   public List<EcsLoadBalancerCache> findAll() {
-    String searchKey = Keys.getLoadBalancerKey("*", "*", "*", "*", "*") + "*";
+    return find("*", "*");
+  }
+
+  private Set<Map<String, Object>> fetchFromCache(String account, String region) {
+    String accountFilter = account != null ? account : "*";
+    String regionFilter = region != null ? region : "*";
+
+    String searchKey = Keys.getLoadBalancerKey("*", accountFilter, regionFilter, "*", "*") + "*";
+
     Collection<String> loadbalancerKeys = cacheView.filterIdentifiers(LOAD_BALANCERS.getNs(), searchKey);
 
-    Set<Map<String, Object>> loadbalancerAttributes = fetchLoadBalancerAttributes(loadbalancerKeys);
-
-    return convertToLoadbalancer(loadbalancerAttributes);
+    return fetchLoadBalancerAttributes(loadbalancerKeys);
   }
 
   public Set<EcsLoadBalancerCache> findWithTargetGroups(Set<String> targetGroups) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,7 @@ import java.util.stream.Collectors;
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.ECS_CLUSTERS;
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.IAM_ROLE;
 
 abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
   private final Logger log = LoggerFactory.getLogger(getClass());
@@ -96,6 +98,7 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
    */
   Set<String> getClusters(AmazonECS ecs, ProviderCache providerCache) {
     Set<String> clusters = providerCache.getAll(ECS_CLUSTERS.toString()).stream()
+      .filter(cacheData ->  cacheData.getAttributes().get("region").equals(region))
       .map(cacheData -> (String) cacheData.getAttributes().get("clusterArn"))
       .collect(Collectors.toSet());
 
@@ -140,8 +143,10 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
 
     Map<String, Collection<CacheData>> dataMap = generateFreshData(items);
 
+    //Old keys can come from different account/region, filter them to the current account/region.
     Set<String> oldKeys = providerCache.getAll(authoritativeKeyName).stream()
       .map(CacheData::getId)
+      .filter(key -> keyAccountRegionFilter(authoritativeKeyName, key))
       .collect(Collectors.toSet());
 
     Map<String, Collection<String>> evictions = computeEvictableData(dataMap.get(authoritativeKeyName), oldKeys);
@@ -159,16 +164,27 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
    * @return Key collection associated to the key namespace the the caching agent is authoritative of.
    */
   private Map<String, Collection<String>> computeEvictableData(Collection<CacheData> newData, Collection<String> oldKeys) {
+    //New data can only come from the current account and region, no need to filter.
     Set<String> newKeys = newData.stream()
       .map(CacheData::getId)
       .collect(Collectors.toSet());
+
     Set<String> evictedKeys = oldKeys.stream()
       .filter(oldKey -> !newKeys.contains(oldKey))
       .collect(Collectors.toSet());
 
     Map<String, Collection<String>> evictionsByKey = new HashMap<>();
     evictionsByKey.put(getAuthoritativeKeyName(), evictedKeys);
+
     return evictionsByKey;
+  }
+
+  protected boolean keyAccountRegionFilter(String authoritativeKeyName, String key) {
+    Map<String, String> keyParts = Keys.parse(key);
+    return keyParts != null &&
+           keyParts.get("account").equals(accountName) &&
+           //IAM role keys are not region specific, so it will be true. The region will be checked of other keys.
+           (authoritativeKeyName.equals(IAM_ROLE.ns) || keyParts.get("region").equals(region));
   }
 
   /**

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -98,7 +98,8 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
    */
   Set<String> getClusters(AmazonECS ecs, ProviderCache providerCache) {
     Set<String> clusters = providerCache.getAll(ECS_CLUSTERS.toString()).stream()
-      .filter(cacheData ->  cacheData.getAttributes().get("region").equals(region))
+      .filter(cacheData ->  cacheData.getAttributes().get("region").equals(region) &&
+                            cacheData.getAttributes().get("account").equals(accountName))
       .map(cacheData -> (String) cacheData.getAttributes().get("clusterArn"))
       .collect(Collectors.toSet());
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -193,7 +193,7 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
    * @param evictions The existing eviction map.
    * @return Eviction map with addtional keys.
    */
-  protected Map<String, Collection<String>> addExtraEvictions(Map<String, Collection<String>> evictions){
+  protected Map<String, Collection<String>> addExtraEvictions(Map<String, Collection<String>> evictions) {
     return evictions;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
@@ -112,12 +112,12 @@ public class ContainerInstanceCachingAgent extends AbstractEcsOnDemandAgent<Cont
     return dataMap;
   }
 
-  public static  Map<String, Object> convertContainerInstanceToAttributes(ContainerInstance containerInstance){
+  public static Map<String, Object> convertContainerInstanceToAttributes(ContainerInstance containerInstance) {
     Map<String, Object> attributes = new HashMap<>();
     attributes.put("containerInstanceArn", containerInstance.getContainerInstanceArn());
     attributes.put("ec2InstanceId", containerInstance.getEc2InstanceId());
-    for(Attribute containerAttribute:containerInstance.getAttributes()){
-      if(containerAttribute.getName().equals("ecs.availability-zone")){
+    for (Attribute containerAttribute : containerInstance.getAttributes()) {
+      if (containerAttribute.getName().equals("ecs.availability-zone")) {
         attributes.put("availabilityZone", containerAttribute.getValue());
       }
     }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.ecs.AmazonECS;
+import com.amazonaws.services.ecs.model.Attribute;
 import com.amazonaws.services.ecs.model.ContainerInstance;
 import com.amazonaws.services.ecs.model.DescribeContainerInstancesRequest;
 import com.amazonaws.services.ecs.model.ListContainerInstancesRequest;
@@ -56,7 +57,7 @@ public class ContainerInstanceCachingAgent extends AbstractEcsOnDemandAgent<Cont
 
   @Override
   public String getAgentType() {
-    return ContainerInstanceCachingAgent.class.getSimpleName();
+    return accountName + "/" + region + "/" + getClass().getSimpleName();
   }
 
   @Override
@@ -115,6 +116,11 @@ public class ContainerInstanceCachingAgent extends AbstractEcsOnDemandAgent<Cont
     Map<String, Object> attributes = new HashMap<>();
     attributes.put("containerInstanceArn", containerInstance.getContainerInstanceArn());
     attributes.put("ec2InstanceId", containerInstance.getEc2InstanceId());
+    for(Attribute containerAttribute:containerInstance.getAttributes()){
+      if(containerAttribute.getName().equals("ecs.availability-zone")){
+        attributes.put("availabilityZone", containerAttribute.getValue());
+      }
+    }
     return attributes;
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
@@ -155,7 +155,7 @@ public class EcsCloudMetricAlarmCachingAgent implements CachingAgent {
 
   @Override
   public String getAgentType() {
-    return  accountName + "/" + region + "/" + getClass().getSimpleName();
+    return accountName + "/" + region + "/" + getClass().getSimpleName();
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
@@ -92,7 +92,10 @@ public class EcsCloudMetricAlarmCachingAgent implements CachingAgent {
     Collection<CacheData> newData = newDataMap.get(ALARMS.toString());
 
     Set<String> oldKeys = providerCache.getAll(ALARMS.toString()).stream()
-      .map(CacheData::getId).collect(Collectors.toSet());
+      .map(CacheData::getId)
+      .filter(this::keyAccountRegionFilter)
+      .collect(Collectors.toSet());
+
     Map<String, Collection<String>> evictionsByKey = computeEvictableData(newData, oldKeys);
 
     return new DefaultCacheResult(newDataMap, evictionsByKey);
@@ -143,9 +146,16 @@ public class EcsCloudMetricAlarmCachingAgent implements CachingAgent {
     return cacheableMetricAlarm;
   }
 
+  private boolean keyAccountRegionFilter(String key) {
+    Map<String, String> keyParts = Keys.parse(key);
+    return keyParts != null &&
+      keyParts.get("account").equals(accountName) &&
+      keyParts.get("region").equals(region);
+  }
+
   @Override
   public String getAgentType() {
-    return getClass().getSimpleName();
+    return  accountName + "/" + region + "/" + getClass().getSimpleName();
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCachingAgent.java
@@ -53,7 +53,7 @@ public class EcsClusterCachingAgent extends AbstractEcsCachingAgent<String> {
 
   @Override
   public String getAgentType() {
-    return EcsClusterCachingAgent.class.getSimpleName();
+    return accountName + "/" + region + "/" + getClass().getSimpleName();
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgent.java
@@ -178,6 +178,7 @@ public class IamRoleCachingAgent implements CachingAgent {
 
     return cacheableRoles;
   }
+  
   private boolean keyAccountFilter(String key) {
     Map<String, String> keyParts = Keys.parse(key);
     return keyParts != null &&

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamRoleCachingAgent.java
@@ -89,13 +89,14 @@ public class IamRoleCachingAgent implements CachingAgent {
     Collection<CacheData> newData = newDataMap.get(IAM_ROLE.toString());
 
     Set<String> oldKeys = providerCache.getAll(IAM_ROLE.toString()).stream()
-      .map(cache -> cache.getId()).collect(Collectors.toSet());
+      .map(CacheData::getId)
+      .filter(this::keyAccountFilter)
+      .collect(Collectors.toSet());
     Map<String, Collection<String>> evictionsByKey = computeEvictableData(newData, oldKeys);
 
     logUpcomingActions(newDataMap, evictionsByKey);
 
-    DefaultCacheResult cacheResult = new DefaultCacheResult(newDataMap, evictionsByKey);
-    return cacheResult;
+    return new DefaultCacheResult(newDataMap, evictionsByKey);
   }
 
   private void logUpcomingActions(Map<String, Collection<CacheData>> newDataMap, Map<String, Collection<String>> evictionsByKey) {
@@ -116,7 +117,9 @@ public class IamRoleCachingAgent implements CachingAgent {
 
   private Map<String, Collection<String>> computeEvictableData(Collection<CacheData> newData, Collection<String> oldKeys) {
 
-    Set<String> newKeys = newData.stream().map(newKey -> newKey.getId()).collect(Collectors.toSet());
+    Set<String> newKeys = newData.stream()
+      .map(CacheData::getId)
+      .collect(Collectors.toSet());
 
     Set<String> evictedKeys = new HashSet<>();
     for (String oldKey : oldKeys) {
@@ -146,7 +149,7 @@ public class IamRoleCachingAgent implements CachingAgent {
   }
 
   Set<IamRole> fetchIamRoles(AmazonIdentityManagement iam, String accountName) {
-    Set<IamRole> cacheableRoles = new HashSet();
+    Set<IamRole> cacheableRoles = new HashSet<>();
     String marker = null;
     do {
       ListRolesRequest request = new ListRolesRequest();
@@ -175,10 +178,15 @@ public class IamRoleCachingAgent implements CachingAgent {
 
     return cacheableRoles;
   }
+  private boolean keyAccountFilter(String key) {
+    Map<String, String> keyParts = Keys.parse(key);
+    return keyParts != null &&
+      keyParts.get("account").equals(accountName);
+  }
 
   @Override
   public String getAgentType() {
-    return IamRoleCachingAgent.class.getSimpleName();
+    return accountName + "/" + getClass().getSimpleName();
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ScalableTargetsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ScalableTargetsCachingAgent.java
@@ -89,7 +89,10 @@ public class ScalableTargetsCachingAgent implements CachingAgent {
     Collection<CacheData> newData = newDataMap.get(SCALABLE_TARGETS.toString());
 
     Set<String> oldKeys = providerCache.getAll(SCALABLE_TARGETS.toString()).stream()
-      .map(CacheData::getId).collect(Collectors.toSet());
+      .map(CacheData::getId)
+      .filter(this::keyAccountRegionFilter)
+      .collect(Collectors.toSet());
+
     Map<String, Collection<String>> evictionsByKey = computeEvictableData(newData, oldKeys);
 
     return new DefaultCacheResult(newDataMap, evictionsByKey);
@@ -140,9 +143,16 @@ public class ScalableTargetsCachingAgent implements CachingAgent {
     return scalableTargets;
   }
 
+  private boolean keyAccountRegionFilter(String key) {
+    Map<String, String> keyParts = Keys.parse(key);
+    return keyParts != null &&
+      keyParts.get("account").equals(accountName) &&
+      keyParts.get("region").equals(region);
+  }
+
   @Override
   public String getAgentType() {
-    return getClass().getSimpleName();
+    return accountName + "/" + region + "/" + getClass().getSimpleName();
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
@@ -83,7 +83,7 @@ public class ServiceCachingAgent extends AbstractEcsOnDemandAgent<Service> {
 
   @Override
   public String getAgentType() {
-    return ServiceCachingAgent.class.getSimpleName();
+    return accountName + "/" + region + "/" + getClass().getSimpleName();
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -69,7 +69,7 @@ public class TaskCachingAgent extends AbstractEcsOnDemandAgent<Task> {
 
   @Override
   public String getAgentType() {
-    return TaskCachingAgent.class.getSimpleName();
+    return accountName + "/" + region + "/" + getClass().getSimpleName();
   }
 
   @Override
@@ -104,7 +104,8 @@ public class TaskCachingAgent extends AbstractEcsOnDemandAgent<Task> {
     for (CacheData onDemand : allOnDemand) {
       Map<String, String> parsedKey = Keys.parse(onDemand.getId());
       if (parsedKey != null && parsedKey.get("type") != null &&
-        (parsedKey.get("type").equals(SERVICES.toString()) || parsedKey.get("type").equals(TASKS.toString()))) {
+        (parsedKey.get("type").equals(SERVICES.toString()) || parsedKey.get("type").equals(TASKS.toString()) &&
+          parsedKey.get("account").equals(accountName) && parsedKey.get("region").equals(region))) {
 
         parsedKey.put("type", "serverGroup");
         parsedKey.put("serverGroup", parsedKey.get("serviceName"));

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -166,7 +166,7 @@ public class TaskCachingAgent extends AbstractEcsOnDemandAgent<Task> {
     return dataMap;
   }
 
-  public static Map<String, Object> convertTaskToAttributes(Task task){
+  public static Map<String, Object> convertTaskToAttributes(Task task) {
     String taskId = StringUtils.substringAfterLast(task.getTaskArn(), "/");
 
     Map<String, Object> attributes = new HashMap<>();

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -102,7 +102,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth> 
     serviceEvicitions = new LinkedList<>();
     taskDefEvicitions = new LinkedList<>();
 
-    Collection<Task> tasks = taskCacheClient.getAll();
+    Collection<Task> tasks = taskCacheClient.getAll(accountName, region);
     if (tasks != null) {
       for (Task task : tasks) {
         String containerInstanceCacheKey = Keys.getContainerInstanceKey(accountName, region, task.getContainerInstanceArn());
@@ -220,7 +220,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth> 
 
   @Override
   public String getAgentType() {
-    return TaskHealthCachingAgent.class.getSimpleName();
+    return accountName + "/" + region + "/" + getClass().getSimpleName();
   }
 
   @Override

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
@@ -31,11 +31,13 @@ import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
-import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.TaskHealth
 import spock.lang.Specification
 import spock.lang.Subject
+
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
+import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.TASKS
 
 class TaskHealthCachingAgentSpec extends Specification {
   def ecs = Mock(AmazonECS)
@@ -72,7 +74,8 @@ class TaskHealthCachingAgentSpec extends Specification {
       containers           : Collections.singletonList(containerMap)
     ]
     def taskCacheData = new DefaultCacheData(taskKey, taskAttributes, Collections.emptyMap())
-    providerCache.getAll(Keys.Namespace.TASKS.toString()) >> Collections.singletonList(taskCacheData)
+    providerCache.filterIdentifiers(_, _) >> []
+    providerCache.getAll(TASKS.toString(), _) >> Collections.singletonList(taskCacheData)
 
     def serviceAttributes = [
       loadBalancers        : Collections.singletonList(loadbalancerMap),
@@ -136,10 +139,10 @@ class TaskHealthCachingAgentSpec extends Specification {
 
     then:
     dataMap.keySet().size() == 1
-    dataMap.containsKey(Namespace.HEALTH.toString())
-    dataMap.get(Namespace.HEALTH.toString()).size() == taskIds.size()
+    dataMap.containsKey(HEALTH.toString())
+    dataMap.get(HEALTH.toString()).size() == taskIds.size()
 
-    for (CacheData cacheData : dataMap.get(Namespace.HEALTH.toString())) {
+    for (CacheData cacheData : dataMap.get(HEALTH.toString())) {
       def attributes = cacheData.getAttributes()
       keys.contains(cacheData.getId())
       taskIds.contains(attributes.get('taskId'))


### PR DESCRIPTION
`getClusters(...)` method in `AbstractEcsCachingAgent` was returning back clusters for all regions and accounts - which caused issues for caching agents extend that calls and calling that method.

When registering with the scheduler, caching agents were imporperly named. This caused only one instance of each caching agent to be registered, even if there were several caching agents for different regions.

This PR fixes the above.

Issue was brought up by a member of the Spinnaker community - on slack, in the ecs channel - when he tried to use clouddriver, having an account with multiple regions. 

@cfieber @ajordens @robzienert @BrunoCarrier