### PR TITLE
feat(artifacts): GCE deploy can consume image artifacts

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactUtils.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactUtils.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.Stack;
 
 public class ArtifactUtils {
+  public static final String GCE_IMAGE_TYPE = "gce/image";
+
   public static void untarStreamToPath(InputStream inputStream, String basePath) throws IOException {
     class DirectoryTimestamp {
       public DirectoryTimestamp(File d, long m) {

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -1,4 +1,5 @@
 dependencies {
+  compile project(":clouddriver-artifacts")
   compile project(":clouddriver-core")
   compile project(":clouddriver-consul")
   compile project(":clouddriver-google-common")

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -143,17 +143,16 @@ class GCEUtil {
           .buildGetRequest(new GenericUrl(reference))
           .setParser(new JsonObjectParser(JacksonFactory.getDefaultInstance()))
           .execute()
-          .parseAs(Image)
       },
       "gce/image",
       task,
       RETRY_ERROR_CODES,
       [],
-      [action: "get", phase: phase, operation: "compute.buildGetRequest.execute", (executor.TAG_SCOPE): executor.SCOPE_ZONAL],
+      [action: "get", phase: phase, operation: "compute.buildGetRequest.execute", (executor.TAG_SCOPE): executor.SCOPE_GLOBAL],
       executor.registry
-    ) as Image
+    ) as HttpResponse
 
-    return result
+    return result.parseAs(Image)
   }
 
   static Image getBootImage(BaseGoogleInstanceDescription description,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
@@ -51,6 +51,10 @@ class BaseGoogleInstanceDescription extends AbstractGoogleCredentialsDescription
 
   String accountName
 
+  // The source of the image to deploy
+  // ARTIFACT: An artifact of type gce/image stored in imageArtifact
+  // STRING:   A string representing a GCE image name in the current
+  //           project, stored in image
   enum ImageSource {
     ARTIFACT, STRING
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.description
 
 import com.netflix.spinnaker.clouddriver.google.model.GoogleDisk
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 import groovy.transform.ToString
@@ -25,7 +26,6 @@ import groovy.transform.ToString
 @Canonical
 @ToString(includeNames = true)
 class BaseGoogleInstanceDescription extends AbstractGoogleCredentialsDescription {
-  String image
   String instanceType
   String minCpuPlatform
   List<GoogleDisk> disks
@@ -43,7 +43,17 @@ class BaseGoogleInstanceDescription extends AbstractGoogleCredentialsDescription
   Boolean automaticRestart
   OnHostMaintenance onHostMaintenance
 
+  // We support passing the image to deploy as either a string or an artifact, but default to
+  // the string for backwards-compatibility
+  ImageSource imageSource = ImageSource.STRING
+  String image
+  Artifact imageArtifact
+
   String accountName
+
+  enum ImageSource {
+    ARTIFACT, STRING
+  }
 
   enum OnHostMaintenance {
     MIGRATE, TERMINATE

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -199,6 +199,7 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
                                                    BASE_PHASE,
                                                    clouddriverUserAgentApplicationName,
                                                    googleConfigurationProperties.baseImageProjects,
+                                                   safeRetry,
                                                    this)
 
     def networkInterface = GCEUtil.buildNetworkInterface(network,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.CreateGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleNetworkProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleSubnetProvider
@@ -50,6 +51,9 @@ class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<Deployme
 
   @Autowired
   String clouddriverUserAgentApplicationName
+
+  @Autowired
+  SafeRetry safeRetry
 
   private static Task getTask() {
     TaskRepository.threadLocalTask.get()
@@ -102,6 +106,7 @@ class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<Deployme
                                                    BASE_PHASE,
                                                    clouddriverUserAgentApplicationName,
                                                    googleConfigurationProperties.baseImageProjects,
+                                                   safeRetry,
                                                    this)
 
     def networkInterface = GCEUtil.buildNetworkInterface(network,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.google.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
+import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BaseGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.description.ModifyGoogleServerGroupInstanceTemplateDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
@@ -71,6 +72,9 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation extends GoogleAtomi
 
   @Autowired
   String clouddriverUserAgentApplicationName
+
+  @Autowired
+  SafeRetry safeRetry
 
   ModifyGoogleServerGroupInstanceTemplateAtomicOperation(ModifyGoogleServerGroupInstanceTemplateDescription description) {
     this.description = description
@@ -171,6 +175,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation extends GoogleAtomi
                                                        BASE_PHASE,
                                                        clouddriverUserAgentApplicationName,
                                                        googleConfigurationProperties.baseImageProjects,
+                                                       safeRetry,
                                                        this)
 
         instanceTemplateProperties.setDisks(attachedDisks)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtilSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtilSpec.groovy
@@ -20,21 +20,27 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.http.HttpRequest
+import com.google.api.client.http.HttpRequestFactory
+import com.google.api.client.http.HttpResponse
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
-import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.GoogleExecutorTraits
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
+import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleOperationException
 import com.netflix.spinnaker.clouddriver.google.deploy.exception.GoogleResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
 import com.netflix.spinnaker.clouddriver.google.model.GoogleServerGroup
-import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.*
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleHttpLoadBalancer
+import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleNetworkLoadBalancer
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -158,6 +164,115 @@ class GCEUtilSpec extends Specification {
         }
       }
       thrown GoogleResourceNotFoundException
+  }
+
+  void "getImageFromArtifact"() {
+    setup:
+    def returnImage
+    def success
+
+    def compute = GroovyMock(Compute)
+    compute.getRequestFactory() >> {
+      def requestFactory = GroovyMock(HttpRequestFactory)
+      requestFactory.buildGetRequest(_) >> {
+        def httpRequest = GroovyMock(HttpRequest)
+        httpRequest.setParser(_) >> {
+          return httpRequest
+        }
+        httpRequest.execute() >> {
+          def response = GroovyMock(HttpResponse)
+          response.isSuccessStatusCode() >> {
+            return success
+          }
+          response.parseAs(_) >> {
+            return returnImage
+          }
+          return response
+        }
+        return httpRequest
+      }
+      return requestFactory
+    }
+
+    def soughtImage = new Image(name: IMAGE_NAME)
+    def artifact = Artifact.builder()
+      .name(IMAGE_NAME)
+      .reference("https://www.googleapis.com/compute/v1/projects/$PROJECT_NAME/global/images/$IMAGE_NAME")
+      .type("gce/image")
+      .build()
+
+    when:
+    returnImage = soughtImage
+    success = true
+    def sourceImage = GCEUtil.getImageFromArtifact(artifact, compute, taskMock, PHASE)
+
+    then:
+    sourceImage == soughtImage
+
+    when:
+    returnImage = soughtImage
+    success = false
+    GCEUtil.getImageFromArtifact(artifact, compute, taskMock, PHASE)
+
+    then:
+    thrown GoogleResourceNotFoundException
+
+    when:
+    artifact = Artifact.builder().type("github/file").build()
+    returnImage = soughtImage
+    success = true
+    GCEUtil.getImageFromArtifact(artifact, compute, taskMock, PHASE)
+
+    then:
+    thrown GoogleOperationException
+  }
+
+  void "getBootImage"() {
+    setup:
+    def credentials = GroovyMock(GoogleNamedAccountCredentials)
+    def compute = GroovyMock(Compute)
+    credentials.compute >> compute
+    credentials.project >> PROJECT_NAME
+    def executor = GroovyMock(GoogleExecutorTraits)
+    def artifact = new Artifact()
+    GroovySpy(GCEUtil, global: true)
+
+    when:
+    def description = new BasicGoogleDeployDescription(credentials: credentials, image: IMAGE_NAME)
+    GCEUtil.getBootImage(description,
+                         taskMock,
+                         PHASE,
+                         GOOGLE_APPLICATION_NAME,
+                         [IMAGE_PROJECT_NAME],
+                         executor)
+
+    then:
+    1 * GCEUtil.queryImage(PROJECT_NAME,
+                           IMAGE_NAME,
+                           credentials,
+                           compute,
+                           taskMock,
+                           PHASE,
+                           GOOGLE_APPLICATION_NAME,
+                           [IMAGE_PROJECT_NAME],
+                           executor) >> { return new Image() }
+    0 * GCEUtil.getImageFromArtifact(*_)
+
+    when:
+    description = new BasicGoogleDeployDescription(credentials: credentials,
+                                                   image: IMAGE_NAME,
+                                                   imageArtifact: artifact,
+                                                   imageSource: "ARTIFACT")
+    GCEUtil.getBootImage(description,
+                         taskMock,
+                         PHASE,
+                         GOOGLE_APPLICATION_NAME,
+                         [IMAGE_PROJECT_NAME],
+                         executor)
+
+    then:
+    0 * GCEUtil.queryImage(*_)
+    1 * GCEUtil.getImageFromArtifact(artifact, compute, taskMock, PHASE) >> { return new Image() }
   }
 
   void "instance metadata with zero key-value pairs roundtrips properly"() {


### PR DESCRIPTION
With this change, a BaseGoogleInstanceDescription can now
optionally contain a reference to an artifact, containing
a gce/image artifact that should be deployed to that image.