### PR TITLE
fix(titus): handle load balancing not enabled in account

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
@@ -260,7 +260,9 @@ public class TitusV2ClusterCachingAgent implements CachingAgent, CustomScheduled
       .record(System.currentTimeMillis() - startScalingPolicyTime, MILLISECONDS);
 
     Long startLoadBalancerTime = System.currentTimeMillis();
-    Map<String, List<String>> allLoadBalancers = titusLoadBalancerClient.getAllLoadBalancers();
+    Map<String, List<String>> allLoadBalancers = titusLoadBalancerClient != null
+      ? titusLoadBalancerClient.getAllLoadBalancers()
+      : Collections.emptyMap();
     PercentileTimer
       .get(registry, metricId.withTag("operation", "getLoadBalancers"))
       .record(System.currentTimeMillis() - startLoadBalancerTime, MILLISECONDS);


### PR DESCRIPTION
Load Balancing can be toggled on and off for Titus. Handle that.