### PR TITLE
fix(provider/kubernetes): only record app relationships for clusters

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -246,11 +246,12 @@ public class KubernetesCacheDataConverter {
       cacheRelationships.put(ARTIFACT.toString(), Collections.singletonList(Keys.artifact(artifact.getType(), artifact.getName(), artifact.getLocation(), artifact.getVersion())));
     }
 
-    cacheRelationships.put(APPLICATIONS.toString(), Collections.singletonList(Keys.application(application)));
-
-    String cluster = moniker.getCluster();
-    if (StringUtils.isNotEmpty(cluster) && hasClusterRelationship) {
-      cacheRelationships.put(CLUSTERS.toString(), Collections.singletonList(Keys.cluster(account, application, cluster)));
+    if (hasClusterRelationship) {
+      cacheRelationships.put(APPLICATIONS.toString(), Collections.singletonList(Keys.application(application)));
+      String cluster = moniker.getCluster();
+      if (StringUtils.isNotEmpty(cluster)) {
+        cacheRelationships.put(CLUSTERS.toString(), Collections.singletonList(Keys.cluster(account, application, cluster)));
+      }
     }
 
     return cacheRelationships;


### PR DESCRIPTION
Another effort at reducing the number of cache objects being deduped and
stored in memory during cache cycles.
