### PR TITLE
fix(provider/kubernetes): be more tolerant of failing health checks

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
@@ -130,12 +130,12 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
   }
 
   public List<String> getDeclaredNamespaces() {
-    if (namespaces != null && !namespaces.isEmpty()) {
-      // If namespaces are provided, used them
-      reconfigureRegistries(namespaces);
-      return namespaces;
-    } else {
-      try {
+    try {
+      if (namespaces != null && !namespaces.isEmpty()) {
+        // If namespaces are provided, used them
+        reconfigureRegistries(namespaces);
+        return namespaces;
+      } else {
         List<String> addedNamespaces = apiAdaptor.getNamespacesByName();
         addedNamespaces.removeAll(omitNamespaces);
 
@@ -148,10 +148,10 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
         oldNamespaces = resultNamespaces;
 
         return resultNamespaces;
-      } catch (Exception e) {
-        LOG.warn("Could not determine kubernetes namespaces. Will try again later.", e);
-        return Lists.newArrayList();
       }
+    } catch (Exception e) {
+      LOG.warn("Could not determine kubernetes namespaces. Will try again later.", e);
+      return Lists.newArrayList();
     }
   }
 


### PR DESCRIPTION
When clouddriver starts and an account is unhealthy due to an
unreachable cluster, it will remain unhealthy until restarted. When
running, it will set the entire pod as unhealthy (even if other accounts
are useable). These changes allow clouddriver to start normally, and
keep other accounts reachable.

Closes: https://github.com/spinnaker/spinnaker/issues/2961

@mdirkse FYI