### PR TITLE
feat(search): Adds parallell executor to search providers.

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
@@ -23,49 +23,14 @@ import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions
 import com.netflix.spinnaker.clouddriver.cache.CacheConfig
 import com.netflix.spinnaker.clouddriver.cache.NoopOnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
-import com.netflix.spinnaker.clouddriver.core.CloudProvider
-import com.netflix.spinnaker.clouddriver.core.DynomiteConfig
-import com.netflix.spinnaker.clouddriver.core.NoopAtomicOperationConverter
-import com.netflix.spinnaker.clouddriver.core.NoopCloudProvider
-import com.netflix.spinnaker.clouddriver.core.ProjectClustersService
-import com.netflix.spinnaker.clouddriver.core.RedisConfig
+import com.netflix.spinnaker.clouddriver.core.*
 import com.netflix.spinnaker.clouddriver.core.agent.CleanupPendingOnDemandCachesAgent
 import com.netflix.spinnaker.clouddriver.core.agent.ProjectClustersCachingAgent
 import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration
 import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfigurationBuilder
 import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
-import com.netflix.spinnaker.clouddriver.model.ApplicationProvider
-import com.netflix.spinnaker.clouddriver.model.CloudMetricProvider
-import com.netflix.spinnaker.clouddriver.model.ClusterProvider
-import com.netflix.spinnaker.clouddriver.model.ElasticIpProvider
-import com.netflix.spinnaker.clouddriver.model.ImageProvider
-import com.netflix.spinnaker.clouddriver.model.InstanceProvider
-import com.netflix.spinnaker.clouddriver.model.InstanceTypeProvider
-import com.netflix.spinnaker.clouddriver.model.KeyPairProvider
-import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider
-import com.netflix.spinnaker.clouddriver.model.ManifestProvider
-import com.netflix.spinnaker.clouddriver.model.NetworkProvider
-import com.netflix.spinnaker.clouddriver.model.NoopApplicationProvider
-import com.netflix.spinnaker.clouddriver.model.NoopCloudMetricProvider
-import com.netflix.spinnaker.clouddriver.model.NoopClusterProvider
-import com.netflix.spinnaker.clouddriver.model.NoopElasticIpProvider
-import com.netflix.spinnaker.clouddriver.model.NoopImageProvider
-import com.netflix.spinnaker.clouddriver.model.NoopInstanceProvider
-import com.netflix.spinnaker.clouddriver.model.NoopInstanceTypeProvider
-import com.netflix.spinnaker.clouddriver.model.NoopKeyPairProvider
-import com.netflix.spinnaker.clouddriver.model.NoopLoadBalancerProvider
-import com.netflix.spinnaker.clouddriver.model.NoopManifestProvider
-import com.netflix.spinnaker.clouddriver.model.NoopNetworkProvider
-import com.netflix.spinnaker.clouddriver.model.NoopReservationReportProvider
-import com.netflix.spinnaker.clouddriver.model.NoopSecurityGroupProvider
-import com.netflix.spinnaker.clouddriver.model.NoopServerGroupManagerProvider
-import com.netflix.spinnaker.clouddriver.model.NoopSubnetProvider
-import com.netflix.spinnaker.clouddriver.model.ReservationReportProvider
-import com.netflix.spinnaker.clouddriver.model.SecurityGroupProvider
-import com.netflix.spinnaker.clouddriver.model.ServerGroupManager
-import com.netflix.spinnaker.clouddriver.model.ServerGroupManagerProvider
-import com.netflix.spinnaker.clouddriver.model.SubnetProvider
+import com.netflix.spinnaker.clouddriver.model.*
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
 import com.netflix.spinnaker.clouddriver.names.NamingStrategy
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationConverter
@@ -73,6 +38,7 @@ import com.netflix.spinnaker.clouddriver.search.ApplicationSearchProvider
 import com.netflix.spinnaker.clouddriver.search.NoopSearchProvider
 import com.netflix.spinnaker.clouddriver.search.ProjectSearchProvider
 import com.netflix.spinnaker.clouddriver.search.SearchProvider
+import com.netflix.spinnaker.clouddriver.search.executor.SearchExecutorConfig
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
@@ -98,7 +64,8 @@ import java.time.Clock
 @Import([
   RedisConfig,
   DynomiteConfig,
-  CacheConfig
+  CacheConfig,
+  SearchExecutorConfig
 ])
 @PropertySource(value = "classpath:META-INF/clouddriver-core.properties", ignoreResourceNotFound = true)
 @EnableConfigurationProperties(ProjectClustersCachingAgentProperties)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/SearchQueryCommand.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/SearchQueryCommand.java
