### PR TITLE
fix(aws): Revert "Use Edda during upsert AMI tags operations (#3034)"

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAmiTagsAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAmiTagsAtomicOperation.groovy
@@ -50,18 +50,11 @@ class UpsertAmiTagsAtomicOperation implements AtomicOperation<Void> {
     task.updateStatus BASE_PHASE, "Initializing Upsert AMI Tags operation for ${descriptor}..."
 
     description.regions.each { String region ->
-      def amazonEC2 = amazonClientProvider.getAmazonEC2(description.credentials, region, false)
+      def amazonEC2 = amazonClientProvider.getAmazonEC2(description.credentials, region, true)
       def describeImagesRequest = new DescribeImagesRequest().withFilters(
         new Filter("name", [description.amiName])
       )
       def images = amazonEC2.describeImages(describeImagesRequest).images
-
-      if (!images?.isEmpty()) {
-        // Edda doesn't support filtering, so we need to do runtime filtering here. This is basically a no-op with
-        // Edda-less deployments.
-        images = images.findAll { it.name == description.amiName }
-      }
-
       if (!images) {
         task.updateStatus BASE_PHASE, "No AMI found for ${descriptor} in ${region}."
         task.fail()


### PR DESCRIPTION
This reverts commit 8d2df55250f31ccaa1ca4b8269bebf2a1de526c8.

Unfortunately, this didn't really move the needle in the direction I was anticipating.

![atlas-graph-rz-17](https://user-images.githubusercontent.com/108741/47103752-c446cd80-d1f4-11e8-9945-1fa0025e37d0.png)
