### PR TITLE
fix(provider/ecs): Gracefully ignore zone lookup for Fargate tasks

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -176,9 +176,8 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
     String address = containerInformationService.getTaskPrivateAddress(account, region, task);
     List<Map<String, Object>> healthStatus = containerInformationService.getHealthStatus(taskId, serviceName, account, region);
+    String availabilityZone = containerInformationService.getTaskZone(account, region, task);
 
-    com.amazonaws.services.ec2.model.Instance ec2Instance = containerInformationService.getEc2Instance(account, region, task);
-    String availabilityZone = ec2Instance.getPlacement().getAvailabilityZone();
     NetworkInterface networkInterface =
       !task.getContainers().isEmpty()
         && !task.getContainers().get(0).getNetworkInterfaces().isEmpty()

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
@@ -144,6 +144,16 @@ public class ContainerInformationService {
     return String.format("%s:%s", hostPrivateIpAddress, hostPort);
   }
 
+  public String getTaskZone(String accountName, String region, Task task) {
+    Instance ec2Instance = getEc2Instance(accountName, region, task);
+    if (ec2Instance != null) {
+      return ec2Instance.getPlacement().getAvailabilityZone();
+    }
+
+    // TODO for tasks not placed on an instance (e.g. Fargate), determine the zone from the network interface attachment
+    return null;
+  }
+
   public Instance getEc2Instance(String ecsAccount, String region, Task task){
     String containerInstanceCacheKey = Keys.getContainerInstanceKey(ecsAccount, region, task.getContainerInstanceArn());
     ContainerInstance containerInstance = containerInstanceCacheClient.get(containerInstanceCacheKey);

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProviderSpec.groovy
@@ -152,6 +152,7 @@ class EcsServerClusterProviderSpec extends Specification {
     containerInformationService.getTaskPrivateAddress(_, _, _) >> "${ip}:1337"
     containerInformationService.getHealthStatus(_, _, _, _) >> [healthStatus]
     containerInformationService.getEc2Instance(_, _, _) >> ec2Instance
+    containerInformationService.getTaskZone(_, _, _) >> availabilityZone
     taskDefinitionCacheClient.get(_) >> taskDefinition
     scalableTargetCacheClient.get(_) >> scalableTarget
     ecsCloudWatchAlarmCacheClient.getMetricAlarms(_, _, _) >> []

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.services
 
 import com.amazonaws.services.ec2.model.Instance
+import com.amazonaws.services.ec2.model.Placement
 import com.amazonaws.services.ecs.model.Container
 import com.amazonaws.services.ecs.model.LoadBalancer
 import com.amazonaws.services.ecs.model.NetworkBinding
@@ -334,6 +335,47 @@ class ContainerInformationServiceSpec extends Specification {
     then:
     IllegalArgumentException exception = thrown()
     exception.message == 'There cannot be more than 1 EC2 container instance for a given region and instance ID.'
+  }
+
+  def 'should return the zone of the container instance for a task'() {
+    given:
+    def task = new Task(containerInstanceArn: 'container-instance-arn')
+    def containerInstance = new ContainerInstance(ec2InstanceId: 'i-deadbeef')
+    def ecsAccount = new ECSCredentialsConfig.Account(
+      name: 'ecs-account',
+      awsAccount: 'aws-test-account'
+    )
+    def givenInstance = new Instance(
+      instanceId: 'i-deadbeef',
+      privateIpAddress: '0.0.0.0',
+      publicIpAddress: '127.0.0.1',
+      placement: new Placement(availabilityZone: 'us-west-1a')
+    )
+
+    containerInstanceCacheClient.get(_) >> containerInstance
+    ecsCredentialsConfig.getAccounts() >> [ecsAccount]
+    ecsInstanceCacheClient.find(_, _, _) >> [givenInstance]
+
+    when:
+    def retrievedZone = service.getTaskZone('ecs-account', 'us-west-1', task)
+
+    then:
+    retrievedZone == 'us-west-1a'
+  }
+
+  def 'should return null when there is no container instance for the task'() {
+    given:
+    def task = new Task(
+      containerInstanceArn: 'container-instance-arn'
+    )
+
+    containerInstanceCacheClient.get(_) >> null
+
+    when:
+    def retrievedZone = service.getTaskZone('test-account', 'us-west-1', task)
+
+    then:
+    retrievedZone == null
   }
 
   def 'should return a cluster name'() {


### PR DESCRIPTION
The zone where a Fargate task lands is not easily retrievable.  Use null zone for Fargate tasks for now.  Also applies to ECS tasks that have not yet been placed on EC2 capacity