### PR TITLE
fix(core): fix error when no matching converter is found

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistry.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistry.groovy
@@ -62,7 +62,8 @@ class AnnotationsBasedAtomicOperationsRegistry extends ApplicationContextAtomicO
 
     if (!converters) {
       throw new AtomicOperationConverterNotFoundException(
-          "No atomic operation converter found for description '${description}' and cloud provider '${cloudProvider}' at version '${version}'"
+          "No atomic operation converter found for description '${description}' and cloud provider '${cloudProvider}'. " +
+          "It is possible that either 1) the account name used for the operation is incorrect, or 2) the account name used for the operation is unhealthy/unable to communicate with ${cloudProvider}."
       )
     }
 


### PR DESCRIPTION
The inclusion of version is a red-herring here, as this error means no
account was registered to handle the operation for the given provider
