### PR TITLE
fix(provider/appengine): dont prepend "gs" to all repository URLs

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineAtomicOperationConverter.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineAtomicOperationConverter.groovy
@@ -46,6 +46,9 @@ class DeployAppengineAtomicOperationConverter extends AbstractAtomicOperationsCr
       switch (description.artifact.type) {
         case 'gcs/object':
           description.repositoryUrl = description.artifact.reference;
+          if (!description.repositoryUrl.startsWith('gs://')) {
+            description.repositoryUrl = "gs://${description.repositoryUrl}"
+          }
           break
         case 'docker/image':
           description.containerImageUrl = description.artifact.name;
@@ -53,10 +56,6 @@ class DeployAppengineAtomicOperationConverter extends AbstractAtomicOperationsCr
         default:
           throw new AppengineDescriptionConversionException("Invalid artifact type for Appengine deploy: ${description.artifact.type}")
       }
-    }
-
-    if (description.repositoryUrl && !description.repositoryUrl.startsWith('gs://')) {
-      description.repositoryUrl = "gs://${description.repositoryUrl}"
     }
 
     return description


### PR DESCRIPTION
Incorrectly assumes that repositoryUrl always refers to a GS repo when it could be a git one instead.

Likely source of the integration test failures.