### PR TITLE
feat(provider/kuberentes): v2 restrict caching by kind

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -46,6 +46,8 @@ class KubernetesConfigurationProperties {
     String namingStrategy = "kubernetesAnnotations"
     Boolean debug = false
     List<CustomKubernetesResource> customResources;
+    List<String> kinds
+    List<String> omitKinds
   }
 
   List<ManagedAccount> accounts = []

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -186,6 +186,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     KubectlJobExecutor jobExecutor;
     Namer namer;
     List<CustomKubernetesResource> customResources;
+    List<String> kinds;
+    List<String> omitKinds;
     boolean debug;
 
     Builder name(String name) {
@@ -326,6 +328,16 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       return this;
     }
 
+    Builder kinds(List<String> kinds) {
+      this.kinds = kinds;
+      return this;
+    }
+
+    Builder omitKinds(List<String> omitKinds) {
+      this.omitKinds = omitKinds;
+      return this;
+    }
+
     private C buildCredentials() {
       switch (providerVersion) {
         case v1:
@@ -361,6 +373,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
               .omitNamespaces(omitNamespaces)
               .registry(spectatorRegistry)
               .customResources(customResources)
+              .kinds(kinds)
+              .omitKinds(omitKinds)
               .debug(debug)
               .jobExecutor(jobExecutor)
               .build();
@@ -376,6 +390,10 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
 
       if ((omitNamespaces != null && !omitNamespaces.isEmpty()) && (namespaces != null && !namespaces.isEmpty())) {
         throw new IllegalArgumentException("At most one of 'namespaces' and 'omitNamespaces' can be specified");
+      }
+
+      if ((omitKinds != null && !omitKinds.isEmpty()) && (kinds != null && !kinds.isEmpty())) {
+        throw new IllegalArgumentException("At most one of 'kinds' and 'omitKinds' can be specified");
       }
 
       if (cacheThreads == 0) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -100,6 +100,8 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .jobExecutor(jobExecutor)
           .namer(namerRegistry.getNamingStrategy(managedAccount.namingStrategy))
           .customResources(managedAccount.customResources)
+          .kinds(managedAccount.kinds)
+          .omitKinds(managedAccount.omitKinds)
           .debug(managedAccount.debug)
           .build()
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesCachingAge
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -47,6 +48,7 @@ public class KubernetesV2CachingAgentDispatcher implements KubernetesCachingAgen
 
   @Override
   public List<KubernetesCachingAgent> buildAllCachingAgents(KubernetesNamedAccountCredentials credentials) {
+    KubernetesV2Credentials v2Credentials = (KubernetesV2Credentials) credentials.getCredentials();
     List<KubernetesCachingAgent> result = new ArrayList<>();
     IntStream.range(0, credentials.getCacheThreads())
         .boxed()
@@ -54,6 +56,7 @@ public class KubernetesV2CachingAgentDispatcher implements KubernetesCachingAgen
             .stream()
             .map(KubernetesResourceProperties::getHandler)
             .filter(Objects::nonNull)
+            .filter(h -> v2Credentials.isValidKind(h.kind()))
             .map(h -> h.buildCachingAgent(credentials, objectMapper, registry, i, credentials.getCacheThreads()))
             .filter(Objects::nonNull)
             .forEach(c -> result.add((KubernetesCachingAgent) c))

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class KubernetesKind {
   public static KubernetesKind CONFIG_MAP = new KubernetesKind("configMap", "cm");
@@ -76,5 +77,11 @@ public class KubernetesKind {
 
     // separate from the above chain to avoid concurrent modification of the values list
     return kindOptional.orElseGet(() -> new KubernetesKind(name));
+  }
+
+  public static List<KubernetesKind> fromStringList(List<String> names) {
+    return names.stream()
+        .map(KubernetesKind::fromString)
+        .collect(Collectors.toList());
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -61,6 +61,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final ObjectMapper mapper = new ObjectMapper();
   private final List<String> namespaces;
   private final List<String> omitNamespaces;
+  private final List<KubernetesKind> kinds;
+  private final List<KubernetesKind> omitKinds;
 
   // TODO(lwander) make configurable
   private final static int namespaceExpirySeconds = 30;
@@ -94,6 +96,16 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private String cachedDefaultNamespace;
 
   private final Path serviceAccountNamespacePath = Paths.get("/var/run/secrets/kubernetes.io/serviceaccount/namespace");
+
+  public boolean isValidKind(KubernetesKind kind) {
+    if (!this.kinds.isEmpty()) {
+      return kinds.contains(kind);
+    } else if (!this.omitKinds.isEmpty()) {
+      return !omitKinds.contains(kind);
+    } else {
+      return true;
+    }
+  }
 
   public String getDefaultNamespace() {
     if (StringUtils.isEmpty(cachedDefaultNamespace)) {
@@ -137,6 +149,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     Registry registry;
     KubectlJobExecutor jobExecutor;
     List<CustomKubernetesResource> customResources;
+    List<String> kinds;
+    List<String> omitKinds;
     boolean debug;
 
     public Builder accountName(String accountName) {
@@ -204,6 +218,16 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       return this;
     }
 
+    public Builder kinds(List<String> kinds) {
+      this.kinds = kinds;
+      return this;
+    }
+
+    public Builder omitKinds(List<String> omitKinds) {
+      this.omitKinds = omitKinds;
+      return this;
+    }
+
     public KubernetesV2Credentials build() {
       KubeConfig kubeconfig;
       try {
@@ -223,6 +247,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       namespaces = namespaces == null ? new ArrayList<>() : namespaces;
       omitNamespaces = omitNamespaces == null ? new ArrayList<>() : omitNamespaces;
       customResources = customResources == null ? new ArrayList<>() : customResources;
+      kinds = kinds == null ? new ArrayList<>() : kinds;
+      omitKinds = omitKinds == null ? new ArrayList<>() : omitKinds;
 
       return new KubernetesV2Credentials(
           accountName,
@@ -236,6 +262,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
           oAuthServiceAccount,
           oAuthScopes,
           customResources,
+          KubernetesKind.fromStringList(kinds),
+          KubernetesKind.fromStringList(omitKinds),
           debug
       );
     }
@@ -252,6 +280,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       String oAuthServiceAccount,
       List<String> oAuthScopes,
       @NotNull List<CustomKubernetesResource> customResources,
+      @NotNull List<KubernetesKind> kinds,
+      @NotNull List<KubernetesKind> omitKinds,
       boolean debug) {
     this.registry = registry;
     this.clock = registry.clock();
@@ -266,6 +296,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.oAuthServiceAccount = oAuthServiceAccount;
     this.oAuthScopes = oAuthScopes;
     this.customResources = customResources;
+    this.kinds = kinds;
+    this.omitKinds = omitKinds;
 
     this.liveNamespaceSupplier = Suppliers.memoizeWithExpiration(() -> jobExecutor.list(this, KubernetesKind.NAMESPACE, "")
         .stream()


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/2283

Sample:

```yaml
kubernetes:
  accounts:
  - name: k8s-v2
    providerVersion: v2
    omitKinds: 
    - ConfigMap
    - Secret
```

will stop caching secrets & configmaps in that account.