### PR TITLE
refactor(google): Remove Task as a paramter for Retry

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/AppengineSafeRetry.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/AppengineSafeRetry.groovy
@@ -44,10 +44,10 @@ class AppengineSafeRetry extends GoogleCommonSafeRetry {
                         List<Integer> successfulErrorCodes,
                         Map tags,
                         Registry registry) {
+    task?.updateStatus tags.phase, "Attempting $tags.action of $resource..."
     return super.doRetry(
       operation,
       resource,
-      task,
       retryCodes,
       successfulErrorCodes,
       maxWaitInterval,

--- a/clouddriver-google-common/clouddriver-google-common.gradle
+++ b/clouddriver-google-common/clouddriver-google-common.gradle
@@ -1,4 +1,5 @@
 dependencies {
-  compile project(":clouddriver-core")
   spinnaker.group('google')
+  spinnaker.group('fiat')
+  compile spinnaker.dependency('spectatorApi')
 }

--- a/clouddriver-google-common/src/test/groovy/com/netflix/spinnaker/clouddriver/googlecommon/deploy/GoogleCommonSafeRetrySpec.groovy
+++ b/clouddriver-google-common/src/test/groovy/com/netflix/spinnaker/clouddriver/googlecommon/deploy/GoogleCommonSafeRetrySpec.groovy
@@ -24,7 +24,6 @@ import com.google.api.client.testing.json.MockJsonFactory
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.clouddriver.data.task.Task
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -71,7 +70,7 @@ class GoogleCommonSafeRetrySpec extends Specification {
 
     when:
       Object result = retrier.doRetry(
-            mockClosure, "resource", Mock(Task),
+            mockClosure, "resource",
             Arrays.asList(500), Arrays.asList(404),
             new Long(-1), new Long(-1), new Long(-1), new Long(maxRetries),
             ImmutableMap.of("action", "test"), registry)
@@ -88,7 +87,7 @@ class GoogleCommonSafeRetrySpec extends Specification {
 
     when:
       Object result = retrier.doRetry(
-            mockClosure, "resource", Mock(Task),
+            mockClosure, "resource",
             Arrays.asList(500), Arrays.asList(404),
             new Long(-1), new Long(-1), new Long(-1), new Long(maxRetries),
             ImmutableMap.of("action", "test"), registry)
@@ -112,7 +111,7 @@ class GoogleCommonSafeRetrySpec extends Specification {
 
     when:
       Object result = retrier.doRetry(
-            mockClosure, "resource", Mock(Task),
+            mockClosure, "resource",
             Arrays.asList(500), Arrays.asList(404),
             new Long(-1), new Long(-1), new Long(-1), new Long(maxAttempts),
             ImmutableMap.of("action", "test"), registry)
@@ -137,7 +136,7 @@ class GoogleCommonSafeRetrySpec extends Specification {
 
     when:
       Object result = retrier.doRetry(
-            mockClosure, "resource", Mock(Task),
+            mockClosure, "resource",
             Arrays.asList(500), Arrays.asList(404),
             new Long(-1), new Long(-1), new Long(-1), new Long(maxRetries),
             ImmutableMap.of("action", "test"), registry)
@@ -162,7 +161,7 @@ class GoogleCommonSafeRetrySpec extends Specification {
 
     when:
       Object result = retrier.doRetry(
-            mockClosure, "resource", Mock(Task),
+            mockClosure, "resource",
             Arrays.asList(500), null,
             new Long(-1), new Long(-1), new Long(-1), new Long(maxRetries),
             ImmutableMap.of("action", "test"), registry)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/SafeRetry.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/SafeRetry.groovy
@@ -48,9 +48,9 @@ class SafeRetry extends GoogleCommonSafeRetry {
                         List<Integer> successfulErrorCodes,
                         Map tags,
                         Registry registry) {
+    task?.updateStatus tags.phase, "Attempting $tags.action of $resource..."
     return super.doRetry(operation,
                          resource,
-                         task,
                          retryCodes,
                          successfulErrorCodes,
                          maxWaitInterval,


### PR DESCRIPTION
Allows use to remove the dependency on `clouddriver-core`. This is mainly useful because Front50 also depends on `clouddriver-google-common` and thereby indirectly on all of clouddriver-core and every dependency it brings in. 

The only class from `clouddriver-core` that is used here is the `data.task.Task` class. I've moved the only usage of the Task class from the abstract class that is shared with Front50 to the 2 classes that implement the abstract `GoogleCommonSafeRetry` class in clouddriver. Currently, in Front50 we simply pass in `null` for the task parameter.