### PR TITLE
feat(reservations): V4 reservation report that proportionally covers shortfalls

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReport.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReport.groovy
@@ -75,6 +75,10 @@ class AmazonReservationReport implements ReservationReport {
     static class V3 extends V2 {
 
     }
+
+    static class V4 extends V3 {
+
+    }
   }
 
   @JsonPropertyOrder(["availabilityZone", "region", "availabilityZoneId", "instanceType", "os", "totalReserved", "totalUsed", "totalSurplus", "details", "accounts"])
@@ -211,6 +215,18 @@ class AmazonReservationReport implements ReservationReport {
 
     @JsonView(Views.V3.class)
     int index
+
+    @JsonView(Views.V4.class)
+    int totalRegionalSurplusForFamily
+
+    @JsonView(Views.V4.class)
+    int totalShortfallForFamily
+
+    @JsonView(Views.V4.class)
+    double percentageOfShortfall
+
+    @JsonView(Views.V4.class)
+    int portionOfAvailableSurplus
   }
 
   static class DescendingOverallReservationDetailComparator implements Comparator<OverallReservationDetail> {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReportBuilder.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReportBuilder.groovy
@@ -24,19 +24,13 @@ import java.util.concurrent.atomic.AtomicInteger
 interface AmazonReservationReportBuilder {
   AmazonReservationReport build(AmazonReservationReport source)
 
-  /**
-   * This version (v3) of the reservation report:
-   *
-   * - normalizes all regional reservations to `fxlarge` instance types
-   *   (fxlarge is equivalent to xlarge but kept separate to prevent confusion with normal xlarge instances)
-   * - attempts to cover all shortfalls with regional reservations (converting `xlarge` to the necessary instance types)
-   */
   @Slf4j
-  class V3 implements AmazonReservationReportBuilder {
+  class Support {
     // relative multipliers for instance types < xlarge where the baseline is xlarge
     // (would be nice if AWS had an API to derive this from)
+    // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/apply_ri.html
     Map<String, Double> instanceTypeMultipliers = [
-      "t2.nano" : 0.03125,
+      "t2.nano"  : 0.03125,
       "t2.micro" : 0.0625,
       "t2.small" : 0.125,
       "t2.medium": 0.25,
@@ -60,47 +54,7 @@ interface AmazonReservationReportBuilder {
       "i3.large" : 0.5
     ]
 
-    AmazonReservationReport build(AmazonReservationReport source) {
-      def reservations = source.reservations.sort(
-        false, new AmazonReservationReport.DescendingOverallReservationDetailComparator()
-      )
-
-      // aggregate all regional reservations for each instance family
-      def regionalReservations = aggregateRegionalReservations(reservations)
-
-      // remove any regional reservations that have been fully utilized (ie. they've all been converted to xlarge)
-      reservations.removeAll { it.availabilityZone == "*" && it.totalSurplus() == 0 }
-
-      // add the aggregated regional reservations
-      reservations.addAll(regionalReservations)
-
-      // used to track the order in which regional reservations are used to cover shortfalls
-      def allocationIndex = new AtomicInteger(0)
-
-      def shortfalls = reservations.findAll { it.totalSurplus() < 0 }
-      shortfalls.each { OverallReservationDetail shortfall ->
-        def regional = regionalReservations.find {
-          it.instanceFamily() == shortfall.instanceFamily() && shortfall.region == it.region && it.os == shortfall.os
-        }
-
-        if (!regional) {
-          // no regional reservation to cover shortfall from
-          return
-        }
-
-        coverShortfall(allocationIndex, regional, shortfall)
-      }
-
-      return new AmazonReservationReport(
-        start: source.start,
-        end: source.end,
-        accounts: source.accounts,
-        reservations: reservations,
-        errorsByRegion: source.errorsByRegion
-      )
-    }
-
-    private List<OverallReservationDetail> aggregateRegionalReservations(List<OverallReservationDetail> reservations) {
+    List<OverallReservationDetail> aggregateRegionalReservations(List<OverallReservationDetail> reservations) {
       def regionalReservations = filterRegionalReservations(reservations)
 
       regionalReservations.groupBy { "${it.region}-${it.instanceFamily()}-${it.os}" }.collect {
@@ -162,7 +116,7 @@ interface AmazonReservationReportBuilder {
     /**
      * @return the multiplier of a given instanceType related to an 'xlarge', or 0 if instanceType is not supported
      */
-    private double getMultiplier(String instanceType) {
+    double getMultiplier(String instanceType) {
       if (!instanceTypeMultipliers.containsKey(instanceType) && !instanceType.endsWith("xlarge")) {
         // not an xlarge instance type (or no explicit multiplier if < xlarge)
         return 0
@@ -177,11 +131,63 @@ interface AmazonReservationReportBuilder {
         instanceType.replaceAll("xlarge", "").replaceAll(instanceFamily + ".", "") ?: "1"
       )
     }
+  }
+
+  /**
+   * This version (v3) of the reservation report:
+   *
+   * - normalizes all regional reservations to `fxlarge` instance types
+   *   (fxlarge is equivalent to xlarge but kept separate to prevent confusion with normal xlarge instances)
+   * - attempts to cover all shortfalls with regional reservations (converting `xlarge` to the necessary instance types)
+   */
+  @Slf4j
+  class V3 implements AmazonReservationReportBuilder {
+    private final Support support = new Support()
+
+    AmazonReservationReport build(AmazonReservationReport source) {
+      def reservations = source.reservations.sort(
+        false, new AmazonReservationReport.DescendingOverallReservationDetailComparator()
+      )
+
+      // aggregate all regional reservations for each instance family
+      def regionalReservations = support.aggregateRegionalReservations(reservations)
+
+      // remove any regional reservations that have been fully utilized (ie. they've all been converted to xlarge)
+      reservations.removeAll { it.availabilityZone == "*" && it.totalSurplus() == 0 }
+
+      // add the aggregated regional reservations
+      reservations.addAll(regionalReservations)
+
+      // used to track the order in which regional reservations are used to cover shortfalls
+      def allocationIndex = new AtomicInteger(0)
+
+      def shortfalls = reservations.findAll { it.totalSurplus() < 0 }
+      shortfalls.each { OverallReservationDetail shortfall ->
+        def regional = regionalReservations.find {
+          it.instanceFamily() == shortfall.instanceFamily() && shortfall.region == it.region && it.os == shortfall.os
+        }
+
+        if (!regional) {
+          // no regional reservation to cover shortfall from
+          return
+        }
+
+        coverShortfall(allocationIndex, regional, shortfall)
+      }
+
+      return new AmazonReservationReport(
+        start: source.start,
+        end: source.end,
+        accounts: source.accounts,
+        reservations: reservations,
+        errorsByRegion: source.errorsByRegion
+      )
+    }
 
     private void coverShortfall(AtomicInteger allocationIndex,
                                 OverallReservationDetail regional,
                                 OverallReservationDetail shortfall) {
-      def multiplier = getMultiplier(shortfall.instanceType)
+      def multiplier = support.getMultiplier(shortfall.instanceType)
       if (!multiplier) {
         // instance type is unsupported (some unknown variant smaller than an xlarge)
         log.warn("Unable to determine multiplier for instance type '${shortfall.instanceType}'")
@@ -227,6 +233,159 @@ interface AmazonReservationReportBuilder {
             targetInstanceQuantity: targetInstanceQuantity,
             targetInstanceType: shortfall.instanceType,
             index: allocationIndex.incrementAndGet()
+          )
+
+          regional.regionalReservedAllocations << allocation
+          shortfall.regionalReservedAllocations << allocation
+        }
+      }
+    }
+  }
+
+  /**
+   * This version (v4) of the reservation report:
+   *
+   * - normalizes all regional reservations to `fxlarge` instance types
+   *   (fxlarge is equivalent to xlarge but kept separate to prevent confusion with normal xlarge instances)
+   * - attempts to cover all shortfalls with a subset of regional reservations (converting `xlarge` to the necessary instance types)
+   *
+   * The subset of regional reservations used to cover is proportional to the shortfall.
+   *
+   * ie)
+   * us-west-2 r3 has a total shortfall of 2000 fxlarge
+   * us-west-2a r3.4xlarge has a shortfall of 200 fxlarge (50 r3.4xlarge)
+   * us-west-2a r3.4xlarge contributes 10% of the total shortfall (200 of 2000)
+   *
+   * us-west-2 r3 has a total of 1500 regional fxlarge reservations
+   * us-west-2a re.4xlarge would be covered with 150 regional reservations (10% of 1500)
+   */
+  @Slf4j
+  class V4 implements AmazonReservationReportBuilder {
+    private final Support support = new Support()
+
+    AmazonReservationReport build(AmazonReservationReport source) {
+      def reservations = source.reservations.sort(
+        false, new AmazonReservationReport.DescendingOverallReservationDetailComparator()
+      )
+
+      // aggregate all regional reservations for each instance family
+      def regionalReservations = support.aggregateRegionalReservations(reservations)
+
+      // remove any regional reservations that have been fully utilized (ie. they've all been converted to xlarge)
+      reservations.removeAll { it.availabilityZone == "*" && it.totalSurplus() == 0 }
+
+      // add the aggregated regional reservations
+      reservations.addAll(regionalReservations)
+
+      Map<String, List<OverallReservationDetail>> allShortfallsByInstanceFamily = reservations
+        .findAll { it.totalSurplus() < 0 }
+        .groupBy { "${it.region()}-${it.instanceFamily()}-${it.os.name}".toString() }
+
+      // used to track the order in which regional reservations are used to cover shortfalls
+      def allocationIndex = new AtomicInteger(0)
+      allShortfallsByInstanceFamily.each { key, value ->
+        def regionalReservationForInstanceFamily = regionalReservations.find {
+          it.instanceFamily() == value[0].instanceFamily() && value[0].region == it.region && it.os == value[0].os
+        }
+
+        if (!regionalReservationForInstanceFamily) {
+          // no regional reservations to cover shortfall from
+          return
+        }
+
+        // total shortfall represented as fxlarge
+        def totalShortfallForInstanceFamily = Math.abs((int) value.sum { OverallReservationDetail detail ->
+          detail.totalSurplus() * support.getMultiplier(detail.instanceType)
+        })
+
+        // track original value as `regionalReservationForInstanceFamily.totalSurplus()` will change
+        // when shortfalls are covered
+        def totalRegionalReservationsForInstanceFamily = regionalReservationForInstanceFamily.totalSurplus()
+
+        value.each { OverallReservationDetail shortfall ->
+          coverShortfall(
+            allocationIndex,
+            regionalReservationForInstanceFamily,
+            totalRegionalReservationsForInstanceFamily,
+            shortfall,
+            totalShortfallForInstanceFamily
+          )
+        }
+      }
+
+      return new AmazonReservationReport(
+        start: source.start,
+        end: source.end,
+        accounts: source.accounts,
+        reservations: reservations,
+        errorsByRegion: source.errorsByRegion
+      )
+    }
+
+    private void coverShortfall(AtomicInteger allocationIndex,
+                                OverallReservationDetail regional,
+                                int totalRegionalSurplusForFamily,
+                                OverallReservationDetail shortfall,
+                                int totalShortfallForFamily) {
+      def multiplier = support.getMultiplier(shortfall.instanceType)
+      if (!multiplier) {
+        // instance type is unsupported (some unknown variant smaller than an xlarge)
+        log.warn("Unable to determine multiplier for instance type '${shortfall.instanceType}'")
+        return
+      }
+
+      // Math.ceil() protects against fractional instances when going from xlarge -> large (0.5 multiplier)
+      int sourceInstancesNeeded = Math.ceil(Math.abs(shortfall.totalSurplus() * multiplier))
+
+      def percentageOfShortfall = Math.abs((double) sourceInstancesNeeded / (double) totalShortfallForFamily)
+      def portionOfAvailableSurplus = (int) Math.floor(totalRegionalSurplusForFamily * percentageOfShortfall)
+
+      if (portionOfAvailableSurplus >= sourceInstancesNeeded) {
+        // we have more instances than necessary to cover the shortfall
+        int targetInstanceQuantity = sourceInstancesNeeded / multiplier
+
+        regional.totalRegionalReserved.addAndGet(-1 * sourceInstancesNeeded)
+        shortfall.totalRegionalReserved.addAndGet(targetInstanceQuantity)
+
+        def allocation = new AmazonReservationReport.Allocation(
+          source: regional.id(),
+          sourceInstanceQuantity: sourceInstancesNeeded,
+          sourceInstanceType: regional.instanceType,
+          target: shortfall.id(),
+          targetInstanceQuantity: targetInstanceQuantity,
+          targetInstanceType: shortfall.instanceType,
+          index: allocationIndex.incrementAndGet(),
+
+          totalRegionalSurplusForFamily : totalRegionalSurplusForFamily,
+          totalShortfallForFamily: totalShortfallForFamily,
+          percentageOfShortfall: percentageOfShortfall,
+          portionOfAvailableSurplus: portionOfAvailableSurplus
+        )
+
+        regional.regionalReservedAllocations << allocation
+        shortfall.regionalReservedAllocations << allocation
+      } else {
+        // determine how much shortfall can be covered as surplus not large enough to cover everything
+        // (may not be entirety of surplus depending on multiplier)
+        int targetInstanceQuantity = Math.floor(portionOfAvailableSurplus / multiplier)
+
+        if (targetInstanceQuantity > 0) {
+          regional.totalRegionalReserved.addAndGet(-1 * (int) (targetInstanceQuantity * multiplier))
+          shortfall.totalRegionalReserved.addAndGet(targetInstanceQuantity)
+
+          def allocation = new AmazonReservationReport.Allocation(
+            source: regional.id(),
+            sourceInstanceQuantity: targetInstanceQuantity * multiplier,
+            sourceInstanceType: regional.instanceType,
+            target: shortfall.id(),
+            targetInstanceQuantity: targetInstanceQuantity,
+            targetInstanceType: shortfall.instanceType,
+            index: allocationIndex.incrementAndGet(),
+
+            totalRegionalSurplusForFamily : totalRegionalSurplusForFamily,
+            totalShortfallForFamily: totalShortfallForFamily,
+            percentageOfShortfall: percentageOfShortfall,
+            portionOfAvailableSurplus: portionOfAvailableSurplus
           )
 
           regional.regionalReservedAllocations << allocation

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgent.groovy
@@ -234,13 +234,24 @@ class ReservationReportCachingAgent implements CachingAgent, CustomScheduledAgen
       Map
     )
 
+
+    def v4 = objectMapper.readValue(
+      objectMapper
+        .writerWithView(AmazonReservationReport.Views.V4.class)
+        .writeValueAsString(
+        new AmazonReservationReportBuilder.V4().build(objectMapper.convertValue(v2, AmazonReservationReport))
+      ),
+      Map
+    )
+
     metricsSupport.registerMetrics(objectMapper.convertValue(v2, AmazonReservationReport))
 
     return new DefaultCacheResult(
       (RESERVATION_REPORTS.ns): [
         new MutableCacheData("v1", ["report": v1], [:]),
         new MutableCacheData("v2", ["report": v2], [:]),
-        new MutableCacheData("v3", ["report": v3], [:])
+        new MutableCacheData("v3", ["report": v3], [:]),
+        new MutableCacheData("v4", ["report": v4], [:])
       ]
     )
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopReservationReportProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopReservationReportProvider.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.model
 
 class NoopReservationReportProvider implements ReservationReportProvider {
   @Override
-  ReservationReport getReservationReport(String name) {
+  ReservationReport getReservationReport(String name, Map<String, String> filters) {
     return null
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ReservationReportProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ReservationReportProvider.groovy
@@ -17,5 +17,5 @@
 package com.netflix.spinnaker.clouddriver.model
 
 interface ReservationReportProvider<T extends ReservationReport> {
-  T getReservationReport(String name)
+  T getReservationReport(String name, Map<String, String> filters)
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ReservationReportController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ReservationReportController.groovy
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -31,12 +32,15 @@ class ReservationReportController {
   List<ReservationReportProvider> reservationProviders
 
   @RequestMapping(method = RequestMethod.GET)
-  Collection<ReservationReport> getReservationReports() {
-    reservationProviders.collect { it.getReservationReport("v1") } - null
+  Collection<ReservationReport> getReservationReports(@RequestParam Map<String, String> filters) {
+    return getReservationReportsByName("v1", filters)
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{name}")
-  Collection<ReservationReport> getReservationReportsByName(@PathVariable String name) {
-    reservationProviders.collect { it.getReservationReport(name) } - null
+  Collection<ReservationReport> getReservationReportsByName(@PathVariable String name,
+                                                            @RequestParam Map<String, String> filters) {
+    return reservationProviders.collect {
+      it.getReservationReport(name, filters)
+    } - null
   }
 }


### PR DESCRIPTION
The V3 reservation report uses regional reservations in a very specific
order to cover shortfalls.

It is problematic if the consumer does not look at all instance types in
a family when determining availability.

This PR uses a proportional approach to cover shortfalls. Each instance
type is allocated a portion of regional reservations in proportion to
how much of the overall shortfall it contributed.

ex)
m4.4xlarge has a shortfall equivalent to 20 fxlarge
m4.* has a total shortfall equivalent to 40 fxlarge

Total regional reservations equivalent to 30 fxlarge

m4.4xlarge would cover shortfall with 50% of the regional reservations
(20/40 * 30 == 15)
