### PR TITLE
feat(titus): split caching into two agents

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.cache
 
-import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.provider.ProviderRegistry
 import com.netflix.spinnaker.clouddriver.search.SearchProvider
@@ -114,28 +113,32 @@ class CatsSearchProvider implements SearchProvider, Runnable {
    */
   @Override
   void run() {
-    log.info("Refreshing Cached Identifiers (instances)")
-    def instanceIdentifiers = providers.findAll { provider ->
-      provider.supportsSearch('instances', Collections.emptyMap())
-    }.collect { provider ->
-      def cache = providerRegistry.getProviderCache(provider.getProviderName())
-      return cache.getIdentifiers("instances").findResults { key ->
-        def v = provider.parseKey(key)
-        if (v) {
-          v["_id"] = key
-        }
+    try {
+      log.info("Refreshing Cached Identifiers (instances)")
+      def instanceIdentifiers = providers.findAll { provider ->
+        provider.supportsSearch('instances', Collections.emptyMap())
+      }.collect { provider ->
+        def cache = providerRegistry.getProviderCache(provider.getProviderName())
+        return cache.getIdentifiers("instances").findResults { key ->
+          def v = provider.parseKey(key)
+          if (v) {
+            v["_id"] = key
+          }
 
-        return v?.collectEntries {
-          [it.key, it.value.toLowerCase()]
+          return v?.collectEntries {
+            [it.key, it.value.toLowerCase()]
+          }
         }
+      }.flatten()
+
+      if (instanceIdentifiers) {
+        cachedIdentifiersByType.set(["instances": instanceIdentifiers])
       }
-    }.flatten()
 
-    if (instanceIdentifiers) {
-      cachedIdentifiersByType.set(["instances": instanceIdentifiers])
+      log.info("Refreshed Cached Identifiers (found ${instanceIdentifiers.size()} instances)")
+    } catch (Exception e) {
+      log.error("Unable to refresh cached identifiers", e)
     }
-
-    log.info("Refreshed Cached Identifiers (found ${instanceIdentifiers.size()} instances)")
   }
 
   @Override

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -137,7 +137,7 @@ class CatsSearchProvider implements SearchProvider, Runnable {
 
       log.info("Refreshed Cached Identifiers (found ${instanceIdentifiers.size()} instances)")
     } catch (Exception e) {
-      log.error("Unable to refresh cached identifiers", e)
+      log.error("Unable to refresh cached identifiers (instances)", e)
     }
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandMetricsSupport.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandMetricsSupport.groovy
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit
 import com.netflix.spectator.api.Timer
 import java.util.function.Supplier
 
+import java.util.function.Supplier
+
 class OnDemandMetricsSupport {
   public static final String ON_DEMAND_TOTAL_TIME = "onDemand_total"
   public static final String DATA_READ = "onDemand_read"

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandMetricsSupport.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandMetricsSupport.groovy
@@ -18,11 +18,9 @@ package com.netflix.spinnaker.clouddriver.cache
 
 import com.netflix.spectator.api.Counter
 import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
 
 import java.util.concurrent.TimeUnit
-import com.netflix.spectator.api.Timer
-import java.util.function.Supplier
-
 import java.util.function.Supplier
 
 class OnDemandMetricsSupport {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/Namespace.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/Namespace.groovy
@@ -38,7 +38,7 @@ enum Namespace {
   RESERVATION_REPORTS,
   RESERVED_INSTANCES
 
-  final String ns
+  public final String ns
   final Set<String> fields
 
   private Namespace(List<String> keyFields = []) {
@@ -48,5 +48,9 @@ enum Namespace {
 
   String toString() {
     ns
+  }
+
+  String getNs() {
+    return ns
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusCloudProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/TitusCloudProvider.groovy
@@ -26,7 +26,7 @@ import java.lang.annotation.Annotation
  */
 @Component
 class TitusCloudProvider implements CloudProvider {
-  static final String ID = 'titus'
+  public static final String ID = 'titus'
   final String id = ID
   final String displayName = "Titus"
   final Class<Annotation> operationAnnotationType = TitusOperation

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.clouddriver.titus.caching
 
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.cache.KeyParser
-import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 import org.springframework.stereotype.Component
+import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 
 @Component("titusKeyParser")
 class Keys implements KeyParser {
@@ -33,7 +33,7 @@ class Keys implements KeyParser {
     HEALTH,
     ON_DEMAND
 
-    final String ns
+    public final String ns
 
     private Namespace() {
       def parts = name().split('_')
@@ -66,6 +66,15 @@ class Keys implements KeyParser {
   }
 
 
+  static enum CachingSchema {
+    V1,
+    V2
+
+    String toLowerCase() {
+      return name().toLowerCase()
+    }
+  }
+
   static Map<String, String> parse(String key) {
     def parts = key.split(':')
 
@@ -77,37 +86,88 @@ class Keys implements KeyParser {
       return null
     }
 
-    def result = [provider: parts[0], type: parts[1]]
+    def result
+    result = [provider: parts[0], type: parts[1]]
 
-    switch (result.type) {
-      case Namespace.IMAGES.ns:
-        result << [account: parts[2], region: parts[3], imageId: parts[4]]
-        break
-      case Namespace.SERVER_GROUPS.ns:
-        def names = Names.parseName(parts[5])
-        result << [application: names.app.toLowerCase(), cluster: parts[2], account: parts[3], region: parts[4], serverGroup: parts[5], stack: names.stack, detail: names.detail, sequence: names.sequence?.toString()]
-        break
-      case Namespace.INSTANCES.ns:
-        result << [id: parts[2]]
-        break
-      case Namespace.CLUSTERS.ns:
-        def names = Names.parseName(parts[4])
-        result << [application: parts[2].toLowerCase(), account: parts[3], cluster: parts[4], stack: names.stack, detail: names.detail]
-        break
-      case Namespace.APPLICATIONS.ns:
-        result << [application: parts[2].toLowerCase()]
-        break
-      case Namespace.HEALTH.ns:
-        result << [id: parts[2], account: parts[3], region: parts[4], provider: parts[5]]
-        break
-      default:
-        return null
-        break
+    if (parts[2] == CachingSchema.V2.toString() || parts[2] == CachingSchema.V2) { // parsing for split caching
+      switch (result.type) {
+        case Namespace.IMAGES.ns:
+          result << [account: parts[3], region: parts[4], imageId: parts[5]]
+          break
+        case Namespace.SERVER_GROUPS.ns:
+          def names = Names.parseName(parts[6])
+          result << [application: names.app.toLowerCase(), cluster: parts[3], account: parts[4], region: parts[5], serverGroup: parts[6], stack: names.stack, detail: names.detail, sequence: names.sequence?.toString()]
+          break
+        case Namespace.INSTANCES.ns:
+          result << [id: parts[3], region: parts[4], instanceId: parts[5]]
+          break
+        case Namespace.CLUSTERS.ns:
+          def names = Names.parseName(parts[5])
+          result << [application: parts[3].toLowerCase(), account: parts[4], cluster: parts[5], stack: names.stack, detail: names.detail]
+          break
+        case Namespace.APPLICATIONS.ns:
+          result << [application: parts[3].toLowerCase()]
+          break
+        case Namespace.HEALTH.ns:
+          result << [id: parts[2], account: parts[2], provider: parts[3]]
+        default:
+          return null
+          break
+      }
+    } else { // original parsing
+      switch (result.type) {
+        case Namespace.IMAGES.ns:
+          result << [account: parts[2], region: parts[3], imageId: parts[4]]
+          break
+        case Namespace.SERVER_GROUPS.ns:
+          def names = Names.parseName(parts[5])
+          result << [application: names.app.toLowerCase(), cluster: parts[2], account: parts[3], region: parts[4], serverGroup: parts[5], stack: names.stack, detail: names.detail, sequence: names.sequence?.toString()]
+          break
+        case Namespace.INSTANCES.ns:
+            result << [id: parts[2], region: parts[3], instanceId: parts[5]]
+          break
+        case Namespace.CLUSTERS.ns:
+          def names = Names.parseName(parts[4])
+          result << [application: parts[2].toLowerCase(), account: parts[3], cluster: parts[4], stack: names.stack, detail: names.detail]
+          break
+        case Namespace.APPLICATIONS.ns:
+          result << [application: parts[2].toLowerCase()]
+          break
+        case Namespace.HEALTH.ns:
+          result << [id: parts[2], account: parts[3], region: parts[4], provider: parts[5]]
+          break
+        default:
+          return null
+          break
+      }
     }
 
-    result
+    return result
   }
 
+  // v2 keys for split provider
+  static String getImageV2Key(String imageId, String accountName, String region) {
+    "${TitusCloudProvider.ID}:${Namespace.IMAGES}:${CachingSchema.V2}:${accountName}:${region}:${imageId}"
+  }
+
+  static String getServerGroupV2Key(String cluster, String autoScalingGroupName, String account, String region) {
+    "${TitusCloudProvider.ID}:${Namespace.SERVER_GROUPS}:${CachingSchema.V2}:${cluster}:${account}:${region}:${autoScalingGroupName}"
+  }
+
+  static String getServerGroupV2Key(String serverGroupName, String account, String region) {
+    Names names = Names.parseName(serverGroupName)
+    return getServerGroupV2Key(names.cluster, names.group, account, region)
+  }
+
+  static String getInstanceV2Key(String instanceId, String account, String region) {
+    "${TitusCloudProvider.ID}:${Namespace.INSTANCES}:${CachingSchema.V2}:${account}:${region}:${instanceId}"
+  }
+
+  static String getClusterV2Key(String clusterName, String application, String account) {
+    "${TitusCloudProvider.ID}:${Namespace.CLUSTERS}:${CachingSchema.V2}:${application?.toLowerCase()}:${account}:${clusterName}"
+  }
+
+  // keys for normal provider
   static String getImageKey(String imageId, String account, String region) {
     "${TitusCloudProvider.ID}:${Namespace.IMAGES}:${account}:${region}:${imageId}"
   }
@@ -117,6 +177,7 @@ class Keys implements KeyParser {
     return getServerGroupKey(names.cluster, names.group, account, region)
   }
 
+  // stack here is Titus Stack, and it's not needed anymore because Titus ids are unique across all stacks
   static String getServerGroupKey(String cluster, String autoScalingGroupName, String account, String region) {
     "${TitusCloudProvider.ID}:${Namespace.SERVER_GROUPS}:${cluster}:${account}:${region}:${autoScalingGroupName}"
   }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
@@ -80,7 +80,7 @@ class Keys implements KeyParser {
     def result
     result = [provider: parts[0], type: parts[1]]
 
-    if (parts[2] == CachingSchema.V2.toString() || parts[2] == CachingSchema.V2) { // parsing for split caching
+    if (parts[2] == CachingSchema.V2.toString()) { // parsing for split caching
       switch (result.type) {
         case Namespace.IMAGES.ns:
           result << [account: parts[3], region: parts[4], imageId: parts[5]]

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.titus.caching
 
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.cache.KeyParser
+import com.netflix.spinnaker.clouddriver.titus.caching.utils.CachingSchema
 import org.springframework.stereotype.Component
 import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 
@@ -63,16 +64,6 @@ class Keys implements KeyParser {
   @Override
   Boolean canParseField(String field) {
     return false
-  }
-
-
-  static enum CachingSchema {
-    V1,
-    V2
-
-    String toLowerCase() {
-      return name().toLowerCase()
-    }
   }
 
   static Map<String, String> parse(String key) {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProvider.groovy
@@ -23,7 +23,8 @@ import com.netflix.spinnaker.clouddriver.cache.KeyParser
 import com.netflix.spinnaker.clouddriver.cache.SearchableProvider
 import com.netflix.spinnaker.clouddriver.eureka.provider.agent.EurekaAwareProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
-import com.netflix.spinnaker.clouddriver.titus.caching.utils.AwsLookupUtil
+import com.netflix.spinnaker.clouddriver.titus.caching.utils.CachingSchema
+import com.netflix.spinnaker.clouddriver.titus.caching.utils.CachingSchemaUtil
 
 import javax.inject.Provider
 
@@ -34,11 +35,11 @@ class TitusCachingProvider implements SearchableProvider, EurekaAwareProvider {
   private final Collection<CachingAgent> agents
   private final KeyParser keyParser = new Keys()
 
-  private Provider<AwsLookupUtil> awsLookupUtil
+  private Provider<CachingSchemaUtil> cachingSchemaUtil
 
-  TitusCachingProvider(Collection<CachingAgent> agents, Provider<AwsLookupUtil> awsLookupUtil) {
+  TitusCachingProvider(Collection<CachingAgent> agents, Provider<CachingSchemaUtil> cachingSchemaUtil) {
     this.agents = Collections.unmodifiableCollection(agents)
-    this.awsLookupUtil = awsLookupUtil
+    this.cachingSchemaUtil = cachingSchemaUtil
   }
 
   @Override
@@ -58,8 +59,8 @@ class TitusCachingProvider implements SearchableProvider, EurekaAwareProvider {
 
   @Override
   String getInstanceKey(Map<String, Object> attributes, String region) {
-    Keys.CachingSchema schema = awsLookupUtil.get().getCachingSchemaForAccount(attributes.accountId)
-    if (schema == Keys.CachingSchema.V2) {
+    CachingSchema schema = cachingSchemaUtil.get().getCachingSchemaForAccount(attributes.accountId)
+    if (schema == CachingSchema.V2) {
       Keys.getInstanceV2Key(attributes.titusTaskId, attributes.accountId, region)
     } else {
       Keys.getInstanceKey(attributes.titusTaskId, attributes.accountId, attributes.titusStack, region)

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
@@ -75,15 +75,12 @@ class TitusCachingProviderConfig {
           )
         } else { //use new split caching for this whole account
           agents << new TitusInstanceCachingAgent(
-            titusCloudProvider,
             titusClientProvider,
             account,
             region,
             objectMapper,
             registry,
-            awsLookupUtilProvider,
-            pollIntervalMillis,
-            timeOutMilis
+            awsLookupUtilProvider
           )
           agents << new TitusV2ClusterCachingAgent(
             titusCloudProvider,

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.titus.caching.agents.TitusClusterCachin
 import com.netflix.spinnaker.clouddriver.titus.caching.agents.TitusInstanceCachingAgent
 import com.netflix.spinnaker.clouddriver.titus.caching.agents.TitusV2ClusterCachingAgent
 import com.netflix.spinnaker.clouddriver.titus.caching.utils.AwsLookupUtil
+import com.netflix.spinnaker.clouddriver.titus.caching.utils.CachingSchemaUtil
 import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -52,14 +53,15 @@ class TitusCachingProviderConfig {
                                             TitusClientProvider titusClientProvider,
                                             ObjectMapper objectMapper,
                                             Registry registry,
-                                            Provider<AwsLookupUtil> awsLookupUtilProvider) {
+                                            Provider<AwsLookupUtil> awsLookupUtilProvider,
+                                            Provider<CachingSchemaUtil> cachingSchemaUtilProvider) {
     List<CachingAgent> agents = []
     def allAccounts = accountCredentialsRepository.all.findAll {
       it instanceof NetflixTitusCredentials
     } as Collection<NetflixTitusCredentials>
     allAccounts.each { NetflixTitusCredentials account ->
       account.regions.each { region ->
-        if (account.splitCachingEnabled == null || !account.splitCachingEnabled) { //default case
+        if (!account.splitCachingEnabled) { //default case
           agents << new TitusClusterCachingAgent(
             titusCloudProvider,
             titusClientProvider,
@@ -97,7 +99,7 @@ class TitusCachingProviderConfig {
         }
       }
     }
-    new TitusCachingProvider(agents, awsLookupUtilProvider)
+    new TitusCachingProvider(agents, cachingSchemaUtilProvider)
   }
 
   @Bean

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusInstanceCachingAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusInstanceCachingAgent.java
@@ -67,39 +67,26 @@ public class TitusInstanceCachingAgent implements CachingAgent {
   private static final List<TaskState> DOWN_TASK_STATES = Arrays.asList(TaskState.STOPPED, TaskState.FAILED, TaskState.CRASHED, TaskState.FINISHED, TaskState.DEAD, TaskState.TERMINATING);
   private static final List<TaskState> STARTING_TASK_STATES = Arrays.asList(TaskState.STARTING, TaskState.DISPATCHED, TaskState.PENDING, TaskState.QUEUED);
 
-  private TitusCloudProvider titusCloudProvider;
-  private TitusClient titusClient;
-  private TitusAutoscalingClient titusAutoscalingClient;
-  private TitusLoadBalancerClient titusLoadBalancerClient;
-  private NetflixTitusCredentials account;
-  private TitusRegion region;
-  private ObjectMapper objectMapper;
-  private Provider<AwsLookupUtil> awsLookupUtil;
-  private long pollIntervalMillis;
-  private long timeoutMillis;
-  private Id metricId;
-  private Registry registry;
+  private final TitusClient titusClient;
+  private final NetflixTitusCredentials account;
+  private final TitusRegion region;
+  private final ObjectMapper objectMapper;
+  private final Provider<AwsLookupUtil> awsLookupUtil;
+  private final Id metricId;
+  private final Registry registry;
 
-  public TitusInstanceCachingAgent(TitusCloudProvider titusCloudProvider,
-                           TitusClientProvider titusClientProvider,
+  public TitusInstanceCachingAgent(TitusClientProvider titusClientProvider,
                            NetflixTitusCredentials account,
                            TitusRegion region,
                            ObjectMapper objectMapper,
                            Registry registry,
-                           Provider<AwsLookupUtil> awsLookupUtil,
-                           Long pollIntervalMillis,
-                           Long timeoutMillis) {
+                           Provider<AwsLookupUtil> awsLookupUtil) {
     this.account = account;
     this.region = region;
 
-    this.titusCloudProvider = titusCloudProvider;
     this.objectMapper = objectMapper;
     this.titusClient = titusClientProvider.getTitusClient(account, region.getName());
-    this.titusAutoscalingClient = titusClientProvider.getTitusAutoscalingClient(account, region.getName());
-    this.titusLoadBalancerClient = titusClientProvider.getTitusLoadBalancerClient(account, region.getName());
     this.awsLookupUtil = awsLookupUtil;
-    this.pollIntervalMillis = pollIntervalMillis;
-    this.timeoutMillis = timeoutMillis;
     this.registry = registry;
 
     this.metricId = registry.createId("titus.cache.instance").withTag("account", account.getName()).withTag("region", region.getName());

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusInstanceCachingAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusInstanceCachingAgent.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.caching.agents;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.histogram.PercentileTimer;
+import com.netflix.spinnaker.cats.agent.*;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.model.HealthState;
+import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider;
+import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider;
+import com.netflix.spinnaker.clouddriver.titus.caching.Keys;
+import com.netflix.spinnaker.clouddriver.titus.caching.TitusCachingProvider;
+import com.netflix.spinnaker.clouddriver.titus.caching.utils.AwsLookupUtil;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusAutoscalingClient;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusClient;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusLoadBalancerClient;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusRegion;
+import com.netflix.spinnaker.clouddriver.titus.client.model.TaskState;
+import com.netflix.spinnaker.clouddriver.titus.client.model.Task;
+import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Provider;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
+import static com.netflix.spinnaker.clouddriver.titus.caching.Keys.Namespace.*;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Caching agent for Titus tasks, mapping to the concept of Spinnaker Instances
+ * A Titus job has a set of Titus tasks.
+ */
+public class TitusInstanceCachingAgent implements CachingAgent {
+
+  private static final Logger log = LoggerFactory.getLogger(TitusInstanceCachingAgent.class);
+  private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {};
+
+
+  private static final java.util.Set<AgentDataType> types = Collections.unmodifiableSet(Stream.of(
+    AUTHORITATIVE.forType(INSTANCES.ns),
+    INFORMATIVE.forType(SERVER_GROUPS.ns)
+  ).collect(Collectors.toSet()));
+
+  private TitusCloudProvider titusCloudProvider;
+  private TitusClient titusClient;
+  private TitusAutoscalingClient titusAutoscalingClient;
+  private TitusLoadBalancerClient titusLoadBalancerClient;
+  private NetflixTitusCredentials account;
+  private TitusRegion region;
+  private ObjectMapper objectMapper;
+  private Provider<AwsLookupUtil> awsLookupUtil;
+  private long pollIntervalMillis;
+  private long timeoutMillis;
+  private Id metricId;
+  private Registry registry;
+
+
+  public TitusInstanceCachingAgent(TitusCloudProvider titusCloudProvider,
+                           TitusClientProvider titusClientProvider,
+                           NetflixTitusCredentials account,
+                           TitusRegion region,
+                           ObjectMapper objectMapper,
+                           Registry registry,
+                           Provider<AwsLookupUtil> awsLookupUtil,
+                           Long pollIntervalMillis,
+                           Long timeoutMillis) {
+    this.account = account;
+    this.region = region;
+
+    this.titusCloudProvider = titusCloudProvider;
+    this.objectMapper = objectMapper;
+    this.titusClient = titusClientProvider.getTitusClient(account, region.getName());
+    this.titusAutoscalingClient = titusClientProvider.getTitusAutoscalingClient(account, region.getName());
+    this.titusLoadBalancerClient = titusClientProvider.getTitusLoadBalancerClient(account, region.getName());
+    this.awsLookupUtil = awsLookupUtil;
+    this.pollIntervalMillis = pollIntervalMillis;
+    this.timeoutMillis = timeoutMillis;
+    this.registry = registry;
+
+    this.metricId = registry.createId("titus.cache.instance").withTag("account", account.getName()).withTag("region", region.getName());
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return types;
+  }
+
+  @Override
+  public Optional<Map<String, String>> getCacheKeyPatterns() {
+    Map<String, String> cachekeyPatterns = new HashMap<>();
+    cachekeyPatterns.put(SERVER_GROUPS.ns, Keys.getServerGroupV2Key("*", "*", account.getName(), region.getName()));
+    cachekeyPatterns.put(INSTANCES.ns, Keys.getInstanceV2Key("*", account.getName(), region.getName()));
+    return Optional.of(cachekeyPatterns);
+  }
+
+  @Override
+  public String getAgentType() {
+    return account.getName() + "/" + region.getName() + "/" + TitusInstanceCachingAgent.class.getSimpleName();
+  }
+
+  @Override
+  public String getProviderName() {
+    return TitusCachingProvider.PROVIDER_NAME;
+  }
+
+  @Override
+  public boolean handlesAccount(String accountName) {
+    return false;
+  }
+
+  static class MutableCacheData implements CacheData {
+
+    final String id;
+    int ttlSeconds = -1;
+    final Map<String, Object> attributes = new HashMap<>();
+    final Map<String, Collection<String>> relationships = new HashMap<>();
+    public MutableCacheData(String id) {
+      this.id = id;
+    }
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public int getTtlSeconds() {
+      return ttlSeconds;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public Map<String, Collection<String>> getRelationships() {
+      return relationships;
+    }
+  }
+
+  private Map<String, CacheData> createCache() {
+    return new HashMap<>();
+  }
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    log.info("Describing items in {}", getAgentType());
+    Long startTime = System.currentTimeMillis();
+
+
+    List<Task> tasks = titusClient.getAllTasks();
+
+    // TODO emjburns: do we want to use timer or PercentileTimer?
+    // PercentileTimer gives us better data but is more runtime expensive to call
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "getAllTasks"))
+      .record(System.currentTimeMillis() - startTime, MILLISECONDS);
+
+    // Titus tasks only know the job ID, we get all job names from titus in one call
+    // and use them to cache the instances.
+    Long jobNamesStartTime = System.currentTimeMillis();
+    Map<String, String> jobNames = titusClient.getAllJobNames();
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "getAllJobNames"))
+      .record(System.currentTimeMillis() - jobNamesStartTime, MILLISECONDS);
+
+
+    Map<String, CacheData> serverGroups = createCache();
+    Map<String, CacheData> instances = createCache();
+
+    for (Task task : tasks) {
+      InstanceData data = new InstanceData(task, jobNames.get(task.getJobId()), account.getName(), region.getName());
+      cacheInstance(data, instances);
+      cacheServerGroup(data, serverGroups);
+    }
+
+    log.info("Caching {} instances in {}", instances.size(), getAgentType());
+    log.info("Caching {} server groups in {}", serverGroups.size(), getAgentType());
+
+    Map<String, Collection<CacheData>> cacheResult = new HashMap<>();
+    cacheResult.put(INSTANCES.ns, instances.values());
+    cacheResult.put(SERVER_GROUPS.ns, serverGroups.values());
+
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "loadData"))
+      .record(System.currentTimeMillis() - startTime, MILLISECONDS);
+    log.info("Caching completed in {}s in {}", MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime), getAgentType());
+
+    return new DefaultCacheResult(cacheResult);
+  }
+
+  private void cacheInstance(InstanceData data, Map<String, CacheData> instances) {
+    CacheData instanceCache = instances.getOrDefault(data.instanceId, new MutableCacheData(data.instanceId));
+    instanceCache.getAttributes().putAll(objectMapper.convertValue(data.task, ATTRIBUTES));
+    instanceCache.getAttributes().put(HEALTH.ns, Collections.singletonList(getTitusHealth(data.task)));
+    instanceCache.getAttributes().put("task", data.task);
+    instanceCache.getAttributes().put("jobId", data.jobId);
+
+    if (!data.serverGroup.isEmpty()) {
+      instanceCache.getRelationships().computeIfAbsent(SERVER_GROUPS.ns, key -> new HashSet<>()).add(data.serverGroup);
+    } else {
+      instanceCache.getRelationships().computeIfAbsent(SERVER_GROUPS.ns, key -> new HashSet<>()).clear();
+    }
+    instances.put(data.instanceId, instanceCache);
+  }
+
+  private void cacheServerGroup(InstanceData data, Map<String, CacheData> serverGroups) {
+    if (!data.serverGroup.isEmpty()) {
+      CacheData serverGroupCache = serverGroups.getOrDefault(data.serverGroup, new MutableCacheData(data.serverGroup));
+      serverGroupCache.getRelationships().computeIfAbsent(INSTANCES.ns, key -> new HashSet<>()).add(data.instanceId);
+      serverGroups.put(data.serverGroup, serverGroupCache);
+    }
+  }
+
+  private Map<String, String> getTitusHealth(Task task) {
+    TaskState taskState = task.getState();
+    HealthState healthState = HealthState.Unknown;
+    if (Arrays.asList(TaskState.STOPPED, TaskState.FAILED, TaskState.CRASHED, TaskState.FINISHED, TaskState.DEAD, TaskState.TERMINATING).contains(taskState)) {
+      healthState = HealthState.Down;
+    } else if (Arrays.asList(TaskState.STARTING, TaskState.DISPATCHED, TaskState.PENDING, TaskState.QUEUED).contains(taskState)) {
+      healthState = HealthState.Starting;
+    }
+
+    Map<String, String> response = new HashMap<>();
+    response.put("type", "Titus");
+    response.put("healthClass", "platform");
+    response.put("state", healthState.toString());
+    return response;
+  }
+
+  private String getAwsAccountId(String account, String region) {
+    return awsLookupUtil.get().awsAccountId(account, region);
+  }
+
+  private String getAwsVpcId(String account, String region) {
+    return awsLookupUtil.get().awsVpcId(account, region);
+  }
+
+  private class InstanceData {
+    // The instance key, not the task id
+    private final String instanceId;
+    private final Task task;
+    private final String jobId;
+    private final String serverGroup;
+
+    InstanceData(Task task, String jobName, String account, String region) {
+      this.instanceId = Keys.getInstanceV2Key(task.getId(), account, region);
+      this.task = task;
+      this.jobId = task.getJobId();
+      this.serverGroup = jobName != null
+        ? Keys.getServerGroupV2Key(jobName, account, region)
+        : "";
+    }
+  }
+
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
@@ -1,0 +1,636 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.caching.agents;
+
+import com.amazonaws.services.elasticloadbalancingv2.model.TargetTypeEnum;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.util.JsonFormat;
+import com.netflix.frigga.Names;
+import com.netflix.frigga.autoscaling.AutoScalingGroupNameBuilder;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.histogram.PercentileTimer;
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.agent.CacheResult;
+import com.netflix.spinnaker.cats.agent.CachingAgent;
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.DefaultCacheData;
+import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.aws.data.ArnUtils;
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent;
+import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport;
+import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider;
+import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider;
+import com.netflix.spinnaker.clouddriver.titus.caching.Keys;
+import com.netflix.spinnaker.clouddriver.titus.caching.TitusCachingProvider;
+import com.netflix.spinnaker.clouddriver.titus.caching.utils.AwsLookupUtil;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusAutoscalingClient;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusClient;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusLoadBalancerClient;
+import com.netflix.spinnaker.clouddriver.titus.client.TitusRegion;
+import com.netflix.spinnaker.clouddriver.titus.client.model.Job;
+import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials;
+import com.netflix.titus.grpc.protogen.ScalingPolicy;
+import com.netflix.titus.grpc.protogen.ScalingPolicyResult;
+import com.netflix.titus.grpc.protogen.ScalingPolicyStatus;
+import io.grpc.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Provider;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.TARGET_GROUPS;
+import static com.netflix.spinnaker.clouddriver.titus.caching.Keys.Namespace.*;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class TitusV2ClusterCachingAgent implements CachingAgent, CustomScheduledAgent, OnDemandAgent {
+
+  private static final Logger log = LoggerFactory.getLogger(TitusV2ClusterCachingAgent.class);
+
+  private static final TypeReference<Map<String, Object>> ANY_MAP = new TypeReference<Map<String, Object>>() {};
+
+  static final java.util.Set<AgentDataType> types = Collections.unmodifiableSet(Stream.of(
+      AUTHORITATIVE.forType(SERVER_GROUPS.ns),
+      AUTHORITATIVE.forType(APPLICATIONS.ns),
+      INFORMATIVE.forType(IMAGES.ns),
+      INFORMATIVE.forType(CLUSTERS.ns),
+      INFORMATIVE.forType(TARGET_GROUPS.ns)
+    ).collect(Collectors.toSet()));
+
+  private TitusCloudProvider titusCloudProvider;
+  private TitusClient titusClient;
+  private TitusAutoscalingClient titusAutoscalingClient;
+  private TitusLoadBalancerClient titusLoadBalancerClient;
+  private NetflixTitusCredentials account;
+  private TitusRegion region;
+  private ObjectMapper objectMapper;
+  private OnDemandMetricsSupport metricsSupport;
+  private Provider<AwsLookupUtil> awsLookupUtil;
+  private long pollIntervalMillis;
+  private long timeoutMillis;
+  private Registry registry;
+  private Id metricId;
+
+  public TitusV2ClusterCachingAgent(TitusCloudProvider titusCloudProvider,
+                           TitusClientProvider titusClientProvider,
+                           NetflixTitusCredentials account,
+                           TitusRegion region,
+                           ObjectMapper objectMapper,
+                           Registry registry,
+                           Provider<AwsLookupUtil> awsLookupUtil,
+                           Long pollIntervalMillis,
+                           Long timeoutMillis) {
+    this.account = account;
+    this.region = region;
+
+    this.titusCloudProvider = titusCloudProvider;
+    this.objectMapper = objectMapper;
+    this.metricsSupport = new OnDemandMetricsSupport(
+      registry,
+      this,
+      titusCloudProvider.getId() + ":" + OnDemandType.ServerGroup
+    );
+    this.titusClient = titusClientProvider.getTitusClient(account, region.getName());
+    this.titusAutoscalingClient = titusClientProvider.getTitusAutoscalingClient(account, region.getName());
+    this.titusLoadBalancerClient = titusClientProvider.getTitusLoadBalancerClient(account, region.getName());
+    this.awsLookupUtil = awsLookupUtil;
+    this.pollIntervalMillis = pollIntervalMillis;
+    this.timeoutMillis = timeoutMillis;
+    this.registry = registry;
+
+    this.metricId = registry.createId("titus.cache.cluster").withTag("account", account.getName()).withTag("region", region.getName());
+  }
+
+  @Override
+  public long getPollIntervalMillis() {
+    return pollIntervalMillis;
+  }
+
+  @Override
+  public long getTimeoutMillis() {
+    return timeoutMillis;
+  }
+
+  @Override
+  public String getProviderName() {
+    return TitusCachingProvider.PROVIDER_NAME;
+  }
+
+  @Override
+  public String getAgentType() {
+    return account.getName() + "/" + region.getName() + "/" + TitusV2ClusterCachingAgent.class.getSimpleName();
+  }
+
+  @Override
+  public String getOnDemandAgentType() {
+    return getAgentType() + "-OnDemand";
+  }
+
+  @Override
+  public OnDemandMetricsSupport getMetricsSupport() {
+    return metricsSupport;
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return types;
+  }
+
+  @Override
+  public Optional<Map<String, String>> getCacheKeyPatterns() {
+    Map<String, String> cachekeyPatterns = new HashMap<>();
+    cachekeyPatterns.put(SERVER_GROUPS.ns, Keys.getServerGroupV2Key("*", "*", account.getName(), region.getName()));
+    return Optional.of(cachekeyPatterns);
+  }
+
+  @Override
+  public boolean handles(OnDemandType type, String cloudProvider) {
+    return type == OnDemandType.ServerGroup && cloudProvider == titusCloudProvider.getId();
+  }
+
+  @Override
+  public OnDemandResult handle(ProviderCache providerCache, Map<String, ?> data) {
+    Long startTime = System.currentTimeMillis();
+
+    if (!data.containsKey("serverGroupName") || !data.containsKey("account") || !data.containsKey("region")) {
+      return null;
+    }
+
+    if (account.getName() != data.get("account")) {
+      return null;
+    }
+
+    if (region.getName() != data.get("region")) {
+      return null;
+    }
+
+    Job job = metricsSupport.readData( () -> {
+      try {
+        return titusClient.findJobByName(data.get("serverGroupName").toString());
+      } catch (io.grpc.StatusRuntimeException e) {
+        if (e.getStatus() == Status.NOT_FOUND) {
+          return null;
+        } else {
+          log.error("Failed to load job {} from titus {}:{}", data.get("serverGroupName").toString(), account.getName(), region.getName(), e);
+        }
+      }
+      return null;
+    });
+
+    OnDemandResult onDemandResult = minimalOnDemand(providerCache, job, data);
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "handleOnDemand"))
+      .record(System.currentTimeMillis() - startTime, MILLISECONDS);
+
+    return onDemandResult;
+  }
+
+  /**
+   * Avoid writing cache results to both ON_DEMAND and SERVER_GROUPS, etc.
+   *
+   * By writing a minimal record to ON_DEMAND only, we eliminate significant overhead (redis and network) at the cost
+   * of an increase in time before a change becomes visible in the UI.
+   *
+   * A change will not be visible until a caching cycle has completed.
+   */
+  private OnDemandResult minimalOnDemand(ProviderCache providerCache, Job job, Map<String, ?> data) {
+    String serverGroupKey = Keys.getServerGroupV2Key(job.getName(), account.getName(), region.getName());
+    Map<String, Collection<CacheData>> cacheResults = new HashMap<>();
+    if (job == null) {
+      // avoid writing an empty onDemand cache record (instead delete any that may have previously existed)
+      providerCache.evictDeletedItems(ON_DEMAND.ns, Collections.singletonList(serverGroupKey));
+    } else {
+      Map <String, Object> attributes = new HashMap<>();
+      attributes.put("cacheTime", new Date());
+      attributes.put("cacheResults", Collections.emptyMap());
+
+      CacheData cacheData = metricsSupport.onDemandStore( () -> new DefaultCacheData(
+        serverGroupKey,
+        10 * 60, // ttl is 10 minutes
+        attributes,
+        Collections.emptyMap()
+      ));
+
+      cacheResults.put(ON_DEMAND.ns, Collections.singletonList(cacheData));
+    }
+    Map<String, Collection<String>> evictions = job == null
+      ? Collections.emptyMap()
+      : Collections.singletonMap(SERVER_GROUPS.ns, Collections.singletonList(serverGroupKey));
+
+    log.info("minimal onDemand cache refresh (data: {}, evictions: {})", data, evictions);
+    return new OnDemandResult(getOnDemandAgentType(), new DefaultCacheResult(cacheResults), evictions);
+  }
+
+
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    Long startTime = System.currentTimeMillis();
+
+    log.info("Describing items in {}", getAgentType());
+    List<CacheData> evictFromOnDemand = new ArrayList<>();
+    List<CacheData> keepInOnDemand = new ArrayList<>();
+
+
+    List<Job> jobs = titusClient.getAllJobsWithoutTasks();
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "getAllTasks"))
+      .record(System.currentTimeMillis() - startTime, MILLISECONDS);
+
+    Long startScalingPolicyTime = System.currentTimeMillis();
+    List<ScalingPolicyResult> scalingPolicyResults = titusAutoscalingClient != null
+      ? titusAutoscalingClient.getAllScalingPolicies()
+      : Collections.emptyList();
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "getScalingPolicies"))
+      .record(System.currentTimeMillis() - startScalingPolicyTime, MILLISECONDS);
+
+    Long startLoadBalancerTime = System.currentTimeMillis();
+    Map<String, List<String>> allLoadBalancers = titusLoadBalancerClient.getAllLoadBalancers();
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "getLoadBalancers"))
+      .record(System.currentTimeMillis() - startLoadBalancerTime, MILLISECONDS);
+
+    Long startJobIdsTime = System.currentTimeMillis();
+    Map<String, List<String>> taskAndJobIds = titusClient.getTaskIdsForJobIds();
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "getJobIds"))
+      .record(System.currentTimeMillis() - startJobIdsTime, MILLISECONDS);
+
+    List<String> serverGroupKeys = jobs.stream()
+      .map(job -> Keys.getServerGroupV2Key(job.getName(), account.getName(), region.getName()))
+      .collect(Collectors.toList());
+
+    List<String> pendingOnDemandRequestKeys = providerCache
+      .filterIdentifiers(ON_DEMAND.ns, Keys.getServerGroupV2Key("*", "*", account.getName(), region.getName()))
+      .stream().filter(serverGroupKeys::contains).collect(Collectors.toList());
+
+    Collection<CacheData> pendingOnDemandRequestsForServerGroups = providerCache.getAll(ON_DEMAND.ns, pendingOnDemandRequestKeys);
+
+    pendingOnDemandRequestsForServerGroups.forEach( onDemandEntry -> {
+      if (Long.parseLong(onDemandEntry.getAttributes().get("cacheTime").toString()) < startTime
+        && Long.parseLong(onDemandEntry.getAttributes().getOrDefault("processedCount", "0").toString()) > 0) {
+        evictFromOnDemand.add(onDemandEntry);
+      } else {
+        keepInOnDemand.add(onDemandEntry);
+      }
+    });
+
+    Map<String, CacheData> onDemandMap = keepInOnDemand.stream().collect(Collectors.toMap(CacheData::getId, it -> it));
+    List<String> evictFromOnDemandIds = evictFromOnDemand.stream().map(CacheData::getId).collect(Collectors.toList());
+
+    CacheResult result = buildCacheResult(
+      jobs,
+      scalingPolicyResults,
+      allLoadBalancers,
+      taskAndJobIds,
+      onDemandMap,
+      evictFromOnDemandIds
+    );
+
+    result.getCacheResults().get(ON_DEMAND.ns).forEach( onDemandEntry -> {
+      onDemandEntry.getAttributes().put("processedTime", System.currentTimeMillis());
+      onDemandEntry.getAttributes().put("processedCount", Long.parseLong(onDemandEntry.getAttributes().getOrDefault("processedCount", "0").toString()) + 1);
+    });
+
+    PercentileTimer
+      .get(registry, metricId.withTag("operation", "loadData"))
+      .record(System.currentTimeMillis() - startTime, MILLISECONDS);
+    return result;
+  }
+
+  /**
+   * Used to build a cache result, whether normal or on demand,
+   * by transforming known Titus objects into Spinnaker cached objects
+   */
+  private CacheResult buildCacheResult(List<Job> jobs,
+                                       List<ScalingPolicyResult> scalingPolicyResults,
+                                       Map<String, List<String>> allLoadBalancers,
+                                       Map<String, List<String>> taskAndJobIds,
+                                       Map<String, CacheData> onDemandKeep,
+                                       List<String> onDemandEvict) {
+    if (onDemandKeep == null) {
+      onDemandKeep = new HashMap<>();
+    }
+    if (onDemandEvict == null) {
+      onDemandEvict = new ArrayList<>();
+    }
+
+    // INITIALIZE CACHES
+    Map<String, CacheData> applicationCache = createCache();
+    Map<String, CacheData> clusterCache = createCache();
+    Map<String, CacheData> serverGroupCache = createCache();
+    Map<String, CacheData> targetGroupCache = createCache();
+    Map<String, CacheData> imageCache = createCache();
+
+    // Ignore policies in a Deleted state (may need to revisit)
+    List cacheablePolicyStates = Arrays.asList(
+      ScalingPolicyStatus.ScalingPolicyState.Pending,
+      ScalingPolicyStatus.ScalingPolicyState.Applied,
+      ScalingPolicyStatus.ScalingPolicyState.Deleting
+    );
+
+    List<ServerGroupData> serverGroupDatas = jobs.stream()
+      .map( job -> {
+        List<ScalingPolicyData> jobScalingPolicies = scalingPolicyResults.stream()
+          .filter( it -> it.getJobId().equalsIgnoreCase(job.getId()) && cacheablePolicyStates.contains(it.getPolicyState()))
+          .map( it -> new ScalingPolicyData(it.getId().getId(), it.getScalingPolicy(), it.getPolicyState()))
+          .collect(Collectors.toList());
+
+        List<String> jobLoadBalancers = allLoadBalancers.getOrDefault(job.getId(), Collections.emptyList());
+        return new ServerGroupData(job, jobScalingPolicies, jobLoadBalancers, taskAndJobIds.get(job.getId()), account.getName(), region.getName());
+      })
+      .collect(Collectors.toList());
+
+    serverGroupDatas.forEach(data -> {
+      cacheApplication(data, applicationCache);
+      cacheCluster(data, clusterCache);
+      cacheServerGroup(data, serverGroupCache);
+      cacheImage(data, imageCache);
+    });
+
+    Map<String, Collection<CacheData>> cacheResults = new HashMap<>();
+    cacheResults.put(APPLICATIONS.ns, applicationCache.values());
+    cacheResults.put(CLUSTERS.ns, clusterCache.values());
+    cacheResults.put(SERVER_GROUPS.ns, serverGroupCache.values());
+    cacheResults.put(TARGET_GROUPS.ns, targetGroupCache.values());
+    cacheResults.put(IMAGES.ns, imageCache.values());
+    cacheResults.put(ON_DEMAND.ns, onDemandKeep.values());
+    Map<String, Collection<String>> evictions = new HashMap<>();
+    evictions.put(ON_DEMAND.ns, onDemandEvict);
+
+    log.info("Caching {} applications in {}", applicationCache.size(), getAgentType());
+    log.info("Caching {} server groups in {}", serverGroupCache.size(), getAgentType());
+    log.info("Caching {} clusters in {}", clusterCache.size(), getAgentType());
+    log.info("Caching {} target groups in {}", targetGroupCache.size(), getAgentType());
+    log.info("Caching {} images in {}", imageCache.size(), getAgentType());
+
+    return new DefaultCacheResult(cacheResults, evictions);
+  }
+
+  /**
+   * Build authoritative cache object for applications based on server group data
+   */
+  private void cacheApplication(ServerGroupData data, Map<String, CacheData> applications) {
+    CacheData applicationCache = applications.getOrDefault(data.appNameKey, new MutableCacheData(data.appNameKey));
+    applicationCache.getAttributes().put("name", data.name.getApp());
+    Map<String, Collection<String>> relationships = applicationCache.getRelationships();
+    relationships.computeIfAbsent(CLUSTERS.ns, key -> new HashSet<>()).add(data.clusterKey);
+    relationships.computeIfAbsent(SERVER_GROUPS.ns, key -> new HashSet<>()).add(data.serverGroupKey);
+    relationships.computeIfAbsent(TARGET_GROUPS.ns, key -> new HashSet<>()).addAll(data.targetGroupKeys);
+    applications.put(data.appNameKey, applicationCache);
+  }
+
+  /**
+   * Build informative cache object for clusters based on server group data
+   */
+  private void cacheCluster(ServerGroupData data, Map<String, CacheData> clusters) {
+    CacheData clusterCache = clusters.getOrDefault(data.clusterKey, new MutableCacheData(data.clusterKey));
+    clusterCache.getAttributes().put("name", data.name.getCluster());
+    Map<String, Collection<String>> relationships = clusterCache.getRelationships();
+    relationships.computeIfAbsent(APPLICATIONS.ns, key -> new HashSet<>()).add(data.appNameKey);
+    relationships.computeIfAbsent(SERVER_GROUPS.ns, key -> new HashSet<>()).add(data.serverGroupKey);
+    relationships.computeIfAbsent(TARGET_GROUPS.ns, key -> new HashSet<>()).addAll(data.targetGroupKeys);
+    clusters.put(data.clusterKey, clusterCache);
+  }
+
+  private void cacheServerGroup(ServerGroupData data, Map<String, CacheData> serverGroups) {
+    CacheData serverGroupCache = serverGroups.getOrDefault(data.serverGroupKey, new MutableCacheData(data.serverGroupKey));
+    List<Map> policies = data.scalingPolicies != null
+      ? data.scalingPolicies.stream().map(ScalingPolicyData::toMap).collect(Collectors.toList())
+      : new ArrayList<>();
+
+    Map<String, Object> attributes = serverGroupCache.getAttributes();
+    attributes.put("job", data.job);
+    attributes.put("scalingPolicies", policies);
+    attributes.put("region", region.getName());
+    attributes.put("account", account.getName());
+    attributes.put("targetGroups", data.targetGroupNames);
+    attributes.put("taskIds", data.taskIds); //todo: needed?
+
+    Map<String, Collection<String>> relationships = serverGroupCache.getRelationships();
+    relationships.computeIfAbsent(APPLICATIONS.ns, key -> new HashSet<>()).add(data.appNameKey);
+    relationships.computeIfAbsent(CLUSTERS.ns, key -> new HashSet<>()).add(data.clusterKey);
+    relationships.computeIfAbsent(TARGET_GROUPS.ns, key -> new HashSet<>()).addAll(data.targetGroupKeys);
+    relationships.computeIfAbsent(IMAGES.ns, key -> new HashSet<>()).add(data.imageKey);
+    relationships.computeIfAbsent(INSTANCES.ns, key -> new HashSet<>()).addAll(data.taskKeys);
+
+    serverGroups.put(data.serverGroupKey, serverGroupCache);
+  }
+
+  private void cacheImage(ServerGroupData data, Map<String, CacheData> images) {
+    CacheData imageCache = images.getOrDefault(data.imageKey, new MutableCacheData(data.imageKey));
+    imageCache.getRelationships().computeIfAbsent(SERVER_GROUPS.ns, key -> new HashSet<>()).add(data.serverGroupKey);
+    images.put(data.imageKey, imageCache);
+  }
+
+  @Override
+  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+    Set<String> keys = providerCache.getIdentifiers("onDemand").stream()
+      .filter(it -> {
+        Map<String, String> key = Keys.parse(it);
+        return key != null &&
+          key.get("type").equals(SERVER_GROUPS.ns) &&
+          key.get("account").equals(account.getName()) &&
+          key.get("region").equals(region.getName());
+      })
+      .collect(Collectors.toSet());
+    return fetchPendingOnDemandRequests(providerCache, keys);
+  }
+
+  private Collection<Map> fetchPendingOnDemandRequests(ProviderCache providerCache, Collection<String> keys) {
+    return providerCache.getAll("onDemand", keys, RelationshipCacheFilter.none()).stream()
+      .map(it -> {
+        Map<String, Object> result = new HashMap<>();
+        result.put("id", it.getId());
+        result.put("details", Keys.parse(it.getId()));
+        result.put("cacheTime", it.getAttributes().get("cacheTime"));
+        result.put("proccessedCount", it.getAttributes().get("processedCount"));
+        result.put("processedTime", it.getAttributes().get("processedTime"));
+        return result;
+      })
+      .collect(Collectors.toList());
+  }
+
+
+  @Override
+  public Map pendingOnDemandRequest(ProviderCache providerCache, String id) {
+    Collection<Map> pendingOnDemandRequests = fetchPendingOnDemandRequests(providerCache, Collections.singletonList(id));
+    return pendingOnDemandRequests.isEmpty()
+      ? Collections.emptyMap()
+      : pendingOnDemandRequests.stream().findFirst().get();
+  }
+
+  private Map<String, CacheData> createCache() {
+    return new HashMap<>();
+  }
+
+  private String getAwsAccountId(String account, String region) {
+    return awsLookupUtil.get().awsAccountId(account, region);
+  }
+  private String getAwsVpcId(String account, String region) {
+    return awsLookupUtil.get().awsVpcId(account, region);
+  }
+
+  static class MutableCacheData implements CacheData {
+
+    final String id;
+
+    int ttlSeconds = -1;
+    final Map<String, Object> attributes = new HashMap<>();
+    final Map<String, Collection<String>> relationships = new HashMap<>(); //default value needs to be empty set!
+    public MutableCacheData(String id) {
+      this.id = id;
+    }
+    @Override
+    public String getId() {
+      return id;
+    }
+    @Override
+    public int getTtlSeconds() {
+      return ttlSeconds;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public Map<String, Collection<String>> getRelationships() {
+      return relationships;
+    }
+
+    @JsonCreator
+    public MutableCacheData(@JsonProperty("id") String id,
+                            @JsonProperty("attributes") Map<String, Object> attributes,
+                            @JsonProperty("relationships") Map<String, Collection<String>> relationships) {
+      this(id);
+      this.attributes.putAll(attributes);
+      this.relationships.putAll(relationships);
+    }
+  }
+
+  private class ScalingPolicyData {
+    String id;
+    ScalingPolicy policy;
+    ScalingPolicyStatus status;
+
+    ScalingPolicyData(ScalingPolicyResult scalingPolicyResult) {
+      this(scalingPolicyResult.getId().getId(), scalingPolicyResult.getScalingPolicy(), scalingPolicyResult.getPolicyState());
+    }
+
+    ScalingPolicyData(String id, ScalingPolicy policy, ScalingPolicyStatus status) {
+      this.id = id;
+      this.policy = policy;
+      this.status = status;
+    }
+
+    protected Map<String, Object> toMap() {
+      Map<String, String> status = new HashMap<>();
+      status.put("state", this.status.getState().name());
+      status.put("reason", this.status.getPendingReason());
+
+      Map<String, Object> result = new HashMap<>();
+      result.put("id", id);
+      result.put("status", status);
+
+      String scalingPolicy;
+
+      try {
+        scalingPolicy = JsonFormat.printer().print(policy);
+        result.put("policy", objectMapper.readValue(scalingPolicy, ANY_MAP));
+      } catch (Exception e) {
+        log.warn("Failed to serialize scaling policy for scaling policy {}", e);
+        result.put("policy", Collections.emptyMap());
+      }
+
+      return result;
+    }
+  }
+
+  private class ServerGroupData {
+
+    final Job job;
+    List<ScalingPolicyData> scalingPolicies;
+    final Names name;
+    final String appNameKey;
+    final String clusterKey;
+    final String serverGroupKey;
+    final String region;
+    final Set<String> targetGroupKeys;
+    final Set<String> targetGroupNames;
+    final String account;
+    final String imageId;
+    final String imageKey;
+    final List<String> taskIds;
+    final List<String> taskKeys;
+
+    ServerGroupData(Job job, List<ScalingPolicyData> scalingPolicies, List<String> targetGroups, List<String> taskIds, String account, String region) {
+      this.job = job;
+      this.scalingPolicies = scalingPolicies;
+      this.imageId = job.getApplicationName() + ":" + job.getVersion();
+      this.imageKey = Keys.getImageV2Key(imageId, getAwsAccountId(account, region), region);
+      this.taskIds = taskIds;
+      this.taskKeys = taskIds == null
+        ? Collections.emptyList()
+        : taskIds.stream().map(it -> Keys.getInstanceV2Key(it, account, region)).collect(Collectors.toList());
+
+      String asgName = job.getName();
+      if (job.getLabels().containsKey("name")) {
+        asgName = job.getLabels().get("name");
+      } else {
+        if (job.getAppName() != null) {
+          AutoScalingGroupNameBuilder asgNameBuilder = new AutoScalingGroupNameBuilder();
+          asgNameBuilder.setAppName(job.getAppName());
+          asgNameBuilder.setDetail(job.getJobGroupDetail());
+          asgNameBuilder.setStack(job.getJobGroupStack());
+          String version = job.getJobGroupSequence();
+          asgName = asgNameBuilder.buildGroupName() + (version != null ? "-" + version : "");
+        }
+      }
+
+      name = Names.parseName(asgName);
+      appNameKey = Keys.getApplicationKey(name.getApp());
+      clusterKey = Keys.getClusterV2Key(name.getCluster(), name.getApp(), account);
+      this.region = region;
+      this.account = account;
+      serverGroupKey = Keys.getServerGroupV2Key(job.getName(), account, region);
+
+      targetGroupNames = targetGroups.stream()
+        .map(ArnUtils::extractTargetGroupName)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toSet());
+
+      targetGroupKeys = targetGroupNames.stream()
+        .map( it -> com.netflix.spinnaker.clouddriver.aws.data.Keys.getTargetGroupKey(it, account, region, TargetTypeEnum.Ip.toString(), getAwsVpcId(account, region)))
+        .collect(Collectors.toSet());
+    }
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
@@ -81,22 +81,20 @@ public class TitusV2ClusterCachingAgent implements CachingAgent, CustomScheduled
       INFORMATIVE.forType(TARGET_GROUPS.ns)
     ).collect(Collectors.toSet()));
 
-  private TitusCloudProvider titusCloudProvider;
-  private TitusClient titusClient;
-  private TitusAutoscalingClient titusAutoscalingClient;
-  private TitusLoadBalancerClient titusLoadBalancerClient;
-  private NetflixTitusCredentials account;
-  private TitusRegion region;
-  private ObjectMapper objectMapper;
-  private OnDemandMetricsSupport metricsSupport;
-  private Provider<AwsLookupUtil> awsLookupUtil;
-  private long pollIntervalMillis;
-  private long timeoutMillis;
-  private Registry registry;
-  private Id metricId;
+  private final TitusClient titusClient;
+  private final TitusAutoscalingClient titusAutoscalingClient;
+  private final TitusLoadBalancerClient titusLoadBalancerClient;
+  private final NetflixTitusCredentials account;
+  private final TitusRegion region;
+  private final ObjectMapper objectMapper;
+  private final OnDemandMetricsSupport metricsSupport;
+  private final Provider<AwsLookupUtil> awsLookupUtil;
+  private final long pollIntervalMillis;
+  private final long timeoutMillis;
+  private final Registry registry;
+  private final Id metricId;
 
-  public TitusV2ClusterCachingAgent(TitusCloudProvider titusCloudProvider,
-                                    TitusClientProvider titusClientProvider,
+  public TitusV2ClusterCachingAgent(TitusClientProvider titusClientProvider,
                                     NetflixTitusCredentials account,
                                     TitusRegion region,
                                     ObjectMapper objectMapper,
@@ -107,12 +105,11 @@ public class TitusV2ClusterCachingAgent implements CachingAgent, CustomScheduled
     this.account = account;
     this.region = region;
 
-    this.titusCloudProvider = titusCloudProvider;
     this.objectMapper = objectMapper;
     this.metricsSupport = new OnDemandMetricsSupport(
       registry,
       this,
-      titusCloudProvider.getId() + ":" + OnDemandType.ServerGroup
+      TitusCloudProvider.ID + ":" + OnDemandType.ServerGroup
     );
     this.titusClient = titusClientProvider.getTitusClient(account, region.getName());
     this.titusAutoscalingClient = titusClientProvider.getTitusAutoscalingClient(account, region.getName());
@@ -169,7 +166,7 @@ public class TitusV2ClusterCachingAgent implements CachingAgent, CustomScheduled
 
   @Override
   public boolean handles(OnDemandType type, String cloudProvider) {
-    return type == OnDemandType.ServerGroup && cloudProvider.equals(titusCloudProvider.getId());
+    return type == OnDemandType.ServerGroup && cloudProvider.equals(TitusCloudProvider.ID);
   }
 
   @Override

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
@@ -29,14 +29,16 @@ import com.netflix.spinnaker.clouddriver.titus.caching.Keys
 import com.netflix.spinnaker.clouddriver.titus.caching.TitusCachingProvider
 import com.netflix.spinnaker.clouddriver.titus.caching.utils.AwsLookupUtil
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
+import com.netflix.spinnaker.clouddriver.titus.client.model.Task
 import com.netflix.spinnaker.clouddriver.titus.model.TitusCluster
 import com.netflix.spinnaker.clouddriver.titus.model.TitusInstance
 import com.netflix.spinnaker.clouddriver.titus.model.TitusServerGroup
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS
 import static com.netflix.spinnaker.clouddriver.titus.caching.Keys.Namespace.*
 
 @Component
@@ -46,6 +48,7 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
   private final Cache cacheView
   private final TitusCachingProvider titusCachingProvider
   private final ObjectMapper objectMapper
+  private final Logger log = LoggerFactory.getLogger(getClass())
 
   @Autowired
   AwsLookupUtil awsLookupUtil
@@ -129,7 +132,10 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
    */
   @Override
   TitusCluster getCluster(String application, String account, String name, boolean includeDetails) {
-    CacheData cluster = cacheView.get(CLUSTERS.ns, Keys.getClusterKey(name, application, account))
+    String clusterKey = (awsLookupUtil.getCachingSchemaForAccount(account) == Keys.CachingSchema.V1
+      ? Keys.getClusterKey(name, application, account)
+      : Keys.getClusterV2Key(name, application, account))
+    CacheData cluster = cacheView.get(CLUSTERS.ns, clusterKey)
     TitusCluster titusCluster = cluster ? translateClusters([cluster], includeDetails)[0] : null
     titusCluster
   }
@@ -148,19 +154,31 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
    */
   @Override
   TitusServerGroup getServerGroup(String account, String region, String name, boolean includeDetails) {
-    String serverGroupKey = Keys.getServerGroupKey(name, account, region)
+    String serverGroupKey = (awsLookupUtil.getCachingSchemaForAccount(account) == Keys.CachingSchema.V1
+      ? Keys.getServerGroupKey(name, account, region)
+      : Keys.getServerGroupV2Key(name, account, region))
     CacheData serverGroupData = cacheView.get(SERVER_GROUPS.ns, serverGroupKey)
     if (serverGroupData == null) {
       return null
     }
     String json = objectMapper.writeValueAsString(serverGroupData.attributes.job)
     Job job = objectMapper.readValue(json, Job)
+
+    if (job.tasks == null || job.tasks.isEmpty()) {
+      // tasks are cached separately from jobs, and we need to construct them
+      Collection<CacheData> data = resolveRelationshipData(serverGroupData, INSTANCES.ns)
+      List<Task> tasks = data.collect{ it ->
+        objectMapper.convertValue(it.attributes.task, Task)
+      }
+      job.tasks = tasks
+    }
+
     TitusServerGroup serverGroup = new TitusServerGroup(job, serverGroupData.attributes.account, serverGroupData.attributes.region)
     serverGroup.placement.account = account
     serverGroup.placement.region = region
     serverGroup.scalingPolicies = serverGroupData.attributes.scalingPolicies
     if (includeDetails) {
-      serverGroup.instances = translateInstances(resolveRelationshipData(serverGroupData, INSTANCES.ns)).values()
+      serverGroup.instances = translateInstances(resolveRelationshipData(serverGroupData, INSTANCES.ns), Collections.singletonList(serverGroupData)).values()
     }
     serverGroup.targetGroups = serverGroupData.attributes.targetGroups
     serverGroup.accountId = awsLookupUtil.awsAccountId(account, region)
@@ -220,19 +238,33 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
       cluster.serverGroups = clusterDataEntry.relationships[SERVER_GROUPS.ns]?.findResults { serverGroups.get(it) }
       cluster
     }
-    clusters
+    return clusters
   }
 
   /**
    * Translate server groups
    */
   private Map<String, TitusServerGroup> translateServerGroups(Collection<CacheData> serverGroupData) {
-    Collection<CacheData> allInstances = resolveRelationshipDataForCollection(serverGroupData, INSTANCES.ns, RelationshipCacheFilter.none())
-    Map<String, TitusInstance> instances = translateInstances(allInstances)
+    Collection<CacheData> allInstances = resolveRelationshipDataForCollection(serverGroupData, INSTANCES.ns, RelationshipCacheFilter.include(SERVER_GROUPS.ns))
+
+    def tasksByJobId = allInstances.groupBy { cacheData ->
+      cacheData.getAttributes().jobId
+    }.collectEntries { key, val ->
+      [(key): val.collect { cacheData ->
+        objectMapper.convertValue(cacheData.attributes.task, Task)
+      }]
+    }
+
+    Map<String, TitusInstance> instances = translateInstances(allInstances, serverGroupData)
 
     Map<String, TitusServerGroup> serverGroups = serverGroupData.collectEntries { serverGroupEntry ->
       String json = objectMapper.writeValueAsString(serverGroupEntry.attributes.job)
       Job job = objectMapper.readValue(json, Job)
+      if (job.tasks == null || job.tasks.isEmpty()) {
+        // job was cached separately, so we need to resolve the tasks
+        job.tasks = tasksByJobId.get(job.id)
+      }
+
       TitusServerGroup serverGroup = new TitusServerGroup(job, serverGroupEntry.attributes.account, serverGroupEntry.attributes.region)
       serverGroup.instances = serverGroupEntry.relationships[INSTANCES.ns]?.findResults { instances.get(it) } as Set
 
@@ -250,22 +282,33 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
       serverGroup.awsAccount = awsLookupUtil.lookupAccount(serverGroupEntry.attributes.account, serverGroupEntry.attributes.region)?.awsAccount
       [(serverGroupEntry.id): serverGroup]
     }
-    serverGroups
+    return serverGroups
   }
 
   /**
    * Translate instances
    */
-  private Map<String, TitusInstance> translateInstances(Collection<CacheData> instanceData) {
+  private Map<String, TitusInstance> translateInstances(Collection<CacheData> instanceData, Collection<CacheData> serverGroupData) {
+    Map<String, Job> jobData = serverGroupData.collectEntries { cacheData ->
+      Job job = objectMapper.convertValue(cacheData.getAttributes().job, Job)
+      [job.id, job]
+    }
     Map<String, TitusInstance> instances = instanceData.collectEntries { instanceEntry ->
-      Job.TaskSummary task = objectMapper.convertValue(instanceEntry.attributes.task, Job.TaskSummary)
-      Job job = objectMapper.convertValue(instanceEntry.attributes.job, Job)
+      Task task = objectMapper.convertValue(instanceEntry.attributes.task, Task)
+
+      Job job
+      if (instanceEntry.attributes.job == null && instanceEntry.relationships[SERVER_GROUPS.ns] && !instanceEntry.relationships[SERVER_GROUPS.ns].empty) {
+        // job needs to be loaded because it was cached separately
+        job = jobData.get(instanceEntry.attributes.jobId)
+      } else {
+        job = objectMapper.convertValue(instanceEntry.attributes.job, Job)
+      }
+
       TitusInstance instance = new TitusInstance(job, task)
       instance.health = instanceEntry.attributes[HEALTH.ns]
       [(instanceEntry.id): instance]
     }
 
-    // Adding health to instances
     Map<String, String> healthKeysToInstance = [:]
     instanceData.each { instanceEntry ->
       externalHealthProviders.each { externalHealthProvider ->
@@ -279,9 +322,13 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
     healths.each { healthEntry ->
       def instanceId = healthKeysToInstance.get(healthEntry.id)
       healthEntry.attributes.remove('lastUpdatedTimestamp')
-      instances[instanceId].health << healthEntry.attributes
+      def health = healthEntry.attributes.collectEntries { key, value ->
+        // groovy + java means that everything must be explicitly a string
+        [(key): value.toString()]
+      }
+      instances[instanceId].health << health
     }
-    instances
+    return instances
   }
 
   // Resolving cache data relationships

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusInstanceProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusInstanceProvider.groovy
@@ -26,13 +26,16 @@ import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 import com.netflix.spinnaker.clouddriver.titus.caching.Keys
 import com.netflix.spinnaker.clouddriver.titus.caching.utils.AwsLookupUtil
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
+import com.netflix.spinnaker.clouddriver.titus.client.model.Task
 import com.netflix.spinnaker.clouddriver.titus.model.TitusInstance
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
-import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS
+import static com.netflix.spinnaker.clouddriver.titus.caching.Keys.Namespace.SERVER_GROUPS
 
 @Component
 class TitusInstanceProvider implements InstanceProvider<TitusInstance> {
@@ -40,6 +43,8 @@ class TitusInstanceProvider implements InstanceProvider<TitusInstance> {
   private final Cache cacheView
   private final ObjectMapper objectMapper
   private final TitusCloudProvider titusCloudProvider
+
+  private final Logger log = LoggerFactory.getLogger(getClass())
 
   @Autowired
   AwsLookupUtil awsLookupUtil
@@ -63,25 +68,50 @@ class TitusInstanceProvider implements InstanceProvider<TitusInstance> {
       return null
     }
 
+    if (account == null || account == "") {
+      return null
+    }
+
     String stack = awsLookupUtil.stack(account)
     if (!stack) {
       stack = 'mainvpc'
     }
 
-    CacheData instanceEntry = cacheView.get(INSTANCES.ns, Keys.getInstanceKey(id, awsAccount, stack, region))
+    Keys.CachingSchema cachingSchema = awsLookupUtil.getCachingSchemaForAccount(account)
+
+    String instanceKey = ( cachingSchema == Keys.CachingSchema.V1
+      ? Keys.getInstanceKey(id, awsAccount, stack, region)
+      : Keys.getInstanceV2Key(id, account, region))
+
+    CacheData instanceEntry = cacheView.get(INSTANCES.ns, instanceKey)
     if (!instanceEntry) {
       return null
     }
-    Job.TaskSummary task = objectMapper.convertValue(instanceEntry.attributes.task, Job.TaskSummary)
-    Job job = objectMapper.convertValue(instanceEntry.attributes.job, Job)
+    Task task = objectMapper.convertValue(instanceEntry.attributes.task, Task)
+    Job job
+    if (instanceEntry.attributes.job == null) {
+      // Instance is cached separately from job, so we must also load the job cache entry
+      if (instanceEntry.relationships[SERVER_GROUPS.ns] && !instanceEntry.relationships[SERVER_GROUPS.ns].empty) {
+        job = loadJob(instanceEntry)
+      } else {
+        log.error( "Task {} in {}:{} does not have a job", task.id, account, region)
+      }
+    } else {
+      // Instance is cached at the same time as job, V1 schema
+      objectMapper.convertValue(instanceEntry.attributes.job, Job)
+    }
+
     TitusInstance instance = new TitusInstance(job, task)
     instance.accountId = awsAccount
+
     instance.health = instance.health ?: []
     if (instanceEntry.attributes[HEALTH.ns]) {
       instance.health.addAll(instanceEntry.attributes[HEALTH.ns])
     }
     if (instanceEntry.relationships[SERVER_GROUPS.ns] && !instanceEntry.relationships[SERVER_GROUPS.ns].empty) {
-      instance.serverGroup = instanceEntry.relationships[SERVER_GROUPS.ns].iterator().next()
+      instance.serverGroup = (cachingSchema == Keys.CachingSchema.V1
+        ? Keys.parse(instanceEntry.relationships[SERVER_GROUPS.ns].iterator().next())
+        : Keys.parse(instanceEntry.relationships[SERVER_GROUPS.ns].iterator().next()).serverGroup)
       instance.cluster =  Names.parseName(instance.serverGroup)?.cluster
     }
     externalHealthProviders.each { externalHealthProvider ->
@@ -92,14 +122,33 @@ class TitusInstanceProvider implements InstanceProvider<TitusInstance> {
       healthKeys.unique().each { key ->
         def externalHealth = cacheView.getAll(HEALTH.ns, key)
         if (externalHealth) {
-          def health = externalHealth*.attributes
-          health.each { it.remove('lastUpdatedTimestamp') }
+          List<Map<String, Object>> health = externalHealth*.attributes
+          health.each {
+            it.remove('lastUpdatedTimestamp')
+            // groovy + java means that everything must be explicitly a string
+            it.allowMultipleEurekaPerAccount = it.allowMultipleEurekaPerAccount.toString()
+          }
+
           instance.health.addAll(health)
         }
       }
     }
     awsLookupUtil.lookupTargetGroupHealth(job, [instance].toSet())
-    instance
+    return instance
+  }
+
+  private Job loadJob(CacheData instanceEntry) {
+    Collection<CacheData> data = resolveRelationshipData(instanceEntry, SERVER_GROUPS.ns)
+    return objectMapper.convertValue(data?.first()?.attributes.job, Job)
+  }
+
+  private Collection<CacheData> resolveRelationshipData(CacheData source, String relationship) {
+    resolveRelationshipData(source, relationship) { true }
+  }
+
+  private Collection<CacheData> resolveRelationshipData(CacheData source, String relationship, Closure<Boolean> relFilter) {
+    Collection<String> filteredRelationships = source.relationships[relationship]?.findAll(relFilter)
+    filteredRelationships ? cacheView.getAll(relationship, filteredRelationships) : []
   }
 
   @Override

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/AwsLookupUtil.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/AwsLookupUtil.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonVpcProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import com.netflix.spinnaker.clouddriver.titus.caching.Keys
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
 import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials
 import com.netflix.spinnaker.clouddriver.titus.model.TitusInstance
@@ -36,15 +35,13 @@ import org.springframework.stereotype.Component
 import javax.annotation.PostConstruct
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH
-import static com.netflix.spinnaker.clouddriver.titus.caching.Keys.CachingSchema.V1
-import static com.netflix.spinnaker.clouddriver.titus.caching.Keys.CachingSchema.V2
 
 @Component
 class AwsLookupUtil {
 
   private Set<AmazonVpc> amazonVpcs
   private List awsAccountLookup
-  private Map<String, Keys.CachingSchema> cachingSchemaForAccounts = [:]
+
 
   @Autowired
   AmazonSecurityGroupProvider awsSecurityGroupProvider
@@ -63,10 +60,6 @@ class AwsLookupUtil {
 
   @Autowired
   AmazonLoadBalancerProvider amazonLoadBalancerProvider
-
-  Keys.CachingSchema getCachingSchemaForAccount(String account) {
-    return cachingSchemaForAccounts.get(account) ?: V1
-  }
 
   Boolean securityGroupIdExists(String account, String region, String securityGroupId) {
     getSecurityGroupDetails(account, region, securityGroupId)?.name != null
@@ -199,8 +192,6 @@ class AwsLookupUtil {
                              awsAccount  : credential.awsAccount,
                              region      : region.name,
                              vpcId       : convertVpcNameToId(credential.awsAccount, region.name, credential.awsVpc)]
-        cachingSchemaForAccounts.put(credential.name, credential.splitCachingEnabled ? V2 : V1)
-        cachingSchemaForAccounts.put(awsAccountId(credential.name, region.name), credential.splitCachingEnabled ? V2 : V1)
       }
     }
   }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/CachingSchema.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/CachingSchema.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.caching.utils;
+
+public enum CachingSchema {
+  V1,
+  V2;
+
+  String toLowerCase() {
+    return name().toLowerCase();
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/CachingSchemaUtil.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/CachingSchemaUtil.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.caching.utils
+
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
+
+@Component
+class CachingSchemaUtil {
+  private Map<String, CachingSchema> cachingSchemaForAccounts = [:]
+
+  @Autowired
+  AccountCredentialsProvider accountCredentialsProvider
+
+  @Autowired
+  AwsLookupUtil awsLookupUtil
+
+  CachingSchema getCachingSchemaForAccount(String account) {
+    return cachingSchemaForAccounts.get(account) ?: CachingSchema.V1
+  }
+
+  @PostConstruct
+  private void init() {
+    accountCredentialsProvider.all.findAll {
+      it instanceof NetflixTitusCredentials
+    }.each { NetflixTitusCredentials credential ->
+      credential.regions.each { region ->
+        cachingSchemaForAccounts.put(credential.name, credential.splitCachingEnabled ? CachingSchema.V2 : CachingSchema.V1)
+        cachingSchemaForAccounts.put(
+          awsLookupUtil.awsAccountId(credential.name, region.name),
+          credential.splitCachingEnabled ? CachingSchema.V2 : CachingSchema.V1
+        )
+      }
+    }
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
@@ -296,7 +296,7 @@ public class RegionScopedTitusClient implements TitusClient {
       .addFields("id")
       .addFields("jobDescriptor.attributes.name");
 
-    List<com.netflix.titus.grpc.protogen.Job> grpcJobs = getJobsWithFilter(jobQuery);
+    List<com.netflix.titus.grpc.protogen.Job> grpcJobs = getJobsWithFilter(jobQuery, 10000);
 
     return grpcJobs.stream()
       .collect(Collectors.toMap(
@@ -316,7 +316,7 @@ public class RegionScopedTitusClient implements TitusClient {
       .addFields("id")
       .addFields("jobId");
 
-    List<com.netflix.titus.grpc.protogen.Task> grpcTasks = getTasksWithFilter(taskQueryBuilder);
+    List<com.netflix.titus.grpc.protogen.Task> grpcTasks = getTasksWithFilter(taskQueryBuilder, 10000);
     return grpcTasks.stream().collect(Collectors.groupingBy(com.netflix.titus.grpc.protogen.Task::getJobId, mapping(com.netflix.titus.grpc.protogen.Task::getId, toList())));
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
@@ -374,7 +374,7 @@ public class RegionScopedTitusClient implements TitusClient {
   }
 
   private List<com.netflix.titus.grpc.protogen.Task> getTasksWithFilter(TaskQuery.Builder taskQueryBuilder) {
-    return getTasksWithFilter(taskQueryBuilder, 1000);
+    return getTasksWithFilter(taskQueryBuilder, titusRegion.getFeatureFlags().contains("largePages") ? 2000 : 1000);
   }
 
   private List<com.netflix.titus.grpc.protogen.Task> getTasksWithFilter(TaskQuery.Builder taskQueryBuilder, Integer pageSize) {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
@@ -34,6 +34,9 @@ import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
 @Slf4j
 public class RegionScopedTitusClient implements TitusClient {
 
@@ -247,7 +250,7 @@ public class RegionScopedTitusClient implements TitusClient {
   }
 
   @Override
-  public List<Job> getAllJobs() {
+  public List<Job> getAllJobsWithTasks() {
     JobQuery.Builder jobQuery = JobQuery.newBuilder()
       .putFilteringCriteria("jobType", "SERVICE")
       .putFilteringCriteria("attributes", "source:spinnaker");
@@ -259,29 +262,13 @@ public class RegionScopedTitusClient implements TitusClient {
   }
 
   private List<Job> getJobs(JobQuery.Builder jobQuery, boolean includeTasks) {
-    List<Job> jobs = new ArrayList<>();
-    List<com.netflix.titus.grpc.protogen.Job> grpcJobs = new ArrayList<>();
-    String cursor = "";
-    boolean hasMore;
-    do {
-      Page.Builder jobPage = Page.newBuilder().setPageSize(1000);
-      if (!cursor.isEmpty()) {
-        jobPage.setCursor(cursor);
-      }
-      jobQuery.setPage(jobPage);
-      JobQuery criteria = jobQuery.build();
-      JobQueryResult resultPage = TitusClientCompressionUtil.attachCaller(grpcBlockingStub).findJobs(criteria);
-      grpcJobs.addAll(resultPage.getItemsList());
-      cursor = resultPage.getPagination().getCursor();
-      hasMore = resultPage.getPagination().getHasMore();
-    } while (hasMore);
-
+    List<com.netflix.titus.grpc.protogen.Job> grpcJobs = getJobsWithFilter(jobQuery);
     final Map<String, List<com.netflix.titus.grpc.protogen.Task>> tasks;
 
     if (includeTasks) {
       List<String> jobIds = Collections.emptyList();
       if (!titusRegion.getFeatureFlags().contains("jobIds")) {
-        jobIds = grpcJobs.stream().map(grpcJob -> grpcJob.getId()).collect(
+        jobIds = grpcJobs.stream().map(com.netflix.titus.grpc.protogen.Job::getId).collect(
           Collectors.toList()
         );
       }
@@ -289,41 +276,127 @@ public class RegionScopedTitusClient implements TitusClient {
     } else {
       tasks = Collections.emptyMap();
     }
-
     return grpcJobs.stream().map(grpcJob -> new Job(grpcJob, tasks.get(grpcJob.getId()))).collect(Collectors.toList());
   }
 
+  @Override
+  public List<Job> getAllJobsWithoutTasks() {
+    JobQuery.Builder jobQuery = JobQuery.newBuilder()
+      .putFilteringCriteria("jobType", "SERVICE")
+      .putFilteringCriteria("attributes", "source:spinnaker");
+
+    return getJobs(jobQuery, false);
+  }
+
+  @Override
+  public Map<String, String> getAllJobNames() {
+    JobQuery.Builder jobQuery = JobQuery.newBuilder()
+      .putFilteringCriteria("jobType", "SERVICE")
+      .putFilteringCriteria("attributes", "source:spinnaker")
+      .addFields("id")
+      .addFields("jobDescriptor.attributes.name");
+
+    List<com.netflix.titus.grpc.protogen.Job> grpcJobs = getJobsWithFilter(jobQuery);
+
+    return grpcJobs.stream()
+      .collect(Collectors.toMap(
+        com.netflix.titus.grpc.protogen.Job::getId,
+        it -> it.getJobDescriptor().getAttributesOrDefault("name", "")
+      ));
+  }
+
+  @Override
+  public Map<String, List<String>> getTaskIdsForJobIds() {
+    String filterByStates = "Accepted,Launched,StartInitiated,Started";
+
+    TaskQuery.Builder taskQueryBuilder = TaskQuery.newBuilder();
+    taskQueryBuilder
+      .putFilteringCriteria("attributes", "source:spinnaker")
+      .putFilteringCriteria("taskStates", filterByStates)
+      .addFields("id")
+      .addFields("jobId");
+
+    List<com.netflix.titus.grpc.protogen.Task> grpcTasks = getTasksWithFilter(taskQueryBuilder);
+    return grpcTasks.stream().collect(Collectors.groupingBy(com.netflix.titus.grpc.protogen.Task::getJobId, mapping(com.netflix.titus.grpc.protogen.Task::getId, toList())));
+  }
+
   private Map<String, List<com.netflix.titus.grpc.protogen.Task>> getTasks(List<String> jobIds, boolean includeDoneJobs) {
-    List<com.netflix.titus.grpc.protogen.Task> tasks = new ArrayList<>();
-    TaskQueryResult taskResults;
+    TaskQuery.Builder taskQueryBuilder = TaskQuery.newBuilder();
+    if (!jobIds.isEmpty()) {
+      taskQueryBuilder.putFilteringCriteria("jobIds", jobIds.stream().collect(Collectors.joining(",")));
+    }
+    if (titusRegion.getFeatureFlags().contains("jobIds")) {
+      taskQueryBuilder.putFilteringCriteria("attributes", "source:spinnaker");
+    }
+    String filterByStates = "Accepted,Launched,StartInitiated,Started";
+    if (includeDoneJobs) {
+      filterByStates = filterByStates + ",KillInitiated,Finished";
+    }
+    taskQueryBuilder.putFilteringCriteria("taskStates", filterByStates);
+
+    List<com.netflix.titus.grpc.protogen.Task> tasks = getTasksWithFilter(taskQueryBuilder);
+    return tasks.stream().collect(Collectors.groupingBy(com.netflix.titus.grpc.protogen.Task::getJobId));
+  }
+
+  @Override
+  public List<Task> getAllTasks() {
+    TaskQuery.Builder taskQueryBuilder = TaskQuery.newBuilder();
+    taskQueryBuilder.putFilteringCriteria("attributes", "source:spinnaker");
+    String filterByStates = "Accepted,Launched,StartInitiated,Started";
+    taskQueryBuilder.putFilteringCriteria("taskStates", filterByStates);
+
+    List<com.netflix.titus.grpc.protogen.Task> tasks = getTasksWithFilter(taskQueryBuilder);
+    return tasks.stream().map(Task::new).collect(toList());
+  }
+
+  private List<com.netflix.titus.grpc.protogen.Job> getJobsWithFilter(JobQuery.Builder jobQueryBuilder) {
+    return getJobsWithFilter(jobQueryBuilder, 1000);
+  }
+
+  private List<com.netflix.titus.grpc.protogen.Job> getJobsWithFilter(JobQuery.Builder jobQueryBuilder, Integer pageSize) {
+    List<com.netflix.titus.grpc.protogen.Job> grpcJobs = new ArrayList<>();
     String cursor = "";
     boolean hasMore;
     do {
-      Page.Builder taskPage = Page.newBuilder().setPageSize(titusRegion.getFeatureFlags().contains("largePages") ? 2000 : 1000);
-      if (!cursor.isEmpty()) {
-        taskPage.setCursor(cursor);
+      if (cursor.isEmpty()) {
+        jobQueryBuilder.setPage(Page.newBuilder().setPageSize(pageSize));
+      } else {
+        jobQueryBuilder.setPage(Page.newBuilder().setCursor(cursor).setPageSize(pageSize));
       }
-      TaskQuery.Builder taskQueryBuilder = TaskQuery.newBuilder();
-      taskQueryBuilder.setPage(taskPage);
-      if (!jobIds.isEmpty()) {
-        taskQueryBuilder.putFilteringCriteria("jobIds", jobIds.stream().collect(Collectors.joining(",")));
+
+      JobQuery criteria = jobQueryBuilder.build();
+      JobQueryResult resultPage = TitusClientCompressionUtil.attachCaller(grpcBlockingStub).findJobs(criteria);
+      grpcJobs.addAll(resultPage.getItemsList());
+      cursor = resultPage.getPagination().getCursor();
+      hasMore = resultPage.getPagination().getHasMore();
+    } while (hasMore);
+    return grpcJobs;
+  }
+
+  private List<com.netflix.titus.grpc.protogen.Task> getTasksWithFilter(TaskQuery.Builder taskQueryBuilder) {
+    return getTasksWithFilter(taskQueryBuilder, 1000);
+  }
+
+  private List<com.netflix.titus.grpc.protogen.Task> getTasksWithFilter(TaskQuery.Builder taskQueryBuilder, Integer pageSize) {
+    List<com.netflix.titus.grpc.protogen.Task> grpcTasks = new ArrayList<>();
+
+    TaskQueryResult taskResults;
+    String cursor = "";
+    boolean hasMore;
+
+    do {
+      if (cursor.isEmpty()) {
+        taskQueryBuilder.setPage(Page.newBuilder().setPageSize(pageSize));
+      } else {
+        taskQueryBuilder.setPage(Page.newBuilder().setCursor(cursor).setPageSize(pageSize));
       }
-      if (titusRegion.getFeatureFlags().contains("jobIds")) {
-        taskQueryBuilder.putFilteringCriteria("attributes", "source:spinnaker");
-      }
-      String filterByStates = "Accepted,Launched,StartInitiated,Started";
-      if (includeDoneJobs) {
-        filterByStates = filterByStates + ",KillInitiated,Finished";
-      }
-      taskQueryBuilder.putFilteringCriteria("taskStates", filterByStates);
       taskResults = TitusClientCompressionUtil.attachCaller(grpcBlockingStub).findTasks(
         taskQueryBuilder.build()
       );
-      tasks.addAll(taskResults.getItemsList());
+      grpcTasks.addAll(taskResults.getItemsList());
       cursor = taskResults.getPagination().getCursor();
       hasMore = taskResults.getPagination().getHasMore();
     } while (hasMore);
-    return tasks.stream().collect(Collectors.groupingBy(task -> task.getJobId()));
+    return grpcTasks;
   }
-
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusClient.java
@@ -99,6 +99,22 @@ public interface TitusClient {
   /**
    * @return
    */
-  public List<Job> getAllJobs();
+  public List<Job> getAllJobsWithTasks();
+
+  /**
+   * For use in TitusV2ClusterCachingAgent
+   * @return all jobs w/o task detail that are managed by Spinnaker
+   */
+  public List<Job> getAllJobsWithoutTasks();
+
+  /**
+   * For use in TitusInstanceCachingAgent
+   * @return all tasks managed by Spinnaker
+   */
+  public List<Task> getAllTasks();
+
+  public Map<String, String> getAllJobNames();
+
+  public Map<String, List<String>> getTaskIdsForJobIds();
 
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusLoadBalancerClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusLoadBalancerClient.java
@@ -30,6 +30,9 @@ public interface TitusLoadBalancerClient {
 
   void removeLoadBalancer(String jobId, String loadBalancerId);
 
+  /**
+   * @return a map of jobId to list of loadbalancerIds
+   */
   Map<String, List<String>> getAllLoadBalancers();
 
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
@@ -23,192 +23,6 @@ import java.util.stream.Collectors;
 
 public class Job {
 
-  public static class TaskSummary {
-
-    public TaskSummary() {
-    }
-
-    public TaskSummary(com.netflix.titus.grpc.protogen.Task grpcTask) {
-      id = grpcTask.getId();
-      state = TaskState.from(grpcTask.getStatus().getState().name(), grpcTask.getStatus().getReasonCode());
-      instanceId = grpcTask.getTaskContextOrDefault("v2.taskInstanceId", id);
-      host = grpcTask.getTaskContextOrDefault("agent.host", null);
-      region = grpcTask.getTaskContextOrDefault("agent.region", null);
-      zone = grpcTask.getTaskContextOrDefault("agent.zone", null);
-      submittedAt = getTimestampFromStatus(grpcTask, TaskStatus.TaskState.Accepted);
-      launchedAt = getTimestampFromStatus(grpcTask, TaskStatus.TaskState.Launched);
-      startedAt = getTimestampFromStatus(grpcTask, TaskStatus.TaskState.StartInitiated);
-      finishedAt = getTimestampFromStatus(grpcTask, TaskStatus.TaskState.Finished);
-      containerIp = grpcTask.getTaskContextOrDefault("task.containerIp", null);
-      logLocation = new HashMap<>();
-      logLocation.put("ui", grpcTask.getLogLocation().getUi().getUrl());
-      logLocation.put("liveStream", grpcTask.getLogLocation().getLiveStream().getUrl());
-      HashMap<String, String> s3 = new HashMap<>();
-      s3.put("accountId", grpcTask.getLogLocation().getS3().getAccountId());
-      s3.put("accountName", grpcTask.getLogLocation().getS3().getAccountName());
-      s3.put("region", grpcTask.getLogLocation().getS3().getRegion());
-      s3.put("bucket", grpcTask.getLogLocation().getS3().getBucket());
-      s3.put("key", grpcTask.getLogLocation().getS3().getKey());
-      logLocation.put("s3", s3);
-    }
-
-    private Date getTimestampFromStatus(com.netflix.titus.grpc.protogen.Task grpcTask, TaskStatus.TaskState state) {
-      return grpcTask.getStatusHistoryList().stream().filter(status -> status.getState().equals(state)).findFirst().map(status -> new Date(status.getTimestamp())).orElse(null);
-    }
-
-    private String id;
-    private String instanceId;
-    private TaskState state;
-    private String host;
-    private String region;
-    private String zone;
-    private Date submittedAt;
-    private Date launchedAt;
-    private Date startedAt;
-    private Date finishedAt;
-    private String message;
-    private Map<String, Object> data;
-    private String stdoutLive;
-    private String logs;
-    private String snapshots;
-    private String containerIp;
-
-    private Map<String, Object> logLocation;
-
-    public String getId() {
-      return id;
-    }
-
-    public void setId(String id) {
-      this.id = id;
-    }
-
-    public String getInstanceId() {
-      return instanceId;
-    }
-
-    public void setInstanceId(String instanceId) {
-      this.instanceId = instanceId;
-    }
-
-    public TaskState getState() {
-      return state;
-    }
-
-    public void setState(TaskState state) {
-      this.state = state;
-    }
-
-    public String getHost() {
-      return host;
-    }
-
-    public void setHost(String host) {
-      this.host = host;
-    }
-
-    public String getRegion() {
-      return region;
-    }
-
-    public void setRegion(String region) {
-      this.region = region;
-    }
-
-    public String getZone() {
-      return zone;
-    }
-
-    public void setZone(String zone) {
-      this.zone = zone;
-    }
-
-    public Date getSubmittedAt() {
-      return submittedAt;
-    }
-
-    public void setSubmittedAt(Date submittedAt) {
-      this.submittedAt = submittedAt;
-    }
-
-    public Date getLaunchedAt() {
-      return launchedAt;
-    }
-
-    public void setLaunchedAt(Date launchedAt) {
-      this.launchedAt = launchedAt;
-    }
-
-    public Date getStartedAt() {
-      return startedAt;
-    }
-
-    public void setStartedAt(Date startedAt) {
-      this.startedAt = startedAt;
-    }
-
-    public Date getFinishedAt() {
-      return finishedAt;
-    }
-
-    public void setFinishedAt(Date finishedAt) {
-      this.finishedAt = finishedAt;
-    }
-
-    public String getMessage() {
-      return message;
-    }
-
-    public void setMessage(String message) {
-      this.message = message;
-    }
-
-    public Map<String, Object> getData() {
-      return data;
-    }
-
-    public void setData(Map<String, Object> data) {
-      this.data = data;
-    }
-
-    public String getStdoutLive() {
-      return stdoutLive;
-    }
-
-    public void setStdoutLive(String stdoutLive) {
-      this.stdoutLive = stdoutLive;
-    }
-
-    public String getLogs() {
-      return logs;
-    }
-
-    public void setLogs(String logs) {
-      this.logs = logs;
-    }
-
-    public String getSnapshots() {
-      return snapshots;
-    }
-
-    public void setSnapshots(String snapshots) {
-      this.snapshots = snapshots;
-    }
-
-    public String getContainerIp() {
-      return containerIp;
-    }
-
-    public void setContainerIp(String containerIp) {
-      this.containerIp = containerIp;
-    }
-
-    public Map<String, Object> getLogLocation() {
-      return logLocation;
-    }
-
-  }
-
   private String id;
   private String name;
   private String type;
@@ -237,7 +51,7 @@ public class Job {
   private int runtimeLimitSecs;
   private boolean allocateIpAddress;
   private Date submittedAt;
-  private List<TaskSummary> tasks;
+  private List<Task> tasks;
   private Map<String, String> labels;
   private List<String> securityGroups;
   private String jobGroupStack;
@@ -288,7 +102,7 @@ public class Job {
     user = grpcJob.getJobDescriptor().getOwner().getTeamEmail();
 
     if (grpcTasks != null) {
-      tasks = grpcTasks.stream().map(grpcTask -> new TaskSummary(grpcTask)).collect(Collectors.toList());
+      tasks = grpcTasks.stream().map(grpcTask -> new Task(grpcTask)).collect(Collectors.toList());
     } else {
       tasks = new ArrayList<>();
     }
@@ -492,11 +306,11 @@ public class Job {
     this.submittedAt = submittedAt;
   }
 
-  public List<TaskSummary> getTasks() {
+  public List<Task> getTasks() {
     return tasks;
   }
 
-  public void setTasks(List<TaskSummary> tasks) {
+  public void setTasks(List<Task> tasks) {
     this.tasks = tasks;
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/config/TitusConfiguration.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/config/TitusConfiguration.groovy
@@ -63,7 +63,7 @@ class TitusConfiguration {
       if (!account.bastionHost && titusCredentialsConfig.defaultBastionHostTemplate) {
         account.bastionHost = titusCredentialsConfig.defaultBastionHostTemplate.replaceAll(Pattern.quote('{{environment}}'), account.environment)
       }
-      NetflixTitusCredentials credentials = new NetflixTitusCredentials(account.name, account.environment, account.accountType, regions, account.bastionHost, account.registry, account.awsAccount, account.awsVpc ?: titusCredentialsConfig.awsVpc, account.discoveryEnabled, account.discovery, account.stack ?: 'mainvpc', account.requiredGroupMembership, account.eurekaName, account.autoscalingEnabled ?: false, account.loadBalancingEnabled ?: false)
+      NetflixTitusCredentials credentials = new NetflixTitusCredentials(account.name, account.environment, account.accountType, regions, account.bastionHost, account.registry, account.awsAccount, account.awsVpc ?: titusCredentialsConfig.awsVpc, account.discoveryEnabled, account.discovery, account.stack ?: 'mainvpc', account.requiredGroupMembership, account.eurekaName, account.autoscalingEnabled ?: false, account.loadBalancingEnabled ?: false, account.splitCachingEnabled ?: false)
       accounts.add(credentials)
       repository.save(account.name, credentials)
     }
@@ -111,6 +111,7 @@ class TitusConfiguration {
       String eurekaName
       Boolean autoscalingEnabled
       Boolean loadBalancingEnabled
+      Boolean splitCachingEnabled
     }
 
     static class Region {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/credentials/NetflixTitusCredentials.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/credentials/NetflixTitusCredentials.groovy
@@ -38,6 +38,7 @@ class NetflixTitusCredentials implements AccountCredentials<TitusCredentials> {
   final String eurekaName
   final boolean autoscalingEnabled
   final boolean loadBalancingEnabled
+  final boolean splitCachingEnabled
 
   private final List<TitusRegion> regions
 
@@ -55,7 +56,8 @@ class NetflixTitusCredentials implements AccountCredentials<TitusCredentials> {
                           List<String> requiredGroupMembership,
                           String eurekaName,
                           boolean autoscalingEnabled,
-                          boolean loadBalancingEnabled
+                          boolean loadBalancingEnabled,
+                          boolean splitCachingEnabled
   ) {
     this.name = name
     this.environment = environment
@@ -72,6 +74,7 @@ class NetflixTitusCredentials implements AccountCredentials<TitusCredentials> {
     this.eurekaName = eurekaName
     this.autoscalingEnabled = autoscalingEnabled
     this.loadBalancingEnabled = loadBalancingEnabled
+    this.splitCachingEnabled = splitCachingEnabled
   }
 
   @Override
@@ -128,4 +131,7 @@ class NetflixTitusCredentials implements AccountCredentials<TitusCredentials> {
     return loadBalancingEnabled
   }
 
+  boolean getSplitCachingEnabled() {
+    return splitCachingEnabled
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.model.Instance
 import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
 import com.netflix.spinnaker.clouddriver.titus.client.model.TaskState
+import com.netflix.spinnaker.clouddriver.titus.client.model.Task
 
 class TitusInstance implements Instance {
 
@@ -49,7 +50,7 @@ class TitusInstance implements Instance {
 
   TitusInstance() {}
 
-  TitusInstance(Job job, Job.TaskSummary task) {
+  TitusInstance(Job job, Task task) {
     id = task.id
     instanceId = task.instanceId
     securityGroups = job.securityGroups?.collect { it -> new TitusSecurityGroup(groupId: it, groupName: "n/a") }
@@ -113,7 +114,7 @@ class TitusInstance implements Instance {
   }
 
   @Override
-  List<Map<String, Object>> getHealth() {
+  List<Map<String, String>> getHealth() {
     health
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusJobStatus.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusJobStatus.groovy
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.model.Instance
 import com.netflix.spinnaker.clouddriver.model.JobState
 import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
-import com.netflix.spinnaker.clouddriver.titus.client.model.Job.TaskSummary
+import com.netflix.spinnaker.clouddriver.titus.client.model.Task
 import com.netflix.spinnaker.clouddriver.titus.client.model.TaskState
 
 /**
@@ -55,12 +55,12 @@ class TitusJobStatus implements com.netflix.spinnaker.clouddriver.model.JobStatu
     name = job.name
     createdTime = job.submittedAt ? job.submittedAt.time : null
     application = Names.parseName(job.name).app
-    TaskSummary task = job.tasks.sort { it.startedAt }.last()
+    Task task = job.tasks.sort { it.startedAt }.last()
     jobState = convertTaskStateToJobState(job, task)
     completionDetails = convertCompletionDetails(task)
   }
 
-  Map<String, String> convertCompletionDetails(TaskSummary task) {
+  Map<String, String> convertCompletionDetails(Task task) {
     [
       message   : task.message,
       taskId    : task.id,
@@ -68,7 +68,7 @@ class TitusJobStatus implements com.netflix.spinnaker.clouddriver.model.JobStatu
     ]
   }
 
-  JobState convertTaskStateToJobState(Job job, TaskSummary task) {
+  JobState convertTaskStateToJobState(Job job, Task task) {
 
     if (job.getJobState() in ["Accepted", "KillInitiated"]) {
       return JobState.Running

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
@@ -103,7 +103,7 @@ class RegionScopedTitusClientSpec extends Specification {
     job != null
 
     logger.info("Jobs request: {}", new Date());
-    List<Job> jobs = titusClient.getAllJobs();
+    List<Job> jobs = titusClient.getAllJobsWithTasks();
     logger.info("Jobs response: {}", new Date());
     logger.info("Jobs");
     logger.info("-----------------------------------------------------------------------------------------------");
@@ -114,7 +114,7 @@ class RegionScopedTitusClientSpec extends Specification {
     int i = 7;
     boolean found = false;
     while (--i > 0) {
-      Job queriedJob = titusClient.getAllJobs().find { it.id == jobId }
+      Job queriedJob = titusClient.getAllJobsWithTasks().find { it.id == jobId }
       if (queriedJob) {
         found = true;
         break;
@@ -166,7 +166,7 @@ class RegionScopedTitusClientSpec extends Specification {
     Job terminatedJob = null;
     while (--j > 0) {
       terminatedJob = titusClient.getJobAndAllRunningAndCompletedTasks(jobId);
-      Job.TaskSummary task = terminatedJob.getTasks().get(0);
+      Task task = terminatedJob.getTasks().get(0);
       if (task.getState() == TaskState.DEAD ||
         task.getState() == TaskState.STOPPED ||
         task.getState() == TaskState.FAILED ||
@@ -186,7 +186,7 @@ class RegionScopedTitusClientSpec extends Specification {
     int k = 14;
     boolean foundAfterTermination = true;
     while (--k > 0) {
-      List<Job> queriedJobs = titusClient.getAllJobs();
+      List<Job> queriedJobs = titusClient.getAllJobsWithTasks();
       if (!queriedJobs.contains(job)) {
         foundAfterTermination = false;
         logger.info("Did NOT find job {} in the list of jobs. Terminate successful.", jobId);

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
@@ -52,7 +52,7 @@ class TitusDeployHandlerSpec extends Specification {
   }
 
   NetflixTitusCredentials testCredentials = new NetflixTitusCredentials(
-    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, "blah", "blah", 7104, [])], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
+    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, "blah", "blah", 7104, [])], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false, false
   )
 
   @Subject

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/DestroyTitusServerGroupAtomicOperationSpec.groovy
@@ -38,7 +38,7 @@ class DestroyTitusServerGroupAtomicOperationSpec extends Specification {
   }
 
   NetflixTitusCredentials testCredentials = new NetflixTitusCredentials(
-    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, "blah", "blah", 7104, [])], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false
+    'test', 'test', 'test', [new TitusRegion('us-east-1', 'test', 'http://foo', false, false, "blah", "blah", 7104, [])], 'test', 'test', 'test', 'test', false, '', 'mainvpc', [], "", false, false, false
   )
 
   DestroyTitusServerGroupDescription description = new DestroyTitusServerGroupDescription(

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.titus.model
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
 import com.netflix.spinnaker.clouddriver.titus.client.model.TaskState
+import com.netflix.spinnaker.clouddriver.titus.client.model.Task
 import spock.lang.Specification
 
 class TitusInstanceSpec extends Specification {
@@ -35,7 +36,7 @@ class TitusInstanceSpec extends Specification {
     ports: [7150] as int[],
     environment: [account: 'test', region: 'us-east-1'],
   )
-  Job.TaskSummary task = new Job.TaskSummary(
+  Task task = new Task(
     id: '5678',
     state: TaskState.RUNNING,
     submittedAt: launchDate,

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroupSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroupSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.titus.model
 
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
 import com.netflix.spinnaker.clouddriver.titus.client.model.TaskState
+import com.netflix.spinnaker.clouddriver.titus.client.model.Task
 import spock.lang.Specification
 
 class TitusServerGroupSpec extends Specification {
@@ -38,7 +39,7 @@ class TitusServerGroupSpec extends Specification {
     instancesDesired: 5,
     environment: [account: 'test'],
     submittedAt: launchDate,
-    tasks: [new Job.TaskSummary(
+    tasks: [new Task(
       id: '5678',
       region: 'us-east-1',
       state: TaskState.RUNNING,


### PR DESCRIPTION
(I'll update this PR with performance numbers, opening for feedback)

Only controller API call that produces different responses is this set:
```
https://localhost:8081/applications/emburnstest/clusters/titustestvpc/emburnstest-responses?expand=false
https://localhost:8081/applications/emburnstest/clusters/titustestvpc/emburnstest-responses?expand=true
```
In the current implementation, both return instance details. This PR changes the response so that when `expand=false` the `instances : []` list is empty. It is populated when `expand=true`.

Also, this PR fixes titus instance searching (it is broken in the current Titus implementation due to incorrect Key parsing)