### PR TITLE
feat(provider/ecs): Destroy Service Atomic Operation

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverter.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
 
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
-import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CloneServiceDescription;
-import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
-import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CloneServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ModifyServiceDescription;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.DestroyServiceAtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
@@ -22,8 +36,8 @@ public class DestroyServiceAtomicOperationConverter extends AbstractAtomicOperat
   }
 
   @Override
-  public DestroyServiceDescription convertDescription(Map input) {
-    DestroyServiceDescription converted = getObjectMapper().convertValue(input, DestroyServiceDescription.class);
+  public ModifyServiceDescription convertDescription(Map input) {
+    ModifyServiceDescription converted = getObjectMapper().convertValue(input, ModifyServiceDescription.class);
     converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
 
     return converted;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/AbstractECSDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/AbstractECSDescription.java
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
-import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
-import org.springframework.stereotype.Component;
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
-@EcsOperation(AtomicOperations.DESTROY_SERVER_GROUP)
-@Component("destroyServiceAtomicOperationValidator")
-public class DestroyServiceAtomicOperationValidator extends ServerGroupDescriptionValidator {
-  public DestroyServiceAtomicOperationValidator(){
-    super("destroyServiceAtomicOperation");
-  }
+@Data
+@EqualsAndHashCode(callSuper = false)
+public abstract class AbstractECSDescription extends AbstractAmazonCredentialsDescription {
+  String application;
+  String region;
+  String stack;
+  String freeFormDetails;
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/AbstractECSDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/AbstractECSDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DestroyServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DestroyServiceDescription.java
@@ -1,8 +1,0 @@
-package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
-
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
-
-public class DestroyServiceDescription extends AbstractAmazonCredentialsDescription {
-
-  // TODO - implement this stub
-}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/ModifyServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/ModifyServiceDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/ModifyServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/ModifyServiceDescription.java
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
-import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
-import org.springframework.stereotype.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
-@EcsOperation(AtomicOperations.DESTROY_SERVER_GROUP)
-@Component("destroyServiceAtomicOperationValidator")
-public class DestroyServiceAtomicOperationValidator extends ServerGroupDescriptionValidator {
-  public DestroyServiceAtomicOperationValidator(){
-    super("destroyServiceAtomicOperation");
-  }
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class ModifyServiceDescription extends AbstractECSDescription {
+  String serverGroupName;
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
@@ -29,18 +29,16 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescription, K> implements AtomicOperation<K> {
+  private final String basePhase;
   @Autowired
   AmazonClientProvider amazonClientProvider;
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider;
   @Autowired
   ContainerInformationService containerInformationService;
-
-  private final String basePhase;
-
   T description;
 
-  AbstractEcsAtomicOperation(T description, String basePhase){
+  AbstractEcsAtomicOperation(T description, String basePhase) {
     this.description = description;
     this.basePhase = basePhase;
 
@@ -63,7 +61,7 @@ public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescriptio
     return amazonClientProvider.getAmazonEcs(credentialAccount, credentialsProvider, region);
   }
 
-  protected String getRegion(){
+  protected String getRegion() {
     return description.getRegion();
   }
 
@@ -71,7 +69,7 @@ public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescriptio
     return (AmazonCredentials) accountCredentialsProvider.getCredentials(description.getCredentialAccount());
   }
 
-   void updateTaskStatus(String status) {
+  void updateTaskStatus(String status) {
     getTask().updateStatus(basePhase, status);
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ecs.AmazonECS;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.AbstractECSDescription;
+import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescription, K> implements AtomicOperation<K> {
+  @Autowired
+  AmazonClientProvider amazonClientProvider;
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider;
+  @Autowired
+  ContainerInformationService containerInformationService;
+
+  private final String basePhase;
+
+  T description;
+
+  AbstractEcsAtomicOperation(T description, String basePhase){
+    this.description = description;
+    this.basePhase = basePhase;
+
+  }
+
+  private static Task getTask() {
+    return TaskRepository.threadLocalTask.get();
+  }
+
+  String getCluster(String service, String account) {
+    String region = getRegion();
+    return containerInformationService.getClusterName(service, account, region);
+  }
+
+  AmazonECS getAmazonEcsClient() {
+    AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
+    String region = getRegion();
+    String credentialAccount = description.getCredentialAccount();
+
+    return amazonClientProvider.getAmazonEcs(credentialAccount, credentialsProvider, region);
+  }
+
+  protected String getRegion(){
+    return description.getRegion();
+  }
+
+  AmazonCredentials getCredentials() {
+    return (AmazonCredentials) accountCredentialsProvider.getCredentials(description.getCredentialAccount());
+  }
+
+   void updateTaskStatus(String status) {
+    getTask().updateStatus(basePhase, status);
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
@@ -37,7 +37,7 @@ public class DestroyServiceAtomicOperation extends AbstractEcsAtomicOperation<Mo
 
   @Override
   public Void operate(List priorOutputs) {
-    updateTaskStatus("Initializing Destroy Amazon ECS Server Group (Service) Operation...");
+    updateTaskStatus("Initializing Destroy Amazon ECS Server Group Operation...");
     AmazonECS ecs = getAmazonEcsClient();
 
     String ecsClusterName = containerInformationService.getClusterName(description.getServerGroupName(), description.getAccount(), description.getRegion());
@@ -51,17 +51,17 @@ public class DestroyServiceAtomicOperation extends AbstractEcsAtomicOperation<Mo
     updateServiceRequest.setDesiredCount(0);
     updateServiceRequest.setCluster(ecsClusterName);
 
-    updateTaskStatus("Scaling " + description.getServerGroupName() + " service down to 0.");
+    updateTaskStatus("Scaling " + description.getServerGroupName() + " server group down to 0.");
     ecs.updateService(updateServiceRequest);
 
     DeleteServiceRequest deleteServiceRequest = new DeleteServiceRequest();
     deleteServiceRequest.setService(description.getServerGroupName());
     deleteServiceRequest.setCluster(ecsClusterName);
 
-    updateTaskStatus("Deleting " + description.getServerGroupName() + " service.");
+    updateTaskStatus("Deleting " + description.getServerGroupName() + " server group.");
     DeleteServiceResult deleteServiceResult = ecs.deleteService(deleteServiceRequest);
 
-    updateTaskStatus("Deleting " + deleteServiceResult.getService().getTaskDefinition() + " task definition belonging to the service.");
+    updateTaskStatus("Deleting " + deleteServiceResult.getService().getTaskDefinition() + " task definition belonging to the server group.");
     ecs.deregisterTaskDefinition(new DeregisterTaskDefinitionRequest().withTaskDefinition(deleteServiceResult.getService().getTaskDefinition()));
 
     return null;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperation.java
@@ -1,24 +1,69 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
-import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.amazonaws.services.ecs.AmazonECS;
+import com.amazonaws.services.ecs.model.DeleteServiceRequest;
+import com.amazonaws.services.ecs.model.DeleteServiceResult;
+import com.amazonaws.services.ecs.model.DeregisterTaskDefinitionRequest;
+import com.amazonaws.services.ecs.model.UpdateServiceRequest;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ModifyServiceDescription;
+import com.netflix.spinnaker.clouddriver.ecs.services.EcsCloudMetricService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
-public class DestroyServiceAtomicOperation implements AtomicOperation<Void> {
+public class DestroyServiceAtomicOperation extends AbstractEcsAtomicOperation<ModifyServiceDescription, Void> {
+  @Autowired
+  EcsCloudMetricService ecsCloudMetricService;
 
-  DestroyServiceDescription description;
-
-  public DestroyServiceAtomicOperation(DestroyServiceDescription description) {
-    this.description = description;
+  public DestroyServiceAtomicOperation(ModifyServiceDescription description) {
+    super(description, "DESTROY_ECS_SERVER_GROUP");
   }
 
   @Override
   public Void operate(List priorOutputs) {
+    updateTaskStatus("Initializing Destroy Amazon ECS Server Group (Service) Operation...");
+    AmazonECS ecs = getAmazonEcsClient();
 
-    // TODO - implement this stub
+    String ecsClusterName = containerInformationService.getClusterName(description.getServerGroupName(), description.getAccount(), description.getRegion());
+
+    updateTaskStatus("Removing MetricAlarms from " + description.getServerGroupName() + ".");
+    ecsCloudMetricService.deleteMetrics(description.getServerGroupName(), description.getAccount(), description.getRegion());
+    updateTaskStatus("Done removing MetricAlarms from " + description.getServerGroupName() + ".");
+
+    UpdateServiceRequest updateServiceRequest = new UpdateServiceRequest();
+    updateServiceRequest.setService(description.getServerGroupName());
+    updateServiceRequest.setDesiredCount(0);
+    updateServiceRequest.setCluster(ecsClusterName);
+
+    updateTaskStatus("Scaling " + description.getServerGroupName() + " service down to 0.");
+    ecs.updateService(updateServiceRequest);
+
+    DeleteServiceRequest deleteServiceRequest = new DeleteServiceRequest();
+    deleteServiceRequest.setService(description.getServerGroupName());
+    deleteServiceRequest.setCluster(ecsClusterName);
+
+    updateTaskStatus("Deleting " + description.getServerGroupName() + " service.");
+    DeleteServiceResult deleteServiceResult = ecs.deleteService(deleteServiceRequest);
+
+    updateTaskStatus("Deleting " + deleteServiceResult.getService().getTaskDefinition() + " task definition belonging to the service.");
+    ecs.deregisterTaskDefinition(new DeregisterTaskDefinitionRequest().withTaskDefinition(deleteServiceResult.getService().getTaskDefinition()));
 
     return null;
   }
-
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DisableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DisableServiceAtomicOperation.java
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
-import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DisableServiceDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
-import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.EnableServiceDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StopServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StopServiceAtomicOperation.java
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
-import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.StopServiceDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpsertScalingPolicyAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpsertScalingPolicyAtomicOperation.java
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
-import com.netflix.spinnaker.clouddriver.ecs.deploy.description.DestroyServiceDescription;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.UpsertScalingPolicyDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CommonValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CommonValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CommonValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CommonValidator.java
@@ -55,42 +55,42 @@ abstract class CommonValidator extends DescriptionValidator {
     return true;
   }
 
-  void validateCapacity(Errors errors, ServerGroup.Capacity capacity){
-    if(capacity != null){
+  void validateCapacity(Errors errors, ServerGroup.Capacity capacity) {
+    if (capacity != null) {
       boolean desiredNotNull = capacity.getDesired() != null;
       boolean minNotNull = capacity.getMin() != null;
       boolean maxNotNull = capacity.getMax() != null;
 
-      if(!desiredNotNull){
+      if (!desiredNotNull) {
         rejectValue(errors, "capacity.desired", "not.nullable");
       }
-      if(!minNotNull){
+      if (!minNotNull) {
         rejectValue(errors, "capacity.min", "not.nullable");
       }
-      if(!maxNotNull){
+      if (!maxNotNull) {
         rejectValue(errors, "capacity.max", "not.nullable");
       }
 
-      positivityCheck(desiredNotNull,capacity.getDesired(), "desired", errors);
-      positivityCheck(minNotNull,capacity.getMin(), "min", errors);
-      positivityCheck(maxNotNull,capacity.getMax(), "max", errors);
+      positivityCheck(desiredNotNull, capacity.getDesired(), "desired", errors);
+      positivityCheck(minNotNull, capacity.getMin(), "min", errors);
+      positivityCheck(maxNotNull, capacity.getMax(), "max", errors);
 
 
-      if(minNotNull && maxNotNull){
-        if(capacity.getMin() > capacity.getMax()){
+      if (minNotNull && maxNotNull) {
+        if (capacity.getMin() > capacity.getMax()) {
           rejectValue(errors, "capacity.min.max.range", "invalid");
         }
 
-        if(desiredNotNull && capacity.getDesired() > capacity.getMax()){
+        if (desiredNotNull && capacity.getDesired() > capacity.getMax()) {
           rejectValue(errors, "capacity.desired", "exceeds.max");
         }
 
-        if(desiredNotNull && capacity.getDesired() < capacity.getMin()){
+        if (desiredNotNull && capacity.getDesired() < capacity.getMin()) {
           rejectValue(errors, "capacity.desired", "less.than.min");
         }
       }
 
-    }else{
+    } else {
       rejectValue(errors, "capacity", "not.nullable");
     }
   }
@@ -99,9 +99,9 @@ abstract class CommonValidator extends DescriptionValidator {
     errors.rejectValue(field, errorKey + "." + field + "." + reason);
   }
 
-  private void positivityCheck(boolean isNotNull, Integer capacity, String fieldName, Errors errors){
-    if(isNotNull && capacity < 0){
-      rejectValue(errors, "capacity."+fieldName, "invalid");
+  private void positivityCheck(boolean isNotNull, Integer capacity, String fieldName, Errors errors) {
+    if (isNotNull && capacity < 0) {
+      rejectValue(errors, "capacity." + fieldName, "invalid");
     }
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CommonValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CommonValidator.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
+import org.springframework.validation.Errors;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+abstract class CommonValidator extends DescriptionValidator {
+  String errorKey;
+
+  public CommonValidator(String erroryKey) {
+    this.errorKey = erroryKey;
+  }
+
+  void validateRegions(AbstractAmazonCredentialsDescription credentialsDescription, Collection<String> regionNames, Errors errors, String attributeName) {
+    if (regionNames.isEmpty()) {
+      rejectValue(errors, attributeName, "empty");
+    } else {
+      Set<String> validRegions = credentialsDescription.getCredentials().getRegions().stream()
+        .map(AmazonCredentials.AWSRegion::getName)
+        .collect(Collectors.toSet());
+
+      if (!validRegions.isEmpty() && !validRegions.containsAll(regionNames)) {
+        rejectValue(errors, attributeName, "not.configured");
+      }
+    }
+  }
+
+  boolean validateCredentials(AbstractAmazonCredentialsDescription credentialsDescription, Errors errors, String attributeName) {
+    if (credentialsDescription.getCredentials() == null) {
+      rejectValue(errors, attributeName, "not.nullable");
+      return false;
+    }
+    return true;
+  }
+
+  void validateCapacity(Errors errors, ServerGroup.Capacity capacity){
+    if(capacity != null){
+      boolean desiredNotNull = capacity.getDesired() != null;
+      boolean minNotNull = capacity.getMin() != null;
+      boolean maxNotNull = capacity.getMax() != null;
+
+      if(!desiredNotNull){
+        rejectValue(errors, "capacity.desired", "not.nullable");
+      }
+      if(!minNotNull){
+        rejectValue(errors, "capacity.min", "not.nullable");
+      }
+      if(!maxNotNull){
+        rejectValue(errors, "capacity.max", "not.nullable");
+      }
+
+      positivityCheck(desiredNotNull,capacity.getDesired(), "desired", errors);
+      positivityCheck(minNotNull,capacity.getMin(), "min", errors);
+      positivityCheck(maxNotNull,capacity.getMax(), "max", errors);
+
+
+      if(minNotNull && maxNotNull){
+        if(capacity.getMin() > capacity.getMax()){
+          rejectValue(errors, "capacity.min.max.range", "invalid");
+        }
+
+        if(desiredNotNull && capacity.getDesired() > capacity.getMax()){
+          rejectValue(errors, "capacity.desired", "exceeds.max");
+        }
+
+        if(desiredNotNull && capacity.getDesired() < capacity.getMin()){
+          rejectValue(errors, "capacity.desired", "less.than.min");
+        }
+      }
+
+    }else{
+      rejectValue(errors, "capacity", "not.nullable");
+    }
+  }
+
+  void rejectValue(Errors errors, String field, String reason) {
+    errors.rejectValue(field, errorKey + "." + field + "." + reason);
+  }
+
+  private void positivityCheck(boolean isNotNull, Integer capacity, String fieldName, Errors errors){
+    if(isNotNull && capacity < 0){
+      rejectValue(errors, "capacity."+fieldName, "invalid");
+    }
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DestroyServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DestroyServiceAtomicOperationValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DestroyServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DestroyServiceAtomicOperationValidator.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 @EcsOperation(AtomicOperations.DESTROY_SERVER_GROUP)
 @Component("destroyServiceAtomicOperationValidator")
 public class DestroyServiceAtomicOperationValidator extends ServerGroupDescriptionValidator {
-  public DestroyServiceAtomicOperationValidator(){
+  public DestroyServiceAtomicOperationValidator() {
     super("destroyServiceAtomicOperation");
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ModifyServiceDescription;
+import org.springframework.validation.Errors;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ServerGroupDescriptionValidator extends CommonValidator {
+
+  public ServerGroupDescriptionValidator(String errorKey) {
+    super(errorKey);
+  }
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+    ModifyServiceDescription typeDescription = (ModifyServiceDescription) description;
+
+    boolean validCredentials = validateCredentials(typeDescription, errors, "credentials");
+
+    if (validCredentials) {
+      validateRegions(typeDescription, Collections.singleton(typeDescription.getRegion()), errors, "region");
+    }
+
+    if (typeDescription.getServerGroupName() == null) {
+      rejectValue(errors, "serverGroupName", "not.nullable");
+    }
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverterSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverterSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverterSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DestroyServiceAtomicOperationConverterSpec.groovy
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters
 
-import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
-import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
-import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.DestroyServiceAtomicOperation
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 
-@EcsOperation(AtomicOperations.DESTROY_SERVER_GROUP)
-@Component("destroyServiceAtomicOperationValidator")
-public class DestroyServiceAtomicOperationValidator extends ServerGroupDescriptionValidator {
-  public DestroyServiceAtomicOperationValidator(){
-    super("destroyServiceAtomicOperation");
+class DestroyServiceAtomicOperationConverterSpec extends ModifyServiceAtomicOperationConverterSpec<DestroyServiceAtomicOperation> {
+  @Override
+  AbstractAtomicOperationsCredentialsSupport getConverter() {
+    new DestroyServiceAtomicOperationConverter(objectMapper: new ObjectMapper())
   }
 }

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/ModifyServiceAtomicOperationConverterSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/ModifyServiceAtomicOperationConverterSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/ModifyServiceAtomicOperationConverterSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/ModifyServiceAtomicOperationConverterSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters
+
+import com.netflix.spinnaker.clouddriver.ecs.TestCredential
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ModifyServiceDescription
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.AbstractEcsAtomicOperation
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+
+abstract class ModifyServiceAtomicOperationConverterSpec<T extends AbstractEcsAtomicOperation> extends Specification {
+  def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+
+  abstract AbstractAtomicOperationsCredentialsSupport getConverter()
+
+  def 'should convert'() {
+    given:
+    def converter = getConverter()
+    converter.accountCredentialsProvider = accountCredentialsProvider
+
+    def serverGroupName = "test"
+    def input = [serverGroupName: serverGroupName, regions: ["us-west-1"], credentials: "test"]
+
+    accountCredentialsProvider.getCredentials(_) >> TestCredential.named('test')
+
+    when:
+    def description = converter.convertDescription(input)
+
+    then:
+    description instanceof ModifyServiceDescription
+
+    when:
+    def operation = converter.convertOperation(input)
+
+    then:
+    operation instanceof T
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CommonAtomicOperation.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CommonAtomicOperation.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops
+
+import com.amazonaws.services.ecs.AmazonECS
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+
+class CommonAtomicOperation extends Specification{
+  def amazonClientProvider = Mock(AmazonClientProvider)
+  def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+  def containerInformationService = Mock(ContainerInformationService)
+  def ecs = Mock(AmazonECS)
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CommonAtomicOperation.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CommonAtomicOperation.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DestroyServiceAtomicOperationSpec.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops
+
+import com.amazonaws.services.ecs.model.DeleteServiceResult
+import com.amazonaws.services.ecs.model.Service
+import com.netflix.spinnaker.clouddriver.ecs.TestCredential
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ModifyServiceDescription
+import com.netflix.spinnaker.clouddriver.ecs.services.EcsCloudMetricService
+
+class DestroyServiceAtomicOperationSpec extends CommonAtomicOperation {
+
+  void 'should execute the operation'() {
+    given:
+    def operation = new DestroyServiceAtomicOperation(new ModifyServiceDescription(
+      serverGroupName: "test-server-group",
+      credentials: TestCredential.named('Test', [:])
+    ))
+
+    operation.amazonClientProvider = amazonClientProvider
+    operation.ecsCloudMetricService = Mock(EcsCloudMetricService)
+    operation.accountCredentialsProvider = accountCredentialsProvider
+    operation.containerInformationService = containerInformationService
+
+    amazonClientProvider.getAmazonEcs(_, _, _) >> ecs
+    containerInformationService.getClusterName(_, _, _) >> 'cluster-name'
+    accountCredentialsProvider.getCredentials(_) >> TestCredential.named("test")
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * ecs.updateService(_)
+    1 * ecs.deleteService(_) >> new DeleteServiceResult().withService(new Service().withTaskDefinition("test"))
+    1 * ecs.deregisterTaskDefinition(_)
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/AbstractValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/AbstractValidatorSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/AbstractValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/AbstractValidatorSpec.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.ecs.TestCredential
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.AbstractECSDescription
+import org.springframework.validation.Errors
+import spock.lang.Specification
+import spock.lang.Subject
+
+abstract class AbstractValidatorSpec extends Specification {
+  @Subject
+  DescriptionValidator validator = getDescriptionValidator()
+  boolean testRegion
+
+  abstract DescriptionValidator getDescriptionValidator()
+
+  abstract AbstractECSDescription getDescription()
+
+  abstract AbstractECSDescription getNulledDescription()
+
+  abstract AbstractECSDescription getInvalidDescription()
+
+  abstract Set<String> notNullableProperties()
+
+  abstract Set<String> invalidProperties()
+
+  abstract String getDescriptionName()
+
+  def setupSpec() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+    setTestRegion()
+  }
+
+  def setTestRegion(){
+    testRegion = true
+  }
+
+  void 'should fail an incorrect region'() {
+    given:
+    def description = getDescription()
+    description.credentials = TestCredential.named('test')
+    description.region = 'wrong-region-test'
+    def errors = Mock(Errors)
+
+    when:
+    if(testRegion) {
+      validator.validate([], description, errors)
+    }
+
+    then:
+    if(testRegion) {
+      1 * errors.rejectValue('region', _)
+    }
+  }
+
+  void 'should fail when required properties are null'() {
+    given:
+    def description = getNulledDescription()
+    def descriptionName = getDescriptionName()
+    def errors = Mock(Errors)
+    def nullProperties = notNullableProperties()
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    for(def nullProperty:nullProperties){
+      1 * errors.rejectValue(nullProperty, "${descriptionName}.${nullProperty}.not.nullable")
+    }
+  }
+
+  void 'should fail when a property is invalid'() {
+    given:
+    def description = getInvalidDescription()
+    def descriptionName = getDescriptionName()
+    def errors = Mock(Errors)
+
+    def invalidFields = invalidProperties()
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    for(String invalidField:invalidFields) {
+      1 * errors.rejectValue(invalidField, "${descriptionName}.${invalidField}.invalid")
+    }
+  }
+
+  void 'should pass validation'() {
+    given:
+    def description = getDescription()
+    def errors = Mock(Errors)
+
+    when:
+    validator.validate([], description, errors)
+
+    then:
+    0 * errors.rejectValue(_, _)
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidatorSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2018 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidatorSpec.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.ecs.TestCredential
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.AbstractECSDescription
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ModifyServiceDescription
+
+class ServerGroupDescriptionValidatorSpec extends AbstractValidatorSpec {
+
+  @Override
+  AbstractECSDescription getNulledDescription() {
+    def description = (ModifyServiceDescription) getDescription()
+    description.credentials = null
+    description.serverGroupName = null
+    description
+  }
+
+  @Override
+  Set<String> notNullableProperties() {
+    ['credentials', 'serverGroupName']
+  }
+
+  @Override
+  String getDescriptionName() {
+    'modifyServiceDescription'
+  }
+
+  @Override
+  AbstractECSDescription getInvalidDescription() {
+    getDescription()
+  }
+
+  @Override
+  Set<String> invalidProperties() {
+    []
+  }
+
+
+  @Override
+  DescriptionValidator getDescriptionValidator() {
+    new ServerGroupDescriptionValidator(getDescriptionName())
+  }
+
+  @Override
+  AbstractECSDescription getDescription() {
+    def description = new ModifyServiceDescription()
+    description.credentials = TestCredential.named('test')
+    description.region = 'us-west-1'
+    description.serverGroupName = 'test'
+    description
+  }
+}


### PR DESCRIPTION
Implemented `DestroyServiceAtomicOperation` responsible for performing `DESTROY_SERVER_GROUP` operation - when called during a stage or directly through UI dropdown on Deck.

Added base `deploy` classes in `description`/`ops`/`validators` packages.

@cfieber @ajordens @robzienert @BrunoCarrier