### PR TITLE
perf(cats): Support `List` -> `Set` relationship deserialization

### DIFF
--- a/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteCache.java
+++ b/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteCache.java
@@ -299,7 +299,10 @@ public class DynomiteCache extends AbstractRedisCache {
 
         Collection<String> deserializedRel;
         try {
-          deserializedRel = objectMapper.readValue(compressionStrategy.decompress(value.getValue()), RELATIONSHIPS);
+          deserializedRel = objectMapper.readValue(
+            compressionStrategy.decompress(value.getValue()),
+            getRelationshipsTypeReference()
+          );
         } catch (JsonProcessingException e) {
           log.warn("Failed processing property '{}' on item '{}'", value.getKey(), itemId(type, id));
           continue;

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
@@ -35,10 +35,14 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractRedisCache implements WriteableCache {
 
+  private static final TypeReference<List<String>> RELATIONSHIPS_LIST = new TypeReference<List<String>>() {
+  };
+  private static final TypeReference<Set<String>> RELATIONSHIPS_SET = new TypeReference<Set<String>>() {
+  };
+
   protected static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {
   };
-  protected static final TypeReference<List<String>> RELATIONSHIPS = new TypeReference<List<String>>() {
-  };
+
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -47,7 +51,10 @@ public abstract class AbstractRedisCache implements WriteableCache {
   protected final ObjectMapper objectMapper;
   protected final RedisCacheOptions options;
 
-  protected AbstractRedisCache(String prefix, RedisClientDelegate redisClientDelegate, ObjectMapper objectMapper, RedisCacheOptions options) {
+  protected AbstractRedisCache(String prefix,
+                               RedisClientDelegate redisClientDelegate,
+                               ObjectMapper objectMapper,
+                               RedisCacheOptions options) {
     this.prefix = prefix;
     this.redisClientDelegate = redisClientDelegate;
     this.objectMapper = objectMapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
@@ -227,5 +234,9 @@ public abstract class AbstractRedisCache implements WriteableCache {
 
   protected String allOfTypeReindex(String type) {
     return String.format("%s:%s:members.2", prefix, type);
+  }
+
+  protected TypeReference getRelationshipsTypeReference() {
+    return options.isTreatRelationshipsAsSet() ? RELATIONSHIPS_SET : RELATIONSHIPS_LIST;
   }
 }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
@@ -285,7 +285,10 @@ public class RedisCache extends AbstractRedisCache {
         String rel = keyResult.get(relIdx);
         if (rel != null) {
           String relType = knownRels.get(relIdx - 1);
-          Collection<String> deserializedRel = objectMapper.readValue(rel, RELATIONSHIPS);
+          Collection<String> deserializedRel = objectMapper.readValue(
+            rel,
+            getRelationshipsTypeReference()
+          );
           relationships.put(relType, deserializedRel);
         }
       }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCacheOptions.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCacheOptions.java
@@ -34,6 +34,7 @@ public class RedisCacheOptions {
     private final int maxEvictBatchSize;
     private final int maxGetBatchSize;
     private final boolean hashingEnabled;
+    private final boolean treatRelationshipsAsSet;
 
     private static int posInt(String name, int value) {
         Preconditions.checkArgument(value > 0, "%s must be a positive integer (%s)", name, value);
@@ -45,7 +46,19 @@ public class RedisCacheOptions {
         return value;
     }
 
-    public RedisCacheOptions(int maxMsetSize, int maxMgetSize, int maxHmgetSize, int maxHmsetSize, int maxSaddSize, int maxDelSize, int maxPipelineSize, int scanSize, int maxMergeBatchSize, int maxEvictBatchSize, int maxGetBatchSize, boolean hashingEnabled) {
+    public RedisCacheOptions(int maxMsetSize,
+                             int maxMgetSize,
+                             int maxHmgetSize,
+                             int maxHmsetSize,
+                             int maxSaddSize,
+                             int maxDelSize,
+                             int maxPipelineSize,
+                             int scanSize,
+                             int maxMergeBatchSize,
+                             int maxEvictBatchSize,
+                             int maxGetBatchSize,
+                             boolean hashingEnabled,
+                             boolean treatRelationshipsAsSet) {
         this.maxMsetSize = posEven("maxMsetSize", maxMsetSize);
         this.maxMgetSize = posInt("maxMgetSize", maxMgetSize);
         this.maxHmgetSize = posInt("maxHmgetSize", maxHmgetSize);
@@ -58,6 +71,7 @@ public class RedisCacheOptions {
         this.maxEvictBatchSize = posInt("maxEvictBatchSize", maxEvictBatchSize);
         this.maxGetBatchSize = posInt("maxGetBatchSize", maxGetBatchSize);
         this.hashingEnabled = hashingEnabled;
+        this.treatRelationshipsAsSet = treatRelationshipsAsSet;
     }
 
     public int getMaxMsetSize() {
@@ -108,12 +122,17 @@ public class RedisCacheOptions {
         return hashingEnabled;
     }
 
+    public boolean isTreatRelationshipsAsSet() {
+        return treatRelationshipsAsSet;
+    }
+
   public static class Builder {
         public static final int DEFAULT_MULTI_OP_SIZE = 10000;
         public static final int DEFAULT_BATCH_SIZE = 5000;
         public static final int DEFAULT_SCAN_SIZE = 25000;
         public static final int DEFAULT_MAX_PIPELINE_SIZE = 5000;
         public static final boolean DEFAULT_HASHING_ENABLED = true;
+        public static final boolean DEFAULT_TREAT_RELATIONSHIPS_AS_SET_DISABLED = false;
 
         int maxMsetSize;
         int maxMgetSize;
@@ -127,6 +146,7 @@ public class RedisCacheOptions {
         int maxEvictBatchSize;
         int maxGetBatchSize;
         boolean hashingEnabled;
+        boolean treatRelationshipsAsSet;
 
         public Builder() {
             batchSize(DEFAULT_BATCH_SIZE);
@@ -134,6 +154,7 @@ public class RedisCacheOptions {
             multiOp(DEFAULT_MULTI_OP_SIZE);
             maxPipeline(DEFAULT_MAX_PIPELINE_SIZE);
             hashing(DEFAULT_HASHING_ENABLED);
+            treatRelationshipsAsSet(DEFAULT_TREAT_RELATIONSHIPS_AS_SET_DISABLED);
         }
 
         public Builder maxMergeBatch(int maxMergeBatch) {
@@ -212,8 +233,26 @@ public class RedisCacheOptions {
             return this;
         }
 
+        public Builder treatRelationshipsAsSet(boolean treatRelationshipsAsSet) {
+            this.treatRelationshipsAsSet = treatRelationshipsAsSet;
+            return this;
+        }
+
         public RedisCacheOptions build() {
-            return new RedisCacheOptions(maxMsetSize, maxMgetSize, maxHmgetSize, maxHmsetSize, maxSaddSize, maxDelSize, maxPipelineSize, scanSize, maxMergeBatchSize, maxEvictBatchSize, maxGetBatchSize, hashingEnabled);
+            return new RedisCacheOptions(
+              maxMsetSize,
+              maxMgetSize,
+              maxHmgetSize,
+              maxHmsetSize,
+              maxSaddSize,
+              maxDelSize,
+              maxPipelineSize,
+              scanSize,
+              maxMergeBatchSize,
+              maxEvictBatchSize,
+              maxGetBatchSize,
+              hashingEnabled,
+              treatRelationshipsAsSet);
         }
 
         public void setBatchSize(int batchSize) {
@@ -318,6 +357,14 @@ public class RedisCacheOptions {
 
         public void setHashingEnabled(boolean hashingEnabled) {
             this.hashingEnabled = hashingEnabled;
+        }
+
+        public boolean isTreatRelationshipsAsSet() {
+            return treatRelationshipsAsSet;
+        }
+
+        public void setTreatRelationshipsAsSet(boolean treatRelationshipsAsSet) {
+            this.treatRelationshipsAsSet = treatRelationshipsAsSet;
         }
   }
 }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/agent/CleanupPendingOnDemandCachesAgentSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/agent/CleanupPendingOnDemandCachesAgentSpec.groovy
@@ -31,7 +31,7 @@ class CleanupPendingOnDemandCachesAgentSpec extends Specification {
   @AutoCleanup("destroy")
   EmbeddedRedis embeddedRedis = EmbeddedRedis.embed()
 
-  def redisCacheOptions = new RedisCacheOptions(50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, true)
+  def redisCacheOptions = new RedisCacheOptions(50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, true, true)
   def redisClientDelegate = new JedisClientDelegate(embeddedRedis.pool as JedisPool)
 
   def "should cleanup onDemand:members set for a provider"() {


### PR DESCRIPTION
Similar to spinnaker/clouddriver#2666 but this time behind a
`caching.redis.treatRelationshipsAsSet` flag.
