### PR TITLE
fix(provider/kubernetes): v2 search omit null

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
@@ -230,6 +230,7 @@ public class KubernetesV2SearchProvider implements SearchProvider {
               return result;
             }
         )
+        .filter(Objects::nonNull)
         .collect(Collectors.toList()));
 
 


### PR DESCRIPTION
Happens only when you have stale cache entries & no v2 accounts registered anymore, but still frustrating since it breaks all of search