### PR TITLE
fix(provider/kubernetes): fix regex perf bug when parsing images

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
@@ -44,6 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -162,6 +163,7 @@ public class ArtifactReplacer {
     private final String replacePath;
     private final String findPath;
     private final Pattern namePattern; // the first group should be the artifact name
+    private final Function<String, String> nameFromReference;
 
     @Getter
     private final ArtifactTypes type;
@@ -184,13 +186,15 @@ public class ArtifactReplacer {
     }
 
     String getNameFromReference(String reference) {
-      if (namePattern == null) {
-        return null;
-      }
-
-      Matcher m = namePattern.matcher(reference);
-      if (m.find() && m.groupCount() > 0 && StringUtils.isNotEmpty(m.group(1))) {
-        return m.group(1);
+      if (nameFromReference != null) {
+        return nameFromReference.apply(reference);
+      } else if (namePattern != null) {
+        Matcher m = namePattern.matcher(reference);
+        if (m.find() && m.groupCount() > 0 && StringUtils.isNotEmpty(m.group(1))) {
+          return m.group(1);
+        } else {
+          return null;
+        }
       } else {
         return null;
       }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacerSpec.groovy
@@ -54,62 +54,18 @@ spec:
     artifact.getReference() == image
 
     where:
-    image                         || name
-    "nginx:112"                   || "nginx"
-    "nginx:1.12-alpine"           || "nginx"
-    "my-nginx:100000"             || "my-nginx"
-    "my.nginx:100000"             || "my.nginx"
-    "reg/repo:1.2.3"              || "reg/repo"
-    "reg.default.svc/r/j:485fabc" || "reg.default.svc/r/j"
-    "reg:5000/r/j:485fabc"        || "reg:5000/r/j"
-    "reg:5000/r__j:485fabc"       || "reg:5000/r__j"
-    "clouddriver"                 || "clouddriver"
-    "localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf" \
-      || "localhost:5000/test/busybox"
-  }
-
-  @Unroll
-  def "does not generate invalid Docker artifacts from image names"() {
-    expect:
-    def deploymentManifest = """
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-app-deployment
-  labels:
-    app: my-app
-spec:
-  template:
-    spec:
-      containers:
-      - name: container
-        image: $image
-      - name: other-container
-        image: my-image:1.0
-"""
-    def artifactReplacer = new ArtifactReplacer()
-    artifactReplacer.addReplacer(ArtifactReplacerFactory.dockerImageReplacer())
-    def manifest = stringToManifest(deploymentManifest)
-    def artifacts = artifactReplacer.findAll(manifest)
-
-    artifacts.size() == 1
-    Artifact artifact = artifacts.toList().get(0)
-    artifact.getType() == ArtifactTypes.DOCKER_IMAGE.toString()
-    artifact.getName() == "my-image"
-    artifact.getReference() == "my-image:1.0"
-
-    where:
-    image                                            | _
-    ":500"                                           | _
-    "'@registry.default.svc/myrepo/jenkins:485fabc'" | _
-    "registry___myrepo/"                             | _
-    "'!!clouddriver'"                                | _
-    "localhost@5000/test/busybox@sha256:cbbf2f9"     | _
-    "registry/myrepo/_myimage:1.2.3"                 | _
-    "nginx:-alpine"                                  | _
-    "nginx:.alpine"                                  | _
-    "reg:5000/r___j:485fabc"                         | _
-    "my..nginx:100000"                               | _
-    "my-_-nginx:100000"                              | _
+    image                                       || name
+    "nginx:112"                                 || "nginx"
+    "nginx:1.12-alpine"                         || "nginx"
+    "my-nginx:100000"                           || "my-nginx"
+    "my.nginx:100000"                           || "my.nginx"
+    "reg/repo:1.2.3"                            || "reg/repo"
+    "reg.repo:123@sha256:13"                    || "reg.repo:123"
+    "reg.default.svc/r/j:485fabc"               || "reg.default.svc/r/j"
+    "reg:5000/r/j:485fabc"                      || "reg:5000/r/j"
+    "reg:5000/r__j:485fabc"                     || "reg:5000/r__j"
+    "clouddriver"                               || "clouddriver"
+    "clouddriver@sha256:9145"                   || "clouddriver"
+    "localhost:5000/test/busybox@sha256:cbbf22" || "localhost:5000/test/busybox"
   }
 }


### PR DESCRIPTION
Tests checking for the validity of an image were removed, since they are
only exercised on already deployed manifest objects. If kubernetes
accepts a docker image, we don't provide any value in refusing to parse
it. Also, parsing it turned out to be very expensive for certain image
configurations.

