### PR TITLE
fix(provider/kubernetes): reduce crd lookups when none exist

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -49,17 +49,24 @@ public class KubernetesUnregisteredCustomResourceCachingAgent extends Kubernetes
       int agentCount) {
     super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount);
 
-    this.liveCrdSupplier = Suppliers.memoizeWithExpiration(() -> credentials.list(KubernetesKind.CUSTOM_RESOURCE_DEFINITION, "")
-        .stream()
-        .map(c -> {
-          Map<String, Object> spec = (Map) c.getOrDefault("spec", new HashMap<>());
-          String scope = (String) spec.getOrDefault("scope", "");
-          Map<String, String> names = (Map) spec.getOrDefault("names", new HashMap<>());
-          String name = names.get("kind");
+    this.liveCrdSupplier = Suppliers.memoizeWithExpiration(() -> {
+      try {
+        return credentials.list(KubernetesKind.CUSTOM_RESOURCE_DEFINITION, "")
+            .stream()
+            .map(c -> {
+              Map<String, Object> spec = (Map) c.getOrDefault("spec", new HashMap<>());
+              String scope = (String) spec.getOrDefault("scope", "");
+              Map<String, String> names = (Map) spec.getOrDefault("names", new HashMap<>());
+              String name = names.get("kind");
 
-          return KubernetesKind.fromString(name, false, scope.equalsIgnoreCase("namespaced"));
-        })
-        .collect(Collectors.toList()), crdExpirySeconds, TimeUnit.SECONDS);
+              return KubernetesKind.fromString(name, false, scope.equalsIgnoreCase("namespaced"));
+            })
+            .collect(Collectors.toList());
+      } catch (KubectlException e) {
+        // not logging here -- it will generate a lot of noise in cases where crds aren't available/registered in the first place
+        return new ArrayList<>();
+      }
+    }, crdExpirySeconds, TimeUnit.SECONDS);
   }
 
   // TODO(lwander) make configurable
@@ -75,10 +82,6 @@ public class KubernetesUnregisteredCustomResourceCachingAgent extends Kubernetes
 
   @Override
   protected List<KubernetesKind> primaryKinds() {
-    try {
-      return liveCrdSupplier.get();
-    } catch (KubectlException e) {
-      return new ArrayList<>();
-    }
+    return liveCrdSupplier.get();
   }
 }


### PR DESCRIPTION
If the call fails, the memoizer can't record the success time, voiding
the use of an expiring memoizer. When a lot of deployments happen at
once, we check all our caching agent's kinds very frequently generating
a lot of calls to the "crd" kind, which are now all memoized.
