### PR TITLE
fix(provider/ecs): Display VPC & security groups based on network config

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/ServiceCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/ServiceCacheClient.java
@@ -58,6 +58,8 @@ public class ServiceCacheClient extends AbstractCacheClient<Service> {
     service.setDesiredCount((Integer) attributes.get("desiredCount"));
     service.setMaximumPercent((Integer) attributes.get("maximumPercent"));
     service.setMinimumHealthyPercent((Integer) attributes.get("minimumHealthyPercent"));
+    service.setSubnets((List<String>)attributes.get("subnets"));
+    service.setSecurityGroups((List<String>)attributes.get("securityGroups"));
 
     if (attributes.containsKey("loadBalancers")) {
       List<Map<String, Object>> loadBalancers = (List<Map<String, Object>>) attributes.get("loadBalancers");

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/Service.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/model/Service.java
@@ -36,5 +36,7 @@ public class Service {
   int maximumPercent;
   int minimumHealthyPercent;
   List<LoadBalancer> loadBalancers;
+  List<String> subnets;
+  List<String> securityGroups;
   long createdAt;
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCachingAgent.java
@@ -77,6 +77,13 @@ public class ServiceCachingAgent extends AbstractEcsOnDemandAgent<Service> {
     attributes.put("maximumPercent", service.getDeploymentConfiguration().getMaximumPercent());
     attributes.put("minimumHealthyPercent", service.getDeploymentConfiguration().getMinimumHealthyPercent());
     attributes.put("loadBalancers", service.getLoadBalancers());
+
+    if (service.getNetworkConfiguration() != null &&
+        service.getNetworkConfiguration().getAwsvpcConfiguration() != null) {
+      attributes.put("subnets", service.getNetworkConfiguration().getAwsvpcConfiguration().getSubnets());
+      attributes.put("securityGroups", service.getNetworkConfiguration().getAwsvpcConfiguration().getSecurityGroups());
+    }
+
     attributes.put("createdAt", service.getCreatedAt().getTime());
 
     return attributes;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -38,6 +38,7 @@ import com.netflix.spinnaker.clouddriver.ecs.model.EcsServerGroup;
 import com.netflix.spinnaker.clouddriver.ecs.model.EcsTask;
 import com.netflix.spinnaker.clouddriver.ecs.model.TaskDefinition;
 import com.netflix.spinnaker.clouddriver.ecs.services.ContainerInformationService;
+import com.netflix.spinnaker.clouddriver.ecs.services.SubnetSelector;
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider;
 import com.netflix.spinnaker.clouddriver.model.Instance;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
@@ -71,12 +72,14 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
   private final EcsCloudWatchAlarmCacheClient ecsCloudWatchAlarmCacheClient;
   private final AccountCredentialsProvider accountCredentialsProvider;
   private final ContainerInformationService containerInformationService;
+  private final SubnetSelector subnetSelector;
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   @Autowired
   public EcsServerClusterProvider(AccountCredentialsProvider accountCredentialsProvider,
                                   ContainerInformationService containerInformationService,
+                                  SubnetSelector subnetSelector,
                                   TaskCacheClient taskCacheClient,
                                   ServiceCacheClient serviceCacheClient,
                                   ScalableTargetCacheClient scalableTargetCacheClient,
@@ -85,6 +88,7 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
                                   EcsCloudWatchAlarmCacheClient ecsCloudWatchAlarmCacheClient) {
     this.accountCredentialsProvider = accountCredentialsProvider;
     this.containerInformationService = containerInformationService;
+    this.subnetSelector = subnetSelector;
     this.taskCacheClient = taskCacheClient;
     this.serviceCacheClient = serviceCacheClient;
     this.scalableTargetCacheClient = scalableTargetCacheClient;
@@ -139,7 +143,7 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
       EcsServerGroup ecsServerGroup = buildEcsServerGroup(credentials.getName(), awsRegion.getName(),
         serviceName, service.getDesiredCount(), instances, service.getCreatedAt(),
-        service.getClusterName(), taskDefinition);
+        service.getClusterName(), taskDefinition, service.getSubnets(), service.getSecurityGroups());
 
       if (ecsServerGroup == null) {
         continue;
@@ -233,7 +237,9 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
                                              Set<Instance> instances,
                                              long creationTime,
                                              String ecsCluster,
-                                             com.amazonaws.services.ecs.model.TaskDefinition taskDefinition) {
+                                             com.amazonaws.services.ecs.model.TaskDefinition taskDefinition,
+                                             List<String> eniSubnets,
+                                             List<String> eniSecurityGroups) {
     ServerGroup.InstanceCounts instanceCounts = buildInstanceCount(instances);
     TaskDefinition ecsTaskDefinition = buildTaskDefinition(taskDefinition);
 
@@ -246,19 +252,34 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
 
     ServerGroup.Capacity capacity = buildServerGroupCapacity(desiredCount, scalableTarget);
 
-    String vpcId = "None"; //ENI will change the way VPCs are handled.
+    String vpcId = "None";
     Set<String> securityGroups = new HashSet<>();
 
     if (!instances.isEmpty()) {
       String taskId = instances.iterator().next().getName();
       String taskKey = Keys.getTaskKey(account, region, taskId);
       Task task = taskCacheClient.get(taskKey);
+
       com.amazonaws.services.ec2.model.Instance ec2Instance = containerInformationService.getEc2Instance(account, region, task);
 
-      vpcId = ec2Instance.getVpcId();
-      securityGroups = ec2Instance.getSecurityGroups().stream()
-        .map(GroupIdentifier::getGroupId)
-        .collect(Collectors.toSet());
+      if (eniSubnets != null && !eniSubnets.isEmpty() && eniSecurityGroups != null && !eniSecurityGroups.isEmpty()) {
+        securityGroups = eniSecurityGroups.stream().collect(Collectors.toSet());
+
+        Collection<String> vpcIds = subnetSelector.getSubnetVpcIds(account, region, eniSubnets);
+
+        if (!vpcIds.isEmpty()) {
+          if (vpcIds.size() > 1) {
+            throw new IllegalArgumentException("Services with multiple VPCs are not supported");
+          }
+
+          vpcId = vpcIds.iterator().next();
+        }
+      } else if (ec2Instance != null) {
+        vpcId = ec2Instance.getVpcId();
+        securityGroups = ec2Instance.getSecurityGroups().stream()
+          .map(GroupIdentifier::getGroupId)
+          .collect(Collectors.toSet());
+      }
     }
 
 

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/CommonCachingAgent.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/CommonCachingAgent.java
@@ -62,6 +62,9 @@ public class CommonCachingAgent {
   static final String TASK_DEFINITION_ARN_1 = ECS_SERIVCE + "task-definition/hello_world:10";
   static final String TASK_DEFINITION_ARN_2 = ECS_SERIVCE + "task-definition/hello_world:20";
 
+  static final String SUBNET_ID_1 = "subnet-1234";
+  static final String SECURITY_GROUP_1 = "sg-1234";
+
   static final AmazonECS ecs = mock(AmazonECS.class);
   static final AmazonClientProvider clientProvider = mock(AmazonClientProvider.class);
   final ProviderCache providerCache = mock(ProviderCache.class);

--- a/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCacheTest.java
+++ b/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/ServiceCacheTest.java
@@ -16,14 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.provider.agent;
 
-import com.amazonaws.services.ecs.model.DeploymentConfiguration;
-import com.amazonaws.services.ecs.model.DescribeServicesRequest;
-import com.amazonaws.services.ecs.model.DescribeServicesResult;
-import com.amazonaws.services.ecs.model.ListClustersRequest;
-import com.amazonaws.services.ecs.model.ListClustersResult;
-import com.amazonaws.services.ecs.model.ListServicesRequest;
-import com.amazonaws.services.ecs.model.ListServicesResult;
-import com.amazonaws.services.ecs.model.Service;
+import com.amazonaws.services.ecs.model.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.cache.CacheData;
@@ -62,6 +55,9 @@ public class ServiceCacheTest extends CommonCachingAgent {
     service.setRoleArn(ROLE_ARN);
     service.setDeploymentConfiguration(new DeploymentConfiguration().withMinimumHealthyPercent(50).withMaximumPercent(100));
     service.setLoadBalancers(Collections.emptyList());
+    service.setNetworkConfiguration(new NetworkConfiguration().withAwsvpcConfiguration(
+      new AwsVpcConfiguration().withSecurityGroups(SECURITY_GROUP_1).withSubnets(SUBNET_ID_1)
+    ));
     service.setDesiredCount(1);
     service.setCreatedAt(new Date());
 
@@ -102,5 +98,11 @@ public class ServiceCacheTest extends CommonCachingAgent {
     Assert.assertTrue("Expected the created at of the service to be " + service.getCreatedAt().getTime() + " but got " + ecsService.getCreatedAt(), service.getCreatedAt().getTime() == ecsService.getCreatedAt());
     Assert.assertTrue("Expected the service to have 0 load balancer but got " + ecsService.getLoadBalancers().size(),
       ecsService.getLoadBalancers().size() == 0);
+    Assert.assertTrue("Expected the service to have 1 subnet but got " + ecsService.getSubnets().size(),ecsService.getSubnets().size() == 1);
+    assertTrue("Expected the service's subnet to be " + SUBNET_ID_1 + " but got " + ecsService.getSubnets().get(0),
+      SUBNET_ID_1.equals(ecsService.getSubnets().get(0)));
+    Assert.assertTrue("Expected the service to have 1 security group but got " + ecsService.getSecurityGroups().size(),ecsService.getSecurityGroups().size() == 1);
+    assertTrue("Expected the service's security group to be " + SECURITY_GROUP_1 + " but got " + ecsService.getSecurityGroups().get(0),
+      SECURITY_GROUP_1.equals(ecsService.getSecurityGroups().get(0)));
   }
 }


### PR DESCRIPTION
Since Fargate tasks don't have an EC2 instance, we need to display their VPC and security groups based on the service's network configuration.  Also applicable to ECS tasks on EC2 capacity, as their ENI security groups can be different from the underlying instance's security groups.