### PR TITLE
feat(aws): Cluster autoscaling policy tagger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ buildscript {
   dependencies {
     classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:4.0.0'
     classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
-    classpath "org.junit.platform:junit-platform-gradle-plugin:${junitPlatformVersion}"
     classpath "com.netflix.nebula:nebula-kotlin-plugin:${kotlinVersion}"
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.157.5'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.159.2'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -16,30 +16,18 @@
 
 package com.netflix.spinnaker.cats.redis.cluster;
 
-import com.netflix.spinnaker.cats.agent.Agent;
-import com.netflix.spinnaker.cats.agent.AgentExecution;
-import com.netflix.spinnaker.cats.agent.AgentLock;
-import com.netflix.spinnaker.cats.agent.AgentScheduler;
-import com.netflix.spinnaker.cats.agent.AgentSchedulerAware;
-import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation;
+import com.netflix.spinnaker.cats.agent.*;
 import com.netflix.spinnaker.cats.module.CatsModuleAware;
 import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-@SuppressFBWarnings
 public class ClusteredAgentScheduler extends CatsModuleAware implements AgentScheduler<AgentLock>, Runnable {
   private static enum Status {
     SUCCESS,

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentScheduler.java
@@ -16,33 +16,16 @@
 
 package com.netflix.spinnaker.cats.redis.cluster;
 
-import com.netflix.spinnaker.cats.agent.Agent;
-import com.netflix.spinnaker.cats.agent.AgentExecution;
-import com.netflix.spinnaker.cats.agent.AgentScheduler;
-import com.netflix.spinnaker.cats.agent.AgentSchedulerAware;
-import com.netflix.spinnaker.cats.agent.CacheResult;
-import com.netflix.spinnaker.cats.agent.CachingAgent;
-import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation;
+import com.netflix.spinnaker.cats.agent.*;
 import com.netflix.spinnaker.cats.module.CatsModuleAware;
 import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 
 /*
  * The idea behind this scheduler is simple. Every agent it owns is always in one of two sorted sets,
@@ -55,7 +38,6 @@ import java.util.concurrent.TimeUnit;
  * cache interval every key will only be removed from Redis once. If the interval is 60s, and the agent polls every 1s,
  * we already have a (30s / 1) * (# of clouddrivers) factor of improvement.
  */
-@SuppressFBWarnings
 public class ClusteredSortAgentScheduler extends CatsModuleAware implements AgentScheduler<ClusteredSortAgentLock>, Runnable {
   private static enum Status {
     SUCCESS,

--- a/cats/cats.gradle
+++ b/cats/cats.gradle
@@ -1,7 +1,6 @@
 tasks.bintrayUpload.enabled = false
 
 subprojects {
-  apply plugin: 'findbugs'
   apply plugin: 'pmd'
 
   dependencies {
@@ -12,10 +11,5 @@ subprojects {
   }
 
   tasks.compileGroovy.enabled = false
-  tasks.findbugsTest.enabled = false
   tasks.pmdTest.enabled = false
-
-  findbugs {
-    ignoreFailures = true
-  }
 }

--- a/clouddriver-elasticsearch-aws/clouddriver-elasticsearch-aws.gradle
+++ b/clouddriver-elasticsearch-aws/clouddriver-elasticsearch-aws.gradle
@@ -1,4 +1,5 @@
 apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "$rootDir/gradle/spek.gradle"
 
 repositories {
   jcenter()

--- a/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/clouddriver/elasticsearch/aws/ClusterScalingPolicyTaggingAgent.kt
+++ b/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/clouddriver/elasticsearch/aws/ClusterScalingPolicyTaggingAgent.kt
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.elasticsearch.aws
+
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.autoscaling.model.ScalingPolicy
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.frigga.Names
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.RunnableAgent
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials.AWSRegion
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
+import com.netflix.spinnaker.clouddriver.model.EntityTags
+import com.netflix.spinnaker.clouddriver.tags.EntityTagger
+import com.netflix.spinnaker.clouddriver.tags.EntityTagger.ENTITY_TYPE_CLUSTER
+import com.netflix.spinnaker.config.ClusterScalingPolicyTaggingAgentProperties
+import com.netflix.spinnaker.kork.core.RetrySupport
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tracks and reports on scaling policies for clusters.
+ *
+ * Indexes scaling policies on a cluster level and alarms whenever a server
+ * group is found that does not conform to the expected scaling policies.
+ *
+ * What scaling policies are desired is determined by the condition of the
+ * oldest server group in the cluster.
+ */
+class ClusterScalingPolicyTaggingAgent (
+  val retrySupport: RetrySupport,
+  val registry: Registry,
+  val amazonClientProvider: AmazonClientProvider,
+  val accounts: Collection<NetflixAmazonCredentials>,
+  val entityTagger : EntityTagger,
+  val objectMapper: ObjectMapper,
+  val properties: ClusterScalingPolicyTaggingAgentProperties
+) : RunnableAgent, CustomScheduledAgent {
+
+  companion object {
+    internal const val ENTITY_TAG_NAME = "spinnaker:scaling_policies"
+    private const val REGISTRY_ID_PREFIX = "agents.clusterScalingPolicyTagging"
+
+    internal val LIST_OF_MAPS = object : TypeReference<List<Map<String, Any>>>() {}
+  }
+
+  private val log = LoggerFactory.getLogger(ClusterScalingPolicyTaggingAgent::class.java)
+
+  private val missingScalingPolicyCounterId = registry.createId("$REGISTRY_ID_PREFIX.serverGroupsMissingPolicies")
+  private val updatedScalingPolicyCounterId = registry.createId("$REGISTRY_ID_PREFIX.clustersUpdated")
+
+  override fun run() {
+    log.info("Searching for cluster scaling policies")
+    for (credentials in accounts) {
+      for (region in credentials.regions) {
+        val amazonAutoScaling = amazonClientProvider.getAutoScaling(credentials, region.name)
+
+        // Assemble an index for the account/region of scaling policies...
+        amazonAutoScaling.describeAutoScalingGroups().autoScalingGroups
+          .let {
+            val scalingPolicies = amazonAutoScaling.describePolicies().scalingPolicies
+            val scalingPoliciesByServerGroupName = scalingPolicies.groupBy { it.autoScalingGroupName }
+            val entityTagsByCluster = entityTagger.taggedEntities(
+              "aws",
+              credentials.accountId,
+              "cluster",
+              ENTITY_TAG_NAME,
+              2000
+            ).groupBy { it.entityRef.entityId }
+
+            AccountRegionIndex(
+              credentials = credentials,
+              region = region,
+              serverGroups = it,
+              scalingPolicies = AccountRegionScalingPolicies(
+                all = scalingPolicies,
+                byServerGroupName = scalingPoliciesByServerGroupName,
+                byCluster = getScalingPoliciesByCluster(it, scalingPoliciesByServerGroupName)
+              ),
+              clusterEntityTags = entityTagsByCluster
+            )
+          }
+          // ...and then process it
+          .run { forAccountRegion(this) }
+      }
+    }
+  }
+
+  /**
+   * Reports on each server group that is missing cluster entity tags.
+   *
+   * If a cluster has server groups older than the old server group boundary,
+   * the oldest server group will be assumed to have the "new" desired state
+   * and will update the cluster entity tags to reflect its state.
+   *
+   * For all clusters that were not modified by old server groups' state,
+   * the entity tags will be updated to reflect any cluster-level changes in
+   * scaling policies (aggregate of scaling policies across all server groups).
+   */
+  internal fun forAccountRegion(accountRegion: AccountRegionIndex) {
+    log.info("Scanning ${accountRegion.credentials.name}/${accountRegion.region.name} for scaling policies")
+
+    val shouldUpdateClusterEntityTags = { it: Pair<String, AutoScalingGroup> ->
+      val boundary = Instant.now().minusMillis(properties.oldServerGroupBoundaryMs)
+      shouldUpdateClusterEntityTags(it.second, accountRegion.credentials, accountRegion.region, boundary)
+    }
+
+    // Report server groups that are missing cluster entity tags.
+    // If the server group is old enough, update the cluster entity tags so
+    // that they match the server group. We can assume that if the server
+    // group is old enough and has deviated from what we have stored in
+    // entity tags, this is the new, desired normal.
+    val updatedClusters = accountRegion.serverGroups
+      .map { Pair(Names.parseName(it.autoScalingGroupName).cluster, it) }
+      .filter { accountRegion.clusterEntityTags.containsKey(it.first) }
+      .filter(shouldUpdateClusterEntityTags)
+      .let { clusterServerGroups ->
+        // It's possible that multiple server groups in a cluster are old
+        // enough to prompt updating the cluster's entity tags. In this case,
+        // we'll take the oldest server group and use that as the assumed
+        // desired state.
+        clusterServerGroups
+          .groupBy { it.first }
+          .entries
+          .map {
+            it.value.sortedBy { it.second.createdTime }.first()
+          }
+      }
+      .also {
+        for ((cluster, serverGroup) in it) {
+          accountRegion.scalingPolicies.byServerGroupName[serverGroup.autoScalingGroupName]?.also { scalingPolicies ->
+            val clusterPolicies = scalingPolicies.toEntityTagValue()
+
+            val logName = serverGroup.toLog(accountRegion.credentials, accountRegion.region)
+            log.info("Updating cluster scaling policies from $logName with: $clusterPolicies")
+
+            retry {
+              entityTagger.tag(
+                "aws",
+                accountRegion.credentials.accountId,
+                accountRegion.region.name,
+                "spinnaker",
+                ENTITY_TYPE_CLUSTER,
+                cluster,
+                ENTITY_TAG_NAME,
+                clusterPolicies,
+                System.currentTimeMillis()
+              )
+            }
+          }
+        }
+
+        registry
+          .counter(updatedScalingPolicyCounterId.withTag("process", "oldestServerGroup"))
+          .increment(it.size.toLong())
+      }
+      .map { it.first }
+
+    // Update the existing entity tags for each cluster to match the scaling
+    // policies generated above. Clusters that were updated by older server
+    // groups are excluded from this process to prevent stomping.
+    // TODO rz - this pattern could potentially introduce flapping if a user
+    // removes scaling policies on a super old server group, then changes
+    // them on a newer server group, but never deletes the really old one.
+    // I'm not sure how often this would actually happen in practice.
+    accountRegion.scalingPolicies.byCluster
+      .filterNot { updatedClusters.contains(it.key) }
+      .also {
+        for ((cluster, scalingPoliciesForCluster) in it) {
+          val clusterPolicies = scalingPoliciesForCluster.toEntityTagValue()
+          log.info("Tagging ${accountRegion.credentials.name}/${accountRegion.region.name}/$cluster " +
+            "scaling policies: $clusterPolicies")
+          retry {
+            entityTagger.tag(
+              "aws",
+              accountRegion.credentials.accountId,
+              accountRegion.region.name,
+              "spinnaker",
+              ENTITY_TYPE_CLUSTER,
+              cluster,
+              ENTITY_TAG_NAME,
+              clusterPolicies,
+              System.currentTimeMillis()
+            )
+          }
+        }
+
+        registry
+          .counter(updatedScalingPolicyCounterId.withTag("process", "serverGroupsAggregate"))
+          .increment(it.size.toLong())
+      }
+  }
+
+  internal fun shouldUpdateClusterEntityTags(
+    serverGroup: AutoScalingGroup,
+    credentials: NetflixAmazonCredentials,
+    region: AWSRegion,
+    oldServerGroupBoundary: Instant
+  ): Boolean {
+    if (serverGroup.createdTime.toInstant().isBefore(oldServerGroupBoundary)) {
+      log.warn(
+        "Old server group is missing cluster scaling policies, " +
+          "assuming system state is desired and updating entity tags: ${serverGroup.toLog(credentials, region)}"
+      )
+      registry.counter(missingScalingPolicyCounterId.withTag("serverGroupAge", "old")).increment()
+      return true
+    } else {
+      log.info("Server group is missing scaling policies: ${serverGroup.toLog(credentials, region)}")
+      registry.counter(missingScalingPolicyCounterId.withTag("serverGroupAge", "new")).increment()
+    }
+
+    return false
+  }
+
+  /**
+   * Groups and de-duplicates all scaling policies by cluster.
+   */
+  internal fun getScalingPoliciesByCluster(
+    serverGroups: List<AutoScalingGroup>,
+    byServerGroupName: IndexedScalingPolicies
+  ): IndexedScalingPolicies {
+    val results = mutableMapOf<String, MutableList<ScalingPolicy>>()
+
+    for (serverGroup in serverGroups) {
+      val cluster = Names.parseName(serverGroup.autoScalingGroupName).cluster
+      results[cluster] = results.getOrDefault(cluster, mutableListOf())
+        .also { clusterPolicies ->
+          for (policy in byServerGroupName.getOrDefault(serverGroup.autoScalingGroupName, emptyList())) {
+            if (clusterPolicies.none { it.isEqual(policy) }) {
+              clusterPolicies.add(policy)
+            }
+          }
+        }
+    }
+
+    return results.filter { it.value.isNotEmpty() }
+  }
+
+  override fun getPollIntervalMillis(): Long = TimeUnit.SECONDS.toMillis(10)
+  override fun getTimeoutMillis(): Long = TimeUnit.SECONDS.toMillis(30)
+  override fun getAgentType(): String = ClusterScalingPolicyTaggingAgent::class.java.simpleName
+  override fun getProviderName(): String = AwsProvider.PROVIDER_NAME
+
+  internal fun List<ScalingPolicy>.toEntityTagValue(): Map<String, Any> =
+    mapOf("value" to objectMapper.convertValue(map { it.toGenericMap(objectMapper) }, LIST_OF_MAPS))
+
+
+  private fun retry(fn: () -> Unit) {
+    retrySupport.retry(fn, 3, 500, false)
+  }
+}
+
+internal typealias IndexedScalingPolicies = Map<String, List<ScalingPolicy>>
+
+internal data class AccountRegionIndex(
+  val credentials: NetflixAmazonCredentials,
+  val region: AWSRegion,
+  val serverGroups: List<AutoScalingGroup>,
+  val scalingPolicies: AccountRegionScalingPolicies,
+  val clusterEntityTags: Map<String, List<EntityTags>>
+)
+
+internal data class AccountRegionScalingPolicies(
+  val all: List<ScalingPolicy>,
+  val byServerGroupName: IndexedScalingPolicies,
+  val byCluster: IndexedScalingPolicies
+)
+
+internal fun AutoScalingGroup.toLog(credentials: NetflixAmazonCredentials, region: AWSRegion) =
+  "${credentials.name}/${region.name}/$autoScalingGroupName"
+
+/**
+ * This isn't exactly scientific, but it's better than just comparing num of scaling policies.
+ */
+internal fun ScalingPolicy.isEqual(scalingPolicy: ScalingPolicy): Boolean {
+  return policyType == scalingPolicy.policyType &&
+    adjustmentType == scalingPolicy.adjustmentType &&
+    minAdjustmentStep == scalingPolicy.minAdjustmentStep &&
+    minAdjustmentMagnitude == scalingPolicy.minAdjustmentMagnitude &&
+    scalingAdjustment == scalingPolicy.scalingAdjustment &&
+    cooldown == scalingPolicy.cooldown &&
+    stepAdjustments.all { a -> scalingPolicy.stepAdjustments.any { b -> a == b } } &&
+    metricAggregationType == scalingPolicy.metricAggregationType &&
+    alarms.size == scalingPolicy.alarms.size &&
+    targetTrackingConfiguration == scalingPolicy.targetTrackingConfiguration
+}
+
+internal fun ScalingPolicy.toGenericMap(objectMapper: ObjectMapper): Map<String, Any?> =
+  objectMapper.convertValue<MutableMap<String, Any?>>(
+    this, object : TypeReference<MutableMap<String, Any?>>() {}
+  ).apply {
+    remove("autoScalingGroupName")
+    remove("policyName")
+    remove("policyARN")
+    set("alarms", alarms.map { mapOf<String, Any?>() })
+  }
+
+/**
+ * This is kinda sad, but Entity Tags are designed to be a map, so if we're storing multiple values, the root-level
+ * object cannot be a list... so we're just embedding it in a simple map.
+ */
+internal fun List<ScalingPolicy>.toEntityTagValue(objectMapper: ObjectMapper): Map<String, Any> =
+  mapOf(
+    "value" to objectMapper.convertValue(
+      map { it.toGenericMap(objectMapper) },
+      ClusterScalingPolicyTaggingAgent.LIST_OF_MAPS
+    )
+  )

--- a/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/clouddriver/elasticsearch/aws/ElasticSearchAmazonInstanceCachingAgent.kt
+++ b/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/clouddriver/elasticsearch/aws/ElasticSearchAmazonInstanceCachingAgent.kt
@@ -60,6 +60,7 @@ class ElasticSearchAmazonInstanceCachingAgent(
   }
 
   override fun run() {
+    return
     val prefix = "aws_instances"
     var previousIndexes = elasticSearchClient.getPreviousIndexes(prefix)
     if (previousIndexes.size > 2) {

--- a/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/clouddriver/elasticsearch/aws/ElasticSearchAmazonScalingPolicyAgentProvider.kt
+++ b/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/clouddriver/elasticsearch/aws/ElasticSearchAmazonScalingPolicyAgentProvider.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.elasticsearch.aws
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.cats.agent.AgentProvider
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.tags.EntityTagger
+import com.netflix.spinnaker.config.ClusterScalingPolicyTaggingAgentProperties
+import com.netflix.spinnaker.kork.core.RetrySupport
+
+open class ElasticSearchAmazonScalingPolicyAgentProvider(
+  private val objectMapper: ObjectMapper,
+  private val retrySupport: RetrySupport,
+  private val registry: Registry,
+  private val amazonClientProvider: AmazonClientProvider,
+  private val accountCredentialsProvider: AccountCredentialsProvider,
+  private val entityTagger : EntityTagger,
+  private val properties: ClusterScalingPolicyTaggingAgentProperties
+) : AgentProvider {
+
+  override fun supports(providerName: String) =
+    providerName.equals(AwsProvider.PROVIDER_NAME, ignoreCase = true)
+
+  override fun agents(): Collection<Agent> {
+    val credentials = accountCredentialsProvider.all.filterIsInstance<NetflixAmazonCredentials>()
+
+    return listOf(
+      ClusterScalingPolicyTaggingAgent(
+        retrySupport,
+        registry,
+        amazonClientProvider,
+        credentials,
+        entityTagger,
+        objectMapper,
+        properties
+      )
+    )
+  }
+}

--- a/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/config/ClusterScalingPolicyTaggingAgentProperties.kt
+++ b/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/config/ClusterScalingPolicyTaggingAgentProperties.kt
@@ -1,11 +1,11 @@
 /*
  * Copyright 2018 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,21 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.spinnaker.config
 
-repositories {
-  jcenter()
-  maven { url "http://dl.bintray.com/jetbrains/spek" }
-}
+import java.time.Duration
 
-dependencies {
-  spinnaker.group('spek')
-
-  testCompile "io.strikt:strikt-core:+"
-  testCompile "com.nhaarman:mockito-kotlin:1.5.0"
-}
-
-test {
-  useJUnitPlatform {
-    includeEngines "spek"
-  }
-}
+data class ClusterScalingPolicyTaggingAgentProperties(
+  /**
+   * [oldServerGroupBoundaryMs] defines how long a server group must exist
+   * before the agent will consider a missing scaling policy as desired.
+   */
+  var oldServerGroupBoundaryMs: Long = Duration.ofHours(8).toMillis()
+)

--- a/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/config/ElasticSearchAmazonConfig.kt
+++ b/clouddriver-elasticsearch-aws/src/main/kotlin/com/netflix/spinnaker/config/ElasticSearchAmazonConfig.kt
@@ -20,23 +20,30 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.elasticsearch.aws.ElasticSearchAmazonCachingAgentProvider
+import com.netflix.spinnaker.clouddriver.elasticsearch.aws.ElasticSearchAmazonScalingPolicyAgentProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
+import com.netflix.spinnaker.clouddriver.tags.EntityTagger
 import com.netflix.spinnaker.kork.core.RetrySupport
 import io.searchbox.client.JestClient
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnProperty("elasticSearch.caching.enabled")
+@EnableConfigurationProperties(ClusterScalingPolicyTaggingAgentProperties::class)
 open class ElasticSearchAmazonConfig {
+
   @Bean
+  @ConditionalOnProperty("elasticSearch.caching.enabled")
   open fun elasticSearchAmazonCachingAgentProvider(objectMapper: ObjectMapper,
                                                    jestClient: JestClient,
                                                    retrySupport: RetrySupport,
                                                    registry: Registry,
                                                    amazonClientProvider: AmazonClientProvider,
-                                                   accountCredentialsProvider: AccountCredentialsProvider) =
+                                                   accountCredentialsProvider: AccountCredentialsProvider,
+                                                   entityTagger: EntityTagger) =
     ElasticSearchAmazonCachingAgentProvider(
       objectMapper,
       jestClient,
@@ -44,5 +51,24 @@ open class ElasticSearchAmazonConfig {
       registry,
       amazonClientProvider,
       accountCredentialsProvider
+    )
+
+  @Bean
+  @ConditionalOnProperty("elasticSearch.scalingPolicies.enabled")
+  open fun elasticSearchAmazonScalingPolicyAgentProvider(objectMapper: ObjectMapper,
+                                                         retrySupport: RetrySupport,
+                                                         registry: Registry,
+                                                         amazonClientProvider: AmazonClientProvider,
+                                                         accountCredentialsProvider: AccountCredentialsProvider,
+                                                         entityTagger: EntityTagger,
+                                                         properties: ClusterScalingPolicyTaggingAgentProperties) =
+    ElasticSearchAmazonScalingPolicyAgentProvider(
+      objectMapper,
+      retrySupport,
+      registry,
+      amazonClientProvider,
+      accountCredentialsProvider,
+      entityTagger,
+      properties
     )
 }

--- a/clouddriver-elasticsearch-aws/src/test/kotlin/com/netflix/spinnaker/clouddriver/elasticsearch/aws/ClusterScalingPolicyTaggingAgentSpec.kt
+++ b/clouddriver-elasticsearch-aws/src/test/kotlin/com/netflix/spinnaker/clouddriver/elasticsearch/aws/ClusterScalingPolicyTaggingAgentSpec.kt
@@ -1,0 +1,517 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.elasticsearch.aws
+
+import com.amazonaws.services.autoscaling.model.Alarm
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.autoscaling.model.ScalingPolicy
+import com.amazonaws.services.autoscaling.model.StepAdjustment
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.model.EntityTags
+import com.netflix.spinnaker.clouddriver.tags.EntityTagger
+import com.netflix.spinnaker.config.ClusterScalingPolicyTaggingAgentProperties
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.nhaarman.mockito_kotlin.*
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import strikt.api.expect
+import strikt.assertions.isA
+import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
+import strikt.assertions.isTrue
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+
+class ClusterScalingPolicyTaggingAgentSpec : Spek({
+
+  val retrySupport = RetrySupport()
+  val registry = NoopRegistry()
+  val objectMapper = ObjectMapper()
+
+  val amazonClientProvider = mock<AmazonClientProvider>()
+  val entityTagger = mock<EntityTagger>()
+
+  fun resetMocks() {
+    reset(amazonClientProvider, entityTagger)
+  }
+
+  describe("running agent for a single account region") {
+    val subject = ClusterScalingPolicyTaggingAgent(
+      retrySupport,
+      registry,
+      amazonClientProvider,
+      listOf(),
+      entityTagger,
+      objectMapper,
+      ClusterScalingPolicyTaggingAgentProperties()
+    )
+
+    val credentials = mock<NetflixAmazonCredentials>()
+    val region = mock<AmazonCredentials.AWSRegion>()
+
+    beforeEachTest {
+      whenever(credentials.name) doReturn "test"
+      whenever(credentials.accountId) doReturn "1234"
+      whenever(region.name) doReturn "us-west-2"
+    }
+
+    afterEachTest {
+      resetMocks()
+      reset(credentials, region)
+    }
+
+    given("no scaling policies exist") {
+      val serverGroups = listOf(
+        serverGroup("clouddriver-test-v000"),
+        serverGroup("orca-test-v000")
+      )
+
+      val accountRegion = AccountRegionIndex(
+        credentials = credentials,
+        region = region,
+        serverGroups = serverGroups,
+        scalingPolicies = AccountRegionScalingPolicies(
+          all = listOf(),
+          byServerGroupName = mapOf(),
+          byCluster = mapOf()
+        ),
+        clusterEntityTags = mapOf()
+      )
+
+      on("poll cycle") {
+        subject.forAccountRegion(accountRegion)
+
+        it("does not tag any entities") {
+          verifyNoMoreInteractions(entityTagger)
+        }
+      }
+    }
+
+    given("all server groups are up to date") {
+      val serverGroups = listOf(
+        serverGroup("clouddriver-test-v000"),
+        serverGroup("orca-test-v000")
+      )
+      val clouddriverPolicy = scalingPolicy {
+        it.policyARN = "arn-a"
+        it.autoScalingGroupName = "clouddriver-test-v000"
+        it.policyType = "river"
+      }
+      val orcaPolicy = scalingPolicy {
+        it.policyARN = "arn-b"
+        it.autoScalingGroupName = "orca-test-v000"
+        it.policyType = "orca"
+      }
+
+      val accountRegion = AccountRegionIndex(
+        credentials = credentials,
+        region = region,
+        serverGroups = serverGroups,
+        scalingPolicies = AccountRegionScalingPolicies(
+          all = listOf(clouddriverPolicy, orcaPolicy),
+          byServerGroupName = mapOf(
+            "clouddriver-test-v000" to listOf(clouddriverPolicy),
+            "orca-test-v000" to listOf(orcaPolicy)
+          ),
+          byCluster = mapOf(
+            "clouddriver-test" to listOf(clouddriverPolicy),
+            "orca-test" to listOf(orcaPolicy)
+          )
+        ),
+        clusterEntityTags = mapOf(
+          "clouddriver-test" to listOf(
+            EntityTags().apply {
+              id = "aws:cluster:clouddriver-test:test:us-west-2"
+              entityRef = EntityTags.EntityRef().apply {
+                entityType = "cluster"
+                entityId = "clouddriver-test"
+                cloudProvider = "aws"
+                accountId = "1234"
+                setRegion("us-west-2")
+              }
+              tags = listOf(
+                EntityTags.EntityTag().apply {
+                  name = "spinnaker:scaling_policies"
+                  namespace = "spinnaker"
+                  value = listOf(clouddriverPolicy).toEntityTagValue(objectMapper)
+                  valueType = EntityTags.EntityTagValueType.`object`
+                }
+              )
+            }
+          ),
+          "orca-test" to listOf(
+            EntityTags().apply {
+              id = "aws:cluster:orca-test:test:us-west-2"
+              entityRef = EntityTags.EntityRef().apply {
+                entityType = "cluster"
+                entityId = "orca-test"
+                cloudProvider = "aws"
+                accountId = "1234"
+                setRegion("us-west-2")
+              }
+              tags = listOf(
+                EntityTags.EntityTag().apply {
+                  name = "spinnaker:scaling_policies"
+                  namespace = "spinnaker"
+                  value = listOf(orcaPolicy).toEntityTagValue(objectMapper)
+                  valueType = EntityTags.EntityTagValueType.`object`
+                }
+              )
+            }
+          )
+        )
+      )
+
+      on("poll cycle") {
+        subject.forAccountRegion(accountRegion)
+
+        it("ensures the cluster reflects the current scaling policies") {
+          verify(entityTagger, times(1)).tag(
+            eq("aws"),
+            eq("1234"),
+            eq("us-west-2"),
+            eq("spinnaker"),
+            eq("cluster"),
+            eq("clouddriver-test"),
+            eq("spinnaker:scaling_policies"),
+            eq(listOf(clouddriverPolicy).toEntityTagValue(objectMapper)),
+            any()
+          )
+          verify(entityTagger, times(1)).tag(
+            eq("aws"),
+            eq("1234"),
+            eq("us-west-2"),
+            eq("spinnaker"),
+            eq("cluster"),
+            eq("orca-test"),
+            eq("spinnaker:scaling_policies"),
+            eq(listOf(orcaPolicy).toEntityTagValue(objectMapper)),
+            any()
+          )
+        }
+      }
+    }
+
+    given("server groups with scaling policies and no cluster entity tags") {
+      val serverGroups = listOf(
+        serverGroup("clouddriver-test-v000"),
+        serverGroup("orca-test-v000")
+      )
+      val clouddriverPolicy1 = scalingPolicy {
+        it.policyARN = "arn-a"
+        it.autoScalingGroupName = "clouddriver-test-v000"
+        it.policyType = "river"
+      }
+      val clouddriverPolicy2 = scalingPolicy {
+        it.policyARN = "arn-a"
+        it.autoScalingGroupName = "clouddriver-test-v001"
+        it.policyType = "river"
+      }
+      val orcaPolicy = scalingPolicy {
+        it.policyARN = "arn-b"
+        it.autoScalingGroupName = "orca-test-v000"
+        it.policyType = "orca"
+      }
+
+      val accountRegion = AccountRegionIndex(
+        credentials = credentials,
+        region = region,
+        serverGroups = serverGroups,
+        scalingPolicies = AccountRegionScalingPolicies(
+          all = listOf(clouddriverPolicy1, clouddriverPolicy2, orcaPolicy),
+          byServerGroupName = mapOf(
+            "clouddriver-test-v000" to listOf(clouddriverPolicy1),
+            "clouddriver-test-v001" to listOf(clouddriverPolicy2),
+            "orca-test-v000" to listOf(orcaPolicy)
+          ),
+          byCluster = mapOf(
+            "clouddriver-test" to listOf(clouddriverPolicy1),
+            "orca-test" to listOf(orcaPolicy)
+          )
+        ),
+        clusterEntityTags = mapOf()
+      )
+
+      on("poll cycle") {
+        subject.forAccountRegion(accountRegion)
+
+        it("saves cluster scaling policies entity tags") {
+          verify(entityTagger, times(1)).tag(
+            eq("aws"),
+            eq("1234"),
+            eq("us-west-2"),
+            eq("spinnaker"),
+            eq("cluster"),
+            eq("clouddriver-test"),
+            eq("spinnaker:scaling_policies"),
+            eq(listOf(clouddriverPolicy1).toEntityTagValue(objectMapper)),
+            any()
+          )
+          verify(entityTagger, times(1)).tag(
+            eq("aws"),
+            eq("1234"),
+            eq("us-west-2"),
+            eq("spinnaker"),
+            eq("cluster"),
+            eq("orca-test"),
+            eq("spinnaker:scaling_policies"),
+            eq(listOf(orcaPolicy).toEntityTagValue(objectMapper)),
+            any()
+          )
+        }
+      }
+    }
+  }
+
+  describe("get scaling policies by cluster") {
+    val subject = ClusterScalingPolicyTaggingAgent(
+      retrySupport,
+      registry,
+      amazonClientProvider,
+      listOf(),
+      entityTagger,
+      objectMapper,
+      ClusterScalingPolicyTaggingAgentProperties()
+    )
+
+    afterGroup {
+      resetMocks()
+    }
+
+    given("multiple server groups in cluster") {
+      val serverGroups = listOf(
+        serverGroup("clouddriver-test-v000"),
+        serverGroup("clouddriver-test-v001")
+      )
+      val scalingPoliciesByServerGroupName = mapOf(
+        "clouddriver-test-v000" to listOf(
+          scalingPolicy { it.withPolicyARN("arn-a").withPolicyType("simple") },
+          scalingPolicy { it.withPolicyARN("arn-b").withPolicyType("targetTracking") },
+          scalingPolicy { it.withPolicyARN("arn-c").withPolicyType("step") }
+        ),
+        "clouddriver-test-v001" to listOf(
+          scalingPolicy { it.withPolicyARN("arn-b").withPolicyType("targetTracking") },
+          scalingPolicy { it.withPolicyARN("arn-c").withPolicyType("step") }
+        )
+      )
+
+      on("method call") {
+        val result = subject.getScalingPoliciesByCluster(serverGroups, scalingPoliciesByServerGroupName)
+
+        it("de-duplicates policies by arn") {
+          expect(result["clouddriver-test"])
+            .isNotNull()
+            .isA<List<ScalingPolicy>>()
+            .map("get scaling policy arns") { map { it.policyType } }
+            .assert("no duplicates exist") {
+              if (this.subject == listOf("simple", "targetTracking", "step")) {
+                pass()
+              } else {
+                fail()
+              }
+            }
+        }
+      }
+    }
+  }
+
+  describe("shouldUpdateClusterEntityTags method") {
+    val subject = ClusterScalingPolicyTaggingAgent(
+      retrySupport,
+      registry,
+      amazonClientProvider,
+      listOf(),
+      entityTagger,
+      objectMapper,
+      ClusterScalingPolicyTaggingAgentProperties()
+    )
+
+    val credentials = mock<NetflixAmazonCredentials>()
+    val region = mock<AmazonCredentials.AWSRegion>()
+
+    beforeGroup {
+      whenever(credentials.name) doReturn "test"
+      whenever(credentials.accountId) doReturn "1234"
+      whenever(region.name) doReturn "us-west-2"
+    }
+
+    afterGroup {
+      resetMocks()
+      reset(credentials, region)
+    }
+
+    on("an old server group") {
+      val serverGroup = serverGroup("clouddriver-test-v000") {
+        it.createdTime = Date.from(Instant.now().minus(Duration.ofDays(30)))
+      }
+      val boundary = Instant.now()
+
+      it("should update entity tags") {
+        expect(subject.shouldUpdateClusterEntityTags(serverGroup, credentials, region, boundary)) {
+          isTrue()
+        }
+      }
+    }
+
+    on("a new server group") {
+      val serverGroup = serverGroup("clouddriver-test-v000") {
+        it.createdTime = Date.from(Instant.now())
+      }
+      val boundary = Instant.now().minus(Duration.ofHours(1))
+
+      it("should not update entity tags") {
+        expect(subject.shouldUpdateClusterEntityTags(serverGroup, credentials, region, boundary)) {
+          isFalse()
+        }
+      }
+    }
+  }
+
+  describe("scaling policy equality") {
+    given("scaling policies that are equal") {
+      val policy1 = ScalingPolicy().apply {
+        policyARN = "arn-a"
+        policyName = "policy1"
+        autoScalingGroupName = "clouddriver-test-v000"
+
+        policyType = "simple"
+        adjustmentType = "something"
+        minAdjustmentStep = 1
+        minAdjustmentMagnitude = 1
+        scalingAdjustment = 1
+        cooldown = 100
+        withStepAdjustments(StepAdjustment().apply {
+            metricIntervalLowerBound = 1.toDouble()
+            metricIntervalUpperBound = 1.toDouble()
+            scalingAdjustment = 1
+          }
+        )
+        metricAggregationType = "something"
+        withAlarms(Alarm().apply {
+          alarmARN = "arn-a"
+          alarmName = "alarm"
+        })
+      }
+      val policy2 = ScalingPolicy().apply {
+        policyARN = "arn-b"
+        policyName = "policy2"
+        autoScalingGroupName = "clouddriver-test-v001"
+
+        policyType = "simple"
+        adjustmentType = "something"
+        minAdjustmentStep = 1
+        minAdjustmentMagnitude = 1
+        scalingAdjustment = 1
+        cooldown = 100
+        withStepAdjustments(StepAdjustment().apply {
+          metricIntervalLowerBound = 1.toDouble()
+          metricIntervalUpperBound = 1.toDouble()
+          scalingAdjustment = 1
+        }
+        )
+        metricAggregationType = "something"
+        withAlarms(Alarm().apply {
+          alarmARN = "arn-a"
+          alarmName = "alarm"
+        })
+      }
+
+      it("evaluates as equal") {
+        expect(policy1.isEqual(policy2)).isTrue()
+      }
+    }
+
+    given("policies that are not equal") {
+      val policy1 = ScalingPolicy().apply {
+        policyARN = "arn-a"
+        policyName = "policy1"
+        autoScalingGroupName = "clouddriver-test-v000"
+
+        policyType = "simple"
+        adjustmentType = "something"
+        minAdjustmentStep = 1
+        minAdjustmentMagnitude = 1
+        scalingAdjustment = 1
+        cooldown = 100
+        withStepAdjustments(StepAdjustment().apply {
+          metricIntervalLowerBound = 1.toDouble()
+          metricIntervalUpperBound = 1.toDouble()
+          scalingAdjustment = 1
+        }
+        )
+        metricAggregationType = "something"
+        withAlarms(Alarm().apply {
+          alarmARN = "arn-a"
+          alarmName = "alarm"
+        })
+      }
+      val policy2 = ScalingPolicy().apply {
+        policyARN = "arn-b"
+        policyName = "policy2"
+        autoScalingGroupName = "clouddriver-test-v001"
+
+        policyType = "DIFFERENT"
+        adjustmentType = "something"
+        minAdjustmentStep = 1
+        minAdjustmentMagnitude = 1
+        scalingAdjustment = 1
+        cooldown = 100
+        withStepAdjustments(StepAdjustment().apply {
+          metricIntervalLowerBound = 1.toDouble()
+          metricIntervalUpperBound = 1.toDouble()
+          scalingAdjustment = 1
+        }
+        )
+        metricAggregationType = "something"
+        withAlarms(Alarm().apply {
+          alarmARN = "arn-a"
+          alarmName = "alarm"
+        })
+      }
+
+      it("evaluates as inequal") {
+        expect(policy1.isEqual(policy2)).isFalse()
+      }
+    }
+  }
+})
+
+private fun serverGroup(name: String): AutoScalingGroup {
+  return serverGroup(name) {
+    it.createdTime = Date.from(Instant.now())
+  }
+}
+
+private fun serverGroup(name: String, fn: ((AutoScalingGroup) -> Unit)?): AutoScalingGroup {
+  return AutoScalingGroup().apply {
+    withAutoScalingGroupName(name)
+    if (fn != null) {
+      fn(this)
+    }
+  }
+}
+
+private fun scalingPolicy(fn: (ScalingPolicy) -> Unit): ScalingPolicy {
+  return ScalingPolicy().apply(fn)
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ jackson.version=2.9.2
 
 junitVersion=1.2.0
 jupiterVersion=5.0.2
-junitLegacyVersion=4.12.0
+junitLegacyVersion=4.12.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.parallel=true
 
 jackson.version=2.9.2
+
+junitVersion=1.2.0
+jupiterVersion=5.0.2
+junitLegacyVersion=4.12.0


### PR DESCRIPTION
Allows us to record an inferred cluster-level desired state
of autoscaling policies based, and then report when policies
drift out of the desired state.

The concept is kinda gnarly, so there's a bunch of comments to go with. 