### PR TITLE
fix(cache): Remove anonymous noop `SearchableProvider`

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CacheConfig.groovy
@@ -70,42 +70,6 @@ class CacheConfig {
   }
 
   @Bean
-  @ConditionalOnMissingBean(SearchableProvider)
-  SearchableProvider noopProvider() {
-    new SearchableProvider() {
-      @Override
-      String getProviderName() {
-        "noop"
-      }
-
-      @Override
-      Collection<CachingAgent> getAgents() {
-        Collections.emptySet()
-      }
-
-      @Override
-      Set<String> getDefaultCaches() {
-        Collections.emptySet()
-      }
-
-      @Override
-      Map<String, String> getUrlMappingTemplates() {
-        Collections.emptyMap()
-      }
-
-      @Override
-      Map<String, SearchableProvider.SearchResultHydrator> getSearchResultHydrators() {
-        Collections.emptyMap()
-      }
-
-      @Override
-      Map<String, String> parseKey(String key) {
-        null
-      }
-    }
-  }
-
-  @Bean
   @ConditionalOnMissingBean(CatsModule)
   CatsModule catsModule(List<Provider> providers, List<ExecutionInstrumentation> executionInstrumentation, NamedCacheFactory cacheFactory, AgentScheduler agentScheduler) {
     new CatsModule.Builder().cacheFactory(cacheFactory).scheduler(agentScheduler).instrumentation(executionInstrumentation).build(providers)


### PR DESCRIPTION
An attempt to cut down on some useless redis calls being made for every
search.

I do not believe there is a need for a default `SearchableProvider`
implementation, there will almost certainly be a concrete `Bean`.
