### PR TITLE
perf(amazon): optimize target group loading for /loadBalancers

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -113,8 +113,8 @@ class Keys implements KeyParser {
         break
       case Namespace.TARGET_GROUPS.ns:
         def names = Names.parseName(parts[4])
-        String vpcId = parts.length > 5 ? (parts[5] ?: null) : null
-        result << [account: parts[2], region: parts[3], targetGroup: parts[4], vpcId: vpcId, application: names.app?.toLowerCase(), stack: names.stack, detail: names.detail]
+        String vpcId = parts.length > 6 ? (parts[6] ?: null) : null
+        result << [account: parts[2], region: parts[3], targetGroup: parts[4], vpcId: vpcId, application: names.app?.toLowerCase(), stack: names.stack, detail: names.detail, targetType: parts[5]]
         break
       case Namespace.CLUSTERS.ns:
         def names = Names.parseName(parts[4])
@@ -170,8 +170,8 @@ class Keys implements KeyParser {
     return key
   }
 
-  static String getTargetGroupKey(String targetGroupName, String account, String region, String vpcId) {
-    "${ID}:${Namespace.TARGET_GROUPS}:${account}:${region}:${targetGroupName}:${vpcId}"
+  static String getTargetGroupKey(String targetGroupName, String account, String region, String targetGroupType, String vpcId) {
+    "${ID}:${Namespace.TARGET_GROUPS}:${account}:${region}:${targetGroupName}:${targetGroupType}:${vpcId}"
   }
 
   static String getClusterKey(String clusterName, String application, String account) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -30,6 +30,7 @@ import com.amazonaws.services.cloudwatch.model.MetricAlarm
 import com.amazonaws.services.ec2.AmazonEC2
 import com.amazonaws.services.ec2.model.DescribeSubnetsRequest
 import com.amazonaws.services.ec2.model.Subnet
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetTypeEnum
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.type.TypeReference
@@ -724,7 +725,7 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
       } as Set).asImmutable()
 
       targetGroupKeys = (targetGroupNames.collect {
-        Keys.getTargetGroupKey(it, account, region, vpcId)
+        Keys.getTargetGroupKey(it, account, region, TargetTypeEnum.Instance.toString(), vpcId)
       } as Set).asImmutable()
 
       instanceIds = (asg.instances.instanceId.collect { Keys.getInstanceKey(it, account, region) } as Set).asImmutable()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
@@ -274,7 +274,15 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
   List<AmazonLoadBalancerSummary> list() {
     def searchKey = Keys.getLoadBalancerKey('*', '*', '*', null, null) + '*'
     Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, searchKey)
-    getSummaryForLoadBalancers(identifiers).values() as List
+    Map<String, Map<String, String>> targetGroupKeys = cacheView.getIdentifiers(TARGET_GROUPS.ns).collectEntries {
+      Map<String, String> parts = Keys.parse(it)
+      Map<String, String> summary = [
+        name: parts.targetGroup,
+        targetType: parts.targetType
+      ]
+      return [(it): summary]
+    }
+    getSummaryForLoadBalancers(identifiers, targetGroupKeys).values() as List
   }
 
   AmazonLoadBalancerSummary get(String name) {
@@ -283,7 +291,7 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
       def key = Keys.parse(it)
       key.loadBalancer == name
     }
-    getSummaryForLoadBalancers(identifiers).get(name)
+    getSummaryForLoadBalancers(identifiers, null).get(name)
   }
 
   List<Map> byAccountAndRegionAndName(String account,
@@ -309,11 +317,18 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
     }
   }
 
