### PR TITLE
chore(build): add debug flag to clouddriver build

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ To start the JVM in debug mode, set the Java system property `DEBUG=true`:
 ```
 
 The JVM will then listen for a debugger to be attached on port 7102.  The JVM will _not_ wait for
-the debugger to be attached before starting Clouddriver; the relevant JVM arguments can seen and be
+the debugger to be attached before starting Clouddriver; the relevant JVM arguments can be seen and
 modified as needed in `build.gradle`.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ This service is the main integration point for Spinnaker cloud providers like AW
 To configure this repo as an Intellij project, run `./gradlew idea` in the root directory. 
 
 Some of the modules make use of [Lombok](https://projectlombok.org/), which will compile correctly on its own. However, for Intellij to make sense of the Lombok annotations, you'll need to install the [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok-plugin) as well as [check 'enable' under annotation processing](https://www.jetbrains.com/help/idea/configuring-annotation-processing.html#3).
+
+### Debugging
+
+To start the JVM in debug mode, set the Java system property `DEBUG=true`:
+```
+./gradlew -DDEBUG=true
+```
+
+The JVM will then listen for a debugger to be attached on port 7102.  The JVM will _not_ wait for
+the debugger to be attached before starting Clouddriver; the relevant JVM arguments can seen and be
+modified as needed in `build.gradle`.

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,12 @@ subprojects { project ->
     }
   }
 
+  tasks.withType(JavaExec) {
+    if (System.getProperty('DEBUG', 'false') == 'true') {
+      jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=7102'
+    }
+  }
+
   dependencies {
     compile spinnaker.dependency('groovy')
     spinnaker.group('test')


### PR DESCRIPTION
Starting clouddriver with /gradlew -DDEBUG=true now causes the JVM to
listen for a remote debugger on port 7102.