### PR TITLE
fix(config): Move core config to clouddriver.config package

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.config
+package com.netflix.spinnaker.clouddriver.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation
@@ -79,13 +79,10 @@ import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvi
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.cglib.beans.BeanMap
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/DeployConfiguration.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/DeployConfiguration.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.config
+package com.netflix.spinnaker.clouddriver.config
 
 import com.netflix.spinnaker.clouddriver.data.task.InMemoryTaskRepository
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/LocalJobConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/LocalJobConfig.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.config
+package com.netflix.spinnaker.clouddriver.config
 
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutor
 import com.netflix.spinnaker.clouddriver.jobs.local.JobExecutorLocal

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/ProjectClustersCachingAgentProperties.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/ProjectClustersCachingAgentProperties.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.config;
+package com.netflix.spinnaker.clouddriver.config;
 
 import com.google.common.base.Strings;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/RetrofitConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/RetrofitConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2018 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.config
+package com.netflix.spinnaker.clouddriver.config
 
 import com.netflix.spinnaker.clouddriver.core.Front50ConfigurationProperties
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.config.OkHttpClientConfiguration
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/agent/ProjectClustersCachingAgent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/agent/ProjectClustersCachingAgent.java
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent;
 import com.netflix.spinnaker.clouddriver.core.ProjectClustersService;
 import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider;
-import com.netflix.spinnaker.config.ProjectClustersCachingAgentProperties;
+import com.netflix.spinnaker.clouddriver.config.ProjectClustersCachingAgentProperties;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -37,6 +37,7 @@ import java.security.Security
 ])
 @ComponentScan([
   'com.netflix.spinnaker.config',
+  'com.netflix.spinnaker.clouddriver.config'
 ])
 @EnableAutoConfiguration(exclude = [
     BatchAutoConfiguration,

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ProjectController.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.clouddriver.core.ProjectClustersService
 import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
-import com.netflix.spinnaker.config.ProjectClustersCachingAgentProperties
+import com.netflix.spinnaker.clouddriver.config.ProjectClustersCachingAgentProperties
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
We need to keep clouddriver specifc Config classes in a clouddriver scoped package. Otherwise when other services depend on clouddriver libraries AND scan the `common com.netflix.spinnaker.config` package, we could end up with conflicting beans.