### PR TITLE
refactor(provider/kubernetes): lay groundwork for "multi-kind" caching agents

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesEventCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesEventCachingAgent.java
@@ -30,6 +30,7 @@ import io.kubernetes.client.models.V1ObjectReference;
 import lombok.Getter;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,8 +69,9 @@ public class KubernetesEventCachingAgent extends KubernetesV2CachingAgent {
   }
 
   @Override
-  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(List<KubernetesManifest> primaryResourceList) {
-    Map<KubernetesManifest, List<KubernetesManifest>> result = primaryResourceList.stream()
+  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(Map<KubernetesKind, List<KubernetesManifest>> primaryResourceList) {
+    Map<KubernetesManifest, List<KubernetesManifest>> result = primaryResourceList.getOrDefault(primaryKind(), new ArrayList<>())
+        .stream()
         .map(m -> ImmutablePair.of(m, KubernetesCacheDataConverter.getResource(m, V1Event.class)))
         .collect(Collectors.toMap(ImmutablePair::getLeft, p -> Collections.singletonList(involvedManifest(p.getRight()))));
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesIngressCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesIngressCachingAgent.java
@@ -69,7 +69,7 @@ public class KubernetesIngressCachingAgent extends KubernetesV2OnDemandCachingAg
   }
 
   @Override
-  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(List<KubernetesManifest> ingresses) {
+  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(Map<KubernetesKind, List<KubernetesManifest>> ingresses) {
     Map<KubernetesManifest, List<KubernetesManifest>> result = new HashMap<>();
 
     BiFunction<String, String, String> manifestName = (namespace, name) -> namespace + ":" + name;
@@ -79,7 +79,7 @@ public class KubernetesIngressCachingAgent extends KubernetesV2OnDemandCachingAg
         .flatMap(Collection::stream)
         .collect(Collectors.toMap((m) -> manifestName.apply(m.getNamespace(), m.getName()), (m) -> m));
 
-    for (KubernetesManifest ingress : ingresses) {
+    for (KubernetesManifest ingress : ingresses.getOrDefault(primaryKind(), new ArrayList<>())) {
       List<KubernetesManifest> attachedServices = new ArrayList<>();
       try {
         attachedServices = KubernetesIngressHandler.attachedServices(ingress)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNamespaceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNamespaceCachingAgent.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -50,15 +51,16 @@ public class KubernetesNamespaceCachingAgent extends KubernetesV2CachingAgent {
   }
 
   @Override
-  protected List<KubernetesManifest> loadPrimaryResourceList() {
+  protected Map<KubernetesKind, List<KubernetesManifest>> loadPrimaryResourceList() {
     reloadNamespaces();
 
     // TODO perf: Only load desired namespaces rather than filter all.
     Set<String> desired = new HashSet<>(this.namespaces);
-    return super.loadPrimaryResourceList()
+    return Collections.singletonMap(KubernetesKind.NAMESPACE, super.loadPrimaryResourceList()
+        .get(KubernetesKind.NAMESPACE)
         .stream()
         .filter(ns -> desired.contains(ns.getName()))
-        .collect(Collectors.toList());
+        .collect(Collectors.toList()));
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesServiceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesServiceCachingAgent.java
@@ -68,7 +68,7 @@ public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAg
   }
 
   @Override
-  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(List<KubernetesManifest> services) {
+  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(Map<KubernetesKind, List<KubernetesManifest>> services) {
     Map<String, Set<KubernetesManifest>> mapLabelToManifest = new HashMap<>();
 
     // TODO perf - this might be excessive when only a small number of services are specified. We could consider
@@ -82,7 +82,7 @@ public class KubernetesServiceCachingAgent extends KubernetesV2OnDemandCachingAg
 
     Map<KubernetesManifest, List<KubernetesManifest>> result = new HashMap<>();
 
-    for (KubernetesManifest service : services) {
+    for (KubernetesManifest service : services.getOrDefault(primaryKind(), new ArrayList<>())) {
       result.put(service, getRelatedManifests(service, mapLabelToManifest));
     }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesStatefulSetCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesStatefulSetCachingAgent.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -69,7 +70,7 @@ public class KubernetesStatefulSetCachingAgent extends KubernetesV2OnDemandCachi
   }
 
   @Override
-  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(List<KubernetesManifest> primaryResourceList) {
+  protected Map<KubernetesManifest, List<KubernetesManifest>> loadSecondaryResourceRelationships(Map<KubernetesKind, List<KubernetesManifest>> primaryResourceList) {
     BiFunction<String, String, String> manifestName = (namespace, name) -> namespace + ":" + name;
 
     Map<String, KubernetesManifest> services = namespaces.stream()
@@ -79,7 +80,7 @@ public class KubernetesStatefulSetCachingAgent extends KubernetesV2OnDemandCachi
 
     Map<KubernetesManifest, List<KubernetesManifest>> result = new HashMap<>();
 
-    for (KubernetesManifest manifest : primaryResourceList) {
+    for (KubernetesManifest manifest : primaryResourceList.getOrDefault(primaryKind(), new ArrayList<>())) {
       String serviceName = KubernetesStatefulSetHandler.serviceName(manifest);
       if (StringUtils.isEmpty(serviceName)) {
         continue;

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesPodCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesPodCachingAgentSpec.groovy
@@ -58,7 +58,7 @@ class KubernetesPodCachingAgentSpec extends Specification {
     def credentials = Mock(KubernetesV2Credentials)
     credentials.getDeclaredNamespaces() >> [NAMESPACE]
 
-    credentials.list(KubernetesKind.POD, NAMESPACE) >> [new ObjectMapper().convertValue(pod, KubernetesManifest.class)]
+    credentials.list([KubernetesKind.POD], NAMESPACE) >> [new ObjectMapper().convertValue(pod, KubernetesManifest.class)]
 
     def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials)
     namedAccountCredentials.getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesReplicaSetCachingAgentSpec.groovy
@@ -62,7 +62,7 @@ class KubernetesReplicaSetCachingAgentSpec extends Specification {
     def credentials = Mock(KubernetesV2Credentials)
     credentials.getDeclaredNamespaces() >> [NAMESPACE]
 
-    credentials.list(KubernetesKind.REPLICA_SET, NAMESPACE) >> [new ObjectMapper().convertValue(replicaSet, KubernetesManifest.class)]
+    credentials.list([KubernetesKind.REPLICA_SET], NAMESPACE) >> [new ObjectMapper().convertValue(replicaSet, KubernetesManifest.class)]
 
     def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials)
     namedAccountCredentials.getCredentials() >> credentials


### PR DESCRIPTION
https://github.com/spinnaker/spinnaker/issues/2644

By default we currently register 23 agents per account, each making several kubectl calls per cycle. Adding agents is increasingly expensive.

All this does is allow us to register caching agents that cache multiple kinds -- no caching agents take advantage of that yet though.

@wjoel FYI