### PR TITLE
fix(artifacts): fixes multiple http base providers - 1.8

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactConfiguration.java
@@ -54,9 +54,6 @@ public class BitbucketArtifactConfiguration {
   ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Autowired
-  OkHttpClient bitbucketOkHttpClient;
-
-  @Autowired
   ObjectMapper objectMapper;
 
   @Bean
@@ -65,7 +62,7 @@ public class BitbucketArtifactConfiguration {
   }
 
   @Bean
-  List<? extends BitbucketArtifactCredentials> bitbucketArtifactCredentials() {
+  List<? extends BitbucketArtifactCredentials> bitbucketArtifactCredentials(OkHttpClient bitbucketOkHttpClient) {
     return bitbucketArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactProviderProperties.java
@@ -19,11 +19,13 @@ package com.netflix.spinnaker.clouddriver.artifacts.bitbucket;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactProvider;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class BitbucketArtifactProviderProperties extends ArtifactProvider<BitbucketArtifactAccount> {
   private boolean enabled;
   private List<BitbucketArtifactAccount> accounts = new ArrayList<>();

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactConfiguration.java
@@ -54,9 +54,6 @@ public class GitHubArtifactConfiguration {
   ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Autowired
-  OkHttpClient gitHubOkHttpClient;
-
-  @Autowired
   ObjectMapper objectMapper;
 
   @Bean
@@ -65,7 +62,7 @@ public class GitHubArtifactConfiguration {
   }
 
   @Bean
-  List<? extends GitHubArtifactCredentials> gitHubArtifactCredentials() {
+  List<? extends GitHubArtifactCredentials> gitHubArtifactCredentials(OkHttpClient gitHubOkHttpClient) {
     return gitHubArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactProviderProperties.java
@@ -19,11 +19,13 @@ package com.netflix.spinnaker.clouddriver.artifacts.github;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactProvider;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class GitHubArtifactProviderProperties extends ArtifactProvider<GitHubArtifactAccount> {
   private boolean enabled;
   private List<GitHubArtifactAccount> accounts = new ArrayList<>();

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactConfiguration.java
@@ -53,9 +53,6 @@ public class GitlabArtifactConfiguration {
   ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Autowired
-  OkHttpClient gitlabOkHttpClient;
-
-  @Autowired
   ObjectMapper objectMapper;
 
   @Bean
@@ -64,7 +61,7 @@ public class GitlabArtifactConfiguration {
   }
 
   @Bean
-  List<? extends GitlabArtifactCredentials> gitlabArtifactCredentials() {
+  List<? extends GitlabArtifactCredentials> gitlabArtifactCredentials(OkHttpClient gitlabOkHttpClient) {
     return gitlabArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactProviderProperties.java
@@ -18,11 +18,13 @@ package com.netflix.spinnaker.clouddriver.artifacts.gitlab;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactProvider;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class GitlabArtifactProviderProperties extends ArtifactProvider<GitlabArtifactAccount> {
   private boolean enabled;
   private List<GitlabArtifactAccount> accounts = new ArrayList<>();

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactConfiguration.java
@@ -51,16 +51,13 @@ public class HttpArtifactConfiguration {
   @Autowired
   ArtifactCredentialsRepository artifactCredentialsRepository;
 
-  @Autowired
-  OkHttpClient httpOkHttpClient;
-
   @Bean
   OkHttpClient httpOkHttpClient() {
     return new OkHttpClient();
   }
 
   @Bean
-  List<? extends HttpArtifactCredentials> httpArtifactCredentials() {
+  List<? extends HttpArtifactCredentials> httpArtifactCredentials(OkHttpClient httpOkHttpClient) {
     List<HttpArtifactCredentials> result = httpArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactProviderProperties.java
@@ -19,11 +19,13 @@ package com.netflix.spinnaker.clouddriver.artifacts.http;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactProvider;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class HttpArtifactProviderProperties extends ArtifactProvider<HttpArtifactAccount> {
   private boolean enabled;
   private List<HttpArtifactAccount> accounts = new ArrayList<>();


### PR DESCRIPTION
when enabling multiple http based artifact providers (http + gitlab +
github) clouddriver filed to start stating that multiple beans were
found.

