### PR TITLE
fix(provider/kubernetes): don't override annotations

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
@@ -65,6 +65,9 @@ public class KubernetesManifestAnnotater {
       return;
     }
 
+    if (annotations.containsKey(key)) {
+      return;
+    }
 
     try {
       if (value instanceof String) {


### PR DESCRIPTION
closes: https://github.com/spinnaker/spinnaker/issues/2830

The reason this worked for stack & detail was because the `moniker` field in the op description likely didn't have them specified.