### PR TITLE
fix(provider/kubernetes): be permissive of unreachable clusters on startup

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -344,8 +344,9 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     List<String> namespaces = getDeclaredNamespaces();
 
     if (namespaces.isEmpty()) {
-      throw new IllegalArgumentException("There are no namespaces configured -- please check that the list of 'omitNamespaces' for account '"
-          + accountName +"' doesn't prevent access from all namespaces in this cluster.");
+      log.warn("There are no namespaces configured (or loadable) -- please check that the list of 'omitNamespaces' for account '"
+          + accountName +"' doesn't prevent access from all namespaces in this cluster, or that the cluster is reachable.");
+      return;
     }
 
     // we are making the assumption that the roles granted to spinnaker for this account in all namespaces are identical.


### PR DESCRIPTION
The recent change allowing clouddriver to determine which kinds are reachable & existing could prevent an account from being added if a cluster was temporarily down