### PR TITLE
fix(cats): saner redis defaults

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCacheOptions.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCacheOptions.java
@@ -127,10 +127,10 @@ public class RedisCacheOptions {
     }
 
   public static class Builder {
-        public static final int DEFAULT_MULTI_OP_SIZE = 10000;
-        public static final int DEFAULT_BATCH_SIZE = 5000;
-        public static final int DEFAULT_SCAN_SIZE = 25000;
-        public static final int DEFAULT_MAX_PIPELINE_SIZE = 5000;
+        public static final int DEFAULT_MULTI_OP_SIZE = 200;
+        public static final int DEFAULT_BATCH_SIZE = 200;
+        public static final int DEFAULT_SCAN_SIZE = 200;
+        public static final int DEFAULT_MAX_PIPELINE_SIZE = 200;
         public static final boolean DEFAULT_HASHING_ENABLED = true;
         public static final boolean DEFAULT_TREAT_RELATIONSHIPS_AS_SET_DISABLED = false;
 

--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisCacheSpec.groovy
@@ -175,7 +175,7 @@ class RedisCacheSpec extends WriteableCacheSpec {
             'test',
             new JedisClientDelegate(pool),
             new ObjectMapper(),
-            RedisCacheOptions.builder().maxMergeBatch(mergeCount).hashing(false).build(),
+            RedisCacheOptions.builder().maxMergeBatch(mergeCount).maxMset(MAX_MSET_SIZE).hashing(false).build(),
             cacheMetrics)
 
         when:
@@ -183,8 +183,8 @@ class RedisCacheSpec extends WriteableCacheSpec {
 
         then:
 
-        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0, 1, 1, 0, 1, 0)
-        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0, 1, 1, 0, 1, 0)
+        fullMerges * cacheMetrics.merge('test', 'foo', mergeCount, mergeCount, 0, 0, 0, 1, mergeCount, 0, 1, 0)
+        finalMergeCount * cacheMetrics.merge('test', 'foo', finalMerge, finalMerge, 0, 0, 0, 1, finalMerge, 0, 1, 0)
 
         where:
         mergeCount << [ 1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 100, 101, 131 ]


### PR DESCRIPTION
- Updating redis scan and multi-key operation batch size defaults based on Netflix's production configuration.