### PR TITLE
feat(kubernetes): surface kind mapping to credentials API

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.module.CatsModule
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
@@ -41,6 +42,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
   @Autowired Registry spectatorRegistry
   @Autowired KubectlJobExecutor jobExecutor
   @Autowired NamerRegistry namerRegistry
+  @Autowired KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap
 
   @Bean
   List<? extends KubernetesNamedAccountCredentials> kubernetesNamedAccountCredentials(
@@ -107,6 +109,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .kinds(managedAccount.kinds)
           .omitKinds(managedAccount.omitKinds)
           .debug(managedAccount.debug)
+          .kubernetesSpinnakerKindMap(kubernetesSpinnakerKindMap)
           .build()
 
         accountCredentialsRepository.save(managedAccount.name, kubernetesAccount)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -82,5 +83,12 @@ public class KubernetesSpinnakerKindMap {
 
   public Set<KubernetesKind> allKubernetesKinds() {
     return kubernetesToSpinnaker.keySet();
+  }
+
+  public Map<String, String> kubernetesToSpinnakerKindStringMap() {
+    return kubernetesToSpinnaker.entrySet().stream().filter(
+      x -> x.getValue() != SpinnakerKind.UNCLASSIFIED && x.getKey() != KubernetesKind.NONE
+    ).collect(
+      Collectors.toMap(x -> x.getKey().toString(), x -> x.getValue().toString()));
   }
 }


### PR DESCRIPTION
Expose the map from k8s resource kinds to Spinnaker kinds.  E.g. ReplicaSet -> ServerGroup; Deployment -> ServerGroupManager

This will be consumed by the UI to correctly route the user from a resource deployed during an execution to its details view.

Fixes https://github.com/spinnaker/spinnaker/issues/2496