### PR TITLE
feat(provider/kubernetes): v2 Add support for RBAC resource kinds

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -357,7 +357,7 @@ public class KubernetesCacheDataConverter {
       log.warn("{}: manifest name may not be null, {}", contextMessage.get(), manifest);
     }
 
-    if (StringUtils.isEmpty(manifest.getNamespace()) && manifest.getKind() != KubernetesKind.NAMESPACE) {
+    if (StringUtils.isEmpty(manifest.getNamespace()) && manifest.getKind().isNamespaced()) {
       log.warn("{}: manifest namespace may not be null, {}", contextMessage.get(), manifest);
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesClusterRoleBindingCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesClusterRoleBindingCachingAgent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
+
+public class KubernetesClusterRoleBindingCachingAgent extends KubernetesV2OnDemandCachingAgent {
+  KubernetesClusterRoleBindingCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+                                           ObjectMapper objectMapper,
+                                           Registry registry,
+                                           int agentIndex,
+                                           int agentCount) {
+    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+  }
+
+  @Getter
+  final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          AUTHORITATIVE.forType(KubernetesKind.CLUSTER_ROLE_BINDING.toString())
+      ))
+  );
+
+  @Override
+  protected boolean hasClusterRelationship() {
+    return false;
+  }
+
+  @Override
+  protected KubernetesKind primaryKind() {
+    return KubernetesKind.CLUSTER_ROLE_BINDING;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesClusterRoleCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesClusterRoleCachingAgent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
+
+public class KubernetesClusterRoleCachingAgent extends KubernetesV2OnDemandCachingAgent {
+  KubernetesClusterRoleCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+                                    ObjectMapper objectMapper,
+                                    Registry registry,
+                                    int agentIndex,
+                                    int agentCount) {
+    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+  }
+
+  @Getter
+  final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          AUTHORITATIVE.forType(KubernetesKind.CLUSTER_ROLE.toString())
+      ))
+  );
+
+  @Override
+  protected boolean hasClusterRelationship() {
+    return false;
+  }
+
+  @Override
+  protected KubernetesKind primaryKind() {
+    return KubernetesKind.CLUSTER_ROLE;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesRoleBindingCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesRoleBindingCachingAgent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
+
+public class KubernetesRoleBindingCachingAgent extends KubernetesV2OnDemandCachingAgent {
+  KubernetesRoleBindingCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+                                    ObjectMapper objectMapper,
+                                    Registry registry,
+                                    int agentIndex,
+                                    int agentCount) {
+    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+  }
+
+  @Getter
+  final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          AUTHORITATIVE.forType(KubernetesKind.ROLE_BINDING.toString())
+      ))
+  );
+
+  @Override
+  protected boolean hasClusterRelationship() {
+    return false;
+  }
+
+  @Override
+  protected KubernetesKind primaryKind() {
+    return KubernetesKind.ROLE_BINDING;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesRoleCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesRoleCachingAgent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
+
+public class KubernetesRoleCachingAgent extends KubernetesV2OnDemandCachingAgent {
+  KubernetesRoleCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+                             ObjectMapper objectMapper,
+                             Registry registry,
+                             int agentIndex,
+                             int agentCount) {
+    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+  }
+
+  @Getter
+  final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          AUTHORITATIVE.forType(KubernetesKind.ROLE.toString())
+      ))
+  );
+
+  @Override
+  protected boolean hasClusterRelationship() {
+    return false;
+  }
+
+  @Override
+  protected KubernetesKind primaryKind() {
+    return KubernetesKind.ROLE;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesServiceAccountCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesServiceAccountCachingAgent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
+
+public class KubernetesServiceAccountCachingAgent extends KubernetesV2OnDemandCachingAgent {
+  KubernetesServiceAccountCachingAgent(KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,
+                                       ObjectMapper objectMapper,
+                                       Registry registry,
+                                       int agentIndex,
+                                       int agentCount) {
+    super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+  }
+
+  @Getter
+  final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          AUTHORITATIVE.forType(KubernetesKind.SERVICE_ACCOUNT.toString())
+      ))
+  );
+
+  @Override
+  protected boolean hasClusterRelationship() {
+    return false;
+  }
+
+  @Override
+  protected KubernetesKind primaryKind() {
+    return KubernetesKind.SERVICE_ACCOUNT;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -250,8 +250,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     reloadNamespaces();
     if (StringUtils.isEmpty(account)
         || StringUtils.isEmpty(name)
-        || StringUtils.isEmpty(namespace)
-        || !namespaces.contains(namespace)) {
+        || (!StringUtils.isEmpty(namespace) && !namespaces.contains(namespace))) {
       return null;
     }
 
@@ -292,7 +291,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
 
     List<String> matchingKeys = infraKeys.stream()
         .filter(i -> i.getAccount().equals(getAccountName())
-            && namespaces.contains(i.getNamespace())
+            && (StringUtils.isEmpty(i.getNamespace())) || namespaces.contains(i.getNamespace())
             && i.getKubernetesKind().equals(primaryKind()))
         .map(Keys.InfrastructureCacheKey::toString)
         .collect(Collectors.toList());

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class KubernetesKind {
+  public static KubernetesKind CLUSTER_ROLE = new KubernetesKind("clusterRole", false);
+  public static KubernetesKind CLUSTER_ROLE_BINDING = new KubernetesKind("clusterRoleBinding", false);
   public static KubernetesKind CONFIG_MAP = new KubernetesKind("configMap", "cm");
   public static KubernetesKind CONTROLLER_REVISION = new KubernetesKind("controllerRevision");
   public static KubernetesKind DAEMON_SET = new KubernetesKind("daemonSet", "ds");
@@ -36,31 +38,48 @@ public class KubernetesKind {
   public static KubernetesKind JOB = new KubernetesKind("job");
   public static KubernetesKind POD = new KubernetesKind("pod", "po");
   public static KubernetesKind REPLICA_SET = new KubernetesKind("replicaSet", "rs");
-  public static KubernetesKind NAMESPACE = new KubernetesKind("namespace", "ns");
+  public static KubernetesKind ROLE = new KubernetesKind("role", false);
+  public static KubernetesKind ROLE_BINDING = new KubernetesKind("roleBinding", false);
+  public static KubernetesKind NAMESPACE = new KubernetesKind("namespace", "ns", false);
   public static KubernetesKind NETWORK_POLICY = new KubernetesKind("networkPolicy", "netpol");
-  public static KubernetesKind PERSISTENT_VOLUME = new KubernetesKind("persistentVolume", "pv");
+  public static KubernetesKind PERSISTENT_VOLUME = new KubernetesKind("persistentVolume", "pv", false);
   public static KubernetesKind PERSISTENT_VOLUME_CLAIM = new KubernetesKind("persistentVolumeClaim", "pvc");
   public static KubernetesKind SECRET = new KubernetesKind("secret");
   public static KubernetesKind SERVICE = new KubernetesKind("service", "svc");
+  public static KubernetesKind SERVICE_ACCOUNT = new KubernetesKind("serviceAccount", "sa");
   public static KubernetesKind STATEFUL_SET = new KubernetesKind("statefulSet");
 
   private final String name;
   private final String alias;
+  private final boolean isNamespaced;
 
   private static List<KubernetesKind> values;
 
-  protected KubernetesKind(String name, String alias) {
+  protected KubernetesKind(String name, String alias, boolean isNamespaced) {
     if (values == null) {
       values = Collections.synchronizedList(new ArrayList<>());
     }
 
     this.name = name;
     this.alias = alias;
+    this.isNamespaced = isNamespaced;
     values.add(this);
   }
 
   protected KubernetesKind(String name) {
-    this(name, null);
+    this(name, null, true);
+  }
+
+  protected KubernetesKind(String name, String alias) {
+    this(name, alias, true);
+  }
+
+  protected KubernetesKind(String name, boolean isNamespaced) {
+    this(name, null, isNamespaced);
+  }
+
+  public boolean isNamespaced() {
+    return this.isNamespaced;
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleBindingHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleBindingHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesClusterRoleBindingCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KubernetesClusterRoleBindingHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.CLUSTER_ROLE_BINDING;
+  }
+
+  @Override
+  public boolean versioned() {
+    return false;
+  }
+
+  @Override
+  public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
+    return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;
+  }
+
+  @Override
+  public Status status(KubernetesManifest manifest) { return new Status(); }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return KubernetesClusterRoleBindingCachingAgent.class;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesClusterRoleCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KubernetesClusterRoleHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.CLUSTER_ROLE;
+  }
+
+  @Override
+  public boolean versioned() {
+    return false;
+  }
+
+  @Override
+  public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
+    return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;
+  }
+
+  @Override
+  public Status status(KubernetesManifest manifest) { return new Status(); }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return KubernetesClusterRoleCachingAgent.class;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleBindingHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleBindingHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesClusterRoleBindingCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KubernetesRoleBindingHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.CLUSTER_ROLE_BINDING;
+  }
+
+  @Override
+  public boolean versioned() {
+    return false;
+  }
+
+  @Override
+  public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
+    return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;
+  }
+
+  @Override
+  public Status status(KubernetesManifest manifest) { return new Status(); }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return KubernetesClusterRoleBindingCachingAgent.class;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesRoleCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KubernetesRoleHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.ROLE;
+  }
+
+  @Override
+  public boolean versioned() {
+    return false;
+  }
+
+  @Override
+  public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
+    return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;
+  }
+
+  @Override
+  public Status status(KubernetesManifest manifest) { return new Status(); }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return KubernetesRoleCachingAgent.class;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceAccountHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceAccountHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesServiceAccountCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KubernetesServiceAccountHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.SERVICE_ACCOUNT;
+  }
+
+  @Override
+  public boolean versioned() {
+    return false;
+  }
+
+  @Override
+  public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
+    return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;
+  }
+
+  @Override
+  public Status status(KubernetesManifest manifest) { return new Status(); }
+
+  @Override
+  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
+    return KubernetesServiceAccountCachingAgent.class;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -104,7 +104,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     Set<Artifact> boundArtifacts = new HashSet<>();
 
     for (KubernetesManifest manifest : inputManifests) {
-      if (StringUtils.isEmpty(manifest.getNamespace())) {
+      if (StringUtils.isEmpty(manifest.getNamespace()) && manifest.getKind().isNamespaced()) {
         manifest.setNamespace(credentials.getDefaultNamespace());
       }
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ManifestController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ManifestController.java
@@ -76,4 +76,10 @@ public class ManifestController {
 
     return manifests.get(0);
   }
+
+  @RequestMapping(value = "/{account:.+}/{name:.+}", method = RequestMethod.GET)
+  Manifest getForAccountLocationAndName(@PathVariable String account,
+                                        @PathVariable String name) {
+    return getForAccountLocationAndName(account, "", name);
+  }
 }


### PR DESCRIPTION
Adds support for ClusterRole, ClusterRoleBinding, Role, RoleBinding and ServiceAccount resource kinds.

Cluster-level resources like Role, ClusterRoleBinding, PersistentVolume, etc. do belong to any namespace, so we also add support for resource kinds without namespaces. Previously the "namespace" resource kind was the only kind which did not belong to a namespace.

While this PR adds a lot of lines, most of it is boilerplate code in the new caching agents and handlers.