### PR TITLE
fix(provider/appengine): surface timeouts to frontend during job execution

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/AppengineJobExecutor.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/AppengineJobExecutor.groovy
@@ -41,9 +41,12 @@ class AppengineJobExecutor {
   void waitForJobCompletion(String jobId) {
     sleep(sleepMs)
     JobStatus jobStatus = jobExecutor.updateJob(jobId)
-    while (jobStatus.state == JobStatus.State.RUNNING) {
+    while (jobStatus != null && jobStatus.state == JobStatus.State.RUNNING) {
       sleep(sleepMs)
       jobStatus = jobExecutor.updateJob(jobId)
+    }
+    if (jobStatus == null) {
+      throw new RuntimeException("job timed out or was cancelled")
     }
     if (jobStatus.result == JobStatus.Result.FAILURE && jobStatus.stdOut) {
       throw new IllegalArgumentException("$jobStatus.stdOut + $jobStatus.stdErr")

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.groovy
@@ -146,7 +146,7 @@ class JobExecutorLocal implements JobExecutor {
         jobStatus.stdErr = errors
         return jobStatus
       } else {
-        // This instance is not managing the job
+        // This instance is not managing the job, it has timed out, or it was cancelled.
         return null
       }
     } catch (Exception e) {


### PR DESCRIPTION
Previously when an appengine deploy took longer than 10 minutes, an error was captured in deck that read `Cannot get property 'state' on null object`.  This PR modifies the message that gets surfaced to read `job timed out or was cancelled`.

Error Before:

![previous_error](https://user-images.githubusercontent.com/34253460/35814914-47067df4-0a65-11e8-881c-552526cd6447.png)

Error After:

![after](https://user-images.githubusercontent.com/34253460/35814920-4bea14a2-0a65-11e8-970e-ecf8fda32fc3.png)