### PR TITLE
refactor(provider/ecs): ECS Accounts - AssumeRoleEcsCredentials

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsInitializer.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/EcsCredentialsInitializer.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.security;
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAssumeRoleAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsLoader;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
@@ -75,7 +76,7 @@ public class EcsCredentialsInitializer implements CredentialsInitializerSynchron
             CredentialsConfig ecsCopy = new CredentialsConfig();
             ecsCopy.setAccounts(Collections.singletonList(account));
 
-            NetflixECSCredentials esCredentials = new NetflixECSCredentials(credentialsLoader.load(ecsCopy).get(0));
+            NetflixECSCredentials esCredentials = new NetflixAssumeRoleEcsCredentials((NetflixAssumeRoleAmazonCredentials)credentialsLoader.load(ecsCopy).get(0));
             credentials.add(esCredentials);
 
             accountCredentialsRepository.save(ecsAccount.getName(), esCredentials);

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/NetflixAssumeRoleEcsCredentials.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/NetflixAssumeRoleEcsCredentials.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.security;
+
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAssumeRoleAmazonCredentials;
+
+public class NetflixAssumeRoleEcsCredentials extends NetflixECSCredentials {
+  private final String assumeRole;
+  private final String sessionName;
+
+  public NetflixAssumeRoleEcsCredentials(NetflixAssumeRoleAmazonCredentials copy) {
+    super(copy);
+    this.assumeRole = copy.getAssumeRole();
+    this.sessionName = copy.getSessionName();
+  }
+
+
+  public String getAssumeRole() {
+    return assumeRole;
+  }
+
+  public String getSessionName() {
+    return sessionName;
+  }
+}


### PR DESCRIPTION
`EcsCredentialsInitializer` now initializes `NetflixAssumeRoleEcsCredentials`. This is needed for the up coming `CreateServerGroupAtomicOperation`, where the assumed role is used during service and autoscaling creation.

@cfieber @ajordens @robzienert @BrunoCarrier