### PR TITLE
feat(reservations): Support for a 'v4' reservation report

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReport.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonReservationReport.groovy
@@ -218,16 +218,16 @@ class AmazonReservationReport implements ReservationReport {
     int index
 
     @JsonView(Views.V3.class)
-    int totalRegionalSurplusForFamily
+    Integer totalRegionalSurplusForFamily
 
     @JsonView(Views.V3.class)
-    int totalShortfallForFamily
+    Integer totalShortfallForFamily
 
     @JsonView(Views.V3.class)
-    double percentageOfShortfall
+    Double percentageOfShortfall
 
     @JsonView(Views.V3.class)
-    int portionOfAvailableSurplus
+    Double portionOfAvailableSurplus
   }
 
   static class DescendingOverallReservationDetailComparator implements Comparator<OverallReservationDetail> {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCertificateCac
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLoadBalancerCachingAgent
 
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservedInstancesCachingAgent
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonS3DataProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig
@@ -61,6 +62,7 @@ class AwsProviderConfig {
   @DependsOn('netflixAmazonCredentials')
   AwsProvider awsProvider(AmazonCloudProvider amazonCloudProvider,
                           AmazonClientProvider amazonClientProvider,
+                          AmazonS3DataProvider amazonS3DataProvider,
                           AccountCredentialsRepository accountCredentialsRepository,
                           ObjectMapper objectMapper,
                           EddaApiFactory eddaApiFactory,
@@ -75,6 +77,7 @@ class AwsProviderConfig {
     synchronizeAwsProvider(awsProvider,
                            amazonCloudProvider,
                            amazonClientProvider,
+                           amazonS3DataProvider,
                            accountCredentialsRepository,
                            objectMapper,
                            eddaApiFactory,
@@ -111,6 +114,7 @@ class AwsProviderConfig {
   AwsProviderSynchronizer synchronizeAwsProvider(AwsProvider awsProvider,
                                                  AmazonCloudProvider amazonCloudProvider,
                                                  AmazonClientProvider amazonClientProvider,
+                                                 AmazonS3DataProvider amazonS3DataProvider,
                                                  AccountCredentialsRepository accountCredentialsRepository,
                                                  ObjectMapper objectMapper,
                                                  EddaApiFactory eddaApiFactory,
@@ -161,7 +165,7 @@ class AwsProviderConfig {
     } else {
       // This caching agent runs across all accounts in one iteration (to maintain consistency).
       newlyAddedAgents << new ReservationReportCachingAgent(
-        registry, amazonClientProvider, allAccounts, objectMapper, reservationReportPool, ctx
+        registry, amazonClientProvider, amazonS3DataProvider, allAccounts, objectMapper, reservationReportPool, ctx
       )
     }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ReservationReportCachingAgentSpec.groovy
@@ -61,8 +61,10 @@ class ReservationReportCachingAgentSpec extends Specification {
     ]
 
     3 * registry.createId("reservedInstances.errors") >> registryId
-    2 * registryId.withTags([account: "test", region: "us-west-1"]) >> registryId
-    1 * registryId.withTags([account: "test", region: "us-west-2"]) >> registryId
+    2 * registryId.withTag("account", "test") >> registryId
+    2 * registryId.withTag("region", "us-west-1") >> registryId
+    1 * registryId.withTag("account", "test") >> registryId
+    1 * registryId.withTag("region", "us-west-2") >> registryId
     3 * registry.counter(registryId) >> counter
     3 * counter.increment()
   }


### PR DESCRIPTION
The V4 reservation report allows an external source (ie. file in s3) to
define how surplus regional reservations should be shared with their
AZ equivalents.

This is likely to remain a Netflix-specific variant.
