### PR TITLE
feat(core): General purpose `DescriptionAuthorizer`

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation
 import com.netflix.spinnaker.cats.agent.NoopExecutionInstrumentation
 import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions
@@ -30,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfiguration
 import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfigurationBuilder
 import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionAuthorizer
 import com.netflix.spinnaker.clouddriver.model.*
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
 import com.netflix.spinnaker.clouddriver.names.NamingStrategy
@@ -43,6 +45,7 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
@@ -55,6 +58,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.PropertySource
 import org.springframework.core.env.Environment
+import org.springframework.security.access.PermissionEvaluator
 import org.springframework.web.client.RestTemplate
 
 import javax.inject.Provider
@@ -272,5 +276,16 @@ class CloudDriverConfig {
   @Bean
   NamerRegistry namerRegistry(Optional<List<NamingStrategy>> namingStrategies) {
     new NamerRegistry(namingStrategies.orElse([]))
+  }
+
+  @Bean
+  DescriptionAuthorizer descriptionAuthorizer(Registry registry,
+                                              ObjectMapper objectMapper,
+                                              Optional<FiatPermissionEvaluator> fiatPermissionEvaluator) {
+    return new DescriptionAuthorizer(
+      registry,
+      objectMapper,
+      fiatPermissionEvaluator
+    )
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.deploy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.security.resources.AccountNameable;
+import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable;
+import com.netflix.spinnaker.clouddriver.security.resources.ResourcesNameable;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.Errors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+public class DescriptionAuthorizer<T> {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final Registry registry;
+  private final ObjectMapper objectMapper;
+  private final FiatPermissionEvaluator fiatPermissionEvaluator;
+
+  private final Id missingApplicationId;
+  private final Id authorizationId;
+
+  public DescriptionAuthorizer(Registry registry,
+                               ObjectMapper objectMapper,
+                               Optional<FiatPermissionEvaluator> fiatPermissionEvaluator) {
+    this.registry = registry;
+    this.objectMapper = objectMapper;
+    this.fiatPermissionEvaluator = fiatPermissionEvaluator.orElse(null);
+
+    this.missingApplicationId = registry.createId("authorization.missingApplication");
+    this.authorizationId = registry.createId("authorization");
+  }
+
+  public void authorize(T description, Errors errors) {
+    if (fiatPermissionEvaluator == null || description == null) {
+      return;
+    }
+
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+    String account = null;
+    List<String> applications = new ArrayList<>();
+
+    if (description instanceof AccountNameable) {
+      AccountNameable accountNameable = (AccountNameable) description;
+      account = accountNameable.getAccount();
+    }
+
+    if (description instanceof ApplicationNameable) {
+      ApplicationNameable applicationNameable = (ApplicationNameable) description;
+      applications.addAll(
+        applicationNameable.getApplications().stream().filter(Objects::nonNull).collect(Collectors.toList())
+      );
+    }
+
+    if (description instanceof ResourcesNameable) {
+      ResourcesNameable resourcesNameable = (ResourcesNameable) description;
+      applications.addAll(
+        resourcesNameable.getResourceApplications().stream().filter(Objects::nonNull).collect(Collectors.toList())
+      );
+    }
+
+
+    boolean hasPermission = true;
+    if (account != null && !fiatPermissionEvaluator.hasPermission(auth, account, "ACCOUNT", "WRITE")) {
+      hasPermission = false;
+      errors.reject("authorization", format("Access denied to account %s", account));
+    }
+
+    if (!applications.isEmpty()) {
+      fiatPermissionEvaluator.storeWholePermission();
+
+      for (String application: applications) {
+        if (!fiatPermissionEvaluator.hasPermission(auth, application, "APPLICATION", "WRITE")) {
+          hasPermission = false;
+          errors.reject("authorization", format("Access denied to application %s", application));
+        }
+      }
+    }
+
+
+    if (account != null && applications.isEmpty()) {
+      registry.counter(
+          missingApplicationId
+            .withTag("descriptionClass", description.getClass().getSimpleName())
+        ).increment();
+
+      String rawJson = null;
+      try {
+        rawJson = objectMapper.writeValueAsString(description);
+      } catch (JsonProcessingException ignored) {}
+
+      log.warn(
+        "No application(s) specified for operation with account restriction (type: {}, rawJson: {})",
+        description.getClass().getSimpleName(),
+        rawJson
+      );
+    }
+
+    registry.counter(
+      authorizationId
+        .withTag("descriptionClass", description.getClass().getSimpleName())
+        .withTag("success", hasPermission)
+    ).increment();
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.groovy
@@ -33,40 +33,4 @@ public abstract class DescriptionValidator<T> implements VersionedCloudProviderO
   }
 
   abstract void validate(List priorDescriptions, T description, Errors errors)
-
-  @Autowired(required = false)
-  FiatPermissionEvaluator permissionEvaluator
-
-  void authorize(T description, Errors errors) {
-    if (!permissionEvaluator) {
-      return
-    }
-
-    Authentication auth = SecurityContextHolder.context.authentication
-
-    if (description instanceof ApplicationNameable) {
-      (description as ApplicationNameable).applications.each { application ->
-        if (!permissionEvaluator.hasPermission(auth, application, 'APPLICATION', 'WRITE')) {
-          errors.reject("authorization", "Access denied to application ${application}")
-        }
-      }
-    }
-
-    if (description instanceof AccountNameable) {
-      AccountNameable asAcct = description as AccountNameable
-      if (!permissionEvaluator.hasPermission(auth, asAcct.account, 'ACCOUNT', 'WRITE')) {
-        errors.reject("authorization", "Access denied to account ${asAcct.account}")
-      }
-    }
-
-    if (description instanceof ResourcesNameable) {
-      ResourcesNameable asResources = description as ResourcesNameable
-      permissionEvaluator.storeWholePermission()
-      asResources.resourceApplications.each { String app ->
-        if (!permissionEvaluator.hasPermission(auth, app, 'APPLICATION', 'WRITE')) {
-          errors.reject("authorization", "Access denied to application ${app}")
-        }
-      }
-    }
-  }
 }

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ResourcesNameable.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ResourcesNameable.java
@@ -20,6 +20,7 @@ import com.netflix.frigga.Names;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -30,8 +31,10 @@ public interface ResourcesNameable {
   Collection<String> getNames();
 
   default Collection<String> getResourceApplications() {
-    return getNames().stream()
-                     .map(name -> Names.parseName(name).getApp())
-                     .collect(Collectors.toList());
+    return getNames()
+      .stream()
+      .filter(Objects::nonNull)
+      .map(name -> Names.parseName(name).getApp())
+      .collect(Collectors.toList());
   }
 }

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ServerGroupNameable.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ServerGroupNameable.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.security.resources;
 import com.netflix.frigga.Names;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -29,6 +30,10 @@ public interface ServerGroupNameable extends ApplicationNameable {
 
   @Override
   default Collection<String> getApplications() {
-    return getServerGroupNames().stream().map(n -> Names.parseName(n).getApp()).collect(Collectors.toList());
+    return getServerGroupNames()
+      .stream()
+      .filter(Objects::nonNull)
+      .map(n -> Names.parseName(n).getApp())
+      .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
Ported the `authorize()` method from `DescriptionValidator` and added
a metric in the event that a description presents an account _but_ no
application(s).

This metric will emit some false positives but still prove useful in the
short-term to highlight descriptions that might not implement
`ApplicationNameable` (or not implement it properly).

The previous behavior expected a `Description` to implement
`DescriptionValidator` in order to have authorization applied, however
this is not a requirement and missed some legitimate scenarios.
