### PR TITLE
feat(entitytags): Reconcile elastic search if entity tags don't exist

### DIFF
--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperation.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperation.java
@@ -54,6 +54,11 @@ public class DeleteEntityTagsAtomicOperation implements AtomicOperation<Void> {
       currentTags = front50Service.getEntityTags(entityTagsDescription.getId());
     } catch (RetrofitError e) {
       getTask().updateStatus(BASE_PHASE, format("Did not find %s in Front50", entityTagsDescription.getId()));
+
+      getTask().updateStatus(BASE_PHASE, format("Deleting %s from ElasticSearch", entityTagsDescription.getId()));
+      entityTagsProvider.delete(entityTagsDescription.getId());
+      getTask().updateStatus(BASE_PHASE, format("Deleted %s from ElasticSearch", entityTagsDescription.getId()));
+
       return null;
     }
 

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperationSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperationSpec.groovy
@@ -43,13 +43,14 @@ class DeleteEntityTagsAtomicOperationSpec extends Specification {
     TaskRepository.threadLocalTask.set(Mock(Task))
   }
 
-  void 'should return immediately if tag not found'() {
+  void 'should remove entityTag from ElasticSearch if not found in Front50'() {
     when:
     description.id = 'abc'
     operation.operate([])
 
     then:
     1 * front50Service.getEntityTags('abc') >> { throw new RetrofitError("a", null, null, null, null, null, null) }
+    1 * entityTagsProvider.delete('abc')
     0 * _
   }
 


### PR DESCRIPTION
Might as well delete any entity tags from elastic search if we determine
they don't exist in front50.
