### PR TITLE
fix(titus): properly set scaling flags when enabling/disabling/resizing

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/ResizeTitusServerGroupAtomicOperation.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/ResizeTitusServerGroupAtomicOperation.groovy
@@ -47,6 +47,11 @@ class ResizeTitusServerGroupAtomicOperation implements AtomicOperation<Void> {
       throw new IllegalArgumentException("No titus server group named '${description.serverGroupName}' found")
     }
 
+    Boolean shouldToggleScalingFlags = !titusClient.getJob(job.id).inService
+    if (shouldToggleScalingFlags) {
+      titusClient.setAutoscaleEnabled(job.id, true)
+    }
+
     titusClient.resizeJob(
       new ResizeJobRequest()
         .withUser(description.user)
@@ -55,6 +60,10 @@ class ResizeTitusServerGroupAtomicOperation implements AtomicOperation<Void> {
         .withInstancesMin(description.capacity.min)
         .withInstancesMax(description.capacity.max)
     )
+
+    if (shouldToggleScalingFlags) {
+      titusClient.setAutoscaleEnabled(job.id, false)
+    }
 
     task.updateStatus PHASE, "Completed resize server group operation for ${description.serverGroupName}"
     null

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
@@ -181,8 +181,8 @@ public class RegionScopedV3TitusClient implements TitusClient {
       JobProcessesUpdate.newBuilder()
         .setServiceJobProcesses(
           ServiceJobSpec.ServiceJobProcesses.newBuilder()
-            .setDisableDecreaseDesired(shouldEnable)
-            .setDisableIncreaseDesired(shouldEnable)
+            .setDisableDecreaseDesired(!shouldEnable)
+            .setDisableIncreaseDesired(!shouldEnable)
             .build()
         )
         .setJobId(jobId)


### PR DESCRIPTION
We got a little confused with our verbs and are setting `disableDecreaseDesired` and `disableIncreaseDesired` to the opposite of what we should be setting them to.

Also, when resizing a disabled job, we need to ensure the flags are set correctly.

There is no plan to expose these flags at the level of granularity AWS exposes them at, so we are not going to try to track them and reset them any more than this when doing a resize.