### PR TITLE
fix(titus): Ensure containerAttributes values are strings

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
@@ -235,7 +235,7 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
         .withInService(description.inService)
         .withMigrationPolicy(description.migrationPolicy)
         .withCredentials(description.credentials.name)
-        .withContainerAttributes(description.containerAttributes)
+        .withContainerAttributes(description.containerAttributes.collectEntries { [(it.key): it.value?.toString()] })
 
       Set<String> securityGroups = []
       description.securityGroups?.each { providedSecurityGroup ->

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
@@ -79,6 +79,10 @@ class TitusDeployHandlerSpec extends Specification {
       interestingHealthProviderNames: [
         "Titus",
         "Discovery"
+      ],
+      containerAttributes: [
+        'k1': 'value1',
+        'k2': 123
       ]
     )
     titusClient.findJobsByApplication(_) >> []


### PR DESCRIPTION
Deploy operations explode if container attributes are received as non-strings.