### PR TITLE
feat(provider/ecs): ECS Load Balancer Provider

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/loadbalancer/EcsLoadBalancerDetail.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/loadbalancer/EcsLoadBalancerDetail.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.model.loadbalancer;
+
+import lombok.Data;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider.Details;
+
+@Data
+public class EcsLoadBalancerDetail implements Details {
+  String account;
+  String region;
+  String name;
+  String vpcId;
+  String type = "aws";
+  String loadBalancerType;
+  List<String> securityGroups = new LinkedList<>();
+  List<String> targetGroups = new LinkedList<>();
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/loadbalancer/EcsLoadBalancerSummary.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/loadbalancer/EcsLoadBalancerSummary.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.model.loadbalancer;
+
+
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider.Item;
+
+
+@Data
+public class EcsLoadBalancerSummary implements Item {
+
+  private String name;
+  private Map<String, EcsLoadBalancerSummaryByAccount> byAccounts = new HashMap<>();
+
+  public EcsLoadBalancerSummary withName(String name) {
+    setName(name);
+    return this;
+  }
+
+  @Override
+  public List getByAccounts() {
+    return byAccounts.values().stream().collect(Collectors.toList());
+  }
+
+  public EcsLoadBalancerSummaryByAccount getOrCreateAccount(String account) {
+    if (!byAccounts.containsKey(account)) {
+      byAccounts.put(account, new EcsLoadBalancerSummaryByAccount().withName(account));
+    }
+    return byAccounts.get(account);
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/loadbalancer/EcsLoadBalancerSummaryByAccount.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/loadbalancer/EcsLoadBalancerSummaryByAccount.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.model.loadbalancer;
+
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider.ByAccount;
+
+@Data
+public class EcsLoadBalancerSummaryByAccount implements ByAccount {
+
+  private String name;
+  private Map<String, EcsLoadBalancerSummaryByRegion> byRegions = new HashMap<>();
+
+  public EcsLoadBalancerSummaryByAccount withName(String name){
+    setName(name);
+    return this;
+  }
+
+  public List getByRegions() {
+    return byRegions.values().stream().collect(Collectors.toList());
+  }
+
+  public EcsLoadBalancerSummaryByRegion getOrCreateRegion(String region) {
+    if (!byRegions.containsKey(region)) {
+      byRegions.put(region, new EcsLoadBalancerSummaryByRegion().withName(region));
+    }
+    return byRegions.get(region);
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/loadbalancer/EcsLoadBalancerSummaryByRegion.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/loadbalancer/EcsLoadBalancerSummaryByRegion.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.model.loadbalancer;
+
+import lombok.Data;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider.ByRegion;
+
+@Data
+public class EcsLoadBalancerSummaryByRegion implements ByRegion {
+  private String name;
+  private List<EcsLoadBalancerSummary> loadBalancers = new LinkedList<>();
+
+  public EcsLoadBalancerSummaryByRegion withName(String name){
+    setName(name);
+    return this;
+  }
+
+  public List getLoadBalancers() {
+    return loadBalancers;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProvider.java
@@ -71,7 +71,6 @@ public class EcsLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadB
     return new ArrayList<>(map.values());
   }
 
-
   @Override
   public Item get(String name) {
     return null;  //TODO - Implement this.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProvider.java
@@ -1,0 +1,98 @@
+package com.netflix.spinnaker.clouddriver.ecs.provider.view;
+
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonLoadBalancer;
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsLoadbalancerCacheClient;
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsLoadBalancerCache;
+import com.netflix.spinnaker.clouddriver.ecs.model.loadbalancer.EcsLoadBalancerDetail;
+import com.netflix.spinnaker.clouddriver.ecs.model.loadbalancer.EcsLoadBalancerSummary;
+import com.netflix.spinnaker.clouddriver.ecs.security.ECSCredentialsConfig;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class EcsLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalancer> {
+
+  private final EcsLoadbalancerCacheClient ecsLoadbalancerCacheClient;
+  private final ECSCredentialsConfig ecsCredentialsConfig;
+
+  @Autowired
+  public EcsLoadBalancerProvider(EcsLoadbalancerCacheClient ecsLoadbalancerCacheClient,
+                                 ECSCredentialsConfig ecsCredentialsConfig) {
+    this.ecsLoadbalancerCacheClient = ecsLoadbalancerCacheClient;
+    this.ecsCredentialsConfig = ecsCredentialsConfig;
+  }
+
+  @Override
+  public String getCloudProvider() {
+    return EcsCloudProvider.ID;
+  }
+
+  @Override
+  public List<Item> list() {
+    Map<String, EcsLoadBalancerSummary> map = new HashMap<>();
+    List<EcsLoadBalancerCache> loadBalancers = ecsLoadbalancerCacheClient.findAll();
+
+    for (EcsLoadBalancerCache lb : loadBalancers) {
+      String account = getEcsAccountName(lb.getAccount());
+      if (account == null) {
+        continue;
+      }
+
+      String name = lb.getLoadBalancerName();
+      String region = lb.getRegion();
+
+      EcsLoadBalancerSummary summary = map.get(name);
+      if (summary == null) {
+        summary = new EcsLoadBalancerSummary().withName(name);
+        map.put(name, summary);
+      }
+
+      EcsLoadBalancerDetail loadBalancer = new EcsLoadBalancerDetail();
+      loadBalancer.setAccount(account);
+      loadBalancer.setRegion(region);
+      loadBalancer.setName(name);
+      loadBalancer.setVpcId(lb.getVpcId());
+      loadBalancer.setSecurityGroups(lb.getSecurityGroups());
+      loadBalancer.setLoadBalancerType(lb.getLoadBalancerType());
+      loadBalancer.setTargetGroups(lb.getTargetGroups());
+
+
+      summary.getOrCreateAccount(account).getOrCreateRegion(region).getLoadBalancers().add(loadBalancer);
+    }
+
+    return new ArrayList<>(map.values());
+  }
+
+
+  @Override
+  public Item get(String name) {
+    return null;  //TODO - Implement this.
+  }
+
+  @Override
+  public List<Details> byAccountAndRegionAndName(String account, String region, String name) {
+    return null;  //TODO - Implement this.  This is used to show the details view of a load balancer which is not even implemented yet
+  }
+
+  @Override
+  public Set<AmazonLoadBalancer> getApplicationLoadBalancers(String application) {
+    return null;  //TODO - Implement this.  This is used to show load balancers and reveals other buttons
+  }
+
+  private String getEcsAccountName(String awsAccountName) {
+    for (ECSCredentialsConfig.Account ecsAccount : ecsCredentialsConfig.getAccounts()) {
+      if (ecsAccount.getAwsAccount().equals(awsAccountName)) {
+        return ecsAccount.getName();
+      }
+    }
+    return null;
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProviderSpec.groovy
@@ -43,7 +43,7 @@ class EcsLoadBalancerProviderSpec extends Specification {
     def expectedNumberOfLoadbalancers = 2
     def givenList = []
     def accounts = []
-    for (int x = 0; x < expectedNumberOfLoadbalancers; x++) {
+    (0..expectedNumberOfLoadbalancers).forEach() {
       givenList << new EcsLoadBalancerCache(
         account: 'test-account-' + x,
         region: 'us-west-' + x,

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProviderSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.view
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider
+import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsLoadbalancerCacheClient
+import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsLoadBalancerCache
+import com.netflix.spinnaker.clouddriver.ecs.security.ECSCredentialsConfig
+import spock.lang.Specification
+import spock.lang.Subject
+
+class EcsLoadBalancerProviderSpec extends Specification {
+  def client = Mock(EcsLoadbalancerCacheClient)
+  def ecsCredentialsConfig = Mock(ECSCredentialsConfig)
+  @Subject
+  def provider = new EcsLoadBalancerProvider(client, ecsCredentialsConfig)
+
+  def 'should retrieve an empty list'() {
+    when:
+    def retrievedList = provider.list()
+
+    then:
+    client.findAll() >> Collections.emptyList()
+    retrievedList.size() == 0
+  }
+
+  def 'should retrieve a list containing load balancers'() {
+    given:
+    def expectedNumberOfLoadbalancers = 2
+    def givenList = []
+    def accounts = []
+    for (int x = 0; x < expectedNumberOfLoadbalancers; x++) {
+      givenList << new EcsLoadBalancerCache(
+        account: 'test-account-' + x,
+        region: 'us-west-' + x,
+        loadBalancerArn: 'arn',
+        loadBalancerType: 'always-classic',
+        cloudProvider: EcsCloudProvider.ID,
+        listeners: [],
+        scheme: 'scheme',
+        availabilityZones: [],
+        ipAddressType: 'ipv4',
+        loadBalancerName: 'load-balancer-' + x,
+        canonicalHostedZoneId: 'zone-id',
+        vpcId: 'vpc-id-' + x,
+        dnsname: 'dns-name',
+        createdTime: System.currentTimeMillis(),
+        subnets: [],
+        securityGroups: [],
+        targetGroups: ['target-group-' + x],
+        serverGroups: []
+      )
+
+      accounts << new ECSCredentialsConfig.Account(
+        name: 'test-account-' + x,
+        awsAccount: 'test-account-' + x
+      )
+    }
+    ecsCredentialsConfig.getAccounts() >> accounts
+
+    when:
+    def retrievedList = provider.list()
+
+    then:
+    client.findAll() >> givenList
+    retrievedList.size() == expectedNumberOfLoadbalancers
+    retrievedList*.getName().containsAll(givenList*.loadBalancerName)
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProviderSpec.groovy
@@ -43,10 +43,10 @@ class EcsLoadBalancerProviderSpec extends Specification {
     def expectedNumberOfLoadbalancers = 2
     def givenList = []
     def accounts = []
-    (0..expectedNumberOfLoadbalancers).forEach() {
+    (1..expectedNumberOfLoadbalancers).forEach() {
       givenList << new EcsLoadBalancerCache(
-        account: 'test-account-' + x,
-        region: 'us-west-' + x,
+        account: 'test-account-' + it,
+        region: 'us-west-' + it,
         loadBalancerArn: 'arn',
         loadBalancerType: 'always-classic',
         cloudProvider: EcsCloudProvider.ID,
@@ -54,20 +54,20 @@ class EcsLoadBalancerProviderSpec extends Specification {
         scheme: 'scheme',
         availabilityZones: [],
         ipAddressType: 'ipv4',
-        loadBalancerName: 'load-balancer-' + x,
+        loadBalancerName: 'load-balancer-' + it,
         canonicalHostedZoneId: 'zone-id',
-        vpcId: 'vpc-id-' + x,
+        vpcId: 'vpc-id-' + it,
         dnsname: 'dns-name',
         createdTime: System.currentTimeMillis(),
         subnets: [],
         securityGroups: [],
-        targetGroups: ['target-group-' + x],
+        targetGroups: ['target-group-' + it],
         serverGroups: []
       )
 
       accounts << new ECSCredentialsConfig.Account(
-        name: 'test-account-' + x,
-        awsAccount: 'test-account-' + x
+        name: 'test-account-' + it,
+        awsAccount: 'test-account-' + it
       )
     }
     ecsCredentialsConfig.getAccounts() >> accounts


### PR DESCRIPTION
Added `EcsLoadBalancerProvider` currently responsible only for providing a list of `LoadBalancers` - used in a by Deck in the deploy stage configuration wizard.

@cfieber @ajordens @robzienert @BrunoCarrier