### PR TITLE
fix(logging): remove use of printStackTrace

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -116,7 +116,7 @@ public class ClusteredAgentScheduler extends CatsModuleAware implements AgentSch
         try {
             runAgents();
         } catch (Throwable t) {
-            t.printStackTrace(System.err);
+            logger.error("Error running agents {}", t.getMessage(), t);
         }
     }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/ResultByZone.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/ResultByZone.groovy
@@ -17,7 +17,9 @@ package com.netflix.spinnaker.clouddriver.aws.model
 
 import com.google.common.collect.ImmutableMap
 import groovy.transform.Canonical
+import groovy.util.logging.Slf4j
 
+@Slf4j
 @Canonical
 class ResultByZone<T> {
   final ImmutableMap<String, T> successfulResults
@@ -42,7 +44,7 @@ class ResultByZone<T> {
     ResultByZone<T> build() {
       def failureStrings = failures.collectEntries { String key, Exception exception ->
         def stringWriter = new StringWriter()
-        exception.printStackTrace(new PrintWriter(stringWriter))
+        log.error(exception.message, exception)
         [(key): stringWriter.toString()]
       }
       of(ImmutableMap.copyOf(successfulResults), ImmutableMap.copyOf(failureStrings))

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -177,9 +177,11 @@ class CatsSearchProvider implements SearchProvider {
     String normalizedWord = q.toLowerCase()
     List<String> matches = cachesToQuery.collect { String cache ->
       List<KeyProcessor> keyProcessors = (this.keyProcessors ?: []).findAll { it.canProcess(cache) }
-
+      log.error("WHAT")
       // if the key represented in the cache doesn't actually exist, don't process it
       Closure keyExists = { String key ->
+        log.error("KEY = {}", key)
+        log.error("KEYPROCESSORS = {}", keyProcessors)
         boolean exists = keyProcessors.empty || keyProcessors.any { it.exists(key) }
         if (!exists) {
           log.warn("found ${cache} key that did not exist: ${key}")
@@ -190,14 +192,19 @@ class CatsSearchProvider implements SearchProvider {
       Closure filtersMatch = { String key ->
         try {
           if (!filters) {
+            log.error("NO FILTER")
             return true
           }
 
           if (keyParsers) {
+            log.error("IN KEYPARSERS")
             KeyParser parser = keyParsers.find { it.cloudProvider == filters.cloudProvider && it.canParseType(cache) }
+            log.error("PARSER = {}", parser)
             if (parser) {
               Map<String, String> parsed = parser.parseKey(key)
+              log.error("PARSED = {}", parsed)
               return filters.entrySet().every { filter ->
+                log.error("FILTER = {}", filter)
                 String[] vals = filter.value.split(',')
                 filter.key == 'cloudProvider' || vals.contains(parsed[filter.key]) ||
                   vals.contains(parsed[parser.getNameMapping(cache)])
@@ -216,6 +223,8 @@ class CatsSearchProvider implements SearchProvider {
         .findAll(keyExists)
         .findAll(filtersMatch)
 
+      log.error("IDENTIFIERS = {}", identifiers)
+      log.error("CACHE = {}", cache)
       return identifiers
     }.flatten()
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
@@ -16,9 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.cache;
 
+import com.google.common.primitives.Ints;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.moniker.Moniker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public interface OnDemandAgent {
+  Logger LOGGER = LoggerFactory.getLogger(OnDemandAgent.class);
+
   String getProviderName();
 
   String getOnDemandAgentType();
@@ -81,10 +86,10 @@ public interface OnDemandAgent {
           .stack(details.get("stack"))
           .detail(details.get("detail"))
           .cluster(details.get("cluster"))
-          .sequence(Integer.valueOf(details.get("sequence")))
+          .sequence(Ints.tryParse(details.get("cluster")))
           .build();
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.error("Error building moniker, details: {}", details, e);
       return null;
     }
   }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamPolicyReader.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamPolicyReader.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -28,7 +30,9 @@ import java.util.Set;
 
 public class IamPolicyReader {
 
-  ObjectMapper mapper;
+  private ObjectMapper mapper;
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
 
   public IamPolicyReader(ObjectMapper objectMapper) {
     this.mapper = objectMapper;
@@ -58,7 +62,7 @@ public class IamPolicyReader {
         }
       }
     } catch (IOException e) {
-      e.printStackTrace();
+      log.error(e.getMessage(), e);
     }
 
     return trustedEntities;

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SecurityGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SecurityGroupController.groovy
@@ -21,6 +21,8 @@ import com.netflix.spinnaker.clouddriver.model.SecurityGroupProvider
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PreAuthorize
@@ -39,6 +41,8 @@ class SecurityGroupController {
 
   @Autowired
   List<SecurityGroupProvider> securityGroupProviders
+
+  final Logger log = LoggerFactory.getLogger(getClass())
 
   @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")
   @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)")
@@ -61,7 +65,7 @@ class SecurityGroupController {
       objs[obj.accountName][obj.cloudProvider][obj.region] << obj.summary
       objs
     }) doOnError {
-      it.printStackTrace()
+      log.error(it.message, it)
     } toBlocking() first()
   }
 


### PR DESCRIPTION
- fixes `NumberFormatException` in `OnDemandAgent` when `details` does not contain a sequence.
- ensures exceptions are always logged via slf4j instead of STDERR. This is important when using logback to ship logs to i.e. logstash or log indexing services.