### PR TITLE
fix(artifacts): s3 improvements

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
@@ -27,4 +27,5 @@ public class S3ArtifactAccount extends ArtifactAccount
   private String name;
   private String apiEndpoint;
   private String apiRegion;
+  private String region;
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
@@ -35,11 +35,13 @@ public class S3ArtifactCredentials implements ArtifactCredentials {
   private final String name;
   private final String apiEndpoint;
   private final String apiRegion;
+  private final String region;
 
   public S3ArtifactCredentials(S3ArtifactAccount account) throws IllegalArgumentException {
     name = account.getName();
     apiEndpoint = account.getApiEndpoint();
     apiRegion = account.getApiRegion();
+    region = account.getRegion();
   }
 
   protected AmazonS3 getS3Client() {
@@ -48,6 +50,9 @@ public class S3ArtifactCredentials implements ArtifactCredentials {
     if (!StringUtils.isEmpty(apiEndpoint)) {
       AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration(apiEndpoint, apiRegion);
       builder.setEndpointConfiguration(endpoint);
+      builder.setPathStyleAccessEnabled(true);
+    } else if (!StringUtils.isEmpty(region)) {
+      builder.setRegion(region);
     }
 
     return builder.build();


### PR DESCRIPTION
this commit fixes two issues with the s3 artifact provider. 1, it adds
support for configuring an s3 region. this is inline with how we already
handle it in front50, allowing for usage of buckets in separate regions.
also, when using `apiEndpoint` we not set `pathStyleAccessEnabled` which
enables support for things like Minio to act as a provider.

@lwander @benjaminws PTAL!