### PR TITLE
chore: add missing copyright headers

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureConfigurationProperties.groovy
@@ -1,8 +1,5 @@
-package com.netflix.spinnaker.clouddriver.aws.lifecycle
-
-import org.springframework.boot.context.properties.ConfigurationProperties
 /*
- * Copyright 2017 Netflix, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +13,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package com.netflix.spinnaker.clouddriver.aws.lifecycle
+
+import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("aws.lifecycleSubscribers.launchFailure")
 class LaunchFailureConfigurationProperties {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/search/ServerGroupKeyProcessor.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/search/ServerGroupKeyProcessor.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.aws.search
 
 import com.netflix.spinnaker.cats.cache.Cache

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/cache/KeysSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/cache/KeysSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.aws.cache
 
 import spock.lang.Specification

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentProviderSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.aws.lifecycle
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/LaunchFailureNotificationAgentSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.aws.lifecycle
 
 import com.amazonaws.services.sns.AmazonSNS

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyProcessor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/KeyProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.cache;
 
 public interface KeyProcessor {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/names/NamingStrategy.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/names/NamingStrategy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.names;
 
 import com.netflix.spinnaker.moniker.Namer;

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/SearchProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/SearchProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.search;
 
 import com.google.common.collect.ImmutableList;

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosSpectatorHandler.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosSpectatorHandler.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos
 
 import com.netflix.spectator.api.Clock

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosConfigurationPropertiesSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosConfigurationPropertiesSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos
 
 import spock.lang.Specification

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/BaseSpecification.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/BaseSpecification.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientCompositeKey

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/instance/TerminateDcosInstancesAndDecrementAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/instance/TerminateDcosInstancesAndDecrementAtomicOperationConverterSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.instance
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/instance/TerminateDcosInstancesAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/instance/TerminateDcosInstancesAtomicOperationConverterSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.instance
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/job/RunDcosJobAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/job/RunDcosJobAtomicOperationConverterSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.job
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/loadbalancer/DeleteDcosLoadBalancerAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/loadbalancer/DeleteDcosLoadBalancerAtomicOperationConverterSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.loadbalancer
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/loadbalancer/UpsertDcosLoadBalancerAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/loadbalancer/UpsertDcosLoadBalancerAtomicOperationConverterSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.loadbalancer
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/DeployDcosServerGroupAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/DeployDcosServerGroupAtomicOperationConverterSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.servergroup
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/DestroyDcosServerGroupAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/DestroyDcosServerGroupAtomicOperationConverterSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.servergroup
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/ResizeDcosServerGroupAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/ResizeDcosServerGroupAtomicOperationConverterSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.servergroup
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/instance/TerminateDcosInstancesAndDecrementAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/instance/TerminateDcosInstancesAndDecrementAtomicOperationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.instance
 
 import com.netflix.spinnaker.clouddriver.data.task.Task

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/instance/TerminateDcosInstancesAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/instance/TerminateDcosInstancesAtomicOperationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.instance
 
 import com.netflix.spinnaker.clouddriver.data.task.Task

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/job/RunDcosJobAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/job/RunDcosJobAtomicOperationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.job
 
 import com.netflix.spinnaker.clouddriver.data.task.Task

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/loadbalancer/DeleteDcosLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/loadbalancer/DeleteDcosLoadBalancerAtomicOperationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.loadbalancer
 
 import com.netflix.spinnaker.clouddriver.data.task.Task

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/loadbalancer/UpsertDcosLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/loadbalancer/UpsertDcosLoadBalancerAtomicOperationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.loadbalancer
 
 import com.google.common.collect.Lists

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DeployDcosServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DeployDcosServerGroupAtomicOperationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.servergroup
 
 import com.netflix.spinnaker.clouddriver.data.task.Task

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DestroyDcosServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DestroyDcosServerGroupAtomicOperationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.servergroup
 
 import com.netflix.spinnaker.clouddriver.data.task.Task

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/ResizeDcosServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/ResizeDcosServerGroupAtomicOperationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.servergroup
 
 import com.netflix.spinnaker.clouddriver.data.task.Task

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/id/DcosSpinnakerAppIdSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/id/DcosSpinnakerAppIdSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.util.id
 
 import com.netflix.frigga.Names

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/id/DcosSpinnakerLbIdSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/id/DcosSpinnakerLbIdSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.util.id
 
 import spock.lang.Specification

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/id/MarathonPathIdSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/id/MarathonPathIdSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.util.id
 
 import spock.lang.Specification

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/mapper/AppToDeployDcosServerGroupDescriptionMapperSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/mapper/AppToDeployDcosServerGroupDescriptionMapperSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.util.mapper
 
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DeployDcosServerGroupDescription

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/mapper/DeployDcosServerGroupDescriptionToAppMapperSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/util/mapper/DeployDcosServerGroupDescriptionToAppMapperSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.util.mapper
 
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DeployDcosServerGroupDescription

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceAndDecrementDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceAndDecrementDescriptionValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.instance
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceDescriptionValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.instance
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/job/RunDcosJobValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/job/RunDcosJobValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.job
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.loadbalancer
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.loadbalancer
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DeployDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DeployDcosServerGroupDescriptionValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DestroyDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DestroyDcosServerGroupDescriptionValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DisableDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DisableDcosServerGroupDescriptionValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/ResizeDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/ResizeDcosServerGroupDescriptionValidatorSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosLoadBalancerSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosLoadBalancerSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.model
 
 import com.netflix.spinnaker.clouddriver.model.HealthState

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosServerGroupSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosServerGroupSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.model
 
 import mesosphere.marathon.client.model.v2.App

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosInstanceCachingAgentSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosInstanceCachingAgentSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosLoadBalancerCachingAgentSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosLoadBalancerCachingAgentSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosSecretsCachingAgentSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosSecretsCachingAgentSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosServerGroupCachingAgentSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.provider.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/TrustAllX509TrustManager.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/TrustAllX509TrustManager.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.docker.registry.security
 
 import java.security.cert.CertificateException

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/CloneServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/CloneServiceAtomicOperationConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
 
 import com.netflix.spinnaker.clouddriver.deploy.DeployAtomicOperation;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DeleteScalingPolicyAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/DeleteScalingPolicyAtomicOperationConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
 
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/StartServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/StartServiceAtomicOperationConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
 
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/StopServiceAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/StopServiceAtomicOperationConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
 
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/UpdateServiceAndTaskConfigAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/UpdateServiceAndTaskConfigAtomicOperationConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
 
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/UpsertScalingPolicyAtomicOperationConverter.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/converters/UpsertScalingPolicyAtomicOperationConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.converters;
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAlarmDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/BasicEcsDeployDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/BasicEcsDeployDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CloneServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CloneServiceDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DeleteScalingPolicyDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/DeleteScalingPolicyDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/StartServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/StartServiceDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/StopServiceDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/StopServiceDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/UpdateServiceAndTaskConfigDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/UpdateServiceAndTaskConfigDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/UpsertScalingPolicyDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/UpsertScalingPolicyDescription.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/handlers/BasicEcsDeployHandler.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/handlers/BasicEcsDeployHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.handlers;
 
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CloneServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CloneServiceAtomicOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DeleteScalingPolicyAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DeleteScalingPolicyAtomicOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StartServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StartServiceAtomicOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ResizeServiceDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StopServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/StopServiceAtomicOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.StopServiceDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpdateServiceAndTaskConfigAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpdateServiceAndTaskConfigAtomicOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.UpdateServiceAndTaskConfigDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpsertScalingPolicyAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/UpsertScalingPolicyAtomicOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.UpsertScalingPolicyDescription;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CloneServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CloneServiceAtomicOperationValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DeleteScalingPolicyAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DeleteScalingPolicyAtomicOperationValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StartServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StartServiceAtomicOperationValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StopServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StopServiceAtomicOperationValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpdateServiceAndTaskConfigAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpdateServiceAndTaskConfigAtomicOperationValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpsertScalingPolicyAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpsertScalingPolicyAtomicOperationValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.provider.view;
 
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonLoadBalancer;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/NetflixECSCredentials.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/security/NetflixECSCredentials.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Lookout, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.ecs.security;
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/events/CreateServerGroupEventHandlerSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/events/CreateServerGroupEventHandlerSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.elasticsearch.events
 
 import com.netflix.spinnaker.clouddriver.elasticsearch.ElasticSearchEntityTagger

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleDistributionPolicy.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleDistributionPolicy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.google.model;
 
 import lombok.AllArgsConstructor;

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/GroupHealthRequest.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/GroupHealthRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.google.provider.agent.util;
 
 import lombok.AllArgsConstructor;

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/LoadBalancerHealthResolution.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/LoadBalancerHealthResolution.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.google.provider.agent.util;
 
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancer;

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/TargetPoolHealthRequest.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/util/TargetPoolHealthRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.google.provider.agent.util;
 
 import lombok.AllArgsConstructor;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgentDispatcher.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.clouddriver.kubernetes.caching;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;


### PR DESCRIPTION
Fixes missing header errors mostly for dcos tests and ecs cloud provider 