### PR TITLE
fix(provider/kubernetes): Adding missing log definition.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DestroyKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DestroyKubernetesAtomicOperation.groovy
@@ -24,7 +24,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.server
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.exception.KubernetesOperationException
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
+import groovy.util.logging.Slf4j
 
+@Slf4j
 class DestroyKubernetesAtomicOperation implements AtomicOperation<Void> {
   private static final String BASE_PHASE = "DESTROY"
 


### PR DESCRIPTION
Got the following error when attempting to shrink a cluster.

No such property: log for class: com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.ops.servergroup.DestroyKubernetesAtomicOperation

