### PR TITLE
fix(provider/kubernetes): v2 check that artifact & cluster account match 

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
@@ -65,9 +65,9 @@ public class ArtifactReplacer {
     return this;
   }
 
-  private static List<Artifact> filterKubernetesArtifactsByNamespace(String namespace, List<Artifact> artifacts) {
+  private static List<Artifact> filterKubernetesArtifactsByNamespaceAndAccount(String namespace, String account, List<Artifact> artifacts) {
     return artifacts.stream()
-        // Keep artifacts that either aren't k8s, or are in the same namespace as our manifest
+        // Keep artifacts that either aren't k8s, or are in the same namespace and account as our manifest
         .filter(a -> {
           String type = a.getType();
           if (StringUtils.isEmpty(type)) {
@@ -79,20 +79,28 @@ public class ArtifactReplacer {
             return true;
           }
 
+          boolean locationMatches;
           String location = a.getLocation();
           if (StringUtils.isEmpty(location)) {
-            return StringUtils.isEmpty(namespace);
+            locationMatches = StringUtils.isEmpty(namespace);
           } else {
-            return location.equals(namespace);
+            locationMatches = location.equals(namespace);
           }
+
+          boolean accountMatches;
+          String artifactAccount = KubernetesArtifactConverter.getAccount(a);
+          // If the artifact fails to provide an account, we'll assume this was unintentional and match anyways
+          accountMatches = StringUtils.isEmpty(artifactAccount) || artifactAccount.equals(account);
+
+          return accountMatches && locationMatches;
         })
         .collect(Collectors.toList());
   }
 
-  public ReplaceResult replaceAll(KubernetesManifest input, List<Artifact> artifacts, String namespace) {
+  public ReplaceResult replaceAll(KubernetesManifest input, List<Artifact> artifacts, String namespace, String account) {
     log.debug("Doing replacement on {} using {}", input, artifacts);
     // final to use in below lambda
-    final List<Artifact> finalArtifacts = filterKubernetesArtifactsByNamespace(namespace, artifacts);
+    final List<Artifact> finalArtifacts = filterKubernetesArtifactsByNamespaceAndAccount(namespace, account, artifacts);
     DocumentContext document;
     try {
       document = JsonPath.using(configuration).parse(mapper.writeValueAsString(input));

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesArtifactConverter.java
@@ -24,8 +24,10 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 
+import java.util.Map;
+
 public abstract class KubernetesArtifactConverter {
-  abstract public Artifact toArtifact(ArtifactProvider artifactProvider, KubernetesManifest manifest);
+  abstract public Artifact toArtifact(ArtifactProvider artifactProvider, KubernetesManifest manifest, String account);
   abstract public KubernetesCoordinates toCoordinates(Artifact artifact);
   abstract public String getDeployedName(Artifact artifact);
 
@@ -51,5 +53,15 @@ public abstract class KubernetesArtifactConverter {
 
   protected String getNamespace(Artifact artifact) {
     return artifact.getLocation();
+  }
+
+  public static String getAccount(Artifact artifact) {
+    String account = "";
+    Map<String, Object> metadata = artifact.getMetadata();
+    if (metadata != null) {
+      account = (String) metadata.getOrDefault("account", "");
+    }
+
+    return account;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverter.java
@@ -22,17 +22,23 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class KubernetesUnversionedArtifactConverter extends KubernetesArtifactConverter {
   @Override
-  public Artifact toArtifact(ArtifactProvider provider, KubernetesManifest manifest) {
+  public Artifact toArtifact(ArtifactProvider provider, KubernetesManifest manifest, String account) {
     String type = getType(manifest);
     String name = manifest.getName();
     String location = manifest.getNamespace();
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("account", account);
     return Artifact.builder()
         .type(type)
         .name(name)
         .location(location)
         .reference(name)
+        .metadata(metadata)
         .build();
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverter.java
@@ -24,7 +24,9 @@ import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,17 +36,20 @@ public class KubernetesVersionedArtifactConverter extends KubernetesArtifactConv
   final private static ObjectMapper objectMapper = new ObjectMapper();
 
   @Override
-  public Artifact toArtifact(ArtifactProvider provider, KubernetesManifest manifest) {
+  public Artifact toArtifact(ArtifactProvider provider, KubernetesManifest manifest, String account) {
     String type = getType(manifest);
     String name = manifest.getName();
     String location = manifest.getNamespace();
     String version = getVersion(provider, type, name, location, manifest);
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("account", account);
     return Artifact.builder()
         .type(type)
         .name(name)
         .location(location)
         .version(version)
         .reference(getDeployedName(name, version))
+        .metadata(metadata)
         .build();
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHandler.java
@@ -64,12 +64,12 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
     artifactReplacer.addReplacer(replacer);
   }
 
-  public ReplaceResult replaceArtifacts(KubernetesManifest manifest, List<Artifact> artifacts) {
-    return artifactReplacer.replaceAll(manifest, artifacts, manifest.getNamespace());
+  public ReplaceResult replaceArtifacts(KubernetesManifest manifest, List<Artifact> artifacts, String account) {
+    return artifactReplacer.replaceAll(manifest, artifacts, manifest.getNamespace(), account);
   }
 
-  public ReplaceResult replaceArtifacts(KubernetesManifest manifest, List<Artifact> artifacts, String namespace) {
-    return artifactReplacer.replaceAll(manifest, artifacts, namespace);
+  public ReplaceResult replaceArtifacts(KubernetesManifest manifest, List<Artifact> artifacts, String namespace, String account) {
+    return artifactReplacer.replaceAll(manifest, artifacts, namespace, account);
   }
 
   protected Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -120,7 +120,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
       }
 
       getTask().updateStatus(OP_NAME, "Swapping out artifacts in " + manifest.getFullResourceName() + " from context...");
-      ReplaceResult replaceResult = deployer.replaceArtifacts(manifest, artifacts);
+      ReplaceResult replaceResult = deployer.replaceArtifacts(manifest, artifacts, description.getAccount());
       deployManifests.add(replaceResult.getManifest());
       boundArtifacts.addAll(replaceResult.getBoundArtifacts());
     }
@@ -151,7 +151,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
         moniker.setCluster(manifest.getFullResourceName());
       }
 
-      Artifact artifact = converter.toArtifact(provider, manifest);
+      Artifact artifact = converter.toArtifact(provider, manifest, description.getAccount());
 
       String version = artifact.getVersion();
       if (StringUtils.isNotEmpty(version) && version.startsWith("v")) {
@@ -169,7 +169,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
       manifest.setName(converter.getDeployedName(artifact));
 
       getTask().updateStatus(OP_NAME, "Swapping out artifacts in " + manifest.getFullResourceName() + " from other deployments...");
-      ReplaceResult replaceResult = deployer.replaceArtifacts(manifest, new ArrayList<>(result.getCreatedArtifacts()));
+      ReplaceResult replaceResult = deployer.replaceArtifacts(manifest, new ArrayList<>(result.getCreatedArtifacts()), description.getAccount());
       boundArtifacts.addAll(replaceResult.getBoundArtifacts());
       manifest = replaceResult.getManifest();
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
@@ -29,9 +29,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHand
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import java.util.ArrayList;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -87,7 +87,7 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
       description.getAllArtifacts();
 
     ReplaceResult replaceResult = patchHandler.replaceArtifacts(description.getPatchBody(),
-      allArtifacts, objToPatch.getNamespace());
+      allArtifacts, objToPatch.getNamespace(), description.getAccount());
 
     if (description.getRequiredArtifacts() != null) {
       Set<Artifact> unboundArtifacts = Sets.difference(new HashSet<>(description.getRequiredArtifacts()),

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
@@ -95,7 +95,7 @@ metadata:
     replicaSetDeployer.kind() >> KIND
     def versionedArtifactConverterMock = Mock(KubernetesVersionedArtifactConverter)
     versionedArtifactConverterMock.getDeployedName(_) >> "$NAME-$VERSION"
-    versionedArtifactConverterMock.toArtifact(_, _) >> new Artifact()
+    versionedArtifactConverterMock.toArtifact(_, _, _) >> new Artifact()
     def registry = new KubernetesResourcePropertyRegistry(Collections.singletonList(replicaSetDeployer),
         new KubernetesSpinnakerKindMap())
 


### PR DESCRIPTION
cherry pick (#2799) into 1.8

When two artifacts with the same name & namespace are deployed to
different clusters, Spinnaker previously couldn't tell them apart when
deciding which to match & replace in a deployed manifest
