### PR TITLE
cleanup(aws): Avoid scheduling `ReconcileClassicLinkSecurityGroupsAgent`

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -116,7 +116,7 @@ public class ClusteredAgentScheduler extends CatsModuleAware implements AgentSch
         try {
             runAgents();
         } catch (Throwable t) {
-            t.printStackTrace(System.err);
+            logger.error("Unable to run agents", t);
         }
     }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -287,7 +287,11 @@ class AwsConfiguration {
     allAccounts.each { account ->
       if (!scheduledAccounts.contains(account)) {
         account.regions.each { region ->
-          newlyAddedAgents << new ReconcileClassicLinkSecurityGroupsAgent(amazonClientProvider, account, region.name, deployDefaults)
+          if (deployDefaults.isReconcileClassicLinkAccount(account)) {
+            newlyAddedAgents << new ReconcileClassicLinkSecurityGroupsAgent(
+              amazonClientProvider, account, region.name, deployDefaults
+            )
+          }
         }
       }
     }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.cache;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.moniker.Moniker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +29,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public interface OnDemandAgent {
+  Logger logger = LoggerFactory.getLogger(OnDemandAgent.class);
+
   String getProviderName();
 
   String getOnDemandAgentType();
@@ -76,15 +80,17 @@ public interface OnDemandAgent {
     }
 
     try {
+      String sequence = details.get("sequence");
+
       return Moniker.builder()
           .app(details.get("application"))
           .stack(details.get("stack"))
           .detail(details.get("detail"))
           .cluster(details.get("cluster"))
-          .sequence(Integer.valueOf(details.get("sequence")))
+          .sequence(sequence != null ? Integer.valueOf(sequence) : null)
           .build();
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.warn("Unable to build moniker (details: {})", e);
       return null;
     }
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
@@ -132,7 +132,6 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
           task.addResultObjects([[type: "EXCEPTION", cause: e.class.simpleName, message: "Orchestration timed out."]])
           task.fail()
         } else {
-          e.printStackTrace()
           def stringWriter = new StringWriter()
           def printWriter = new PrintWriter(stringWriter)
           e.printStackTrace(printWriter)

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamPolicyReader.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamPolicyReader.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -27,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class IamPolicyReader {
+  private static final Logger logger = LoggerFactory.getLogger(IamPolicyReader.class);
 
   ObjectMapper mapper;
 
@@ -58,7 +61,7 @@ public class IamPolicyReader {
         }
       }
     } catch (IOException e) {
-      e.printStackTrace();
+      logger.error("Unable to extract trusted entities (policyDocument: {})", urlEncodedPolicyDocument, e);
     }
 
     return trustedEntities;

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SecurityGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SecurityGroupController.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.model.SecurityGroupProvider
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.access.prepost.PostAuthorize
 import org.springframework.security.access.prepost.PreAuthorize
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/securityGroups")
 @RestController
+@Slf4j
 class SecurityGroupController {
 
   @Autowired
@@ -61,7 +63,7 @@ class SecurityGroupController {
       objs[obj.accountName][obj.cloudProvider][obj.region] << obj.summary
       objs
     }) doOnError {
-      it.printStackTrace()
+      log.error("Unable to list security groups", it)
     } toBlocking() first()
   }
 


### PR DESCRIPTION
Only schedule this agent for accounts where it is explicitly enabled.

This PR also cleans up some unnecessary usage of `e.printStackTrace()`.
