### PR TITLE
chore(provider/kubernetes): reduce log level for artifact swapping

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
@@ -65,7 +65,7 @@ public class ArtifactReplacer {
   }
 
   public ReplaceResult replaceAll(KubernetesManifest input, List<Artifact> artifacts) {
-    log.info("Doing replacement on {} using {}", input, artifacts);
+    log.debug("Doing replacement on {} using {}", input, artifacts);
     DocumentContext document;
     try {
       document = JsonPath.using(configuration).parse(mapper.writeValueAsString(input));


### PR DESCRIPTION
This prints each entire manifest during a deploy, and is rather noisy.