### PR TITLE
fix(entitytags): Reconciliation API for Entity Tags

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.aws.model.*
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
 import com.netflix.spinnaker.clouddriver.core.provider.agent.ExternalHealthProvider
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
+import com.netflix.spinnaker.clouddriver.model.ServerGroupProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -35,7 +36,7 @@ import org.springframework.stereotype.Component
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 
 @Component
-class AmazonClusterProvider implements ClusterProvider<AmazonCluster> {
+class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGroupProvider {
 
   private final AmazonCloudProvider amazonCloudProvider
   private final Cache cacheView
@@ -370,5 +371,18 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster> {
   @Override
   AmazonCluster getCluster(String application, String account, String name) {
     return getCluster(application, account, name, true)
+  }
+
+  @Override
+  Collection<String> getServerGroupIdentifiers(String account, String region) {
+    account = Optional.ofNullable(account).orElse("*")
+    region = Optional.ofNullable(region).orElse("*")
+
+    return cacheView.filterIdentifiers(SERVER_GROUPS.ns, Keys.getServerGroupKey("*", "*", account, region))
+  }
+
+  @Override
+  String buildServerGroupIdentifier(String account, String region, String serverGroupName) {
+    return Keys.getServerGroupKey(serverGroupName, account, region)
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTagsProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTagsProvider.java
@@ -67,14 +67,24 @@ public interface EntityTagsProvider {
   void delete(String id);
 
   /**
+   * Delete EntityTags
+   */
+  void bulkDelete(Collection<EntityTags> multipleEntityTags);
+
+  /**
    * Reindex all EntityTags
    */
   void reindex();
 
   /**
-   * Fetch metadata (counts of EntityTags broken down by Elasticsearch and Front50)
+   * Fetch delta (counts of EntityTags broken down by Elasticsearch and Front50)
    *
    * Can be used to identify when Elasticsearch and Front50 are out-of-sync.
    */
-  Map metadata();
+  Map delta();
+
+  /**
+   * Remove all entity tags referencing entities that no longer exist (in a clouddriver cache).
+   */
+  Map reconcile(String cloudProvider, String account, String region, boolean dryRun);
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroupProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroupProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model;
+
+import java.util.Collection;
+
+public interface ServerGroupProvider {
+  String getCloudProviderId();
+
+  Collection<String> getServerGroupIdentifiers(String account, String region);
+
+  String buildServerGroupIdentifier(String account, String region, String serverGroupName);
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsReconciler.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsReconciler.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.model;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
+import com.netflix.spinnaker.clouddriver.model.EntityTags;
+import com.netflix.spinnaker.clouddriver.model.ServerGroupProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.clouddriver.tags.EntityTagger.ENTITY_TYPE_SERVER_GROUP;
+
+@Component
+public class ElasticSearchEntityTagsReconciler {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final Front50Service front50Service;
+  private final Map<String, ServerGroupProvider> serverGroupProviderByCloudProvider = new HashMap<>();
+
+  @Autowired
+  public ElasticSearchEntityTagsReconciler(Front50Service front50Service,
+                                           Collection<ServerGroupProvider> serverGroupProviders) {
+    this.front50Service = front50Service;
+
+    for (ServerGroupProvider serverGroupProvider : serverGroupProviders) {
+      serverGroupProviderByCloudProvider.put(serverGroupProvider.getCloudProviderId(), serverGroupProvider);
+    }
+  }
+
+  /**
+   * Remove any orphaned entity tags from elastic search in a specific account/region and cloud provider.
+   */
+  Map reconcile(ElasticSearchEntityTagsProvider entityTagsProvider,
+                String cloudProvider,
+                String account,
+                String region,
+                boolean dryRun) {
+    Collection<EntityTags> allEntityTags = front50Service.getAllEntityTags(false);
+
+    List<EntityTags> allServerGroupEntityTags = filter(
+      allEntityTags,
+      cloudProvider,
+      account,
+      region
+    );
+
+    List<EntityTags> existingServerGroupEntityTags = filter(
+      Collections.singletonList(cloudProvider),
+      allServerGroupEntityTags
+    );
+
+    log.debug(
+      "Found {} server group entity tags (valid: {}, invalid: {}, dryRun: {})",
+      allServerGroupEntityTags.size(),
+      existingServerGroupEntityTags.size(),
+      allServerGroupEntityTags.size() - existingServerGroupEntityTags.size(),
+      dryRun
+    );
+
+    List<EntityTags> orphanedServerGroupEntityTags = new ArrayList<>(allServerGroupEntityTags);
+    orphanedServerGroupEntityTags.removeAll(existingServerGroupEntityTags);
+
+    if (!dryRun) {
+      entityTagsProvider.bulkDelete(orphanedServerGroupEntityTags);
+
+      log.info("Removed {} orphaned entity tags", orphanedServerGroupEntityTags.size());
+    }
+
+    return ImmutableMap.builder()
+      .put("dryRun", dryRun)
+      .put("orphanCount", orphanedServerGroupEntityTags.size())
+      .build();
+  }
+
+  /**
+   * Filter out any orphaned entity tags that reference a non-existent server group.
+   *
+   * This is invoked as part of the re-indexing process where historical data is imported from Front50.
+   */
+  public List<EntityTags> filter(Collection<EntityTags> entityTags) {
+    return filter(serverGroupProviderByCloudProvider.keySet(), entityTags);
+  }
+
+  private List<EntityTags> filter(Collection<String> cloudProviders,
+                                  Collection<EntityTags> entityTags) {
+    Set<String> serverGroupIdentifiers = serverGroupProviderByCloudProvider.values()
+      .stream()
+      .filter(p -> cloudProviders.contains(p.getCloudProviderId()))
+      .flatMap(p -> p.getServerGroupIdentifiers(null, null).stream())
+      .map(String::toLowerCase)
+      .collect(Collectors.toSet());
+
+    Set<String> missingServerGroupEntityTags = entityTags
+      .stream()
+      .filter(e -> e.getEntityRef() != null)
+
+      // if cloud provider is unknown, entity tags should _not_ be filtered out
+      .filter(e -> cloudProviders.contains(e.getEntityRef().getCloudProvider()))
+
+      // not all entity types are filterable
+      .filter(e -> ENTITY_TYPE_SERVER_GROUP.equalsIgnoreCase(e.getEntityRef().getEntityType()))
+
+      // find any entity tags that reference a non-existent server group
+      .filter(e -> !serverGroupIdentifiers.contains(buildServerGroupIdentifier(e.getEntityRef())))
+      .map(EntityTags::getId)
+      .collect(Collectors.toSet());
+
+    return entityTags
+      .stream()
+      .filter(e -> !missingServerGroupEntityTags.contains(e.getId()))
+      .collect(Collectors.toList());
+  }
+
+  private List<EntityTags> filter(Collection<EntityTags> entityTags,
+                                  String cloudProvider,
+                                  String account,
+                                  String region) {
+    return entityTags.stream()
+      .filter(e -> e.getEntityRef() != null)
+      .filter(e -> ENTITY_TYPE_SERVER_GROUP.equalsIgnoreCase(e.getEntityRef().getEntityType()))
+      .filter(e -> cloudProvider.equalsIgnoreCase(e.getEntityRef().getCloudProvider()))
+      .filter(e -> account == null || account.equalsIgnoreCase(e.getEntityRef().getAccount()))
+      .filter(e -> region == null || region.equalsIgnoreCase(e.getEntityRef().getRegion()))
+
+      // tag must be > 14 days old (temporary safe guard)
+      .filter(e -> e.getLastModified() < System.currentTimeMillis() - TimeUnit.DAYS.toMillis(14))
+      .collect(Collectors.toList());
+  }
+
+  private String buildServerGroupIdentifier(EntityTags.EntityRef entityRef) {
+    ServerGroupProvider serverGroupProvider = serverGroupProviderByCloudProvider.get(entityRef.getCloudProvider());
+    return serverGroupProvider.buildServerGroupIdentifier(
+      entityRef.getAccount(),
+      entityRef.getRegion(),
+      entityRef.getEntityId()
+    ).toLowerCase();
+  }
+}

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfig.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfig.java
@@ -40,9 +40,13 @@ public class ElasticSearchConfig {
     String elasticSearchConnection = elasticSearchConfigProperties.getConnection();
 
     JestClientFactory factory = new JestClientFactory();
-    factory.setHttpClientConfig(
-      (new HttpClientConfig.Builder(elasticSearchConnection)).multiThreaded(true).build()
-    );
+
+    HttpClientConfig.Builder builder = new HttpClientConfig.Builder(elasticSearchConnection)
+      .readTimeout(elasticSearchConfigProperties.getReadTimeout())
+      .connTimeout(elasticSearchConfigProperties.getConnectionTimeout())
+      .multiThreaded(true);
+
+    factory.setHttpClientConfig(builder.build());
     return factory.getObject();
   }
 

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfigProperties.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfigProperties.java
@@ -23,6 +23,9 @@ public class ElasticSearchConfigProperties {
   private String activeIndex;
   private String connection;
 
+  private int readTimeout = 30000;
+  private int connectionTimeout = 10000;
+
   public String getActiveIndex() {
     return activeIndex;
   }
@@ -37,5 +40,21 @@ public class ElasticSearchConfigProperties {
 
   public void setConnection(String connection) {
     this.connection = connection;
+  }
+
+  public int getReadTimeout() {
+    return readTimeout;
+  }
+
+  public void setReadTimeout(int readTimeout) {
+    this.readTimeout = readTimeout;
+  }
+
+  public int getConnectionTimeout() {
+    return connectionTimeout;
+  }
+
+  public void setConnectionTimeout(int connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
   }
 }

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProviderSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProviderSpec.groovy
@@ -18,9 +18,11 @@
 package com.netflix.spinnaker.clouddriver.elasticsearch.model
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.clouddriver.model.EntityTags
 import com.netflix.spinnaker.config.ElasticSearchConfig
 import com.netflix.spinnaker.config.ElasticSearchConfigProperties
+import com.netflix.spinnaker.kork.core.RetrySupport
 import io.searchbox.client.JestClient
 import io.searchbox.indices.CreateIndex
 import io.searchbox.indices.DeleteIndex
@@ -40,13 +42,16 @@ class ElasticSearchEntityTagsProviderSpec extends Specification {
   JestClient jestClient
 
   @Shared
-  ObjectMapper objectMapper = new ObjectMapper()
-
-  @Shared
   ElasticSearchConfigProperties elasticSearchConfigProperties
 
-  @Shared
+  RetrySupport retrySupport = Spy(RetrySupport) {
+    _ * sleep(_) >> { /* do nothing */ }
+  }
+
+  ObjectMapper objectMapper = new ObjectMapper()
+  Front50Service front50Service = Mock(Front50Service)
   ElasticSearchEntityTagsProvider entityTagsProvider
+  ElasticSearchEntityTagsReconciler entityTagsReconciler = Mock(ElasticSearchEntityTagsReconciler)
 
   def setupSpec() {
     def elasticSearchSettings = Settings.settingsBuilder()
@@ -66,13 +71,6 @@ class ElasticSearchEntityTagsProviderSpec extends Specification {
     )
     def config = new ElasticSearchConfig()
     jestClient = config.jestClient(elasticSearchConfigProperties)
-
-    entityTagsProvider = new ElasticSearchEntityTagsProvider(
-      objectMapper,
-      null,
-      jestClient,
-      elasticSearchConfigProperties
-    )
   }
 
   def setup() {
@@ -104,6 +102,15 @@ class ElasticSearchEntityTagsProviderSpec extends Specification {
     jestClient.execute(new CreateIndex.Builder(elasticSearchConfigProperties.activeIndex)
       .settings(settings)
       .build());
+
+    entityTagsProvider = new ElasticSearchEntityTagsProvider(
+      retrySupport,
+      objectMapper,
+      front50Service,
+      jestClient,
+      entityTagsReconciler,
+      elasticSearchConfigProperties
+    )
   }
 
   def "should support single result retrieval by `EntityTags.id` and `EntityTags.tags`"() {
@@ -199,6 +206,57 @@ class ElasticSearchEntityTagsProviderSpec extends Specification {
     ["a": ["b": ["c"]]]                  || ["a.b": ["c"]]
     ["a": ["b": ["c": ["d"]]]]           || ["a.b.c": ["d"]]
     ["a": ["b": ["c": ["d"]]], "e": "f"] || ["a.b.c": ["d"], "e": "f"]
+  }
+
+  def "should filter entity tags when performing a reindex"() {
+    given:
+    def allEntityTags = [
+      buildEntityTags("aws:servergroup:clouddriver-main-v001:myaccount:us-west-1", [:]),
+      buildEntityTags("aws:servergroup:clouddriver-main-v002:myaccount:us-west-1", [:]),
+    ]
+
+    when:
+    entityTagsProvider.reindex()
+
+    then:
+    1 * front50Service.getAllEntityTags(true) >> { return allEntityTags }
+    1 * entityTagsReconciler.filter(allEntityTags) >> { return [ allEntityTags[1] ] }
+
+    entityTagsProvider.verifyIndex(allEntityTags[1])
+    !entityTagsProvider.get(allEntityTags[0].id).isPresent()
+  }
+
+  def "should delete multiple entity tags (bulk)"() {
+    given:
+    def allEntityTags = [
+      buildEntityTags("aws:servergroup:clouddriver-main-v001:myaccount:us-west-1", [:]),
+      buildEntityTags("aws:servergroup:clouddriver-main-v002:myaccount:us-west-1", [:]),
+      buildEntityTags("aws:servergroup:clouddriver-main-v003:myaccount:us-west-1", [:]),
+    ]
+    allEntityTags.each {
+      entityTagsProvider.index(it)
+      entityTagsProvider.verifyIndex(it)
+    }
+
+    when:
+    entityTagsProvider.bulkDelete(allEntityTags)
+
+    then:
+    verifyNotIndexed(allEntityTags[0])
+    verifyNotIndexed(allEntityTags[1])
+    verifyNotIndexed(allEntityTags[2])
+
+  }
+
+  boolean verifyNotIndexed(EntityTags entityTags) {
+    return (1..5).any {
+      if (!entityTagsProvider.get(entityTags.id).isPresent()) {
+        return true
+      }
+
+      Thread.sleep(500)
+      return false
+    }
   }
 
   private static EntityTags buildEntityTags(String id, Map<String, String> tags, String namespace = "default") {

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsReconcilerSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsReconcilerSpec.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.model
+
+import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.clouddriver.model.EntityTags
+import com.netflix.spinnaker.clouddriver.model.ServerGroupProvider
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit;
+
+class ElasticSearchEntityTagsReconcilerSpec extends Specification {
+  def allEntityTags = [
+    buildEntityTags("id-1", "aws", "servergroup", "clouddriver-main-v001", "myaccount", "us-west-1"),
+    buildEntityTags("id-2", "aws", "servergroup", "clouddriver-main-v002", "myaccount", "us-west-2"),
+    buildEntityTags("id-3", "aws", "servergroup", "clouddriver-main-v003", "myaccount", "us-west-1"),
+    buildEntityTags("id-4", "k8s", "servergroup", "clouddriver-main-v004", "myaccount", "us-west-1"),
+    buildEntityTags("id-5", "titus", "servergroup", "clouddriver-main-v005", "myaccount", "us-west-1"),
+    buildEntityTags("id-6", "aws", "cluster", "clouddriver-main", "myaccount", "us-east-1"),
+  ]
+
+  def front50Service = Mock(Front50Service) {
+    _ * getAllEntityTags(_) >> { return allEntityTags }
+  }
+
+  def amazonServerGroupProvider = Mock(ServerGroupProvider) {
+    _ * getCloudProviderId() >> { return "aws" }
+    _ * buildServerGroupIdentifier(_, _, _) >> { String account, String region, String entityId ->
+      return "aws:servergroups:${entityId}:${account}:${region}"
+    }
+  }
+
+  def titusServerGroupProvider = Mock(ServerGroupProvider) {
+    _ * getCloudProviderId() >> { return "titus" }
+    _ * buildServerGroupIdentifier(_, _, _) >> { String account, String region, String entityId ->
+      return "titus:servergroups:${entityId}:${account}:${region}"
+    }
+  }
+
+  def entityTagsProvider = Mock(ElasticSearchEntityTagsProvider)
+
+
+  @Shared
+  def thirteenDaysAgo = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(13)
+
+  @Shared
+  def fifteenDaysAgo = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(15)
+
+  @Subject
+  def entityTagsReconciler = new ElasticSearchEntityTagsReconciler(
+    front50Service,
+    [amazonServerGroupProvider, titusServerGroupProvider]
+  )
+
+  def "should build provider-specific identifier"() {
+    expect:
+    entityTagsReconciler.buildServerGroupIdentifier(
+      buildEntityTags("id", "aws", "servergroup", "clouddriver-main-v003", "myaccount", "us-west-1").entityRef
+    ) == "aws:servergroups:clouddriver-main-v003:myaccount:us-west-1"
+  }
+
+  def "should exclude any entity tags that reference a non-existent server group"() {
+    when:
+    def filteredEntityTags = entityTagsReconciler.filter(allEntityTags)
+
+    then:
+    1 * amazonServerGroupProvider.getServerGroupIdentifiers(null, null) >> {
+      return [
+        "aws:servergroups:clouddriver-main-v001:myaccount:us-west-1"
+      ]
+    }
+    1 * titusServerGroupProvider.getServerGroupIdentifiers(null, null) >> {
+      return [
+        "titus:servergroups:clouddriver-main-v005:myaccount:us-west-1"
+      ]
+    }
+
+    // entity tags for an unsupported cloud provider (k8s) or entity type (cluster) should _not_ be filtered out
+    filteredEntityTags*.id == ["id-1", "id-4", "id-5", "id-6"]
+  }
+
+  @Unroll
+  def "should reconcile and bulk delete any entity tags that reference a non-existent server group"() {
+    given:
+    allEntityTags.each { it.lastModified = 0 }
+
+    when:
+    def results = entityTagsReconciler.reconcile(entityTagsProvider, "aws", "myaccount", "us-west-1", dryRun)
+
+    then:
+    1 * amazonServerGroupProvider.getServerGroupIdentifiers(null, null) >> {
+      return [
+        "aws:servergroups:clouddriver-main-v001:myaccount:us-west-1"
+      ]
+    }
+
+    (expectedBulkDelete ? 1 : 0) * entityTagsProvider.bulkDelete({ Collection<EntityTags> multipleEntityTags ->
+      multipleEntityTags*.entityRef.entityId == ["clouddriver-main-v003"]
+    })
+    results.orphanCount == 1
+
+    where:
+    dryRun || expectedBulkDelete
+    true   || false
+    false  || true
+  }
+
+  @Unroll
+  def "should filter entity tags by cloud provider, account and region"() {
+    given:
+    allEntityTags.each {
+      it.setLastModified(lastModified)
+    }
+
+    when:
+    def results = entityTagsReconciler.filter(allEntityTags, cloudProvider, account, region)*.entityRef.entityId
+
+    then:
+    results == expectedEntityTags
+
+    where:
+    cloudProvider | account     | region      | lastModified    || expectedEntityTags
+    "none"        | null        | null        | thirteenDaysAgo || []
+    "aws"         | null        | null        | thirteenDaysAgo || []
+    "aws"         | "none"      | null        | fifteenDaysAgo  || []
+    "aws"         | null        | "none"      | fifteenDaysAgo  || []
+    "aws"         | null        | null        | fifteenDaysAgo  || ["clouddriver-main-v001", "clouddriver-main-v002", "clouddriver-main-v003"]
+    "aws"         | "myaccount" | null        | fifteenDaysAgo  || ["clouddriver-main-v001", "clouddriver-main-v002", "clouddriver-main-v003"]
+    "aws"         | "myaccount" | null        | fifteenDaysAgo  || ["clouddriver-main-v001", "clouddriver-main-v002", "clouddriver-main-v003"]
+    "aws"         | "myaccount" | "us-west-1" | fifteenDaysAgo  || ["clouddriver-main-v001", "clouddriver-main-v003"]
+  }
+
+  private static EntityTags buildEntityTags(String id,
+                                            String cloudProvider,
+                                            String entityType,
+                                            String entityId,
+                                            String account,
+                                            String region) {
+    return new EntityTags(
+      id: id,
+      entityRef: new EntityTags.EntityRef(
+        cloudProvider: cloudProvider,
+        entityType: entityType,
+        entityId: entityId,
+        account: account,
+        region: region
+      )
+    )
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.cats.cache.CacheFilter
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
 import com.netflix.spinnaker.clouddriver.core.provider.agent.ExternalHealthProvider
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
+import com.netflix.spinnaker.clouddriver.model.ServerGroupProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 import com.netflix.spinnaker.clouddriver.titus.caching.Keys
 import com.netflix.spinnaker.clouddriver.titus.caching.TitusCachingProvider
@@ -35,10 +36,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS
 import static com.netflix.spinnaker.clouddriver.titus.caching.Keys.Namespace.*
 
 @Component
-class TitusClusterProvider implements ClusterProvider<TitusCluster> {
+class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroupProvider {
 
   private final TitusCloudProvider titusCloudProvider
   private final Cache cacheView
@@ -181,6 +183,19 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster> {
     return true
   }
 
+  @Override
+  Collection<String> getServerGroupIdentifiers(String account, String region) {
+    account = Optional.ofNullable(account).orElse("*")
+    region = Optional.ofNullable(region).orElse("*")
+
+    return cacheView.filterIdentifiers(SERVER_GROUPS.ns, Keys.getServerGroupKey("*", "*", account, region))
+  }
+
+  @Override
+  String buildServerGroupIdentifier(String account, String region, String serverGroupName) {
+    return Keys.getServerGroupKey(serverGroupName, account, region)
+  }
+
   // Private methods
   private Map<String, Set<TitusCluster>> getClustersInternal(String applicationName, boolean includeDetails) {
     CacheData application = cacheView.get(APPLICATIONS.ns, Keys.getApplicationKey(applicationName))
@@ -284,5 +299,4 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster> {
     Collection<String> filteredRelationships = source.relationships[relationship]?.findAll(relFilter)
     filteredRelationships ? cacheView.getAll(relationship, filteredRelationships) : []
   }
-
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/admin/EntityTagsAdminController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/admin/EntityTagsAdminController.java
@@ -17,9 +17,12 @@
 package com.netflix.spinnaker.clouddriver.controllers.admin;
 
 import com.netflix.spinnaker.clouddriver.model.EntityTagsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
@@ -28,6 +31,8 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/admin/tags")
 public class EntityTagsAdminController {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
   private final EntityTagsProvider entityTagsProvider;
 
   @Autowired(required = false)
@@ -40,8 +45,16 @@ public class EntityTagsAdminController {
     entityTagsProvider.reindex();
   }
 
-  @RequestMapping(value = "/metadata", method = RequestMethod.GET)
-  Map metadata() {
-    return entityTagsProvider.metadata();
+  @RequestMapping(value = "/delta", method = RequestMethod.GET)
+  Map delta() {
+    return entityTagsProvider.delta();
+  }
+
+  @RequestMapping(value = "/reconcile", method = RequestMethod.POST)
+  Map reconcile(@RequestParam(name = "dryRun", defaultValue = "true") Boolean dryRun,
+                @RequestParam(name = "cloudProvider") String cloudProvider,
+                @RequestParam(name = "account", required = false) String account,
+                @RequestParam(name = "region", required = false) String region) {
+    return entityTagsProvider.reconcile(cloudProvider, account, region, Optional.ofNullable(dryRun).orElse(true));
   }
 }


### PR DESCRIPTION
This PR introduces a new administrative api supporting reconcilation of
entity tags against the current cached set of server groups.

Entity Tags that reference a non-existent server group will be removed
from elastic search.

A subsequent effort will provide a means to perform reconciliation
against `front50`.

The API is exposed directly on `clouddriver`:

```
curl -X POST localhost:8101/admin/tags/reconcile?cloudProvider=aws&account=test&region=us-west-2
```
