### PR TITLE
feat(provider/kubernetes) k8s resource whitelisting using annotation …

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -55,6 +55,7 @@ class KubernetesConfigurationProperties {
     List<KubernetesCachingPolicy> cachingPolicies;
     List<String> kinds
     List<String> omitKinds
+    Boolean onlySpinnakerManaged
   }
 
   List<ManagedAccount> accounts = []

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -70,6 +70,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
   private final Registry spectatorRegistry;
   private final AccountCredentialsRepository accountCredentialsRepository;
   private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
+  private final Boolean onlySpinnakerManaged;
 
   KubernetesNamedAccountCredentials(String name,
                                     ProviderVersion providerVersion,
@@ -93,7 +94,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
                                     Permissions permissions,
                                     Registry spectatorRegistry,
                                     KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-                                    C credentials) {
+                                    C credentials,
+                                    Boolean onlySpinnakerManaged) {
     this.name = name;
     this.providerVersion = providerVersion;
     this.environment = environment;
@@ -117,6 +119,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     this.spectatorRegistry = spectatorRegistry;
     this.credentials = credentials;
     this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
+    this.onlySpinnakerManaged = onlySpinnakerManaged;
   }
 
   public List<String> getNamespaces() {
@@ -188,6 +191,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     return kindMap;
   }
 
