### PR TITLE
fix(provider/kubernetes): tolerate null selectors and statuses.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesAutoscalerStatus.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesAutoscalerStatus.groovy
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v1.model
 
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesModelUtil
 import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler
+import groovy.util.logging.Slf4j
 
+@Slf4j
 class KubernetesAutoscalerStatus {
   Integer currentCpuUtilization
   Integer currentReplicas
@@ -28,9 +30,13 @@ class KubernetesAutoscalerStatus {
   KubernetesAutoscalerStatus() { }
 
   KubernetesAutoscalerStatus(HorizontalPodAutoscaler autoscaler) {
-    this.currentCpuUtilization = autoscaler.status.currentCPUUtilizationPercentage
-    this.currentReplicas = autoscaler.status.currentReplicas
-    this.desiredReplicas = autoscaler.status.desiredReplicas
-    this.lastScaleTime = KubernetesModelUtil.translateTime(autoscaler.status.lastScaleTime)
+    if (autoscaler.status == null) {
+      log.warn("Autoscaler on ${autoscaler.metadata.name} has a null status. The replicaset may be missing a CPU request.")
+    } else {
+      this.currentCpuUtilization = autoscaler.status.currentCPUUtilizationPercentage
+      this.currentReplicas = autoscaler.status.currentReplicas
+      this.desiredReplicas = autoscaler.status.desiredReplicas
+      this.lastScaleTime = KubernetesModelUtil.translateTime(autoscaler.status.lastScaleTime)
+    }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesControllersCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesControllersCachingAgent.groovy
@@ -409,7 +409,7 @@ class KubernetesControllersCachingAgent extends KubernetesV1CachingAgent impleme
     }
 
     Map<String, String> getSelector() {
-      statefulController ? statefulController.spec.selector.matchLabels : daemonController.spec.selector.matchLabels
+      statefulController ? statefulController.spec.selector?.matchLabels : daemonController.spec.selector?.matchLabels
     }
 
     boolean exists() {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -427,7 +427,7 @@ class KubernetesServerGroupCachingAgent extends KubernetesV1CachingAgent impleme
     }
 
     Map<String, String> getSelector() {
-      replicaSet ? replicaSet.spec.selector.matchLabels : replicationController.spec.selector
+      replicaSet ? replicaSet.spec.selector?.matchLabels : replicationController.spec.selector
     }
 
     boolean exists() {


### PR DESCRIPTION
Here are another couple cases where we've seen `NullPointerException`s in our production spinnakers. The exceptions were causing some entire clusters not to load, and thus not to show up in the Clusters page for a given app.

This fix has already been deployed and validated in both our test and prod environments. Since deploying it, all NPE's have disappeared from the logs, and several cases of missing clusters have resolved.