### PR TITLE
chore(*): Bump spinnaker-dependencies to 0.142.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.134.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.142.1'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/security/TestDefaults.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/security/TestDefaults.groovy
@@ -568,7 +568,7 @@ trait TestDefaults {
     [ guestCpus: 8, name: 'n1-standard-8' ]
   ]
 
-  static final Map<String, List> INSTANCE_TYPE_LIST = [
+  final Map<String, List> INSTANCE_TYPE_LIST = [
     items: [
       'zones/us-central1-a': [
         machineTypes: INSTANCE_TYPES_WITH_16


### PR DESCRIPTION
@duftler @lwander Trying to update to spinnaker-dependencies to 0.142.1, but one test is failing. I thrashed on it all day and I couldn't really figure out why the ObjectMapper started failing. My initially inclination was going to be to refactor `TestDefaults` to not use maps, but the actual objects, but don't want to go down this path if there's something simpler. Would any of you Googlers be able to pull this down and give it a pair of eyes? 