### PR TITLE
fix(titus): Ensure that Titus operations enforce WRITE access to applications

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/description/EnableDisableDescriptionTrait.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/description/EnableDisableDescriptionTrait.groovy
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.deploy.description
 
-trait EnableDisableDescriptionTrait {
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
+
+trait EnableDisableDescriptionTrait implements ServerGroupNameable {
   String serverGroupName
 
   Integer getDesiredPercentage() {
@@ -25,5 +27,10 @@ trait EnableDisableDescriptionTrait {
 
   void setDesiredPercentage(Integer _) {
     throw new IllegalArgumentException("The selected provider hasn't implemented enabling/disabling by percentage yet")
+  }
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [serverGroupName]
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/AbstractRegionAsgInstanceIdsDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/AbstractRegionAsgInstanceIdsDescription.groovy
@@ -16,9 +16,16 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
-abstract class AbstractRegionAsgInstanceIdsDescription extends AbstractTitusCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
+
+abstract class AbstractRegionAsgInstanceIdsDescription extends AbstractTitusCredentialsDescription implements ServerGroupNameable {
   String region
   String asgName
   List<String> instanceIds
   Integer targetHealthyDeployPercentage
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [asgName]
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DestroyTitusServerGroupDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DestroyTitusServerGroupDescription.groovy
@@ -16,8 +16,15 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
-class DestroyTitusServerGroupDescription extends AbstractTitusCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
+
+class DestroyTitusServerGroupDescription extends AbstractTitusCredentialsDescription implements ServerGroupNameable {
   String region
   String serverGroupName
   String user
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [serverGroupName]
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DetachTitusInstancesDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DetachTitusInstancesDescription.groovy
@@ -16,11 +16,18 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
-class DetachTitusInstancesDescription extends AbstractTitusCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
+
+class DetachTitusInstancesDescription extends AbstractTitusCredentialsDescription implements ServerGroupNameable {
   String region
   List<String> instanceIds
   boolean decrementDesiredCapacity
   boolean adjustMinIfNecessary
   String asgName
   String user
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [asgName]
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/ResizeTitusServerGroupDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/ResizeTitusServerGroupDescription.groovy
@@ -16,13 +16,19 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
 import groovy.transform.Canonical
 
-class ResizeTitusServerGroupDescription extends AbstractTitusCredentialsDescription {
+class ResizeTitusServerGroupDescription extends AbstractTitusCredentialsDescription implements ServerGroupNameable {
   String region
   String serverGroupName
   String user
   Capacity capacity
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return [serverGroupName]
+  }
 
   @Canonical
   static class Capacity {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.groovy
@@ -18,11 +18,12 @@ package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
+import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
 import com.netflix.spinnaker.clouddriver.titus.client.model.Efs
 import com.netflix.spinnaker.clouddriver.titus.client.model.MigrationPolicy
 import groovy.transform.Canonical
 
-class TitusDeployDescription extends AbstractTitusCredentialsDescription implements DeployDescription {
+class TitusDeployDescription extends AbstractTitusCredentialsDescription implements DeployDescription, ApplicationNameable {
   String region
   String subnet
   List<String> zones
@@ -59,6 +60,11 @@ class TitusDeployDescription extends AbstractTitusCredentialsDescription impleme
   Collection<OperationEvent> events = []
 
   Source source = new Source()
+
+  @Override
+  Collection<String> getApplications() {
+    return [application]
+  }
 
   @Canonical
   static class Capacity {


### PR DESCRIPTION
The majority of Titus operations were not implementing one of:
- `ApplicationNameable`
- `ServerGroupNameable`
- `ResourcesNameable`

In these cases, there was no check being performed that a particular
operation had access to the application owning the particular resource
being modified.
