### PR TITLE
fix(docker): logs the registry address when a tag cannot be loaded

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -96,7 +96,7 @@ class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, Age
       try {
         tags = credentials.client.getTags(repository)
       } catch (e) {
-        log.error("Could not load tags for ${repository}", e)
+        log.error("Could not load tags for ${repository} in ${credentials.client.address}", e)
       }
       def name = tags?.name
       def imageTags = tags?.tags


### PR DESCRIPTION
Logs out the address of the docker registry when a tag cannot be found. This is useful when there are multiple docker registries configured with similar tag names