### PR TITLE
fix(perf): reverts DefaultProviderCache metric changes

### DIFF
--- a/cats/cats-core/cats-core.gradle
+++ b/cats/cats-core/cats-core.gradle
@@ -1,7 +1,6 @@
 dependencies {
   compile spinnaker.dependency('slf4jApi')
   compile spinnaker.dependency('jacksonAnnotations')
-  compile spinnaker.dependency('spectatorApi')
 
   testCompile project(":cats:cats-test")
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/module/CatsModule.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/module/CatsModule.java
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.cats.module;
 
-import com.netflix.spectator.api.NoopRegistry;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentScheduler;
 import com.netflix.spinnaker.cats.agent.CompositeExecutionInstrumentation;
 import com.netflix.spinnaker.cats.agent.DefaultAgentScheduler;
@@ -55,7 +53,6 @@ public interface CatsModule {
         private NamedCacheFactory cacheFactory;
         private AgentScheduler scheduler;
         private Collection<ExecutionInstrumentation> instrumentations = new LinkedList<>();
-        private Registry registry = new NoopRegistry();
 
         public Builder scheduler(AgentScheduler agentScheduler) {
             if (this.scheduler != null) {
@@ -90,11 +87,6 @@ public interface CatsModule {
             return this;
         }
 
-        public Builder registry(Registry registry) {
-            this.registry = registry;
-            return this;
-        }
-
         public CatsModule build(Provider... providers) {
             return build(Arrays.asList(providers));
         }
@@ -114,7 +106,7 @@ public interface CatsModule {
             if (cacheFactory == null) {
                 cacheFactory = new InMemoryNamedCacheFactory();
             }
-            return new DefaultCatsModule(providers, cacheFactory, scheduler, instrumentation, registry);
+            return new DefaultCatsModule(providers, cacheFactory, scheduler, instrumentation);
         }
     }
 

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/module/DefaultCatsModule.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/module/DefaultCatsModule.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.cats.module;
 
-import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentController;
 import com.netflix.spinnaker.cats.agent.AgentScheduler;
 import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation;
@@ -36,9 +35,9 @@ public class DefaultCatsModule implements CatsModule {
     private final Cache view;
     private final ExecutionInstrumentation executionInstrumentation;
 
-    public DefaultCatsModule(Collection<Provider> providers, NamedCacheFactory namedCacheFactory, AgentScheduler agentScheduler, ExecutionInstrumentation executionInstrumentation, Registry registry) {
+    public DefaultCatsModule(Collection<Provider> providers, NamedCacheFactory namedCacheFactory, AgentScheduler agentScheduler, ExecutionInstrumentation executionInstrumentation) {
         this.namedCacheFactory = namedCacheFactory;
-        providerRegistry = new DefaultProviderRegistry(providers, namedCacheFactory, registry);
+        providerRegistry = new DefaultProviderRegistry(providers, namedCacheFactory);
         this.agentScheduler = agentScheduler;
 
         if (agentScheduler instanceof CatsModuleAware) {

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderCache.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderCache.java
@@ -16,15 +16,11 @@
 
 package com.netflix.spinnaker.cats.provider;
 
-import com.netflix.spectator.api.Counter;
-import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.CacheFilter;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.cats.cache.WriteableCache;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,19 +40,15 @@ import java.util.Set;
  */
 public class DefaultProviderCache implements ProviderCache {
 
-    private final Logger log = LoggerFactory.getLogger(DefaultProviderCache.class);
-
     private static final String ALL_ID = "_ALL_"; //dirty = true
     private static final Map<String, Object> ALL_ATTRIBUTE = Collections.unmodifiableMap(new HashMap<String, Object>(1) {{
         put("id", ALL_ID);
     }});
 
     private final WriteableCache backingStore;
-    private final Registry registry;
 
-    public DefaultProviderCache(WriteableCache backingStore, Registry registry) {
+    public DefaultProviderCache(WriteableCache backingStore) {
         this.backingStore = backingStore;
-        this.registry = registry;
     }
 
     @Override
@@ -141,121 +133,28 @@ public class DefaultProviderCache implements ProviderCache {
         Map<String, Collection<String>> evictions = new HashMap<>();
 
         for (String type : allTypes) {
-            final boolean authoritative = authoritativeTypes.contains(type);
-            final Set<String> previousIdentifiers = authoritative ? getExistingSourceIdentifiers(type, sourceAgentType) : Collections.emptySet();
-            final int originalSetSize = authoritative ? previousIdentifiers.size() : -1;
-            int newItems = 0;
-            final int cacheResultSize;
+            final Collection<String> previousSet;
+            if (authoritativeTypes.contains(type)) {
+                previousSet = getExistingSourceIdentifiers(type, sourceAgentType);
+            } else {
+                previousSet = new HashSet<>();
+            }
             if (cacheResult.getCacheResults().containsKey(type)) {
-                final Collection<CacheData> cacheResultsForType = cacheResult.getCacheResults().get(type);
-                cacheResultSize = cacheResultsForType.size();
-                cacheDataType(type, sourceAgentType, cacheResultsForType);
-                if (authoritative) {
-                    for (CacheData data : cacheResultsForType) {
-                        if (!previousIdentifiers.remove(data.getId())) {
-                            newItems++;
-                        }
-                    }
+                cacheDataType(type, sourceAgentType, cacheResult.getCacheResults().get(type));
+                for (CacheData data : cacheResult.getCacheResults().get(type)) {
+                    previousSet.remove(data.getId());
                 }
-            } else {
-              cacheResultSize = 0;
             }
-            final Set<String> evictionsForType = new HashSet<>();
-            final int explicitEvictionSize;
             if (cacheResult.getEvictions().containsKey(type)) {
-                evictionsForType.addAll(cacheResult.getEvictions().get(type));
-                explicitEvictionSize = evictions.size();
-            } else {
-                explicitEvictionSize = 0;
+              previousSet.addAll(cacheResult.getEvictions().get(type));
             }
-
-            final int noLongerPresentItemsCount;
-            if (authoritative) {
-                noLongerPresentItemsCount = previousIdentifiers.size();
-                evictionsForType.addAll(previousIdentifiers);
-            } else {
-                noLongerPresentItemsCount = -1;
-            }
-
-            if (!evictionsForType.isEmpty()) {
-                evictions.put(type, evictionsForType);
-            }
-
-            final int totalEvictions = evictionsForType.size();
-            final int changedItems = totalEvictions + newItems;
-            final int changedPercentage = originalSetSize > 0 ? (int) Math.round(((double) changedItems / (double) originalSetSize) * 100d) : -1;
-            final boolean highChangePercentage = changedPercentage > 5;
-            final String authoritativeLabel = authoritative ? "authoritative" : "informative";
-
-            Object[] params = {
-                authoritativeLabel,
-                sourceAgentType,
-                type,
-                originalSetSize,
-                cacheResultSize,
-                newItems,
-                explicitEvictionSize,
-                noLongerPresentItemsCount,
-                totalEvictions,
-                changedItems,
-                changedPercentage
-            };
-
-            Map<String, String> metricTags = new HashMap<>();
-            metricTags.put("authoritative", authoritativeLabel);
-            metricTags.put("sourceAgentType", sourceAgentType);
-            metricTags.put("type", type);
-            metricTags.put("highChangePercentage", Boolean.toString(highChangePercentage));
-
-            MetricBuilder mb = new MetricBuilder(registry, metricTags, "cats.defaultProviderCache.putCacheResult.");
-
-            mb.counter("cacheResultSize").increment(cacheResultSize);
-            mb.counter("newItems").increment(newItems);
-            mb.counter("explicitEvictions").increment(explicitEvictionSize);
-            if (authoritative) {
-                mb.counter("noLongerPresentItems").increment(noLongerPresentItemsCount);
-            }
-            mb.counter("totalEvictions").increment(totalEvictions);
-            mb.counter("changedItems").increment(changedItems);
-
-            if (changedItems > 0) {
-                if (highChangePercentage) {
-                    mb.counter("highChangePercentage").increment();
-                    log.warn("High changed percentage. " + DEBUG_METRICS, params);
-                } else {
-                    log.debug(DEBUG_METRICS, params);
-                }
+            if (!previousSet.isEmpty()) {
+              evictions.put(type, previousSet);
             }
         }
 
         for (Map.Entry<String, Collection<String>> eviction : evictions.entrySet()) {
           evictDeletedItems(eviction.getKey(), eviction.getValue());
-        }
-    }
-
-    private static final String DEBUG_METRICS = "{} cache results for sourceAgentType {} type {}. " +
-        "originalDataSetSize={}," +
-        "cacheResultSize={}," +
-        "newItems={}," +
-        "explicitEvictions={}," +
-        "noLongerPresentItems={}," +
-        "totalEvictions={}," +
-        "changedItems={}," +
-        "changedPercentage={}";
-
-    private static class MetricBuilder {
-        private final Registry registry;
-        private final Map<String, String> baseTags;
-        private final String metricPrefix;
-
-        public MetricBuilder(Registry registry, Map<String, String> baseTags, String metricPrefix) {
-            this.registry = registry;
-            this.baseTags = baseTags;
-            this.metricPrefix = metricPrefix;
-        }
-
-        public Counter counter(String metricName) {
-            return registry.counter(registry.createId(metricPrefix + metricName, baseTags));
         }
     }
 
@@ -294,7 +193,7 @@ public class DefaultProviderCache implements ProviderCache {
         return Collections.unmodifiableCollection(response);
     }
 
-    private Set<String> getExistingSourceIdentifiers(String type, String sourceAgentType) {
+    private Collection<String> getExistingSourceIdentifiers(String type, String sourceAgentType) {
         CacheData all = backingStore.get(type, ALL_ID);
         if (all == null) {
             return new HashSet<>();
@@ -303,10 +202,7 @@ public class DefaultProviderCache implements ProviderCache {
         if (relationship == null) {
             return new HashSet<>();
         }
-        if (relationship instanceof Set) {
-          return (Set<String>) relationship;
-        }
-        return new HashSet<>(relationship);
+        return relationship;
     }
 
     private void cacheDataType(String type, String sourceAgentType, Collection<CacheData> items) {

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderRegistry.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/provider/DefaultProviderRegistry.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.cats.provider;
 
-import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory;
 
@@ -29,10 +28,10 @@ public class DefaultProviderRegistry implements ProviderRegistry {
     private final ConcurrentMap<String, ProviderCache> providerCaches = new ConcurrentHashMap<>();
     private final Collection<Provider> providers;
 
-    public DefaultProviderRegistry(Collection<Provider> providers, NamedCacheFactory cacheFactory, Registry registry) {
+    public DefaultProviderRegistry(Collection<Provider> providers, NamedCacheFactory cacheFactory) {
         this.providers = Collections.unmodifiableCollection(providers);
         for (Provider provider : providers) {
-            providerCaches.put(provider.getProviderName(), new DefaultProviderCache(cacheFactory.getCache(provider.getProviderName()), registry));
+            providerCaches.put(provider.getProviderName(), new DefaultProviderCache(cacheFactory.getCache(provider.getProviderName())));
         }
     }
 

--- a/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/provider/DefaultProviderCacheSpec.groovy
+++ b/cats/cats-core/src/test/groovy/com/netflix/spinnaker/cats/provider/DefaultProviderCacheSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.cats.provider
 
-import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.cats.agent.CacheResult
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult
 import com.netflix.spinnaker.cats.cache.*
@@ -29,7 +28,7 @@ class DefaultProviderCacheSpec extends CacheSpec {
     @Override
     Cache getSubject() {
         backingStore = new InMemoryCache()
-        new DefaultProviderCache(backingStore, new NoopRegistry())
+        new DefaultProviderCache(backingStore)
     }
 
     void populateOne(String type, String id, CacheData cacheData = createData(id)) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CacheConfig.groovy
@@ -74,17 +74,8 @@ class CacheConfig {
 
   @Bean
   @ConditionalOnMissingBean(CatsModule)
-  CatsModule catsModule(List<Provider> providers,
-                        List<ExecutionInstrumentation> executionInstrumentation,
-                        NamedCacheFactory cacheFactory,
-                        AgentScheduler agentScheduler,
-                        Registry registry) {
-    return new CatsModule.Builder()
-      .cacheFactory(cacheFactory)
-      .scheduler(agentScheduler)
-      .instrumentation(executionInstrumentation)
-      .registry(registry)
-      .build(providers)
+  CatsModule catsModule(List<Provider> providers, List<ExecutionInstrumentation> executionInstrumentation, NamedCacheFactory cacheFactory, AgentScheduler agentScheduler) {
+    new CatsModule.Builder().cacheFactory(cacheFactory).scheduler(agentScheduler).instrumentation(executionInstrumentation).build(providers)
   }
 
   @Bean

--- a/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
+++ b/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.security
 
-import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.cats.agent.NoopExecutionInstrumentation
 import com.netflix.spinnaker.cats.mem.InMemoryNamedCacheFactory
 import com.netflix.spinnaker.cats.module.DefaultCatsModule
@@ -120,7 +119,7 @@ class ProviderUtilsSpec extends Specification {
       def executionInstrumentation = new NoopExecutionInstrumentation()
 
     when:
-      new DefaultCatsModule([agentSchedulerAwareProvider], namedCacheFactory, scheduler, executionInstrumentation, new NoopRegistry())
+      new DefaultCatsModule([agentSchedulerAwareProvider], namedCacheFactory, scheduler, executionInstrumentation)
 
     then:
       scheduler.scheduled.collect { it.agent } == [testAgent1]
@@ -163,7 +162,7 @@ class ProviderUtilsSpec extends Specification {
       def catsModule
 
     when:
-      catsModule = new DefaultCatsModule([agentSchedulerAwareProvider], namedCacheFactory, scheduler, executionInstrumentation, new NoopRegistry())
+      catsModule = new DefaultCatsModule([agentSchedulerAwareProvider], namedCacheFactory, scheduler, executionInstrumentation)
 
     then:
       scheduler.scheduled.collect { it.agent } == [testAgent1, testAgent2, testAgent3, testAgent4, testAgent5]


### PR DESCRIPTION
Revert "fix(perf): fix performance regression due to default provider cache metrics causing extra redis reads. (#2816)"
This reverts commit 45642482c98d670df82b9853c63a9222f5aa5a65.

Revert "feat(cache): metrics on putCacheResult. (#2790)"
This reverts commit e78a1aebc28d3afadf358e7e69ed739c299e88dd.
