### PR TITLE
fix(provider/gce): Stop modifying onDemand namespace in force cache r…

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleLoadBalancerCachingAgent.groovy
@@ -265,12 +265,14 @@ abstract class AbstractGoogleLoadBalancerCachingAgent extends AbstractGoogleCach
       new TypeReference<Map<String, List<MutableCacheData>>>() {})
 
     onDemandData.each { String namespace, List<MutableCacheData> cacheDatas ->
-      cacheDatas.each { MutableCacheData cacheData ->
-        cacheResultBuilder.namespace(namespace).keep(cacheData.id).with { it ->
-          it.attributes = cacheData.attributes
-          it.relationships = Utils.mergeOnDemandCacheRelationships(cacheData.relationships, it.relationships)
+      if (namespace != 'onDemand') {
+        cacheDatas.each { MutableCacheData cacheData ->
+          cacheResultBuilder.namespace(namespace).keep(cacheData.id).with { it ->
+            it.attributes = cacheData.attributes
+            it.relationships = Utils.mergeOnDemandCacheRelationships(cacheData.relationships, it.relationships)
+          }
+          cacheResultBuilder.onDemand.toKeep.remove(cacheData.id)
         }
-        cacheResultBuilder.onDemand.toKeep.remove(cacheData.id)
       }
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -314,12 +314,14 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
       new TypeReference<Map<String, List<MutableCacheData>>>() {})
 
     onDemandData.each { String namespace, List<MutableCacheData> cacheDatas ->
-      cacheDatas.each { MutableCacheData cacheData ->
-        cacheResultBuilder.namespace(namespace).keep(cacheData.id).with { it ->
-          it.attributes = cacheData.attributes
-          it.relationships = Utils.mergeOnDemandCacheRelationships(cacheData.relationships, it.relationships)
+      if (namespace != 'onDemand') {
+        cacheDatas.each { MutableCacheData cacheData ->
+          cacheResultBuilder.namespace(namespace).keep(cacheData.id).with { it ->
+            it.attributes = cacheData.attributes
+            it.relationships = Utils.mergeOnDemandCacheRelationships(cacheData.relationships, it.relationships)
+          }
+          cacheResultBuilder.onDemand.toKeep.remove(cacheData.id)
         }
-        cacheResultBuilder.onDemand.toKeep.remove(cacheData.id)
       }
     }
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -264,12 +264,14 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
       cacheResultBuilder.onDemand.toKeep[securityGroupKey].attributes.cacheResults as String,
       new TypeReference<Map<String, List<MutableCacheData>>>() {})
     onDemandData.each { String namespace, List<MutableCacheData> cacheDatas ->
-      cacheDatas.each { MutableCacheData cacheData ->
-        cacheResultBuilder.namespace(namespace).keep(cacheData.id).with { it ->
-          it.attributes = cacheData.attributes
-          it.relationships = Utils.mergeOnDemandCacheRelationships(cacheData.relationships, it.relationships)
+      if (namespace != 'onDemand') {
+        cacheDatas.each { MutableCacheData cacheData ->
+          cacheResultBuilder.namespace(namespace).keep(cacheData.id).with { it ->
+            it.attributes = cacheData.attributes
+            it.relationships = Utils.mergeOnDemandCacheRelationships(cacheData.relationships, it.relationships)
+          }
+          cacheResultBuilder.onDemand.toKeep.remove(cacheData.id)
         }
-        cacheResultBuilder.onDemand.toKeep.remove(cacheData.id)
       }
     }
   }


### PR DESCRIPTION
…efreshes.

When moving onDemand data to the proper key spaces in handle(), we were
accidentally and unnecessarily modifying the onDemand key space in place.
This eventually leads to very bad redis performance at certain scales.