### PR TITLE
feat(provider/kubernetes): split kubernetes pod logs by container #3360

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppengineInstanceProvider.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppengineInstanceProvider.groovy
@@ -32,7 +32,7 @@ import static com.netflix.spinnaker.clouddriver.appengine.cache.Keys.Namespace.L
 import static com.netflix.spinnaker.clouddriver.appengine.cache.Keys.Namespace.SERVER_GROUPS
 
 @Component
-class AppengineInstanceProvider implements InstanceProvider<AppengineInstance> {
+class AppengineInstanceProvider implements InstanceProvider<AppengineInstance, String> {
   @Autowired
   Cache cacheView
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonInstanceProvider.groovy
@@ -35,7 +35,7 @@ import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IN
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS
 
 @Component
-class AmazonInstanceProvider implements InstanceProvider<AmazonInstance> {
+class AmazonInstanceProvider implements InstanceProvider<AmazonInstance, String> {
 
   final String cloudProvider = AmazonCloudProvider.ID
   private final Cache cacheView

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/view/AzureInstanceProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/view/AzureInstanceProvider.groovy
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class AzureInstanceProvider implements InstanceProvider<AzureInstance> {
+class AzureInstanceProvider implements InstanceProvider<AzureInstance, String> {
   final String cloudProvider = AzureCloudProvider.ID
   private final AzureCloudProvider azureCloudProvider
   private final Cache cacheView

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ContainerLog.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ContainerLog.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Data
+@NoArgsConstructor
+public class ContainerLog {
+  private String name;
+  private String output;
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/InstanceProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/InstanceProvider.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.model
 
-interface InstanceProvider<T extends Instance> {
+interface InstanceProvider<T extends Instance, S> {
 
   /**
    * Returns the platform the instance provider
@@ -26,5 +26,5 @@ interface InstanceProvider<T extends Instance> {
 
   T getInstance(String account, String region, String id)
 
-  String getConsoleOutput(String account, String region, String id)
+  S getConsoleOutput(String account, String region, String id)
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopInstanceProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopInstanceProvider.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.model
 
-class NoopInstanceProvider implements InstanceProvider<Instance> {
+class NoopInstanceProvider implements InstanceProvider<Instance, String> {
 
   final String cloudProvider = "none"
 

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/view/DcosInstanceProvider.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/view/DcosInstanceProvider.groovy
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class DcosInstanceProvider implements InstanceProvider<DcosInstance> {
+class DcosInstanceProvider implements InstanceProvider<DcosInstance, String> {
   private final Cache cacheView
   private final ObjectMapper objectMapper
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/view/EcsInstanceProvider.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 @Component
-public class EcsInstanceProvider implements InstanceProvider<EcsTask> {
+public class EcsInstanceProvider implements InstanceProvider<EcsTask, String> {
 
   private final TaskCacheClient taskCacheClient;
   private final ContainerInstanceCacheClient containerInstanceCacheClient;

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
@@ -39,7 +39,7 @@ import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.*
 
 @Component
 @Slf4j
-class GoogleInstanceProvider implements InstanceProvider<GoogleInstance.View>, GoogleExecutorTraits {
+class GoogleInstanceProvider implements InstanceProvider<GoogleInstance.View, String>, GoogleExecutorTraits {
 
   @Autowired
   final Cache cacheView

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackInstanceProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackInstanceProvider.groovy
@@ -35,7 +35,7 @@ import static com.netflix.spinnaker.clouddriver.openstack.cache.Keys.Namespace.I
 import static com.netflix.spinnaker.clouddriver.openstack.cache.Keys.Namespace.LOAD_BALANCERS
 
 @Component
-class OpenstackInstanceProvider implements InstanceProvider<OpenstackInstance.View> {
+class OpenstackInstanceProvider implements InstanceProvider<OpenstackInstance.View, String> {
   final String cloudProvider = OpenstackCloudProvider.ID
   final Cache cacheView
   final AccountCredentialsProvider accountCredentialsProvider

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/provider/view/OracleInstanceProvider.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/provider/view/OracleInstanceProvider.groovy
@@ -28,7 +28,7 @@ import static com.netflix.spinnaker.clouddriver.oracle.cache.Keys.Namespace.INST
 
 @Slf4j
 @Component
-class OracleInstanceProvider implements InstanceProvider<OracleInstance> {
+class OracleInstanceProvider implements InstanceProvider<OracleInstance, String> {
 
   private final Cache cacheView
   final ObjectMapper objectMapper

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusInstanceProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusInstanceProvider.groovy
@@ -40,7 +40,7 @@ import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.IN
 import static com.netflix.spinnaker.clouddriver.titus.caching.Keys.Namespace.SERVER_GROUPS
 
 @Component
-class TitusInstanceProvider implements InstanceProvider<TitusInstance> {
+class TitusInstanceProvider implements InstanceProvider<TitusInstance, String> {
   final String cloudProvider = TitusCloudProvider.ID
   private final Cache cacheView
   private final ObjectMapper objectMapper

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/InstanceController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/InstanceController.groovy
@@ -60,7 +60,7 @@ class InstanceController {
                        @PathVariable String region,
                        @PathVariable String id) {
     String providerParam = cloudProvider ?: provider
-    Collection<String> outputs = instanceProviders.findResults {
+    Collection outputs = instanceProviders.findResults {
       if (!providerParam || it.cloudProvider == providerParam) {
         return it.getConsoleOutput(account, region, id)
       }


### PR DESCRIPTION
Closes [issue #3360](https://github.com/spinnaker/spinnaker/issues/3360)

Updates `{account}/{region}/{id}/console` endpoint to return list of container logs for Kubernetes v1 and v2 providers rather than a string concatenation of each container log.

cc @danielpeach @lwander 


