### PR TITLE
feat(provider/kuberntes): deploy priority

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -65,5 +65,6 @@ class LinkedDockerRegistryConfiguration {
 class CustomKubernetesResource {
   String kubernetesKind
   String spinnakerKind = KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED.toString()
+  String deployPriority = "100"
   boolean versioned = false
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CustomKubernetesHandlerFactory.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CustomKubernetesHandlerFactory.java
@@ -36,8 +36,8 @@ import com.netflix.spinnaker.clouddriver.model.Manifest;
 import lombok.extern.slf4j.Slf4j;
 
 public class CustomKubernetesHandlerFactory {
-  public static KubernetesHandler create(KubernetesKind kubernetesKind, SpinnakerKind spinnakerKind, boolean versioned) {
-    return new Handler(kubernetesKind, spinnakerKind, versioned);
+  public static KubernetesHandler create(KubernetesKind kubernetesKind, SpinnakerKind spinnakerKind, boolean versioned, int deployPriority) {
+    return new Handler(kubernetesKind, spinnakerKind, versioned, deployPriority);
   }
 
   @Slf4j
@@ -45,11 +45,18 @@ public class CustomKubernetesHandlerFactory {
     private final KubernetesKind kubernetesKind;
     private final SpinnakerKind spinnakerKind;
     private final boolean versioned;
+    private final int deployPriority;
 
-    Handler(KubernetesKind kubernetesKind, SpinnakerKind spinnakerKind, boolean versioned) {
+    Handler(KubernetesKind kubernetesKind, SpinnakerKind spinnakerKind, boolean versioned, int deployPriority) {
       this.kubernetesKind = kubernetesKind;
       this.spinnakerKind = spinnakerKind;
       this.versioned = versioned;
+      this.deployPriority = deployPriority;
+    }
+
+    @Override
+    public int deployPriority() {
+      return deployPriority;
     }
 
     @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleBindingHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleBindingHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.ROLE_BINDING_PRIORITY;
+
 @Component
 public class KubernetesClusterRoleBindingHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return ROLE_BINDING_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CLUSTER_ROLE_BINDING;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.ROLE_PRIORITY;
+
 @Component
 public class KubernetesClusterRoleHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return ROLE_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CLUSTER_ROLE;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesConfigMapHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesConfigMapHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.MOUNTABLE_DATA_PRIORITY;
+
 @Component
 public class KubernetesConfigMapHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return MOUNTABLE_DATA_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CONFIG_MAP;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesControllerRevisionHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesControllerRevisionHandler.java
@@ -28,6 +28,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class KubernetesControllerRevisionHandler extends KubernetesHandler implements CanDelete {
   @Override
+  public int deployPriority() {
+    throw new IllegalStateException("Controller revisions cannot be deployed.");
+  }
+
+  @Override
   public KubernetesKind kind() {
     return KubernetesKind.CONTROLLER_REVISION;
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
@@ -33,6 +33,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
+
 @Component
 public class KubernetesDaemonSetHandler extends KubernetesHandler implements
     CanResize,
@@ -48,6 +50,11 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler implements
     registerReplacer(ArtifactReplacerFactory.secretVolumeReplacer());
     registerReplacer(ArtifactReplacerFactory.configMapEnvFromReplacer());
     registerReplacer(ArtifactReplacerFactory.secretEnvFromReplacer());
+  }
+
+  @Override
+  public int deployPriority() {
+    return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Component;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA2;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
 
 @Component
 public class KubernetesDeploymentHandler extends KubernetesHandler implements
@@ -50,6 +51,11 @@ public class KubernetesDeploymentHandler extends KubernetesHandler implements
     registerReplacer(ArtifactReplacerFactory.secretVolumeReplacer());
     registerReplacer(ArtifactReplacerFactory.configMapEnvFromReplacer());
     registerReplacer(ArtifactReplacerFactory.secretEnvFromReplacer());
+  }
+
+  @Override
+  public int deployPriority() {
+    return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
@@ -28,6 +28,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class KubernetesEventHandler extends KubernetesHandler {
   @Override
+  public int deployPriority() {
+    throw new IllegalStateException("Events cannot be deployed.");
+  }
+
+  @Override
   public KubernetesKind kind() {
     return KubernetesKind.EVENT;
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHorizontalPodAutoscalerHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHorizontalPodAutoscalerHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_ATTACHMENT_PRIORITY;
+
 @Component
 public class KubernetesHorizontalPodAutoscalerHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return WORKLOAD_ATTACHMENT_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.HORIZONTAL_POD_AUTOSCALER;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
@@ -39,9 +39,15 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.NETWORK_RESOURCE_PRIORITY;
 
 @Component
 public class KubernetesIngressHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return NETWORK_RESOURCE_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.INGRESS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
@@ -33,6 +33,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
+
 @Component
 public class KubernetesJobHandler extends KubernetesHandler implements
   CanDelete,
@@ -44,6 +46,11 @@ public class KubernetesJobHandler extends KubernetesHandler implements
     registerReplacer(ArtifactReplacerFactory.secretVolumeReplacer());
     registerReplacer(ArtifactReplacerFactory.configMapEnvFromReplacer());
     registerReplacer(ArtifactReplacerFactory.secretEnvFromReplacer());
+  }
+
+  @Override
+  public int deployPriority() {
+    return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNamespaceHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNamespaceHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.NAMESPACE_PRIORITY;
+
 @Component
 public class KubernetesNamespaceHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return NAMESPACE_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.NAMESPACE;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNetworkPolicyHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNetworkPolicyHandler.java
@@ -29,8 +29,15 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.NETWORK_RESOURCE_PRIORITY;
+
 @Component
 public class KubernetesNetworkPolicyHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return NETWORK_RESOURCE_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.NETWORK_POLICY;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeClaimHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeClaimHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.MOUNTABLE_DATA_PRIORITY;
+
 @Component
 public class KubernetesPersistentVolumeClaimHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return MOUNTABLE_DATA_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.PERSISTENT_VOLUME_CLAIM;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.MOUNTABLE_DATA_BACKING_RESOURCE_PRIORITY;
+
 @Component
 public class KubernetesPersistentVolumeHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return MOUNTABLE_DATA_BACKING_RESOURCE_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.PERSISTENT_VOLUME;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
@@ -34,6 +34,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_PRIORITY;
+
 @Component
 public class KubernetesPodHandler extends KubernetesHandler implements CanDelete {
   public KubernetesPodHandler() {
@@ -44,6 +46,11 @@ public class KubernetesPodHandler extends KubernetesHandler implements CanDelete
             .type(ArtifactTypes.DOCKER_IMAGE)
             .build()
     );
+  }
+
+  @Override
+  public int deployPriority() {
+    return WORKLOAD_PRIORITY.getValue();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA2;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
 
 @Component
 public class KubernetesReplicaSetHandler extends KubernetesHandler implements
@@ -50,6 +51,11 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler implements
     registerReplacer(ArtifactReplacerFactory.secretVolumeReplacer());
     registerReplacer(ArtifactReplacerFactory.configMapEnvFromReplacer());
     registerReplacer(ArtifactReplacerFactory.secretEnvFromReplacer());
+  }
+
+  @Override
+  public int deployPriority() {
+    return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleBindingHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleBindingHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.ROLE_BINDING_PRIORITY;
+
 @Component
 public class KubernetesRoleBindingHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return ROLE_BINDING_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.ROLE_BINDING;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.ROLE_PRIORITY;
+
 @Component
 public class KubernetesRoleHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return ROLE_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.ROLE;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesSecretHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesSecretHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.MOUNTABLE_DATA_PRIORITY;
+
 @Component
 public class KubernetesSecretHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return MOUNTABLE_DATA_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.SECRET;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceAccountHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceAccountHandler.java
@@ -25,8 +25,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.SERVICE_ACCOUNT_PRIORITY;
+
 @Component
 public class KubernetesServiceAccountHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return SERVICE_ACCOUNT_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.SERVICE_ACCOUNT;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandler.java
@@ -32,9 +32,15 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.V1;
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.NETWORK_RESOURCE_PRIORITY;
 
 @Component
 public class KubernetesServiceHandler extends KubernetesHandler implements CanDelete {
+  @Override
+  public int deployPriority() {
+    return NETWORK_RESOURCE_PRIORITY.getValue();
+  }
+
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.SERVICE;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -18,8 +18,6 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacerFactory;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacer;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactTypes;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesStatefulSetCachingAgent;
@@ -34,6 +32,8 @@ import io.kubernetes.client.models.V1beta2StatefulSetStatus;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
 
 @Component
 public class KubernetesStatefulSetHandler extends KubernetesHandler implements
@@ -51,6 +51,11 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler implements
     registerReplacer(ArtifactReplacerFactory.secretVolumeReplacer());
     registerReplacer(ArtifactReplacerFactory.configMapEnvFromReplacer());
     registerReplacer(ArtifactReplacerFactory.secretEnvFromReplacer());
+  }
+
+  @Override
+  public int deployPriority() {
+    return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -130,6 +131,10 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     if (!unboundArtifacts.isEmpty()) {
       throw new IllegalArgumentException("The following artifacts could not be bound: '" + unboundArtifacts + "' . Failing the stage as this is likely a configuration error.");
     }
+
+    getTask().updateStatus(OP_NAME, "Sorting manifests by priority...");
+    deployManifests.sort(Comparator.comparingInt(m -> findResourceProperties(m).getHandler().deployPriority()));
+    getTask().updateStatus(OP_NAME, "Deploy order is: " + String.join(", ", deployManifests.stream().map(KubernetesManifest::getFullResourceName).collect(Collectors.toList())));
 
     OperationResult result = new OperationResult();
     for (KubernetesManifest manifest : deployManifests) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/HandlerPrioritySpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/HandlerPrioritySpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class HandlerPrioritySpec extends Specification {
+  @Unroll
+  void "check that #a is deployed before (has lower priority rating) #b"() {
+    when:
+    def aPriority = a.deployPriority()
+    def bPriority = b.deployPriority()
+
+    then:
+    aPriority < bPriority
+
+    where:
+    a                                    | b
+    new KubernetesNetworkPolicyHandler() | new KubernetesPodHandler()
+    new KubernetesNetworkPolicyHandler() | new KubernetesDeploymentHandler()
+    new KubernetesNetworkPolicyHandler() | new KubernetesStatefulSetHandler()
+    new KubernetesNetworkPolicyHandler() | new KubernetesDaemonSetHandler()
+    new KubernetesNetworkPolicyHandler() | new KubernetesReplicaSetHandler()
+    new KubernetesNamespaceHandler()     | new KubernetesNetworkPolicyHandler()
+    new KubernetesNamespaceHandler()     | new KubernetesRoleBindingHandler()
+    new KubernetesNamespaceHandler()     | new KubernetesRoleHandler()
+    new KubernetesNamespaceHandler()     | new KubernetesIngressHandler()
+    new KubernetesServiceHandler()       | new KubernetesPodHandler()
+    new KubernetesServiceHandler()       | new KubernetesDeploymentHandler()
+    new KubernetesConfigMapHandler()     | new KubernetesPodHandler()
+    new KubernetesConfigMapHandler()     | new KubernetesDeploymentHandler()
+    new KubernetesConfigMapHandler()     | new KubernetesStatefulSetHandler()
+    new KubernetesConfigMapHandler()     | new KubernetesDaemonSetHandler()
+    new KubernetesConfigMapHandler()     | new KubernetesReplicaSetHandler()
+  }
+}


### PR DESCRIPTION
There were two ways to do this,

1. Infer a dependency graph from the manifests, and walk the graph to deploy

2. Manually assign deployment priorities

While 1 seems cleaner, it has a few problems:

a) All relationships (e.g. a pod can mount a config map) need to be declared ahead of time

b) Not all relationships are as easily inferrable as "resource A references B by name"

  For example, we want a network policy governing pods' access to exist before the pods do, but this requires matching the pod labels, or knowing both exist in the same namespace

c) It's difficult to express in config how to determine what relationships to look for (dependencies to walk) for user-defined CRDs/TPRs

Closes https://github.com/spinnaker/spinnaker/issues/2304