### PR TITLE
feat(provider/kubernetes): Add Builder to KubernetesImageDescription

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.KubernetesKindAtomicOperationDescription
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
-import lombok.Builder
+import groovy.transform.builder.Builder
 
 @AutoClone
 @Canonical

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/servergroup/DeployKubernetesAtomicOperationDescription.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.KubernetesKindAtomicOperationDescription
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
+import lombok.Builder
 
 @AutoClone
 @Canonical
@@ -82,6 +83,7 @@ class KubernetesContainerPort {
 
 @AutoClone
 @Canonical
+@Builder
 class KubernetesImageDescription {
   String uri
   String registry


### PR DESCRIPTION
Some existing code is using an auto-generated constructor for KubernetesImageDescription, which is fragile as added fields can change the meaning of the constructor. Add a Builder annotation so this code can use the more robust builder pattern.