### PR TITLE
fix(aws): avoid terminating instances when lifecycle hooks are present

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/event/AfterResizeEvent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/event/AfterResizeEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.event;
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
+
+public class AfterResizeEvent {
+  private final Task task;
+  private final AmazonEC2 amazonEC2;
+  private final AmazonAutoScaling amazonAutoScaling;
+  private final AutoScalingGroup autoScalingGroup;
+  private final ServerGroup.Capacity capacity;
+
+  public AfterResizeEvent(Task task,
+                          AmazonEC2 amazonEC2,
+                          AmazonAutoScaling amazonAutoScaling, AutoScalingGroup autoScalingGroup,
+                          ServerGroup.Capacity capacity) {
+    this.task = task;
+    this.amazonEC2 = amazonEC2;
+    this.amazonAutoScaling = amazonAutoScaling;
+    this.autoScalingGroup = autoScalingGroup;
+    this.capacity = capacity;
+  }
+
+  public Task getTask() {
+    return task;
+  }
+
+  public AmazonEC2 getAmazonEC2() {
+    return amazonEC2;
+  }
+
+  public AmazonAutoScaling getAmazonAutoScaling() {
+    return amazonAutoScaling;
+  }
+
+  public AutoScalingGroup getAutoScalingGroup() {
+    return autoScalingGroup;
+  }
+
+  public ServerGroup.Capacity getCapacity() {
+    return capacity;
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/event/AfterResizeEventHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/event/AfterResizeEventHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.event;
+
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.autoscaling.model.Instance;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
+import com.google.common.collect.Lists;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public interface AfterResizeEventHandler {
+  int MAX_SIMULTANEOUS_TERMINATIONS = 100;
+  String PHASE = "RESIZE";
+
+  void handle(AfterResizeEvent event);
+
+  default void terminateInstancesInAutoScalingGroup(Task task, AmazonEC2 amazonEC2, AutoScalingGroup autoScalingGroup) {
+    String serverGroupName = autoScalingGroup.getAutoScalingGroupName();
+
+    List<String> instanceIds = autoScalingGroup
+      .getInstances()
+      .stream()
+      .map(Instance::getInstanceId)
+      .collect(Collectors.toList());
+
+    int terminatedCount = 0;
+    for (List<String> partition : Lists.partition(instanceIds, MAX_SIMULTANEOUS_TERMINATIONS)) {
+      try {
+        terminatedCount += partition.size();
+        task.updateStatus(
+          PHASE,
+          String.format("Terminating %d of %d instances in %s", terminatedCount, instanceIds.size(), serverGroupName)
+        );
+        amazonEC2.terminateInstances(new TerminateInstancesRequest().withInstanceIds(partition));
+      } catch (Exception e) {
+        task.updateStatus(
+          PHASE,
+          String.format("Unable to terminate instances, reason: '%s'", e.getMessage())
+        );
+      }
+    }
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/event/DefaultAfterResizeEventHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/event/DefaultAfterResizeEventHandler.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.event;
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.autoscaling.model.DescribeLifecycleHooksRequest;
+import com.amazonaws.services.autoscaling.model.DescribeLifecycleHooksResult;
+import com.amazonaws.services.autoscaling.model.LifecycleHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DefaultAfterResizeEventHandler implements AfterResizeEventHandler {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  /**
+   * There is an opportunity to expedite a resize to zero by explicitly terminating instances
+   * (server group _must not_ be attached to a load balancer nor have any life cycle hooks)
+   */
+  @Override
+  public void handle(AfterResizeEvent event) {
+    AutoScalingGroup autoScalingGroup = event.getAutoScalingGroup();
+
+    if (event.getCapacity().getDesired() > 0) {
+      return;
+    }
+
+    if (!autoScalingGroup.getLoadBalancerNames().isEmpty() || !autoScalingGroup.getTargetGroupARNs().isEmpty()) {
+      event.getTask().updateStatus(
+        PHASE,
+        "Skipping explicit instance termination, server group is attached to one or more load balancers"
+      );
+      return;
+    }
+
+    try {
+      List<LifecycleHook> existingLifecycleHooks = fetchTerminatingLifecycleHooks(
+        event.getAmazonAutoScaling(),
+        autoScalingGroup.getAutoScalingGroupName()
+      );
+      if (!existingLifecycleHooks.isEmpty()) {
+        event.getTask().updateStatus(
+          PHASE,
+          "Skipping explicit instance termination, server group has one or more lifecycle hooks"
+        );
+        return;
+      }
+    } catch (Exception e) {
+      log.error(
+        "Unable to fetch lifecycle hooks (serverGroupName: {}, arn: {})",
+        autoScalingGroup.getAutoScalingGroupName(),
+        autoScalingGroup.getAutoScalingGroupARN(),
+        e
+      );
+
+      event.getTask().updateStatus(
+        PHASE,
+        String.format(
+          "Skipping explicit instance termination, unable to fetch lifecycle hooks (reason: '%s')",
+          e.getMessage()
+        )
+      );
+      return;
+    }
+
+    terminateInstancesInAutoScalingGroup(
+      event.getTask(), event.getAmazonEC2(), event.getAutoScalingGroup()
+    );
+  }
+
+  private static List<LifecycleHook> fetchTerminatingLifecycleHooks(AmazonAutoScaling amazonAutoScaling,
+                                                                    String serverGroupName) {
+    DescribeLifecycleHooksRequest request = new DescribeLifecycleHooksRequest()
+      .withAutoScalingGroupName(serverGroupName);
+
+    return amazonAutoScaling.describeLifecycleHooks(request)
+      .getLifecycleHooks()
+      .stream()
+      .filter(h -> "autoscaling:EC2_INSTANCE_TERMINATING".equalsIgnoreCase(h.getLifecycleTransition()))
+      .collect(Collectors.toList());
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
@@ -46,6 +46,8 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.LocalFileUserDataPr
 import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.NullOpUserDataProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.userdata.UserDataProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.validators.BasicAmazonDeployDescriptionValidator
+import com.netflix.spinnaker.clouddriver.aws.event.AfterResizeEventHandler
+import com.netflix.spinnaker.clouddriver.aws.event.DefaultAfterResizeEventHandler
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonServerGroup
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
@@ -318,6 +320,12 @@ class AwsConfiguration {
   @Bean
   AmazonServerGroupProvider amazonServerGroupProvider(ApplicationContext applicationContext) {
     return new AmazonServerGroupProvider(applicationContext)
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(AfterResizeEventHandler)
+  DefaultAfterResizeEventHandler defaultAfterResizeEventHandler() {
+    return new DefaultAfterResizeEventHandler();
   }
 
   class AmazonServerGroupProvider {

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/event/DefaultAfterResizeEventHandlerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/event/DefaultAfterResizeEventHandlerSpec.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.event
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup
+import com.amazonaws.services.autoscaling.model.DescribeLifecycleHooksRequest
+import com.amazonaws.services.autoscaling.model.DescribeLifecycleHooksResult
+import com.amazonaws.services.autoscaling.model.Instance
+import com.amazonaws.services.autoscaling.model.LifecycleHook
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.model.TerminateInstancesRequest
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DefaultAfterResizeEventHandlerSpec extends Specification {
+  def task = Mock(Task)
+  def amazonEC2 = Mock(AmazonEC2)
+  def amazonAutoScaling = Mock(AmazonAutoScaling)
+
+  def autoScalingGroup = new AutoScalingGroup().withAutoScalingGroupName("app-v001")
+  def capacity = new ServerGroup.Capacity(0, 100, 0)
+
+  def event = new AfterResizeEvent(
+    task,
+    amazonEC2,
+    amazonAutoScaling,
+    autoScalingGroup,
+    capacity
+  )
+
+  @Subject
+  def eventHandler = new DefaultAfterResizeEventHandler()
+
+  def "should no-op if capacity > 0"() {
+    given:
+    capacity.desired = 1
+
+    when:
+    eventHandler.handle(event)
+
+    then:
+    0 * _
+  }
+
+  def "should no-op if load balancers present"() {
+    given:
+    autoScalingGroup.withLoadBalancerNames("my-loadbalancer")
+
+    when:
+    eventHandler.handle(event)
+
+    then:
+    1 * task.updateStatus("RESIZE", "Skipping explicit instance termination, server group is attached to one or more load balancers")
+    0 * _
+  }
+
+  def "should no-op if terminating lifecycle hook present"() {
+    when:
+    eventHandler.handle(event)
+
+    then:
+    1 * amazonAutoScaling.describeLifecycleHooks(_) >> {
+      return new DescribeLifecycleHooksResult()
+        .withLifecycleHooks([new LifecycleHook().withLifecycleTransition("autoscaling:EC2_INSTANCE_TERMINATING")])
+    }
+
+    1 * task.updateStatus("RESIZE", "Skipping explicit instance termination, server group has one or more lifecycle hooks")
+    0 * _
+  }
+
+  def "should explicitly terminate instances"() {
+    given:
+    autoScalingGroup.withInstances(new Instance().withInstanceId("i-12345678"))
+
+    when:
+    eventHandler.handle(event)
+
+    then:
+    1 * amazonAutoScaling.describeLifecycleHooks(_) >> { return new DescribeLifecycleHooksResult() }
+
+    1 * task.updateStatus("RESIZE", "Terminating 1 of 1 instances in app-v001")
+    1 * amazonEC2.terminateInstances({ TerminateInstancesRequest r -> r.instanceIds == ["i-12345678"] })
+    0 * _
+  }
+}


### PR DESCRIPTION
This PR introduces an extension point allowing for custom behavior to
happen during a resize asg operation.

The default behavior has been modified such that instances will not be
explicitly terminated during a resize _if_ a terminating lifecycle hook
is present on the asg.

replaces spinnaker/clouddriver#2900
fixes spinnaker/spinnaker#3229
