### PR TITLE
feat(aws): Track the instanceIds being disabled

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -148,6 +148,10 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
       if (instanceIds && credentials.discoveryEnabled && description.desiredPercentage && disable) {
         instanceIds = discoverySupport.getInstanceToModify(credentials.name, region, serverGroupName, instanceIds, description.desiredPercentage)
         task.updateStatus phaseName, "Only disabling instances $instanceIds on ASG $serverGroupName with percentage ${description.desiredPercentage}"
+
+        task.addResultObjects([
+          ["instanceIdsToDisable": instanceIds]
+        ])
       }
 
       // ELB/ALB registration


### PR DESCRIPTION
This allows `orca` to make a more informed decision when verifying that
a specific percentage of a server group has been disabled.
