### PR TITLE
fix(entitytags): Don't set _type field on Elasticsearch documents

### DIFF
--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfigProperties.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfigProperties.java
@@ -66,11 +66,19 @@ public class ElasticSearchConfigProperties {
     this.connectionTimeout = connectionTimeout;
   }
 
-  public void setSingleMappingType(boolean singleMappingType) { this.singleMappingType = singleMappingType; }
+  public void setSingleMappingType(boolean singleMappingType) {
+    this.singleMappingType = singleMappingType;
+  }
 
-  public boolean isSingleMappingType() { return singleMappingType; }
+  public boolean isSingleMappingType() {
+    return singleMappingType;
+  }
 
-  public void setMappingTypeName(String mappingTypeName) { this.mappingTypeName = mappingTypeName; }
+  public void setMappingTypeName(String mappingTypeName) {
+    this.mappingTypeName = mappingTypeName;
+  }
 
-  public String getMappingTypeName() { return mappingTypeName; }
+  public String getMappingTypeName() {
+    return mappingTypeName;
+  }
 }

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfigProperties.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfigProperties.java
@@ -26,6 +26,14 @@ public class ElasticSearchConfigProperties {
   private int readTimeout = 30000;
   private int connectionTimeout = 10000;
 
+  // As of Elasticsearch 6.0, new indices can only contain a single mapping type. Setting singleMappingType to true
+  // will index all documents under a single mapping type.  When singleMappingType is false (which is the default),
+  // the mapping type of each document is set to the type of the entity being tagged.
+  // The name of the unique mapping type is configurable as mappingTypeName, but is defaulted to "_doc", which is
+  // recommended for forward compatibility with Elasticsearch 7.0.
+  private boolean singleMappingType = false;
+  private String mappingTypeName = "_doc";
+
   public String getActiveIndex() {
     return activeIndex;
   }
@@ -57,4 +65,12 @@ public class ElasticSearchConfigProperties {
   public void setConnectionTimeout(int connectionTimeout) {
     this.connectionTimeout = connectionTimeout;
   }
+
+  public void setSingleMappingType(boolean singleMappingType) { this.singleMappingType = singleMappingType; }
+
+  public boolean isSingleMappingType() { return singleMappingType; }
+
+  public void setMappingTypeName(String mappingTypeName) { this.mappingTypeName = mappingTypeName; }
+
+  public String getMappingTypeName() { return mappingTypeName; }
 }


### PR DESCRIPTION
Storing multiple mapping types in the same index is deprecated in Elasticsearch 6 and will be removed in Elasticsearch 7. Add a config parameter indicating that only one mapping type per index is supported (defaulting to false, for backwards compatibility). If that parameter is set, all documents will their type set to the config parameter mappingTypeName, which defaults to Elasticsearch's recommended value of _doc.