### PR TITLE
feat(web): Include `capacity` in `ServerGroupViewModel`

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
@@ -232,6 +232,9 @@ class ServerGroupController {
     Moniker moniker
     Map buildInfo
     Long createdTime
+
+    ServerGroup.Capacity capacity
+
     List<InstanceViewModel> instances
     Set<String> loadBalancers
     Set<String> targetGroups
@@ -276,6 +279,8 @@ class ServerGroupController {
       if (serverGroup.hasProperty("targetGroups")) {
         targetGroups = serverGroup.targetGroups
       }
+
+      capacity = serverGroup.getCapacity()
     }
   }
 


### PR DESCRIPTION
It would be useful in `deck` to have the server group capacity
available for all server groups by default.
