### PR TITLE
fix(caching): caching agent metricsSupport being null obscures original exception

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.groovy
@@ -104,7 +104,9 @@ class CatsOnDemandCacheUpdater implements OnDemandCacheUpdater {
           log.info("$agent.providerName/$agent?.onDemandAgentType handled $type in ${TimeUnit.NANOSECONDS.toMillis(elapsed)} millis. Payload: $data")
         }
       } catch (e) {
-        agent.metricsSupport.countError()
+        if (agent.metricsSupport != null) {
+          agent.metricsSupport.countError()
+        }
         log.warn("$agent.providerName/$agent.onDemandAgentType failed to handle on demand update for $type", e)
       }
     }


### PR DESCRIPTION
We're getting an NPE here while running build integration tests which are obscuring the actual failure.