### PR TITLE
refactor(core): Move models used in clouddriver-web to clouddriver-core

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/edda/EddaApi.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/edda/EddaApi.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.edda
 
 import com.amazonaws.services.elasticloadbalancingv2.model.Listener
 import com.netflix.spinnaker.clouddriver.aws.model.edda.EddaRule
-import com.netflix.spinnaker.clouddriver.aws.model.edda.LoadBalancerInstanceState
+import com.netflix.spinnaker.clouddriver.model.edda.LoadBalancerInstanceState
 import com.netflix.spinnaker.clouddriver.aws.model.edda.TargetGroupAttributes
 import com.netflix.spinnaker.clouddriver.aws.model.edda.TargetGroupHealth
 import retrofit.http.GET

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
@@ -46,8 +46,8 @@ import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.data.ArnUtils
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import com.netflix.spinnaker.clouddriver.aws.edda.EddaApi
-import com.netflix.spinnaker.clouddriver.aws.model.InstanceTargetGroupState
-import com.netflix.spinnaker.clouddriver.aws.model.InstanceTargetGroups
+import com.netflix.spinnaker.clouddriver.model.InstanceTargetGroupState
+import com.netflix.spinnaker.clouddriver.model.InstanceTargetGroups
 import com.netflix.spinnaker.clouddriver.aws.model.edda.EddaRule
 import com.netflix.spinnaker.clouddriver.aws.model.edda.TargetGroupAttributes
 import com.netflix.spinnaker.clouddriver.aws.model.edda.TargetGroupHealth
@@ -56,7 +56,6 @@ import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
-import retrofit.RetrofitError
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
@@ -32,9 +32,9 @@ import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
-import com.netflix.spinnaker.clouddriver.aws.model.edda.InstanceLoadBalancers
-import com.netflix.spinnaker.clouddriver.aws.model.edda.LoadBalancerInstance
-import com.netflix.spinnaker.clouddriver.aws.model.edda.LoadBalancerInstanceState
+import com.netflix.spinnaker.clouddriver.model.edda.InstanceLoadBalancers
+import com.netflix.spinnaker.clouddriver.model.edda.LoadBalancerInstance
+import com.netflix.spinnaker.clouddriver.model.edda.LoadBalancerInstanceState
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
 import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
 import groovy.util.logging.Slf4j

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/EddaLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/EddaLoadBalancerCachingAgent.groovy
@@ -29,8 +29,8 @@ import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.edda.EddaApi
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
-import com.netflix.spinnaker.clouddriver.aws.model.edda.InstanceLoadBalancers
-import com.netflix.spinnaker.clouddriver.aws.model.edda.LoadBalancerInstanceState
+import com.netflix.spinnaker.clouddriver.model.edda.InstanceLoadBalancers
+import com.netflix.spinnaker.clouddriver.model.edda.LoadBalancerInstanceState
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.HEALTH

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/InstanceTargetGroupState.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/InstanceTargetGroupState.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model
+package com.netflix.spinnaker.clouddriver.model
 
 import com.netflix.spinnaker.clouddriver.model.HealthState
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/InstanceTargetGroups.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/InstanceTargetGroups.groovy
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model
+package com.netflix.spinnaker.clouddriver.model
 
-import com.netflix.spinnaker.clouddriver.model.HealthState
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.Immutable
-import groovy.transform.TypeCheckingMode
 
 @CompileStatic
 @Immutable

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Role.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Role.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2017 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model.edda
+package com.netflix.spinnaker.clouddriver.model;
 
-import groovy.transform.Canonical
+import java.util.Collection;
 
