### PR TITLE
feat(aws/loadbalancing) connection draining support

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfiguration.groovy
@@ -189,6 +189,12 @@ class AwsConfiguration {
       LOG,
       MODIFY
     }
+
+    public static class LoadBalancerDefaults {
+      Boolean crossZoneBalancingDefault = true
+      Boolean connectionDrainingDefault = false
+      Integer deregistrationDelayDefault = null
+    }
     String iamRole
     String classicLinkSecurityGroupName
     boolean addAppGroupsToClassicLink = false
@@ -200,6 +206,7 @@ class AwsConfiguration {
     ReconcileMode reconcileClassicLinkSecurityGroups = ReconcileMode.NONE
     List<String> reconcileClassicLinkAccounts = []
     String defaultBlockDeviceType = "standard"
+    LoadBalancerDefaults loadBalancing = new LoadBalancerDefaults()
     AmazonBlockDevice unknownInstanceTypeBlockDevice = new AmazonBlockDevice(
       deviceName: "/dev/sdb", size: 20, volumeType: defaultBlockDeviceType
     )
@@ -209,7 +216,7 @@ class AwsConfiguration {
         return false
       }
       List<String> reconcileAccounts = reconcileClassicLinkAccounts ?: []
-      return reconcileAccounts.isEmpty() || reconcileAccounts.contains(credentials.getName());
+      return reconcileAccounts.isEmpty() || reconcileAccounts.contains(credentials.getName())
     }
 
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmazonLoadBalancerClassicDescription.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmazonLoadBalancerClassicDescription.java
@@ -27,6 +27,8 @@ public class UpsertAmazonLoadBalancerClassicDescription extends UpsertAmazonLoad
   private Integer unhealthyThreshold = 2;
   private Integer healthyThreshold = 10;
   private String application;
+  private Boolean connectionDraining;
+  private Integer deregistrationDelay;
 
   public List<Listener> getListeners() {
     return listeners;
@@ -84,7 +86,7 @@ public class UpsertAmazonLoadBalancerClassicDescription extends UpsertAmazonLoad
     this.crossZoneBalancing = crossZoneBalancing;
   }
 
-  private Boolean crossZoneBalancing = Boolean.TRUE;
+  private Boolean crossZoneBalancing;
 
   public String getApplication() {
     return application;
@@ -100,6 +102,22 @@ public class UpsertAmazonLoadBalancerClassicDescription extends UpsertAmazonLoad
 
   public void setHealthCheckPort(Integer healthCheckPort) {
     this.healthCheckPort = healthCheckPort;
+  }
+
+  public Boolean getConnectionDraining() {
+    return connectionDraining;
+  }
+
+  public void setConnectionDraining(Boolean connectionDraining) {
+    this.connectionDraining = connectionDraining;
+  }
+
+  public Integer getDeregistrationDelay() {
+    return deregistrationDelay;
+  }
+
+  public void setDeregistrationDelay(Integer deregistrationDelay) {
+    this.deregistrationDelay = deregistrationDelay;
   }
 
   public static class Listener {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/CreateAmazonLoadBalancerDescriptionValidator.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/CreateAmazonLoadBalancerDescriptionValidator.java
@@ -69,6 +69,12 @@ class CreateAmazonLoadBalancerDescriptionValidator extends AmazonDescriptionVali
         if (classicDescription.getListeners() == null || classicDescription.getListeners().size() == 0) {
           errors.rejectValue("listeners", "createAmazonLoadBalancerDescription.listeners.empty");
         }
+
+        if (classicDescription.getDeregistrationDelay() != null) {
+          if (classicDescription.getDeregistrationDelay() < 1 || classicDescription.getDeregistrationDelay() > 3600) {
+            errors.rejectValue("deregistrationDelay", "createAmazonLoadBalancerDescription.deregistrationDelay.invalid");
+          }
+        }
         break;
       case APPLICATION:
         UpsertAmazonLoadBalancerV2Description albDescription = (UpsertAmazonLoadBalancerV2Description) description;

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerV2AtomicOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerV2AtomicOperationSpec.groovy
@@ -20,6 +20,7 @@ import com.amazonaws.services.elasticloadbalancingv2.AmazonElasticLoadBalancing
 import com.amazonaws.services.elasticloadbalancingv2.model.*
 import com.amazonaws.services.shield.AWSShield
 import com.amazonaws.services.shield.model.CreateProtectionRequest
+import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerV2Description
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonLoadBalancerType
@@ -104,6 +105,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperationSpec extends Specification {
   def setup() {
     operation.amazonClientProvider = mockAmazonClientProvider
     operation.regionScopedProviderFactory = regionScopedProviderFactory
+    operation.deployDefaults = new AwsConfiguration.DeployDefaults()
   }
 
   void "should create load balancer"() {


### PR DESCRIPTION
Adds configurable connection draining support and defaults for classic loadbalancers.
Moves the default for cross zone balancing into a configurable option.

When modifying an existing load balancer, load balancer attributes are
not modified unless explicitly included in the request.