@@ -1,0 +1,45 @@
+package com.netflix.spinnaker.clouddriver.search;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchQueryCommand {
+  /**
+   * the phrase to query
+   */
+  String q;
+
+  /**
+   * (optional) a filter, used to only return results of that type. If no value is supplied, all types will be returned
+   */
+  List<String> type;
+
+  /**
+   * a filter, used to only return results from providers whose platform value matches this
+   */
+  String platform = "";
+
+  /**
+   * the page number, starting with 1
+   */
+  Integer page = 1;
+
+  /**
+   * the maximum number of results to return per page
+   */
+  Integer pageSize = 10;
+
+  /**
+   * (optional) a map of ad-hoc key-value pairs to further filter the keys,
+   * based on the map provided by {@link com.netflix.spinnaker.oort.aws.data.Keys#parse(java.lang.String)}
+   * potential matches must fully intersect the filter map entries
+   */
+  Map<String, String> filters;
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutor.java
@@ -16,10 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.search.executor;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.search.SearchProvider;
 import com.netflix.spinnaker.clouddriver.search.SearchQueryCommand;
 import com.netflix.spinnaker.clouddriver.search.SearchResultSet;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +34,9 @@ public class SearchExecutor {
   private Integer timeout;
   private ExecutorService executor;
 
+  @Autowired
+  Registry registry;
+
   SearchExecutor(SearchExecutorConfigProperties configProperties) {
     this.timeout = configProperties.getTimeout();
     this.executor = Executors.newFixedThreadPool(configProperties.getThreadPoolSize());
@@ -40,7 +45,7 @@ public class SearchExecutor {
   public List<SearchResultSet> searchAllProviders(List<SearchProvider> providers,
                                                   SearchQueryCommand searchQuery) {
     List<Callable<SearchResultSet>> searchTasks = providers.stream().
-      map(p -> new SearchTask(p, searchQuery)).
+      map(p -> new SearchTask(p, searchQuery, registry)).
       collect(Collectors.toList());
     List<Future<SearchResultSet>> resultFutures = null;
     try {
@@ -53,10 +58,10 @@ public class SearchExecutor {
     if (resultFutures == null) {
       return Collections.EMPTY_LIST;
     }
-    return resultFutures.stream().map(f -> getFuture(f)).collect(Collectors.toList());
+    return resultFutures.stream().map(f -> getFuture(f, registry, searchQuery.getQ())).collect(Collectors.toList());
   }
 
-  private static SearchResultSet getFuture(Future<SearchResultSet> f) {
+  private static SearchResultSet getFuture(Future<SearchResultSet> f, Registry registry, String q) {
     SearchResultSet resultSet = null;
     try {
       resultSet = f.get();
@@ -64,6 +69,8 @@ public class SearchExecutor {
       log.error(String.format("Retrieving future %s failed", f), e);
     } catch (CancellationException _) {
       log.error(String.format("Retrieving result failed due to cancelled task: %s", f));
+      String counterId = String.format("searchExecutor.%s.failures", q != null ? q : "*");
+      registry.counter(registry.createId(counterId)).increment(1);
     }
 
     if (resultSet == null) {
@@ -75,10 +82,12 @@ public class SearchExecutor {
   private static class SearchTask implements Callable<SearchResultSet> {
     private SearchProvider provider;
     private SearchQueryCommand searchQuery;
+    private Registry registry;
 
-    SearchTask(SearchProvider provider, SearchQueryCommand searchQuery) {
+    SearchTask(SearchProvider provider, SearchQueryCommand searchQuery, Registry registry) {
       this.provider = provider;
       this.searchQuery = searchQuery;
+      this.registry = registry;
     }
 
     public SearchResultSet call() {
@@ -89,16 +98,18 @@ public class SearchExecutor {
         .filter(e -> !provider.excludedFilters().contains(e.getKey()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+      String q = searchQuery.getQ();
       try {
         if (searchQuery.getType() != null && !searchQuery.getType().isEmpty()) {
-          return provider.search(searchQuery.getQ(), searchQuery.getType(), searchQuery.getPage(),
+          return provider.search(q, searchQuery.getType(), searchQuery.getPage(),
                                  searchQuery.getPageSize(), filters);
         } else {
-          return provider.search(searchQuery.getQ(), searchQuery.getPage(), searchQuery.getPageSize(), filters);
+          return provider.search(q, searchQuery.getPage(), searchQuery.getPageSize(), filters);
         }
       } catch (Exception e) {
-        log.error(String.format("Search for '%s' in '%s' failed",
-          searchQuery.getQ(), searchQuery.getPlatform()), e);
+        log.error(String.format("Search for '%s' in '%s' failed", q, searchQuery.getPlatform()), e);
+        String counterId = String.format("searchExecutor.%s.failures", q != null ? q : "*");
+        registry.counter(registry.createId(counterId)).increment(1);
         return new SearchResultSet().setTotalMatches(0).setResults(Collections.EMPTY_LIST);
       }
     }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.search.executor;
+
+import com.netflix.spinnaker.clouddriver.search.SearchProvider;
+import com.netflix.spinnaker.clouddriver.search.SearchQueryCommand;
+import com.netflix.spinnaker.clouddriver.search.SearchResultSet;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class SearchExecutor {
+  private Integer timeout;
+  private ExecutorService executor;
+
+  SearchExecutor(SearchExecutorConfigProperties configProperties) {
+    this.timeout = configProperties.getTimeout();
+    this.executor = Executors.newFixedThreadPool(configProperties.getThreadPoolSize());
+  }
+
+  public List<SearchResultSet> searchAllProviders(List<SearchProvider> providers,
+                                                  SearchQueryCommand searchQuery) {
+    List<Callable<SearchResultSet>> searchTasks = providers.stream().
+      map(p -> new SearchTask(p, searchQuery)).
+      collect(Collectors.toList());
+    List<Future<SearchResultSet>> resultFutures = null;
+    try {
+      resultFutures = executor.invokeAll(searchTasks, timeout, TimeUnit.SECONDS);
+    } catch (InterruptedException ie) {
+      log.error(String.format("Search for '%s' in '%s' interrupted",
+                searchQuery.getQ(), searchQuery.getPlatform()), ie);
+    }
+
+    if (resultFutures == null) {
+      return Collections.EMPTY_LIST;
+    }
+    return resultFutures.stream().map(f -> getFuture(f)).collect(Collectors.toList());
+  }
+
+  private static SearchResultSet getFuture(Future<SearchResultSet> f) {
+    SearchResultSet resultSet = null;
+    try {
+      resultSet = f.get();
+    } catch (ExecutionException | InterruptedException e) {
+      log.error(String.format("Retrieving future %s failed", f), e);
+    } catch (CancellationException _) {
+      log.error(String.format("Retrieving result failed due to cancelled task: %s", f));
+    }
+
+    if (resultSet == null) {
+      return new SearchResultSet().setTotalMatches(0).setResults(Collections.EMPTY_LIST);
+    }
+    return resultSet;
+  }
+
+  private static class SearchTask implements Callable<SearchResultSet> {
+    private SearchProvider provider;
+    private SearchQueryCommand searchQuery;
+
+    SearchTask(SearchProvider provider, SearchQueryCommand searchQuery) {
+      this.provider = provider;
+      this.searchQuery = searchQuery;
+    }
+
+    public SearchResultSet call() {
+      Map<String, String> filters = searchQuery
+        .getFilters()
+        .entrySet()
+        .stream()
+        .filter(e -> !provider.excludedFilters().contains(e.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+      try {
+        if (searchQuery.getType() != null && !searchQuery.getType().isEmpty()) {
+          return provider.search(searchQuery.getQ(), searchQuery.getType(), searchQuery.getPage(),
+                                 searchQuery.getPageSize(), filters);
+        } else {
+          return provider.search(searchQuery.getQ(), searchQuery.getPage(), searchQuery.getPageSize(), filters);
+        }
+      } catch (Exception e) {
+        log.error(String.format("Search for '%s' in '%s' failed",
+          searchQuery.getQ(), searchQuery.getPlatform()), e);
+        return new SearchResultSet().setTotalMatches(0).setResults(Collections.EMPTY_LIST);
+      }
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutorConfig.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutorConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.search.executor;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnExpression("${search.executor.enabled:false}")
+@EnableConfigurationProperties(SearchExecutorConfigProperties.class)
+public class SearchExecutorConfig {
+  @Bean
+  SearchExecutor searchExecutor(SearchExecutorConfigProperties configProperties) {
+    return new SearchExecutor(configProperties);
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutorConfigProperties.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutorConfigProperties.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.search.executor;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@NoArgsConstructor
+@ConfigurationProperties("search.executor")
+class SearchExecutorConfigProperties {
+  private Boolean enabled;
+  private Integer threadPoolSize;
+  private Integer timeout;
+}


### PR DESCRIPTION
Previously the search providers ran sequentially. If one provider
took far too long, the upstream service would disconnect before
any results were returned from the other providers. This adds a
circuitbreaker to cap the seach processing time and parallelize
the providers so that one provider's failure won't affect other
providers' results. The new circuitbreaker is configurable; by
default the previous behavior is preserved.