-@Canonical
-class LoadBalancerInstanceState {
-  String name
-  String loadBalancerType = 'classic'
-  List<LoadBalancerInstance> instances
+public interface Role {
+
+  String getName();
+  String getId();
+  Collection<? extends TrustRelationship> getTrustRelationships();
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/RoleProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/RoleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2017 Lookout, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model.edda
+package com.netflix.spinnaker.clouddriver.model;
 
-import groovy.transform.Canonical
+import java.util.Collection;
 
-@Canonical
-class LoadBalancerInstance {
-  String instanceId
-  String state
-  String reasonCode
-  String description
+public interface RoleProvider {
+
+  String getCloudProvider();
+
+  Collection<? extends Role> getAll();
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/TrustRelationship.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/TrustRelationship.java
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model;
+package com.netflix.spinnaker.clouddriver.model;
 
-import java.util.Collection;
+/**
+ * A trust relationship allows a user or service to assume that role.
+ */
+public interface TrustRelationship {
 
-public interface RoleProvider {
+  String getType();
 
-  String getCloudProvider();
-
-  Collection<? extends Role> getAll();
+  /*
+  The value represents an ID, ARN, or any other way of identifying the principal
+   */
+  String getValue();
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/edda/InstanceLoadBalancerState.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/edda/InstanceLoadBalancerState.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model.edda
+package com.netflix.spinnaker.clouddriver.model.edda
 
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import groovy.transform.CompileStatic

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/edda/InstanceLoadBalancers.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/edda/InstanceLoadBalancers.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model.edda
+package com.netflix.spinnaker.clouddriver.model.edda
 
 import com.netflix.spinnaker.clouddriver.model.Health
 import com.netflix.spinnaker.clouddriver.model.HealthState

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/edda/LoadBalancerInstance.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/edda/LoadBalancerInstance.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2014 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model;
+package com.netflix.spinnaker.clouddriver.model.edda
 
-import java.util.Collection;
+import groovy.transform.Canonical
 
-public interface Role {
-
-  String getName();
-  String getId();
-  Collection<? extends TrustRelationship> getTrustRelationships();
+@Canonical
+class LoadBalancerInstance {
+  String instanceId
+  String state
+  String reasonCode
+  String description
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/edda/LoadBalancerInstanceState.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/edda/LoadBalancerInstanceState.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Lookout, Inc.
+ * Copyright 2014 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model;
+package com.netflix.spinnaker.clouddriver.model.edda
 
-/**
- * A trust relationship allows a user or service to assume that role.
- */
-public interface TrustRelationship {
+import groovy.transform.Canonical
 
-  String getType();
-
-  /*
-  The value represents an ID, ARN, or any other way of identifying the principal
-   */
-  String getValue();
+@Canonical
+class LoadBalancerInstanceState {
+  String name
+  String loadBalancerType = 'classic'
+  List<LoadBalancerInstance> instances
 }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/model/edda/InstanceLoadBalancerStateSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/model/edda/InstanceLoadBalancerStateSpec.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model.edda
+package com.netflix.spinnaker.clouddriver.model.edda
 
 import spock.lang.Specification
 

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/model/edda/InstanceLoadBalancersSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/model/edda/InstanceLoadBalancersSpec.groovy
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.aws.model.edda
+package com.netflix.spinnaker.clouddriver.model.edda
 
 import com.netflix.spinnaker.clouddriver.model.HealthState
+import com.netflix.spinnaker.clouddriver.model.edda.InstanceLoadBalancers
+import com.netflix.spinnaker.clouddriver.model.edda.LoadBalancerInstance
+import com.netflix.spinnaker.clouddriver.model.edda.LoadBalancerInstanceState
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/IamRole.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/IamRole.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.cache.model;
 
-import com.netflix.spinnaker.clouddriver.aws.model.Role;
-import com.netflix.spinnaker.clouddriver.aws.model.TrustRelationship;
+import com.netflix.spinnaker.clouddriver.model.Role;
+import com.netflix.spinnaker.clouddriver.model.TrustRelationship;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamTrustRelationship.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/IamTrustRelationship.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
-import com.netflix.spinnaker.clouddriver.aws.model.TrustRelationship;
+import com.netflix.spinnaker.clouddriver.model.TrustRelationship;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsRoleProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsRoleProvider.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.provider.view;
 
-import com.netflix.spinnaker.clouddriver.aws.model.RoleProvider;
+import com.netflix.spinnaker.clouddriver.model.RoleProvider;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
 import com.netflix.spinnaker.clouddriver.ecs.cache.client.IamRoleCacheClient;
 import com.netflix.spinnaker.clouddriver.ecs.cache.model.IamRole;

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/RoleController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/RoleController.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.controllers;
 
-import com.netflix.spinnaker.clouddriver.aws.model.Role;
-import com.netflix.spinnaker.clouddriver.aws.model.RoleProvider;
+import com.netflix.spinnaker.clouddriver.model.Role;
+import com.netflix.spinnaker.clouddriver.model.RoleProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,7 +42,7 @@ public class RoleController {
     if (roleProviders == null) {
       return Collections.emptyList();
     }
-    
+
     Set<Role> roles = roleProviders.stream()
       .filter(roleProvider -> roleProvider.getCloudProvider().equals(cloudProvider))
       .flatMap(roleProvider -> roleProvider.getAll().stream())

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.clouddriver.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
-import com.netflix.spinnaker.clouddriver.aws.model.InstanceTargetGroups
-import com.netflix.spinnaker.clouddriver.aws.model.edda.InstanceLoadBalancers
+import com.netflix.spinnaker.clouddriver.model.InstanceTargetGroups
+import com.netflix.spinnaker.clouddriver.model.edda.InstanceLoadBalancers
 import com.netflix.spinnaker.clouddriver.model.Cluster
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
 import com.netflix.spinnaker.clouddriver.model.Instance

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupManagerController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupManagerController.java
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.clouddriver.model.ServerGroupManagerProvider;
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;


### PR DESCRIPTION
This allows clouddriver-web to not have a compile time dependency on clouddriver-aws
Part of https://github.com/spinnaker/spinnaker/issues/3114#