### PR TITLE
provider/kubernetes: remove versioning of HorizontalPodAutoscalers

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHorizontalPodAutoscalerHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHorizontalPodAutoscalerHandler.java
@@ -41,7 +41,7 @@ public class KubernetesHorizontalPodAutoscalerHandler extends KubernetesHandler 
 
   @Override
   public boolean versioned() {
-    return true;
+    return false;
   }
 
   @Override


### PR DESCRIPTION
When deploying updates to a HorizontalPodAutoscaler, versioning them
will create multiple instances of the HPA, all of which still try to
target/autoscale the scaleTargetRef. Since I don't believe there are
other resource types that refer to a HPA, it is not clear that this
needs to be versioned like ConfigMaps or Secrets.

