### PR TITLE
fix(aws): Only log warrning if `lastModified` not present and non-empty

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
@@ -338,7 +338,7 @@ class AmazonApplicationLoadBalancerCachingAgent extends AbstractAmazonLoadBalanc
     def listenerAssociations = this.buildListenerAssociations(loadBalancing, allLoadBalancers, useEdda)
 
     if (!start) {
-      if (useEdda) {
+      if (useEdda && allTargetGroups) {
         log.warn("${agentType} did not receive lastModified value in response metadata")
       }
       start = System.currentTimeMillis()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
@@ -139,7 +139,7 @@ class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAg
     }
 
     if (!start) {
-      if (account.eddaEnabled) {
+      if (account.eddaEnabled && allLoadBalancers) {
         log.warn("${agentType} did not receive lastModified value in response metadata")
       }
       start = System.currentTimeMillis()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
@@ -145,7 +145,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
             return new DefaultCacheResult([(SECURITY_GROUPS.ns): providerCache.getAll(SECURITY_GROUPS.ns, sgIds)])
           }
         }
-      } else {
+      } else if (securityGroups) {
         log.warn("${agentType} did not receive lastModified value in response metadata")
       }
       evictions[ON_DEMAND.ns] = [lastModifiedKey]

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -291,7 +291,7 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
     }
 
     if (!start) {
-      if (account.eddaEnabled) {
+      if (account.eddaEnabled && asgs) {
         log.warn("${agentType} did not receive lastModified value in response metadata")
       }
       start = System.currentTimeMillis()


### PR DESCRIPTION
Currently logs are being littered with warnings in regions that are
otherwise empty.
