### PR TITLE
fix(titus): revert netty but keep titusRegion.url change

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/SimpleGrpcChannelFactory.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/SimpleGrpcChannelFactory.groovy
@@ -20,17 +20,11 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.titus.client.TitusRegion
 import com.netflix.spinnaker.clouddriver.titus.client.model.GrpcChannelFactory
 import io.grpc.ManagedChannel
-import io.grpc.netty.shaded.io.grpc.netty.NegotiationType
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
+import io.grpc.ManagedChannelBuilder
 
 class SimpleGrpcChannelFactory implements GrpcChannelFactory {
   @Override
   ManagedChannel build(TitusRegion titusRegion, String environment, String eurekaName, long defaultConnectTimeOut, Registry registry) {
-    return NettyChannelBuilder
-      .forAddress(titusRegion.url, titusRegion.port)
-      .negotiationType(NegotiationType.TLS)
-      .maxHeaderListSize(65536)
-      .maxInboundMessageSize(65536)
-      .build()
+    return ManagedChannelBuilder.forAddress(titusRegion.url, titusRegion.port).usePlaintext(true).build();
   }
 }


### PR DESCRIPTION
Reverting netty channel builder but keeping the property change of `.url`