### PR TITLE
fix(provider/kubernetes): bind initContainers

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacerFactory.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacerFactory.java
@@ -40,8 +40,8 @@ public class ArtifactReplacerFactory {
 
   public static Replacer dockerImageReplacer() {
     return Replacer.builder()
-        .replacePath("$..spec.template.spec.containers.[?( @.image == \"{%name%}\" )].image")
-        .findPath("$..spec.template.spec.containers.*.image")
+        .replacePath("$..spec.template.spec['containers', 'initContainers'].[?( @.image == \"{%name%}\" )].image")
+        .findPath("$..spec.template.spec['containers', 'initContainers'].*.image")
         .nameFromReference(ref -> {
           int atIndex = ref.indexOf('@');
           // @ can only show up in image references denoting a digest
@@ -65,7 +65,7 @@ public class ArtifactReplacerFactory {
         .type(ArtifactTypes.DOCKER_IMAGE)
         .build();
   }
-
+  
   public static Replacer configMapVolumeReplacer() {
     return Replacer.builder()
         .replacePath("$..spec.template.spec.volumes.[?( @.configMap.name == \"{%name%}\" )].configMap.name")
@@ -84,32 +84,32 @@ public class ArtifactReplacerFactory {
 
   public static Replacer configMapKeyValueFromReplacer() {
     return Replacer.builder()
-        .replacePath("$..spec.template.spec.containers.*.env.[?( @.valueFrom.configMapKeyRef.name == \"{%name%}\" )].valueFrom.configMapKeyRef.name")
-        .findPath("$..spec.template.spec.containers.*.env.*.valueFrom.configMapKeyRef.name")
+        .replacePath("$..spec.template.spec['containers', 'initContainers'].*.env.[?( @.valueFrom.configMapKeyRef.name == \"{%name%}\" )].valueFrom.configMapKeyRef.name")
+        .findPath("$..spec.template.spec['containers', 'initContainers'].*.env.*.valueFrom.configMapKeyRef.name")
         .type(ArtifactTypes.KUBERNETES_CONFIG_MAP)
         .build();
   }
 
   public static Replacer secretKeyValueFromReplacer() {
     return Replacer.builder()
-        .replacePath("$..spec.template.spec.containers.*.env.[?( @.valueFrom.secretKeyRef.name == \"{%name%}\" )].valueFrom.secretKeyRef.name")
-        .findPath("$..spec.template.spec.containers.*.env.*.valueFrom.secretKeyRef.name")
+        .replacePath("$..spec.template.spec['containers', 'initContainers'].*.env.[?( @.valueFrom.secretKeyRef.name == \"{%name%}\" )].valueFrom.secretKeyRef.name")
+        .findPath("$..spec.template.spec['containers', 'initContainers'].*.env.*.valueFrom.secretKeyRef.name")
         .type(ArtifactTypes.KUBERNETES_SECRET)
         .build();
   }
 
   public static Replacer configMapEnvFromReplacer() {
     return Replacer.builder()
-        .replacePath("$..spec.template.spec.containers.*.envFrom.[?( @.configMapRef.name == \"{%name%}\" )].configMapRef.name")
-        .findPath("$..spec.template.spec.containers.*.envFrom.*.configMapRef.name")
+        .replacePath("$..spec.template.spec['containers', 'initContainers'].*.envFrom.[?( @.configMapRef.name == \"{%name%}\" )].configMapRef.name")
+        .findPath("$..spec.template.spec['containers', 'initContainers'].*.envFrom.*.configMapRef.name")
         .type(ArtifactTypes.KUBERNETES_CONFIG_MAP)
         .build();
   }
 
   public static Replacer secretEnvFromReplacer() {
     return Replacer.builder()
-        .replacePath("$..spec.template.spec.containers.*.envFrom.[?( @.secretRef.name == \"{%name%}\" )].secretRef.name")
-        .findPath("$..spec.template.spec.containers.*.envFrom.*.secretRef.name")
+        .replacePath("$..spec.template.spec['containers', 'initContainers'].*.envFrom.[?( @.secretRef.name == \"{%name%}\" )].secretRef.name")
+        .findPath("$..spec.template.spec['containers', 'initContainers'].*.envFrom.*.secretRef.name")
         .type(ArtifactTypes.KUBERNETES_SECRET)
         .build();
   }


### PR DESCRIPTION
adds support for binding initContainer images in the
`dockerImageReplacer`.

fixes spinnaker/spinnaker#2535