### PR TITLE
fix(core): Correctly track any OperationalEvents generated by a deploy

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.deploy
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import com.netflix.spinnaker.clouddriver.orchestration.events.CreateServerGroupEvent
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -30,7 +29,6 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult> {
   DeployHandlerRegistry deploymentHandlerRegistry
 
   private final DeployDescription description
-  private final Collection<OperationEvent> events = []
 
   DeployAtomicOperation(DeployDescription description) {
     this.description = description
@@ -42,7 +40,7 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult> {
 
   @Override
   Collection<OperationEvent> getEvents() {
-    return events
+    return this.description.getEvents() ?: []
   }
 
   @Override
@@ -58,9 +56,6 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult> {
 
     task.updateStatus TASK_PHASE, "Invoking Handler."
     def deploymentResult = deployHandler.handle(description, priorOutputs)
-
-    def events = description.getEvents() ?: []
-    events.addAll(events)
 
     task.updateStatus TASK_PHASE, "Server Groups: ${deploymentResult.serverGroupNames} created."
 

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/events/CreateServerGroupEventHandler.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/events/CreateServerGroupEventHandler.java
@@ -21,11 +21,15 @@ import com.netflix.spinnaker.clouddriver.orchestration.events.CreateServerGroupE
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEventHandler;
 import com.netflix.spinnaker.clouddriver.tags.EntityTagger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CreateServerGroupEventHandler implements OperationEventHandler {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
   private final ElasticSearchEntityTagger serverGroupTagger;
 
   @Autowired
@@ -38,6 +42,8 @@ public class CreateServerGroupEventHandler implements OperationEventHandler {
     if (!(operationEvent instanceof CreateServerGroupEvent)) {
       return;
     }
+
+    log.debug("Handling create server group event ({})", operationEvent);
 
     CreateServerGroupEvent createServerGroupEvent = (CreateServerGroupEvent) operationEvent;
     serverGroupTagger.deleteAll(

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/events/DeleteServerGroupEventHandler.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/events/DeleteServerGroupEventHandler.java
@@ -21,11 +21,15 @@ import com.netflix.spinnaker.clouddriver.orchestration.events.DeleteServerGroupE
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEventHandler;
 import com.netflix.spinnaker.clouddriver.tags.EntityTagger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DeleteServerGroupEventHandler implements OperationEventHandler {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
   private final ElasticSearchEntityTagger serverGroupTagger;
 
   @Autowired
@@ -38,6 +42,8 @@ public class DeleteServerGroupEventHandler implements OperationEventHandler {
     if (!(operationEvent instanceof DeleteServerGroupEvent)) {
       return;
     }
+
+    log.debug("Handling delete server group event ({})", operationEvent);
 
     DeleteServerGroupEvent deleteServerGroupEvent = (DeleteServerGroupEvent) operationEvent;
     serverGroupTagger.deleteAll(


### PR DESCRIPTION
Silly logic error was preventing this from happening previously.
