### PR TITLE
fix(provider/dcos): Cache per cluster/service account pair.

### DIFF
--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosServerGroup.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosServerGroup.groovy
@@ -77,10 +77,10 @@ class DcosServerGroup implements ServerGroup, Serializable {
     this.account = account
   }
 
-  DcosServerGroup(String account, String cluster, String clusterUrl, App app) {
+  DcosServerGroup(String cluster, String clusterUrl, App app) {
     this.app = app
     this.json = app.toString()
-    def id = DcosSpinnakerAppId.parse(app.id, account).get()
+    def id = DcosSpinnakerAppId.parse(app.id).get()
     this.name = id.serverGroupName.group
     this.dcosCluster = cluster
     this.clusterUrl = clusterUrl

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosClusterAware.java
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosClusterAware.java
@@ -1,0 +1,13 @@
+package com.netflix.spinnaker.clouddriver.dcos.provider.agent;
+
+import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials;
+
+import java.util.Collection;
+
+public interface DcosClusterAware {
+  String getClusterName();
+
+  String getServiceAccountUID();
+
+  Collection<DcosAccountCredentials> getAccounts();
+}

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosClusterAware.java
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosClusterAware.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 Cerner Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.netflix.spinnaker.clouddriver.dcos.provider.agent;
 
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials;

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosSecretsCachingAgent.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosSecretsCachingAgent.groovy
@@ -33,9 +33,8 @@ import mesosphere.dcos.client.DCOSException
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 
 @Slf4j
-class DcosSecretsCachingAgent implements CachingAgent, AccountAware {
+class DcosSecretsCachingAgent implements CachingAgent {
 
-  private final String accountName
   private final String clusterName
   private final DcosClusterCredentials clusterCredentials
   private final DcosAccountCredentials credentials
@@ -46,12 +45,10 @@ class DcosSecretsCachingAgent implements CachingAgent, AccountAware {
                                                                         AUTHORITATIVE.forType(Keys.Namespace.SECRETS.ns),
                                                                       ] as Set)
 
-  DcosSecretsCachingAgent(String accountName,
-                          String clusterName,
+  DcosSecretsCachingAgent(String clusterName,
                           DcosAccountCredentials credentials,
                           DcosClientProvider clientProvider,
                           ObjectMapper objectMapper) {
-    this.accountName = accountName
     this.clusterName = clusterName
     this.clusterCredentials = credentials.getCredentialsByCluster(clusterName)
     this.credentials = credentials
@@ -62,17 +59,12 @@ class DcosSecretsCachingAgent implements CachingAgent, AccountAware {
 
   @Override
   String getAgentType() {
-    "${accountName}/${clusterName}/${DcosSecretsCachingAgent.simpleName}"
+    "${clusterName}/${DcosSecretsCachingAgent.simpleName}"
   }
 
   @Override
   String getProviderName() {
     DcosProvider.name
-  }
-
-  @Override
-  String getAccountName() {
-    accountName
   }
 
   @Override
@@ -88,7 +80,7 @@ class DcosSecretsCachingAgent implements CachingAgent, AccountAware {
     try {
       secrets = dcosClient.listSecrets(clusterCredentials.secretStore, "").secrets
     } catch (DCOSException e) {
-      log.error("Unable to cache secrets for account [${accountName}] and cluster [${clusterName}].", e)
+      log.error("Unable to cache secrets for cluster=[${clusterName}] using serviceAccount=[${clusterCredentials.dcosConfig.credentials.uid}]", e)
     }
 
     buildCacheResult(secrets)

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/BaseSpecification.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/BaseSpecification.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.dcos.DcosConfigurationProperties
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosClusterCredentials
 import mesosphere.dcos.client.Config
+import mesosphere.dcos.client.model.DCOSAuthCredentials
 import spock.lang.Specification
 
 class BaseSpecification extends Specification {
@@ -31,11 +32,17 @@ class BaseSpecification extends Specification {
   public static
   final DEFAULT_COMPOSITE_KEY = DcosClientCompositeKey.buildFromVerbose(DEFAULT_ACCOUNT, DEFAULT_REGION).get()
   public static final BAD_ACCOUNT = 'bad-acct'
+  public static final DEFAULT_DCOS_UID = "default_uid"
 
   def defaultCredentialsBuilder() {
+
+    def dcosAuthCreds = Mock(DCOSAuthCredentials) {
+      getUid() >> DEFAULT_DCOS_UID
+    }
+
     DcosAccountCredentials.builder().account(DEFAULT_ACCOUNT).environment('test').accountType('test').requiredGroupMembership([])
       .dockerRegistries([new DcosConfigurationProperties.LinkedDockerRegistryConfiguration(accountName: 'dockerReg')])
-      .clusters([DcosClusterCredentials.builder().key(DEFAULT_COMPOSITE_KEY).dcosUrl('https://test.url.com').secretStore('default').dcosConfig(Config.builder().build()).build()])
+      .clusters([DcosClusterCredentials.builder().key(DEFAULT_COMPOSITE_KEY).dcosUrl('https://test.url.com').secretStore('default').dcosConfig(Config.builder().withCredentials(dcosAuthCreds).build()).build()])
   }
 
   def emptyCredentialsBuilder() {

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosServerGroupSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosServerGroupSpec.groovy
@@ -41,7 +41,7 @@ class DcosServerGroupSpec extends Specification {
     lbApp.getLabels() >> ["HAPROXY_GROUP": "${ACCOUNT}_${goodLb},wrongaccount_${badLb}"]
 
     when:
-    @Subject def serverGroup = new DcosServerGroup(ACCOUNT, REGION, DCOS_URL, lbApp)
+    @Subject def serverGroup = new DcosServerGroup(REGION, DCOS_URL, lbApp)
 
     then:
     serverGroup.loadBalancers.size() == 1

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosSecretsCachingAgentSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosSecretsCachingAgentSpec.groovy
@@ -48,7 +48,7 @@ class DcosSecretsCachingAgentSpec extends BaseSpecification {
       getDcosClient(credentials, DEFAULT_REGION) >> dcosClient
     }
 
-    subject = new DcosSecretsCachingAgent(DEFAULT_ACCOUNT, DEFAULT_REGION, credentials, clientProvider, objectMapper)
+    subject = new DcosSecretsCachingAgent(DEFAULT_REGION, credentials, clientProvider, objectMapper)
   }
 
   void "Should cache secrets when the account has permission to list secrets"() {


### PR DESCRIPTION
Caches DC/OS data at the cluster level instead of account level for DC/OS accounts. This prevents duplicate caching and API calls when multiple Spinnaker accounts exist for the same DC/OS cluster.