### PR TITLE
feat(artifacts): Update google deploy validator to handle artifacts

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/BasicGoogleDeployDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/BasicGoogleDeployDescriptionValidator.groovy
@@ -40,7 +40,7 @@ class BasicGoogleDeployDescriptionValidator extends DescriptionValidator<BasicGo
     def helper = new StandardGceAttributeValidator("basicGoogleDeployDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)
-    helper.validateImage(description.image)
+    helper.validateImage(description.imageSource, description.image, description.imageArtifact)
     helper.validateInstanceType(description.instanceType,
                                 description.regional ? description.region : description.zone,
                                 description.credentials)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CreateGoogleInstanceDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CreateGoogleInstanceDescriptionValidator.groovy
@@ -38,7 +38,7 @@ class CreateGoogleInstanceDescriptionValidator extends DescriptionValidator<Crea
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)
     helper.validateInstanceName(description.instanceName)
-    helper.validateImage(description.image)
+    helper.validateImage(description.imageSource, description.image, description.imageArtifact)
     helper.validateInstanceType(description.instanceType, description.zone, description.credentials)
     helper.validateInstanceTypeDisks(googleDeployDefaults.determineInstanceTypeDisk(description.instanceType),
                                      description.disks)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
@@ -410,9 +410,9 @@ class StandardGceAttributeValidatorSpec extends Specification {
       0 * errors._
 
     when:
-    validator.validateImage(null, "Unchecked", null)
+      validator.validateImage(null, "Unchecked", null)
     then:
-    0 * errors._
+      0 * errors._
   }
 
   void "invalid image name"() {
@@ -427,47 +427,47 @@ class StandardGceAttributeValidatorSpec extends Specification {
       0 * errors._
 
     when:
-    validator.validateImage(null, "", null)
+      validator.validateImage(null, "", null)
     then:
-    1 * errors.rejectValue("image", "${DECORATOR}.image.empty")
-    0 * errors._
+      1 * errors.rejectValue("image", "${DECORATOR}.image.empty")
+      0 * errors._
   }
 
   void "valid image artifact"() {
     setup:
-    def errors = Mock(Errors)
-    def validator = new StandardGceAttributeValidator(DECORATOR, errors)
-    def artifact = Artifact.ArtifactBuilder.newInstance().type("gce/image").build()
+      def errors = Mock(Errors)
+      def validator = new StandardGceAttributeValidator(DECORATOR, errors)
+      def artifact = Artifact.ArtifactBuilder.newInstance().type("gce/image").build()
 
     when:
-    validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", artifact)
+      validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", artifact)
     then:
-    0 * errors._
+      0 * errors._
   }
 
   void "missing image artifact"() {
     setup:
-    def errors = Mock(Errors)
-    def validator = new StandardGceAttributeValidator(DECORATOR, errors)
+      def errors = Mock(Errors)
+      def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
-    validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", null)
+      validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", null)
     then:
-    1 * errors.rejectValue("imageArtifact", "${DECORATOR}.imageArtifact.empty")
-    0 * errors._
+      1 * errors.rejectValue("imageArtifact", "${DECORATOR}.imageArtifact.empty")
+      0 * errors._
   }
 
   void "invalid image artifact type"() {
     setup:
-    def errors = Mock(Errors)
-    def validator = new StandardGceAttributeValidator(DECORATOR, errors)
-    def artifact = Artifact.ArtifactBuilder.newInstance().type("github/file").build()
+      def errors = Mock(Errors)
+      def validator = new StandardGceAttributeValidator(DECORATOR, errors)
+      def artifact = Artifact.ArtifactBuilder.newInstance().type("github/file").build()
 
     when:
-    validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", artifact)
+      validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", artifact)
     then:
-    1 * errors.rejectValue("imageArtifact.type", "${DECORATOR}.imageArtifact.type.invalid")
-    0 * errors._
+      1 * errors.rejectValue("imageArtifact.type", "${DECORATOR}.imageArtifact.type.invalid")
+      0 * errors._
   }
 
   void "valid instance name"() {

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.google.deploy.description.BaseGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoHealingPolicy
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
@@ -24,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
@@ -398,14 +400,19 @@ class StandardGceAttributeValidatorSpec extends Specification {
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
-      validator.validateImage("Unchecked")
+      validator.validateImage(BaseGoogleInstanceDescription.ImageSource.STRING, "Unchecked", null)
     then:
       0 * errors._
 
     when:
-      validator.validateImage(" ")
+      validator.validateImage(BaseGoogleInstanceDescription.ImageSource.STRING, " ", null)
     then:
       0 * errors._
+
+    when:
+    validator.validateImage(null, "Unchecked", null)
+    then:
+    0 * errors._
   }
 
   void "invalid image name"() {
@@ -414,10 +421,53 @@ class StandardGceAttributeValidatorSpec extends Specification {
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
-      validator.validateImage("")
+      validator.validateImage(BaseGoogleInstanceDescription.ImageSource.STRING, "", null)
     then:
       1 * errors.rejectValue("image", "${DECORATOR}.image.empty")
       0 * errors._
+
+    when:
+    validator.validateImage(null, "", null)
+    then:
+    1 * errors.rejectValue("image", "${DECORATOR}.image.empty")
+    0 * errors._
+  }
+
+  void "valid image artifact"() {
+    setup:
+    def errors = Mock(Errors)
+    def validator = new StandardGceAttributeValidator(DECORATOR, errors)
+    def artifact = Artifact.ArtifactBuilder.newInstance().type("gce/image").build()
+
+    when:
+    validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", artifact)
+    then:
+    0 * errors._
+  }
+
+  void "missing image artifact"() {
+    setup:
+    def errors = Mock(Errors)
+    def validator = new StandardGceAttributeValidator(DECORATOR, errors)
+
+    when:
+    validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", null)
+    then:
+    1 * errors.rejectValue("imageArtifact", "${DECORATOR}.imageArtifact.empty")
+    0 * errors._
+  }
+
+  void "invalid image artifact type"() {
+    setup:
+    def errors = Mock(Errors)
+    def validator = new StandardGceAttributeValidator(DECORATOR, errors)
+    def artifact = Artifact.ArtifactBuilder.newInstance().type("github/file").build()
+
+    when:
+    validator.validateImage(BaseGoogleInstanceDescription.ImageSource.ARTIFACT, "", artifact)
+    then:
+    1 * errors.rejectValue("imageArtifact.type", "${DECORATOR}.imageArtifact.type.invalid")
+    0 * errors._
   }
 
   void "valid instance name"() {


### PR DESCRIPTION
Now that an instance's image can be either a string or an artifact, update the validation to allow either of these cases.