### PR TITLE
fix(aws) Security group retrieval fix

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProvider.groovy
@@ -66,7 +66,7 @@ class AmazonSecurityGroupProvider implements SecurityGroupProvider<AmazonSecurit
   @Override
   Collection<AmazonSecurityGroup> getAll(boolean includeRules) {
     if (!includeRules) {
-      def identifiers = cacheView.getIdentifiers(SECURITY_GROUPS.ns)
+      def identifiers = cacheView.filterIdentifiers(SECURITY_GROUPS.ns, Keys.getSecurityGroupKey('*', '*', '*', '*', '*'))
       return identifiers.collect {
         Map parts = Keys.parse(it)
         new AmazonSecurityGroup(


### PR DESCRIPTION
A small regression of this https://github.com/spinnaker/clouddriver/pull/2539

Using this `cacheView.getIdentifiers(SECURITY_GROUPS.ns)` fetches all security groups (including from providers other than AWS) which will then result in NPE.
The fix will fetch keys for all security groups but only from AWS.