### PR TITLE
feat(provider/kubernetes): Parse container URI in clouddriver

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/KubernetesUtil.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/KubernetesUtil.groovy
@@ -93,19 +93,26 @@ class KubernetesUtil {
     image
   }
 
+  private static void populateFieldsFromUri(KubernetesImageDescription image) {
+    def uri = image.uri
+    if (uri) {
+      uri = extractRegistry(uri, image)
+      uri = extractDigestOrTag(uri, image)
+      // The repository is what's left after extracting the registry, and digest/tag
+      image.repository = uri
+    }
+  }
+
   static KubernetesImageDescription buildImageDescription(String image) {
     def result = new KubernetesImageDescription()
-
-    image = extractRegistry(image, result)
-    image = extractDigestOrTag(image, result)
-    // The repository is what's left after extracting the registry, and digest/tag
-    result.repository = image
-
+    result.uri = image
     normalizeImageDescription(result)
     result
   }
 
   static Void normalizeImageDescription(KubernetesImageDescription image) {
+    populateFieldsFromUri(image)
+
     if (!image.registry) {
       image.registry = DEFAULT_REGISTRY
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -83,6 +83,7 @@ class KubernetesContainerPort {
 @AutoClone
 @Canonical
 class KubernetesImageDescription {
+  String uri
   String registry
   String repository
   String tag


### PR DESCRIPTION
Allow Orca to send just the container URI to clouddriver, so that the parsing logic in Clouddriver can be used to parse this into registry, repository, and tag, avoiding the need to re-implement this in Orca.