### PR TITLE
fix(caching): add config for number of concurrent scheduled agents

### DIFF
--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentSchedulerSpec.groovy
@@ -55,7 +55,9 @@ class ClusteredAgentSchedulerSpec extends Specification {
           new DefaultNodeStatusProvider(),
           lockPollingScheduler,
           agentExecutionScheduler,
-          ".*"
+          ".*",
+          null,
+          null
         )
     }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/JedisCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/JedisCacheConfig.groovy
@@ -74,7 +74,9 @@ class JedisCacheConfig {
         new DefaultNodeIdentity(redisHost, redisPort),
         agentIntervalProvider,
         nodeStatusProvider,
-        redisConfigurationProperties.agent.enabledPattern
+        redisConfigurationProperties.agent.enabledPattern,
+        redisConfigurationProperties.agent.maxConcurrentAgents,
+        redisConfigurationProperties.agent.agentLockAcquisitionIntervalSeconds
       );
     } else if (redisConfigurationProperties.scheduler.equalsIgnoreCase("sort")) {
       new ClusteredSortAgentScheduler(jedisPool, nodeStatusProvider, agentIntervalProvider, redisConfigurationProperties.parallelism ?: -1);

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfigurationProperties.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfigurationProperties.groovy
@@ -34,6 +34,8 @@ class RedisConfigurationProperties {
   @Canonical
   static class AgentConfiguration {
     String enabledPattern = ".*"
+    Integer maxConcurrentAgents
+    Integer agentLockAcquisitionIntervalSeconds
   }
 
   @NestedConfigurationProperty


### PR DESCRIPTION
(Please view with ["ignore whitespace"](https://blog.github.com/2011-10-21-github-secrets/#whitespace)).

We just saw clouddriver try and acquire all the locks, then die. This makes the max number of caching agents to schedule at once and the interval at which we schedule configurable. It defaults to the current behavior.

Set with:
```
redis:
  agent:
    maxConcurrentAgents: 100
    agentLockAcquisitionIntervalSeconds: 5
```