### PR TITLE
fix(provider/gce): Wait for batch requests to finish before returning

### DIFF
--- a/clouddriver-google-common/src/main/groovy/com/netflix/spinnaker/clouddriver/googlecommon/batch/GoogleBatchRequest.java
+++ b/clouddriver-google-common/src/main/groovy/com/netflix/spinnaker/clouddriver/googlecommon/batch/GoogleBatchRequest.java
@@ -41,9 +41,11 @@ import java.util.concurrent.TimeUnit;
 public class GoogleBatchRequest {
 
   private static final int MAX_BATCH_SIZE = 100; // Platform specified max to not overwhelm batch backends.
-  private static final int DEFAULT_EXECUTE_TIMEOUT_MINUTES = 10;
   private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = (int) TimeUnit.MINUTES.toMillis(2);
   private static final int DEFAULT_READ_TIMEOUT_MILLIS = (int) TimeUnit.MINUTES.toMillis(2);
+  // Many requests (ex: caching load balancers) have callbacks that execute further requests, up to a depth of 3-4
+  // requests. For this reason, make the overall execute timeout a factor of ~5 longer than the individual timeouts.
+  private static final int DEFAULT_EXECUTE_TIMEOUT_MINUTES = 10;
 
   private List<QueuedRequest> queuedRequests;
   private String clouddriverUserAgentApplicationName;

--- a/clouddriver-google-common/src/main/groovy/com/netflix/spinnaker/clouddriver/googlecommon/batch/GoogleBatchRequest.java
+++ b/clouddriver-google-common/src/main/groovy/com/netflix/spinnaker/clouddriver/googlecommon/batch/GoogleBatchRequest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 public class GoogleBatchRequest {
 
   private static final int MAX_BATCH_SIZE = 100; // Platform specified max to not overwhelm batch backends.
+  private static final int DEFAULT_EXECUTE_TIMEOUT_MINUTES = 10;
   private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = (int) TimeUnit.MINUTES.toMillis(2);
   private static final int DEFAULT_READ_TIMEOUT_MILLIS = (int) TimeUnit.MINUTES.toMillis(2);
 
@@ -81,6 +82,14 @@ public class GoogleBatchRequest {
       log.error("Executing queued batches failed.", e);
     }
     threadPool.shutdown();
+
+    try {
+      if (!threadPool.awaitTermination(DEFAULT_EXECUTE_TIMEOUT_MINUTES, TimeUnit.MINUTES)) {
+        throw new IllegalStateException("Timed out waiting for GoogleBatchRequest.");
+      }
+    } catch (InterruptedException intex) {
+      throw new IllegalStateException(intex);
+    }
   }
 
   private void executeInternalBatch(BatchRequest b) {


### PR DESCRIPTION
We currently send GCE batch requests to a thread pool for execution but don't wait for execution to finish. This leads to race conditions where cache refresh requests can return success before the cache is actually updated.