### PR TITLE
fix(titus): add retry to kill task, ignore NOT_FOUND

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusException.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus;
+
+public class TitusException extends RuntimeException {
+  public TitusException(String message) {
+    super(message);
+  }
+
+  public TitusException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TitusException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/config/TitusConfiguration.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/config/TitusConfiguration.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentia
 import com.netflix.spinnaker.clouddriver.titus.deploy.handlers.TitusDeployHandler
 import com.netflix.spinnaker.clouddriver.titus.health.TitusHealthIndicator
 import com.netflix.spinnaker.clouddriver.titus.v3client.SimpleGrpcChannelFactory
+import com.netflix.spinnaker.kork.core.RetrySupport
 import groovy.util.logging.Slf4j
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -70,8 +71,8 @@ class TitusConfiguration {
   }
 
   @Bean
-  TitusClientProvider titusClientProvider(Registry registry, Optional<List<TitusJobCustomizer>> titusJobCustomizers, GrpcChannelFactory grpcChannelFactory) {
-    return new TitusClientProvider(registry, titusJobCustomizers.orElse(Collections.emptyList()), grpcChannelFactory)
+  TitusClientProvider titusClientProvider(Registry registry, Optional<List<TitusJobCustomizer>> titusJobCustomizers, GrpcChannelFactory grpcChannelFactory, RetrySupport retrySupport) {
+    return new TitusClientProvider(registry, titusJobCustomizers.orElse(Collections.emptyList()), grpcChannelFactory, retrySupport)
   }
 
   @Bean

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
@@ -21,6 +21,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import com.netflix.frigga.Names;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.titus.TitusException;
 import com.netflix.spinnaker.clouddriver.titus.client.TitusClient;
 import com.netflix.spinnaker.clouddriver.titus.client.TitusClientObjectMapper;
 import com.netflix.spinnaker.clouddriver.titus.client.TitusJobCustomizer;
@@ -213,12 +214,12 @@ public class RegionScopedV3TitusClient implements TitusClient {
           killTaskWithRetry(id, terminateTasksAndShrinkJob);
         } catch (Exception e) {
           failedTasks.add(id);
-          log.error("Failed to terminate and shrink titus task {}. Exception: {}", id, e);
+          log.error("Failed to terminate and shrink titus task {} in account {} and region {}", id, titusRegion.getAccount(), titusRegion.getName(), e);
         }
       }
     );
-    if (!failedTasks.isEmpty() && failedTasks.size() > 0) {
-      throw new RuntimeException("Failed to terminate and shrink titus tasks: " + StringUtils.join(failedTasks, ","));
+    if (!failedTasks.isEmpty()) {
+      throw new TitusException("Failed to terminate and shrink titus tasks: " + StringUtils.join(failedTasks, ","));
     }
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
@@ -29,7 +29,9 @@ import com.netflix.spinnaker.clouddriver.titus.client.model.*;
 import com.netflix.spinnaker.clouddriver.titus.client.model.HealthStatus;
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job;
 import com.netflix.spinnaker.clouddriver.titus.client.model.Task;
+import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.titus.grpc.protogen.*;
+import io.grpc.Status;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
@@ -65,9 +67,11 @@ public class RegionScopedV3TitusClient implements TitusClient {
 
   private final JobManagementServiceGrpc.JobManagementServiceBlockingStub grpcBlockingStub;
 
+  private final RetrySupport retrySupport;
 
-  public RegionScopedV3TitusClient(TitusRegion titusRegion, Registry registry, List<TitusJobCustomizer> titusJobCustomizers, String environment, String eurekaName, GrpcChannelFactory grpcChannelFactory) {
-    this(titusRegion, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, TitusClientObjectMapper.configure(), registry, titusJobCustomizers, environment, eurekaName, grpcChannelFactory);
+
+  public RegionScopedV3TitusClient(TitusRegion titusRegion, Registry registry, List<TitusJobCustomizer> titusJobCustomizers, String environment, String eurekaName, GrpcChannelFactory grpcChannelFactory, RetrySupport retrySupport) {
+    this(titusRegion, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, TitusClientObjectMapper.configure(), registry, titusJobCustomizers, environment, eurekaName, grpcChannelFactory, retrySupport);
   }
 
   public RegionScopedV3TitusClient(TitusRegion titusRegion,
@@ -78,13 +82,15 @@ public class RegionScopedV3TitusClient implements TitusClient {
                                    List<TitusJobCustomizer> titusJobCustomizers,
                                    String environment,
                                    String eurekaName,
-                                   GrpcChannelFactory channelFactory
+                                   GrpcChannelFactory channelFactory,
+                                   RetrySupport retrySupport
   ) {
     this.titusRegion = titusRegion;
     this.registry = registry;
     this.titusJobCustomizers = titusJobCustomizers;
     this.environment = environment;
     this.objectMapper = objectMapper;
+    this.retrySupport = retrySupport;
 
     String titusHost = "";
     try {
@@ -203,8 +209,22 @@ public class RegionScopedV3TitusClient implements TitusClient {
   @Override
   public void terminateTasksAndShrink(TerminateTasksAndShrinkJobRequest terminateTasksAndShrinkJob) {
     terminateTasksAndShrinkJob.getTaskIds().forEach(id ->
-      grpcBlockingStub.killTask(TaskKillRequest.newBuilder().setTaskId(id).setShrink(terminateTasksAndShrinkJob.isShrink()).build())
+      killTaskWithRetry(id, terminateTasksAndShrinkJob)
     );
+  }
+
+  private void killTaskWithRetry(String id, TerminateTasksAndShrinkJobRequest terminateTasksAndShrinkJob) {
+    try {
+      grpcBlockingStub.killTask(TaskKillRequest.newBuilder().setTaskId(id).setShrink(terminateTasksAndShrinkJob.isShrink()).build());
+    } catch (io.grpc.StatusRuntimeException e){
+      if (e.getStatus() == Status.NOT_FOUND) {
+        log.warn("Titus task {} not found, continuing with terminate tasks and shrink job request.", id);
+      } else {
+        retrySupport.retry(() ->
+            grpcBlockingStub.killTask(TaskKillRequest.newBuilder().setTaskId(id).setShrink(terminateTasksAndShrinkJob.isShrink()).build())
+        , 10, 2, false);
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
We're seeing occasional failures when a titus task cannot be found, and causes the operation to fail. If the task is terminate and shrink it's ok to ignore NOT_FOUND, but otherwise we should retry in case of transient failures. 