### PR TITLE
fix(provider/kubernetes): record if a crd is namespace-scoped (#2849)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -64,7 +64,7 @@ public class KubernetesKind {
 
   private final String name;
   private final String alias;
-  private final boolean isNamespaced;
+  private boolean isNamespaced;
   // generally reserved for workloads, can be read as "does this belong to a spinnaker cluster?"
   private final boolean hasClusterRelationship;
   // was this kind found after spinnaker started?
@@ -144,10 +144,11 @@ public class KubernetesKind {
 
       // separate from the above chain to avoid concurrent modification of the values list
       return kindOptional.orElseGet(() -> {
-        log.info("Dynamically registering {}", name);
+        log.info("Dynamically registering {}, (namespaced: {}, registered: {})", name, namespaced, registered);
         KubernetesKind result = new KubernetesKind(name);
         result.isDynamic = true;
         result.isRegistered = registered;
+        result.isNamespaced = namespaced;
         return result;
       });
     }


### PR DESCRIPTION
This was generating a lot of incorrect log warnings about kinds missing
namespaces during caching

Cherrypick into 1.9