### PR TITLE
fix(security): Correctly determine application when terminating instances

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/RebootInstancesAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/RebootInstancesAtomicOperationConverter.groovy
@@ -45,15 +45,15 @@ class RebootInstancesAtomicOperationConverter extends AbstractAtomicOperationsCr
     converted.credentials = getCredentialsObject(input.credentials as String)
 
     try {
-      def applications = converted.instanceIds.findResults {
+      def serverGroups = converted.instanceIds.findResults {
         def instance = amazonInstanceProvider.getInstance(converted.credentials.name, converted.region, it)
         return instance?.any()?.get("serverGroup")
       } as Set<String>
-      converted.applications = applications
+      converted.serverGroups = serverGroups
     } catch (Exception e) {
-      converted.applications = []
+      converted.serverGroups = []
       log.error(
-        "Unable to determine application for instances (instanceIds: {}, account: {}, region: {})",
+        "Unable to determine server groups for instances (instanceIds: {}, account: {}, region: {})",
         converted.instanceIds,
         converted.credentials.name,
         converted.region,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/TerminateInstancesAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/TerminateInstancesAtomicOperationConverter.groovy
@@ -16,16 +16,23 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.converters
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonInstanceProvider
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.TerminateInstancesDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.TerminateInstancesAtomicOperation
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-@AmazonOperation(AtomicOperations.TERMINATE_INSTANCES)
+@Slf4j
 @Component("terminateInstancesDescription")
+@AmazonOperation(AtomicOperations.TERMINATE_INSTANCES)
 class TerminateInstancesAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  @Autowired
+  AmazonInstanceProvider amazonInstanceProvider
+
   @Override
   AtomicOperation convertOperation(Map input) {
     new TerminateInstancesAtomicOperation(convertDescription(input))
@@ -35,6 +42,24 @@ class TerminateInstancesAtomicOperationConverter extends AbstractAtomicOperation
   TerminateInstancesDescription convertDescription(Map input) {
     def converted = objectMapper.convertValue(input, TerminateInstancesDescription)
     converted.credentials = getCredentialsObject(input.credentials as String)
+
+    try {
+      def serverGroups = converted.instanceIds.findResults {
+        def instance = amazonInstanceProvider.getInstance(converted.credentials.name, converted.region, it)
+        return instance?.any()?.get("serverGroup")
+      } as Set<String>
+      converted.serverGroups = serverGroups
+    } catch (Exception e) {
+      converted.serverGroups = []
+      log.error(
+        "Unable to determine server groups for instances (instanceIds: {}, account: {}, region: {})",
+        converted.instanceIds,
+        converted.credentials.name,
+        converted.region,
+        e
+      )
+    }
+
     converted
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/RebootInstancesDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/RebootInstancesDescription.groovy
@@ -16,11 +16,16 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
 
-class RebootInstancesDescription extends AbstractAmazonCredentialsDescription implements ApplicationNameable {
+class RebootInstancesDescription extends AbstractAmazonCredentialsDescription implements ServerGroupNameable {
   String region
   List<String> instanceIds
 
-  Set<String> applications
+  Set<String> serverGroups
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return serverGroups
+  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/TerminateInstancesDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/TerminateInstancesDescription.groovy
@@ -15,7 +15,16 @@
  */
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
-class TerminateInstancesDescription extends AbstractAmazonCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
+
+class TerminateInstancesDescription extends AbstractAmazonCredentialsDescription implements ServerGroupNameable {
   String region
   List<String> instanceIds
+
+  Set<String> serverGroups
+
+  @Override
+  Collection<String> getServerGroupNames() {
+    return serverGroups
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TerminateTitusInstancesDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TerminateTitusInstancesDescription.groovy
@@ -16,8 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.description
 
-class TerminateTitusInstancesDescription extends AbstractTitusCredentialsDescription {
+import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
+
+class TerminateTitusInstancesDescription extends AbstractTitusCredentialsDescription implements ApplicationNameable {
   String region
   List<String> instanceIds
   String user
+
+  Set<String> applications
 }


### PR DESCRIPTION
This PR will lookup previously cached AWS/Titus instances to determine
their owning application.
