### PR TITLE
feat(provider/docker): adding passwordCommand option for retrieving d…

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/config/DockerRegistryConfigurationProperties.groovy
@@ -31,6 +31,8 @@ class DockerRegistryConfigurationProperties {
     String password
     // File containing docker password in plaintext.
     String passwordFile
+    // Command to run to get a docker password
+    String passwordCommand
     // File containing docker's auth config (managed by docker-cli). Typically `~/.docker/config.json`.
     String dockerconfigFile
     // Docker registry user email address.

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryCredentialsInitializer.groovy
@@ -67,6 +67,7 @@ class DockerRegistryCredentialsInitializer implements CredentialsInitializerSync
           .accountType(managedAccount.accountType ?: managedAccount.name)
           .address(managedAccount.address)
           .password(managedAccount.password)
+          .passwordCommand(managedAccount.passwordCommand)
           .username(managedAccount.username)
           .email(managedAccount.email)
           .passwordFile(managedAccount.passwordFile)

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
@@ -34,6 +34,7 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
     String address
     String username
     String password
+    String passwordCommand
     File passwordFile
     File dockerconfigFile
     String email
@@ -77,6 +78,11 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
 
     Builder password(String address) {
       this.password = address
+      return this
+    }
+
+    Builder passwordCommand(String passwordCommand) {
+      this.passwordCommand = passwordCommand
       return this
     }
 
@@ -162,6 +168,7 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
                                                        address,
                                                        username,
                                                        password,
+                                                       passwordCommand,
                                                        passwordFile,
                                                        dockerconfigFile,
                                                        email,
@@ -184,6 +191,7 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
                                         String address,
                                         String username,
                                         String password,
+                                        String passwordCommand,
                                         File passwordFile,
                                         File dockerconfigFile,
                                         String email,
@@ -203,6 +211,7 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
          address,
          username,
          password,
+         passwordCommand,
          passwordFile,
          dockerconfigFile,
          email,
@@ -225,6 +234,7 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
                                         String address,
                                         String username,
                                         String password,
+                                        String passwordCommand,
                                         File passwordFile,
                                         File dockerconfigFile,
                                         String email,
@@ -250,6 +260,7 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
     this.accountName = accountName
     this.environment = environment
     this.accountType = accountType
+    this.passwordCommand = passwordCommand
     this.passwordFile = passwordFile
     this.cacheThreads = cacheThreads ?: 1
     this.cacheIntervalSeconds = cacheIntervalSeconds ?: 30
@@ -338,6 +349,7 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
         .email(email)
         .username(username)
         .password(password)
+        .passwordCommand(passwordCommand)
         .passwordFile(passwordFile)
         .clientTimeoutMillis(clientTimeoutMillis)
         .paginateSize(paginateSize)
@@ -365,6 +377,7 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
   final String username
   @JsonIgnore
   final String password
+  final String passwordCommand
   final File passwordFile
   final String email
   final boolean trackDigests

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenServiceSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenServiceSpec.groovy
@@ -121,4 +121,16 @@ class DockerBearerTokenServiceSpec extends Specification {
     then:
       new String(Base64.decoder.decode(fileTokenService.getBasicAuth().bytes)) == "$username:$passwordContents"
   }
+
+  void "should run a command to get password, and correctly prepare the basic auth string."() {
+    setup:
+      def passwordCommand = "echo hunter2"
+      def username = "username"
+      def password = ""
+      def actualPassword = "hunter2"
+    when:
+      def passwordCommandService = new DockerBearerTokenService(username, password, passwordCommand)
+    then:
+      new String(Base64.decoder.decode(passwordCommandService.getBasicAuth().bytes)) == "$username:$actualPassword"
+  }
 }


### PR DESCRIPTION
…ocker credentials (#2837)

Allows users to use passwordCommand instead of password or passwordFile if their setup isn't conducive to the latter two options. This refreshes the credentials anytime the docker creds are used (every time it caches images), so an agent wasn't needed to re-initialize credentials constantly.