### PR TITLE
feat(provider/ecs): Terminate Instances Atomic Operation

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/TerminateInstancesAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/TerminateInstancesAtomicOperationConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.TerminateInstancesDescription;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.TerminateInstancesAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@EcsOperation(AtomicOperations.TERMINATE_INSTANCES)
+@Component("ecsTerminateInstances")
+public class TerminateInstancesAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new TerminateInstancesAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public TerminateInstancesDescription convertDescription(Map input) {
+    TerminateInstancesDescription converted = new TerminateInstancesDescription();
+    converted.setCredentials(getCredentialsObject(input.get("credentials").toString()));
+    converted.setRegion(input.get("region").toString());
+    List<String> ecsTaskIds = new ArrayList<>();
+    for (Object id : (List) input.get("instanceIds")) {
+      ecsTaskIds.add(id.toString());
+    }
+    converted.setEcsTaskIds(ecsTaskIds);
+    return converted;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/TerminateInstancesDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/TerminateInstancesDescription.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class TerminateInstancesDescription extends AbstractECSDescription {
+  List<String> ecsTaskIds;
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstancesAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstancesAtomicOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
+
+import com.amazonaws.services.ecs.AmazonECS;
+import com.amazonaws.services.ecs.model.StopTaskRequest;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.TerminateInstancesDescription;
+
+import java.util.List;
+
+public class TerminateInstancesAtomicOperation extends AbstractEcsAtomicOperation<TerminateInstancesDescription, Void> {
+
+  public TerminateInstancesAtomicOperation(TerminateInstancesDescription description) {
+    super(description, "TERMINATE_ECS_INSTANCES");
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+    updateTaskStatus("Initializing Terminate ECS Instances Operation...");
+    AmazonECS ecs = getAmazonEcsClient();
+
+    for (String taskId : description.getEcsTaskIds()) {
+      updateTaskStatus("Terminating instance: " + taskId);
+      String clusterArn = containerInformationService.getClusterArn(description.getCredentialAccount(), description.getRegion(), taskId);
+      StopTaskRequest request = new StopTaskRequest().withTask(taskId).withCluster(clusterArn);
+      ecs.stopTask(request);
+    }
+
+    return null;
+  }
+
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/TerminateInstancesDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/TerminateInstancesDescriptionValidator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
+
+import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.TerminateInstancesDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@EcsOperation(AtomicOperations.TERMINATE_INSTANCES)
+@Component("ecsTerminateInstancesDescriptionValidator")
+public class TerminateInstancesDescriptionValidator extends CommonValidator {
+  public static final Pattern TASK_ID_PATTERN = Pattern.compile("[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}");
+
+  public TerminateInstancesDescriptionValidator() {
+    super("terminateInstancesDescription");
+  }
+
+  @Override
+  public void validate(List priorDescriptions, Object description, Errors errors) {
+    TerminateInstancesDescription typedDescription = (TerminateInstancesDescription) description;
+    boolean validCredentials = validateCredentials(typedDescription, errors, "credentials");
+
+    if (validCredentials) {
+      validateRegions(typedDescription, Collections.singleton(typedDescription.getRegion()), errors, "region");
+    }
+
+    if (typedDescription.getEcsTaskIds() != null) {
+      typedDescription.getEcsTaskIds().forEach(taskId -> {
+          if (!TASK_ID_PATTERN.matcher(taskId).find()) {
+            rejectValue(errors, "ecsTaskIds." + taskId, "invalid");
+          }
+        }
+      );
+    } else {
+      rejectValue(errors, "ecsTaskIds", "not.nullable");
+    }
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/TerminateInstanceAtomicOperationConverterSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/TerminateInstanceAtomicOperationConverterSpec.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.converters
+
+import com.netflix.spinnaker.clouddriver.ecs.TestCredential
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.TerminateInstancesDescription
+import com.netflix.spinnaker.clouddriver.ecs.deploy.ops.TerminateInstancesAtomicOperation
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import spock.lang.Specification
+
+class TerminateInstanceAtomicOperationConverterSpec extends Specification {
+  def accountCredentialsProvider = Mock(AccountCredentialsProvider)
+
+  def 'should convert'() {
+    given:
+    def converter = new TerminateInstancesAtomicOperationConverter()
+    converter.accountCredentialsProvider = accountCredentialsProvider
+
+    def instanceIds = ['id-1', 'id-2']
+    def input = [instanceIds: instanceIds, region: 'us-west-1', credentials: 'test']
+
+    accountCredentialsProvider.getCredentials(_) >> TestCredential.named('test')
+
+    when:
+    def description = converter.convertDescription(input)
+
+    then:
+    description instanceof TerminateInstancesDescription
+    description.getEcsTaskIds() == instanceIds
+
+    when:
+    def operation = converter.convertOperation(input)
+
+    then:
+    operation instanceof TerminateInstancesAtomicOperation
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstanceAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstanceAtomicOperationSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.ecs.TestCredential
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.TerminateInstancesDescription
+
+class TerminateInstanceAtomicOperationSpec extends CommonAtomicOperation {
+  void 'should execute the operation'() {
+    given:
+    def operation = new TerminateInstancesAtomicOperation(new TerminateInstancesDescription(
+      credentials: TestCredential.named('Test', [:]),
+      ecsTaskIds: ['deadbeef-1111-4637-ab84-606f0c77af42', 'deadbeef-2222-4637-ab84-606f0c77af42']
+    ))
+
+    operation.amazonClientProvider = amazonClientProvider
+    operation.accountCredentialsProvider = accountCredentialsProvider
+    operation.containerInformationService = containerInformationService
+
+    amazonClientProvider.getAmazonEcs(_, _, _) >> ecs
+    containerInformationService.getClusterArn(_, _, _) >> 'cluster-arn'
+    accountCredentialsProvider.getCredentials(_) >> TestCredential.named("test")
+
+    when:
+    operation.operate([])
+
+    then:
+    2 * ecs.stopTask(_)
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/TerminateInstanceDescriptionValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/TerminateInstanceDescriptionValidatorSpec.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy.validators
+
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.ecs.TestCredential
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.AbstractECSDescription
+import com.netflix.spinnaker.clouddriver.ecs.deploy.description.TerminateInstancesDescription
+
+class TerminateInstanceDescriptionValidatorSpec extends AbstractValidatorSpec {
+  def invalidTaskId = 'some-invalid-task-id'
+
+  @Override
+  AbstractECSDescription getNulledDescription() {
+    def description = (TerminateInstancesDescription) getDescription()
+    description.credentials = null
+    description.ecsTaskIds = null
+    description
+  }
+
+  @Override
+  Set<String> notNullableProperties() {
+    ['credentials', 'ecsTaskIds']
+  }
+
+  @Override
+  AbstractECSDescription getInvalidDescription() {
+    def description = (TerminateInstancesDescription) getDescription()
+    description.ecsTaskIds = [invalidTaskId]
+    description
+  }
+
+  @Override
+  Set<String> invalidProperties() {
+    ["ecsTaskIds.${invalidTaskId}"]
+  }
+
+
+  @Override
+  String getDescriptionName() {
+    'terminateInstancesDescription'
+  }
+
+  @Override
+  DescriptionValidator getDescriptionValidator() {
+    new TerminateInstancesDescriptionValidator()
+  }
+
+  @Override
+  AbstractECSDescription getDescription() {
+    def description = new TerminateInstancesDescription()
+    description.credentials = TestCredential.named('test')
+    description.region = 'us-west-1'
+    description.ecsTaskIds = ['deadbeef-33f7-4637-ab84-606f0c77af42']
+    description
+  }
+}


### PR DESCRIPTION
Implemented `TerminateInstancesAtomicOperation` responsible for performing `TERMINATE_INSTANCES` operation, when called during a stage or through the drop down UI on Deck.

Terminates the given ECS Tasks of an ECS Service. The ECS Task is represented as a Spinnaker Instance.

@cfieber @ajordens @robzienert @BrunoCarrier