### PR TITLE
fix(aws): Equality of `RateLimitingRequestHandler` should not depend on counter

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AwsSdkClientSupplier.java
@@ -56,7 +56,13 @@ public class AwsSdkClientSupplier {
   public AwsSdkClientSupplier(RateLimiterSupplier rateLimiterSupplier, Registry registry, RetryPolicy retryPolicy, List<RequestHandler2> requestHandlers, AWSProxy proxy, boolean useGzip) {
     this.rateLimiterSupplier = Objects.requireNonNull(rateLimiterSupplier);
     this.registry = Objects.requireNonNull(registry);
-    awsSdkClients = CacheBuilder.newBuilder().recordStats().build(new SdkClientCacheLoader(retryPolicy, requestHandlers, proxy, useGzip));
+    awsSdkClients = CacheBuilder
+      .newBuilder()
+      .recordStats()
+      .expireAfterAccess(10, TimeUnit.MINUTES)
+      .build(
+        new SdkClientCacheLoader(retryPolicy, requestHandlers, proxy, useGzip)
+      );
     LoadingCacheMetrics.instrument("awsSdkClientSupplier", registry, awsSdkClients);
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimitingRequestHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/RateLimitingRequestHandler.java
@@ -21,6 +21,8 @@ import com.amazonaws.handlers.RequestHandler2;
 import com.google.common.util.concurrent.RateLimiter;
 import com.netflix.spectator.api.Counter;
 
+import java.util.Objects;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -47,17 +49,12 @@ public class RateLimitingRequestHandler extends RequestHandler2 {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-
     RateLimitingRequestHandler that = (RateLimitingRequestHandler) o;
-
-    if (!counter.equals(that.counter)) return false;
-    return rateLimiter.equals(that.rateLimiter);
+    return Objects.equals(rateLimiter, that.rateLimiter);
   }
 
   @Override
   public int hashCode() {
-    int result = counter.hashCode();
-    result = 31 * result + rateLimiter.hashCode();
-    return result;
+    return Objects.hash(rateLimiter);
   }
 }


### PR DESCRIPTION
There is no guarantee that a `Counter` will be re-used across requests.

At Netflix, we're seeing an issue wherein the `AwsSdkClientSupplier`
has a zero hit rate due to the `Counter` reference changing between
requests to the same account/region.

This PR also introduces a TTL on the sdk clients cache (10min after access)
to offer future protection against poor hash/equals performance.
