### PR TITLE
feat(aws): add support for resizing ASGs with optional min/max/desired

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
@@ -16,13 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
 
+class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
   String serverGroupName
   String region
-
-  Capacity capacity = new Capacity()
-
+  ServerGroup.Capacity capacity
   List<AsgTargetDescription> asgs = []
 
   @Deprecated
@@ -31,23 +30,12 @@ class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
   @Deprecated
   List<String> regions = []
 
-  static class Capacity {
-    int min
-    int max
-    int desired
-
-    @Override
-    String toString() {
-      return "min: $min, max: $max, desired: $desired"
-    }
-  }
-
   static class Constraints {
-    Capacity capacity
+    ServerGroup.Capacity capacity
   }
 
   static class AsgTargetDescription extends AsgDescription {
-    Capacity capacity = new Capacity()
+    ServerGroup.Capacity capacity = new ServerGroup.Capacity()
     Constraints constraints = new Constraints()
 
     @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperation.groovy
@@ -61,6 +61,12 @@ class ResizeAsgAtomicOperation implements AtomicOperation<Void> {
                          ServerGroup.Capacity capacity,
                          ResizeAsgDescription.Constraints constraints) {
     task.updateStatus PHASE, "Beginning resize of ${asgName} in ${region} to ${capacity}."
+
+    if (capacity.min == null && capacity.max == null && capacity.desired == null) {
+      task.updateStatus PHASE, "Skipping resize of ${asgName} in ${region}, at least one field in ${capacity} needs to be non-null"
+      return
+    }
+
     def autoScaling = amazonClientProvider.getAutoScaling(description.credentials, region, true)
     def describeAutoScalingGroups = autoScaling.describeAutoScalingGroups(
       new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(asgName)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperation.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescrip
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -57,7 +58,7 @@ class ResizeAsgAtomicOperation implements AtomicOperation<Void> {
 
   private void resizeAsg(String asgName,
                          String region,
-                         ResizeAsgDescription.Capacity capacity,
+                         ServerGroup.Capacity capacity,
                          ResizeAsgDescription.Constraints constraints) {
     task.updateStatus PHASE, "Beginning resize of ${asgName} in ${region} to ${capacity}."
     def autoScaling = amazonClientProvider.getAutoScaling(description.credentials, region, true)
@@ -71,6 +72,7 @@ class ResizeAsgAtomicOperation implements AtomicOperation<Void> {
 
     validateConstraints(constraints, describeAutoScalingGroups.getAutoScalingGroups().get(0))
 
+    // min, max and desired may be null
     def request = new UpdateAutoScalingGroupRequest().withAutoScalingGroupName(asgName)
         .withMinSize(capacity.min)
         .withMaxSize(capacity.max)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ResizeAsgAtomicOperationUnitSpec.groovy
@@ -149,4 +149,8 @@ class ResizeAsgAtomicOperationUnitSpec extends Specification {
     0       | 0       | 0       | 1 // not the same as (null, null, null)
     null    | null    | null    | 0
   }
+
+  private static ServerGroup.Capacity capacity(int min, int max, int desired) {
+    return new ServerGroup.Capacity(min: min, max: max, desired: desired)
+  }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResizeAsgDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResizeAsgDescriptionValidatorSpec.groovy
@@ -20,10 +20,12 @@ import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import org.springframework.validation.Errors
 import spock.lang.Shared
+import spock.lang.Specification
 
-class ResizeAsgDescriptionValidatorSpec {
+class ResizeAsgDescriptionValidatorSpec extends Specification {
 
   @Shared
   DescriptionValidator validator = new ResizeAsgDescriptionValidator()
@@ -34,7 +36,7 @@ class ResizeAsgDescriptionValidatorSpec {
       asgs: [new ResizeAsgDescription.AsgTargetDescription(
         serverGroupName: "foo",
         region: "us-west-1",
-        capacity: new ResizeAsgDescription.Capacity(min: 5, max: 3)
+        capacity: new ServerGroup.Capacity(min: 5, max: 3)
       )],
       credentials: Stub(NetflixAmazonCredentials)
     )
@@ -47,7 +49,7 @@ class ResizeAsgDescriptionValidatorSpec {
     1 * errors.rejectValue('capacity', _, ['5', '3'], _)
 
     when:
-    description.asgs[0].capacity = new ResizeAsgDescription.Capacity(min: 3, max: 5, desired: 7)
+    description.asgs[0].capacity = new ServerGroup.Capacity(min: 3, max: 5, desired: 7)
     validator.validate([], description, errors)
 
     then:


### PR DESCRIPTION
We need to replace ResizeAsgDescription.Capacity with something that has
optional (i.e. nullable) fields. ServerGroup.Capacity happens to have
exactly that.
