### PR TITLE
feat(aws): Allow self-referencing security group clone ops

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperation.groovy
@@ -18,10 +18,12 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup
 
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.ec2.model.IpPermission
+import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupIngressConverter.ConvertedIngress
+import com.netflix.spinnaker.clouddriver.aws.deploy.ops.securitygroup.SecurityGroupLookupFactory.SecurityGroupLookup
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -45,16 +47,12 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
   @Override
   Void operate(List priorOutputs) {
     final securityGroupLookup = securityGroupLookupFactory.getInstance(description.region)
-    final ipPermissionsFromDescription = SecurityGroupIngressConverter.
-      convertIngressToIpPermissions(securityGroupLookup, description)
-    if (ipPermissionsFromDescription.missingSecurityGroups) {
-      def missingSecurityGroupDescriptions = ipPermissionsFromDescription.missingSecurityGroups.collect {
-        "'${it.name ?: it.id}' in '${it.accountName ?: description.credentialAccount}' ${it.vpcId ?: description.vpcId ?: 'EC2-classic'}"
-      }
-      def securityGroupsDoNotExistErrorMessage = "The following security groups do not exist: ${missingSecurityGroupDescriptions.join(", ")}"
-      task.updateStatus BASE_PHASE, securityGroupsDoNotExistErrorMessage
-      throw new IllegalStateException(securityGroupsDoNotExistErrorMessage)
-    }
+
+    // Get all of the ingress rules from the description. Will fail the operation if any upstream security groups
+    // are missing, unless they're self-referential to the security group being upserted. In the case of a
+    // self-referential security group, we don't want to fail the upsert if the security group doesn't exist, as we'll
+    // be creating it next.
+    ConvertedIngress ipPermissionsFromDescription = convertDescriptionToIngress(securityGroupLookup, description, true)
 
     def securityGroupUpdater = securityGroupLookup.getSecurityGroupByName(
       description.credentialAccount,
@@ -62,6 +60,7 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
       description.vpcId
     )
 
+    // Create or update the security group itself. If the security group exists, also get the security group rules.
     List<IpPermission> existingIpPermissions
     if (securityGroupUpdater.present) {
       securityGroupUpdater = securityGroupUpdater.get()
@@ -88,9 +87,16 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
       }
     }
 
+    // Second conversion of desired security group rules. If any upstream groups (including self-referential) are
+    // missing, the operation will fail.
+    if (!ipPermissionsFromDescription.missingSecurityGroups.selfReferencing.isEmpty()) {
+      ipPermissionsFromDescription = convertDescriptionToIngress(securityGroupLookup, description, false)
+    }
+
     List<IpPermission> ipPermissionsToAdd = ipPermissionsFromDescription.converted - existingIpPermissions
     List<IpPermission> ipPermissionsToRemove = existingIpPermissions - ipPermissionsFromDescription.converted
 
+    // Converge on the desired final set of security group rules
     if (ipPermissionsToAdd) {
       try {
         securityGroupUpdater.addIngress(ipPermissionsToAdd)
@@ -112,4 +118,19 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
     null
   }
 
+  private ConvertedIngress convertDescriptionToIngress(SecurityGroupLookup securityGroupLookup, UpsertSecurityGroupDescription description, boolean ignoreSelfReferencingRules) {
+    ConvertedIngress ipPermissionsFromDescription = SecurityGroupIngressConverter.
+      convertIngressToIpPermissions(securityGroupLookup, description)
+
+    if (ipPermissionsFromDescription.missingSecurityGroups.anyMissing(ignoreSelfReferencingRules)) {
+      def missingSecurityGroupDescriptions = ipPermissionsFromDescription.missingSecurityGroups.all.collect {
+        "'${it.name ?: it.id}' in '${it.accountName ?: description.credentialAccount}' ${it.vpcId ?: description.vpcId ?: 'EC2-classic'}"
+      }
+      def securityGroupsDoNotExistErrorMessage = "The following security groups do not exist: ${missingSecurityGroupDescriptions.join(", ")}"
+      task.updateStatus BASE_PHASE, securityGroupsDoNotExistErrorMessage
+      throw new IllegalStateException(securityGroupsDoNotExistErrorMessage)
+    }
+
+    return ipPermissionsFromDescription
+  }
 }


### PR DESCRIPTION
Performs an upsert in a two-phase operation if the security group has self-referencing rules and does not already exist.