### PR TITLE
fix(provider/kubernetes): don't fail credentials lookup if cluster is…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -309,7 +309,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         result = liveNamespaceSupplier.get();
 
       } catch (KubectlException e) {
-        throw new RuntimeException(e);
+        log.warn("Could not list namespaces for account {}: {}", accountName, e.getMessage());
+        return new ArrayList<>();
       }
     }
 


### PR DESCRIPTION
… unreachable

