### PR TITLE
perf(provider/kubernetes): v2 small perf improvements

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -43,10 +43,10 @@ import java.util.stream.Collectors;
 @Component
 @Slf4j
 public class KubectlJobExecutor {
-  @Value("${kubernetes.kubectl.poll.minSleepMillis:100}")
+  @Value("${kubernetes.kubectl.poll.minSleepMillis:200}")
   Long minSleepMillis;
 
-  @Value("${kubernetes.kubectl.poll.maxSleepMillis:2000}")
+  @Value("${kubernetes.kubectl.poll.maxSleepMillis:4000}")
   Long maxSleepMillis;
 
   @Value("${kubernetes.kubectl.poll.timeoutMillis:100000}")
@@ -387,7 +387,7 @@ public class KubectlJobExecutor {
 
     while (totalSleep < timeoutMillis && interrupts < maxInterruptRetries) {
       try {
-        Thread.sleep(totalSleep);
+        Thread.sleep(nextSleep);
       } catch (InterruptedException e) {
         log.warn("{} was interrupted", jobId, e);
         interrupts += 1;


### PR DESCRIPTION
Not sure if this addresses https://github.com/spinnaker/spinnaker/issues/2334, but it does cut down the number of kubectl calls to roughly 1/3 by reducing redundant namespace calls.