### PR TITLE
fix(cats): remove obsolete reindex code

### DIFF
--- a/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteCache.java
+++ b/cats/cats-dynomite/src/main/java/com/netflix/spinnaker/cats/dynomite/cache/DynomiteCache.java
@@ -166,8 +166,6 @@ public class DynomiteCache extends AbstractRedisCache {
             expireOperations.incrementAndGet();
           }
 
-          p.sadd(allOfTypeReindex(type), item.getId());
-          saddOperations.incrementAndGet();
           p.sadd(allOfTypeId(type), item.getId());
           saddOperations.incrementAndGet();
 
@@ -214,8 +212,6 @@ public class DynomiteCache extends AbstractRedisCache {
         for (List<String> idPartition : Lists.partition(identifiers, options.getMaxDelSize())) {
           String[] ids = idPartition.toArray(new String[idPartition.size()]);
           pipeline.srem(allOfTypeId(type), ids);
-          sremOperations.incrementAndGet();
-          pipeline.srem(allOfTypeReindex(type), ids);
           sremOperations.incrementAndGet();
         }
 
@@ -453,10 +449,5 @@ public class DynomiteCache extends AbstractRedisCache {
   @Override
   protected String allOfTypeId(String type) {
     return format("{%s:%s}:members", prefix, type);
-  }
-
-  @Override
-  protected String allOfTypeReindex(String type) {
-    return format("{%s:%s}:members.2", prefix, type);
   }
 }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
@@ -232,10 +232,6 @@ public abstract class AbstractRedisCache implements WriteableCache {
     return String.format("%s:%s:members", prefix, type);
   }
 
-  protected String allOfTypeReindex(String type) {
-    return String.format("%s:%s:members.2", prefix, type);
-  }
-
   protected TypeReference getRelationshipsTypeReference() {
     return options.isTreatRelationshipsAsSet() ? RELATIONSHIPS_SET : RELATIONSHIPS_LIST;
   }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
@@ -133,8 +133,6 @@ public class RedisCache extends AbstractRedisCache {
       redisClientDelegate.withMultiKeyPipeline(pipeline -> {
         for (List<String> idPart : Iterables.partition(idSet, options.getMaxSaddSize())) {
           final String[] ids = idPart.toArray(new String[idPart.size()]);
-          pipeline.sadd(allOfTypeReindex(type), ids);
-          saddOperations.incrementAndGet();
           pipeline.sadd(allOfTypeId(type), ids);
           saddOperations.incrementAndGet();
         }
@@ -213,8 +211,6 @@ public class RedisCache extends AbstractRedisCache {
       for (List<String> idPartition : Lists.partition(identifiers, options.getMaxDelSize())) {
         String[] ids = idPartition.toArray(new String[idPartition.size()]);
         pipeline.srem(allOfTypeId(type), ids);
-        sremOperations.incrementAndGet();
-        pipeline.srem(allOfTypeReindex(type), ids);
         sremOperations.incrementAndGet();
       }
 

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
@@ -136,7 +136,7 @@ class RedisCacheSpec extends WriteableCacheSpec {
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 1, 1, 1, 0, )
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, )
 
         when: //second write, hash matches
         ((WriteableCache) cache).merge('foo', data)
@@ -149,7 +149,7 @@ class RedisCacheSpec extends WriteableCacheSpec {
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 1, 1, 1, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 1, 1, 1, 1, 0)
     }
 
     def 'should not write an item if it is unchanged'() {
@@ -160,7 +160,7 @@ class RedisCacheSpec extends WriteableCacheSpec {
         ((WriteableCache) cache).merge('foo', data)
 
         then:
-        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 2, 1, 1, 1, 0)
+        1 * cacheMetrics.merge('test', 'foo', 1, 1, 0, 0, 1, 1, 1, 1, 1, 0)
 
         when:
         ((WriteableCache) cache).merge('foo', data)
@@ -183,8 +183,8 @@ class RedisCacheSpec extends WriteableCacheSpec {
 
         then:
 
-        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0, 2, 1, 0, 1, 0)
-        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0, 2, 1, 0, 1, 0)
+        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0, 1, 1, 0, 1, 0)
+        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0, 1, 1, 0, 1, 0)
 
         where:
         mergeCount << [ 1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 100, 101, 131 ]


### PR DESCRIPTION
Removes unnecessary double writes of allOfTypeId sets.
