### PR TITLE
fix(image): don't add beginning glob to image search

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupController.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/AmazonNamedImageLookupController.groovy
@@ -75,7 +75,7 @@ class AmazonNamedImageLookupController {
 
     // Wrap in '*' if there are no glob-style characters in the query string
     if (!isAmi && !glob.contains('*') && !glob.contains('?') && !glob.contains('[') && !glob.contains('\\')) {
-      glob = "*${glob}*"
+      glob = "${glob}*"
     }
 
     def namedImageSearch = Keys.getNamedImageKey(lookupOptions.account ?: '*', glob)


### PR DESCRIPTION
When we're searching for an image, there doesn't seem to be a reason why we should add a glob to the front of the query here. Specifying a package of `ate` (query like `find?q=ate`) in a find image stage would lead match `gate`, which doesn't seem like desired behavior. 

Is there some scenario I'm missing here where the first `*` is needed?