### PR TITLE
fix(entitytags): Avoid an `UnsupportedOperationException`

### DIFF
--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperation.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/BulkUpsertEntityTagsAtomicOperation.java
@@ -62,8 +62,17 @@ public class BulkUpsertEntityTagsAtomicOperation implements AtomicOperation<Bulk
 
   public BulkUpsertEntityTagsAtomicOperationResult operate(List priorOutputs) {
     BulkUpsertEntityTagsAtomicOperationResult result = new BulkUpsertEntityTagsAtomicOperationResult();
-    List<EntityTags> entityTags = bulkUpsertEntityTagsDescription.entityTags;
 
+    if (bulkUpsertEntityTagsDescription.entityTags != null) {
+      // ensure that this collection is _not_ unmodifiable
+      bulkUpsertEntityTagsDescription.entityTags = new ArrayList<>(
+        bulkUpsertEntityTagsDescription.entityTags
+      );
+    } else {
+      bulkUpsertEntityTagsDescription.entityTags = new ArrayList<>();
+    }
+
+    List<EntityTags> entityTags = bulkUpsertEntityTagsDescription.entityTags;
     addTagIdsIfMissing(entityTags, result);
 
     mergeTags(bulkUpsertEntityTagsDescription);


### PR DESCRIPTION
Avoid the resulting `UnsupportedOperationException` stemming from
`entityTags.removeAll()` when `entityTags` is an empty unmodifiable
list.
