### PR TITLE
fix(provider/ecs): Handle null startedAt field for tasks

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskCacheClient.java
@@ -52,7 +52,9 @@ public class TaskCacheClient extends AbstractCacheClient<Task> {
     task.setGroup((String) attributes.get("group"));
     task.setLastStatus((String) attributes.get("lastStatus"));
     task.setDesiredStatus((String) attributes.get("desiredStatus"));
-    task.setStartedAt((Long) attributes.get("startedAt"));
+    if (attributes.containsKey("startedAt")) {
+      task.setStartedAt((Long) attributes.get("startedAt"));
+    }
 
     if (attributes.containsKey("containers")) {
       List<Map<String, Object>> containers = (List<Map<String, Object>>) attributes.get("containers");

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -177,7 +177,9 @@ public class TaskCachingAgent extends AbstractEcsOnDemandAgent<Task> {
     attributes.put("containers", task.getContainers());
     attributes.put("lastStatus", task.getLastStatus());
     attributes.put("desiredStatus", task.getDesiredStatus());
-    attributes.put("startedAt", task.getStartedAt().getTime());
+    if (task.getStartedAt() != null) {
+      attributes.put("startedAt", task.getStartedAt().getTime());
+    }
     attributes.put("attachments", task.getAttachments());
 
     return attributes;


### PR DESCRIPTION
ECS tasks can have a null startedAt field for a short period -- this handles that gracefully