### PR TITLE
fix(security): Handle empty `TerminateTitusInstancesDescription`

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TerminateTitusInstancesDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TerminateTitusInstancesDescription.groovy
@@ -24,4 +24,13 @@ class TerminateTitusInstancesDescription extends AbstractTitusCredentialsDescrip
   String user
 
   Set<String> applications
+
+  @Override
+  boolean requiresApplicationRestriction() {
+    if (instanceIds == null || instanceIds.isEmpty()) {
+      return false
+    }
+
+    return true
+  }
 }


### PR DESCRIPTION
Suppress an unnecessary `WARN` when a terminate description does not
specify any `instanceIds`.

(noticed this internally)
