### PR TITLE
feat(security): Support multiple applications in `ApplicationNameable`

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -20,12 +20,13 @@ import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
+import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 
 @AutoClone
 @Canonical
-class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription implements DeployDescription {
+class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription implements DeployDescription, ApplicationNameable {
   String application
   String amiName
   String stack
@@ -95,6 +96,11 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   Capacity capacity = new Capacity()
   Source source = new Source()
   Map<String, String> tags
+
+  @Override
+  Collection<String> getApplications() {
+    return [application]
+  }
 
   @Canonical
   static class Capacity {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ResizeAsgDescription.groovy
@@ -17,18 +17,16 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
 
-class ResizeAsgDescription extends AbstractAmazonCredentialsDescription {
-  String serverGroupName
-  String region
+class ResizeAsgDescription extends AbstractAmazonCredentialsDescription implements ServerGroupNameable {
   ServerGroup.Capacity capacity
   List<AsgTargetDescription> asgs = []
 
-  @Deprecated
-  String asgName
-
-  @Deprecated
-  List<String> regions = []
+  @Override
+  Collection<String> getServerGroupNames() {
+    return asgs.collect { it.serverGroupName }
+  }
 
   static class Constraints {
     ServerGroup.Capacity capacity

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/TerminateInstanceAndDecrementAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/TerminateInstanceAndDecrementAsgDescription.groovy
@@ -16,10 +16,17 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-class TerminateInstanceAndDecrementAsgDescription extends AbstractAmazonCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
+
+class TerminateInstanceAndDecrementAsgDescription extends AbstractAmazonCredentialsDescription implements ServerGroupNameable {
   String asgName
   String instance
   String region
   Boolean adjustMinIfNecessary
   Boolean setMaxToNewDesired
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [asgName]
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.groovy
@@ -45,9 +45,10 @@ public abstract class DescriptionValidator<T> implements VersionedCloudProviderO
     Authentication auth = SecurityContextHolder.context.authentication
 
     if (description instanceof ApplicationNameable) {
-      ApplicationNameable asApp = description as ApplicationNameable
-      if (!permissionEvaluator.hasPermission(auth, asApp.application, 'APPLICATION', 'WRITE')) {
-        errors.reject("authorization", "Access denied to application ${asApp.application}")
+      (description as ApplicationNameable).applications.each { application ->
+        if (!permissionEvaluator.hasPermission(auth, application, 'APPLICATION', 'WRITE')) {
+          errors.reject("authorization", "Access denied to application ${application}")
+        }
       }
     }
 
@@ -61,7 +62,7 @@ public abstract class DescriptionValidator<T> implements VersionedCloudProviderO
     if (description instanceof ResourcesNameable) {
       ResourcesNameable asResources = description as ResourcesNameable
       permissionEvaluator.storeWholePermission()
-      asResources.applications.each { String app ->
+      asResources.resourceApplications.each { String app ->
         if (!permissionEvaluator.hasPermission(auth, app, 'APPLICATION', 'WRITE')) {
           errors.reject("authorization", "Access denied to application ${app}")
         }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidatorSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidatorSpec.groovy
@@ -43,7 +43,7 @@ class DescriptionValidatorSpec extends Specification {
     TestValidator validator = new TestValidator(permissionEvaluator: evaluator)
 
     TestDescription description = new TestDescription(account: "testAccount",
-                                                      application: "testApplication",
+                                                      applications: ["testApplication"],
                                                       names: ["thing1", "thing2"])
     Errors errors = new DescriptionValidationErrors(description)
 
@@ -65,7 +65,7 @@ class DescriptionValidatorSpec extends Specification {
 
   class TestDescription implements AccountNameable, ApplicationNameable, ResourcesNameable {
     String account
-    String application
+    Collection<String> applications
     List<String> names
   }
 }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/description/servergroup/AbstractDcosServerGroupDescription.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/description/servergroup/AbstractDcosServerGroupDescription.groovy
@@ -23,4 +23,9 @@ import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable;
 abstract class AbstractDcosServerGroupDescription extends AbstractDcosCredentialsDescription implements ServerGroupNameable {
   String serverGroupName
   boolean forceDeployment = true
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [serverGroupName]
+  }
 }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/description/servergroup/DeployDcosServerGroupDescription.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/description/servergroup/DeployDcosServerGroupDescription.groovy
@@ -65,6 +65,11 @@ class DeployDcosServerGroupDescription extends AbstractDcosCredentialsDescriptio
 
   boolean forceDeployment
 
+  @Override
+  Collection<String> getApplications() {
+    return [application]
+  }
+
   @Canonical
   static class Container {
     String type

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BasicGoogleDeployDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BasicGoogleDeployDescription.groovy
@@ -83,12 +83,12 @@ class BasicGoogleDeployDescription extends BaseGoogleInstanceDescription impleme
     Integer desired
   }
 
-  String getApplication() {
+  Collection<String> getApplications() {
     if (application) {
-      return application
+      return Collections.singletonList(application)
     }
     if (source && source.serverGroupName) {
-      return Names.parseName(source.serverGroupName).app
+      return Collections.singletonList(Names.parseName(source.serverGroupName).app)
     }
   }
 
@@ -98,5 +98,10 @@ class BasicGoogleDeployDescription extends BaseGoogleInstanceDescription impleme
     String region
     String serverGroupName
     Boolean useSourceCapacity
+
+    @Override
+    Collection<String> getServerGroupNames() {
+      return Collections.singletonList(serverGroupName)
+    }
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/EnableDisableGoogleServerGroupDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/EnableDisableGoogleServerGroupDescription.groovy
@@ -30,4 +30,9 @@ class EnableDisableGoogleServerGroupDescription extends AbstractGoogleCredential
 
   @Deprecated
   String zone
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [getServerGroupName()]
+  }
 }

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/description/BasicOracleDeployDescription.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/description/BasicOracleDeployDescription.groovy
@@ -29,4 +29,9 @@ class BasicOracleDeployDescription extends BaseOracleInstanceDescription impleme
   ServerGroup.Capacity capacity
   //targetSize takes precedence if targetSize and capacity.desired are both specified.
   Integer targetSize
+
+  @Override
+  Collection<String> getApplications() {
+    return [application]
+  }
 }

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/description/CreateLoadBalancerDescription.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/description/CreateLoadBalancerDescription.groovy
@@ -44,4 +44,9 @@ class CreateLoadBalancerDescription extends AbstractOracleCredentialsDescription
       return this.application + "-" + stack
     }
   }
+
+  @Override
+  Collection<String> getApplications() {
+    return [application]
+  }
 }

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/description/DeleteLoadBalancerDescription.java
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/description/DeleteLoadBalancerDescription.java
@@ -10,6 +10,9 @@ package com.netflix.spinnaker.clouddriver.oracle.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class DeleteLoadBalancerDescription extends AbstractOracleCredentialsDescription implements ApplicationNameable {
   String application;
   String loadBalancerId;
@@ -25,5 +28,10 @@ public class DeleteLoadBalancerDescription extends AbstractOracleCredentialsDesc
   }
   public void setLoadBalancerId(String loadBalancerId) {
     this.loadBalancerId = loadBalancerId;
+  }
+
+  @Override
+  public Collection<String> getApplications() {
+    return Collections.singleton(application);
   }
 }

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/description/EnableDisableOracleServerGroupDescription.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/description/EnableDisableOracleServerGroupDescription.groovy
@@ -20,4 +20,9 @@ class EnableDisableOracleServerGroupDescription extends AbstractOracleCredential
 
   String region
   String accountName
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [getServerGroupName()]
+  }
 }

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/op/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/op/AbstractEnableDisableAtomicOperation.groovy
@@ -41,7 +41,7 @@ abstract class AbstractEnableDisableAtomicOperation implements AtomicOperation<V
 
     task.updateStatus phaseName, "Initializing $verb server group operation for $description.serverGroupName in " +
       "$description.region..."
-    def serverGroup = oracleServerGroupService.getServerGroup(description.credentials, description.application, description.serverGroupName)
+
     //TODO stop all instances in sg
     if (disable) {
       task.updateStatus phaseName, "$presentParticipling server group from Http(s) load balancers..."

--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/op/DisableOracleServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/op/DisableOracleServerGroupAtomicOperationSpec.groovy
@@ -47,6 +47,5 @@ class DisableOracleServerGroupAtomicOperationSpec extends Specification {
 
     then:
     1 * sgService.disableServerGroup(_, _, "sg1")
-    1 * sgService.getServerGroup(_, _, "sg1") >> new OracleServerGroup(loadBalancerId: "ocid.lb.oc1..12345")
   }
 }

--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/op/EnableOracleServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/op/EnableOracleServerGroupAtomicOperationSpec.groovy
@@ -46,6 +46,5 @@ class EnableOracleServerGroupAtomicOperationSpec extends Specification {
 
     then:
     1 * sgService.enableServerGroup(_, _, "sg1")
-    1 * sgService.getServerGroup(_, _, "sg1") >> new OracleServerGroup(loadBalancerId: "ocid.lb.oc1..12345")
   }
 }

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ApplicationNameable.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ApplicationNameable.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Google, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.security.resources
+package com.netflix.spinnaker.clouddriver.security.resources;
+
+import java.util.Collection;
 
 /**
- * Denotes an operation description operates on a specific application resource.
+ * Denotes an operation description operates on one or more specific application resources.
  */
-interface ApplicationNameable {
-  String getApplication()
+public interface ApplicationNameable {
+  Collection<String> getApplications();
 }

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ResourcesNameable.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ResourcesNameable.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 public interface ResourcesNameable {
   Collection<String> getNames();
 
-  default List<String> getApplications() {
+  default Collection<String> getResourceApplications() {
     return getNames().stream()
                      .map(name -> Names.parseName(name).getApp())
                      .collect(Collectors.toList());

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ServerGroupNameable.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ServerGroupNameable.java
@@ -18,15 +18,17 @@ package com.netflix.spinnaker.clouddriver.security.resources;
 
 import com.netflix.frigga.Names;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 /**
- * Convenience trait for parsing the application name out of a description with a "serverGroupName"
- * property.
+ * Convenience trait for parsing application names out of a description with one or more server group names.
  */
 public interface ServerGroupNameable extends ApplicationNameable {
-  String getServerGroupName();
+  Collection<String> getServerGroupNames();
 
   @Override
-  default String getApplication() {
-    return Names.parseName(getServerGroupName()).getApp();
+  default Collection<String> getApplications() {
+    return getServerGroupNames().stream().map(n -> Names.parseName(n).getApp()).collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
Allow an implementation of `ApplicationNameable` to support authorization
checks against _multiple_ applications.

This handles scenarios where a particular operation may target multiple
server groups that may or may not exist in the same application.