-  private Map<String, AmazonLoadBalancerSummary> getSummaryForLoadBalancers(Collection<String> loadBalancerKeys) {
+  private Map<String, Map<String, String>> getTargetGroupSummariesForLoadBalancer(Collection<CacheData> loadBalancerData) {
+    Collection<CacheData> targetGroupData = resolveRelationshipDataForCollection(loadBalancerData, TARGET_GROUPS.ns)
+    return targetGroupData.collectEntries {
+      [(it.id): [ name: it.attributes.targetGroupName, targetType: it.attributes.targetType ]]
+    }
+  }
+
+  private Map<String, AmazonLoadBalancerSummary> getSummaryForLoadBalancers(Collection<String> loadBalancerKeys, Map<String, Map<String, String>> targetGroupMap) {
     Map<String, AmazonLoadBalancerSummary> map = [:]
     Collection<CacheData> loadBalancerData = cacheView.getAll(LOAD_BALANCERS.ns, loadBalancerKeys, RelationshipCacheFilter.include(TARGET_GROUPS.ns))
     Map<String, CacheData> loadBalancers = loadBalancerData.collectEntries { [(it.id): it] }
-    Map<String, CacheData> targetGroups = resolveRelationshipDataForCollection(loadBalancerData, TARGET_GROUPS.ns).collectEntries { [(it.id): it] }
+    targetGroupMap = targetGroupMap ?: getTargetGroupSummariesForLoadBalancer(loadBalancerData)
 
     for (lb in loadBalancerKeys) {
       CacheData loadBalancerFromCache = loadBalancers[lb]
@@ -345,15 +360,7 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
         // provider type.
         if (loadBalancerFromCache.relationships[TARGET_GROUPS.ns]) {
           loadBalancer.targetGroups = loadBalancerFromCache.relationships[TARGET_GROUPS.ns].findResults {
-            def targetGroup = targetGroups[it]
-            if (!targetGroup) {
-              return null
-            }
-
-            return [
-              name: targetGroup.attributes.targetGroupName,
-              targetType: targetGroup.attributes.targetType
-            ]
+            targetGroupMap[it]
           }
         }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsTargetGroupCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/EcsTargetGroupCacheClient.java
@@ -47,7 +47,7 @@ public class EcsTargetGroupCacheClient {
   }
 
   public List<EcsTargetGroup> findAll() {
-    String searchKey = Keys.getTargetGroupKey("*", "*", "*", "*") + "*";
+    String searchKey = Keys.getTargetGroupKey("*", "*", "*", "*", "*") + "*";
     Collection<String> targetGroupKeys = cacheView.filterIdentifiers(TARGET_GROUPS.getNs(), searchKey);
 
     Set<Map<String, Object>> targetGroupAttributes = fetchLoadBalancerAttributes(targetGroupKeys);

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsLoadbalancerCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsLoadbalancerCacheClientSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.cache
 
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetTypeEnum
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
@@ -45,7 +46,7 @@ class EcsLoadbalancerCacheClientSpec extends Specification {
     def targetGroupName = 'test-target-group'
 
     def loadbalancerKey = Keys.getLoadBalancerKey(loadBalancerName, account, region, vpcId, loadBalancerType)
-    def targetGroupKey = Keys.getTargetGroupKey(targetGroupName, account, region, vpcId)
+    def targetGroupKey = Keys.getTargetGroupKey(targetGroupName, account, region, TargetTypeEnum.Instance.toString(), vpcId)
 
     def givenEcsLoadbalancer = new EcsLoadBalancerCache(
       account: account,

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsTargetGroupCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/EcsTargetGroupCacheClientSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.cache
 
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetTypeEnum
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.Cache
@@ -44,7 +45,7 @@ class EcsTargetGroupCacheClientSpec extends Specification {
     def targetGroupName = 'test-target-group'
 
     def loadbalancerKey = Keys.getLoadBalancerKey(loadBalancerName, account, region, vpcId, loadBalancerType)
-    def targetGroupKey = Keys.getTargetGroupKey(targetGroupName, account, region, vpcId)
+    def targetGroupKey = Keys.getTargetGroupKey(targetGroupName, account, region, TargetTypeEnum.Instance.toString(), vpcId)
 
     def givenEcsTargetGroup = new EcsTargetGroup(
       loadBalancerNames: [loadBalancerName],

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusClusterCachingAgent.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusClusterCachingAgent.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.caching.agents
 
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetTypeEnum
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -32,6 +33,7 @@ import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.data.ArnUtils
+import com.netflix.spinnaker.clouddriver.aws.data.Keys as AwsKeys
 import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
@@ -475,7 +477,7 @@ class TitusClusterCachingAgent implements CachingAgent, CustomScheduledAgent, On
       } as Set).asImmutable()
 
       targetGroupKeys = (targetGroupNames.collect {
-        com.netflix.spinnaker.clouddriver.aws.data.Keys.getTargetGroupKey(it, getAwsAccountId(account, region), region, getAwsVpcId(account, region))
+        AwsKeys.getTargetGroupKey(it, getAwsAccountId(account, region), region, TargetTypeEnum.Ip.toString(), getAwsVpcId(account, region))
       } as Set).asImmutable()
 
     }


### PR DESCRIPTION
Incremental update to the `/{cloudProvider}/loadBalancers` endpoint for AWS. By adding the target type to the target group key, we can fetch them all once and parse them instead of going to Redis once for each ALB and fetching the full target group details.

This is not going to be a major performance improvement on its own, I don't think: it seems like we're cutting the number of entries we get from Redis by about 33% (although that number would grow larger as ALBs supplant CLBs). The structure of the response to the call is much more complex than the comparable one to fetch all security groups - in addition to target groups, we include security group IDs associate with the load balancer for some reason, and I'm not sure who is using that data.

There are additional improvements we're considering making in Deck - mostly around _not calling this endpoint_ unless we need to. At Netflix, over 99% of our clusters follow the established naming conventions, and use load balancers and target groups that are named after the application, so we'll have that data available when configuring a deployment cluster. We might as well just show that list and provide a link to "Show all Load Balancers" to enable the < 1% of users to pick load balancers from different applications.