### PR TITLE
feat(provider/ecs): ECS Instance Provider

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/ContainerInstanceCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/ContainerInstanceCacheClient.java
@@ -20,11 +20,13 @@ import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.ContainerInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
 import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.CONTAINER_INSTANCES;
 
+@Component
 public class ContainerInstanceCacheClient extends AbstractCacheClient<ContainerInstance> {
 
   @Autowired
@@ -38,6 +40,7 @@ public class ContainerInstanceCacheClient extends AbstractCacheClient<ContainerI
     Map<String, Object> attributes = cacheData.getAttributes();
     containerInstance.setArn((String) attributes.get("containerInstanceArn"));
     containerInstance.setEc2InstanceId((String) attributes.get("ec2InstanceId"));
+    containerInstance.setAvailabilityZone((String) attributes.get("availabilityZone"));
 
     return containerInstance;
   }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/ContainerInstance.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/ContainerInstance.java
@@ -22,4 +22,5 @@ import lombok.Data;
 public class ContainerInstance {
   String arn;
   String ec2InstanceId;
+  String availabilityZone;
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsTask.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/EcsTask.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.model;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
+import com.netflix.spinnaker.clouddriver.model.HealthState;
+import com.netflix.spinnaker.clouddriver.model.Instance;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class EcsTask implements Instance, Serializable {
+  private String name;
+  private HealthState healthState;
+  private Long launchTime;
+  private String zone;
+  private List<Map<String, String>> health;
+  private String providerType;
+  private String cloudProvider;
+  private String privateAddress;
+
+  public EcsTask(String name, Long launchTime, String lastStatus, String desiredStatus, String availabilityZone, List<Map<String, String>> health, String privateAddress) {
+    this.name = name;
+    providerType = cloudProvider = EcsCloudProvider.ID;
+    this.launchTime = launchTime;
+    this.health = health;
+    healthState = calculateHealthState(lastStatus, desiredStatus);
+    zone = availabilityZone;
+    this.privateAddress = privateAddress;
+  }
+
+  /**
+   * Maps the Last Status and Desired Status of a Tasks to a Health State understandable by Spinnaker
+   * <p>
+   * The mapping is based on:
+   * <p>
+   * Task Life Cycle: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_life_cycle.html
+   *
+   * @param lastStatus    Last reported status of the Task
+   * @param desiredStatus Desired status of the Task
+   * @return Spinnaker understandable Health State
+   */
+  private HealthState calculateHealthState(String lastStatus, String desiredStatus) {
+    HealthState currentState = null;
+
+    if ("RUNNING".equals(desiredStatus) && "PENDING".equals(lastStatus)) {
+      currentState = HealthState.Starting;
+    } else if ("RUNNING".equals(lastStatus)) {
+      currentState = HealthState.Up;
+    } else if ("STOPPED".equals(desiredStatus)) {
+      currentState = HealthState.Down;
+    } else {
+      currentState = HealthState.Unknown;
+    }
+
+    return currentState;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
@@ -88,10 +88,10 @@ public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
   }
 
   private boolean isValidId(String id, String region) {
-    String id_regex = "[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}";
-    String id_only = String.format("^%s$", id_regex);
-    String arn = String.format("arn:aws:ecs:%s:\\d*:task/%s", region, id_regex);
-    return id.matches(id_only) || id.matches(arn);
+    String idRegex = "[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}";
+    String idOnly = String.format("^%s$", idRegex);
+    String arn = String.format("arn:aws:ecs:%s:\\d*:task/%s", region, idRegex);
+    return id.matches(idOnly) || id.matches(arn);
   }
 
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.view;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient;
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskCacheClient;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.ContainerInstance;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.Task;
+import com.netflix.spinnaker.clouddriver.ecs.model.EcsTask;
+import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService;
+import com.netflix.spinnaker.clouddriver.model.InstanceProvider;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
+
+  private final TaskCacheClient taskCacheClient;
+  private final ContainerInstanceCacheClient containerInstanceCacheClient;
+  private ContainerInformationService containerInformationService;
+
+  @Autowired
+  public EcsInstanceProvider(ContainerInformationService containerInformationService,
+                             TaskCacheClient taskCacheClient,
+                             ContainerInstanceCacheClient containerInstanceCacheClient) {
+    this.containerInformationService = containerInformationService;
+    this.taskCacheClient = taskCacheClient;
+    this.containerInstanceCacheClient = containerInstanceCacheClient;
+  }
+
+  @Override
+  public String getCloudProvider() {
+    return EcsCloudProvider.ID;
+  }
+
+  @Override
+  public EcsTask getInstance(String account, String region, String id) {
+    if (!isValidId(id, region))
+      return null;
+
+    EcsTask ecsInstance = null;
+
+    String key = Keys.getTaskKey(account, region, id);
+    Task task = taskCacheClient.get(key);
+    if (task == null) {
+      return null;
+    }
+
+    key = Keys.getContainerInstanceKey(account, region, task.getContainerInstanceArn());
+    ContainerInstance containerInstance = containerInstanceCacheClient.get(key);
+
+    if (containerInstance != null) {
+      String serviceName = StringUtils.substringAfter(task.getGroup(), "service:");
+      Long launchTime = task.getStartedAt();
+
+      List<Map<String, String>> healthStatus = containerInformationService.getHealthStatus(id, serviceName, account, region);
+      String address = containerInformationService.getTaskPrivateAddress(account, region, task);
+
+      ecsInstance = new EcsTask(id, launchTime, task.getLastStatus(), task.getDesiredStatus(), containerInstance.getAvailabilityZone(), healthStatus, address);
+    }
+
+    return ecsInstance;
+  }
+
+  @Override
+  public String getConsoleOutput(String account, String region, String id) {
+    return null;
+  }
+
+  private boolean isValidId(String id, String region) {
+    String id_regex = "[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}";
+    String id_only = String.format("^%s$", id_regex);
+    String arn = String.format("arn:aws:ecs:%s:\\d*:task/%s", region, id_regex);
+    return id.matches(id_only) || id.matches(arn);
+  }
+
+}
+

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProviderSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.view
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.ec2.AmazonEC2
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskCacheClient
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.ContainerInstance
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.Task
+import com.netflix.spinnaker.clouddriver.ecs.model.EcsTask
+import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+import spock.lang.Subject
+
+class EcsInstanceProviderSpec extends Specification {
+  def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+  def amazonClientProvider = Mock(AmazonClientProvider)
+  def containerInformationService = Mock(ContainerInformationService)
+  def taskCacheClient = Mock(TaskCacheClient)
+  def containerInstanceCacheClient = Mock(ContainerInstanceCacheClient)
+
+  @Subject
+  def provider = new EcsInstanceProvider(containerInformationService, taskCacheClient,
+                                         containerInstanceCacheClient)
+
+  def 'should return an EcsTask'() {
+    given:
+    def region = 'us-west-1'
+    def account = 'test-account'
+    def taskId = 'deadbeef-94f3-4994-8e81-339c4d1be1ba'
+    def taskArn = 'arn:aws:ecs:' + region + ':123456789012:task/' + taskId
+    def address = '127.0.0.1:1337'
+    def startTime = System.currentTimeMillis()
+
+    def netflixAmazonCredentials = Mock(NetflixAmazonCredentials)
+    def awsCredentialsProvider = Mock(AWSCredentialsProvider)
+    def amazonEC2 = Mock(AmazonEC2)
+
+    def task = new Task(
+      taskId: taskId,
+      taskArn: taskArn,
+      lastStatus: 'RUNNING',
+      desiredStatus: 'RUNNING',
+      startedAt: startTime,
+    )
+
+    def containerInstance =  new ContainerInstance()
+
+    def ecsTask = new EcsTask(taskId, startTime, 'RUNNING', 'RUNNING',
+      null, null, address)
+
+    taskCacheClient.get(_) >> task
+    accountCredentialsProvider.getCredentials(_) >> netflixAmazonCredentials
+    netflixAmazonCredentials.getCredentialsProvider() >> awsCredentialsProvider
+    amazonClientProvider.getAmazonEC2(_, _, _) >> amazonEC2
+    containerInstanceCacheClient.get(_) >> containerInstance
+    containerInformationService.getTaskPrivateAddress(_, _, _) >> address
+
+    when:
+    def taskInstance = provider.getInstance(account, region, taskId)
+
+    then:
+    taskInstance == ecsTask
+  }
+}


### PR DESCRIPTION
Added `EcsInstanceProvider` which is responsible for providing an "instance" representation of an ECS Task - used for displaying the instances in server groups.

Updated `ContainerInstance` and `ContainerInstanceCacheClient` to have an `availabilityZone`.

@cfieber @ajordens @robzienert @BrunoCarrier