### PR TITLE
fix(provider/kubernetes): v2 Fix validation to not require namespace

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
@@ -85,8 +85,8 @@ public class KubernetesValidationUtil {
       return false;
     }
 
-    if (!validateNotEmpty("namespace", namespace)) {
-      return false;
+    if (StringUtils.isEmpty(namespace)) {
+      return true;
     }
 
     AccountCredentials credentials = provider.getCredentials(accountName);

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtilSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtilSpec.groovy
@@ -49,6 +49,8 @@ class KubernetesValidationUtilSpec extends Specification {
 
     where:
     testNamespace       || expectedResult
+    null                || true
+    ""                  || true
     "test-namespace"    || true
     "omit-namespace"    || false
     "unknown-namespace" || false


### PR DESCRIPTION
Access to resources that do not belong to any namespace should be permitted, since there is no namespace to use for restricting access.