### PR TITLE
feat(provider/kubernetes): add UID field to LoadBalancerInstance

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerInstance.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerInstance.java
@@ -20,6 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -29,6 +30,21 @@ import java.util.Map;
 @NoArgsConstructor
 public class LoadBalancerInstance {
   String id;
+  String uid;
   String zone;
   Map<String, Object> health;
+
+  public LoadBalancerInstance(String id, String zone, Map<String, Object> health) {
+    this.id = id;
+    this.zone = zone;
+    this.health = health;
+  }
+
+  public String getUid() {
+    if (StringUtils.isEmpty(uid)) {
+      return id;
+    } else {
+      return uid;
+    }
+  }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Instance.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Instance.java
@@ -91,6 +91,7 @@ public class KubernetesV2Instance extends ManifestBasedModel implements Instance
           return result;
         }))
         .id(getName())
+        .uid(getUid())
         .zone(getZone())
         .build();
   }


### PR DESCRIPTION
As with https://github.com/spinnaker/clouddriver/pull/2751 this is to get unique IDs into Deck for Kubernetes instances.