### PR TITLE
fix(titus): change titus api to make intent of getJob more explicit

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusJobProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusJobProvider.groovy
@@ -64,14 +64,14 @@ class TitusJobProvider implements JobProvider<TitusJobStatus> {
   @Override
   TitusJobStatus collectJob(String account, String location, String id) {
     TitusClient titusClient = titusClientProvider.getTitusClient(accountCredentialsProvider.getCredentials(account), location)
-    Job job = titusClient.getJob(id)
+    Job job = titusClient.getJobAndAllRunningAndCompletedTasks(id)
     new TitusJobStatus(job, account, location)
   }
 
   @Override
   Map<String, Object> getFileContents(String account, String location, String id, String fileName) {
     TitusClient titusClient = titusClientProvider.getTitusClient(accountCredentialsProvider.getCredentials(account), location)
-    Job job = titusClient.getJob(id)
+    Job job = titusClient.getJobAndAllRunningAndCompletedTasks(id)
 
     def fileContents
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusClient.java
@@ -27,7 +27,7 @@ public interface TitusClient {
    * @param jobId
    * @return
    */
-  public Job getJob(String jobId);
+  public Job getJobAndAllRunningAndCompletedTasks(String jobId);
 
   /**
    * @param jobName

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClient.java
@@ -102,7 +102,7 @@ public class RegionScopedV3TitusClient implements TitusClient {
   // ------------------------------------------------------------------------------------------
 
   @Override
-  public Job getJob(String jobId) {
+  public Job getJobAndAllRunningAndCompletedTasks(String jobId) {
     return new Job(grpcBlockingStub.findJob(JobId.newBuilder().setId(jobId).build()), getTasks(Arrays.asList(jobId), true).get(jobId));
   }
 

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClientSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/v3client/RegionScopedV3TitusClientSpec.groovy
@@ -89,7 +89,7 @@ class RegionScopedV3TitusClientSpec extends Specification {
     logger.info("jobId: {}", jobId);
 
     when:
-    Job job = titusClient.getJob(jobId);
+    Job job = titusClient.getJobAndAllRunningAndCompletedTasks(jobId);
 
     then:
     logger.info("job {}", job);
@@ -130,7 +130,7 @@ class RegionScopedV3TitusClientSpec extends Specification {
     // ******************************************************************************************************************
 
     when:
-    job = titusClient.getJob(jobId);
+    job = titusClient.getJobAndAllRunningAndCompletedTasks(jobId);
     logger.info("Found submitted job in the list of jobs");
 
     then:
@@ -151,7 +151,7 @@ class RegionScopedV3TitusClientSpec extends Specification {
       .withInstancesMax(10)
     )
 
-    job = titusClient.getJob(jobId);
+    job = titusClient.getJobAndAllRunningAndCompletedTasks(jobId);
 
     then:
     job.instancesDesired == 1
@@ -167,7 +167,7 @@ class RegionScopedV3TitusClientSpec extends Specification {
     boolean terminated = false;
     Job terminatedJob = null;
     while (--j > 0) {
-      terminatedJob = titusClient.getJob(jobId);
+      terminatedJob = titusClient.getJobAndAllRunningAndCompletedTasks(jobId);
       Job.TaskSummary task = terminatedJob.getTasks().get(0);
       if (task.getState() == TaskState.DEAD ||
         task.getState() == TaskState.STOPPED ||


### PR DESCRIPTION
getJob in titus can be very expensive if there are a lot of terminated tasks in services. This method is really intended to be used with the run job stage, so making it clearer in the api that this is the case