### PR TITLE
fix(provider/kubernetes): avoid caching empty artifacts (#2841)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
@@ -196,15 +196,19 @@ public class KubernetesManifestAnnotater {
         .setSecurityGroups(getAnnotation(annotations, SECURITY_GROUPS, new TypeReference<List<String>>() {}));
   }
 
-  public static Artifact getArtifact(KubernetesManifest manifest) {
+  public static Optional<Artifact> getArtifact(KubernetesManifest manifest) {
     Map<String, String> annotations = manifest.getAnnotations();
+    String type = getAnnotation(annotations, TYPE, new TypeReference<String>() {});
+    if (StringUtils.isEmpty(type)) {
+      return Optional.empty();
+    }
 
-    return Artifact.builder()
-        .type(getAnnotation(annotations, TYPE, new TypeReference<String>() {}))
+    return Optional.of(Artifact.builder()
+        .type(type)
         .name(getAnnotation(annotations, NAME, new TypeReference<String>() {}))
         .location(getAnnotation(annotations, LOCATION, new TypeReference<String>() {}))
         .version(getAnnotation(annotations, VERSION, new TypeReference<String>() {}))
-        .build();
+        .build());
   }
 
   public static Moniker getMoniker(KubernetesManifest manifest) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestMetadata.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestMetadata.java
@@ -24,12 +24,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Optional;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class KubernetesManifestMetadata {
   KubernetesManifestSpinnakerRelationships relationships;
-  Artifact artifact;
+  Optional<Artifact> artifact;
   Moniker moniker;
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang.StringUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -101,7 +102,13 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Void
     }
 
     int maxVersionHistory = strategy.getMaxVersionHistory();
-    Artifact artifact = KubernetesManifestAnnotater.getArtifact(manifest);
+    Optional<Artifact> optional = KubernetesManifestAnnotater.getArtifact(manifest);
+    if (!optional.isPresent()) {
+      return new ArrayList<>();
+    }
+
+    Artifact artifact = optional.get();
+
     List<Artifact> artifacts = artifactProvider.getArtifacts(artifact.getType(), artifact.getName(), artifact.getLocation())
         .stream()
         .filter(a -> a.getMetadata() != null && accountName.equals(a.getMetadata().get("account")))


### PR DESCRIPTION
This is a fairly significant CPU improvement when caching large
clusters. We're seeing ~5-10% reduction in CPU usage during cache data
construction by not creating & passing around empty artifacts for every
resource deployed to a given cluster.

Cherry pick into 1.9