### PR TITLE
fix(eureka): `getInstanceToModify` calculation was incorrect with multiple health statuses

### DIFF
--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
@@ -275,8 +275,15 @@ abstract class AbstractEurekaSupport {
 
     instances.each { instanceId ->
       def instanceInExistingServerGroup = serverGroup.instances.find { it.name == instanceId }
-      instanceInExistingServerGroup?.health?.each { Map<String, String> health ->
-        if (DiscoveryStatus.Enable.value.equalsIgnoreCase(health?.eurekaStatus)) {
+      if (instanceInExistingServerGroup) {
+        boolean isUp = false
+        instanceInExistingServerGroup.health?.flatten()?.each { Map<String, String> health ->
+          if (DiscoveryStatus.Enable.value.equalsIgnoreCase(health?.eurekaStatus)) {
+            isUp = true
+          }
+        }
+
+        if (isUp) {
           unmodified.add(instanceId)
         } else {
           modified.add(instanceId)

--- a/clouddriver-eureka/src/test/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupportSpec.groovy
+++ b/clouddriver-eureka/src/test/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupportSpec.groovy
@@ -39,7 +39,7 @@ class AbstractEurekaSupportSpec extends Specification {
     1 * clusterProvider.getServerGroup("test", "us-west-2", "asg-v001") >> {
       return serverGroup(
         instancesInServerGroup.collect {
-          instance(it.key, ["eurekaStatus": it.value])
+          instance(it.key, [["eurekaStatus": it.value], ["notEurekaStatus": it.value]])
         }
       )
     }
@@ -63,10 +63,10 @@ class AbstractEurekaSupportSpec extends Specification {
     }
   }
 
-  Instance instance(String name, Map<String, String> health) {
+  Instance instance(String name, List<Map<String, String>> healths) {
     return Mock(Instance) {
       _ * getName() >> { return name }
-      _ * getHealth() >> { return [health] }
+      _ * getHealth() >> { return healths }
     }
   }
 


### PR DESCRIPTION
Previously it was iterating through each `health` and double counting
instances that had both eureka and non-eureka health statuses.
