### PR TITLE
fix(provider/kubernetes): v2 Allow ":" in keys

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -88,6 +88,7 @@ public class Keys {
   private static String createKey(Object... elems) {
     List<String> components = Arrays.stream(elems)
         .map(s -> s == null ? "" : s.toString())
+        .map(s -> s.replaceAll(":", ";"))
         .collect(Collectors.toList());
     components.add(0, provider);
     return String.join(":", components);
@@ -118,6 +119,10 @@ public class Keys {
 
     if (parts.length < 3 || !parts[0].equals(provider)) {
       return Optional.empty();
+    }
+
+    for (String part : parts) {
+      part.replaceAll(";", ":");
     }
 
     try {


### PR DESCRIPTION
Colons are allowed in Kubernetes resource names, and used by default for several RBAC roles like "system:masters".

Replace ";" with ";" when storing the key, and do the opposite when retrieving the key.