### PR TITLE
feat(provider/appengine): config files from artifacts

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineAtomicOperationConverter.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineAtomicOperationConverter.groovy
@@ -63,6 +63,10 @@ class DeployAppengineAtomicOperationConverter extends AbstractAtomicOperationsCr
           throw new AppengineDescriptionConversionException("Invalid artifact type for Appengine deploy: ${description.artifact.type}")
       }
     }
+    if (input.configArtifacts) {
+      def configArtifacts = input.configArtifacts
+      description.configArtifacts = configArtifacts.collect({ objectMapper.convertValue(it, Artifact) })
+    }
 
     return description
   }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
@@ -37,6 +37,7 @@ class DeployAppengineDescription extends AbstractAppengineCredentialsDescription
   String applicationDirectoryRoot
   List<String> configFilepaths
   List<String> configFiles
+  List<Artifact> configArtifacts
   Boolean promote
   Boolean stopPreviousVersion
   String containerImageUrl // app engine flex only

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
@@ -69,7 +69,7 @@ class DeployAppengineDescriptionValidator extends DescriptionValidator<DeployApp
     helper.validateStack(description.stack, "stack")
     helper.validateDetails(description.freeFormDetails, "freeFormDetails")
 
-    if (!(description.configFilepaths || description.configFiles)) {
+    if (!(description.configFilepaths || description.configFiles || description.configArtifacts)) {
       helper.validateNotEmpty(description.configFilepaths, "configFilepaths")
       helper.validateNotEmpty(description.configFiles, "configFiles")
     }


### PR DESCRIPTION
Allow artifacts to be used as config files when deploying to AppEngine. The artifacts are downloaded and supplied to the `gcloud app deploy` command alongside any other config files specified as file paths or provided as text. Accompanying changes in Orca, Gate, and Deck incoming.

Contributes to https://github.com/spinnaker/spinnaker/issues/3476