### PR TITLE
fix(provider/dcos): less verbose spectator metrics labels for dc/os exceptions

### DIFF
--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosSpectatorHandler.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosSpectatorHandler.groovy
@@ -64,7 +64,7 @@ class DcosSpectatorHandler implements InvocationHandler {
                 tags.put("success", "true")
             } else {
                 tags.put("success", "false")
-                tags.put("reason", failure.getClass().getSimpleName() + ": " + failure.getMessage())
+                tags.put("reason", failure.getClass().getSimpleName())
             }
 
             registry.timer(registry.createId("dcos.api", tags))


### PR DESCRIPTION
Removes the full failure message from the reason for dc/os exceptions in spectator metrics labels, since having the full failure message is not the point of a label.
