### PR TITLE
fix(titus): don't ask for instances when they're not wanted

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ClusterProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ClusterProvider.java
@@ -71,6 +71,11 @@ public interface ClusterProvider<T extends Cluster> {
   @Empty
   Set<T> getClusters(String application, String account);
 
+  @Empty
+  default Set<T> getClusters(String application, String account, boolean includeDetails) {
+    return getClusters(application, account);
+  }
+
   /**
    * Looks up a cluster known to this provider to be for a specified application, within a specified {@link com.netflix.spinnaker.clouddriver.security.AccountCredentials}, and with the specified name.
    *

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
@@ -112,10 +112,21 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
    *
    * @param applicationName
    * @param account
-   * @return
+   * @return clusters with the instances
    */
   @Override
   Set<TitusCluster> getClusters(String applicationName, String account) {
+    return getClusters(applicationName, account, true)
+  }
+
+  /**
+   *
+   * @param applicationName
+   * @param account
+   * @return
+   */
+  @Override
+  Set<TitusCluster> getClusters(String applicationName, String account, boolean includeDetails) {
     CacheData application = cacheView.get(APPLICATIONS.ns, Keys.getApplicationKey(applicationName),
       RelationshipCacheFilter.include(CLUSTERS.ns))
     if (application == null) {
@@ -125,7 +136,7 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
       Keys.parse(it).account == account
     }
     Collection<CacheData> clusters = cacheView.getAll(CLUSTERS.ns, clusterKeys)
-    translateClusters(clusters, true) as Set<TitusCluster>
+    translateClusters(clusters, includeDetails) as Set<TitusCluster>
   }
 
   /**

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy
@@ -78,7 +78,7 @@ class ClusterController {
   @RequestMapping(value = "/{account:.+}", method = RequestMethod.GET)
   Set<ClusterViewModel> getForAccount(@PathVariable String application, @PathVariable String account) {
     def clusters = clusterProviders.collect {
-      def clusters = (Set<Cluster>) it.getClusters(application, account)
+      def clusters = (Set<Cluster>) it.getClusters(application, account, false)
       def clusterViews = []
       for (cluster in clusters) {
         clusterViews << new ClusterViewModel(

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterControllerSpec.groovy
@@ -132,7 +132,7 @@ class ClusterControllerSpec extends Specification {
       clusterController.getForAccount("app", "account")
 
     then:
-      1 * clusterProvider1.getClusters(_, _) >> null
+      1 * clusterProvider1.getClusters(_, _, false) >> null
       thrown NotFoundException
   }
 


### PR DESCRIPTION
When getting clusters by account we don't want the instances. In the titusClusterProvider we were returning instances and then throwing them away. Now, we can optionally not ask for instances.