### PR TITLE
fix(provider/kubernetes): v2 Fix stability check for DaemonSet

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
@@ -92,7 +92,7 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler implements
     }
 
     existing = status.getUpdatedNumberScheduled();
-    if (existing == null || desiredReplicas > existing) {
+    if (existing != null && desiredReplicas > existing) {
       return result.unstable("Waiting for all updated replicas to be scheduled");
     }
 


### PR DESCRIPTION
"status.getUpdatedNumberScheduled" may be null for DaemonSets that have not been updated.

Deployments of new DaemonSet get stuck without this, and DaemonSets that have not been updated but are discovered by clouddriver are stuck in "Transitioning" state in the UI.