### PR TITLE
fix(titus): Align default caching agent timeout with AWS (every 30s)

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
@@ -37,12 +37,10 @@ import javax.inject.Provider
 @Configuration
 class TitusCachingProviderConfig {
 
-  @Value('${titus.pollIntervalMillis:10000}')
-  // 10 seconds
+  @Value('${titus.pollIntervalMillis:30000}')
   Long pollIntervalMillis
 
   @Value('${titus.timeoutMillis:300000}')
-  // 5 minutes
   Long timeOutMilis
 
   @Bean


### PR DESCRIPTION
Now that the `TitusClusterCachingAgent` supports on-demand cache
refreshes, it seems unnecessary to have the agent run every 10s.

This PR aligns the caching interval with that of AWS (30s).
