### PR TITLE
fix(caching): Fix on-demand cache result return status

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsOnDemandCacheUpdater.groovy
@@ -84,12 +84,12 @@ class CatsOnDemandCacheUpdater implements OnDemandCacheUpdater {
             continue;
           }
           if (!agent.metricsSupport) {
-            hasOnDemandResults = false
             continue;
           }
           if (result.cacheResult) {
-            hasOnDemandResults = !(result.cacheResult.cacheResults ?: [:]).values().flatten().isEmpty() && !agentScheduler.atomic
-            if (hasOnDemandResults) {
+            boolean agentHasOnDemandResults = !(result.cacheResult.cacheResults ?: [:]).values().flatten().isEmpty() && !agentScheduler.atomic
+            if (agentHasOnDemandResults) {
+              hasOnDemandResults = true;
               result.cacheResult.cacheResults.each { k, v ->
                 if (v) {
                   cachedIdentifiersByType[k].addAll(v*.id)


### PR DESCRIPTION
When multiple caching agents handle an on-demand refresh, the return
status is currently based only on the result of the last agent.  Instead
we should return a PENDING result if *any* of the caching agents find
results, rather than only if that last one does.