### PR TITLE
fix(web): Increase default page size for entity tags from 2000 -> 5000

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/EntityTagsController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/EntityTagsController.java
@@ -58,7 +58,7 @@ public class EntityTagsController {
                                      @RequestParam(value = "account", required = false) String account,
                                      @RequestParam(value = "region", required = false) String region,
                                      @RequestParam(value = "namespace", required = false) String namespace,
-                                     @RequestParam(value = "maxResults", required = false, defaultValue = "2000") int maxResults,
+                                     @RequestParam(value = "maxResults", required = false, defaultValue = "5000") int maxResults,
                                      @RequestParam Map<String, Object> allParameters) {
 
     Map<String, Object> tags = allParameters.entrySet().stream()


### PR DESCRIPTION
We need to get better at cleaning up entity tags but I've spot checked
a couple of large applications and the load time is reasonable.
