### PR TITLE
fix(eureka): Handle missing instances when determining what to disable

### DIFF
--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
@@ -269,25 +269,26 @@ abstract class AbstractEurekaSupport {
     if (!serverGroup) {
       return []
     }
-    List<String> modified = []
-    List<String> unmodified = []
+
+    Set<String> modified = []
+    Set<String> unmodified = []
 
     instances.each { instanceId ->
-      boolean isUp = false
-      serverGroup.instances.find { it.name == instanceId }?.health.flatten().each {
-        Map<String, String> health ->
-          if (DiscoveryStatus.Enable.value.equalsIgnoreCase(health?.eurekaStatus)) {
-            isUp = true
-          }
-      }
-      if (isUp) {
-        unmodified.add(instanceId)
-      } else {
-        modified.add(instanceId)
+      def instanceInExistingServerGroup = serverGroup.instances.find { it.name == instanceId }
+      instanceInExistingServerGroup?.health?.each { Map<String, String> health ->
+        if (DiscoveryStatus.Enable.value.equalsIgnoreCase(health?.eurekaStatus)) {
+          unmodified.add(instanceId)
+        } else {
+          modified.add(instanceId)
+        }
       }
     }
 
-    return EnableDisablePercentageCategorizer.getInstancesToModify(modified, unmodified, desiredPercentage)
+    return EnableDisablePercentageCategorizer.getInstancesToModify(
+      modified as List<String>,
+      unmodified as List<String>,
+      desiredPercentage
+    )
   }
 
   enum DiscoveryStatus {

--- a/clouddriver-eureka/src/test/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupportSpec.groovy
+++ b/clouddriver-eureka/src/test/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupportSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.eureka.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.eureka.api.Eureka
+import com.netflix.spinnaker.clouddriver.model.ClusterProvider
+import com.netflix.spinnaker.clouddriver.model.Instance
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll;
+
+class AbstractEurekaSupportSpec extends Specification {
+  def clusterProvider = Mock(ClusterProvider)
+
+  @Subject
+  def eurekaSupport = new MyEurekaSupport(clusterProviders: [clusterProvider])
+
+  @Unroll
+  def ""() {
+    when:
+    def instancesToModify = eurekaSupport.getInstanceToModify("test", "us-west-2", "asg-v001", allInstances, percentageToDisable)
+
+    then:
+    1 * clusterProvider.getServerGroup("test", "us-west-2", "asg-v001") >> {
+      return serverGroup(
+        instancesInServerGroup.collect {
+          instance(it.key, ["eurekaStatus": it.value])
+        }
+      )
+    }
+
+    instancesToModify == expectedInstancesToModify
+
+    where:
+    allInstances          | instancesInServerGroup                  | percentageToDisable || expectedInstancesToModify
+    ["i-1", "i-2"]        | ["i-1": "UP"]                           | 50                  || ["i-1"]                // i-2 doesn't actually exist so should be skipped
+    ["i-1", "i-2"]        | ["i-1": "OUT_OF_SERVICE"]               | 50                  || []                     // i-1 is already disabled
+    ["i-1", "i-2"]        | ["i-1": "UP"]                           | 1                   || ["i-1"]                // always round up when determining what to disable
+    ["i-1", "i-2", "i-3"] | ["i-1": "UP", "i-2": "UP", "i-3": "UP"] | 100                 || ["i-1", "i-2", "i-3"]
+    ["i-1", "i-2", "i-3"] | ["i-1": "UP", "i-2": "UP", "i-3": "UP"] | 30                  || ["i-1"]
+    ["i-1", "i-2", "i-3"] | ["i-1": "UP", "i-2": "UP", "i-3": "UP"] | 60                  || ["i-1", "i-2"]
+    ["i-1", "i-2", "i-3"] | ["i-1": "UP", "i-2": "UP", "i-3": "UP"] | 90                  || ["i-1", "i-2", "i-3"]
+  }
+
+  ServerGroup serverGroup(List<Instance> instances) {
+    return Mock(ServerGroup) {
+      _ * getInstances() >> { return instances }
+    }
+  }
+
+  Instance instance(String name, Map<String, String> health) {
+    return Mock(Instance) {
+      _ * getName() >> { return name }
+      _ * getHealth() >> { return [health] }
+    }
+  }
+
+  class MyEurekaSupport extends AbstractEurekaSupport {
+    @Override
+    Eureka getEureka(Object credentials, String region) {
+      throw new UnsupportedOperationException()
+    }
+
+    @Override
+    boolean verifyInstanceAndAsgExist(Object credentials, String region, String instanceId, String asgName) {
+      throw new UnsupportedOperationException()
+    }
+  }
+}
+
+


### PR DESCRIPTION
`getInstanceToModify()` is currently passed a set of instances that have
been fetched directly from AWS.

In the event of autoscaling, it's highly likely that some number of
these instances have not yet been cached by `clouddriver`.

This PR ignores any instances that have not been cached and excludes
them in the `desiredPercentage` calculation.

Previously this failed with:

```
NullPointerException; Message: Cannot invoke method flatten() on null object
```