### PR TITLE
feat(provider/cf): Open Service Broker model and operations

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Domains.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Domains.java
@@ -30,6 +30,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -77,9 +78,8 @@ public class Domains {
     }
   }
 
-  @Nullable
-  public CloudFoundryDomain findByName(String domainName) throws CloudFoundryApiException {
-    return all().stream().filter(d -> d.getName().equals(domainName)).findFirst().orElse(null);
+  public Optional<CloudFoundryDomain> findByName(String domainName) throws CloudFoundryApiException {
+    return all().stream().filter(d -> d.getName().equals(domainName)).findFirst();
   }
 
   public List<CloudFoundryDomain> all() throws CloudFoundryApiException {

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ResourceNotFoundException.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ResourceNotFoundException.java
@@ -16,5 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client;
 
-class ResourceNotFoundException extends Exception {
+class ResourceNotFoundException extends RuntimeException {
+  ResourceNotFoundException(String message) {
+    super(message);
+  }
+
+  ResourceNotFoundException() {
+  }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
@@ -17,15 +17,24 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.api.ServiceInstanceService;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.CreateServiceBinding;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Resource;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstanceInfo;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.ErrorDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.*;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryServerGroup;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryService;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryServicePlan;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import lombok.RequiredArgsConstructor;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.collectPageResources;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.safelyCall;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
 @RequiredArgsConstructor
 public class ServiceInstances {
@@ -36,17 +45,115 @@ public class ServiceInstances {
       String spaceGuid = cloudFoundryServerGroup.getSpace().getId();
       String query = "name IN " + String.join(",", serviceNames);
 
-      List<Resource<ServiceInstanceInfo>> serviceInstances = collectPageResources("service instances", pg -> api.all(pg, spaceGuid, query));
+      List<Resource<ServiceInstance>> serviceInstances = collectPageResources("service instances", pg -> api.all(pg, spaceGuid, query));
 
       if (serviceInstances.size() != serviceNames.size()) {
-        throw new CloudFoundryApiException("Number of service instances does not match the number of service names.");
+        throw new CloudFoundryApiException("Number of service instances does not match the number of service names");
       }
 
-      for (Resource<ServiceInstanceInfo> serviceInstance : serviceInstances) {
+      for (Resource<ServiceInstance> serviceInstance : serviceInstances) {
         api.createServiceBinding(new CreateServiceBinding(
           serviceInstance.getMetadata().getGuid(),
           cloudFoundryServerGroup.getId()
         ));
+      }
+    }
+  }
+
+  private Resource<Service> findServiceByServiceName(String serviceName) {
+    List<Resource<Service>> services = collectPageResources("services by name",
+      pg -> api.findService(pg, singletonList("label:" + serviceName)));
+    return Optional.ofNullable(services.get(0)).orElse(null);
+  }
+
+  private List<CloudFoundryServicePlan> findAllServicePlansByServiceName(String serviceName) {
+    Resource<Service> service = findServiceByServiceName(serviceName);
+    List<Resource<ServicePlan>> services = collectPageResources("service plans by id",
+      pg -> api.findServicePlans(pg, singletonList("service_guid:" + service.getMetadata().getGuid())));
+
+    return services.stream()
+      .map(resource -> CloudFoundryServicePlan.builder()
+        .name(resource.getEntity().getName())
+        .id(resource.getMetadata().getGuid())
+        .build())
+      .collect(toList());
+  }
+
+  public List<CloudFoundryService> findAllServices() {
+    List<Resource<Service>> services = collectPageResources("all service", pg -> api.findService(pg, null));
+    return services.stream()
+      .map(serviceResource ->
+        CloudFoundryService.builder()
+          .name(serviceResource.getEntity().getLabel())
+          .servicePlans(findAllServicePlansByServiceName(serviceResource.getEntity().getLabel()))
+          .build())
+      .collect(toList());
+  }
+
+  private Resource<ServiceInstance> getServiceInstances(CloudFoundrySpace space, @Nullable String serviceInstanceName) throws CloudFoundryApiException {
+    List<String> queryParams = serviceInstanceName != null ? singletonList("name IN " + serviceInstanceName) : emptyList();
+    List<Resource<ServiceInstance>> services = collectPageResources("service instances by space and name",
+      pg -> api.findAllServiceInstancesBySpaceId(space.getId(), pg, queryParams));
+
+    if (services.isEmpty()) {
+      throw new CloudFoundryApiException("No services instances with name + '" + serviceInstanceName + "' found in space " + space.getName());
+    }
+
+    if (services.size() > 1 && serviceInstanceName != null) {
+      throw new CloudFoundryApiException(services.size() + " services instances found with name " +
+        serviceInstanceName + " in space " + space.getName() + ", but expected only 1");
+    }
+
+    return services.get(0);
+  }
+
+  public void deleteServiceInstance(CloudFoundrySpace space, String serviceInstanceName) throws CloudFoundryApiException {
+    Resource<ServiceInstance> serviceInstance = getServiceInstances(space, serviceInstanceName);
+    String serviceInstanceId = serviceInstance.getMetadata().getGuid();
+    List<Resource<ServiceBinding>> serviceBindings = collectPageResources("service bindings",
+      pg -> api.getBindingsForServiceInstance(serviceInstanceId, pg, null));
+
+    if (serviceBindings.isEmpty()) {
+      safelyCall(() -> api.deleteServiceInstance(serviceInstanceId));
+    } else {
+      throw new CloudFoundryApiException("Unable to delete service instance while " + serviceBindings.size() + " service binding(s) exist");
+    }
+  }
+
+  public void createServiceInstance(String newServiceInstanceName, String serviceName, String servicePlanName,
+                                    Set<String> tags, String parameters, CloudFoundrySpace space)
+    throws CloudFoundryApiException, ResourceNotFoundException {
+
+    List<CloudFoundryServicePlan> cloudFoundryServicePlans = findAllServicePlansByServiceName(serviceName);
+    if (cloudFoundryServicePlans.isEmpty()) {
+      throw new ResourceNotFoundException("No plans available for service name '" + serviceName + "'");
+    }
+
+    String servicePlanId = cloudFoundryServicePlans.stream()
+      .filter(plan -> plan.getName().equals(servicePlanName))
+      .findAny()
+      .orElseThrow(() -> new ResourceNotFoundException("Service '" + serviceName + "' does not have a matching plan '" + servicePlanName + "'"))
+      .getId();
+
+    CreateServiceInstance command = new CreateServiceInstance();
+    command.setName(newServiceInstanceName);
+    command.setSpaceGuid(space.getId());
+    command.setServicePlanGuid(servicePlanId);
+    command.setTags(tags);
+    command.setParameters(parameters);
+
+    try {
+      safelyCall(() -> api.createServiceInstance(command));
+    } catch (CloudFoundryApiException e) {
+      if (ErrorDescription.Code.SERVICE_ALREADY_EXISTS == e.getErrorCode()) {
+        Resource<ServiceInstance> serviceInstanceResource = getServiceInstances(space, newServiceInstanceName);
+        if (serviceInstanceResource.getEntity().getServicePlanGuid().equals(command.getServicePlanGuid())) {
+          safelyCall(() -> api.updateServiceInstance(serviceInstanceResource.getMetadata().getGuid(), command));
+        } else {
+          throw new CloudFoundryApiException("A service with name '" + serviceName + "' exists but has a different plan");
+        }
+      } else {
+        throw e;
       }
     }
   }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ApplicationService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ApplicationService.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.CreateApplication;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ApplicationEnv;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.InstanceStatus;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.MapRoute;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ServiceInstanceService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ServiceInstanceService.java
@@ -16,16 +16,37 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.CreateServiceBinding;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Page;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstanceInfo;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.*;
 import retrofit.client.Response;
 import retrofit.http.*;
 
+import java.util.List;
+
 public interface ServiceInstanceService {
   @GET("/v2/spaces/{guid}/service_instances")
-  Page<ServiceInstanceInfo> all(@Query("page") Integer page, @Path("guid") String spaceGuid, @Query("q") String queryParam);
+  Page<ServiceInstance> all(@Query("page") Integer page, @Path("guid") String spaceGuid, @Query("q") String queryParam);
 
   @POST("/v2/service_bindings?accepts_incomplete=true")
   Response createServiceBinding(@Body CreateServiceBinding body);
+
+  @GET("/v2/spaces/{guid}/service_instances")
+  Page<ServiceInstance> findAllServiceInstancesBySpaceId(@Path("guid") String spaceGuid, @Query("page") Integer page, @Query("q") List<String> queryParams);
+
+  @GET("/v2/services")
+  Page<Service> findService(@Query("page") Integer page, @Query("q") List<String> queryParams);
+
+  @GET("/v2/service_plans")
+  Page<ServicePlan> findServicePlans(@Query("page") Integer page, @Query("q") List<String> queryParams);
+
+  @POST("/v2/service_instances?accepts_incomplete=false")
+  Response createServiceInstance(@Body CreateServiceInstance body);
+
+  @PUT("/v2/service_instances/{guid}?accepts_incomplete=false")
+  Response updateServiceInstance(@Path("guid") String serviceInstanceGuid, @Body CreateServiceInstance body);
+
+  @GET("/v2/service_instances/{guid}/service_bindings")
+  Page<ServiceBinding> getBindingsForServiceInstance(@Path("guid") String serviceInstanceGuid, @Query("page") Integer page, @Query("q") List<String> queryParams);
+
+  @DELETE("/v2/service_instances/{guid}?accepts_incomplete=false")
+  Response deleteServiceInstance(@Path("guid") String serviceInstanceGuid);
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/ErrorDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/ErrorDescription.java
@@ -87,7 +87,8 @@ public class ErrorDescription {
     ROUTE_HOST_TAKEN("CF-RouteHostTaken"),
     ROUTE_PATH_TAKEN("CF-RoutePathTaken"),
     ROUTE_PORT_TAKEN("CF-RoutePortTaken"),
-    RESOURCE_NOT_FOUND("CF-ResourceNotFound");
+    RESOURCE_NOT_FOUND("CF-ResourceNotFound"),
+    SERVICE_ALREADY_EXISTS("60002");
 
     private final String code;
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/RouteId.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/RouteId.java
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
+
+import javax.annotation.Nullable;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
+public class RouteId {
+  private String host;
+  private String path;
 
-  private String spaceGuid;
+  @Nullable
+  private Integer port;
+
+  private String domainGuid;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ApplicationEnv.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ApplicationEnv.java
@@ -29,6 +29,6 @@ public class ApplicationEnv {
   @Data
   public static class SystemEnv {
     @JsonProperty("VCAP_SERVICES")
-    private Map<String, List<ServiceInstanceInfo>> vcapServices;
+    private Map<String, List<ServiceInstance>> vcapServices;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/CreateServiceInstance.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/CreateServiceInstance.java
@@ -16,20 +16,22 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
 
-@NoArgsConstructor
-@AllArgsConstructor
+import javax.annotation.Nullable;
+import java.util.Set;
+
 @Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateServiceInstance {
   private String spaceGuid;
+  private String name;
+  private String servicePlanGuid;
+
+  @Nullable
+  private Set<String> tags;
+
+  @Nullable
+  private String parameters;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/Service.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/Service.java
@@ -16,20 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
-  private String spaceGuid;
+public class Service {
+  private String label;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ServiceBinding.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ServiceBinding.java
@@ -16,20 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
-  private String spaceGuid;
+public class ServiceBinding {
+  private String appGuid;
+  private String serviceInstanceGuid;
+  private String name;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ServiceInstance.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ServiceInstance.java
@@ -16,20 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
-  private String spaceGuid;
+public class ServiceInstance {
+  private String name;
+  private String plan;
+  private String servicePlanGuid;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ServicePlan.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ServicePlan.java
@@ -16,20 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
-  private String spaceGuid;
+public class ServicePlan {
+  private String id;
+  private String name;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/controller/ServiceBrokerController.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/controller/ServiceBrokerController.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.controller;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker.Service;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker.ServiceProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collection;
+
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/servicebroker")
+public class ServiceBrokerController {
+  private final Collection<ServiceProvider> serviceProviders;
+
+  @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
+  @GetMapping("/{account}/services")
+  public Collection<Service> listServices(@RequestParam(value = "cloudProvider") String cloudProvider,
+                                          @PathVariable String account) {
+    return serviceProviders.stream()
+      .filter(serviceProvider -> serviceProvider.getCloudProvider().equals(cloudProvider))
+      .flatMap(serviceProvider -> serviceProvider.getServices(account).stream())
+      .sorted(comparing(Service::getName))
+      .collect(toList());
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceAtomicOperationConverter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeleteCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeleteCloudFoundryServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@CloudFoundryOperation(AtomicOperations.DELETE_SERVICE)
+@Component
+public class DeleteCloudFoundryServiceAtomicOperationConverter extends AbstractCloudFoundryAtomicOperationConverter {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new DeleteCloudFoundryServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public DeleteCloudFoundryServiceDescription convertDescription(Map input) {
+    DeleteCloudFoundryServiceDescription converted =  getObjectMapper().convertValue(input,DeleteCloudFoundryServiceDescription.class);
+    converted.setClient(getClient(input));
+    converted.setSpace(findSpace(converted.getRegion(), converted.getClient())
+      .orElseThrow(() -> new IllegalArgumentException("Unable to find space '" + converted.getRegion() + "'.")));
+    return converted;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.artifacts.gcs.GcsArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.artifacts.http.HttpArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryOperation;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.artifacts.PackageArtifactCredentials;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeployCloudFoundryServerGroupAtomicOperation;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.provider.view.CloudFoundryClusterProvider;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeployCloudFoundryServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@CloudFoundryOperation(AtomicOperations.DEPLOY_SERVICE)
+@Component
+public class DeployCloudFoundryServiceAtomicOperationConverter extends AbstractCloudFoundryAtomicOperationConverter {
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new DeployCloudFoundryServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public DeployCloudFoundryServiceDescription convertDescription(Map input) {
+    DeployCloudFoundryServiceDescription converted = getObjectMapper().convertValue(input, DeployCloudFoundryServiceDescription.class);
+    converted.setClient(getClient(input));
+    converted.setSpace(findSpace(converted.getRegion(), converted.getClient())
+      .orElseThrow(() -> new IllegalArgumentException("Unable to find space '" + converted.getRegion() + "'.")));
+    return converted;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/TerminateCloudFoundryInstancesAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/TerminateCloudFoundryInstancesAtomicOperationConverter.java
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.Termina
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.TerminateCloudFoundryInstancesAtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
-import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/AbstractCloudFoundryDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/AbstractCloudFoundryDescription.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
 import lombok.Data;
 
 @Data

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/AbstractCloudFoundryLoadBalancerDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/AbstractCloudFoundryLoadBalancerDescription.java
@@ -18,8 +18,10 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public abstract class AbstractCloudFoundryLoadBalancerDescription extends AbstractCloudFoundryDescription {
   CloudFoundrySpace space;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeleteCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeleteCloudFoundryServiceDescription.java
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
+import lombok.EqualsAndHashCode;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
-  private String spaceGuid;
+@EqualsAndHashCode(callSuper = true)
+public class DeleteCloudFoundryServiceDescription extends AbstractCloudFoundryDescription {
+  String serviceName;
+  CloudFoundrySpace space;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServiceDescription.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
+import lombok.EqualsAndHashCode;
 
-@NoArgsConstructor
-@AllArgsConstructor
+import java.util.Set;
+
 @Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
-  private String spaceGuid;
+@EqualsAndHashCode(callSuper = true)
+public class DeployCloudFoundryServiceDescription extends DeleteCloudFoundryServiceDescription {
+  String service;
+  String servicePlan;
+  Set<String> tags;
+  String parameters;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeleteCloudFoundryServiceAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeleteCloudFoundryServiceAtomicOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeleteCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class DeleteCloudFoundryServiceAtomicOperation implements AtomicOperation<Void> {
+  private static final String PHASE = "DELETE_SERVICE";
+  private final DeleteCloudFoundryServiceDescription description;
+
+  private static Task getTask() {
+    return TaskRepository.threadLocalTask.get();
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+    Task task = getTask();
+    task.updateStatus(PHASE, "Initializing the removal of service instance '" + description.getServiceName() + "' from space " + description.getSpace().getName());
+    description.getClient()
+      .getServiceInstances()
+      .deleteServiceInstance(description.getSpace(), description.getServiceName());
+    task.updateStatus(PHASE, "Done removing service instance '" + description.getServiceName() + "'");
+    return null;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class DeployCloudFoundryServiceAtomicOperation implements AtomicOperation<Void> {
+  private static final String PHASE = "DEPLOY_SERVICE";
+  private final DeployCloudFoundryServiceDescription description;
+
+  private static Task getTask() {
+    return TaskRepository.threadLocalTask.get();
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+    Task task = getTask();
+    task.updateStatus(PHASE, "Creating service instance '" + description.getServiceName() + "' from service " + description.getService() + " and service plan " + description.getServicePlan());
+    description
+      .getClient()
+      .getServiceInstances()
+      .createServiceInstance(description.getServiceName(),
+        description.getService(),
+        description.getServicePlan(),
+        description.getTags(),
+        description.getParameters(),
+        description.getSpace());
+    task.updateStatus(PHASE, "Created service instance '" + description.getServiceName() + "'");
+    return null;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UpsertCloudFoundryLoadBalancerAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UpsertCloudFoundryLoadBalancerAtomicOperation.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.UpsertCloudFoundryLoadBalancerDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryLoadBalancer;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
@@ -40,8 +41,8 @@ public class UpsertCloudFoundryLoadBalancerAtomicOperation implements AtomicOper
     getTask().updateStatus(PHASE, "Creating load balancer in '" + description.getRegion() + "'");
 
     CloudFoundryClient client = description.getClient();
-    CloudFoundryLoadBalancer loadBalancer = client.getRoutes().createRoute(description.getHost(), description.getPath(),
-      description.getPort(), description.getDomain().getId(), description.getSpace().getId());
+    CloudFoundryLoadBalancer loadBalancer = client.getRoutes().createRoute(new RouteId(description.getHost(), description.getPath(), description.getPort(), description.getDomain().getId()),
+      description.getSpace().getId());
 
     if (loadBalancer != null) {
       getTask().updateStatus(PHASE, "Done creating load balancer");

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryService.java
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker.Service;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
+import java.util.Collection;
 
-  private String spaceGuid;
+@Value
+@EqualsAndHashCode(callSuper = false)
+@Builder
+@JsonDeserialize(builder = CloudFoundryService.CloudFoundryServiceBuilder.class)
+public class CloudFoundryService extends CloudFoundryModel implements Service {
+  String name;
+  Collection<CloudFoundryServicePlan> servicePlans;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServicePlan.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServicePlan.java
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker.ServicePlan;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
-  private String spaceGuid;
+@Value
+@EqualsAndHashCode(callSuper = false)
+@Builder
+@JsonDeserialize(builder = CloudFoundryServicePlan.CloudFoundryServicePlanBuilder.class)
+public class CloudFoundryServicePlan extends CloudFoundryModel implements ServicePlan {
+  String name;
+  String id;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/view/CloudFoundryServiceProvider.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/view/CloudFoundryServiceProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.provider.view;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryService;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker.ServiceProvider;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Component
+public class CloudFoundryServiceProvider implements ServiceProvider {
+  final private AccountCredentialsProvider accountCredentialsProvider;
+
+  @Autowired
+  public CloudFoundryServiceProvider(AccountCredentialsProvider accountCredentialsProvider) {
+    this.accountCredentialsProvider = accountCredentialsProvider;
+  }
+
+  @Override
+  public Collection<CloudFoundryService> getServices(String account) {
+    CloudFoundryCredentials credentials = (CloudFoundryCredentials) accountCredentialsProvider.getCredentials(account);
+    return credentials
+      .getCredentials()
+      .getServiceInstances()
+      .findAllServices();
+  }
+
+  @Override
+  public String getCloudProvider() {
+    return CloudFoundryCloudProvider.ID;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/servicebroker/AtomicOperations.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/servicebroker/AtomicOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
-
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
-
-  private String spaceGuid;
+public class AtomicOperations {
+  public static final String DEPLOY_SERVICE = "deployService";
+  public static final String DELETE_SERVICE = "deleteService";
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/servicebroker/Service.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/servicebroker/Service.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
+import java.util.Collection;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
+public interface Service {
+  String getName();
 
-  private String spaceGuid;
+  Collection<? extends ServicePlan> getServicePlans();
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/servicebroker/ServicePlan.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/servicebroker/ServicePlan.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker;
 
-import lombok.Data;
-
-@Data
-public class ServiceInstanceInfo {
-  private String name;
-  private String plan;
+public interface ServicePlan {
+  String getName();
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/servicebroker/ServiceProvider.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/servicebroker/ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.servicebroker;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.Delegate;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-public class Route {
-  @JsonIgnore
-  @Delegate
-  private RouteId routeId = new RouteId();
+import java.util.Collection;
 
-  private String spaceGuid;
+public interface ServiceProvider {
+  String getCloudProvider();
+
+  Collection<? extends Service> getServices(String account);
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/RouteTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/RouteTest.java
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RouteTest {
+  @Test
+  void routeSerialization() throws IOException {
+    RouteId routeId = new RouteId("host", "path", 8080, "domainId");
+    Route route = new Route(routeId, "spaceId");
+
+    String routeSerialized = new ObjectMapper()
+      .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+      .writeValueAsString(route);
+    assertThat(routeSerialized).isEqualTo("{\"domainGuid\":\"domainId\",\"host\":\"host\",\"path\":\"path\",\"port\":8080,\"spaceGuid\":\"spaceId\"}");
+    assertThat(new ObjectMapper().readValue(routeSerialized, Route.class).getRouteId()).isEqualTo(routeId);
+  }
+}


### PR DESCRIPTION
This contains the necessary operations to support deploy and delete Open Service Broker service stages. Aside from Cloud Foundry, Kubernetes also provides a service catalog that presents an aggregate view of Open Service Broker services and allows for deploying, deleting, and binding those services.

More detail on our reasoning around OSB service provisioning [here](https://docs.google.com/document/d/1cEkB2SdgrUNg1biNjHPd5H0WNv9IJSt1IDfSu4mKfc0/edit?usp=sharing).