### PR TITLE
feat(provider/ecs): ECS Images Controller

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesController.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesController.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.controllers;
+
+import com.netflix.spinnaker.clouddriver.ecs.model.EcsDockerImage;
+import com.netflix.spinnaker.clouddriver.ecs.provider.view.ImageRepositoryProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/ecs/images")
+public class EcsImagesController {
+  private final List<ImageRepositoryProvider> imageRepositoryProviders;
+
+  @Autowired
+  public EcsImagesController(List<ImageRepositoryProvider> imageRepositoryProviders) {
+    this.imageRepositoryProviders = imageRepositoryProviders;
+  }
+
+  @RequestMapping(value = "/find", method = RequestMethod.GET)
+  public List<EcsDockerImage> findImage(@RequestParam("q") String dockerImageUrl, HttpServletRequest request) {
+    for (ImageRepositoryProvider provider : imageRepositoryProviders) {
+      if (provider.handles(dockerImageUrl)) {
+        return provider.findImage(dockerImageUrl);
+      }
+    }
+
+    throw new Error("The URL is not support by any of the providers. Currently enabled and supported providers are: " +
+      imageRepositoryProviders.stream().
+        map(ImageRepositoryProvider::getRepositoryName).
+        collect(Collectors.joining(", ")) + ".");
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesControllerSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesControllerSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.controllers
+
+import com.netflix.spinnaker.clouddriver.ecs.provider.view.EcrImageProvider
+import spock.lang.Specification
+import spock.lang.Subject
+
+class EcsImagesControllerSpec extends Specification {
+  def ecrImageProvider = Mock(EcrImageProvider)
+  @Subject
+  def controller = new EcsImagesController([ecrImageProvider])
+
+  def 'should retrieve image details based on tagged url'() {
+    given:
+    def tag = 'latest'
+    def region = 'us-west-1'
+    def repoName = 'test-repo'
+    def accountId = '123456789012'
+    def digest = 'sha256:deadbeef785192c146085da66a4261e25e79a6210103433464eb7f79deadbeef'
+    def url = accountId + '.dkr.ecr.' + region + '.amazonaws.com/' + repoName + ':' + tag
+
+    def expectedMaps = [[
+                          region    : region,
+                          imageName : accountId + '.dkr.ecr.' + region + '.amazonaws.com/' + repoName + '@' + digest,
+                          amis      : ['us-west-1': Collections.singletonList(digest)],
+                          attributes: [creationDate: new Date()]
+                        ]]
+
+    ecrImageProvider.getRepositoryName() >> 'ECR'
+    ecrImageProvider.handles(url) >> true
+    ecrImageProvider.findImage(url) >> expectedMaps
+
+    when:
+    def retrievedMap = controller.findImage(url, null)
+
+    then:
+    retrievedMap == expectedMaps
+  }
+}


### PR DESCRIPTION
Added `EcsImagesController` which is responsible for providing AWS/ECR docker images on the `/ecs/images/find` endpoint. Used during `Find Image from Tags` stage.

@cfieber @ajordens @robzienert @BrunoCarrier