### PR TITLE
fix(provider/aws): LifecycleNotification JsonMappingException

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/NotificationMessage.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/NotificationMessage.java
@@ -36,7 +36,7 @@ public class NotificationMessage {
   String statusMessage;
 
   @JsonProperty("Details")
-  Map<String, String> details;
+  Map<String, Object> details;
 
   @JsonProperty("RequestID")
   Integer requestId;


### PR DESCRIPTION
LifecycleNotifications now have nested objects (`InvokingAlarms`).
Stumbled around for some AWS docs to no immediate avail, but a snippet:

```
{'Message': {'Description': 'Launching a new EC2 instance: REDACTED',
  'Details': {'Availability Zone': 'us-east-1d',
            'InvokingAlarms': [{'AWSAccountId': 'REDACTED',
                                'AlarmDescription': None,
                                'AlarmName': 'awsec2-REDACTED-High-CPU-Utilization',
                                'NewStateReason': 'Threshold Crossed: 1 datapoint (5.984999999999999) was less than or equal to the threshold (40.0).',
                                'NewStateValue': 'ALARM',
                                'OldStateValue': 'ALARM',
                                'Region': 'US - N. Virginia',
                                'StateChangeTime': 1402188328924L,
                                'Trigger': {'ComparisonOperator': 'LessThanOrEqualToThreshold',
                                            'Dimensions': [{'name': 'AutoScalingGroupName',
                                                            'value': 'REDACTED'}],
                                            'EvaluationPeriods': 1,
                                            'MetricName': 'CPUUtilization',
                                            'Namespace': 'AWS/EC2',
                                            'Period': 900,
                                            'Statistic': 'AVERAGE',
                                            'Threshold': 40,
                                            'Unit': None}}]},
  'EC2InstanceId': 'REDACTED',
  // ...
  'Time': '2014-06-09T12:47:23.288Z'}
```
