### PR TITLE
fix(provider/kubernetes): security groups are related to apps

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
@@ -233,7 +233,6 @@ public class KubernetesV2SearchProvider implements SearchProvider {
         .filter(Objects::nonNull)
         .collect(Collectors.toList()));
 
-
     results = results.stream()
         .filter(r -> typeSet.contains(r.get("type")) || typeSet.contains(r.get("group")))
         .collect(Collectors.toList());

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -50,7 +50,7 @@ public class KubernetesKind {
   public static KubernetesKind ROLE = new KubernetesKind("role", false);
   public static KubernetesKind ROLE_BINDING = new KubernetesKind("roleBinding", false);
   public static KubernetesKind NAMESPACE = new KubernetesKind("namespace", "ns", false, false);
-  public static KubernetesKind NETWORK_POLICY = new KubernetesKind("networkPolicy", "netpol");
+  public static KubernetesKind NETWORK_POLICY = new KubernetesKind("networkPolicy", "netpol", true, true);
   public static KubernetesKind PERSISTENT_VOLUME = new KubernetesKind("persistentVolume", "pv", false, false);
   public static KubernetesKind PERSISTENT_VOLUME_CLAIM = new KubernetesKind("persistentVolumeClaim", "pvc");
   public static KubernetesKind SECRET = new KubernetesKind("secret");


### PR DESCRIPTION
We recently pruned the resources that are related to applications to speed up the caching by shrinking how tightly connected the graph of resources -> logical groupings was. By removing network policies, they became unsearchable by removing the edge from apps -> security policies.