### PR TITLE
fix(provider/kubernetes): v2 Fix artifact replacers for StatefulSets

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacerFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactTypes;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
@@ -45,13 +46,11 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler implements
     ServerGroupHandler {
 
   public KubernetesStatefulSetHandler() {
-    registerReplacer(
-        ArtifactReplacer.Replacer.builder()
-            .replacePath("$.spec.template.spec.containers.[?( @.image == \"{%name%}\" )].image")
-            .findPath("$.spec.template.spec.containers.*.image")
-            .type(ArtifactTypes.DOCKER_IMAGE)
-            .build()
-    );
+    registerReplacer(ArtifactReplacerFactory.dockerImageReplacer());
+    registerReplacer(ArtifactReplacerFactory.configMapVolumeReplacer());
+    registerReplacer(ArtifactReplacerFactory.secretVolumeReplacer());
+    registerReplacer(ArtifactReplacerFactory.configMapEnvFromReplacer());
+    registerReplacer(ArtifactReplacerFactory.secretEnvFromReplacer());
   }
 
   @Override


### PR DESCRIPTION
The handler for statefulsets was essentially using a hard-coded `ArtifactReplacerFactory.dockerImageReplacer()`, and was missing replacers for configmaps, secrets, etc.