### PR TITLE
fix(provider/kubernetes): v2 Avoid NPE for unsupported k8s kinds

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -109,7 +109,13 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
       }
 
       KubernetesResourceProperties properties = findResourceProperties(manifest);
+      if (properties == null) {
+        throw new IllegalArgumentException("Unsupported Kubernetes object kind '" + manifest.getKind().toString() + "', unable to continue.");
+      }
       KubernetesHandler deployer = properties.getHandler();
+      if (deployer == null) {
+        throw new IllegalArgumentException("No deployer available for Kubernetes object kind '" + manifest.getKind().toString() + "', unable to continue.");
+      }
 
       getTask().updateStatus(OP_NAME, "Swapping out artifacts in " + manifest.getFullResourceName() + " from context...");
       ReplaceResult replaceResult = deployer.replaceArtifacts(manifest, artifacts);


### PR DESCRIPTION
Show a nice error message from an `IllegalArgumentException` instead of an incomprehensible NPE stack trace when a user attempts to deploy an unsupported resource kind.

Instead of this:
![unsupported-kubernetes-kind-npe](https://user-images.githubusercontent.com/252950/37986708-7a75af3e-31fc-11e8-91e4-2a7036406b1f.png)

We show this:
![unsupported-kubernetes-kind](https://user-images.githubusercontent.com/252950/37986729-848ec37a-31fc-11e8-8568-81b822d87690.png)

(I will shortly submit a PR to fix the support for rolebindings)