### PR TITLE
refactor(build): Depend on aws-sdk-s3 instead of the entire sdk

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -1,8 +1,6 @@
 dependencies {
   compile project(":clouddriver-core")
 
-  spinnaker.group('amazon')
-
   compile spinnaker.dependency("frigga")
   compile spinnaker.dependency("bootActuator")
   compile spinnaker.dependency("bootWeb")
@@ -10,4 +8,5 @@ dependencies {
 
   compile spinnaker.dependency("googleStorage")
   compile "org.apache.commons:commons-compress:1.14"
+  compile "com.amazonaws:aws-java-sdk-s3:${spinnaker.version("aws")}"
 }


### PR DESCRIPTION
For a modular cloud driver build, with say only the kubernetes provider, this reduces the number of JARs in `lib` from 326 to 185

Part of spinnaker/spinnaker#3114