### PR TITLE
perf(aws): Optimize the retrieval of all security groups

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SecurityGroupProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SecurityGroupProvider.groovy
@@ -20,15 +20,15 @@ interface SecurityGroupProvider<T extends SecurityGroup> {
 
   String getCloudProvider()
 
-  Set<T> getAll(boolean includeRules)
+  Collection<T> getAll(boolean includeRules)
 
-  Set<T> getAllByRegion(boolean includeRules, String region)
+  Collection<T> getAllByRegion(boolean includeRules, String region)
 
-  Set<T> getAllByAccount(boolean includeRules, String account)
+  Collection<T> getAllByAccount(boolean includeRules, String account)
 
-  Set<T> getAllByAccountAndName(boolean includeRules, String account, String name)
+  Collection<T> getAllByAccountAndName(boolean includeRules, String account, String name)
 
-  Set<T> getAllByAccountAndRegion(boolean includeRule, String account, String region)
+  Collection<T> getAllByAccountAndRegion(boolean includeRule, String account, String region)
 
   T get(String account, String region, String name, String vpcId)
 


### PR DESCRIPTION
When `includeRules` is `false`, the cache key for a security group
actually includes all relevant information.

We _do not_ need to retrieve all objects and can instead just parse
keys and manually construct an `AmazonSecurityGroup`.

There is _some_ chance that the set of identifiers includes some
security groups that do not actually exist. I believe this to be of
minimal risk and the performance benefits outweigh the potential for
issue.

The return types in `SecurityGroupProvider` were changed from `Set` to
`List`. It turns out that converting a list of 20k items to a set takes
a non-zero amount of time.
