### PR TITLE
feat(provider/ecs): Add support for Fargate launch type

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
@@ -51,6 +51,8 @@ public class CreateServerGroupDescription extends AbstractECSDescription {
   String subnetType;
   Integer healthCheckGracePeriodSeconds;
 
+  String launchType;
+
   @Override
   public String getRegion() {
     //CreateServerGroupDescription does not contain a region. Instead it has AvailabilityZones

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -72,6 +72,7 @@ public class CreateServerGroupAtomicOperation extends AbstractEcsAtomicOperation
 
   private static final String NECESSARY_TRUSTED_SERVICE = "ecs-tasks.amazonaws.com";
   public static final String AWSVPC_NETWORK_MODE = "awsvpc";
+  public static final String FARGATE_LAUNCH_TYPE = "FARGATE";
 
   @Autowired
   EcsCloudMetricService ecsCloudMetricService;
@@ -98,11 +99,12 @@ public class CreateServerGroupAtomicOperation extends AbstractEcsAtomicOperation
 
     String serverGroupVersion = inferNextServerGroupVersion(ecs);
 
+    String ecsServiceRole = inferAssumedRoleArn(credentials);
+
     updateTaskStatus("Creating Amazon ECS Task Definition...");
-    TaskDefinition taskDefinition = registerTaskDefinition(ecs, serverGroupVersion);
+    TaskDefinition taskDefinition = registerTaskDefinition(ecs, ecsServiceRole, serverGroupVersion);
     updateTaskStatus("Done creating Amazon ECS Task Definition...");
 
-    String ecsServiceRole = inferAssumedRoleArn(credentials);
     Service service = createService(ecs, taskDefinition, ecsServiceRole, serverGroupVersion);
 
     String resourceId = registerAutoScalingGroup(credentials, service);
@@ -117,7 +119,7 @@ public class CreateServerGroupAtomicOperation extends AbstractEcsAtomicOperation
     return makeDeploymentResult(service);
   }
 
-  private TaskDefinition registerTaskDefinition(AmazonECS ecs, String version) {
+  private TaskDefinition registerTaskDefinition(AmazonECS ecs, String ecsServiceRole, String version) {
 
     Collection<KeyValuePair> containerEnvironment = new LinkedList<>();
     containerEnvironment.add(new KeyValuePair().withName("SERVER_GROUP").withValue(version));
@@ -163,6 +165,16 @@ public class CreateServerGroupAtomicOperation extends AbstractEcsAtomicOperation
       request.setTaskRoleArn(description.getIamRole());
     }
 
+    if (!StringUtils.isEmpty(description.getLaunchType())) {
+      request.setRequiresCompatibilities(Arrays.asList(description.getLaunchType()));
+    }
+
+    if (FARGATE_LAUNCH_TYPE.equals(description.getLaunchType())) {
+      request.setExecutionRoleArn(ecsServiceRole);
+      request.setCpu(description.getComputeUnits().toString());
+      request.setMemory(description.getReservedMemory().toString());
+    }
+
     RegisterTaskDefinitionResult registerTaskDefinitionResult = ecs.registerTaskDefinition(request);
 
     return registerTaskDefinitionResult.getTaskDefinition();
@@ -206,6 +218,10 @@ public class CreateServerGroupAtomicOperation extends AbstractEcsAtomicOperation
         .withSecurityGroups(securityGroupIds)
         .withSubnets(subnetIds);
       request.withNetworkConfiguration(new NetworkConfiguration().withAwsvpcConfiguration(awsvpcConfiguration));
+    }
+
+    if (!StringUtils.isEmpty(description.getLaunchType())) {
+      request.withLaunchType(description.getLaunchType());
     }
 
     if (description.getHealthCheckGracePeriodSeconds() != null) {

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -141,7 +141,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     result.getServerGroupNameByRegion().get('us-west-1').contains(serviceName)
   }
 
-  def 'should create a service using VPC mode'() {
+  def 'should create a service using VPC and Fargate mode'() {
     given:
     def description = new CreateServerGroupDescription(
       credentials: TestCredential.named('Test', [:]),
@@ -160,6 +160,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       availabilityZones: ['us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c']],
       autoscalingPolicies: [],
       placementStrategySequence: [],
+      launchType: 'FARGATE',
       networkMode: 'awsvpc',
       subnetType: 'public',
       securityGroupNames: ['helloworld']
@@ -199,6 +200,11 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.containerDefinitions.get(0).portMappings.get(0).containerPort == 1337
       request.containerDefinitions.get(0).portMappings.get(0).hostPort == 0
       request.containerDefinitions.get(0).portMappings.get(0).protocol == 'tcp'
+      request.requiresCompatibilities.size() == 1
+      request.requiresCompatibilities.get(0) == 'FARGATE'
+      request.memory == 9001
+      request.cpu == 9002
+      request.executionRoleArn == 'arn:aws:iam::test:test-role'
     }) >> new RegisterTaskDefinitionResult().withTaskDefinition(taskDefinition)
 
     1 * iamClient.getRole(_) >> new GetRoleResult().withRole(role)
@@ -209,6 +215,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.networkConfiguration.awsvpcConfiguration.subnets == ['subnet-12345']
       request.networkConfiguration.awsvpcConfiguration.securityGroups == ['sg-12345']
       request.role == null
+      request.launchType == 'FARGATE'
     } as CreateServiceRequest) >> new CreateServiceResult().withService(service)
 
     result.getServerGroupNames().size() == 1


### PR DESCRIPTION
Adds support for the Fargate launch type for ECS provider

Notes:
* Uses the Spinnaker-managed role for the ECS account as the ECS execution role (same as how it used for the ECS service role)
* Sets the task's hard limits for CPU/memory to the same as the CPU/memory setting of the single container
* Explicitly setting the launch type to 'EC2' is supported, as well as null launch type value