### PR TITLE
feat(kubernetes): add manifest warnings

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Manifest.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Manifest.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.model;
 
 import com.netflix.spinnaker.moniker.Moniker;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,6 +29,7 @@ public interface Manifest {
   String getAccount();
   String getLocation();
   Status getStatus();
+  List<Warning> getWarnings();
 
   @Data
   class Status {
@@ -79,5 +81,12 @@ public interface Manifest {
       boolean state;
       String message;
     }
+  }
+
+  @Data
+  @Builder
+  public static class Warning {
+    private String type;
+    private String message;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Manifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Manifest.java
@@ -43,4 +43,5 @@ public class KubernetesV2Manifest implements Manifest {
   private Status status;
   private Set<Artifact> artifacts = new HashSet<>();
   private List<KubernetesManifest> events = new ArrayList<>();
+  private List<Warning> warnings = new ArrayList<>();
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -99,6 +99,7 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
         .status(handler.status(manifest))
         .artifacts(handler.listArtifacts(manifest))
         .events(events)
+        .warnings(handler.listWarnings(manifest))
         .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHandler.java
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import com.netflix.spinnaker.clouddriver.model.Manifest.Warning;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +56,10 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
   abstract public boolean versioned();
   abstract public SpinnakerKind spinnakerKind();
   abstract public Status status(KubernetesManifest manifest);
+
+  public List<Warning> listWarnings(KubernetesManifest manifest) {
+    return new ArrayList<>();
+  }
 
   public List<String> sensitiveKeys() {
     return new ArrayList<>();


### PR DESCRIPTION
Adds a generic "warnings" mechanism. Warnings should be used to signal potential problems to users, but Spinnaker itself shouldn't act on them (e.g., by cancelling an operation).
