### PR TITLE
fix(provider/kubernetes): v2 search omit null (#2568)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
@@ -230,6 +230,7 @@ public class KubernetesV2SearchProvider implements SearchProvider {
               return result;
             }
         )
+        .filter(Objects::nonNull)
         .collect(Collectors.toList()));
 
 


### PR DESCRIPTION
cherry-pick 1.7