### PR TITLE
feat(entity_tagger): Support generic tag interface

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
@@ -25,7 +25,16 @@ import com.fasterxml.jackson.databind.ObjectMapper
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class EntityTags {
+  /**
+   * Unique identifier for a collection of EntityTag
+   */
   String id
+
+  /**
+   * The string replacement pattern used to generate the id.
+   *
+   * Example: "{{cloudProvider}}:{{entityType}}:{{entityId}}:{{account}}:{{region}}"
+   */
   String idPattern
 
   Long lastModified
@@ -113,8 +122,19 @@ class EntityTags {
 
   static class EntityTag {
     String name
+
+    /**
+     * Scoping of the tag, allowing reuse of the same entity tag name across different partitions.
+     *
+     * This can also be used to restrict who has access to modify a particular groups of tags
+     */
     String namespace
+
+    /**
+     * An additional, optional, grouping mechanism separate from namespace.
+     */
     String category
+
     Object value
     EntityTagValueType valueType
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/tags/EntityTagger.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/tags/EntityTagger.groovy
@@ -18,6 +18,9 @@ package com.netflix.spinnaker.clouddriver.tags
 
 import com.netflix.spinnaker.clouddriver.model.EntityTags;
 
+/**
+ * Provides a mechanism for attaching arbitrary metadata to resources within cloud providers.
+ */
 interface EntityTagger {
   public static final String ENTITY_TYPE_SERVER_GROUP = "servergroup"
   public static final String ENTITY_TYPE_CLUSTER = "cluster"
@@ -45,7 +48,7 @@ interface EntityTagger {
   void tag(String cloudProvider,
            String accountId,
            String region,
-           String category,
+           String namespace,
            String entityType,
            String entityId,
            String tagName,

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/tags/EntityTagger.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/tags/EntityTagger.groovy
@@ -42,6 +42,16 @@ interface EntityTagger {
               String value,
               Long timestamp)
 
+  void tag(String cloudProvider,
+           String accountId,
+           String region,
+           String category,
+           String entityType,
+           String entityId,
+           String tagName,
+           Object value,
+           Long timestamp)
+
   Collection<EntityTags> taggedEntities(String cloudProvider,
                                         String accountId,
                                         String entityType,

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ElasticSearchEntityTagger.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ElasticSearchEntityTagger.java
@@ -21,12 +21,13 @@ import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTask;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.elasticsearch.converters.DeleteEntityTagsAtomicOperationConverter;
+import com.netflix.spinnaker.clouddriver.elasticsearch.converters.UpsertEntityTagsAtomicOperationConverter;
 import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.DeleteEntityTagsDescription;
 import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.UpsertEntityTagsDescription;
 import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
-import com.netflix.spinnaker.clouddriver.elasticsearch.ops.DeleteEntityTagsAtomicOperation;
-import com.netflix.spinnaker.clouddriver.elasticsearch.ops.UpsertEntityTagsAtomicOperation;
 import com.netflix.spinnaker.clouddriver.model.EntityTags;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import com.netflix.spinnaker.clouddriver.tags.EntityTagger;
 import com.netflix.spinnaker.kork.core.RetrySupport;
@@ -49,19 +50,17 @@ public class ElasticSearchEntityTagger implements EntityTagger {
   private static final String NOTICE_TYPE = "notice";
   private static final String NOTICE_KEY_PREFIX = "spinnaker_ui_notice:";
 
-  private final RetrySupport retrySupport;
-  private final Front50Service front50Service;
-  private final AccountCredentialsProvider accountCredentialsProvider;
   private final ElasticSearchEntityTagsProvider entityTagsProvider;
 
-  public ElasticSearchEntityTagger(RetrySupport retrySupport,
-                                   Front50Service front50Service,
-                                   AccountCredentialsProvider accountCredentialsProvider,
-                                   ElasticSearchEntityTagsProvider entityTagsProvider) {
-    this.retrySupport = retrySupport;
-    this.front50Service = front50Service;
-    this.accountCredentialsProvider = accountCredentialsProvider;
+  private final UpsertEntityTagsAtomicOperationConverter upsertEntityTagsAtomicOperationConverter;
+  private final DeleteEntityTagsAtomicOperationConverter deleteEntityTagsAtomicOperationConverter;
+
+  public ElasticSearchEntityTagger(ElasticSearchEntityTagsProvider entityTagsProvider,
+                                   UpsertEntityTagsAtomicOperationConverter upsertEntityTagsAtomicOperationConverter,
+                                   DeleteEntityTagsAtomicOperationConverter deleteEntityTagsAtomicOperationConverter) {
     this.entityTagsProvider = entityTagsProvider;
+    this.upsertEntityTagsAtomicOperationConverter = upsertEntityTagsAtomicOperationConverter;
+    this.deleteEntityTagsAtomicOperationConverter = deleteEntityTagsAtomicOperationConverter;
   }
 
   @Override
@@ -111,6 +110,28 @@ public class ElasticSearchEntityTagger implements EntityTagger {
       value,
       timestamp
     );
+  }
+
+  @Override
+  public void tag(String cloudProvider,
+                  String accountId,
+                  String region,
+                  String category,
+                  String entityType,
+                  String entityId,
+                  String tagName,
+                  Object value,
+                  Long timestamp) {
+    upsertEntityTags(
+      tagName,
+      cloudProvider,
+      accountId,
+      region,
+      category,
+      entityType,
+      entityId,
+      value,
+      timestamp);
   }
 
   @Override
@@ -168,27 +189,9 @@ public class ElasticSearchEntityTagger implements EntityTagger {
     delete(deleteEntityTagsDescription);
   }
 
-  @VisibleForTesting
-  protected void run(DeleteEntityTagsAtomicOperation deleteEntityTagsAtomicOperation) {
-    deleteEntityTagsAtomicOperation.operate(Collections.emptyList());
-  }
-
   private void delete(DeleteEntityTagsDescription deleteEntityTagsDescription) {
-    DeleteEntityTagsAtomicOperation deleteEntityTagsAtomicOperation = new DeleteEntityTagsAtomicOperation(
-      front50Service,
-      entityTagsProvider,
-      deleteEntityTagsDescription
-    );
-
-    Task originalTask = TaskRepository.threadLocalTask.get();
-    try {
-      TaskRepository.threadLocalTask.set(
-        Optional.ofNullable(originalTask).orElse(new DefaultTask(ElasticSearchEntityTagger.class.getSimpleName()))
-      );
-      run(deleteEntityTagsAtomicOperation);
-    } finally {
-      TaskRepository.threadLocalTask.set(originalTask);
-    }
+    AtomicOperation<?> operation = deleteEntityTagsAtomicOperationConverter.buildOperation(deleteEntityTagsDescription);
+    operate(operation);
   }
 
   private void upsertEntityTags(String type,
@@ -202,22 +205,45 @@ public class ElasticSearchEntityTagger implements EntityTagger {
                                 String key,
                                 String value,
                                 Long timestamp) {
-    UpsertEntityTagsAtomicOperation upsertEntityTagsAtomicOperation = new UpsertEntityTagsAtomicOperation(
-      retrySupport,
-      front50Service,
-      accountCredentialsProvider,
-      entityTagsProvider,
-      upsertEntityTagsDescription(
-        type, prefix, cloudProvider, accountId, region, category, entityType, entityId, key, value, timestamp
-      )
-    );
 
+
+    upsertEntityTags(
+      upsertEntityTagsDescription(type, prefix, cloudProvider, accountId, region, category, entityType, entityId, key, value, timestamp));
+  }
+
+   private void upsertEntityTags(String name,
+      String cloudProvider,
+      String accountId,
+      String region,
+      String category,
+      String entityType,
+      String entityId,
+      Object tagValue,
+      Long timestamp) {
+    upsertEntityTags(upsertEntityTagsDescription(name, cloudProvider, accountId, region, category, entityType, entityId, tagValue, timestamp));
+  }
+
+  private void upsertEntityTags(UpsertEntityTagsDescription description) {
+    AtomicOperation<?> operation = upsertEntityTagsAtomicOperationConverter.buildOperation(description);
+
+    operate(operation);
+  }
+
+  private void operate(AtomicOperation<?> operation) {
+    Task originalTask = TaskRepository.threadLocalTask.get();
     try {
-      TaskRepository.threadLocalTask.set(new DefaultTask(this.getClass().getSimpleName()));
-      upsertEntityTagsAtomicOperation.operate(Collections.emptyList());
+      TaskRepository.threadLocalTask.set(
+        Optional.ofNullable(originalTask).orElse(new DefaultTask(ElasticSearchEntityTagger.class.getSimpleName()))
+      );
+      run(operation);
     } finally {
-      TaskRepository.threadLocalTask.set(null);
+      TaskRepository.threadLocalTask.set(originalTask);
     }
+  }
+
+  @VisibleForTesting
+  protected void run(AtomicOperation<?> operation) {
+    operation.operate(Collections.emptyList());
   }
 
   private static UpsertEntityTagsDescription upsertEntityTagsDescription(String type,
@@ -231,6 +257,22 @@ public class ElasticSearchEntityTagger implements EntityTagger {
                                                                          String key,
                                                                          String value,
                                                                          Long timestamp) {
+
+    String name = prefix + key;
+    Map<String, String> tagValue = new HashMap<>();
+    tagValue.put("message", value);
+    tagValue.put("type", type);
+    return upsertEntityTagsDescription(name, cloudProvider, accountId, region, category, entityType, entityId, tagValue, timestamp);
+  }
+  private static UpsertEntityTagsDescription upsertEntityTagsDescription(String name,
+                                                                         String cloudProvider,
+                                                                         String accountId,
+                                                                         String region,
+                                                                         String category,
+                                                                         String entityType,
+                                                                         String entityId,
+                                                                         Object entityTagValue,
+                                                                         Long timestamp) {
     EntityTags.EntityRef entityRef = new EntityTags.EntityRef();
     entityRef.setEntityType(entityType);
     entityRef.setEntityId(entityId);
@@ -238,16 +280,11 @@ public class ElasticSearchEntityTagger implements EntityTagger {
     entityRef.setAccountId(accountId);
     entityRef.setRegion(region);
 
-    Map<String, String> entityTagValue = new HashMap<>();
-    entityTagValue.put("message", value);
-    entityTagValue.put("type", type);
-
     EntityTags.EntityTag entityTag = new EntityTags.EntityTag();
-    entityTag.setName(prefix + key);
+    entityTag.setName(name);
     entityTag.setValue(entityTagValue);
     entityTag.setCategory(category);
     entityTag.setTimestamp(timestamp);
-    entityTag.setValueType(EntityTags.EntityTagValueType.object);
 
     UpsertEntityTagsDescription upsertEntityTagsDescription = new UpsertEntityTagsDescription();
     upsertEntityTagsDescription.setEntityRef(entityRef);

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/DeleteEntityTagsAtomicOperationConverter.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/DeleteEntityTagsAtomicOperationConverter.java
@@ -40,7 +40,7 @@ public class DeleteEntityTagsAtomicOperationConverter extends AbstractAtomicOper
   public DeleteEntityTagsAtomicOperationConverter(ObjectMapper objectMapper,
                                                   Front50Service front50Service,
                                                   ElasticSearchEntityTagsProvider entityTagsProvider) {
-    this.objectMapper = objectMapper
+    this.objectMapper = objectMapper.copy()
       .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
@@ -49,8 +49,12 @@ public class DeleteEntityTagsAtomicOperationConverter extends AbstractAtomicOper
   }
 
   public AtomicOperation convertOperation(Map input) {
+    return buildOperation(convertDescription(input));
+  }
+
+  public AtomicOperation buildOperation(DeleteEntityTagsDescription description) {
     return new DeleteEntityTagsAtomicOperation(
-      front50Service, entityTagsProvider, this.convertDescription(input)
+      front50Service, entityTagsProvider, description
     );
   }
 

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverter.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverter.java
@@ -64,11 +64,13 @@ public class UpsertEntityTagsAtomicOperationConverter extends AbstractAtomicOper
 
   public AtomicOperation buildOperation(UpsertEntityTagsDescription description) {
     description.getTags().forEach(UpsertEntityTagsAtomicOperationConverter::setTagValueType);
-    return new UpsertEntityTagsAtomicOperation(retrySupport,
+    return new UpsertEntityTagsAtomicOperation(
+      retrySupport,
       front50Service,
       accountCredentialsProvider,
       entityTagsProvider,
-      description);
+      description
+    );
   }
 
   public UpsertEntityTagsDescription convertDescription(Map input) {

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverter.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverter.java
@@ -48,7 +48,7 @@ public class UpsertEntityTagsAtomicOperationConverter extends AbstractAtomicOper
                                                   Front50Service front50Service,
                                                   AccountCredentialsProvider accountCredentialsProvider,
                                                   ElasticSearchEntityTagsProvider entityTagsProvider) {
-    this.objectMapper = objectMapper
+    this.objectMapper = objectMapper.copy()
       .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
@@ -59,14 +59,20 @@ public class UpsertEntityTagsAtomicOperationConverter extends AbstractAtomicOper
   }
 
   public AtomicOperation convertOperation(Map input) {
-    return new UpsertEntityTagsAtomicOperation(
-      retrySupport, front50Service, accountCredentialsProvider, entityTagsProvider, this.convertDescription(input)
-    );
+    return buildOperation(convertDescription(input));
+  }
+
+  public AtomicOperation buildOperation(UpsertEntityTagsDescription description) {
+    description.getTags().forEach(UpsertEntityTagsAtomicOperationConverter::setTagValueType);
+    return new UpsertEntityTagsAtomicOperation(retrySupport,
+      front50Service,
+      accountCredentialsProvider,
+      entityTagsProvider,
+      description);
   }
 
   public UpsertEntityTagsDescription convertDescription(Map input) {
     UpsertEntityTagsDescription upsertEntityTagsDescription = objectMapper.convertValue(input, UpsertEntityTagsDescription.class);
-    upsertEntityTagsDescription.getTags().forEach(UpsertEntityTagsAtomicOperationConverter::setTagValueType);
     return upsertEntityTagsDescription;
   }
 

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfig.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfig.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.config;
 
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.elasticsearch.ElasticSearchEntityTagger;
+import com.netflix.spinnaker.clouddriver.elasticsearch.converters.DeleteEntityTagsAtomicOperationConverter;
+import com.netflix.spinnaker.clouddriver.elasticsearch.converters.UpsertEntityTagsAtomicOperationConverter;
 import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import com.netflix.spinnaker.kork.core.RetrySupport;
@@ -51,12 +53,11 @@ public class ElasticSearchConfig {
   }
 
   @Bean
-  ElasticSearchEntityTagger elasticSearchEntityTagger(RetrySupport retrySupport,
-                                                      Front50Service front50Service,
-                                                      AccountCredentialsProvider accountCredentialsProvider,
-                                                      ElasticSearchEntityTagsProvider elasticSearchEntityTagsProvider) {
+  ElasticSearchEntityTagger elasticSearchEntityTagger(ElasticSearchEntityTagsProvider elasticSearchEntityTagsProvider,
+                                                      UpsertEntityTagsAtomicOperationConverter upsertEntityTagsAtomicOperationConverter,
+                                                      DeleteEntityTagsAtomicOperationConverter deleteEntityTagsAtomicOperationConverter) {
     return new ElasticSearchEntityTagger(
-      retrySupport, front50Service, accountCredentialsProvider, elasticSearchEntityTagsProvider
+      elasticSearchEntityTagsProvider, upsertEntityTagsAtomicOperationConverter, deleteEntityTagsAtomicOperationConverter
     );
   }
 }

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ElasticSearchEntityTaggerSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ElasticSearchEntityTaggerSpec.groovy
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.clouddriver.elasticsearch
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTask
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.elasticsearch.converters.DeleteEntityTagsAtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.elasticsearch.ops.DeleteEntityTagsAtomicOperation
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import spock.lang.Specification
 import spock.lang.Unroll;
 
@@ -79,9 +81,13 @@ class ElasticSearchEntityTaggerSpec extends Specification {
   void "should only mutate threadLocalTask if null"() {
     given:
     Task threadLocalTask = null
-    def serverGroupTagger = new ElasticSearchEntityTagger(null, null, null, null) {
+    def deleteConverter = Stub(DeleteEntityTagsAtomicOperationConverter) {
+      buildOperation(_) >> Stub(AtomicOperation)
+    }
+
+    def serverGroupTagger = new ElasticSearchEntityTagger(null, null, deleteConverter) {
       @Override
-      protected void run(DeleteEntityTagsAtomicOperation deleteEntityTagsAtomicOperation) {
+      protected void run(AtomicOperation<?> operation) {
         threadLocalTask = TaskRepository.threadLocalTask.get()
       }
     }

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ElasticSearchEntityTaggerSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ElasticSearchEntityTaggerSpec.groovy
@@ -20,15 +20,14 @@ import com.netflix.spinnaker.clouddriver.data.task.DefaultTask
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.elasticsearch.converters.DeleteEntityTagsAtomicOperationConverter
-import com.netflix.spinnaker.clouddriver.elasticsearch.ops.DeleteEntityTagsAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import spock.lang.Specification
-import spock.lang.Unroll;
+import spock.lang.Unroll
 
 class ElasticSearchEntityTaggerSpec extends Specification {
   void "should construct valid UpsertEntityTagsDescription"() {
     when:
-    def description = ElasticSearchEntityTagger.upsertEntityTagsDescription(
+    def categorizedDescription = ElasticSearchEntityTagger.upsertCategorizedEntityTagsDescription(
       ElasticSearchEntityTagger.ALERT_TYPE,
       ElasticSearchEntityTagger.ALERT_KEY_PREFIX,
       "myCloudProvider",
@@ -43,6 +42,37 @@ class ElasticSearchEntityTaggerSpec extends Specification {
     )
 
     then:
+    categorizedDescription.isPartial
+    categorizedDescription.entityRef.region == "us-east-1"
+    categorizedDescription.entityRef.accountId == "100"
+    categorizedDescription.entityRef.entityType == "servergroup"
+    categorizedDescription.entityRef.entityId == "myServerGroup-v001"
+    categorizedDescription.entityRef.cloudProvider == "myCloudProvider"
+
+    categorizedDescription.tags.size() == 1
+    categorizedDescription.tags[0].name == "spinnaker_ui_alert:my_event"
+    categorizedDescription.tags[0].value == [
+      message: "This server group failed to launch!",
+      type   : "alert"
+    ]
+    categorizedDescription.tags[0].timestamp == 500L
+    categorizedDescription.tags[0].category == "mycategory"
+
+    when:
+    def description = ElasticSearchEntityTagger.upsertEntityTagsDescription(
+      "scaling_policies",
+      "myCloudProvider",
+      "100",
+      "us-east-1",
+      "mynamespace",
+      null,
+      "servergroup",
+      "myServerGroup-v001",
+      "{'foo':'bar'}",
+      500L
+    )
+
+    then:
     description.isPartial
     description.entityRef.region == "us-east-1"
     description.entityRef.accountId == "100"
@@ -51,13 +81,12 @@ class ElasticSearchEntityTaggerSpec extends Specification {
     description.entityRef.cloudProvider == "myCloudProvider"
 
     description.tags.size() == 1
-    description.tags[0].name == "spinnaker_ui_alert:my_event"
-    description.tags[0].value == [
-      message: "This server group failed to launch!",
-      type   : "alert"
-    ]
+    description.tags[0].name == "scaling_policies"
+    description.tags[0].namespace == "mynamespace"
+    description.tags[0].value == "{'foo':'bar'}"
     description.tags[0].timestamp == 500L
-    description.tags[0].category == "mycategory"
+    description.tags[0].category == null
+
   }
 
   @Unroll

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverterSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/converters/UpsertEntityTagsAtomicOperationConverterSpec.groovy
@@ -39,9 +39,10 @@ class UpsertEntityTagsAtomicOperationConverterSpec extends Specification {
         [name: "myTag", value: tagValue]
       ]
     ]
+    def description = converter.convertDescription(entityTags)
 
     when:
-    def description = converter.convertDescription(entityTags)
+    converter.buildOperation(description)
 
     then:
     description.tags[0].valueType == expectedValueType


### PR DESCRIPTION
Same thing as @cfieber's pull request, but with comments addressed and changed the interface method to expect `namespace` instead of `category`, since `category` is really only specific to alerts & notices at this point.

Also added a wee bit of docs around a few properties that were confusing me.

Prior art: https://github.com/spinnaker/clouddriver/pull/2540