### PR TITLE
Always honor the server property of a kubeconfig cluster block

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesConfigParser.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesConfigParser.groovy
@@ -99,9 +99,7 @@ class KubernetesConfigParser {
       config.setNoProxy(noProxyList)
     }
     if (currentCluster != null) {
-      if (!currentCluster.getServer().endsWith("/")) {
-        config.setMasterUrl(currentCluster.getServer() + "/")
-      }
+      config.setMasterUrl(currentCluster.getServer() + (currentCluster.getServer().endsWith("/") ? "":  "/"))
 
       config.setNamespace(currentContext.getNamespace())
       config.setTrustCerts(currentCluster.getInsecureSkipTlsVerify() != null && currentCluster.getInsecureSkipTlsVerify())

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesConfigParserSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesConfigParserSpec.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Bol.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v1.security
+
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+class KubernetesConfigParserSpec extends Specification {
+
+  void "master url should be set irregardless of trailing slash"() {
+    setup:
+    def f = Files.createTempFile("kubeconfig", "tmp")
+    f.setText("""
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /opt/spinnaker/config/ca.crt
+    server: https://1.2.3.4/
+  name: tst
+contexts:
+- context:
+    cluster: tst
+    user: tst
+  name: tst
+current-context: tst
+kind: Config
+preferences: {}
+users:
+- name: tst
+  user:
+    client-certificate: /opt/spinnaker/config/client.crt
+    client-key: /opt/spinnaker/config/client.key
+""")
+
+    when:
+    def result = KubernetesConfigParser.withKubeConfig(f.toFile().getAbsolutePath(), "tst", "tst", "tst", ["default"])
+
+    then:
+    result.getMasterUrl() == "https://1.2.3.4/"
+
+    cleanup:
+    Files.delete(f)
+  }
+}


### PR DESCRIPTION
Always use the server property of a cluster in the kubeconfig file as the master URL.

Fixes spinnaker/spinnaker#3005