### PR TITLE
fix(titus): actually ignore NOT_FOUND

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClient.java
@@ -236,7 +236,7 @@ public class RegionScopedTitusClient implements TitusClient {
               .build()
           );
         } catch (io.grpc.StatusRuntimeException e) {
-          if (e.getStatus() == Status.NOT_FOUND) {
+          if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
             log.warn("Titus task {} not found, continuing with terminate tasks and shrink job request.", id);
             return Empty.newBuilder().build();
           }


### PR DESCRIPTION
Check the actual code instead of the status object.

Verified locally by submitting a terminate task for two instances I'd already terminated, and the task succeeded.