### PR TITLE
fix(provider/docker): Clear docker token cache after 401

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
@@ -211,6 +211,10 @@ class DockerBearerTokenService {
     return token
   }
 
+  public void clearToken(String repository) {
+    cachedTokens.remove(repository)
+  }
+
   private interface TokenService {
     @GET("/{path}")
     @Headers([


### PR DESCRIPTION
If a 401 is received from the Docker registry, the cached token is
cleared so it isn't reused if a new token isn't acquired. Subsequent
requests will then get a new token, if necessary.

fixes spinnaker/spinnaker#2039
