### PR TITLE
fix(provider/kubernetes): lookup of oldest server group (#2573)

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
@@ -230,6 +230,7 @@ class ClusterController {
 
       return serverGroups
     }.flatten()
+    .findAll { it.createdTime != null }
     .sort { a, b -> b.createdTime <=> a.createdTime }
 
     def expandServerGroup = { ServerGroup serverGroup ->


### PR DESCRIPTION
This isn't ideal, since what's really happening is we are querying each
cloud provider (even ones not in use, in this case k8s v2) if it
supports 'minimal clusters'. v1 doesn't, v2 does. This winds up loading
the same cache entry twice, once with and once without a timestamp. As a
result, some cache entries show up twice, at the end of the list of
returned server groups.
