### PR TITLE
feat(provider/cf): add provider skeleton with credentials management

### DIFF
--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -1,0 +1,16 @@
+dependencies {
+  compile project(":clouddriver-artifacts")
+  compile project(":clouddriver-core")
+
+  compile spinnaker.dependency('frigga')
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('bootWeb')
+
+  compile spinnaker.dependency('korkArtifacts')
+  compile spinnaker.dependency('lombok')
+
+  spinnaker.group('retrofitDefault')
+  spinnaker.group('test')
+
+  compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${spinnaker.version("jackson")}"
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/CloudFoundryCloudProvider.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/CloudFoundryCloudProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry;
+
+import com.netflix.spinnaker.clouddriver.core.CloudProvider;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+
+@Component
+public class CloudFoundryCloudProvider implements CloudProvider {
+  @Override
+  public String getId() {
+    return "cloudfoundry";
+  }
+
+  @Override
+  public String getDisplayName() {
+    return "Cloud Foundry";
+  }
+
+  @Override
+  public Class<? extends Annotation> getOperationAnnotationType() {
+    return CloudFoundryOperation.class;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/CloudFoundryConfiguration.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/CloudFoundryConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry;
+
+import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.config.CloudFoundryConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentialsInitializer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableConfigurationProperties
+@EnableScheduling
+@ConditionalOnProperty("cloudfoundry.enabled")
+@ComponentScan("com.netflix.spinnaker.clouddriver.cloudfoundry")
+public class CloudFoundryConfiguration {
+
+  @Bean
+  CloudFoundryConfigurationProperties cloudFoundryConfigurationProperties() {
+    return new CloudFoundryConfigurationProperties();
+  }
+
+  @Bean
+  CloudFoundrySynchronizerTypeWrapper cloudFoundrySynchronizerTypeWrapper() {
+    return new CloudFoundrySynchronizerTypeWrapper();
+  }
+
+  @Bean
+  CloudFoundryCredentialsInitializer cloudFoundryCredentialsInitializer() {
+    return new CloudFoundryCredentialsInitializer();
+  }
+
+  public static class CloudFoundryProviderSynchronizer {
+  }
+
+  class CloudFoundrySynchronizerTypeWrapper implements ProviderSynchronizerTypeWrapper {
+    @Override
+    public Class getSynchronizerType() {
+      return CloudFoundryProviderSynchronizer.class;
+    }
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/CloudFoundryOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/CloudFoundryOperation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@interface CloudFoundryOperation {
+  String value();
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryClient.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryClient.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.client;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CloudFoundryClient {
+  private final String account;
+  private final String apiHost;
+  private final String user;
+  private final String password;
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/config/CloudFoundryConfigurationProperties.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/config/CloudFoundryConfigurationProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.config;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Data
+@ConfigurationProperties("cloudfoundry")
+public class CloudFoundryConfigurationProperties {
+  private List<ManagedAccount> accounts = new ArrayList<>();
+
+  @Getter
+  @Setter
+  @ToString(exclude = "password")
+  public static class ManagedAccount {
+    private String name;
+    private String api;
+    private String user;
+    private String password;
+    private String environment;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/CloudFoundryProvider.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/CloudFoundryProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.provider;
+
+import com.netflix.spinnaker.cats.agent.Agent;
+import com.netflix.spinnaker.cats.agent.AgentSchedulerAware;
+import com.netflix.spinnaker.clouddriver.cache.SearchableProvider;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Getter
+public class CloudFoundryProvider extends AgentSchedulerAware implements SearchableProvider {
+  // todo(jkschneider): add default caches
+  final Set<String> defaultCaches = Collections.emptySet();
+  final Map<String, String> urlMappingTemplates = Collections.emptyMap();
+  // todo(jkschneider): add search result hydrator
+  final Map<SearchableResource, SearchResultHydrator> searchResultHydrators = Collections.emptyMap();
+  private final String id = "cloudfoundry";
+  private final String providerName = CloudFoundryProvider.class.getName();
+  private final Collection<Agent> agents;
+
+  @Override
+  public Map<String, String> parseKey(String key) {
+    // todo(jkschneider): parse keys
+    return Collections.emptyMap();
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.provider.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.cats.agent.*;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.provider.CloudFoundryProvider;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
+import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Getter
+@Slf4j
+public class CloudFoundryCachingAgent implements CachingAgent, AccountAware {
+  final String providerName = CloudFoundryProvider.class.getName();
+  final Collection<AgentDataType> providedDataTypes = Arrays.asList(
+    AgentDataType.Authority.AUTHORITATIVE.forType(Namespace.APPLICATIONS.ns),
+    AgentDataType.Authority.AUTHORITATIVE.forType(Namespace.CLUSTERS.ns),
+    AgentDataType.Authority.AUTHORITATIVE.forType(Namespace.SERVER_GROUPS.ns),
+    AgentDataType.Authority.AUTHORITATIVE.forType(Namespace.INSTANCES.ns),
+    AgentDataType.Authority.AUTHORITATIVE.forType(Namespace.LOAD_BALANCERS.ns)
+  );
+  private final CloudFoundryCredentials credentials;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    log.info("Caching all resources in Cloud Foundry account $accountName");
+
+    // todo(jkschneider): cache all Cloud Foundry resources
+    return new DefaultCacheResult(Collections.emptyMap());
+  }
+
+  @Override
+  public String getAccountName() {
+    return credentials.getName();
+  }
+
+  @Override
+  public String getAgentType() {
+    return getAccountName() + "/" + getClass().getSimpleName();
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/config/CloudFoundryProviderConfig.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/config/CloudFoundryProviderConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.provider.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.provider.CloudFoundryProvider;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.provider.agent.CloudFoundryCachingAgent;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Scope;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Configuration
+public class CloudFoundryProviderConfig {
+
+  @Bean
+  @DependsOn("cloudFoundryAccountCredentials")
+  public CloudFoundryProvider cloudFoundryProvider(AccountCredentialsRepository accountCredentialsRepository,
+                                                   ObjectMapper objectMapper) {
+    CloudFoundryProvider provider = new CloudFoundryProvider(
+      Collections.newSetFromMap(new ConcurrentHashMap<>()));
+    synchronizeCloudFoundryProvider(provider, accountCredentialsRepository, objectMapper);
+    return provider;
+  }
+
+  @Bean
+  public CloudFoundryProviderSynchronizerTypeWrapper cloudFoundryProviderSynchronizerTypeWrapper() {
+    return new CloudFoundryProviderSynchronizerTypeWrapper();
+  }
+
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  @Bean
+  public CloudFoundryProviderSynchronizer synchronizeCloudFoundryProvider(CloudFoundryProvider cloudFoundryProvider,
+                                                                          AccountCredentialsRepository accountCredentialsRepository,
+                                                                          ObjectMapper objectMapper) {
+    Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(cloudFoundryProvider);
+    Set<CloudFoundryCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository,
+      CloudFoundryCredentials.class);
+
+    objectMapper.enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    cloudFoundryProvider.getAgents().addAll(allAccounts.stream()
+      .map(credentials -> !scheduledAccounts.contains(credentials.getName()) ?
+        new CloudFoundryCachingAgent(credentials, objectMapper) :
+        null)
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList()));
+
+    return new CloudFoundryProviderSynchronizer();
+  }
+
+  class CloudFoundryProviderSynchronizerTypeWrapper implements ProviderSynchronizerTypeWrapper {
+    @Override
+    public Class getSynchronizerType() {
+      return CloudFoundryProviderSynchronizer.class;
+    }
+  }
+
+  class CloudFoundryProviderSynchronizer {
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.security;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+public class CloudFoundryCredentials implements AccountCredentials<CloudFoundryClient> {
+  private final String name;
+  private final String environment;
+  private final String accountType = "cloudfoundry";
+  private final String cloudProvider = "cloudfoundry";
+
+  @Deprecated
+  private final List<String> requiredGroupMembership = Collections.emptyList();
+
+  @JsonIgnore
+  private final CloudFoundryClient credentials;
+
+  public CloudFoundryCredentials(String name, String apiHost, String userName, String password, String environment) {
+    this.name = name;
+    this.environment = environment;
+    this.credentials = new CloudFoundryClient(name, apiHost, userName, password);
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsInitializer.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsInitializer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.security;
+
+import com.netflix.spinnaker.cats.module.CatsModule;
+import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.config.CloudFoundryConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable;
+import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Configuration
+public class CloudFoundryCredentialsInitializer implements CredentialsInitializerSynchronizable {
+
+  @Bean
+  public List<? extends CloudFoundryCredentials> cloudFoundryAccountCredentials(CloudFoundryConfigurationProperties cloudFoundryConfigurationProperties,
+                                                                                AccountCredentialsRepository accountCredentialsRepository,
+                                                                                ApplicationContext applicationContext,
+                                                                                List<ProviderSynchronizerTypeWrapper> providerSynchronizerTypeWrappers) {
+    return synchronizeCloudFoundryAccounts(cloudFoundryConfigurationProperties, null, accountCredentialsRepository,
+      applicationContext, providerSynchronizerTypeWrappers);
+  }
+
+  @Override
+  public String getCredentialsSynchronizationBeanName() {
+    return "synchronizeCloudFoundryAccounts";
+  }
+
+  @SuppressWarnings("unchecked")
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  @Bean
+  public List<? extends CloudFoundryCredentials> synchronizeCloudFoundryAccounts(CloudFoundryConfigurationProperties cloudFoundryConfigurationProperties,
+                                                                                 CatsModule catsModule,
+                                                                                 AccountCredentialsRepository accountCredentialsRepository,
+                                                                                 ApplicationContext applicationContext,
+                                                                                 List<ProviderSynchronizerTypeWrapper> providerSynchronizerTypeWrappers) {
+    List<?> deltas = ProviderUtils.calculateAccountDeltas(accountCredentialsRepository, CloudFoundryCredentials.class,
+      cloudFoundryConfigurationProperties.getAccounts());
+
+    List<CloudFoundryConfigurationProperties.ManagedAccount> accountsToAdd = (List<CloudFoundryConfigurationProperties.ManagedAccount>) deltas.get(0);
+    List<String> namesOfDeletedAccounts = (List<String>) deltas.get(1);
+
+    for (CloudFoundryConfigurationProperties.ManagedAccount managedAccount : accountsToAdd) {
+      CloudFoundryCredentials cloudFoundryAccountCredentials = new CloudFoundryCredentials(
+        managedAccount.getName(),
+        managedAccount.getApi(),
+        managedAccount.getUser(),
+        managedAccount.getPassword(),
+        managedAccount.getEnvironment()
+      );
+      accountCredentialsRepository.save(managedAccount.getName(), cloudFoundryAccountCredentials);
+    }
+
+    ProviderUtils.unscheduleAndDeregisterAgents(namesOfDeletedAccounts, catsModule);
+
+    if (!accountsToAdd.isEmpty() && catsModule != null) {
+      ProviderUtils.synchronizeAgentProviders(applicationContext, providerSynchronizerTypeWrappers);
+    }
+
+    return accountCredentialsRepository.getAll().stream()
+      .filter(CloudFoundryCredentials.class::isInstance)
+      .map(CloudFoundryCredentials.class::cast)
+      .collect(Collectors.toList());
+  }
+}

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -42,6 +42,7 @@ dependencies {
   compile project(':clouddriver-oracle')
   compile project(':clouddriver-dcos')
   compile project(':clouddriver-titus')
+  compile project(':clouddriver-cloudfoundry')
 
   runtime spinnaker.dependency('kork')
   compile spinnaker.dependency('korkWeb')

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.appengine.artifacts.AppengineStorageCon
 import com.netflix.spinnaker.clouddriver.artifacts.ArtifactConfiguration
 import com.netflix.spinnaker.clouddriver.aws.AwsConfiguration
 import com.netflix.spinnaker.clouddriver.azure.AzureConfiguration
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryConfiguration
 import com.netflix.spinnaker.clouddriver.core.CloudDriverConfig
 import com.netflix.spinnaker.clouddriver.core.RetrofitConfig
 import com.netflix.spinnaker.clouddriver.dcos.DcosConfiguration
@@ -72,7 +73,8 @@ import java.security.Security
   EurekaProviderConfiguration,
   DcosConfiguration,
   LocalJobConfig,
-  TitusConfiguration
+  TitusConfiguration,
+  CloudFoundryConfiguration
 ])
 @ComponentScan([
   'com.netflix.spinnaker.config',

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,7 @@ enum Platform {
   APPENGINE,
   AWS, // Any thoughts on renaming this provider to EC2?
   AZURE,
+  CLOUDFOUNDRY,
   DCOS,
   GCE,
   GCP,
@@ -56,6 +57,9 @@ def includePlatform(Platform platform) {
     case Platform.AZURE:
       include 'clouddriver-azure'
       break
+    case Platform.CLOUDFOUNDRY:
+      include 'clouddriver-cloudfoundry'
+      break
     case Platform.DCOS:
       include 'clouddriver-dcos'
       break
@@ -88,6 +92,7 @@ def includePlatform(Platform platform) {
       includePlatform(Platform.APPENGINE)
       includePlatform(Platform.AWS)
       includePlatform(Platform.AZURE)
+      includePlatform(Platform.CLOUDFOUNDRY)
       includePlatform(Platform.DCOS)
       includePlatform(Platform.GCE)
       includePlatform(Platform.GCP)
@@ -102,7 +107,6 @@ def includePlatform(Platform platform) {
 includePlatforms.split(",").each {
   includePlatform(it)
 }
-
 
 def setBuildFile(project) {
   project.buildFileName = "${project.name}.gradle"


### PR DESCRIPTION
Based on a conversation with @duftler, we're splitting up the Cloud Foundry provider submission into individual PRs that can be reviewed in smaller chunks.

This initial PR contains the skeleton of the provider, up to and including credentials.

```yml
cloudfoundry:
  enabled: true
  accounts:
    - name: pivotalwebservices
      user: MYUSER
      password: MYPASSWORD
      api: api.run.pivotal.io
```

cc / @ethanfrogers 