+  public Boolean getOnlySpinnakerManaged() { return onlySpinnakerManaged; }
+
   @Override
   public List<String> getRequiredGroupMembership() {
     return requiredGroupMembership;
@@ -230,6 +235,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     boolean debug;
     boolean checkPermissionsOnStartup;
     KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
+    boolean onlySpinnakerManaged;
 
     Builder kubernetesSpinnakerKindMap(KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
       this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
@@ -414,6 +420,11 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       return this;
     }
 
+    Builder onlySpinnakerManaged(Boolean onlySpinnakerManaged) {
+      this.onlySpinnakerManaged = onlySpinnakerManaged;
+      return this;
+    }
+
     private C buildCredentials() {
       switch (providerVersion) {
         case v1:
@@ -458,6 +469,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
               .debug(debug)
               .checkPermissionsOnStartup(checkPermissionsOnStartup)
               .jobExecutor(jobExecutor)
+              .onlySpinnakerManaged(onlySpinnakerManaged)
               .build();
         default:
           throw new IllegalArgumentException("Unknown provider type: " + providerVersion);
@@ -547,7 +559,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
           permissions,
           spectatorRegistry,
           kubernetesSpinnakerKindMap,
-          credentials
+          credentials,
+          onlySpinnakerManaged
       );
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -113,6 +113,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .debug(managedAccount.debug)
           .checkPermissionsOnStartup(managedAccount.checkPermissionsOnStartup == null ? true : managedAccount.checkPermissionsOnStartup)
           .kubernetesSpinnakerKindMap(kubernetesSpinnakerKindMap)
+          .onlySpinnakerManaged(managedAccount.onlySpinnakerManaged == null ? false : managedAccount.onlySpinnakerManaged)
           .build()
 
         accountCredentialsRepository.save(managedAccount.name, kubernetesAccount)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -68,8 +68,8 @@ public class KubernetesCacheDataConverter {
   private static final int logicalTtlSeconds = toIntExact(TimeUnit.MINUTES.toSeconds(10));
   private static final int infrastructureTtlSeconds = -1;
 
-  public static CacheData convertAsArtifact(String account, KubernetesManifest manifest) {
-    KubernetesCachingProperties cachingProperties = KubernetesManifestAnnotater.getCachingProperties(manifest);
+  public static CacheData convertAsArtifact(String account, KubernetesManifest manifest, boolean onlySpinnakerManaged) {
+    KubernetesCachingProperties cachingProperties = KubernetesManifestAnnotater.getCachingProperties(manifest, onlySpinnakerManaged);
     if (cachingProperties.isIgnore()) {
       return null;
     }
@@ -171,8 +171,8 @@ public class KubernetesCacheDataConverter {
 
   public static CacheData convertAsResource(String account,
       KubernetesManifest manifest,
-      List<KubernetesManifest> resourceRelationships) {
-    KubernetesCachingProperties cachingProperties = KubernetesManifestAnnotater.getCachingProperties(manifest);
+      List<KubernetesManifest> resourceRelationships, boolean onlySpinnakerManaged) {
+    KubernetesCachingProperties cachingProperties = KubernetesManifestAnnotater.getCachingProperties(manifest, onlySpinnakerManaged);
     if (cachingProperties.isIgnore()) {
       return null;
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -138,7 +138,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
         .peek(m -> RegistryUtils.removeSensitiveKeys(propertyRegistry, accountName, m))
         .map(rs -> {
           try {
-            return KubernetesCacheDataConverter.convertAsResource(accountName, rs, relationships.get(rs));
+            return KubernetesCacheDataConverter.convertAsResource(accountName, rs, relationships.get(rs), credentials.getOnlySpinnakerManaged());
           } catch (Exception e) {
             log.warn("Failure converting {} as resource", rs, e);
             return null;
@@ -155,7 +155,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
     resourceData.addAll(resources.values()
         .stream()
         .flatMap(Collection::stream)
-        .map(rs -> KubernetesCacheDataConverter.convertAsArtifact(accountName, rs))
+        .map(rs -> KubernetesCacheDataConverter.convertAsArtifact(accountName, rs, credentials.getOnlySpinnakerManaged()))
         .filter(Objects::nonNull)
         .collect(Collectors.toList()));
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
@@ -208,12 +208,13 @@ public class KubernetesManifestAnnotater {
         .build();
   }
 
-  public static KubernetesCachingProperties getCachingProperties(KubernetesManifest manifest) {
+  public static KubernetesCachingProperties getCachingProperties(KubernetesManifest manifest, boolean onlySpinnakerManaged) {
     Map<String, String> annotations = manifest.getAnnotations();
-
+    boolean shouldIgnore = getAnnotation(annotations, IGNORE_CACHING, new TypeReference<Boolean>() {}, false) ||
+      (onlySpinnakerManaged  && getAnnotation(annotations, APPLICATION, new TypeReference<String>() {}, "").equals(""));
     return KubernetesCachingProperties.builder()
-        .ignore(getAnnotation(annotations, IGNORE_CACHING, new TypeReference<Boolean>() {}, false))
-        .build();
+      .ignore(shouldIgnore)
+      .build();
   }
 
   public static KubernetesManifestStrategy getStrategy(KubernetesManifest manifest) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -66,6 +66,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final List<KubernetesKind> omitKinds;
   @Getter private final boolean serviceAccount;
   @Getter private boolean metrics;
+  private boolean onlySpinnakerManaged;
   @Getter private final List<KubernetesCachingPolicy> cachingPolicies;
 
   // TODO(lwander) make configurable
@@ -94,6 +95,10 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   @JsonIgnore
   @Getter
   private final String oAuthServiceAccount;
+
+  public boolean getOnlySpinnakerManaged() {
+    return onlySpinnakerManaged;
+  }
 
   @JsonIgnore
   @Getter
@@ -179,6 +184,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     boolean checkPermissionsOnStartup;
     boolean serviceAccount;
     boolean metrics;
+    boolean onlySpinnakerManaged;
 
     public Builder accountName(String accountName) {
       this.accountName = accountName;
@@ -280,6 +286,11 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       return this;
     }
 
+    public Builder onlySpinnakerManaged(boolean onlySpinnakerManaged) {
+      this.onlySpinnakerManaged = onlySpinnakerManaged;
+      return this;
+    }
+
     public KubernetesV2Credentials build() {
       namespaces = namespaces == null ? new ArrayList<>() : namespaces;
       omitNamespaces = omitNamespaces == null ? new ArrayList<>() : omitNamespaces;
@@ -306,6 +317,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
           KubernetesKind.registeredStringList(kinds),
           KubernetesKind.registeredStringList(omitKinds),
           metrics,
+          onlySpinnakerManaged,
           checkPermissionsOnStartup,
           debug
       );
@@ -329,6 +341,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       @NotNull List<KubernetesKind> kinds,
       @NotNull List<KubernetesKind> omitKinds,
       boolean metrics,
+      boolean onlySpinnakerManaged,
       boolean checkPermissionsOnStartup,
       boolean debug) {
     this.registry = registry;
@@ -349,6 +362,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.cachingPolicies = cachingPolicies;
     this.kinds = kinds;
     this.metrics = metrics;
+    this.onlySpinnakerManaged = onlySpinnakerManaged;
     this.omitKinds = omitKinds;
 
     this.liveNamespaceSupplier = Suppliers.memoizeWithExpiration(() -> jobExecutor.list(this, Collections.singletonList(KubernetesKind.NAMESPACE), "")


### PR DESCRIPTION
…moniker.spinnaker.io/application

Added a property called "onlySpinnakerManaged" to the kubernetesV2 provider that whitelists applications that have the spinnaker application moniker annotation. The property is passed from the KubwernetesV2Credentials to the KubernetesManifestAnnotator to affect how it determines whether a resource is ignored.

Use:
Add the onlySpinnakerManaged property to the clouddriver profile under a kubernetes provider set to true. Spinnaker will ignore resources without the application moniker annotation.
