### PR TITLE
fix(provider/kubernetes): make request timeout configurable (#2869)

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -37,6 +37,7 @@ class KubernetesConfigurationProperties {
     String kubeconfigFile
     String kubeconfigContents
     String kubectlExecutable
+    Integer kubectlRequestTimeoutSeconds;
     Boolean serviceAccount
     Boolean configureImagePullSecrets
     List<String> namespaces

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -204,6 +204,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     String kubeconfigFile;
     String kubeconfigContents;
     String kubectlExecutable;
+    Integer kubectlRequestTimeoutSeconds;
     Boolean serviceAccount;
     Boolean configureImagePullSecrets;
     List<String> namespaces;
@@ -292,6 +293,11 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
 
     Builder kubectlExecutable(String kubectlExecutable) {
       this.kubectlExecutable = kubectlExecutable;
+      return this;
+    }
+
+    Builder kubectlRequestTimeoutSeconds(Integer kubectlRequestTimeoutSeconds) {
+      this.kubectlRequestTimeoutSeconds = kubectlRequestTimeoutSeconds;
       return this;
     }
 
@@ -420,6 +426,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
               .accountName(name)
               .kubeconfigFile(kubeconfigFile)
               .kubectlExecutable(kubectlExecutable)
+              .kubectlRequestTimeoutSeconds(kubectlRequestTimeoutSeconds)
               .context(context)
               .oAuthServiceAccount(oAuthServiceAccount)
               .oAuthScopes(oAuthScopes)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -92,6 +92,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .kubeconfigFile(managedAccount.kubeconfigFile)
           .kubeconfigContents(managedAccount.kubeconfigContents)
           .kubectlExecutable(managedAccount.kubectlExecutable)
+          .kubectlRequestTimeoutSeconds(managedAccount.kubectlRequestTimeoutSeconds)
           .serviceAccount(managedAccount.serviceAccount)
           .configureImagePullSecrets(managedAccount.configureImagePullSecrets)
           .namespaces(managedAccount.namespaces)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -439,6 +439,10 @@ public class KubectlJobExecutor {
       command.add(executable);
     }
 
+    if (credentials.getKubectlRequestTimeoutSeconds() != null) {
+      command.add("--request-timeout=" + credentials.getKubectlRequestTimeoutSeconds());
+    }
+
     if (credentials.isDebug()) {
       command.add("-v");
       command.add("9");

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -77,6 +77,9 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   @Getter
   private final String kubectlExecutable;
 
+  @Getter
+  private final Integer kubectlRequestTimeoutSeconds;
+
   // remove when kubectl is no longer a dependency
   @Getter
   private final String kubeconfigFile;
@@ -146,6 +149,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     String kubeconfigFile;
     String context;
     String kubectlExecutable;
+    Integer kubectlRequestTimeoutSeconds;
     String oAuthServiceAccount;
     List<String> oAuthScopes;
     String userAgent;
@@ -172,6 +176,11 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
     public Builder kubectlExecutable(String kubectlExecutable) {
       this.kubectlExecutable = kubectlExecutable;
+      return this;
+    }
+
+    public Builder kubectlRequestTimeoutSeconds(Integer kubectlRequestTimeoutSeconds) {
+      this.kubectlRequestTimeoutSeconds = kubectlRequestTimeoutSeconds;
       return this;
     }
 
@@ -261,6 +270,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
           registry,
           kubeconfigFile,
           kubectlExecutable,
+          kubectlRequestTimeoutSeconds,
           context,
           oAuthServiceAccount,
           oAuthScopes,
@@ -281,6 +291,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       @NotNull Registry registry,
       String kubeconfigFile,
       String kubectlExecutable,
+      Integer kubectlRequestTimeoutSeconds,
       String context,
       String oAuthServiceAccount,
       List<String> oAuthScopes,
@@ -298,6 +309,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.jobExecutor = jobExecutor;
     this.debug = debug;
     this.kubectlExecutable = kubectlExecutable;
+    this.kubectlRequestTimeoutSeconds = kubectlRequestTimeoutSeconds;
     this.kubeconfigFile = kubeconfigFile;
     this.context = context;
     this.oAuthServiceAccount = oAuthServiceAccount;


### PR DESCRIPTION
Prevents caching agents from stacking up while failing to ever complete
when indexing unavailable clusters. Will need to be set by a
user/operator.

Cherry pick into 1.9