### PR TITLE
fix(provider/ecs): Fix ECS only using Management Account

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonClientProvider.java
@@ -287,12 +287,13 @@ public class AmazonClientProvider {
     return awsSdkClientSupplier.getClient(AmazonEC2ClientBuilder.class, AmazonEC2.class, accountName, awsCredentialsProvider, region);
   }
 
-  public AmazonECS getAmazonEcs(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return awsSdkClientSupplier.getClient(AmazonECSClientBuilder.class, AmazonECS.class, accountName, awsCredentialsProvider, region);
+  public AmazonECS getAmazonEcs(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
+    return proxyHandlerBuilder.getProxyHandler(AmazonECS.class, AmazonECSClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonIdentityManagement getIam(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return awsSdkClientSupplier.getClient(AmazonIdentityManagementClientBuilder.class, AmazonIdentityManagement.class, accountName, awsCredentialsProvider, region);
+  public AmazonIdentityManagement getIam(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
+    return proxyHandlerBuilder.getProxyHandler(AmazonIdentityManagement.class, AmazonIdentityManagementClientBuilder.class, amazonCredentials, region, skipEdda);
+    // return awsSdkClientSupplier.getClient(AmazonIdentityManagementClientBuilder.class, AmazonIdentityManagement.class, accountName, awsCredentialsProvider, region);
   }
 
   public AWSLambda getAmazonLambda(NetflixAmazonCredentials amazonCredentials, String region) {
@@ -436,11 +437,11 @@ public class AmazonClientProvider {
     return awsSdkClientSupplier.getClient(AWSShieldClientBuilder.class, AWSShield.class, accountName, awsCredentialsProvider, region);
   }
 
-  public AWSApplicationAutoScaling getAmazonApplicationAutoScaling(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return awsSdkClientSupplier.getClient(AWSApplicationAutoScalingClientBuilder.class, AWSApplicationAutoScaling.class, accountName, awsCredentialsProvider, region);
+  public AWSApplicationAutoScaling getAmazonApplicationAutoScaling(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
+    return proxyHandlerBuilder.getProxyHandler(AWSApplicationAutoScaling.class, AWSApplicationAutoScalingClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 
-  public AmazonECR getAmazonEcr(String accountName, AWSCredentialsProvider awsCredentialsProvider, String region) {
-    return awsSdkClientSupplier.getClient(AmazonECRClientBuilder.class, AmazonECR.class, accountName, awsCredentialsProvider, region);
+  public AmazonECR getAmazonEcr(NetflixAmazonCredentials amazonCredentials, String region, boolean skipEdda) {
+    return proxyHandlerBuilder.getProxyHandler(AmazonECR.class, AmazonECRClientBuilder.class, amazonCredentials, region, skipEdda);
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
@@ -20,6 +20,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.ecs.AmazonECS;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.AbstractECSDescription;
@@ -56,9 +57,9 @@ public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescriptio
   AmazonECS getAmazonEcsClient() {
     AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
     String region = getRegion();
-    String credentialAccount = description.getCredentialAccount();
+    NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
-    return amazonClientProvider.getAmazonEcs(credentialAccount, credentialsProvider, region);
+    return amazonClientProvider.getAmazonEcs(credentialAccount, region, false);
   }
 
   protected String getRegion() {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -44,6 +44,7 @@ import com.amazonaws.services.identitymanagement.model.GetRoleResult;
 import com.amazonaws.services.identitymanagement.model.Role;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.AssumeRoleAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAssumeRoleAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CreateServerGroupDescription;
@@ -270,23 +271,23 @@ public class CreateServerGroupAtomicOperation extends AbstractEcsAtomicOperation
 
   private AWSApplicationAutoScaling getAmazonApplicationAutoScalingClient() {
     AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
-    String credentialAccount = description.getCredentialAccount();
+    NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
-    return amazonClientProvider.getAmazonApplicationAutoScaling(credentialAccount, credentialsProvider, getRegion());
+    return amazonClientProvider.getAmazonApplicationAutoScaling(credentialAccount, getRegion(), false);
   }
 
   private AmazonElasticLoadBalancing getAmazonElasticLoadBalancingClient() {
     AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
-    String credentialAccount = description.getCredentialAccount();
+    NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
-    return amazonClientProvider.getAmazonElasticLoadBalancingV2(credentialAccount, credentialsProvider, getRegion());
+    return amazonClientProvider.getAmazonElasticLoadBalancingV2(credentialAccount, getRegion(), false);
   }
 
   private AmazonIdentityManagement getAmazonIdentityManagementClient() {
     AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
-    String credentialAccount = description.getCredentialAccount();
+    NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
-    return amazonClientProvider.getAmazonIdentityManagement(credentialAccount, credentialsProvider, getRegion());
+    return amazonClientProvider.getAmazonIdentityManagement(credentialAccount, getRegion(), false);
   }
 
   private String getServerGroupName(Service service) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.applicationautoscaling.model.ScalableTarget;
 import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace;
 import com.amazonaws.services.ecs.AmazonECS;
 import com.amazonaws.services.ecs.model.UpdateServiceRequest;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ModifyServiceDescription;
 
 import java.util.ArrayList;
@@ -95,9 +96,9 @@ public class EnableServiceAtomicOperation extends AbstractEcsAtomicOperation<Mod
   private AWSApplicationAutoScaling getAmazonApplicationAutoScalingClient() {
     AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
     String region = description.getRegion();
-    String credentialAccount = description.getCredentialAccount();
+    NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
-    return amazonClientProvider.getAmazonApplicationAutoScaling(credentialAccount, credentialsProvider, region);
+    return amazonClientProvider.getAmazonApplicationAutoScaling(credentialAccount, region, false);
   }
 
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/ResizeServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/ResizeServiceAtomicOperation.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace;
 import com.amazonaws.services.ecs.AmazonECS;
 import com.amazonaws.services.ecs.model.Service;
 import com.amazonaws.services.ecs.model.UpdateServiceRequest;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ResizeServiceDescription;
 import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
@@ -88,8 +89,8 @@ public class ResizeServiceAtomicOperation extends AbstractEcsAtomicOperation<Res
   private AWSApplicationAutoScaling getAmazonApplicationAutoScalingClient() {
     AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
     String region = description.getRegion();
-    String credentialAccount = description.getCredentialAccount();
+    NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
-    return amazonClientProvider.getAmazonApplicationAutoScaling(credentialAccount, credentialsProvider, region);
+    return amazonClientProvider.getAmazonApplicationAutoScaling(credentialAccount, region, false);
   }
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsCachingAgent.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
 import org.slf4j.Logger;
@@ -50,11 +51,13 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
 
   final AmazonClientProvider amazonClientProvider;
   final AWSCredentialsProvider awsCredentialsProvider;
+  final NetflixAmazonCredentials account;
   final String region;
   final String accountName;
 
-  AbstractEcsCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
-    this.accountName = accountName;
+  AbstractEcsCachingAgent(NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+    this.account = account;
+    this.accountName = account.getName();
     this.region = region;
     this.amazonClientProvider = amazonClientProvider;
     this.awsCredentialsProvider = awsCredentialsProvider;
@@ -84,7 +87,7 @@ abstract class AbstractEcsCachingAgent<T> implements CachingAgent {
   public CacheResult loadData(ProviderCache providerCache) {
     String authoritativeKeyName = getAuthoritativeKeyName();
 
-    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+    AmazonECS ecs = amazonClientProvider.getAmazonEcs(account, region, false);
     List<T> items = getItems(ecs, providerCache);
     return buildCacheResult(authoritativeKeyName, items, providerCache);
   }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsOnDemandAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsOnDemandAgent.java
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent;
 import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
@@ -35,8 +36,8 @@ import java.util.Map;
 abstract class AbstractEcsOnDemandAgent<T> extends AbstractEcsCachingAgent<T> implements OnDemandAgent {
   final OnDemandMetricsSupport metricsSupport;
 
-  AbstractEcsOnDemandAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
-    super(accountName, region, amazonClientProvider, awsCredentialsProvider);
+  AbstractEcsOnDemandAgent(NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
+    super(account, region, amazonClientProvider, awsCredentialsProvider);
     this.metricsSupport = new OnDemandMetricsSupport(registry, this, EcsCloudProvider.ID + ":" + EcsCloudProvider.ID + ":${OnDemandAgent.OnDemandType.ServerGroup}");
   }
 
@@ -66,7 +67,7 @@ abstract class AbstractEcsOnDemandAgent<T> extends AbstractEcsCachingAgent<T> im
       return null;
     }
 
-    AmazonECS ecs = amazonClientProvider.getAmazonEcs(accountName, awsCredentialsProvider, region);
+    AmazonECS ecs = amazonClientProvider.getAmazonEcs(account, region, false);
 
     List<T> items = metricsSupport.readData(new Closure<List<T>>(this, this) {
       public List<T> doCall() {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ContainerInstanceCachingAgent.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,8 +52,8 @@ public class ContainerInstanceCachingAgent extends AbstractEcsOnDemandAgent<Cont
   ));
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  public ContainerInstanceCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
-    super(accountName, region, amazonClientProvider, awsCredentialsProvider, registry);
+  public ContainerInstanceCachingAgent(NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
+    super(account, region, amazonClientProvider, awsCredentialsProvider, registry);
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsCloudMetricAlarmCachingAgent.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
 import org.slf4j.Logger;
@@ -54,14 +55,16 @@ public class EcsCloudMetricAlarmCachingAgent implements CachingAgent {
   private final Logger log = LoggerFactory.getLogger(getClass());
   private AmazonClientProvider amazonClientProvider;
   private AWSCredentialsProvider awsCredentialsProvider;
+  private NetflixAmazonCredentials account;
   private String accountName;
   private String region;
 
-  public EcsCloudMetricAlarmCachingAgent(String accountName, String region,
+  public EcsCloudMetricAlarmCachingAgent(NetflixAmazonCredentials account, String region,
                                          AmazonClientProvider amazonClientProvider,
                                          AWSCredentialsProvider awsCredentialsProvider) {
     this.region = region;
-    this.accountName = accountName;
+    this.account = account;
+    this.accountName = account.getName();
     this.amazonClientProvider = amazonClientProvider;
     this.awsCredentialsProvider = awsCredentialsProvider;
   }
@@ -85,7 +88,7 @@ public class EcsCloudMetricAlarmCachingAgent implements CachingAgent {
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    AmazonCloudWatch cloudWatch = amazonClientProvider.getAmazonCloudWatch(accountName, awsCredentialsProvider, region);
+    AmazonCloudWatch cloudWatch = amazonClientProvider.getAmazonCloudWatch(account, region, false);
 
     Set<MetricAlarm> cacheableMetricAlarm = fetchMetricAlarms(cloudWatch);
     Map<String, Collection<CacheData>> newDataMap = generateFreshData(cacheableMetricAlarm);

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/EcsClusterCachingAgent.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -47,8 +48,8 @@ public class EcsClusterCachingAgent extends AbstractEcsCachingAgent<String> {
   ));
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  public EcsClusterCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
-    super(accountName, region, amazonClientProvider, awsCredentialsProvider);
+  public EcsClusterCachingAgent(NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider) {
+    super(account, region, amazonClientProvider, awsCredentialsProvider);
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ScalableTargetsCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ScalableTargetsCachingAgent.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
 import org.slf4j.Logger;
@@ -57,15 +58,17 @@ public class ScalableTargetsCachingAgent implements CachingAgent {
   private final ObjectMapper objectMapper;
   private AmazonClientProvider amazonClientProvider;
   private AWSCredentialsProvider awsCredentialsProvider;
+  private NetflixAmazonCredentials account;
   private String accountName;
   private String region;
 
-  public ScalableTargetsCachingAgent(String accountName, String region,
+  public ScalableTargetsCachingAgent(NetflixAmazonCredentials account, String region,
                                      AmazonClientProvider amazonClientProvider,
                                      AWSCredentialsProvider awsCredentialsProvider,
                                      ObjectMapper objectMapper) {
     this.region = region;
-    this.accountName = accountName;
+    this.account = account;
+    this.accountName = account.getName();
     this.amazonClientProvider = amazonClientProvider;
     this.awsCredentialsProvider = awsCredentialsProvider;
     this.objectMapper = objectMapper;
@@ -82,7 +85,7 @@ public class ScalableTargetsCachingAgent implements CachingAgent {
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    AWSApplicationAutoScaling autoScalingClient = amazonClientProvider.getAmazonApplicationAutoScaling(accountName, awsCredentialsProvider, region);
+    AWSApplicationAutoScaling autoScalingClient = amazonClientProvider.getAmazonApplicationAutoScaling(account, region, false);
 
     Set<ScalableTarget> scalableTargets = fetchScalableTargets(autoScalingClient);
     Map<String, Collection<CacheData>> newDataMap = generateFreshData(scalableTargets);

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -54,8 +55,8 @@ public class ServiceCachingAgent extends AbstractEcsOnDemandAgent<Service> {
   ));
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  public ServiceCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
-    super(accountName, region, amazonClientProvider, awsCredentialsProvider, registry);
+  public ServiceCachingAgent(NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
+    super(account, region, amazonClientProvider, awsCredentialsProvider, registry);
   }
 
   public static Map<String, Object> convertServiceToAttributes(String accountName, String region, Service service) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import groovy.lang.Closure;
 import org.apache.commons.lang3.StringUtils;
@@ -58,8 +59,8 @@ public class TaskCachingAgent extends AbstractEcsOnDemandAgent<Task> {
   ));
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  public TaskCachingAgent(String accountName, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
-    super(accountName, region, amazonClientProvider, awsCredentialsProvider, registry);
+  public TaskCachingAgent(NetflixAmazonCredentials account, String region, AmazonClientProvider amazonClientProvider, AWSCredentialsProvider awsCredentialsProvider, Registry registry) {
+    super(account, region, amazonClientProvider, awsCredentialsProvider, registry);
   }
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgent.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.TaskDefinitionCacheClient;
 import org.slf4j.Logger;
@@ -56,12 +57,12 @@ public class TaskDefinitionCachingAgent extends AbstractEcsOnDemandAgent<TaskDef
 
   private ObjectMapper objectMapper;
 
-  public TaskDefinitionCachingAgent(String accountName, String region,
+  public TaskDefinitionCachingAgent(NetflixAmazonCredentials account, String region,
                                     AmazonClientProvider amazonClientProvider,
                                     AWSCredentialsProvider awsCredentialsProvider,
                                     Registry registry,
                                     ObjectMapper objectMapper) {
-    super(accountName, region, amazonClientProvider, awsCredentialsProvider, registry);
+    super(account, region, amazonClientProvider, awsCredentialsProvider, registry);
     this.objectMapper = objectMapper;
   }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent;
 import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.ContainerInstanceCacheClient;
@@ -68,11 +69,11 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth> 
   private Collection<String> taskDefEvicitions;
   private ObjectMapper objectMapper;
 
-  public TaskHealthCachingAgent(String accountName, String region,
+  public TaskHealthCachingAgent(NetflixAmazonCredentials account, String region,
                                 AmazonClientProvider amazonClientProvider,
                                 AWSCredentialsProvider awsCredentialsProvider,
                                 ObjectMapper objectMapper) {
-    super(accountName, region, amazonClientProvider, awsCredentialsProvider);
+    super(account, region, amazonClientProvider, awsCredentialsProvider);
     this.objectMapper = objectMapper;
   }
 
@@ -93,7 +94,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth> 
     TaskCacheClient taskCacheClient = new TaskCacheClient(providerCache, objectMapper);
     ServiceCacheClient serviceCacheClient = new ServiceCacheClient(providerCache, objectMapper);
 
-    AmazonElasticLoadBalancing amazonloadBalancing = amazonClientProvider.getAmazonElasticLoadBalancingV2(accountName, awsCredentialsProvider, region);
+    AmazonElasticLoadBalancing amazonloadBalancing = amazonClientProvider.getAmazonElasticLoadBalancingV2(account, region, false);
 
     ContainerInstanceCacheClient containerInstanceCacheClient = new ContainerInstanceCacheClient(providerCache);
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
@@ -81,18 +81,18 @@ public class EcsProviderConfig {
 
     for (NetflixAmazonCredentials credentials : allAccounts) {
       if (credentials.getCloudProvider().equals(EcsCloudProvider.ID)) {
-        newAgents.add(new IamRoleCachingAgent(credentials.getName(), amazonClientProvider, awsCredentialsProvider, iamPolicyReader)); // IAM is region-agnostic, so one caching agent per account is enough
+        newAgents.add(new IamRoleCachingAgent(credentials, amazonClientProvider, awsCredentialsProvider, iamPolicyReader)); // IAM is region-agnostic, so one caching agent per account is enough
 
         for (AWSRegion region : credentials.getRegions()) {
           if (!scheduledAccounts.contains(credentials.getName())) {
-            newAgents.add(new EcsClusterCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
-            newAgents.add(new ServiceCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
-            newAgents.add(new TaskCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
-            newAgents.add(new ContainerInstanceCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
-            newAgents.add(new TaskDefinitionCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, registry, objectMapper));
-            newAgents.add(new TaskHealthCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, objectMapper));
-            newAgents.add(new EcsCloudMetricAlarmCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider));
-            newAgents.add(new ScalableTargetsCachingAgent(credentials.getName(), region.getName(), amazonClientProvider, awsCredentialsProvider, objectMapper));
+            newAgents.add(new EcsClusterCachingAgent(credentials, region.getName(), amazonClientProvider, awsCredentialsProvider));
+            newAgents.add(new ServiceCachingAgent(credentials, region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
+            newAgents.add(new TaskCachingAgent(credentials, region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
+            newAgents.add(new ContainerInstanceCachingAgent(credentials, region.getName(), amazonClientProvider, awsCredentialsProvider, registry));
+            newAgents.add(new TaskDefinitionCachingAgent(credentials, region.getName(), amazonClientProvider, awsCredentialsProvider, registry, objectMapper));
+            newAgents.add(new TaskHealthCachingAgent(credentials, region.getName(), amazonClientProvider, awsCredentialsProvider, objectMapper));
+            newAgents.add(new EcsCloudMetricAlarmCachingAgent(credentials, region.getName(), amazonClientProvider, awsCredentialsProvider));
+            newAgents.add(new ScalableTargetsCachingAgent(credentials, region.getName(), amazonClientProvider, awsCredentialsProvider, objectMapper));
           }
         }
       }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
@@ -87,7 +87,7 @@ public class EcrImageProvider implements ImageRepositoryProvider {
       throw new IllegalArgumentException("The repository URI provided does not belong to a region that the credentials have access to or the region is not valid.");
     }
 
-    AmazonECR amazonECR = amazonClientProvider.getAmazonEcr(credentials.getName(), credentials.getCredentialsProvider(), region);
+    AmazonECR amazonECR = amazonClientProvider.getAmazonEcr(credentials, region, false);
 
     ListImagesResult result = amazonECR.listImages(new ListImagesRequest().withRegistryId(accountId).withRepositoryName(repository));
     DescribeImagesResult imagesResult = amazonECR.describeImages(new DescribeImagesRequest().withRegistryId(accountId).withRepositoryName(repository).withImageIds(result.getImageIds()));

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/EcsCloudMetricService.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/EcsCloudMetricService.java
@@ -34,6 +34,7 @@ import com.amazonaws.services.cloudwatch.model.MetricAlarm;
 import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.EcsCloudWatchAlarmCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.EcsMetricAlarm;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
@@ -95,8 +96,8 @@ public class EcsCloudMetricService {
   }
 
   private void deregisterScalableTargets(Set<String> resources, String account, String region) {
-    AmazonCredentials credentials = (AmazonCredentials) accountCredentialsProvider.getCredentials(account);
-    AWSApplicationAutoScaling autoScaling = amazonClientProvider.getAmazonApplicationAutoScaling(account, credentials.getCredentialsProvider(), region);
+    NetflixAmazonCredentials credentials = (NetflixAmazonCredentials) accountCredentialsProvider.getCredentials(account);
+    AWSApplicationAutoScaling autoScaling = amazonClientProvider.getAmazonApplicationAutoScaling(credentials, region, false);
 
     Map<String, Set<String>> resourceMap = new HashMap<>();
     for (String resource : resources) {
@@ -184,10 +185,10 @@ public class EcsCloudMetricService {
                                       String serviceName,
                                       String resourceId) {
 
-    AmazonCredentials credentials = (AmazonCredentials) accountCredentialsProvider.getCredentials(account);
+    NetflixAmazonCredentials credentials = (NetflixAmazonCredentials) accountCredentialsProvider.getCredentials(account);
 
-    AmazonCloudWatch cloudWatch = amazonClientProvider.getAmazonCloudWatch(account, credentials.getCredentialsProvider(), region);
-    AWSApplicationAutoScaling autoScalingClient = amazonClientProvider.getAmazonApplicationAutoScaling(account, credentials.getCredentialsProvider(), region);
+    AmazonCloudWatch cloudWatch = amazonClientProvider.getAmazonCloudWatch(credentials, region, false);
+    AWSApplicationAutoScaling autoScalingClient = amazonClientProvider.getAmazonApplicationAutoScaling(credentials, region, false);
 
     DescribeAlarmsResult describeAlarmsResult = cloudWatch.describeAlarms(new DescribeAlarmsRequest()
       .withAlarmNames(alarmNames));


### PR DESCRIPTION
Modify the AmazonClientProvider methods to pass in NetflixAmazonCredentials instead, as the previous approach used only the management account's credentials.

See [Clouddriver ECS doesn't support multiple accounts](https://github.com/spinnaker/spinnaker/issues/2583)

