### PR TITLE
feat(cache): metrics on putCacheResult.

### DIFF
--- a/cats/cats-core/cats-core.gradle
+++ b/cats/cats-core/cats-core.gradle
@@ -1,6 +1,7 @@
 dependencies {
   compile spinnaker.dependency('slf4jApi')
   compile spinnaker.dependency('jacksonAnnotations')
+  compile spinnaker.dependency('spectatorApi')
 
   testCompile project(":cats:cats-test")
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/module/CatsModule.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/module/CatsModule.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.cats.module;
 
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentScheduler;
 import com.netflix.spinnaker.cats.agent.CompositeExecutionInstrumentation;
 import com.netflix.spinnaker.cats.agent.DefaultAgentScheduler;
@@ -53,6 +55,7 @@ public interface CatsModule {
         private NamedCacheFactory cacheFactory;
         private AgentScheduler scheduler;
         private Collection<ExecutionInstrumentation> instrumentations = new LinkedList<>();
+        private Registry registry = new NoopRegistry();
 
         public Builder scheduler(AgentScheduler agentScheduler) {
             if (this.scheduler != null) {
@@ -87,6 +90,11 @@ public interface CatsModule {
             return this;
         }
 
+        public Builder registry(Registry registry) {
+            this.registry = registry;
+            return this;
+        }
+
         public CatsModule build(Provider... providers) {
             return build(Arrays.asList(providers));
         }
@@ -106,7 +114,7 @@ public interface CatsModule {
             if (cacheFactory == null) {
                 cacheFactory = new InMemoryNamedCacheFactory();
             }
-            return new DefaultCatsModule(providers, cacheFactory, scheduler, instrumentation);
+            return new DefaultCatsModule(providers, cacheFactory, scheduler, instrumentation, registry);
         }
     }
 

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/module/DefaultCatsModule.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/module/DefaultCatsModule.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.cats.module;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentController;
 import com.netflix.spinnaker.cats.agent.AgentScheduler;
 import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation;
@@ -35,9 +36,9 @@ public class DefaultCatsModule implements CatsModule {
     private final Cache view;
     private final ExecutionInstrumentation executionInstrumentation;
 
-    public DefaultCatsModule(Collection<Provider> providers, NamedCacheFactory namedCacheFactory, AgentScheduler agentScheduler, ExecutionInstrumentation executionInstrumentation) {
+    public DefaultCatsModule(Collection<Provider> providers, NamedCacheFactory namedCacheFactory, AgentScheduler agentScheduler, ExecutionInstrumentation executionInstrumentation, Registry registry) {
         this.namedCacheFactory = namedCacheFactory;
-        providerRegistry = new DefaultProviderRegistry(providers, namedCacheFactory);
+        providerRegistry = new DefaultProviderRegistry(providers, namedCacheFactory, registry);
         this.agentScheduler = agentScheduler;
 
         if (agentScheduler instanceof CatsModuleAware) {

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderRegistry.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderRegistry.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.cats.provider;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory;
 
@@ -28,10 +29,10 @@ public class DefaultProviderRegistry implements ProviderRegistry {
     private final ConcurrentMap<String, ProviderCache> providerCaches = new ConcurrentHashMap<>();
     private final Collection<Provider> providers;
 
-    public DefaultProviderRegistry(Collection<Provider> providers, NamedCacheFactory cacheFactory) {
+    public DefaultProviderRegistry(Collection<Provider> providers, NamedCacheFactory cacheFactory, Registry registry) {
         this.providers = Collections.unmodifiableCollection(providers);
         for (Provider provider : providers) {
-            providerCaches.put(provider.getProviderName(), new DefaultProviderCache(cacheFactory.getCache(provider.getProviderName())));
+            providerCaches.put(provider.getProviderName(), new DefaultProviderCache(cacheFactory.getCache(provider.getProviderName()), registry));
         }
     }
 

--- a/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/provider/DefaultProviderCacheSpec.groovy
+++ b/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/provider/DefaultProviderCacheSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.cats.provider
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult
 import com.netflix.spinnaker.cats.cache.*
@@ -28,7 +29,7 @@ class DefaultProviderCacheSpec extends CacheSpec {
     @Override
     Cache getSubject() {
         backingStore = new InMemoryCache()
-        new DefaultProviderCache(backingStore)
+        new DefaultProviderCache(backingStore, new NoopRegistry())
     }
 
     void populateOne(String type, String id, CacheData cacheData = createData(id)) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CacheConfig.groovy
@@ -74,8 +74,17 @@ class CacheConfig {
 
   @Bean
   @ConditionalOnMissingBean(CatsModule)
-  CatsModule catsModule(List<Provider> providers, List<ExecutionInstrumentation> executionInstrumentation, NamedCacheFactory cacheFactory, AgentScheduler agentScheduler) {
-    new CatsModule.Builder().cacheFactory(cacheFactory).scheduler(agentScheduler).instrumentation(executionInstrumentation).build(providers)
+  CatsModule catsModule(List<Provider> providers,
+                        List<ExecutionInstrumentation> executionInstrumentation,
+                        NamedCacheFactory cacheFactory,
+                        AgentScheduler agentScheduler,
+                        Registry registry) {
+    return new CatsModule.Builder()
+      .cacheFactory(cacheFactory)
+      .scheduler(agentScheduler)
+      .instrumentation(executionInstrumentation)
+      .registry(registry)
+      .build(providers)
   }
 
   @Bean

--- a/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
+++ b/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.security
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.cats.agent.NoopExecutionInstrumentation
 import com.netflix.spinnaker.cats.mem.InMemoryNamedCacheFactory
 import com.netflix.spinnaker.cats.module.DefaultCatsModule
@@ -119,7 +120,7 @@ class ProviderUtilsSpec extends Specification {
       def executionInstrumentation = new NoopExecutionInstrumentation()
 
     when:
-      new DefaultCatsModule([agentSchedulerAwareProvider], namedCacheFactory, scheduler, executionInstrumentation)
+      new DefaultCatsModule([agentSchedulerAwareProvider], namedCacheFactory, scheduler, executionInstrumentation, new NoopRegistry())
 
     then:
       scheduler.scheduled.collect { it.agent } == [testAgent1]
@@ -162,7 +163,7 @@ class ProviderUtilsSpec extends Specification {
       def catsModule
 
     when:
-      catsModule = new DefaultCatsModule([agentSchedulerAwareProvider], namedCacheFactory, scheduler, executionInstrumentation)
+      catsModule = new DefaultCatsModule([agentSchedulerAwareProvider], namedCacheFactory, scheduler, executionInstrumentation, new NoopRegistry())
 
     then:
       scheduler.scheduled.collect { it.agent } == [testAgent1, testAgent2, testAgent3, testAgent4, testAgent5]


### PR DESCRIPTION
Adds logging and metrics on putCacheResult capturing rate of change on a type from a specific agent.

Context: We had an issue where one of our data sources was periodically flopping between current and a very old result set, causing significant churn in the data set against redis and corresponding significant uptick in replication traffic