### PR TITLE
chore(redis): `JedisPool` metrics (numActive, numIdle, numWaiters)

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -209,7 +209,7 @@ public class ClusteredAgentScheduler extends CatsModuleAware implements AgentSch
   public void schedule(Agent agent,
                        AgentExecution agentExecution,
                        ExecutionInstrumentation executionInstrumentation) {
-    if (!enabledAgentPattern.matcher(agent.getClass().getSimpleName().toLowerCase()).matches()) {
+    if (!enabledAgentPattern.matcher(agent.getAgentType().toLowerCase()).matches()) {
       logger.debug(
         "Agent is not enabled (agent: {}, agentType: {}, pattern: {})",
         agent.getClass().getSimpleName(),

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfig.groovy
@@ -63,7 +63,21 @@ class RedisConfig {
   JedisPool jedisPool(Registry registry,
                       RedisConfigurationProperties redisConfigurationProperties,
                       GenericObjectPoolConfig redisPoolConfig) {
-    return createPool(registry, redisPoolConfig, redisConfigurationProperties.connection, redisConfigurationProperties.timeout, "primaryDefault")
+    def jedisPool = createPool(
+      registry,
+      redisPoolConfig,
+      redisConfigurationProperties.connection,
+      redisConfigurationProperties.timeout,
+      "primaryDefault"
+    )
+
+    registry.gauge("jedis.pool.maxIdle", jedisPool, { JedisPool p -> return p.internalPool.maxIdle as Double })
+    registry.gauge("jedis.pool.minIdle", jedisPool, { JedisPool p -> return p.internalPool.minIdle as Double })
+    registry.gauge("jedis.pool.numActive", jedisPool, { JedisPool p -> return p.internalPool.numActive as Double })
+    registry.gauge("jedis.pool.numIdle", jedisPool, { JedisPool p -> return p.internalPool.numIdle as Double })
+    registry.gauge("jedis.pool.numWaiters", jedisPool, { JedisPool p -> return p.internalPool.numWaiters as Double })
+
+    return jedisPool
   }
 
   private static JedisPool createPool(Registry registry,


### PR DESCRIPTION
Also updated the `ClusteredAgentScheduler` to compare `getAgentType()`
rather than `agent.class.simpleName` when determining whether the
agent should be scheduled.
