### PR TITLE
fix(provider/oracle): add private key passphrase

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactAccount.java
@@ -23,5 +23,6 @@ public class OracleArtifactAccount extends ArtifactAccount {
   private String userId;
   private String fingerprint;
   private String sshPrivateKeyFilePath;
+  private String privateKeyPassphrase;
   private String tenancyId;
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactClient.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactClient.java
@@ -37,12 +37,13 @@ public class OracleArtifactClient {
 
   private Client client;
 
-  public OracleArtifactClient(String userId, String sshPrivateKeyFilePath, String fingerprint, String tenancyId) {
+  public OracleArtifactClient(String userId, String sshPrivateKeyFilePath, String privateKeyPassphrase, String fingerprint, String tenancyId) {
     Supplier<InputStream> privateKeySupplier = new SimplePrivateKeySupplier(sshPrivateKeyFilePath);
     AuthenticationDetailsProvider provider = SimpleAuthenticationDetailsProvider.builder()
             .userId(userId)
             .fingerprint(fingerprint)
             .privateKeySupplier(privateKeySupplier)
+            .passPhrase(privateKeyPassphrase)
             .tenantId(tenancyId)
             .build();
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactCredentials.java
@@ -40,6 +40,7 @@ public class OracleArtifactCredentials implements ArtifactCredentials {
   private final String userId;
   private final String fingerprint;
   private final String sshPrivateKeyFilePath;
+  private final String privateKeyPassphrase;
   private final String tenancyId;
 
   @JsonIgnore
@@ -53,9 +54,10 @@ public class OracleArtifactCredentials implements ArtifactCredentials {
     this.userId = account.getUserId();
     this.fingerprint = account.getFingerprint();
     this.sshPrivateKeyFilePath = account.getSshPrivateKeyFilePath();
+    this.privateKeyPassphrase = account.getPrivateKeyPassphrase();
     this.tenancyId = account.getTenancyId();
 
-    this.client = new OracleArtifactClient(userId, sshPrivateKeyFilePath, fingerprint, tenancyId);
+    this.client = new OracleArtifactClient(userId, sshPrivateKeyFilePath, privateKeyPassphrase, fingerprint, tenancyId);
   }
 
   public InputStream download(Artifact artifact) throws IOException {

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/config/OracleConfigurationProperties.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/config/OracleConfigurationProperties.groovy
@@ -24,6 +24,7 @@ class OracleConfigurationProperties {
     String userId
     String fingerprint
     String sshPrivateKeyFilePath
+    String privateKeyPassphrase
     String tenancyId
     String region
   }

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/security/OracleCredentialsInitializer.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/security/OracleCredentialsInitializer.groovy
@@ -60,6 +60,7 @@ class OracleCredentialsInitializer implements CredentialsInitializerSynchronizab
           userId(managedAccount.userId).
           fingerprint(managedAccount.fingerprint).
           sshPrivateKeyFilePath(managedAccount.sshPrivateKeyFilePath).
+          privateKeyPassphrase(managedAccount.privateKeyPassphrase).
           tenancyId(managedAccount.tenancyId).
           region(managedAccount.region).
           build()

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/security/OracleNamedAccountCredentials.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/security/OracleNamedAccountCredentials.groovy
@@ -32,6 +32,7 @@ class OracleNamedAccountCredentials implements AccountCredentials<Object> {
   String userId
   String fingerprint
   String sshPrivateKeyFilePath
+  String privateKeyPassphrase
   String tenancyId
   String region
   List<String> requiredGroupMembership = []
@@ -51,6 +52,7 @@ class OracleNamedAccountCredentials implements AccountCredentials<Object> {
                                     String userId,
                                     String fingerprint,
                                     String sshPrivateKeyFilePath,
+                                    String privateKeyPassphrase,
                                     String tenancyId,
                                     String region) {
     this.name = name
@@ -61,6 +63,7 @@ class OracleNamedAccountCredentials implements AccountCredentials<Object> {
     this.userId = userId
     this.fingerprint = fingerprint
     this.sshPrivateKeyFilePath = sshPrivateKeyFilePath
+    this.privateKeyPassphrase = privateKeyPassphrase
     this.tenancyId = tenancyId
     this.region = region
 
@@ -71,6 +74,7 @@ class OracleNamedAccountCredentials implements AccountCredentials<Object> {
       .userId(this.userId)
       .fingerprint(this.fingerprint)
       .privateKeySupplier(privateKeySupplier)
+      .passPhrase(this.privateKeyPassphrase)
       .tenantId(this.tenancyId)
       .build()
 
@@ -100,6 +104,7 @@ class OracleNamedAccountCredentials implements AccountCredentials<Object> {
     String userId
     String fingerprint
     String sshPrivateKeyFilePath
+    String privateKeyPassphrase
     String tenancyId
     String region
 
@@ -143,6 +148,11 @@ class OracleNamedAccountCredentials implements AccountCredentials<Object> {
       return this
     }
 
+    Builder privateKeyPassphrase(String privateKeyPassphrase) {
+      this.privateKeyPassphrase = privateKeyPassphrase
+      return this
+    }
+
     Builder tenancyId(String tenancyId) {
       this.tenancyId = tenancyId
       return this
@@ -163,6 +173,7 @@ class OracleNamedAccountCredentials implements AccountCredentials<Object> {
         this.userId,
         this.fingerprint,
         this.sshPrivateKeyFilePath,
+        this.privateKeyPassphrase,
         this.tenancyId,
         this.region)
     }


### PR DESCRIPTION
Allow oracle provider and oracle artifact to use private key file with passphrase.
Related halyard PR is https://github.com/spinnaker/halyard/pull/1070.