### PR TITLE
feat(artifacts): Add custom API endpoint for S3 client

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
@@ -25,4 +25,6 @@ import lombok.EqualsAndHashCode;
 public class S3ArtifactAccount extends ArtifactAccount
 {
   private String name;
+  private String apiEndpoint;
+  private String apiRegion;
 }


### PR DESCRIPTION
Currently the S3 client does not support custom API endpoints. This PR adds `apiEndpoint` and `apiRegion` fields to `artifacts.s3.accounts`, and adds them to the S3 client.