### PR TITLE
fix(openstack/javadoc): Add placeholder javadoc class comment to make…

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/StackChecker.java
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/StackChecker.java
@@ -21,7 +21,10 @@ import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackPro
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.heat.Stack;
 
-class StackChecker implements BlockingStatusChecker.StatusChecker<Stack> {
+/**
+ * This class checks if an OpenStack stack is in a ready state.
+ */
+public class StackChecker implements BlockingStatusChecker.StatusChecker<Stack> {
   Operation operation;
 
   enum Operation {


### PR DESCRIPTION
… gradle javadoc happy.

Otherwise, our build fails with:

```
:clouddriver-openstack:javadoc
javadoc: error - No public or protected classes found to document.
1 error
:clouddriver-openstack:javadoc FAILED
```