### PR TITLE
feat(provider/ecs): Add server group setting for public IP address

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
@@ -49,6 +49,7 @@ public class CreateServerGroupDescription extends AbstractECSDescription {
   List<PlacementStrategy> placementStrategySequence;
   String networkMode;
   String subnetType;
+  Boolean associatePublicIpAddress;
   Integer healthCheckGracePeriodSeconds;
 
   @Override

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -205,6 +205,11 @@ public class CreateServerGroupAtomicOperation extends AbstractEcsAtomicOperation
       AwsVpcConfiguration awsvpcConfiguration = new AwsVpcConfiguration()
         .withSecurityGroups(securityGroupIds)
         .withSubnets(subnetIds);
+
+      if (description.getAssociatePublicIpAddress() != null) {
+        awsvpcConfiguration.withAssignPublicIp(description.getAssociatePublicIpAddress() ? "ENABLED" : "DISABLED");
+      }
+
       request.withNetworkConfiguration(new NetworkConfiguration().withAwsvpcConfiguration(awsvpcConfiguration));
     }
 

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -162,7 +162,8 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       placementStrategySequence: [],
       networkMode: 'awsvpc',
       subnetType: 'public',
-      securityGroupNames: ['helloworld']
+      securityGroupNames: ['helloworld'],
+      associatePublicIpAddress: true
     )
 
     def operation = new CreateServerGroupAtomicOperation(description)
@@ -208,6 +209,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     1 * ecs.createService({ CreateServiceRequest request ->
       request.networkConfiguration.awsvpcConfiguration.subnets == ['subnet-12345']
       request.networkConfiguration.awsvpcConfiguration.securityGroups == ['sg-12345']
+      request.networkConfiguration.awsvpcConfiguration.assignPublicIp == 'ENABLED'
       request.role == null
     } as CreateServiceRequest) >> new CreateServiceResult().withService(service)
 


### PR DESCRIPTION
Support associating public IP addresses with ECS tasks when using VPC networking mode