### PR TITLE
fix(provider/openstack): Use directUrl property for image location

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackImageV2Provider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackImageV2Provider.groovy
@@ -32,7 +32,7 @@ class OpenstackImageV2Provider implements OpenstackImageProvider, OpenstackReque
       .id(image.id)
       .status(image.status?.value())
       .size(image.size)
-      .location(image.locations?.get(0)?.toString())
+      .location(image.directUrl)
       .createdAt(image.createdAt?.time)
       .updatedAt(image.updatedAt?.time)
       .properties(properties)

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackImageV2ClientProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackImageV2ClientProviderSpec.groovy
@@ -23,7 +23,7 @@ import org.openstack4j.api.image.v2.ImageService
 import org.openstack4j.model.image.v2.Image
 import org.springframework.http.HttpStatus
 
-class OpenstackImageV1ClientProviderSpec extends OpenstackClientProviderSpec {
+class OpenstackImageV2ClientProviderSpec extends OpenstackClientProviderSpec {
 
   def "list images succeeds"() {
     setup:
@@ -31,7 +31,7 @@ class OpenstackImageV1ClientProviderSpec extends OpenstackClientProviderSpec {
     ImageService imageService = Mock(ImageService)
     def imageLocation = "http://example.com/image.iso"
     Image image = Mock(Image) {
-      getLocations() >> [imageLocation]
+      getDirectUrl() >> imageLocation
     }
 
     when:


### PR DESCRIPTION
workaround for issue in Openstack4j library, locations cannot be
used without fix https://github.com/ContainX/openstack4j/pull/1096

Spinnaker issue: https://github.com/spinnaker/spinnaker/issues/3018