### PR TITLE
fix(provider/kubernetes): only load relevant on demand keys

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -111,7 +111,9 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     List<CacheData> keepInOnDemand = new ArrayList<>();
     List<CacheData> evictFromOnDemand = new ArrayList<>();
 
-    providerCache.getAll(ON_DEMAND_TYPE, primaryKeys).forEach(cd -> {
+    Collection<String> existingKeys = providerCache.existingIdentifiers(ON_DEMAND_TYPE, primaryKeys);
+
+    providerCache.getAll(ON_DEMAND_TYPE, existingKeys).forEach(cd -> {
       // can't be a ternary op due to restrictions on non-statement expressions in lambdas
       if (shouldKeepInOnDemand(start, cd)) {
         keepInOnDemand.add(cd);


### PR DESCRIPTION
This greatly speeds up (testings shows reduction of ~25% time spent) caching
runs for large agents.
