### PR TITLE
fix(provider/gce): Filter instance caching by location. (#2991)

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -423,7 +423,8 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
       DistributionPolicy distributionPolicy = instanceGroupManager?.getDistributionPolicy()
       // The distribution policy zones are URLs.
       List<String> zones = distributionPolicy?.getZones()?.collect { Utils.getLocalName(it.getZone()) }
-      List<GoogleInstance> groupInstances = instances.findAll { it.getName().startsWith(instanceGroupManager.getBaseInstanceName()) }
+
+      List<GoogleInstance> groupInstances = instances.findAll { it.getName().startsWith(instanceGroupManager.getBaseInstanceName()) && it.getRegion() == region }
 
       Map<String, Integer> namedPorts = [:]
       instanceGroupManager.namedPorts.each { namedPorts[(it.name)] = it.port }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
@@ -462,7 +462,7 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
 
     GoogleServerGroup buildServerGroupFromInstanceGroupManager(InstanceGroupManager instanceGroupManager, List<GoogleInstance> instances) {
       String zone = Utils.getLocalName(instanceGroupManager.zone)
-      List<GoogleInstance> groupInstances = instances.findAll { it.getName().startsWith(instanceGroupManager.getBaseInstanceName()) }
+      List<GoogleInstance> groupInstances = instances.findAll { it.getName().startsWith(instanceGroupManager.getBaseInstanceName()) && it.getZone() == zone }
 
       Map<String, Integer> namedPorts = [:]
       instanceGroupManager.namedPorts.each { namedPorts[(it.name)] = it.port }


### PR DESCRIPTION
Previously we were including all instances in all locations of a given
server group in each server group written to the cache.

Cherry pick of https://github.com/spinnaker/clouddriver/pull/2991.