### PR TITLE
feat(provider/cf): caching agent backwards compatibility to CAPI 2.94.0/3.29.0

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -96,7 +96,7 @@ public class Applications {
   private CloudFoundryServerGroup map(Application application) {
     CloudFoundryServerGroup.State state = CloudFoundryServerGroup.State.valueOf(application.getState());
 
-    CloudFoundrySpace space = safelyCall(() -> spaces.findById(application.getRelationships().get("space").getData().getGuid())).orElse(null);
+    CloudFoundrySpace space = safelyCall(() -> spaces.findById(application.getLinks().get("space").getGuid())).orElse(null);
     ApplicationEnv applicationEnv = safelyCall(() -> api.findApplicationEnvById(application.getGuid())).orElse(null);
     Process process = safelyCall(() -> api.findProcessById(application.getGuid())).orElse(null);
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/Application.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/Application.java
@@ -27,5 +27,5 @@ public class Application {
   private String guid;
   private String state;
   private ZonedDateTime createdAt;
-  private Map<String, ToOneRelationship> relationships;
+  private Map<String, Link> links;
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/LinkTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/LinkTest.java
@@ -16,17 +16,15 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3;
 
-import lombok.Data;
+import org.junit.jupiter.api.Test;
 
-@Data
-public class Link {
-  private String href;
+import static org.assertj.core.api.Assertions.assertThat;
 
-  /**
-   * If this link's last path segment is a GUID (i.e. it refers to a single resource),
-   * then this extracts that GUID.
-   */
-  public String getGuid() {
-    return href.substring(href.lastIndexOf('/') + 1);
+class LinkTest {
+  @Test
+  void getGuid() {
+    Link link = new Link();
+    link.setHref("https://api.sys.calabasas.cf-app.com/v3/spaces/72d50cd9-434e-4738-9349-cb146987b963");
+    assertThat(link.getGuid()).isEqualTo("72d50cd9-434e-4738-9349-cb146987b963");
   }
 }


### PR DESCRIPTION
We originally intended to support PCF 2.0+, but this minor change allows us to support PCF 1.12 as well.