### PR TITLE
feat(web): Allow for request queue size to be overridden dynamically

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.configuration.CredentialsConfiguration
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueueConfiguration
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -68,8 +69,10 @@ public class WebConfig extends WebMvcConfigurerAdapter {
   }
 
   @Bean
-  RequestQueue requestQueue(RequestQueueConfiguration requestQueueConfiguration, Registry registry) {
-    return RequestQueue.forConfig(registry, requestQueueConfiguration);
+  RequestQueue requestQueue(DynamicConfigService dynamicConfigService,
+                            RequestQueueConfiguration requestQueueConfiguration,
+                            Registry registry) {
+    return RequestQueue.forConfig(dynamicConfigService, registry, requestQueueConfiguration);
   }
 
   @Bean

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/RequestQueue.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/RequestQueue.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.requestqueue;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.requestqueue.pooled.PooledRequestQueue;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -30,24 +31,50 @@ public interface RequestQueue {
   long DEFAULT_TIMEOUT_MILLIS = 60000;
   long DEFAULT_START_WORK_TIMEOUT_MILLIS = 10000;
 
-  static RequestQueue forConfig(Registry registry, RequestQueueConfiguration config) {
+  static RequestQueue forConfig(DynamicConfigService dynamicConfigService,
+                                Registry registry,
+                                RequestQueueConfiguration config) {
     if (!config.isEnabled()) {
       return noop();
     }
 
-    return pooled(registry, config.getStartWorkTimeoutMillis(), config.getTimeoutMillis(), config.getPoolSize());
+    return pooled(
+      dynamicConfigService,
+      registry,
+      config.getStartWorkTimeoutMillis(),
+      config.getTimeoutMillis(),
+      config.getPoolSize()
+    );
   }
 
   static RequestQueue noop() {
     return new NOOP();
   }
 
-  static RequestQueue pooled(Registry registry, int poolSize) {
-    return pooled(registry, DEFAULT_START_WORK_TIMEOUT_MILLIS, DEFAULT_TIMEOUT_MILLIS, poolSize);
+  static RequestQueue pooled(DynamicConfigService dynamicConfigService,
+                             Registry registry,
+                             int poolSize) {
+    return pooled(
+      dynamicConfigService,
+      registry,
+      DEFAULT_START_WORK_TIMEOUT_MILLIS,
+      DEFAULT_TIMEOUT_MILLIS,
+      poolSize
+    );
   }
 
-  static RequestQueue pooled(Registry registry, long startWorkTimeoutMillis, long timeoutMillis, int poolSize) {
-    return new PooledRequestQueue(registry, startWorkTimeoutMillis, timeoutMillis, poolSize);
+  static RequestQueue pooled(DynamicConfigService dynamicConfigService,
+                             Registry registry,
+                             long startWorkTimeoutMillis,
+                             long timeoutMillis,
+                             int poolSize) {
+    return new PooledRequestQueue(
+      dynamicConfigService,
+      registry,
+      startWorkTimeoutMillis,
+      timeoutMillis,
+      poolSize
+    );
   }
 
   default long getDefaultTimeoutMillis() {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueue.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueue.java
@@ -17,9 +17,12 @@
 package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
 
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import javax.annotation.PreDestroy;
 import java.util.Collection;
@@ -29,24 +32,33 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class PooledRequestQueue implements RequestQueue {
+  private final Logger log = LoggerFactory.getLogger(getClass());
   private final ConcurrentMap<String, Queue<PooledRequest<?>>> partitionedRequests = new ConcurrentHashMap<>();
   private final PollCoordinator pollCoordinator = new PollCoordinator();
 
   private final long defaultStartWorkTimeout;
   private final long defaultTimeout;
-  private final ExecutorService executorService;
+  private final int defaultCorePoolSize;
+  private final ThreadPoolExecutor executorService;
   private final BlockingQueue<Runnable> submittedRequests;
   private final Collection<Queue<PooledRequest<?>>> requestQueues;
   private final RequestDistributor requestDistributor;
+
+  private final DynamicConfigService dynamicConfigService;
   private final Registry registry;
 
-  public PooledRequestQueue(Registry registry, long defaultStartWorkTimeout, long defaultTimeout, int requestPoolSize) {
+
+
+  public PooledRequestQueue(DynamicConfigService dynamicConfigService,
+                            Registry registry,
+                            long defaultStartWorkTimeout,
+                            long defaultTimeout,
+                            int requestPoolSize) {
 
     if (defaultStartWorkTimeout <= 0) {
       throw new IllegalArgumentException("defaultStartWorkTimeout");
@@ -59,13 +71,21 @@ public class PooledRequestQueue implements RequestQueue {
     if (requestPoolSize < 1) {
       throw new IllegalArgumentException("requestPoolSize");
     }
+
+    this.dynamicConfigService = dynamicConfigService;
     this.registry = registry;
+
     this.defaultStartWorkTimeout = defaultStartWorkTimeout;
     this.defaultTimeout = defaultTimeout;
+    this.defaultCorePoolSize = requestPoolSize;
+
     this.submittedRequests = new LinkedBlockingQueue<>();
     registry.gauge("pooledRequestQueue.executorQueue.size", submittedRequests, Queue::size);
+
     final int actualThreads = requestPoolSize + 1;
     this.executorService = new ThreadPoolExecutor(actualThreads, actualThreads, 0, TimeUnit.MILLISECONDS, submittedRequests);
+    registry.gauge("pooledRequestQueue.corePoolSize", executorService, ThreadPoolExecutor::getCorePoolSize);
+
     this.requestQueues = new CopyOnWriteArrayList<>();
     this.requestDistributor = new RequestDistributor(registry, pollCoordinator, executorService, requestQueues);
     executorService.submit(requestDistributor);
@@ -124,6 +144,26 @@ public class PooledRequestQueue implements RequestQueue {
       throw t;
     } finally {
       registry.timer(id).record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  @Scheduled(fixedDelayString = "${requestQueue.corePoolSizeRefreshMs:120000}")
+  public void refreshCorePoolSize() {
+    int currentCorePoolSize = executorService.getCorePoolSize();
+    int desiredCorePoolSize = dynamicConfigService.getConfig(
+      Integer.class,
+      "requestQueue.poolSize",
+      defaultCorePoolSize
+    ) + 1;
+
+    if (desiredCorePoolSize != currentCorePoolSize) {
+      log.info(
+        "Updating core pool size (original: {}, updated: {})",
+        currentCorePoolSize,
+        desiredCorePoolSize
+      );
+      executorService.setCorePoolSize(desiredCorePoolSize);
+      executorService.setMaximumPoolSize(desiredCorePoolSize);
     }
   }
 }

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueueSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueueSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.requestqueue.pooled
 
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import spock.lang.Specification
 
 import java.util.concurrent.Callable
@@ -24,9 +25,11 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
 
 class PooledRequestQueueSpec extends Specification {
+  def dynamicConfigService = Mock(DynamicConfigService)
+
   def "should execute requests"() {
     given:
-    def queue = new PooledRequestQueue(new NoopRegistry(), 1000, 1000, 1)
+    def queue = new PooledRequestQueue(dynamicConfigService, new NoopRegistry(), 1000, 1000, 1)
 
     when:
     Long result = queue.execute("foo", { return 12345L })
@@ -37,7 +40,7 @@ class PooledRequestQueueSpec extends Specification {
 
   def "should time out if request does not complete"() {
     given:
-    def queue = new PooledRequestQueue(new NoopRegistry(), 5000, 10, 1)
+    def queue = new PooledRequestQueue(dynamicConfigService, new NoopRegistry(), 5000, 10, 1)
 
     when:
     queue.execute("foo", { Thread.sleep(20); return 12345L })
@@ -48,7 +51,7 @@ class PooledRequestQueueSpec extends Specification {
 
   def "should time out if request does not start in time"() {
     given: "a queue with one worker thread"
-    def queue = new PooledRequestQueue(new NoopRegistry(), 10, 10, 1)
+    def queue = new PooledRequestQueue(dynamicConfigService, new NoopRegistry(), 10, 10, 1)
     AtomicBoolean itRan = new AtomicBoolean(false)
     Callable<Void> didItRun = {
       itRan.set(true)


### PR DESCRIPTION
```
Most typically, core and maximum pool sizes are set only upon
construction, but they may also be changed dynamically using
setCorePoolSize(int) and setMaximumPoolSize(int).

If the new value is smaller than the current value, excess existing
threads will be terminated when they next become idle. If larger, new
threads will, if needed, be started to execute any queued tasks.
```

^^ from JDK documentation
