### PR TITLE
feat(provider/kubernetes): v2 per-account, custom resources

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgent.java
@@ -34,8 +34,8 @@ public abstract class KubernetesCachingAgent<C extends KubernetesCredentials> im
   final protected C credentials;
   final protected ObjectMapper objectMapper;
 
-  final private int agentIndex;
-  final private int agentCount;
+  final protected int agentIndex;
+  final protected int agentCount;
 
   protected List<String> namespaces;
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.config
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import com.netflix.spinnaker.fiat.model.resources.Permissions
 import groovy.transform.ToString
@@ -44,6 +45,7 @@ class KubernetesConfigurationProperties {
     Permissions.Builder permissions = new Permissions.Builder()
     String namingStrategy = "kubernetesAnnotations"
     Boolean debug = false
+    List<CustomKubernetesResource> customResources;
   }
 
   List<ManagedAccount> accounts = []
@@ -53,4 +55,11 @@ class KubernetesConfigurationProperties {
 class LinkedDockerRegistryConfiguration {
   String accountName
   List<String> namespaces
+}
+
+@ToString(includeNames = true)
+class CustomKubernetesResource {
+  String kubernetesKind
+  String spinnakerKind = KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED.toString()
+  boolean versioned = false
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.security;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.CustomKubernetesResource;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
@@ -185,6 +186,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     AccountCredentialsRepository accountCredentialsRepository;
     KubectlJobExecutor jobExecutor;
     Namer namer;
+    List<CustomKubernetesResource> customResources;
     boolean debug;
 
     Builder name(String name) {
@@ -320,6 +322,11 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       return this;
     }
 
+    Builder customResources(List<CustomKubernetesResource> customResources) {
+      this.customResources = customResources;
+      return this;
+    }
+
     private C buildCredentials() {
       switch (providerVersion) {
         case v1:
@@ -354,6 +361,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
               .namespaces(namespaces)
               .omitNamespaces(omitNamespaces)
               .registry(spectatorRegistry)
+              .customResources(customResources)
               .debug(debug)
               .jobExecutor(jobExecutor)
               .build();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -99,6 +99,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .spectatorRegistry(spectatorRegistry)
           .jobExecutor(jobExecutor)
           .namer(namerRegistry.getNamingStrategy(managedAccount.namingStrategy))
+          .customResources(managedAccount.customResources)
           .debug(managedAccount.debug)
           .build()
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverter.java
@@ -21,9 +21,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoo
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import org.springframework.stereotype.Component;
 
-@Component
 public class KubernetesUnversionedArtifactConverter extends KubernetesArtifactConverter {
   @Override
   public Artifact toArtifact(ArtifactProvider provider, KubernetesManifest manifest) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverter.java
@@ -31,15 +31,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Component
 @Slf4j
 public class KubernetesVersionedArtifactConverter extends KubernetesArtifactConverter {
-  final private ObjectMapper objectMapper;
-
-  @Autowired
-  public KubernetesVersionedArtifactConverter(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
-  }
+  final private static ObjectMapper objectMapper = new ObjectMapper();
 
   @Override
   public Artifact toArtifact(ArtifactProvider provider, KubernetesManifest manifest) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderConfig.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderConfig.java
@@ -22,7 +22,14 @@ import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper;
 import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesUnversionedArtifactConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentDispatcher;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.CustomKubernetesHandlerFactory;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
@@ -47,10 +54,13 @@ class KubernetesV2ProviderConfig implements Runnable {
   @DependsOn("kubernetesNamedAccountCredentials")
   KubernetesV2Provider kubernetesV2Provider(KubernetesCloudProvider kubernetesCloudProvider,
       AccountCredentialsRepository accountCredentialsRepository,
-      KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher) {
+      KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher,
+      KubernetesResourcePropertyRegistry kubernetesResourcePropertyRegistry
+  ) {
     this.kubernetesV2Provider = new KubernetesV2Provider();
     this.accountCredentialsRepository = accountCredentialsRepository;
     this.kubernetesV2CachingAgentDispatcher = kubernetesV2CachingAgentDispatcher;
+    this.kubernetesResourcePropertyRegistry = kubernetesResourcePropertyRegistry;
 
     ScheduledExecutorService poller = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory(KubernetesV2ProviderConfig.class.getSimpleName()));
 
@@ -62,6 +72,7 @@ class KubernetesV2ProviderConfig implements Runnable {
   private KubernetesV2Provider kubernetesV2Provider;
   private AccountCredentialsRepository accountCredentialsRepository;
   private KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher;
+  private KubernetesResourcePropertyRegistry kubernetesResourcePropertyRegistry;
 
   @Bean
   KubernetesV2ProviderSynchronizerTypeWrapper kubernetesV2ProviderSynchronizerTypeWrapper() {
@@ -84,13 +95,25 @@ class KubernetesV2ProviderConfig implements Runnable {
 
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   @Bean
-  KubernetesV2ProviderSynchronizer synchronizeKubernetesV2Provider(KubernetesV2Provider kubernetesV2Provider,
-      AccountCredentialsRepository accountCredentialsRepository) {
+  KubernetesV2ProviderSynchronizer synchronizeKubernetesV2Provider(
+      KubernetesV2Provider kubernetesV2Provider,
+      AccountCredentialsRepository accountCredentialsRepository
+  ) {
     Set<KubernetesNamedAccountCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, KubernetesNamedAccountCredentials.class, ProviderVersion.v2);
 
     kubernetesV2Provider.getAgents().clear();
 
     for (KubernetesNamedAccountCredentials credentials : allAccounts) {
+      KubernetesV2Credentials v2Credentials = (KubernetesV2Credentials) credentials.getCredentials();
+      v2Credentials.getCustomResources().forEach(cr -> {
+        try {
+          KubernetesResourceProperties properties = KubernetesResourceProperties.fromCustomResource(cr);
+          kubernetesResourcePropertyRegistry.registerAccountProperty(credentials.getName(), properties);
+        } catch (Exception e) {
+          log.warn("Error encountered registering {}: ", cr, e);
+        }
+      });
+
       List<Agent> newlyAddedAgents = kubernetesV2CachingAgentDispatcher.buildAllCachingAgents(credentials)
           .stream()
           .map(c -> (Agent) c)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
@@ -129,7 +129,7 @@ public class KubernetesV2SearchProvider implements SearchProvider {
       Keys.InfrastructureCacheKey infraKey = (Keys.InfrastructureCacheKey) parsedKey;
       type = kindMap.translateKubernetesKind(infraKey.getKubernetesKind()).toString();
 
-      KubernetesResourceProperties properties = registry.get(infraKey.getKubernetesKind());
+      KubernetesResourceProperties properties = registry.get(infraKey.getAccount(), infraKey.getKubernetesKind());
       if (properties == null) {
         log.warn("No hydrator for type {}, this is possibly a developer error", infraKey.getKubernetesKind());
         return null;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/CustomKubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/CustomKubernetesCachingAgentFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+
+public class CustomKubernetesCachingAgentFactory {
+  public static KubernetesV2OnDemandCachingAgent create(
+      KubernetesKind kind,
+      KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+      ObjectMapper objectMapper,
+      Registry registry,
+      int agentIndex,
+      int agentCount
+  ) {
+    return new Agent(
+        kind,
+        namedAccountCredentials,
+        objectMapper,
+        registry,
+        agentIndex,
+        agentCount
+    );
+  }
+
+  private static class Agent extends KubernetesV2OnDemandCachingAgent {
+    private final KubernetesKind kind;
+
+    Agent(
+        KubernetesKind kind,
+        KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+        ObjectMapper objectMapper,
+        Registry registry,
+        int agentIndex,
+        int agentCount
+    ) {
+      super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+      this.kind = kind;
+    }
+
+    @Override
+    protected KubernetesKind primaryKind() {
+      return this.kind;
+    }
+
+    @Override
+    final public Collection<AgentDataType> getProvidedDataTypes() {
+      return Collections.unmodifiableSet(
+          new HashSet<>(Collections.singletonList(
+              AUTHORITATIVE.forType(this.kind.toString())
+          ))
+      );
+    }
+
+    @Override
+    public String getAgentType() {
+      return String.format("%s/CustomKubernetes(%s)[%d/%d]", accountName, kind, agentIndex + 1, agentCount);
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
@@ -67,7 +68,12 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
     }
 
     CacheData data = dataOptional.get();
-    KubernetesHandler handler = registry.get(kind).getHandler();
+    KubernetesResourceProperties properties = registry.get(account, kind);
+    if (properties == null) {
+      return null;
+    }
+
+    KubernetesHandler handler = properties.getHandler();
 
     KubernetesManifest manifest = KubernetesCacheDataConverter.getManifest(data);
     Moniker moniker = KubernetesCacheDataConverter.getMoniker(data);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
@@ -17,8 +17,11 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.config.CustomKubernetesResource;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesUnversionedArtifactConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.CustomKubernetesHandlerFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer.KubernetesHandler;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,6 +35,19 @@ import lombok.NoArgsConstructor;
 public class KubernetesResourceProperties {
   KubernetesHandler handler;
   boolean versioned;
-  KubernetesVersionedArtifactConverter versionedConverter;
-  KubernetesUnversionedArtifactConverter unversionedConverter;
+  KubernetesVersionedArtifactConverter versionedConverter = new KubernetesVersionedArtifactConverter();
+  KubernetesUnversionedArtifactConverter unversionedConverter = new KubernetesUnversionedArtifactConverter();
+
+  public static KubernetesResourceProperties fromCustomResource(CustomKubernetesResource customResource) {
+    KubernetesHandler handler = CustomKubernetesHandlerFactory.create(KubernetesKind.fromString(customResource.getKubernetesKind()),
+        KubernetesSpinnakerKindMap.SpinnakerKind.fromString(customResource.getSpinnakerKind()),
+        customResource.isVersioned());
+
+    return KubernetesResourceProperties.builder()
+        .handler(handler)
+        .versioned(customResource.isVersioned())
+        .versionedConverter(new KubernetesVersionedArtifactConverter())
+        .unversionedConverter(new KubernetesUnversionedArtifactConverter())
+        .build();
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
@@ -54,7 +54,7 @@ public class KubernetesSpinnakerKindMap {
       return Arrays.stream(values())
           .filter(k -> k.toString().equalsIgnoreCase(name))
           .findFirst()
-          .orElseThrow(() -> new IllegalArgumentException("No matching kind with name " + name + " exists"));
+          .orElse(UNCLASSIFIED);
     }
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/CanDeploy.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/CanDeploy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+
+public interface CanDeploy {
+  default OperationResult deploy(KubernetesV2Credentials credentials, KubernetesManifest manifest) {
+    credentials.deploy(manifest);
+    return new OperationResult().addManifest(manifest);
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/CustomKubernetesHandlerFactory.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/CustomKubernetesHandlerFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.CustomKubernetesCachingAgentFactory;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.model.Manifest;
+
+public class CustomKubernetesHandlerFactory {
+  public static KubernetesHandler create(KubernetesKind kubernetesKind, SpinnakerKind spinnakerKind, boolean versioned) {
+    return new Handler(kubernetesKind, spinnakerKind, versioned);
+  }
+
+  private static class Handler extends KubernetesHandler {
+    private final KubernetesKind kubernetesKind;
+    private final SpinnakerKind spinnakerKind;
+    private final boolean versioned;
+
+    Handler(KubernetesKind kubernetesKind, SpinnakerKind spinnakerKind, boolean versioned) {
+      this.kubernetesKind = kubernetesKind;
+      this.spinnakerKind = spinnakerKind;
+      this.versioned = versioned;
+    }
+
+    @Override
+    public KubernetesKind kind() {
+      return kubernetesKind;
+    }
+
+    @Override
+    public boolean versioned() {
+      return versioned;
+    }
+
+    @Override
+    public SpinnakerKind spinnakerKind() {
+      return spinnakerKind;
+    }
+
+    @Override
+    public Manifest.Status status(KubernetesManifest manifest) {
+      return new Manifest.Status();
+    }
+
+    @Override
+    public KubernetesV2CachingAgent buildCachingAgent(
+        KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+        ObjectMapper objectMapper,
+        Registry registry,
+        int agentIndex,
+        int agentCount
+    ) {
+      return CustomKubernetesCachingAgentFactory.create(
+          kubernetesKind,
+          namedAccountCredentials,
+          objectMapper,
+          registry,
+          agentIndex,
+          agentCount
+      );
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deployer/KubernetesHandler.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.deployer;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacer.ReplaceResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
@@ -27,27 +29,27 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.Kub
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import lombok.Getter;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.extern.slf4j.Slf4j;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public abstract class KubernetesHandler {
-  @Autowired
-  protected ObjectMapper objectMapper;
+@Slf4j
+public abstract class KubernetesHandler implements CanDeploy, CanDelete {
+  protected final static ObjectMapper objectMapper = new ObjectMapper();
 
-  @Getter
-  @Autowired
-  protected KubectlJobExecutor jobExecutor;
+  private final ArtifactReplacer artifactReplacer = new ArtifactReplacer();
 
-  private ArtifactReplacer artifactReplacer = new ArtifactReplacer();
+  abstract public KubernetesKind kind();
+  abstract public boolean versioned();
+  abstract public SpinnakerKind spinnakerKind();
+  abstract public Status status(KubernetesManifest manifest);
 
   protected void registerReplacer(ArtifactReplacer.Replacer replacer) {
     artifactReplacer.addReplacer(replacer);
@@ -57,24 +59,56 @@ public abstract class KubernetesHandler {
     return artifactReplacer.replaceAll(manifest, artifacts);
   }
 
+  protected Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return null;
+  }
+
   public Set<Artifact> listArtifacts(KubernetesManifest manifest) {
     return artifactReplacer.findAll(manifest);
   }
 
-  public OperationResult deployAugmentedManifest(KubernetesV2Credentials credentials, KubernetesManifest manifest) {
-    deploy(credentials, manifest);
-    return new OperationResult().addManifest(manifest);
+  public KubernetesV2CachingAgent buildCachingAgent(
+      KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+      ObjectMapper objectMapper,
+      Registry registry,
+      int agentIndex,
+      int agentCount
+  ) {
+    Constructor constructor;
+    Class<? extends KubernetesV2CachingAgent> clazz = cachingAgentClass();
+
+    if (clazz == null) {
+      log.error("No caching agent was registered for {} -- no resources will be cached", kind());
+    }
+
+    try {
+      constructor = clazz.getDeclaredConstructor(
+          KubernetesNamedAccountCredentials.class,
+          ObjectMapper.class,
+          Registry.class,
+          int.class,
+          int.class
+      );
+    } catch (NoSuchMethodException e) {
+      log.warn("Missing canonical constructor for {} caching agent", kind(), e);
+      return null;
+    }
+
+    try {
+      constructor.setAccessible(true);
+      return (KubernetesV2CachingAgent) constructor.newInstance(
+          namedAccountCredentials,
+          objectMapper,
+          registry,
+          agentIndex,
+          agentCount
+      );
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      log.warn("Can't invoke caching agent constructor for {} caching agent", kind(), e);
+      return null;
+    }
   }
 
-  abstract public KubernetesKind kind();
-  abstract public boolean versioned();
-  abstract public SpinnakerKind spinnakerKind();
-  abstract public Status status(KubernetesManifest manifest);
-  abstract public Class<? extends KubernetesV2CachingAgent> cachingAgentClass();
-
-  protected void deploy(KubernetesV2Credentials credentials, KubernetesManifest manifest) {
-    credentials.deploy(manifest);
-  }
 
   public Map<String, Object> hydrateSearchResult(Keys.InfrastructureCacheKey key, KubernetesCacheUtils cacheUtils) {
     Map<String, Object> result = objectMapper.convertValue(key, new TypeReference<Map<String, Object>>() {});

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
@@ -36,11 +36,13 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
   private final KubernetesDeleteManifestDescription description;
   private final KubernetesV2Credentials credentials;
   private final KubernetesResourcePropertyRegistry registry;
+  private final String accountName;
   private static final String OP_NAME = "DELETE_KUBERNETES_MANIFEST";
 
   public KubernetesDeleteManifestOperation(KubernetesDeleteManifestDescription description, KubernetesResourcePropertyRegistry registry) {
     this.description = description;
     this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.accountName = description.getCredentials().getName();
     this.registry = registry;
   }
 
@@ -62,7 +64,7 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
     OperationResult result = new OperationResult();
     coordinates.forEach(c -> {
       getTask().updateStatus(OP_NAME, "Looking up resource properties for " + c.getKind() + "...");
-      KubernetesResourceProperties properties = registry.get(c.getKind());
+      KubernetesResourceProperties properties = registry.get(accountName, c.getKind());
       KubernetesHandler deployer = properties.getHandler();
 
       if (!(deployer instanceof CanDelete)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPauseRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPauseRolloutManifestOperation.java
@@ -34,11 +34,13 @@ public class KubernetesPauseRolloutManifestOperation implements AtomicOperation<
   private final KubernetesPauseRolloutManifestDescription description;
   private final KubernetesV2Credentials credentials;
   private final KubernetesResourcePropertyRegistry registry;
+  private final String accountName;
   private static final String OP_NAME = "PAUSE_ROLLOUT_KUBERNETES_MANIFEST";
 
   public KubernetesPauseRolloutManifestOperation(KubernetesPauseRolloutManifestDescription description, KubernetesResourcePropertyRegistry registry) {
     this.description = description;
     this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.accountName = description.getCredentials().getName();
     this.registry = registry;
   }
 
@@ -52,7 +54,7 @@ public class KubernetesPauseRolloutManifestOperation implements AtomicOperation<
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
-    KubernetesResourceProperties properties = registry.get(coordinates.getKind());
+    KubernetesResourceProperties properties = registry.get(accountName, coordinates.getKind());
     KubernetesHandler deployer = properties.getHandler();
 
     if (!(deployer instanceof CanPauseRollout)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesResumeRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesResumeRolloutManifestOperation.java
@@ -34,11 +34,13 @@ public class KubernetesResumeRolloutManifestOperation implements AtomicOperation
   private final KubernetesResumeRolloutManifestDescription description;
   private final KubernetesV2Credentials credentials;
   private final KubernetesResourcePropertyRegistry registry;
+  private final String accountName;
   private static final String OP_NAME = "RESUME_ROLLOUT_KUBERNETES_MANIFEST";
 
   public KubernetesResumeRolloutManifestOperation(KubernetesResumeRolloutManifestDescription description, KubernetesResourcePropertyRegistry registry) {
     this.description = description;
     this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.accountName = description.getCredentials().getName();
     this.registry = registry;
   }
 
@@ -52,7 +54,7 @@ public class KubernetesResumeRolloutManifestOperation implements AtomicOperation
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
-    KubernetesResourceProperties properties = registry.get(coordinates.getKind());
+    KubernetesResourceProperties properties = registry.get(accountName, coordinates.getKind());
     KubernetesHandler deployer = properties.getHandler();
 
     if (!(deployer instanceof CanResumeRollout)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesScaleManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesScaleManifestOperation.java
@@ -34,11 +34,13 @@ public class KubernetesScaleManifestOperation implements AtomicOperation<Void> {
   private final KubernetesScaleManifestDescription description;
   private final KubernetesV2Credentials credentials;
   private final KubernetesResourcePropertyRegistry registry;
+  private final String accountName;
   private static final String OP_NAME = "SCALE_KUBERNETES_MANIFEST";
 
   public KubernetesScaleManifestOperation(KubernetesScaleManifestDescription description, KubernetesResourcePropertyRegistry registry) {
     this.description = description;
     this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.accountName = description.getCredentials().getName();
     this.registry = registry;
   }
 
@@ -52,7 +54,7 @@ public class KubernetesScaleManifestOperation implements AtomicOperation<Void> {
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
-    KubernetesResourceProperties properties = registry.get(coordinates.getKind());
+    KubernetesResourceProperties properties = registry.get(accountName, coordinates.getKind());
     KubernetesHandler deployer = properties.getHandler();
 
     if (!(deployer instanceof CanScale)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesUndoRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesUndoRolloutManifestOperation.java
@@ -34,11 +34,13 @@ public class KubernetesUndoRolloutManifestOperation implements AtomicOperation<V
   private final KubernetesUndoRolloutManifestDescription description;
   private final KubernetesV2Credentials credentials;
   private final KubernetesResourcePropertyRegistry registry;
+  private final String accountName;
   private static final String OP_NAME = "DELETE_KUBERNETES_MANIFEST";
 
   public KubernetesUndoRolloutManifestOperation(KubernetesUndoRolloutManifestDescription description, KubernetesResourcePropertyRegistry registry) {
     this.description = description;
     this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.accountName = description.getCredentials().getName();
     this.registry = registry;
   }
 
@@ -52,7 +54,7 @@ public class KubernetesUndoRolloutManifestOperation implements AtomicOperation<V
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
-    KubernetesResourceProperties properties = registry.get(coordinates.getKind());
+    KubernetesResourceProperties properties = registry.get(accountName, coordinates.getKind());
     KubernetesHandler deployer = properties.getHandler();
 
     if (!(deployer instanceof CanUndoRollout)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/servergroup/KubernetesResizeServerGroupOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/servergroup/KubernetesResizeServerGroupOperation.java
@@ -34,11 +34,13 @@ public class KubernetesResizeServerGroupOperation implements AtomicOperation<Voi
   private final KubernetesResizeServerGroupDescription description;
   private final KubernetesV2Credentials credentials;
   private final KubernetesResourcePropertyRegistry registry;
+  private final String accountName;
   private static final String OP_NAME = "RESIZE_KUBERNETES_SERVER_GROUP";
 
   public KubernetesResizeServerGroupOperation(KubernetesResizeServerGroupDescription description, KubernetesResourcePropertyRegistry registry) {
     this.description = description;
     this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.accountName = description.getCredentials().getName();
     this.registry = registry;
   }
 
@@ -52,7 +54,7 @@ public class KubernetesResizeServerGroupOperation implements AtomicOperation<Voi
     KubernetesCoordinates coordinates = description.getCoordinates();
 
     getTask().updateStatus(OP_NAME, "Looking up resource properties...");
-    KubernetesResourceProperties properties = registry.get(coordinates.getKind());
+    KubernetesResourceProperties properties = registry.get(accountName, coordinates.getKind());
     KubernetesHandler deployer = properties.getHandler();
 
     if (!(deployer instanceof CanResize)) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.CustomKubernetesResource;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
@@ -52,6 +53,9 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final ObjectMapper mapper = new ObjectMapper();
   private final List<String> namespaces;
   private final List<String> omitNamespaces;
+
+  @Getter
+  private final List<CustomKubernetesResource> customResources;
 
   // remove when kubectl is no longer a dependency
   @Getter
@@ -107,6 +111,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     List<String> omitNamespaces = new ArrayList<>();
     Registry registry;
     KubectlJobExecutor jobExecutor;
+    List<CustomKubernetesResource> customResources;
     boolean debug;
 
     public Builder accountName(String accountName) {
@@ -154,6 +159,11 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       return this;
     }
 
+    public Builder customResources(List<CustomKubernetesResource> customResources) {
+      this.customResources = customResources;
+      return this;
+    }
+
     public Builder debug(boolean debug) {
       this.debug = debug;
       return this;
@@ -187,6 +197,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
       namespaces = namespaces == null ? new ArrayList<>() : namespaces;
       omitNamespaces = omitNamespaces == null ? new ArrayList<>() : omitNamespaces;
+      customResources = customResources == null ? new ArrayList<>() : customResources;
 
       return new KubernetesV2Credentials(
           accountName,
@@ -199,6 +210,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
           context,
           oAuthServiceAccount,
           oAuthScopes,
+          customResources,
           debug
       );
     }
@@ -214,6 +226,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       String context,
       String oAuthServiceAccount,
       List<String> oAuthScopes,
+      @NotNull List<CustomKubernetesResource> customResources,
       boolean debug) {
     this.registry = registry;
     this.clock = registry.clock();
@@ -227,6 +240,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.context = context;
     this.oAuthServiceAccount = oAuthServiceAccount;
     this.oAuthScopes = oAuthScopes;
+    this.customResources = customResources;
   }
 
   @Override

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
@@ -99,7 +99,7 @@ class KubernetesVersionedArtifactConverterSpec extends Specification {
 
     artifactProvider.getArtifacts(type, name, location) >> artifacts
 
-    def converter = new KubernetesVersionedArtifactConverter(new ObjectMapper())
+    def converter = new KubernetesVersionedArtifactConverter()
 
     then:
     converter.getVersion(artifactProvider, type, name, location, manifest1) == version1

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
@@ -92,20 +92,19 @@ metadata:
     credentials.deploy(_, _) >> null
 
     def replicaSetDeployer = new KubernetesReplicaSetHandler()
-    replicaSetDeployer.objectMapper = new ObjectMapper()
     replicaSetDeployer.versioned() >> true
     replicaSetDeployer.kind() >> KIND
     def versionedArtifactConverterMock = Mock(KubernetesVersionedArtifactConverter)
     versionedArtifactConverterMock.getDeployedName(_) >> "$NAME-$VERSION"
     versionedArtifactConverterMock.toArtifact(_, _) >> new Artifact()
     def registry = new KubernetesResourcePropertyRegistry(Collections.singletonList(replicaSetDeployer),
-        new KubernetesSpinnakerKindMap(),
-        versionedArtifactConverterMock,
-        new KubernetesUnversionedArtifactConverter())
+        new KubernetesSpinnakerKindMap())
 
     NamerRegistry.lookup().withProvider(KubernetesCloudProvider.ID)
       .withAccount(ACCOUNT)
       .setNamer(KubernetesManifest.class, new KubernetesManifestNamer())
+
+    registry.get("any", KubernetesKind.REPLICA_SET).versionedConverter = versionedArtifactConverterMock
     
     def deployOp = new KubernetesDeployManifestOperation(deployDescription, registry, null)
 


### PR DESCRIPTION
This allows you to register (for now, only rudimentary) support for
custom resources, or resources not handled by Spinnaker.

So far, I haven't made `ReplicationControllers` explicitly deployable
using Spinnaker. With this patch, and the following config in my
clouddriver.yml, they could be deployed:

```yaml
kubernetes:
  accounts:
  - name: my-k8s-v2-account
    customResources:
    - kubernetesKind: ReplicationController
      spinnakerKind: ServerGroups
      versioned: true
```
