### PR TITLE
feat(provider/cf): add model and cache keys

### DIFF
--- a/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
+++ b/clouddriver-cloudfoundry/clouddriver-cloudfoundry.gradle
@@ -1,3 +1,7 @@
+test {
+  useJUnitPlatform()
+}
+
 dependencies {
   compile project(":clouddriver-artifacts")
   compile project(":clouddriver-core")
@@ -10,7 +14,9 @@ dependencies {
   compile spinnaker.dependency('lombok')
 
   spinnaker.group('retrofitDefault')
-  spinnaker.group('test')
+
+  testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
+  testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
 
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${spinnaker.version("jackson")}"
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/Keys.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/Keys.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.cache;
+
+import com.netflix.spinnaker.clouddriver.cache.KeyParser;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryLoadBalancer;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider.ID;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.cache.Keys.Namespace.*;
+
+@Component("CloudFoundryInfraKeys")
+public class Keys implements KeyParser {
+
+  @Nullable
+  public static Map<String, String> parse(String key) {
+    String[] parts = key.split(":");
+
+    if (parts.length < 2 || !parts[0].equals(ID)) {
+      return null;
+    }
+
+    Map<String, String> result = new HashMap<>();
+    result.put("provider", parts[0]);
+
+    String type = parts[1];
+    result.put("type", type);
+
+    if (Namespace.APPLICATIONS.ns.equals(type)) {
+      result.put("name", parts[2]);
+    } else if (Namespace.LOAD_BALANCERS.ns.equals(type)) {
+      result.put("account", parts[2]);
+      result.put("id", parts[3]);
+      result.put("host", parts[4].isEmpty() ? null : parts[4]);
+      result.put("domain", parts[5]);
+      result.put("path", parts[6].isEmpty() ? null : parts[6]);
+      result.put("port", Integer.parseInt(parts[7]) == -1 ? null : parts[7]);
+      result.put("region", parts[8]);
+    } else if (Namespace.CLUSTERS.ns.equals(type)) {
+      result.put("account", parts[2]);
+      result.put("guid", parts[3]);
+      result.put("name", parts[4]);
+    } else if (Namespace.INSTANCES.ns.equals(type)) {
+      result.put("account", parts[2]);
+      result.put("appGuid", parts[3]);
+      result.put("name", parts[4]);
+    } else if (Namespace.SERVER_GROUPS.ns.equals(type)) {
+      result.put("account", parts[2]);
+      result.put("name", parts[3]);
+      result.put("region", parts[4]);
+    } else {
+      return null;
+    }
+
+    return result;
+  }
+
+  public static String getApplicationKey(String app) {
+    return ID + ":" + APPLICATIONS + ":" + app;
+  }
+
+  public static String getAllLoadBalancers() {
+    return ID + ":" + LOAD_BALANCERS + ":*";
+  }
+
+  public static String getLoadBalancerKey(String account, CloudFoundryLoadBalancer lb) {
+    return ID +
+      ":" + LOAD_BALANCERS +
+      ":" + account +
+      ":" + lb.getId() +
+      ":" + (lb.getHost() != null ? lb.getHost() : "") +
+      ":" + lb.getDomain().getName() +
+      ":" + (lb.getPath() != null ? lb.getPath() : "") +
+      ":" + (lb.getPort() != null ? lb.getPort() : -1) +
+      ":" + lb.getRegion();
+  }
+
+  public static String getClusterKey(String account, String app, String name) {
+    return ID +
+      ":" + CLUSTERS +
+      ":" + account +
+      ":" + app +
+      ":" + name;
+  }
+
+  public static String getServerGroupKey(String account, String name, String region) {
+    return ID +
+      ":" + SERVER_GROUPS +
+      ":" + account +
+      ":" + name +
+      ":" + region;
+  }
+
+  public static String getInstanceKey(String account, String instanceName) {
+    return ID +
+      ":" + INSTANCES +
+      ":" + account +
+      ":" + instanceName;
+  }
+
+  @Override
+  public String getCloudProvider() {
+    // This is intentionally 'aws'. See in todos in SearchController#search for why.
+    return "aws";
+  }
+
+  @Override
+  public Map<String, String> parseKey(String key) {
+    return parse(key);
+  }
+
+  @Override
+  public Boolean canParseType(String type) {
+    return Arrays.stream(Namespace.values()).anyMatch(it -> it.ns.equals(type));
+  }
+
+  @Override
+  public Boolean canParseField(String field) {
+    return false;
+  }
+
+  enum Namespace {
+    APPLICATIONS("applications"),
+    LOAD_BALANCERS("loadBalancers"),
+    CLUSTERS("clusters"),
+    SERVER_GROUPS("serverGroups"),
+    INSTANCES("instances");
+
+    final String ns;
+
+    Namespace(String ns) {
+      this.ns = ns;
+    }
+
+    public String toString() {
+      return ns;
+    }
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/ResourceCacheData.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/ResourceCacheData.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.cache;
+
+import com.netflix.spinnaker.cats.cache.CacheData;
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+class ResourceCacheData implements CacheData {
+  final String id;
+  final Map<String, Collection<String>> relationships;
+  final Map<String, Object> attributes;
+  final int ttlSeconds = -1;
+
+  ResourceCacheData(String id, Object resource, Map<String, Collection<String>> relationships) {
+    this.id = id;
+
+    this.attributes = new HashMap<>();
+    this.attributes.put("resource", resource);
+
+    this.relationships = relationships;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryApplication.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryApplication.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.clouddriver.model.Application;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.*;
+
+@RequiredArgsConstructor
+@Getter
+public class CloudFoundryApplication implements Application {
+  private final String name;
+
+  @JsonIgnore
+  private final List<CloudFoundryCluster> clusters;
+
+  private final Map<String, String> attributes;
+
+  @Override
+  public Map<String, Set<String>> getClusterNames() {
+    return clusters.stream().collect(groupingBy(CloudFoundryCluster::getAccountName,
+      mapping(CloudFoundryCluster::getName, toSet())));
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryBuildpack.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryBuildpack.java
@@ -14,29 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
-
-import java.lang.annotation.Annotation;
-
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
-
-  @Override
-  public String getId() {
-    return ID;
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
-  }
+public class CloudFoundryBuildpack {
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryCluster.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryCluster.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import com.netflix.frigga.Names;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider;
+import com.netflix.spinnaker.clouddriver.model.Cluster;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.Set;
+
+@AllArgsConstructor
+@EqualsAndHashCode(of = {"name", "accountName"}, callSuper = false)
+@Getter
+public class CloudFoundryCluster extends CloudFoundryModel implements Cluster {
+  private final String accountName;
+  private final String name;
+  private final Set<CloudFoundryServerGroup> serverGroups;
+  private final Set<CloudFoundryLoadBalancer> loadBalancers;
+
+  public String getStack() {
+    return Names.parseName(name).getStack();
+  }
+
+  public String getDetail() {
+    return Names.parseName(name).getDetail();
+  }
+
+  public String getType() {
+    return CloudFoundryCloudProvider.ID;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryDomain.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryDomain.java
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-import java.lang.annotation.Annotation;
+import javax.annotation.Nullable;
 
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
+@AllArgsConstructor
+@ToString
+@EqualsAndHashCode(of = "id")
+@Getter
+public class CloudFoundryDomain {
+  private final String id;
+  private final String name;
 
-  @Override
-  public String getId() {
-    return ID;
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
-  }
+  @Nullable
+  private final CloudFoundryOrganization organization;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryDroplet.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryDroplet.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.netflix.spinnaker.clouddriver.model.Image;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode(of = "id")
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CloudFoundryDroplet implements Image {
+  String id;
+  String name;
+  CloudFoundrySpace space;
+  String stack;
+  Collection<CloudFoundryBuildpack> buildpacks;
+  CloudFoundryPackage sourcePackage;
+  String packageChecksum;
+
+  @Override
+  public String getRegion() {
+    return space != null ? space.getRegion() : null;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryImage.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryImage.java
@@ -14,29 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+import com.netflix.spinnaker.clouddriver.model.Image;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-import java.lang.annotation.Annotation;
-
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
-
-  @Override
-  public String getId() {
-    return ID;
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
-  }
+@RequiredArgsConstructor
+@Getter
+public class CloudFoundryImage implements Image {
+  private final String id;
+  private final String name;
+  private final String region;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryInstance.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryInstance.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider;
+import com.netflix.spinnaker.clouddriver.model.HealthState;
+import com.netflix.spinnaker.clouddriver.model.Instance;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode(of = {"appGuid", "key"}, callSuper = false)
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CloudFoundryInstance extends CloudFoundryModel implements Instance {
+  private final String appGuid;
+
+  /*
+   * A sequence number that may get recycled when instances come and go.
+   */
+  private final String key;
+
+  private final HealthState healthState;
+  private final String details;
+  private final Long launchTime;
+  private final String zone;
+
+  @Override
+  public List<Map<String, Object>> getHealth() {
+    Map<String, Object> health = new HashMap<>();
+    health.put("healthClass", "platform");
+    health.put("state", healthState.toString());
+    return Collections.singletonList(health);
+  }
+
+  @Deprecated
+  public String getProviderType() {
+    return CloudFoundryCloudProvider.ID;
+  }
+
+  public String getId() {
+    return appGuid + "-" + key;
+  }
+
+  public String getName() {
+    return appGuid + "-" + key;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryLoadBalancer.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryLoadBalancer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
+import com.netflix.spinnaker.moniker.Moniker;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode(of = "id", callSuper = false)
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CloudFoundryLoadBalancer extends CloudFoundryModel implements LoadBalancer, Cloneable {
+  private static final Moniker EMPTY_MONIKER = new Moniker();
+
+  private final String account;
+  private final String id;
+  @Nullable
+  private final String host;
+  @Nullable
+  private final String path;
+  @Nullable
+  private final Integer port;
+  private final CloudFoundrySpace space;
+  private final CloudFoundryDomain domain;
+
+  @JsonIgnore
+  private final Set<CloudFoundryServerGroup> mappedApps;
+
+  @JsonProperty
+  public String getName() {
+    return host + "." + domain + "." + getName() + (port == null ? "" : "-" + port) + (path == null ? "" : "/" + path);
+  }
+
+  @Override
+  public Moniker getMoniker() {
+    return EMPTY_MONIKER;
+  }
+
+  @Override
+  public Set<LoadBalancerServerGroup> getServerGroups() {
+    return mappedApps.stream().map(app ->
+      new LoadBalancerServerGroup(
+        app.getName(),
+        account,
+        app.getRegion(),
+        app.getState() == CloudFoundryServerGroup.State.STOPPED,
+        emptySet(),
+        app.getInstances()
+          .stream()
+          .map(it -> new LoadBalancerInstance(it.getId(), it.getName(), null, it.getHealth().get(0)))
+          .collect(toSet())
+      )
+    ).collect(toSet());
+  }
+
+  @Deprecated
+  public String getType() {
+    return CloudFoundryCloudProvider.ID;
+  }
+
+  public String getRegion() {
+    return space != null ? space.getRegion() : null;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryModel.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryModel.java
@@ -14,29 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider;
 
-import java.lang.annotation.Annotation;
-
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
-
-  @Override
-  public String getId() {
-    return ID;
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
+abstract class CloudFoundryModel {
+  public String getCloudProvider() {
+    return CloudFoundryCloudProvider.ID;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryOrganization.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryOrganization.java
@@ -14,29 +14,18 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
-import java.lang.annotation.Annotation;
-
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
-
-  @Override
-  public String getId() {
-    return ID;
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
-  }
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode(of = "id")
+@Getter
+class CloudFoundryOrganization {
+  private final String id;
+  private final String name;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryPackage.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryPackage.java
@@ -14,29 +14,22 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+/*
+ * A package is an application’s ‘source code’; either raw bits for your application or a pointer to these bits.
+ */
+public class CloudFoundryPackage {
+  /*
+   * This endpoint downloads the bits of an existing package.
+   */
+  private String downloadUrl;
 
-import java.lang.annotation.Annotation;
-
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
-
-  @Override
-  public String getId() {
-    return ID;
+  public String getDownloadUrl() {
+    return downloadUrl;
   }
 
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
+  public void setDownloadUrl(String downloadUrl) {
+    this.downloadUrl = downloadUrl;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryRegion.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryRegion.java
@@ -14,29 +14,11 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
 
-import java.lang.annotation.Annotation;
-
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
-
-  @Override
-  public String getId() {
-    return ID;
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
-  }
+@RequiredArgsConstructor
+class CloudFoundryRegion {
+  private final String name;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.frigga.Names;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider;
+import com.netflix.spinnaker.clouddriver.model.Image;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
+import com.netflix.spinnaker.moniker.Moniker;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.clouddriver.model.HealthState.*;
+import static java.util.Collections.*;
+
+@RequiredArgsConstructor
+@ToString
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CloudFoundryServerGroup extends CloudFoundryModel implements ServerGroup {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  private final String account;
+  private final String name;
+  private final String id;
+  private final Integer memory;
+  private final Set<CloudFoundryInstance> instances;
+  private final CloudFoundryDroplet droplet;
+  private final Integer diskQuota;
+  private final State state;
+  private final CloudFoundrySpace space;
+  private final Long createdTime;
+  private final List<CloudFoundryLoadBalancer> routes;
+  private final List<CloudFoundryServiceInstance> serviceInstances;
+
+  @Override
+  public ImagesSummary getImagesSummary() {
+    return new ImagesSummary() {
+      @Override
+      public List<? extends ImageSummary> getSummaries() {
+        return singletonList(
+          new ImageSummary() {
+            @Override
+            public String getServerGroupName() {
+              return name;
+            }
+
+            @Override
+            public String getImageName() {
+              return name + "-droplet";
+            }
+
+            @Override
+            public String getImageId() {
+              return droplet == null ? "unknown" : droplet.getId();
+            }
+
+            @Override
+            public Map<String, Object> getImage() {
+              return mapper.convertValue(this, new TypeReference<Map>() {
+              });
+            }
+
+            @Override
+            public Map<String, Object> getBuildInfo() {
+              return emptyMap();
+            }
+          }
+        );
+      }
+    };
+  }
+
+  public Image getImage() {
+    return new CloudFoundryImage(droplet == null ? "unknown" : droplet.getId(), name + "-droplet", space.getRegion());
+  }
+
+  public Map getBuildInfo() {
+    Map<String, Object> buildInfo = new HashMap<>();
+    buildInfo.put("droplet", droplet);
+    buildInfo.put("serviceInstances", serviceInstances);
+    buildInfo.put("id", id);
+    return buildInfo;
+  }
+
+  @Deprecated
+  @Override
+  public ImageSummary getImageSummary() {
+    return getImagesSummary() != null ? getImagesSummary().getSummaries().get(0) : null;
+  }
+
+  @Override
+  public String getRegion() {
+    return space.getRegion();
+  }
+
+  @Override
+  public Boolean isDisabled() {
+    return state == State.STOPPED;
+  }
+
+  @Override
+  public Set<String> getZones() {
+    return singleton(space.getName());
+  }
+
+  @Override
+  public Set<String> getLoadBalancers() {
+    return routes.stream().map(CloudFoundryLoadBalancer::getName).collect(Collectors.toSet());
+  }
+
+  @Override
+  public Set<String> getSecurityGroups() {
+    return emptySet();
+  }
+
+  @Override
+  public Map<String, Object> getLaunchConfig() {
+    return emptyMap();
+  }
+
+  @Override
+  public InstanceCounts getInstanceCounts() {
+    return new InstanceCounts(
+      instances.size(),
+      (int) instances.stream().filter(in -> Up.equals(in.getHealthState())).count(),
+      (int) instances.stream().filter(in -> Down.equals(in.getHealthState())).count(),
+      (int) instances.stream().filter(in -> Unknown.equals(in.getHealthState())).count(),
+      (int) instances.stream().filter(in -> OutOfService.equals(in.getHealthState())).count(),
+      (int) instances.stream().filter(in -> Starting.equals(in.getHealthState())).count()
+    );
+  }
+
+  @Override
+  public Capacity getCapacity() {
+    return new ServerGroup.Capacity(instances.size(), instances.size(), instances.size());
+  }
+
+  public String getStack() {
+    return Names.parseName(name).getStack();
+  }
+
+  public String getDetail() {
+    return Names.parseName(name).getDetail();
+  }
+
+  public Moniker getMoniker() {
+    Moniker moniker = NamerRegistry.getDefaultNamer().deriveMoniker(this);
+    return new Moniker(moniker.getApp(), moniker.getCluster(), moniker.getDetail(), moniker.getStack(),
+      moniker.getSequence() == null ? 0 : moniker.getSequence());
+  }
+
+  @Deprecated
+  public String getType() {
+    return CloudFoundryCloudProvider.ID;
+  }
+
+  enum State {
+    STOPPED,
+    STARTED
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServiceInstance.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServiceInstance.java
@@ -14,29 +14,15 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-import java.lang.annotation.Annotation;
-
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
-
-  @Override
-  public String getId() {
-    return ID;
-  }
-
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
-  }
+@AllArgsConstructor
+@Getter
+class CloudFoundryServiceInstance {
+  private final String serviceName;
+  private final String name;
+  private final String plan;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundrySpace.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundrySpace.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@ToString
+@Getter
+public class CloudFoundrySpace {
+  private final String id;
+  private final String name;
+  CloudFoundryOrganization organization;
+
+  public static CloudFoundrySpace fromRegion(String region) {
+    String[] parts = region.split(">");
+    String orgName = parts[0].trim();
+    String spaceName = parts[1].trim();
+    return new CloudFoundrySpace(null, spaceName, new CloudFoundryOrganization(null, orgName));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    CloudFoundrySpace that = (CloudFoundrySpace) o;
+
+    if (name != null ? !name.equals(that.name) : that.name != null) return false;
+    return organization != null ? organization.getName().equals(that.organization.getName()) :
+      that.organization == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + (organization.getName() != null ? organization.getName().hashCode() : 0);
+    return result;
+  }
+
+  @JsonIgnore
+  String getRegion() {
+    return organization.getName() + " > " + name;
+  }
+}

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryApplicationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryApplicationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudFoundryApplicationTest {
+  @Test
+  void getClusterNamesGroupsByAccount() {
+    CloudFoundryApplication app = new CloudFoundryApplication(
+      "app",
+      Arrays.asList(
+        new CloudFoundryCluster("dev", "app-dev1", emptySet(), emptySet()),
+        new CloudFoundryCluster("dev", "app-dev2", emptySet(), emptySet()),
+        new CloudFoundryCluster("prod", "app-prod", emptySet(), emptySet())
+      ),
+      emptyMap()
+    );
+
+    Map<String, Set<String>> clusterNames = app.getClusterNames();
+
+    assertThat(clusterNames).hasSize(2);
+    assertThat(clusterNames.get("dev")).containsExactlyInAnyOrder("app-dev1", "app-dev2");
+    assertThat(clusterNames.get("prod")).containsExactly("app-prod");
+  }
+}

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryClusterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryClusterTest.java
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-import java.lang.annotation.Annotation;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
+class CloudFoundryClusterTest {
+  private CloudFoundryCluster cluster = new CloudFoundryCluster("dev", "app-dev-detail", emptySet(), emptySet());
 
-  @Override
-  public String getId() {
-    return ID;
+  @Test
+  void getStack() {
+    assertThat(cluster.getStack()).isEqualTo("dev");
   }
 
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
+  @Test
+  void getDetail() {
+    assertThat(cluster.getDetail()).isEqualTo("detail");
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryLoadBalancerTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryLoadBalancerTest.java
@@ -14,29 +14,27 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.netflix.spinnaker.clouddriver.core.CloudProvider;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-import java.lang.annotation.Annotation;
+import static java.util.Collections.emptySet;
 
-@Component
-public class CloudFoundryCloudProvider implements CloudProvider {
-  public static String ID = "cloudfoundry";
+class CloudFoundryLoadBalancerTest {
+  private CloudFoundryOrganization org = new CloudFoundryOrganization("orgId", "org");
 
-  @Override
-  public String getId() {
-    return ID;
-  }
+  private CloudFoundryLoadBalancer loadBalancer = new CloudFoundryLoadBalancer(
+    "dev",
+    "id",
+    "host",
+    "path",
+    8080,
+    new CloudFoundrySpace("spaceId", "space", org),
+    new CloudFoundryDomain("domainId", "domain", org),
+    emptySet()
+  );
 
-  @Override
-  public String getDisplayName() {
-    return "Cloud Foundry";
-  }
-
-  @Override
-  public Class<? extends Annotation> getOperationAnnotationType() {
-    return CloudFoundryOperation.class;
+  @Test
+  void getName() {
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundrySpaceTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundrySpaceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudFoundrySpaceTest {
+
+  @Test
+  void fromRegion() {
+    CloudFoundrySpace space = CloudFoundrySpace.fromRegion("org>space");
+
+    assertThat(space.getName()).isEqualTo("space");
+    assertThat(space.getOrganization().getName()).isEqualTo("org");
+
+    space = CloudFoundrySpace.fromRegion("org > space");
+
+    assertThat(space.getName()).isEqualTo("space");
+    assertThat(space.getOrganization().getName()).isEqualTo("org");
+  }
+
+  @Test
+  void equality() {
+    CloudFoundrySpace space = CloudFoundrySpace.fromRegion("org>space");
+    CloudFoundrySpace space2 = CloudFoundrySpace.fromRegion("org > space");
+
+    assertThat(space).isEqualTo(space2);
+    assertThat(space.hashCode()).isEqualTo(space2.hashCode());
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Cluster.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Cluster.java
@@ -69,7 +69,7 @@ public interface Cluster {
    */
   @Empty
   @JsonSerialize(nullsUsing = NullCollectionSerializer.class)
-  Set<ServerGroup> getServerGroups();
+  Set<? extends ServerGroup> getServerGroups();
 
   /**
    * A set of {@link LoadBalancer} objects that are associated with this cluster
@@ -79,7 +79,7 @@ public interface Cluster {
   @Empty
   @JsonSerialize(nullsUsing = NullCollectionSerializer.class)
   // TODO(ttomsu): Why are load balancers associated with Clusters instead of ServerGroups?
-  Set<LoadBalancer> getLoadBalancers();
+  Set<? extends LoadBalancer> getLoadBalancers();
 
   @Data
   @NoArgsConstructor

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.java
@@ -100,7 +100,7 @@ public interface ServerGroup {
    * @return set of instances or an empty set if none exist
    */
   @Empty
-  Set<Instance> getInstances();
+  Set<? extends Instance> getInstances();
 
   /**
    * The names of the load balancers associated with this server group


### PR DESCRIPTION
Adds Cloud Foundry implementation of Spinnaker model objects.

Previous PRs in this sequence: #2838, #2828.