### PR TITLE
fix(provider/kubernetes): v2 Fix support for clusterrolebindings

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesClusterRoleBindingCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesClusterRoleBindingCachingAgent.java
@@ -46,7 +46,7 @@ public class KubernetesClusterRoleBindingCachingAgent extends KubernetesV2OnDema
   @Getter
   final private Collection<AgentDataType> providedDataTypes = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
-          AUTHORITATIVE.forType(KubernetesKind.ROLE_BINDING.toString())
+          AUTHORITATIVE.forType(KubernetesKind.CLUSTER_ROLE_BINDING.toString())
       ))
   );
 
@@ -57,6 +57,6 @@ public class KubernetesClusterRoleBindingCachingAgent extends KubernetesV2OnDema
 
   @Override
   protected KubernetesKind primaryKind() {
-    return KubernetesKind.ROLE_BINDING;
+    return KubernetesKind.CLUSTER_ROLE_BINDING;
   }
 }


### PR DESCRIPTION
The change in https://github.com/spinnaker/clouddriver/pull/2457 incorrectly modified the KubernetesClusterRoleBindingCachingAgent.