### PR TITLE
fix(provider/openstack): tolerate null stack, for real this time.

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgent.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgent.groovy
@@ -214,7 +214,7 @@ class OpenstackServerGroupCachingAgent extends AbstractOpenstackCachingAgent imp
       .account(accountName)
       .region(region)
       .name(stack?.name)
-      .createdTime(DateUtils.parseZonedDateTime(stack.creationTime).toInstant().toEpochMilli())
+      .createdTime(stack == null ? null : DateUtils.parseZonedDateTime(stack.creationTime).toInstant().toEpochMilli())
       .scalingConfig(buildScalingConfig(params))
       .launchConfig(launchConfig)
       .loadBalancers(loadbalancerIds)


### PR DESCRIPTION
We spotted NullPointerExceptions in the logs our production spinnaker at Target, coming from this line. Given that the previous line does a null check on `stack`, it only makes sense that this line would, too.