### PR TITLE
fix(artifacts/gcs): fix version resolution

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactCredentials.java
@@ -87,7 +87,7 @@ public class GcsArtifactCredentials implements ArtifactCredentials {
     String bucketName = reference.substring(0, slash);
     String path = reference.substring(slash + 1);
 
-    int pound = reference.lastIndexOf("#");
+    int pound = path.lastIndexOf("#");
     if (pound >= 0) {
       generation = Long.valueOf(path.substring(pound + 1));
       path = path.substring(0, pound);


### PR DESCRIPTION
We were finding the index in one string, and taking a substring in another