### PR TITLE
feat(artifacts): expose types supported by a given artifact credential

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
@@ -27,6 +27,8 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Request.Builder;
 import com.squareup.okhttp.Response;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
@@ -41,6 +43,7 @@ import java.io.InputStream;
 @Data
 public class BitbucketArtifactCredentials implements ArtifactCredentials {
   private final String name;
+  private final List<String> types = Arrays.asList("bitbucket/file");
 
   @JsonIgnore
   private final Builder requestBuilder;
@@ -102,11 +105,6 @@ public class BitbucketArtifactCredentials implements ArtifactCredentials {
     } catch (IOException e) {
       throw new FailedDownloadException("Unable to download the contents of artifact " + artifact + ": " + e.getMessage(), e);
     }
-  }
-
-  @Override
-  public boolean handlesType(String type) {
-    return type.equals("bitbucket/file");
   }
 
   public class FailedDownloadException extends IOException {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/ArtifactCredentials.java
@@ -21,9 +21,14 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 public interface ArtifactCredentials {
   String getName();
-  boolean handlesType(String type);
+  List<String> getTypes();
   InputStream download(Artifact artifact) throws IOException;
+
+  default boolean handlesType(String type) {
+    return getTypes().stream().anyMatch(it -> it.equals(type));
+  }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactCredentials.java
@@ -20,6 +20,8 @@ package com.netflix.spinnaker.clouddriver.artifacts.embedded;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
@@ -33,6 +35,8 @@ import java.util.Base64;
 @Data
 public class EmbeddedArtifactCredentials implements ArtifactCredentials {
   private final String name;
+  private final List<String> types = Arrays.asList("embedded/base64");
+
   @JsonIgnore
   private final Base64.Decoder base64Decoder;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactCredentials.java
@@ -27,6 +27,8 @@ import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.StorageScopes;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -43,6 +45,7 @@ public class GcsArtifactCredentials implements ArtifactCredentials {
   @JsonIgnore
   private final Storage storage;
   private final String name;
+  private final List<String> types = Arrays.asList("gcs/object");
 
   public GcsArtifactCredentials(String applicationName, GcsArtifactAccount account) throws IOException, GeneralSecurityException {
     HttpTransport transport = GoogleNetHttpTransport.newTrustedTransport();
@@ -95,10 +98,5 @@ public class GcsArtifactCredentials implements ArtifactCredentials {
         .setGeneration(generation);
 
     return get.executeMediaAsInputStream();
-  }
-
-  @Override
-  public boolean handlesType(String type) {
-    return type.equals("gcs/object");
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactCredentials.java
@@ -27,6 +27,8 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Request.Builder;
 import com.squareup.okhttp.Response;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
@@ -41,6 +43,7 @@ import java.io.InputStream;
 @Data
 public class GitHubArtifactCredentials implements ArtifactCredentials {
   private final String name;
+  private final List<String> types = Arrays.asList("github/file");
 
   @JsonIgnore
   private final Builder requestBuilder;
@@ -131,11 +134,6 @@ public class GitHubArtifactCredentials implements ArtifactCredentials {
     } catch (IOException e) {
       throw new FailedDownloadException("Unable to download the contents of artifact " + artifact + ": " + e.getMessage(), e);
     }
-  }
-
-  @Override
-  public boolean handlesType(String type) {
-    return type.equals("github/file");
   }
 
   @Data

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactCredentials.java
@@ -25,6 +25,8 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Request.Builder;
 import com.squareup.okhttp.Response;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -38,6 +40,7 @@ import java.io.InputStream;
 @Data
 public class GitlabArtifactCredentials implements ArtifactCredentials {
   private final String name;
+  private final List<String> types = Arrays.asList("gitlab/file");
 
   @JsonIgnore
   private final Builder requestBuilder;
@@ -108,11 +111,6 @@ public class GitlabArtifactCredentials implements ArtifactCredentials {
     } catch (IOException e) {
       throw new com.netflix.spinnaker.clouddriver.artifacts.gitlab.GitlabArtifactCredentials.FailedDownloadException("Unable to download the contents of artifact " + artifact + ": " + e.getMessage(), e);
     }
-  }
-
-  @Override
-  public boolean handlesType(String type) {
-    return type.equals("gitlab/file");
   }
 
   public class FailedDownloadException extends IOException {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactCredentials.java
@@ -27,6 +27,8 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Request.Builder;
 import com.squareup.okhttp.Response;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
@@ -41,6 +43,7 @@ import java.io.InputStream;
 @Data
 public class HttpArtifactCredentials implements ArtifactCredentials {
   private final String name;
+  private final List<String> types = Arrays.asList("http/file");
 
   @JsonIgnore
   private final Builder requestBuilder;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
@@ -20,6 +20,8 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3Object;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
@@ -36,6 +38,7 @@ public class S3ArtifactCredentials implements ArtifactCredentials {
   private final String apiEndpoint;
   private final String apiRegion;
   private final String region;
+  private final List<String> types = Arrays.asList("s3/object");
 
   public S3ArtifactCredentials(S3ArtifactAccount account) throws IllegalArgumentException {
     name = account.getName();
@@ -73,10 +76,5 @@ public class S3ArtifactCredentials implements ArtifactCredentials {
     String path = reference.substring(slash + 1);
     S3Object s3obj = getS3Client().getObject(bucketName, path);
     return s3obj.getObjectContent();
-  }
-
-  @Override
-  public boolean handlesType(String type) {
-    return type.equals("s3/object");
   }
 }


### PR DESCRIPTION
I initially planned to return only a single artifact type for a given credential but I think there are realistic potential use cases for a credential supporting multiple types: a github or gitlab commit object, an embedded artifact that isn't base64-encoded, gcs or s3 object metadata.