### PR TITLE
feat(core): give clouddriver the option to shutdown gracefully

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ClouddriverHostname.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ClouddriverHostname.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.core;
+
+
+import java.net.InetAddress;
+import java.util.UUID;
+
+public class ClouddriverHostname {
+  public final static String ID = id();
+
+  private static String id() {
+    String hostname;
+    try {
+      hostname = InetAddress.getLocalHost().getHostName();
+    } catch (Exception e) {
+      hostname = "UNKNOWN";
+    }
+
+    return UUID.randomUUID() + "@" + hostname;
+  }
+
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.data.task
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.clouddriver.core.ClouddriverHostname
 import groovy.transform.CompileStatic
 import groovy.transform.Immutable
 
@@ -28,9 +29,14 @@ public class DefaultTask implements Task {
   private static final Logger log = Logger.getLogger(DefaultTask.name)
 
   final String id
+  final String ownerId = ClouddriverHostname.ID
   private final Deque<Status> statusHistory = new ConcurrentLinkedDeque<Status>()
   private final Deque<Object> resultObjects = new ConcurrentLinkedDeque<Object>()
   final long startTimeMs = System.currentTimeMillis()
+
+  public String getOwnerId() {
+    return ownerId
+  }
 
   public DefaultTask(String id) {
     this(id, 'INIT', "Creating task ${id}")

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/InMemoryTaskRepository.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/InMemoryTaskRepository.groovy
@@ -52,6 +52,11 @@ class InMemoryTaskRepository implements TaskRepository {
     repository.values() as List
   }
 
+  @Override
+  List<Task> listByThisInstance() {
+    return list()
+  }
+
   private String getNextId() {
     while (true) {
       def maybeNext = new BigInteger(new Random().nextInt(Integer.MAX_VALUE)).toString(36)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Task.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Task.groovy
@@ -45,6 +45,11 @@ public interface Task {
   List<? extends Status> getHistory()
 
   /**
+   * The id of the clouddriver instance that submitted this task
+    */
+  String getOwnerId()
+
+  /**
    * This method is used to update the status of the Task with given phase and status strings.
    * @param phase
    * @param status

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/TaskRepository.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/TaskRepository.groovy
@@ -69,4 +69,9 @@ public interface TaskRepository {
    * @return list of tasks
    */
   List<Task> list()
+
+  /**
+   * Lists all tasks owned by this instance
+   */
+  List<Task> listByThisInstance()
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.data.task.jedis
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.clouddriver.core.ClouddriverHostname
 import com.netflix.spinnaker.clouddriver.data.task.Status
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskState
@@ -30,14 +31,16 @@ class JedisTask implements Task {
 
   final String id
   final long startTimeMs
+  final String ownerId
 
   @JsonIgnore
   final boolean previousRedis
 
-  JedisTask(String id, long startTimeMs, RedisTaskRepository repository, boolean previousRedis) {
+  JedisTask(String id, long startTimeMs, RedisTaskRepository repository, String ownerId, boolean previousRedis) {
     this.id = id
     this.startTimeMs = startTimeMs
     this.repository = repository
+    this.ownerId = ownerId
     this.previousRedis = previousRedis
   }
 
@@ -80,6 +83,11 @@ class JedisTask implements Task {
     } else {
       status
     }
+  }
+
+  @Override
+  String getOwnerId() {
+    return ownerId
   }
 
   @Override

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.data.task.jedis
 
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
 import com.netflix.spinnaker.clouddriver.data.task.Status
+import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskState
 import spock.lang.Shared
 import spock.lang.Specification
@@ -36,7 +37,7 @@ class JedisTaskSpec extends Specification {
 
   void setup() {
     repository = Mock(RedisTaskRepository)
-    task = new JedisTask('666', System.currentTimeMillis(), repository, false)
+    task = new JedisTask('666', System.currentTimeMillis(), repository, "owner", false)
   }
 
   void 'updating task status adds a history entry'() {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/TaskController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/TaskController.groovy
@@ -57,12 +57,12 @@ class TaskController {
   @PreDestroy
   public void destroy() {
     long start = System.currentTimeMillis()
-    def tasks = list()
+    def tasks = taskRepository.listByThisInstance()
     while (tasks && !tasks.isEmpty() &&
         (System.currentTimeMillis() - start) / TimeUnit.SECONDS.toMillis(1) < shutdownWaitSeconds) {
       log.info("There are {} task(s) still running... sleeping before shutting down", tasks.size())
       sleep(1000)
-      tasks = list()
+      tasks = taskRepository.listByThisInstance()
     }
 
     if (tasks && !tasks.isEmpty()) {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/TaskController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/TaskController.groovy
@@ -19,19 +19,26 @@ package com.netflix.spinnaker.clouddriver.controllers
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
 
-import javax.servlet.http.HttpServletRequest
+import javax.annotation.PreDestroy
+import java.util.concurrent.TimeUnit
 
 @RequestMapping("/task")
 @RestController
+@Slf4j
 class TaskController {
   @Autowired
   TaskRepository taskRepository
+
+  @Value('${admin.tasks.shutdownWaitSeconds:-1}')
+  Long shutdownWaitSeconds
 
   @RequestMapping(value = "/{id}", method = RequestMethod.GET)
   Task get(@PathVariable("id") String id) {
@@ -45,5 +52,21 @@ class TaskController {
   @RequestMapping(method = RequestMethod.GET)
   List<Task> list() {
     taskRepository.list()
+  }
+
+  @PreDestroy
+  public void destroy() {
+    long start = System.currentTimeMillis()
+    def tasks = list()
+    while (tasks && !tasks.isEmpty() &&
+        (System.currentTimeMillis() - start) / TimeUnit.SECONDS.toMillis(1) < shutdownWaitSeconds) {
+      log.info("There are {} task(s) still running... sleeping before shutting down", tasks.size())
+      sleep(1000)
+      tasks = list()
+    }
+
+    if (tasks && !tasks.isEmpty()) {
+      log.error("Shutting down while tasks '{}' are still in progress!", tasks)
+    }
   }
 }

--- a/halconfig/clouddriver.yml
+++ b/halconfig/clouddriver.yml
@@ -1,5 +1,7 @@
 # halconfig
 
+admin.tasks.shutdownWaitSeconds: 600 # 10 minutes
+
 server:
   port: ${services.clouddriver.port:7002}
   address: ${services.clouddriver.host:localhost}


### PR DESCRIPTION
We have some tasks in GCP that take several minutes to finish. If clouddriver dies while the task is in progress the pipeline task can never complete. In the cases where we can safely shutdown clouddriver nodes (e.g. during update), giving it the option to drain work prevents this.

This is only enabled for halyard installations right now.