### PR TITLE
fix(search) less redis interaction on instance cache

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -119,7 +119,7 @@ class CatsSearchProvider implements SearchProvider, Runnable {
       provider.supportsSearch('instances', Collections.emptyMap())
     }.collect { provider ->
       def cache = providerRegistry.getProviderCache(provider.getProviderName())
-      return cache.existingIdentifiers("instances", cache.getIdentifiers("instances")).findResults { key ->
+      return cache.getIdentifiers("instances").findResults { key ->
         def v = provider.parseKey(key)
         if (v) {
           v["_id"] = key


### PR DESCRIPTION
removes the existingIdentifiers call on the in-memory instance cache

as this cache is loaded per clouddriver instance it can balloon out to a
large number of exists calls
