### PR TITLE
feat(sql): Add SqlTaskRepository

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/DualTaskRepositoryConfiguration.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/DualTaskRepositoryConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.core;
+
+import com.netflix.spinnaker.clouddriver.data.task.DualTaskRepository;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.List;
+
+@Configuration
+@ConditionalOnExpression("${dualTaskRepository.enabled:false}")
+public class DualTaskRepositoryConfiguration {
+
+  @Primary
+  @Bean
+  TaskRepository taskRepository(
+    @Value("dualTaskRepository.primaryClass") String primaryClass,
+    @Value("dualTaskRepository.previousClass") String previousClass,
+    List<TaskRepository> allRepositories
+  ) {
+    return new DualTaskRepository(primaryClass, previousClass, allRepositories);
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfig.groovy
@@ -47,6 +47,7 @@ class RedisConfig {
   }
 
   @Bean
+  @ConditionalOnExpression('${redis.taskRepository.enabled:true}')
   TaskRepository taskRepository(RedisClientDelegate redisClientDelegate, Optional<RedisClientDelegate> redisClientDelegatePrevious) {
     new RedisTaskRepository(redisClientDelegate, redisClientDelegatePrevious)
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepository.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepository.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.data.task;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+public class DualTaskRepository implements TaskRepository {
+
+  private final static Logger log = LoggerFactory.getLogger(DualTaskRepository.class);
+
+  private final TaskRepository primary;
+  private final TaskRepository previous;
+
+  public DualTaskRepository(String primaryClass,
+                            String previousClass,
+                            List<TaskRepository> allRepositories) {
+    allRepositories.forEach(r -> log.info("Available TaskRepository: {}", r.getClass().getSimpleName()));
+
+    primary = findTaskRepositoryByClass(primaryClass, allRepositories);
+    previous = findTaskRepositoryByClass(previousClass, allRepositories);
+
+    log.info(
+      "Selected primary: {}, previous: {}",
+      primary.getClass().getSimpleName(),
+      previous.getClass().getSimpleName()
+    );
+  }
+
+  private static TaskRepository findTaskRepositoryByClass(String className, List<TaskRepository> allRepositories) {
+    Class<?> repositoryClass;
+    try {
+      repositoryClass = Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(format("No class found for %s", className), e);
+    }
+    return allRepositories.stream()
+      .filter(repositoryClass::isInstance)
+      .findFirst()
+      .orElseThrow(() -> new IllegalStateException(format("No TaskRepository bean of class %s found", className)));
+  }
+
+  @Override
+  public Task create(String phase, String status) {
+    return primary.create(phase, status);
+  }
+
+  @Override
+  public Task create(String phase, String status, String clientRequestId) {
+    return primary.create(phase, status, clientRequestId);
+  }
+
+  @Override
+  public Task get(String id) {
+    return Optional.ofNullable(primary.get(id)).orElse(previous.get(id));
+  }
+
+  @Override
+  public Task getByClientRequestId(String clientRequestId) {
+    return Optional
+      .ofNullable(primary.getByClientRequestId(clientRequestId))
+      .orElse(previous.getByClientRequestId(clientRequestId));
+  }
+
+  @Override
+  public List<Task> list() {
+    List<Task> tasks = primary.list();
+    tasks.addAll(previous.list());
+    return tasks;
+  }
+
+  @Override
+  public List<Task> listByThisInstance() {
+    return primary.listByThisInstance();
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/InMemoryTaskRepository.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/InMemoryTaskRepository.groovy
@@ -16,11 +16,19 @@
 
 package com.netflix.spinnaker.clouddriver.data.task
 
+import groovy.util.logging.Slf4j
+
 import java.util.concurrent.ConcurrentHashMap
 
+@Slf4j
 class InMemoryTaskRepository implements TaskRepository {
+
   private final Map<String, Task> repository = new ConcurrentHashMap<>()
   private final Map<String, Task> clientRequestRepository = new ConcurrentHashMap<>()
+
+  InMemoryTaskRepository() {
+    log.info("Using ${getClass().simpleName}")
+  }
 
   @Override
   Task create(String phase, String status, String clientRequestId) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/RedisTaskRepository.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/RedisTaskRepository.java
@@ -69,6 +69,8 @@ public class RedisTaskRepository implements TaskRepository {
   public RedisTaskRepository(RedisClientDelegate redisClientDelegate, Optional<RedisClientDelegate> redisClientDelegatePrevious) {
     this.redisClientDelegate = redisClientDelegate;
     this.redisClientDelegatePrevious = redisClientDelegatePrevious;
+
+    log.info("Using {}", RedisTaskRepository.class.getSimpleName());
   }
 
   @Override

--- a/clouddriver-sql/clouddriver-sql.gradle
+++ b/clouddriver-sql/clouddriver-sql.gradle
@@ -14,22 +14,16 @@
  * limitations under the License.
  */
 
-apply plugin: "nebula.kotlin"
-apply plugin: "kotlin-spring"
+apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "$rootDir/gradle/spek.gradle"
 
-configurations.all {
-  resolutionStrategy {
-    eachDependency { details ->
-      if (details.requested.group == "org.jetbrains.kotlin") {
-        details.useVersion kotlinVersion
-      }
-    }
-  }
-}
+dependencies {
+  compile project(":clouddriver-core")
+  compile spinnaker.dependency("korkSql")
+  compile spinnaker.dependency("ulid")
 
-compileKotlin {
-  kotlinOptions {
-    languageVersion = "1.2"
-    jvmTarget = "1.8"
-  }
+  runtime "mysql:mysql-connector-java:8.0.12"
+
+  testCompile project(":clouddriver-core-tck")
+  testCompile spinnaker.dependency("korkSqlTest")
 }

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlProvider.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlProvider.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.cats.agent.AgentSchedulerAware
+import com.netflix.spinnaker.cats.provider.Provider
+
+class SqlProvider(
+  private val agents: MutableList<Agent>
+) : AgentSchedulerAware(), Provider {
+  override fun getProviderName(): String = javaClass.name
+  override fun getAgents(): MutableCollection<Agent> = agents
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.netflix.spinnaker.clouddriver.data.task.Status
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskDisplayStatus
+import com.netflix.spinnaker.clouddriver.data.task.TaskState
+import org.slf4j.LoggerFactory
+
+class SqlTask(
+  private val id: String,
+  internal val ownerId: String,
+  internal val requestId: String,
+  internal val startTimeMs: Long,
+  private val repository: SqlTaskRepository
+) : Task {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(SqlTask::class.java)
+  }
+
+  override fun getId() = id
+  override fun getOwnerId() = ownerId
+  override fun getStartTimeMs() = startTimeMs
+
+  override fun getResultObjects() = repository.getResultObjects(this)
+
+  override fun addResultObjects(results: MutableList<Any>) {
+    if (results.isEmpty()) {
+      return
+    }
+    repository.addResultObjects(results, this)
+  }
+
+  override fun getHistory(): List<Status> {
+    val status = repository.getHistory(this).map { TaskDisplayStatus(it) }
+    return if (status.isNotEmpty() && status.last().isCompleted) {
+      status.subList(0, status.size - 1)
+    } else {
+      status
+    }
+  }
+
+  override fun updateStatus(phase: String, status: String) {
+    repository.updateCurrentStatus(this, phase, status)
+    log.debug("Updated status: phase={} status={}", phase, status)
+  }
+
+  override fun complete() {
+    repository.updateState(this, TaskState.COMPLETED)
+  }
+
+  override fun fail() {
+    repository.updateState(this, TaskState.FAILED)
+  }
+
+  override fun getStatus(): Status? {
+    return repository.currentState(this)
+  }
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskCleanupAgent.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskCleanupAgent.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.RunnableAgent
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
+import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
+import com.netflix.spinnaker.clouddriver.data.task.TaskState.COMPLETED
+import com.netflix.spinnaker.clouddriver.data.task.TaskState.FAILED
+import com.netflix.spinnaker.config.SqlTaskCleanupAgentProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import org.jooq.DSLContext
+import org.jooq.impl.DSL.field
+import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.util.Arrays
+import java.util.concurrent.TimeUnit
+
+/**
+ * Cleans up completed Tasks after a configurable TTL.
+ */
+class SqlTaskCleanupAgent(
+  private val jooq: DSLContext,
+  private val clock: Clock,
+  private val registry: Registry,
+  private val properties: SqlTaskCleanupAgentProperties,
+  private val sqlRetryProperties: SqlRetryProperties
+) : RunnableAgent, CustomScheduledAgent {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  private val deletedId = registry.createId("sql.taskCleanupAgent.deleted")
+  private val timingId = registry.createId("sql.taskCleanupAgent.timing")
+
+  override fun run() {
+    val candidates = jooq.withRetry(sqlRetryProperties.reads) {
+      val candidates = it.select(field("id"), field("task_id"))
+        .from(taskStatesTable)
+        .where(
+          field("state").`in`(COMPLETED.toString(), FAILED.toString())
+            .and(field("created_at").greaterOrEqual(
+              clock.instant().minusMillis(properties.completedTtlMs).toEpochMilli())
+            )
+        )
+        .fetch()
+
+      val candidateTaskIds = candidates.map { r -> r.field("task_id").getValue(r) }.filterNotNull().toTypedArray()
+      val candidateTaskStateIds = candidates.map { r -> r.field("id").getValue(r) }.filterNotNull().toTypedArray()
+
+      val candidateResultIds = it.select(field("id"))
+        .from(taskResultsTable)
+        .where(field("task_id").`in`(candidateTaskIds))
+        .fetch("id")
+        .filterNotNull()
+        .toTypedArray()
+
+      CleanupCandidateIds(
+        taskIds = candidateTaskIds,
+        stateIds = candidateTaskStateIds,
+        resultIds = candidateResultIds
+      )
+    }
+
+    if (candidates.hasAny()) {
+      log.info(
+        "Cleaning up {} completed tasks ({} states, {} result objects)",
+        candidates.taskIds.size,
+        candidates.stateIds.size,
+        candidates.resultIds.size
+      )
+
+      registry.timer(timingId).record {
+        jooq.transactional(sqlRetryProperties.transactions) {
+          jooq.deleteFrom(taskResultsTable).where(field("id").`in`(candidates.resultIds))
+          jooq.deleteFrom(taskStatesTable).where(field("id").`in`(candidates.stateIds))
+          jooq.deleteFrom(tasksTable).where(field("id").`in`(candidates.taskIds))
+        }
+      }
+      registry.counter(deletedId).increment(candidates.taskIds.size.toLong())
+    }
+  }
+
+  override fun getAgentType(): String = javaClass.simpleName
+  override fun getProviderName(): String = CoreProvider.PROVIDER_NAME
+  override fun getPollIntervalMillis(): Long = DEFAULT_POLL_INTERVAL_MILLIS
+  override fun getTimeoutMillis(): Long = DEFAULT_TIMEOUT_MILLIS
+
+  companion object {
+    private val DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(5)
+    private val DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(3)
+  }
+}
+
+private data class CleanupCandidateIds(
+  val taskIds: Array<Any>,
+  val stateIds: Array<Any>,
+  val resultIds: Array<Any>
+) {
+  fun hasAny() = taskIds.isNotEmpty()
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as CleanupCandidateIds
+
+    if (!Arrays.equals(taskIds, other.taskIds)) return false
+    if (!Arrays.equals(stateIds, other.stateIds)) return false
+    if (!Arrays.equals(resultIds, other.resultIds)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = Arrays.hashCode(taskIds)
+    result = 31 * result + Arrays.hashCode(stateIds)
+    result = 31 * result + Arrays.hashCode(resultIds)
+    return result
+  }
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.core.ClouddriverHostname
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
+import com.netflix.spinnaker.clouddriver.data.task.Status
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.data.task.TaskState
+import com.netflix.spinnaker.clouddriver.data.task.TaskState.FAILED
+import com.netflix.spinnaker.clouddriver.data.task.TaskState.STARTED
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import de.huxhorn.sulky.ulid.ULID
+import org.jooq.DSLContext
+import org.jooq.Record
+import org.jooq.Select
+import org.jooq.impl.DSL
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.sql
+import org.slf4j.LoggerFactory
+import java.time.Clock
+
+class SqlTaskRepository(
+  private val jooq: DSLContext,
+  private val mapper: ObjectMapper,
+  private val clock: Clock,
+  private val sqlRetryProperties: SqlRetryProperties
+) : TaskRepository {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  init {
+    log.info("Using ${javaClass.simpleName}")
+  }
+
+  override fun create(phase: String, status: String): Task {
+    return create(phase, status, ulid.nextULID())
+  }
+
+  override fun create(phase: String, status: String, clientRequestId: String): Task {
+    var task = SqlTask(ulid.nextULID(), ClouddriverHostname.ID, clientRequestId, clock.millis(), this)
+    val historyId = ulid.nextULID()
+
+    jooq.transactional(sqlRetryProperties.transactions) { ctx ->
+      val existingTask = findByRequestId(clientRequestId)
+      if (existingTask != null) {
+        task = existingTask as SqlTask
+        addToHistory(ctx, historyId, existingTask.id, FAILED, phase, "Duplicate of $clientRequestId")
+      } else {
+        val pairs = mapOf(
+          field("id") to task.id,
+          field("owner_id") to task.ownerId,
+          field("request_id") to task.requestId,
+          field("created_at") to task.startTimeMs
+        )
+
+        ctx.insertInto(tasksTable, *pairs.keys.toTypedArray()).values(*pairs.values.toTypedArray()).execute()
+        addToHistory(ctx, historyId, task.id, STARTED, phase, status)
+      }
+    }
+
+    return task
+  }
+
+  override fun get(id: String): Task? {
+    return jooq.withRetry(sqlRetryProperties.reads) {
+      it.select(tasksFields)
+        .from(tasksTable)
+        .where(field("id").eq(id))
+        .fetchTask()
+    }
+  }
+
+  override fun getByClientRequestId(clientRequestId: String): Task? {
+    return jooq.withRetry(sqlRetryProperties.reads) {
+      it.select(tasksFields)
+        .from(tasksTable)
+        .where(field("request_id").eq(clientRequestId))
+        .fetchTask()
+    }
+  }
+
+  override fun list(): MutableList<Task> {
+    return jooq.withRetry(sqlRetryProperties.reads) {
+      it.select(tasksFields)
+        .from(tasksTable)
+        .where(field("id").`in`(*runningTaskIds(it)))
+        .fetchTasks()
+        .toMutableList()
+    }
+  }
+
+  override fun listByThisInstance(): MutableList<Task> {
+    return jooq.withRetry(sqlRetryProperties.reads) {
+      it.select(tasksFields)
+        .from(tasksTable)
+        .where(
+          field("owner_id").eq(ClouddriverHostname.ID)
+            .and(field("id").`in`(*runningTaskIds(it)))
+        )
+        .fetchTasks()
+        .toMutableList()
+    }
+  }
+
+  private fun findByRequestId(requestId: String): Task? {
+    return jooq.withRetry(sqlRetryProperties.reads) {
+      it.select(tasksFields)
+        .from(tasksTable)
+        .where(field("request_id").eq(requestId))
+        .fetchTask()
+    }
+  }
+
+  internal fun getResultObjects(task: Task): MutableList<Any> {
+    return jooq.withRetry(sqlRetryProperties.reads) {
+      it.select(taskResultsFields)
+        .from(taskResultsTable)
+        .where(field("task_id").eq(task.id))
+        .fetchResultObjects()
+        .toMutableList()
+    }
+  }
+
+  internal fun getHistory(task: Task): List<Status> {
+    return jooq.withRetry(sqlRetryProperties.reads) {
+      it.select(taskStatesFields)
+        .from(taskStatesTable)
+        .where(field("task_id").eq(task.id))
+        .orderBy(field("created_at").asc())
+        .fetchTaskStatuses()
+        .toList()
+    }
+  }
+
+  internal fun currentState(task: Task): DefaultTaskStatus? {
+    return jooq.withRetry(sqlRetryProperties.reads) {
+      selectLatestState(jooq, task.id)
+    }
+  }
+
+  internal fun addResultObjects(results: List<Any>, task: Task) {
+    val resultIdPairs = results.map { ulid.nextULID() to it }.toMap()
+
+    jooq.transactional(sqlRetryProperties.transactions) { ctx ->
+      ctx.select(taskStatesFields)
+        .from(taskStatesTable)
+        .where(field("task_id").eq(task.id))
+        .orderBy(field("created_at").asc())
+        .limit(1)
+        .fetchTaskStatus()
+        ?.run {
+          ensureUpdateable()
+        }
+
+      resultIdPairs.forEach { result ->
+        ctx.insertInto(taskResultsTable, listOf(field("id"), field("task_id"), field("body")))
+          .values(listOf(
+            result.key,
+            task.id,
+            mapper.writeValueAsString(result.value)
+          ))
+          .execute()
+      }
+    }
+  }
+
+  internal fun updateCurrentStatus(task: Task, phase: String, status: String) {
+    val historyId = ulid.nextULID()
+    jooq.transactional(sqlRetryProperties.transactions) { ctx ->
+      val state = selectLatestState(ctx, task.id)
+      addToHistory(ctx, historyId, task.id, state?.state ?: STARTED, phase, status)
+    }
+  }
+
+  private fun addToHistory(ctx: DSLContext, id: String, taskId: String, state: TaskState, phase: String, status: String) {
+    ctx
+      .insertInto(
+        taskStatesTable,
+        listOf(field("id"), field("task_id"), field("created_at"), field("state"), field("phase"), field("status"))
+      )
+      .values(listOf(id, taskId, clock.millis(), state.toString(), phase, status))
+      .execute()
+  }
+
+  internal fun updateState(task: Task, state: TaskState) {
+    val historyId = ulid.nextULID()
+    jooq.transactional(sqlRetryProperties.transactions) { ctx ->
+      selectLatestState(ctx, task.id)?.let {
+        addToHistory(ctx, historyId, task.id, state, it.phase, it.status)
+      }
+    }
+  }
+
+  private fun selectLatestState(ctx: DSLContext, taskId: String): DefaultTaskStatus? {
+    return ctx.select(taskStatesFields)
+      .from(taskStatesTable)
+      .where(field("task_id").eq(taskId))
+      .orderBy(field("created_at").desc())
+      .limit(1)
+      .fetchTaskStatus()
+  }
+
+  /**
+   * Since task statuses are insert-only, we first need to find the most
+   * recent status record for each task ID and the filter that result set
+   * down to the ones that are running.
+   */
+  private fun runningTaskIds(ctx: DSLContext): Array<String> {
+    return ctx.select()
+      .from(taskStatesTable.`as`("a"))
+      .innerJoin(
+        ctx.select(field("task_id"), DSL.max(field("created_at")).`as`("created"))
+          .from(taskStatesTable)
+          .groupBy(field("task_id"))
+          .asTable("b")
+      ).on(sql("a.task_id = b.task_id and a.created_at = b.created"))
+      .where(field("a.state").eq(TaskState.STARTED.toString()))
+      .fetch("task_id", String::class.java)
+      .toTypedArray()
+  }
+
+  private fun Select<out Record>.fetchTasks() =
+    TaskMapper(this@SqlTaskRepository).map(fetch().intoResultSet())
+
+  private fun Select<out Record>.fetchTask() =
+    fetchTasks().firstOrNull()
+
+  private fun Select<out Record>.fetchTaskStatuses() =
+    TaskStatusMapper().map(fetch().intoResultSet())
+
+  private fun Select<out Record>.fetchTaskStatus() =
+    fetchTaskStatuses().firstOrNull()
+
+  private fun Select<out Record>.fetchResultObjects() =
+    TaskResultObjectMapper(mapper).map(fetch().intoResultSet())
+
+  companion object {
+    private val ulid = ULID()
+  }
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import java.sql.ResultSet
+
+class TaskMapper(
+  private val sqlTaskRepository: SqlTaskRepository
+) {
+
+  fun map(rs: ResultSet): Collection<Task> {
+    val results = mutableListOf<SqlTask>()
+    while (rs.next()) {
+      results.add(
+        SqlTask(
+          rs.getString("id"),
+          rs.getString("owner_id"),
+          rs.getString("request_id"),
+          rs.getLong("created_at"),
+          sqlTaskRepository
+        )
+      )
+    }
+    return results
+  }
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskResultObjectMapper.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskResultObjectMapper.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.IOException
+import java.lang.String.format
+import java.sql.ResultSet
+
+class TaskResultObjectMapper(
+  private val mapper: ObjectMapper
+) {
+
+  fun map(rs: ResultSet): Collection<Any> {
+    val results = mutableListOf<Any>()
+
+    while (rs.next()) {
+      try {
+        results.add(mapper.readValue(rs.getString("body"), Map::class.java))
+      } catch (e: IOException) {
+        val id = rs.getString("id")
+        val taskId = rs.getString("task_id")
+        throw RuntimeException(
+          format("Failed to convert result object body to map (id: %s, taskId: %s)", id, taskId),
+          e
+        )
+      }
+    }
+
+    return results
+  }
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskStatusMapper.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskStatusMapper.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
+import com.netflix.spinnaker.clouddriver.data.task.TaskState
+import java.sql.ResultSet
+
+class TaskStatusMapper {
+
+  fun map(rs: ResultSet): Collection<DefaultTaskStatus> {
+    val results = mutableListOf<DefaultTaskStatus>()
+
+    while (rs.next()) {
+      results.add(
+        DefaultTaskStatus.create(
+          rs.getString("phase"),
+          rs.getString("status"),
+          TaskState.valueOf(rs.getString("state"))
+        )
+      )
+    }
+
+    return results
+  }
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/sql.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/sql.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql
+
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.table
+
+internal val retrySupport = RetrySupport()
+
+internal val tasksTable = table("tasks")
+internal val taskStatesTable = table("task_states")
+internal val taskResultsTable = table("task_results")
+
+internal val tasksFields = listOf("id", "request_id", "owner_id", "created_at").map { field(it) }
+internal val taskStatesFields = listOf("id", "task_id", "created_at", "state", "phase", "status").map { field(it) }
+internal val taskResultsFields = listOf("id", "task_id", "body").map { field(it) }
+
+/**
+ * Run the provided [fn] in a transaction.
+ */
+internal fun DSLContext.transactional(retryProperties: RetryProperties, fn: (DSLContext) -> Unit) {
+  retrySupport.retry({
+    transaction { ctx ->
+      fn(DSL.using(ctx))
+    }
+  }, retryProperties.maxRetries, retryProperties.backoffMs, false)
+}
+
+/**
+ * Run the provided [fn] with retry support.
+ */
+internal fun <T> DSLContext.withRetry(retryProperties: RetryProperties, fn: (DSLContext) -> T): T {
+  return retrySupport.retry({
+    fn(this)
+  }, retryProperties.maxRetries, retryProperties.backoffMs, false)
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.sql.SqlProvider
+import com.netflix.spinnaker.clouddriver.sql.SqlTaskCleanupAgent
+import com.netflix.spinnaker.clouddriver.sql.SqlTaskRepository
+import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
+import com.netflix.spinnaker.kork.sql.config.SqlProperties
+import org.jooq.DSLContext
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import java.time.Clock
+
+@Configuration
+@ConditionalOnProperty("sql.enabled")
+@Import(DefaultSqlConfiguration::class)
+@EnableConfigurationProperties(SqlTaskCleanupAgentProperties::class)
+class SqlConfiguration {
+
+  @Bean
+  @ConditionalOnProperty("sql.taskRepository.enabled")
+  fun taskRepository(jooq: DSLContext, clock: Clock, sqlProperties: SqlProperties): TaskRepository =
+    SqlTaskRepository(jooq, ObjectMapper(), clock, sqlProperties.retries)
+
+  @Bean
+  @ConditionalOnProperty("sql.taskRepository.enabled")
+  fun sqlTaskCleanupAgent(jooq: DSLContext,
+                          clock: Clock,
+                          registry: Registry,
+                          properties: SqlTaskCleanupAgentProperties,
+                          sqlProperties: SqlProperties): SqlTaskCleanupAgent =
+    SqlTaskCleanupAgent(jooq, clock, registry, properties, sqlProperties.retries)
+
+  @Bean
+  @ConditionalOnProperty("sql.taskRepository.enabled")
+  fun sqlProvider(sqlTaskCleanupAgent: SqlTaskCleanupAgent): SqlProvider =
+    SqlProvider(mutableListOf(sqlTaskCleanupAgent))
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlTaskCleanupAgentProperties.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlTaskCleanupAgentProperties.kt
@@ -1,11 +1,11 @@
 /*
  * Copyright 2018 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,23 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.spinnaker.config
 
-apply plugin: "nebula.kotlin"
-apply plugin: "kotlin-spring"
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.util.concurrent.TimeUnit
 
-configurations.all {
-  resolutionStrategy {
-    eachDependency { details ->
-      if (details.requested.group == "org.jetbrains.kotlin") {
-        details.useVersion kotlinVersion
-      }
-    }
-  }
-}
-
-compileKotlin {
-  kotlinOptions {
-    languageVersion = "1.2"
-    jvmTarget = "1.8"
-  }
-}
+@ConfigurationProperties("sql.agent.taskCleanup")
+data class SqlTaskCleanupAgentProperties(
+  var completedTtlMs: Long = TimeUnit.MINUTES.toMillis(30)
+)

--- a/clouddriver-sql/src/main/resources/db/changelog-master.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog-master.yml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+- include:
+    file: changelog/20180919-initial-schema.yml
+    relativeToChangelogFile: true

--- a/clouddriver-sql/src/main/resources/db/changelog/20180919-initial-schema.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20180919-initial-schema.yml
@@ -1,0 +1,171 @@
+databaseChangeLog:
+- changeSet:
+    id: create-tasks-table
+    author: robzienert
+    changes:
+    - createTable:
+        tableName: tasks
+        columns:
+        - column:
+            name: id
+            type: char(36)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: request_id
+            type: varchar(255)
+            constraints:
+              nullable: false
+        - column:
+            name: owner_id
+            type: varchar(255)
+            constraints:
+              nullable: false
+        - column:
+            name: created_at
+            type: bigint
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: tasks
+
+- changeSet:
+    id: create-task-states-table
+    author: robzienert
+    changes:
+    - createTable:
+        tableName: task_states
+        columns:
+        - column:
+            name: id
+            type: char(36)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: task_id
+            type: char(36)
+            constraints:
+              nullable: false
+        - column:
+            name: created_at
+            type: bigint
+            constraints:
+              nullable: false
+        - column:
+            name: state
+            type: varchar(10)
+            constraints:
+              nullable: false
+        - column:
+            name: phase
+            type: varchar(255)
+            constraints:
+              nullable: false
+        - column:
+            name: status
+            type: text
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: task_states
+
+- changeSet:
+    id: mysql-change-state-stauts-to-enum-type
+    author: robzienert
+    changes:
+    - sql:
+        dbms: mysql
+        sql: ALTER TABLE `task_states` MODIFY COLUMN `state` ENUM("STARTED", "COMPLETED", "FAILED") NOT NULL DEFAULT "STARTED"
+
+- changeSet:
+    id: create-task-results-table
+    author: robzienert
+    changes:
+    - createTable:
+        tableName: task_results
+        columns:
+        - column:
+            name: id
+            type: char(36)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: task_id
+            type: char(36)
+            constraints:
+              nullable: false
+        - column:
+            name: body
+            type: longtext
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: task_results
+
+- changeSet:
+    id: create-indices
+    author: robzienert
+    changes:
+    - createIndex:
+        indexName: task_request_id_idx
+        tableName: tasks
+        columns:
+        - column:
+            name: request_id
+    - createIndex:
+        indexName: task_owner_id_idx
+        tableName: tasks
+        columns:
+        - column:
+            name: owner_id
+    - createIndex:
+        indexName: task_created_at_idx
+        tableName: tasks
+        columns:
+        - column:
+            name: created_at
+    - createIndex:
+        indexName: task_states_taskid_createdat_idx
+        tableName: task_states
+        columns:
+        - column:
+            name: task_id
+        - column:
+            name: created_at
+    - createIndex:
+        indexName: result_objects_task_idx
+        tableName: task_results
+        columns:
+        - column:
+            name: task_id
+    rollback:
+    - dropIndex:
+        indexName: task_request_id_idx
+        tableName: tasks
+    - dropIndex:
+        indexName: task_owner_id_idx
+        tableName: tasks
+    - dropIndex:
+        indexName: task_created_at_idx
+        tableName: tasks
+    - dropIndex:
+        indexName: result_objects_task_idx
+        tableName: task_results

--- a/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
+++ b/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.core.test.TaskRepositoryTck;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties;
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil;
+import org.junit.After;
+
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class SqlTaskRepositoryTest extends TaskRepositoryTck {
+
+  private SqlTestUtil.TestDatabase database;
+
+  @Override
+  protected TaskRepository createTaskRepository() {
+    database = SqlTestUtil.initDatabase();
+    return new SqlTaskRepository(
+      database.context,
+      new ObjectMapper(),
+      Clock.systemDefaultZone(),
+      new SqlRetryProperties()
+    );
+  }
+
+  @After
+  public void cleanup() {
+    Optional.ofNullable(database).ifPresent(d -> SqlTestUtil.cleanupDb(d, Arrays.asList(
+      "tasks",
+      "task_states",
+      "task_results"
+    )));
+  }
+}

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -30,6 +30,7 @@ dependencies {
   compile project(':clouddriver-core')
   compile project(':clouddriver-security')
   compile project(':clouddriver-artifacts')
+  compile project(':clouddriver-sql')
 
   runtime spinnaker.dependency('kork')
   compile spinnaker.dependency('korkWeb')

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.security.config.SecurityConfig
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.web.support.SpringBootServletInitializer
 import org.springframework.context.annotation.ComponentScan
@@ -42,6 +43,7 @@ import java.security.Security
 @EnableAutoConfiguration(exclude = [
     BatchAutoConfiguration,
     GroovyTemplateAutoConfiguration,
+    DataSourceAutoConfiguration
 ])
 @EnableScheduling
 class Main extends SpringBootServletInitializer {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@ org.gradle.parallel=true
 jackson.version=2.9.2
 
 includeCloudProviders=all
+
+kotlinVersion=1.2.71

--- a/gradle/spek.gradle
+++ b/gradle/spek.gradle
@@ -14,22 +14,27 @@
  * limitations under the License.
  */
 
-apply plugin: "org.junit.platform.gradle.plugin"
-
 repositories {
   jcenter()
-  maven { url "http://dl.bintray.com/jetbrains/spek" }
 }
 
 dependencies {
-  spinnaker.group('spek')
+  testCompile "org.junit.platform:junit-platform-runner:${spinnaker.version("junit5")}"
+  testCompile "org.jetbrains.spek:spek-api:${spinnaker.version("spek")}"
+  testCompile "org.jetbrains.spek:spek-subject-extension:${spinnaker.version("spek")}"
+  testCompile "com.nhaarman:mockito-kotlin:1.5.0"
+  testCompile "org.assertj:assertj-core:3.9.0"
+  testCompile "org.junit.jupiter:junit-jupiter-api:${spinnaker.version("jupiter")}"
+
+  testRuntime "org.junit.platform:junit-platform-launcher:${spinnaker.version("junit5")}"
+  testRuntime "org.junit.jupiter:junit-jupiter-engine:${spinnaker.version("jupiter")}"
+  testRuntime "org.junit.vintage:junit-vintage-engine:${spinnaker.version("junitVintage")}"
+  testRuntime "org.jetbrains.spek:spek-junit-platform-engine:${spinnaker.version("spek")}"
+  testCompile "io.strikt:strikt-core:0.11.5"
 }
 
-junitPlatform {
-  platformVersion junitVersion
-  filters {
-    engines {
-      include "spek", "junit-vintage", "junit-jupiter"
-    }
+test {
+  useJUnitPlatform {
+    includeEngines "spek", "junit-vintage", "junit-jupiter"
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,6 +28,7 @@ include 'cats:cats-core',
   'clouddriver-cloudfoundry',
   'clouddriver-consul',
   'clouddriver-core',
+  'clouddriver-core-tck',
   'clouddriver-dcos',
   'clouddriver-docker',
   'clouddriver-ecs',
@@ -40,9 +41,9 @@ include 'cats:cats-core',
   'clouddriver-openstack',
   'clouddriver-oracle',
   'clouddriver-security',
+  'clouddriver-sql',
   'clouddriver-titus',
-  'clouddriver-web',
-  'clouddriver-core-tck'
+  'clouddriver-web'
 
 def cloudProviderProjects = [
   'appengine':  [':clouddriver-appengine', ':clouddriver-google-common'],


### PR DESCRIPTION
Adds a durable task store for clouddriver.

By itself, this PR isn't particularly interesting since clouddriver tasks
are non-durable and short-lived.

Depends on https://github.com/spinnaker/spinnaker-dependencies/pull/243