### PR TITLE
fix(cats): Avoid searching without query string

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -237,7 +237,17 @@ class CatsSearchProvider implements SearchProvider, Runnable {
           return true
         }
       }
-      log.info("no query string specified, looked for sensible default and found: ${q}")
+
+      if (q) {
+        log.info(
+          "no query string specified, looked for sensible default and found: {} (cachesToQuery: {})",
+          q,
+          cachesToQuery
+        )
+      } else {
+        log.info("no query string specified and no sensible default found (cachesToQuery: {})", cachesToQuery)
+        return []
+      }
     }
 
     log.info("Querying ${cachesToQuery} for term: ${q}")


### PR DESCRIPTION
`/search?type=instances&cloudProvider=aws` is a surefire way to
unhappiness.

Looking through our logs, I do not see any legitimate searches w/o
a query string.
