### PR TITLE
feat(provider/kubernetes): register batchv1 api

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
@@ -34,6 +34,7 @@ public class KubernetesApiVersion {
   public static KubernetesApiVersion NETWORKING_K8S_IO_V1 = new KubernetesApiVersion("network.k8s.io/v1");
   public static KubernetesApiVersion APPS_V1BETA1 = new KubernetesApiVersion("apps/v1beta1");
   public static KubernetesApiVersion APPS_V1BETA2 = new KubernetesApiVersion("apps/v1beta2");
+  public static KubernetesApiVersion BATCH_V1 = new KubernetesApiVersion("batch/v1");
 
   private final String name;
 


### PR DESCRIPTION
Note, this isn't totally necessary since once you have jobs in your k8s
cluster, Spinnaker will register this. But since we do it for other APIs
that we support "out of the box", we may as well be consistent.
