### PR TITLE
fix(provider/kubernetes): skip redundant check of kinds already omitted (#2866)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -356,7 +356,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
     log.info("Checking permissions on configured kinds... {}", allKinds);
     for (KubernetesKind kind : allKinds) {
-      if (kind == KubernetesKind.NONE) {
+      if (kind == KubernetesKind.NONE || omitKinds.contains(kind)) {
         continue;
       }
 


### PR DESCRIPTION
Cherry pick into 1.9
