### PR TITLE
fix(security): Override `requiresApplicationRestriction` as needed

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/AllowLaunchDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/AllowLaunchDescription.groovy
@@ -20,4 +20,9 @@ class AllowLaunchDescription extends AbstractAmazonCredentialsDescription {
   String account
   String amiName
   String region
+
+  @Override
+  boolean requiresApplicationRestriction() {
+    return false
+  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/InstanceTargetGroupRegistrationDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/InstanceTargetGroupRegistrationDescription.groovy
@@ -16,6 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-class InstanceTargetGroupRegistrationDescription extends AbstractRegionAsgInstanceIdsDescription {
+import com.netflix.spinnaker.clouddriver.security.resources.ResourcesNameable
+
+class InstanceTargetGroupRegistrationDescription extends AbstractRegionAsgInstanceIdsDescription implements ResourcesNameable {
   List<String> targetGroupNames
+
+  @Override
+  Collection<String> getNames() {
+    return targetGroupNames ?: []
+  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/RebootInstancesDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/RebootInstancesDescription.groovy
@@ -16,7 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-class RebootInstancesDescription extends AbstractAmazonCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
+
+class RebootInstancesDescription extends AbstractAmazonCredentialsDescription implements ApplicationNameable {
   String region
   List<String> instanceIds
+
+  Set<String> applications
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmiTagsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/UpsertAmiTagsDescription.groovy
@@ -21,4 +21,9 @@ class UpsertAmiTagsDescription extends AbstractAmazonCredentialsDescription {
   String amiName
   Collection<String> regions
   Map<String, String> tags
+
+  @Override
+  boolean requiresApplicationRestriction() {
+    return false
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
@@ -31,6 +31,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.Errors;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -77,14 +78,20 @@ public class DescriptionAuthorizer<T> {
     if (description instanceof ApplicationNameable) {
       ApplicationNameable applicationNameable = (ApplicationNameable) description;
       applications.addAll(
-        applicationNameable.getApplications().stream().filter(Objects::nonNull).collect(Collectors.toList())
+        Optional.ofNullable(applicationNameable.getApplications()).orElse(Collections.emptyList())
+          .stream()
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList())
       );
     }
 
     if (description instanceof ResourcesNameable) {
       ResourcesNameable resourcesNameable = (ResourcesNameable) description;
       applications.addAll(
-        resourcesNameable.getResourceApplications().stream().filter(Objects::nonNull).collect(Collectors.toList())
+        Optional.ofNullable(resourcesNameable.getResourceApplications()).orElse(Collections.emptyList())
+          .stream()
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList())
       );
     }
 

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/AccountNameable.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/AccountNameable.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 Google, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,11 +14,18 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.security.resources
+package com.netflix.spinnaker.clouddriver.security.resources;
 
 /**
  * Denotes an operation description operates on a specific account.
  */
-interface AccountNameable {
-  String getAccount()
+public interface AccountNameable {
+  String getAccount();
+
+  /**
+   * @return whether or not this operation description expects to be further restricted by one or more applications
+   */
+  default boolean requiresApplicationRestriction() {
+    return true;
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DeregisterTitusInstanceFromLoadBalancerDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DeregisterTitusInstanceFromLoadBalancerDescription.groovy
@@ -22,5 +22,8 @@ import groovy.transform.Canonical
 @AutoClone
 @Canonical
 class DeregisterTitusInstanceFromLoadBalancerDescription extends AbstractTitusCredentialsDescription {
-
+  @Override
+  boolean requiresApplicationRestriction() {
+    return false
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/ModifyTitusAsgLaunchConfigurationDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/ModifyTitusAsgLaunchConfigurationDescription.groovy
@@ -22,5 +22,8 @@ import groovy.transform.Canonical
 @AutoClone
 @Canonical
 class ModifyTitusAsgLaunchConfigurationDescription extends AbstractTitusCredentialsDescription {
-
+  @Override
+  boolean requiresApplicationRestriction() {
+    return false
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/UpsertTitusScalingPolicyDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/UpsertTitusScalingPolicyDescription.groovy
@@ -26,6 +26,7 @@ import com.google.protobuf.DoubleValue
 import com.google.protobuf.Int32Value
 import com.google.protobuf.Int64Value
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAlarmDescription
+import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
 import com.netflix.titus.grpc.protogen.*
 import com.netflix.titus.grpc.protogen.AlarmConfiguration.ComparisonOperator
 import com.netflix.titus.grpc.protogen.AlarmConfiguration.Statistic
@@ -33,7 +34,9 @@ import com.netflix.titus.grpc.protogen.ScalingPolicy.Builder
 import com.netflix.titus.grpc.protogen.StepScalingPolicy.AdjustmentType
 import com.netflix.titus.grpc.protogen.StepScalingPolicy.MetricAggregationType
 
-class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescription {
+class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescription implements ApplicationNameable {
+  String application
+
   // required
   String region
   String jobId
@@ -47,6 +50,11 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
   TargetTrackingConfiguration targetTrackingConfiguration
 
   UpsertAlarmDescription alarm
+
+  @Override
+  Collection<String> getApplications() {
+    return [application]
+  }
 
   static class Step {
     Collection<StepAdjustment> stepAdjustments
@@ -209,4 +217,6 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
 
     description
   }
+
+
 }


### PR DESCRIPTION
A few `Description` classes legitimately do not need to be further
restricted by application.

Some `Description` classes need to determine applications by
fetching cached data (or looking directly at a cloud provider).