### PR TITLE
fix(cats): Remove unsupported annotations

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.cats.module.CatsModuleAware;
 import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-@SuppressFBWarnings
 public class ClusteredAgentScheduler extends CatsModuleAware implements AgentScheduler<AgentLock>, Runnable {
   private static enum Status {
     SUCCESS,

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentScheduler.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.cats.agent.CachingAgent;
 import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation;
 import com.netflix.spinnaker.cats.module.CatsModuleAware;
 import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
@@ -55,7 +54,6 @@ import java.util.concurrent.TimeUnit;
  * cache interval every key will only be removed from Redis once. If the interval is 60s, and the agent polls every 1s,
  * we already have a (30s / 1) * (# of clouddrivers) factor of improvement.
  */
-@SuppressFBWarnings
 public class ClusteredSortAgentScheduler extends CatsModuleAware implements AgentScheduler<ClusteredSortAgentLock>, Runnable {
   private static enum Status {
     SUCCESS,


### PR DESCRIPTION
Newer versions of spinnaker-dependencies do not include FindBugs.

clouddriver fails to build since upgrading spinnaker-dependencies to 0.158.0: https://github.com/spinnaker/clouddriver/pull/2732

https://github.com/spinnaker/clouddriver/pull/2825 fixed this for the 1.8 branch, and the discussion suggests dropping the annotations, so that's what this commit does.