### PR TITLE
fix(reservations): Sort by instance type and then availability zone

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReport.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReport.groovy
@@ -219,16 +219,16 @@ class AmazonReservationReport implements ReservationReport {
       def r = a.region <=> b.region
 
       if (!r) {
-        r = a.availabilityZone <=> b.availabilityZone
-      }
-
-      if (!r) {
         r = a.instanceFamily() <=> b.instanceFamily()
       }
 
       if (!r) {
         // overall sort is descending but instance type should be ascending
         r = normalizeInstanceType(b.instanceType) <=> normalizeInstanceType(a.instanceType)
+      }
+
+      if (!r) {
+        r = a.availabilityZone <=> b.availabilityZone
       }
 
       if (!r) {


### PR DESCRIPTION
Previously:

"us-east-1e:r3.2xlarge"
"us-east-1e:r3.4xlarge"
"us-east-1e:r3.8xlarge"
"us-east-1d:r3.2xlarge"
"us-east-1d:r3.4xlarge"
"us-east-1d:r3.8xlarge"

Now:

"us-east-1e:r3.2xlarge"
"us-east-1d:r3.2xlarge"
"us-east-1e:r3.4xlarge"
"us-east-1d:r3.4xlarge"
"us-east-1e:r3.8xlarge"
"us-east-1d:r3.8xlarge"
