### PR TITLE
fix(provider/kubernetes): don't record namespace relationship in cache (#2859)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -210,10 +210,6 @@ public class KubernetesCacheDataConverter {
     cacheRelationships.putAll(ownerReferenceRelationships(account, namespace, manifest.getOwnerReferences()));
     cacheRelationships.putAll(implicitRelationships(manifest, account, resourceRelationships));
 
-    if (isNamespaced && StringUtils.isNotEmpty(namespace)) {
-      cacheRelationships.putAll(namespaceRelationship(account, namespace));
-    }
-
     String key = Keys.infrastructure(kind, account, namespace, name);
     return new DefaultCacheData(key, infrastructureTtlSeconds, attributes, cacheRelationships);
   }
@@ -308,17 +304,6 @@ public class KubernetesCacheDataConverter {
       keys.add(Keys.infrastructure(kind, account, namespace, name));
       relationships.put(kind.toString(), keys);
     }
-
-    return relationships;
-  }
-
-  static Map<String, Collection<String>> namespaceRelationship(String account, String namespace) {
-    Map<String, Collection<String>> relationships = new HashMap<>();
-    relationships.put(NAMESPACE.toString(),
-        Collections.singletonList(
-            Keys.infrastructure(NAMESPACE, account, namespace, namespace)
-        )
-    );
 
     return relationships;
   }


### PR DESCRIPTION
This was generating very large (1 per resource) numbers of duplicate
cache entries that both ate up memory, and required expensive
relationship merging & deduping later. We don't actually make use of
this relationship anywhere, and it can be infered from a resource's key
in the cache, making it redundant.

Cherry pick into 1.9