### PR TITLE
fix(core): Front50 perf; separate normalized allow list method

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
@@ -48,15 +48,10 @@ public class ProjectClustersService {
   }
 
   public Map<String, List<ClusterModel>> getProjectClusters(List<String> projectNames) {
-    List<Map> projects = front50Service.searchForProjects(Collections.emptyMap(), 1000);
-
     Map<String, List<ProjectClustersService.ClusterModel>> projectClusters = new HashMap<>();
 
-    for (Map projectMap : projects) {
-      String projectName = (String) projectMap.getOrDefault("name", "UNKNOWN");
-      if (!projectNames.contains(projectName)) {
-        continue;
-      }
+    for (String projectName : projectNames) {
+      Map projectMap = front50Service.getProject(projectName);
 
       Project project;
       try {
@@ -68,6 +63,7 @@ public class ProjectClustersService {
 
       if (project.config.clusters.isEmpty()) {
         projectClusters.put(project.name, Collections.emptyList());
+        log.debug("Project '{}' does not have any clusters", projectName);
         continue;
       }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/agent/ProjectClustersCachingAgent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/agent/ProjectClustersCachingAgent.java
@@ -66,7 +66,7 @@ public class ProjectClustersCachingAgent implements CachingAgent, CustomSchedule
       Collections.singletonList(
         new MutableCacheData(
           "v1",
-          new HashMap<>(projectClustersService.getProjectClusters(properties.getAllowList())),
+          new HashMap<>(projectClustersService.getProjectClusters(properties.getNormalizedAllowList())),
           Collections.emptyMap()
         )
       )

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/config/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/config/CloudDriverConfig.groovy
@@ -83,7 +83,9 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.cglib.beans.BeanMap
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/config/ProjectClustersCachingAgentProperties.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/config/ProjectClustersCachingAgentProperties.java
@@ -31,13 +31,17 @@ public class ProjectClustersCachingAgentProperties {
   List<String> allowList = new ArrayList<>();
 
   public List<String> getAllowList() {
-    return allowList.stream()
-      .filter(p -> !Strings.isNullOrEmpty(p))
-      .map(String::toLowerCase)
-      .collect(Collectors.toList());
+    return allowList;
   }
 
   public void setAllowList(List<String> allowList) {
     this.allowList = allowList;
+  }
+
+  public List<String> getNormalizedAllowList() {
+    return allowList.stream()
+      .filter(p -> !Strings.isNullOrEmpty(p))
+      .map(String::toLowerCase)
+      .collect(Collectors.toList());
   }
 }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersServiceSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersServiceSpec.groovy
@@ -73,7 +73,7 @@ class ProjectClustersServiceSpec extends Specification {
 
     then:
     result["Spinnaker"].isEmpty()
-    1 * front50Service.searchForProjects(_, _) >> { [projectConfig] }
+    1 * front50Service.getProject(_) >> { projectConfig }
     0 * _
   }
 
@@ -107,7 +107,7 @@ class ProjectClustersServiceSpec extends Specification {
     clusters[0].applications[1].clusters[0].instanceCounts.down == 1
     clusters[0].applications[1].clusters[0].instanceCounts.up == 1
 
-    1 * front50Service.searchForProjects(_, _) >> { [projectConfig] }
+    1 * front50Service.getProject(_) >> { projectConfig }
     1 * clusterProvider.getClusterDetails("orca") >> [
       prod: [new TestCluster(
         name: "orca-main",
@@ -141,7 +141,7 @@ class ProjectClustersServiceSpec extends Specification {
     then:
     clusters.size() == 1
     clusters[0].applications.application == ["orca", "deck"]
-    1 * front50Service.searchForProjects(_, _) >> { [projectConfig] }
+    1 * front50Service.getProject(_) >> { projectConfig }
     1 * clusterProvider.getClusterDetails("orca") >> [
       prod: [new TestCluster(
         name: "orca-main",
@@ -175,7 +175,7 @@ class ProjectClustersServiceSpec extends Specification {
     then:
     clusters.size() == 1
     clusters[0].applications.application == ["deck"]
-    1 * front50Service.searchForProjects(_, _) >> { [projectConfig] }
+    1 * front50Service.getProject(_) >> { projectConfig }
     1 * clusterProvider.getClusterDetails("orca") >> [
       prod: [new TestCluster(
         name: "orca-main",
@@ -214,7 +214,7 @@ class ProjectClustersServiceSpec extends Specification {
     clusters[0].instanceCounts.up == 2
     clusters[0].instanceCounts.starting == 0
 
-    1 * front50Service.searchForProjects(_, _) >> { [projectConfig] }
+    1 * front50Service.getProject(_) >> { projectConfig }
     1 * clusterProvider.getClusterDetails("orca") >> [
       prod: [
         new TestCluster(
@@ -259,7 +259,7 @@ class ProjectClustersServiceSpec extends Specification {
     clusters[0].instanceCounts.total == 2
     clusters[0].instanceCounts.up == 2
 
-    1 * front50Service.searchForProjects(_, _) >> { [projectConfig] }
+    1 * front50Service.getProject(_) >> { projectConfig }
     1 * clusterProvider.getClusterDetails("orca") >> [
       prod: [
         new TestCluster(
@@ -291,7 +291,7 @@ class ProjectClustersServiceSpec extends Specification {
     clusters[0].instanceCounts.total == 1
     clusters[0].instanceCounts.up == 1
 
-    1 * front50Service.searchForProjects(_, _) >> { [projectConfig] }
+    1 * front50Service.getProject(_) >> { projectConfig }
     1 * clusterProvider.getClusterDetails("orca") >> [
       prod: [
         new TestCluster(
@@ -363,7 +363,7 @@ class ProjectClustersServiceSpec extends Specification {
     westCluster.instanceCounts.total == 3
     westCluster.instanceCounts.up == 3
 
-    1 * front50Service.searchForProjects(_, _) >> { [projectConfig] }
+    1 * front50Service.getProject(_) >> { projectConfig }
     1 * clusterProvider.getClusterDetails("orca") >> [
       prod: [
         new TestCluster(

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectController.groovy
@@ -51,7 +51,7 @@ class ProjectController {
 
   @RequestMapping(method= RequestMethod.GET, value = "/clusters")
   List<ClusterModel> getClusters(@PathVariable String project) {
-    if (projectClustersCachingAgentProperties.getAllowList().contains(project.toLowerCase())) {
+    if (projectClustersCachingAgentProperties.getNormalizedAllowList().contains(project.toLowerCase())) {
       CacheData cacheData = cacheView.get(Namespace.PROJECT_CLUSTERS.ns, "v1")
       if (cacheData == null) {
         throw new NotFoundException("Projects not cached")


### PR DESCRIPTION
* Moved to calling front50 for each individual project rather than everything, since we only cache a handful of projects.
* I didn't test the caching agent after normalizing the project names to lowercase, which broke things because I'm bad.