### PR TITLE
feat(provider/kubernetes): make id field unique, add name field for full resource name

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Instance.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Instance.java
@@ -26,18 +26,18 @@ import java.util.Map;
  */
 public interface Instance {
   /**
-   * The name of the instance
+   * The name of the instance.  By convention this is expected to be globally unique.
    *
    * @return instance name
    */
   String getName();
 
   /**
-   * The instances unique identifier
+   * The human-readable name of the instance
    *
-   * @return the instances uid
+   * @return human-readable name
    */
-  default String getUid() {
+  default String getHumanReadableName() {
     return getName();
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerInstance.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerInstance.java
@@ -30,7 +30,7 @@ import java.util.Map;
 @NoArgsConstructor
 public class LoadBalancerInstance {
   String id;
-  String uid;
+  String name;
   String zone;
   Map<String, Object> health;
 
@@ -40,11 +40,11 @@ public class LoadBalancerInstance {
     this.health = health;
   }
 
-  public String getUid() {
-    if (StringUtils.isEmpty(uid)) {
+  public String getName()  {
+    if (StringUtils.isEmpty(name)) {
       return id;
     } else {
-      return uid;
+      return name;
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Instance.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Instance.java
@@ -91,12 +91,23 @@ public class KubernetesV2Instance extends ManifestBasedModel implements Instance
           return result;
         }))
         .id(getName())
-        .uid(getUid())
         .zone(getZone())
+        .name(getHumanReadableName())
         .build();
   }
 
   public HealthState getHealthState() {
     return KubernetesModelUtil.getHealthState(health);
+  }
+
+  // An implementor of the Instance interface is implicitly expected to return a globally-unique ID
+  // as its name because InstanceViewModel serializes it as such for API responses and Deck then
+  // relies on it to disambiguate between instances.
+  public String getName() {
+    return super.getUid();
+  }
+
+  public String getHumanReadableName() {
+    return super.getName();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/ManifestBasedModel.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/ManifestBasedModel.java
@@ -89,7 +89,7 @@ abstract public class ManifestBasedModel {
     } catch (ParseException e) {
       log.warn("Failed to parse timestamp: ", e);
     }
-    
+
     return null;
   }
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
@@ -294,7 +294,7 @@ class ServerGroupController {
 
   static class InstanceViewModel {
     String id
-    String uid
+    String name
     List<Map<String, Object>> health
     String healthState
     Long launchTime
@@ -302,7 +302,7 @@ class ServerGroupController {
 
     InstanceViewModel(Instance instance) {
       id = instance.name
-      uid = instance.uid
+      name = instance.humanReadableName
       healthState = instance.getHealthState().toString()
       launchTime = instance.getLaunchTime()
       availabilityZone = instance.getZone()


### PR DESCRIPTION
DONT MERGE until a parallel PR in Deck has been approved (https://github.com/spinnaker/deck/pull/5506).

The `Instance` interface has an implicit constraint on it that the `name` field should return a globally unique ID for the resources it fronts.  This constraint is relied upon by Deck to disambiguate between instances in various UI contexts.  A non-unique string name can cause some strange UI behaviour.  See here for an example: https://github.com/spinnaker/spinnaker/issues/2979

Previously, a k8s v2 resource returned its "fullResourceName" as its `Instance.name` but this could lead to non-unique IDs being serialized by an InstanceViewModel or LoadBalancerInstance.  This PR makes the k8s v2 provider return a resource's uuid in place of its name when responding to requests for ServerGroup Instances or LoadBalancer Instances and also introduces a `name` field to those serialized responses so that the fullResourceName is still available to consumers of those APIs.