### PR TITLE
feat(provider/appengine): Enables App Engine Standard Java 8.

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jdk-alpine
 
 MAINTAINER delivery-engineering@netflix.com
 
@@ -8,7 +8,7 @@ RUN apk --no-cache add --update bash wget unzip python=2.7.14-r2 && \
   wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && \
   unzip -qq google-cloud-sdk.zip -d /opt && \
   rm google-cloud-sdk.zip && \
-  CLOUDSDK_PYTHON="python2.7" /opt/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false --disable-installation-options && \
+  CLOUDSDK_PYTHON="python2.7" /opt/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false --additional-components app-engine-java && \
   rm -rf ~/.config/gcloud
 
 RUN wget https://storage.googleapis.com/kubernetes-release/release/stable.txt && wget https://storage.googleapis.com/kubernetes-release/release/$(cat stable.txt)/bin/linux/amd64/kubectl && \
@@ -22,4 +22,5 @@ RUN adduser -D -S spinnaker
 
 USER spinnaker
 
+WORKDIR /home/spinnaker
 CMD ["/opt/clouddriver/bin/clouddriver"]


### PR DESCRIPTION
This enables the App Engine provider to deploy Standard Java App Engine apps. This change only modifies the container, changing:

* The base image from JRE to JDK. `gcloud app deploy` always does inspection/compilation when deploying Java apps.
* The Google Cloud SDK install to include the Java App Engine components (also removing a deprecated flag in the install command).
* The current working directory. An issue with the Google Cloud SDK breaks Java App Engine deployments if the cwd is '/'.

This was tested against the App Engine Standard Java 8 "getting started" app "helloworld" from https://github.com/GoogleCloudPlatform/getting-started-java/tree/master/appengine-standard-java8/helloworld

Approach was discussed with @danielpeach offline.