### PR TITLE
feat(build): separate release management opinions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,22 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 buildscript {
   ext {
-    springBootVersion = "1.5.10.RELEASE"
     kotlinVersion = "1.2.41"
     junitPlatformVersion = "1.0.2"
   }
   repositories {
-    mavenCentral()
+    mavenLocal()
     jcenter()
     maven { url "http://spinnaker.bintray.com/gradle" }
     maven { url "https://plugins.gradle.org/m2/" }
   }
+
   dependencies {
-    classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:4.0.0'
-    classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
+    classpath 'com.netflix.spinnaker.gradle:spinnaker-dev-plugin:4.1.0-SNAPSHOT'
     classpath "org.junit.platform:junit-platform-gradle-plugin:${junitPlatformVersion}"
     classpath "com.netflix.nebula:nebula-kotlin-plugin:${kotlinVersion}"
   }
@@ -36,11 +34,14 @@ buildscript {
 
 allprojects {
   group = "com.netflix.spinnaker.clouddriver"
-  apply plugin: 'spinnaker.project'
+  apply plugin: 'spinnaker.base-project'
   apply plugin: 'groovy'
 
   ext {
     spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.154.4'
+    versions = [
+      kork: '1.132.0-SNAPSHOT'
+    ]
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]
@@ -129,4 +130,4 @@ subprojects { project ->
   }
 }
 
-defaultTasks ':clouddriver-web:bootRun'
+defaultTasks ':clouddriver-web:run'

--- a/cats/cats.gradle
+++ b/cats/cats.gradle
@@ -1,4 +1,4 @@
-tasks.bintrayUpload.enabled = false
+tasks.findByName('bintrayUpload')?.enabled = false
 
 subprojects {
   apply plugin: 'findbugs'

--- a/clouddriver-oracle-bmcs/clouddriver-oracle-bmcs.gradle
+++ b/clouddriver-oracle-bmcs/clouddriver-oracle-bmcs.gradle
@@ -64,10 +64,12 @@ dependencies {
 }
 
 def allSourceSets = sourceSets
-license {
-  header project.file('oracle-source-header')
-  includes(["**/*.groovy", "**/*.java", "**/*.properties"])
-  strictCheck true
-  skipExistingHeaders false
-  sourceSets = allSourceSets
+
+def licenseExtension = project.extensions.findByName('license')
+if (licenseExtension != null) {
+  licenseExtension.header project.file('oracle-source-header')
+  licenseExtension.includes(["**/*.groovy", "**/*.java", "**/*.properties"])
+  licenseExtension.strictCheck true
+  licenseExtension.skipExistingHeaders false
+  licenseExtension.sourceSets = allSourceSets
 }

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -1,17 +1,11 @@
-apply plugin: 'org.springframework.boot'
-// Applying the spring-boot plugin pulls in a newer version of jedis that we can't use yet. The
-// other ways to override versions (namely the subprojects.configurations.all.resolutionStrategy in
-// build.gradle) didn't work.
-ext['jedis.version'] = spinnaker.version('jedis')
-
-apply plugin: 'spinnaker.package'
+apply plugin: 'spinnaker.application'
 
 ext {
   springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
-  repackage = System.getProperty('springBoot.repackage', "false")
 }
 
-tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
+mainClassName = 'com.netflix.spinnaker.clouddriver.Main'
+run {
   systemProperty('spring.config.location', project.springConfigLocation)
 }
 
@@ -23,7 +17,6 @@ configurations.all {
 
 repositories {
   maven { url "http://adxsnapshots.azurewebsites.net" }
-  maven { url 'https://dl.bintray.com/netflixoss' }
 }
 
 dependencies {
@@ -53,6 +46,4 @@ dependencies {
   //this brings in the jetty GzipFilter which boot will autoconfigure
   runtime 'org.eclipse.jetty:jetty-servlets:9.2.11.v20150529'
 }
-
-tasks.bootRepackage.enabled = Boolean.valueOf(project.repackage)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,0 @@
-org.gradle.parallel=true
-
-jackson.version=2.9.2

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script will build the project.
 
-GRADLE="./gradlew --no-daemon --max-workers=1"
+GRADLE="./gradlew -I gradle/init-publish.gradle --no-daemon --max-workers=1"
 export GRADLE_OPTS="-Xmx1g -Xms1g"
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then

--- a/gradle/init-publish.gradle
+++ b/gradle/init-publish.gradle
@@ -1,0 +1,33 @@
+initscript {
+    repositories {
+      mavenLocal()
+      jcenter()
+      maven { url 'http://dl.bintray.com/spinnaker/gradle/' }
+      maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+      classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:4.1.0-SNAPSHOT'
+    }
+}
+
+import com.netflix.spinnaker.gradle.project.SpinnakerProjectPlugin
+
+rootProject {
+  buildscript {
+    repositories {
+      mavenLocal()
+      jcenter()
+      maven { url 'http://dl.bintray.com/spinnaker/gradle/' }
+      maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+      classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:4.1.0-SNAPSHOT'
+    }
+  }
+}
+
+allprojects {
+  apply plugin: SpinnakerProjectPlugin
+}
+
+

--- a/gradle/installViaTravis.sh
+++ b/gradle/installViaTravis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script will build the project.
 
-GRADLE="./gradlew --no-daemon --max-workers=1"
+GRADLE="./gradlew -I gradle/init-publish.gradle --no-daemon --max-workers=1"
 export GRADLE_OPTS="-Xmx1g -Xms1g"
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then


### PR DESCRIPTION
see spinnaker/spinnaker#2844 for context
see spinnaker/spinnaker-gradle-project#39 for plugin changes

moves to publishing opinions via include file
removes spring boot plugin, was only used for bootRun,
switched to application plugin run configuration.
