### PR TITLE
fix(startup): Fix startup warnings

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/EntityTagsController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/EntityTagsController.java
@@ -42,7 +42,7 @@ public class EntityTagsController {
   private final MessageSource messageSource;
   private final EntityTagsProvider tagProvider;
 
-  @Autowired(required = false)
+  @Autowired
   public EntityTagsController(MessageSource messageSource,
                               Optional<EntityTagsProvider> tagProvider) {
     this.messageSource = messageSource;

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/admin/EntityTagsAdminController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/admin/EntityTagsAdminController.java
@@ -35,7 +35,7 @@ public class EntityTagsAdminController {
 
   private final EntityTagsProvider entityTagsProvider;
 
-  @Autowired(required = false)
+  @Autowired
   public EntityTagsAdminController(Optional<EntityTagsProvider> entityTagsProvider) {
     this.entityTagsProvider = entityTagsProvider.orElse(null);
   }


### PR DESCRIPTION
Remove two warnings on startup about optional constructors being effectively required due to the lack of a default constructor.