### PR TITLE
fix(artifacts): S3 is unable to talk to custom API endpoint

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
@@ -25,4 +25,6 @@ import lombok.EqualsAndHashCode;
 public class S3ArtifactAccount extends ArtifactAccount
 {
   private String name;
+  private String apiEndpoint;
+  private String apiRegion;
 }


### PR DESCRIPTION
Currently the S3 client fails to support custom API endpoints. We fixed this by having the S3 client read `apiEndpoint` and `apiRegion` from `artifacts.s3.accounts`.