### PR TITLE
feat(titus): adding feature flag in region scoped titus client

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusRegion.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusRegion.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.client;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,7 +31,7 @@ public class TitusRegion {
   private final String applicationName;
   private final String url;
   private final int port;
-  private final Boolean experimentalFeaturesEnabled;
+  private final List<String> featureFlags;
 
   private <T> T notNull(T val, String name) {
     if (val == null) {
@@ -49,7 +50,7 @@ public class TitusRegion {
                      String applicationName,
                      String url,
                      Integer port,
-                     Boolean experimentalFeaturesEnabled
+                     List<String> featureFlags
   ) {
     this.name = notNull(name, "name");
     this.account = notNull(account, "account");
@@ -65,15 +66,15 @@ public class TitusRegion {
     } else {
       this.port = 7104;
     }
-    if (experimentalFeaturesEnabled == null) {
-      this.experimentalFeaturesEnabled = false;
+    if (featureFlags == null) {
+      this.featureFlags = new ArrayList<>();
     } else {
-      this.experimentalFeaturesEnabled = experimentalFeaturesEnabled;
+      this.featureFlags = featureFlags;
     }
   }
 
-  public TitusRegion(String name, String account, String endpoint, Boolean autoscalingEnabled, Boolean loadBalancingEnabled, String apiVersion, String applicationName, String url, Integer port, Boolean experimentalFeaturesEnabled) {
-    this(name, account, endpoint, autoscalingEnabled, loadBalancingEnabled, Collections.emptyList(), apiVersion, applicationName, url, port, experimentalFeaturesEnabled);
+  public TitusRegion(String name, String account, String endpoint, Boolean autoscalingEnabled, Boolean loadBalancingEnabled, String apiVersion, String applicationName, String url, Integer port, List<String> featureFlags) {
+    this(name, account, endpoint, autoscalingEnabled, loadBalancingEnabled, Collections.emptyList(), apiVersion, applicationName, url, port, featureFlags);
   }
 
   public String getAccount() {
@@ -112,8 +113,8 @@ public class TitusRegion {
 
   public String getUrl() { return url; }
 
-  public Boolean getExperimentalFeaturesEnabled() {
-    return experimentalFeaturesEnabled;
+  public List<String> getFeatureFlags() {
+    return featureFlags;
   }
 
   @Override

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusRegion.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusRegion.java
@@ -30,6 +30,7 @@ public class TitusRegion {
   private final String applicationName;
   private final String url;
   private final int port;
+  private final Boolean experimentalFeaturesEnabled;
 
   private <T> T notNull(T val, String name) {
     if (val == null) {
@@ -47,7 +48,8 @@ public class TitusRegion {
                      String apiVersion,
                      String applicationName,
                      String url,
-                     Integer port
+                     Integer port,
+                     Boolean experimentalFeaturesEnabled
   ) {
     this.name = notNull(name, "name");
     this.account = notNull(account, "account");
@@ -63,10 +65,15 @@ public class TitusRegion {
     } else {
       this.port = 7104;
     }
+    if (experimentalFeaturesEnabled == null) {
+      this.experimentalFeaturesEnabled = false;
+    } else {
+      this.experimentalFeaturesEnabled = experimentalFeaturesEnabled;
+    }
   }
 
-  public TitusRegion(String name, String account, String endpoint, Boolean autoscalingEnabled, Boolean loadBalancingEnabled, String apiVersion, String applicationName, String url, Integer port) {
-    this(name, account, endpoint, autoscalingEnabled, loadBalancingEnabled, Collections.emptyList(), apiVersion, applicationName, url, port);
+  public TitusRegion(String name, String account, String endpoint, Boolean autoscalingEnabled, Boolean loadBalancingEnabled, String apiVersion, String applicationName, String url, Integer port, Boolean experimentalFeaturesEnabled) {
+    this(name, account, endpoint, autoscalingEnabled, loadBalancingEnabled, Collections.emptyList(), apiVersion, applicationName, url, port, experimentalFeaturesEnabled);
   }
 
   public String getAccount() {
@@ -104,6 +111,10 @@ public class TitusRegion {
   public Integer getPort() { return port; }
 
   public String getUrl() { return url; }
+
+  public Boolean getExperimentalFeaturesEnabled() {
+    return experimentalFeaturesEnabled;
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/config/TitusConfiguration.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/config/TitusConfiguration.groovy
@@ -57,7 +57,7 @@ class TitusConfiguration {
     List<NetflixTitusCredentials> accounts = new ArrayList<>()
     for (TitusCredentialsConfig.Account account in titusCredentialsConfig.accounts) {
       List<TitusRegion> regions = account.regions.collect {
-        new TitusRegion(it.name, account.name, it.endpoint, it.autoscalingEnabled, it.loadBalancingEnabled, it.apiVersion, it.applicationName, it.url, it.port, it.experimentalFeaturesEnabled)
+        new TitusRegion(it.name, account.name, it.endpoint, it.autoscalingEnabled, it.loadBalancingEnabled, it.apiVersion, it.applicationName, it.url, it.port, it.featureFlags)
       }
       if (!account.bastionHost && titusCredentialsConfig.defaultBastionHostTemplate) {
         account.bastionHost = titusCredentialsConfig.defaultBastionHostTemplate.replaceAll(Pattern.quote('{{environment}}'), account.environment)
@@ -121,7 +121,7 @@ class TitusConfiguration {
       String applicationName
       String url
       Integer port
-      Boolean experimentalFeaturesEnabled
+      List<String> featureFlags
     }
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/config/TitusConfiguration.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/config/TitusConfiguration.groovy
@@ -57,7 +57,7 @@ class TitusConfiguration {
     List<NetflixTitusCredentials> accounts = new ArrayList<>()
     for (TitusCredentialsConfig.Account account in titusCredentialsConfig.accounts) {
       List<TitusRegion> regions = account.regions.collect {
-        new TitusRegion(it.name, account.name, it.endpoint, it.autoscalingEnabled, it.loadBalancingEnabled, it.apiVersion, it.applicationName, it.url, it.port)
+        new TitusRegion(it.name, account.name, it.endpoint, it.autoscalingEnabled, it.loadBalancingEnabled, it.apiVersion, it.applicationName, it.url, it.port, it.experimentalFeaturesEnabled)
       }
       if (!account.bastionHost && titusCredentialsConfig.defaultBastionHostTemplate) {
         account.bastionHost = titusCredentialsConfig.defaultBastionHostTemplate.replaceAll(Pattern.quote('{{environment}}'), account.environment)
@@ -121,6 +121,7 @@ class TitusConfiguration {
       String applicationName
       String url
       Integer port
+      Boolean experimentalFeaturesEnabled
     }
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.titus.client.model.Job;
 import com.netflix.spinnaker.clouddriver.titus.client.model.Task;
 import com.netflix.titus.grpc.protogen.*;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -97,8 +98,11 @@ public class RegionScopedV3TitusClient implements TitusClient {
     }
     this.grpcBlockingStub = JobManagementServiceGrpc.newBlockingStub(channelFactory.build(titusRegion, environment, eurekaName, DEFAULT_CONNECT_TIMEOUT, registry));
 
-    if (titusRegion.getExperimentalFeaturesEnabled()) {
-      log.info("Experimental Titus V3 client features enabled for account {} and region {}", titusRegion.getAccount(), titusRegion.getName());
+    if (!titusRegion.getFeatureFlags().isEmpty()) {
+      log.info("Experimental Titus V3 client feature flags {} enabled for account {} and region {}",
+        StringUtils.join(titusRegion.getFeatureFlags(),","),
+        titusRegion.getAccount(),
+        titusRegion.getName());
     }
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
@@ -30,7 +30,7 @@ import com.netflix.spinnaker.clouddriver.titus.client.model.HealthStatus;
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job;
 import com.netflix.spinnaker.clouddriver.titus.client.model.Task;
 import com.netflix.titus.grpc.protogen.*;
-import groovy.util.logging.Log;
+import lombok.extern.slf4j.Slf4j;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Log
+@Slf4j
 public class RegionScopedV3TitusClient implements TitusClient {
 
   /**
@@ -96,6 +96,10 @@ public class RegionScopedV3TitusClient implements TitusClient {
 
     }
     this.grpcBlockingStub = JobManagementServiceGrpc.newBlockingStub(channelFactory.build(titusRegion, environment, eurekaName, DEFAULT_CONNECT_TIMEOUT, registry));
+
+    if (titusRegion.getExperimentalFeaturesEnabled()) {
+      log.info("Experimental Titus V3 client features enabled for account {} and region {}", titusRegion.getAccount(), titusRegion.getName());
+    }
   }
 
   // APIs

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
@@ -52,7 +52,7 @@ class TitusDeployHandlerSpec extends Specification {
   }
 
   NetflixTitusCredentials testCredentials = new NetflixTitusCredentials(
-    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, '2', "blah", "blah", 7104, false)], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
+    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, '2', "blah", "blah", 7104, [])], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
   )
 
   @Subject

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
@@ -52,7 +52,7 @@ class TitusDeployHandlerSpec extends Specification {
   }
 
   NetflixTitusCredentials testCredentials = new NetflixTitusCredentials(
-    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, '2', "blah", "blah", 7104)], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
+    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, '2', "blah", "blah", 7104, false)], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
   )
 
   @Subject

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusServerGroupAtomicOperationSpec.groovy
@@ -38,7 +38,7 @@ class DestroyTitusServerGroupAtomicOperationSpec extends Specification {
   }
 
   NetflixTitusCredentials testCredentials = new NetflixTitusCredentials(
-    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, '2', "blah", "blah", 7104)], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
+    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, '2', "blah", "blah", 7104, false)], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
   )
 
   DestroyTitusServerGroupDescription description = new DestroyTitusServerGroupDescription(

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusServerGroupAtomicOperationSpec.groovy
@@ -38,7 +38,7 @@ class DestroyTitusServerGroupAtomicOperationSpec extends Specification {
   }
 
   NetflixTitusCredentials testCredentials = new NetflixTitusCredentials(
-    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, '2', "blah", "blah", 7104, false)], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
+    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, '2', "blah", "blah", 7104, [])], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
   )
 
   DestroyTitusServerGroupDescription description = new DestroyTitusServerGroupDescription(

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClientSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClientSpec.groovy
@@ -33,7 +33,7 @@ class RegionScopedV3TitusClientSpec extends Specification {
     setup:
     Logger logger = LoggerFactory.getLogger(TitusClient)
     TitusRegion titusRegion = new TitusRegion(
-      "us-east-1", "test", "http://titusapi.mainvpc.us-east-1.dyntest.netflix.net:7001/", "3", "blah", "blah", 7104
+      "us-east-1", "test", "http://titusapi.mainvpc.us-east-1.dyntest.netflix.net:7001/", "3", "blah", "blah", 7104, false
     );
     TitusClient titusClient = new RegionScopedV3TitusClient(titusRegion, new NoopRegistry(), Collections.emptyList(), "test", "titusapigrpc-mcetest-mainvpc");
 

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClientSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClientSpec.groovy
@@ -33,7 +33,7 @@ class RegionScopedV3TitusClientSpec extends Specification {
     setup:
     Logger logger = LoggerFactory.getLogger(TitusClient)
     TitusRegion titusRegion = new TitusRegion(
-      "us-east-1", "test", "http://titusapi.mainvpc.us-east-1.dyntest.netflix.net:7001/", "3", "blah", "blah", 7104, false
+      "us-east-1", "test", "http://titusapi.mainvpc.us-east-1.dyntest.netflix.net:7001/", "3", "blah", "blah", 7104, []
     );
     TitusClient titusClient = new RegionScopedV3TitusClient(titusRegion, new NoopRegistry(), Collections.emptyList(), "test", "titusapigrpc-mcetest-mainvpc");
 


### PR DESCRIPTION
Titus Region Client can now behave differently in different Titus regions, so we can slowly roll out new client features.

Config option is at the region level, just like `apiVersion`, and is controlled with Boolean flag `experimentalFeaturesEnabled`