### PR TITLE
feature(provider/ecs) Added Role Controller.

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/RoleController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/RoleController.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.controllers;
+
+import com.netflix.spinnaker.clouddriver.aws.model.Role;
+import com.netflix.spinnaker.clouddriver.aws.model.RoleProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/roles")
+public class RoleController {
+
+  @Autowired
+  List<RoleProvider> roleProviders;
+
+  @RequestMapping(method = RequestMethod.GET, value = "/{cloudProvider}")
+  Collection<Role> getRoles(@PathVariable String cloudProvider) {
+    Set<Role> roles = roleProviders.stream()
+      .filter(roleProvider -> roleProvider.getCloudProvider().equals(cloudProvider))
+      .flatMap(roleProvider -> roleProvider.getAll().stream())
+      .collect(Collectors.toSet());
+
+    return roles;
+  }
+}


### PR DESCRIPTION
Added `RoleController` responsible for listening on `/roles/{cloudProvider}` endpoint. Uses `RoleProvider` to provide back the information. An implementation of a `RoleProvider` that already exists is `EcsRoleProvider`.

@cfieber @ajordens @robzienert @BrunoCarrier