### PR TITLE
test(provider/cf): added test for deploy operation

### DIFF
--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -132,6 +132,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
           "instances", 7,
           "memory", "1G",
           "disk_quota", "2048M",
+          "buildpack", "buildpack1",
           "services", List.of(
             "service1"
           ).asJava(),
@@ -154,6 +155,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
         .setInstances(7)
         .setMemory("1G")
         .setDiskQuota("2048M")
+        .setBuildpack("buildpack1")
         .setServices(List.of("service1").asJava())
         .setRoutes(List.of(
           "www.example.com/foo"

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
@@ -16,15 +16,25 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 
+import com.netflix.spinnaker.clouddriver.cloudfoundry.artifacts.ArtifactCredentialsFromString;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.Applications;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.MockCloudFoundryClient;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.RouteId;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessStats;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryDomain;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryLoadBalancer;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryOrganization;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.*;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.provider.view.CloudFoundryClusterProvider;
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTask;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import io.vavr.collection.HashMap;
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,9 +45,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Index.atIndex;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class DeployCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFoundryAtomicOperationTest {
+
+  private final CloudFoundryClient cloudFoundryClient = new MockCloudFoundryClient();
+
+  DefaultTask testTask = new DefaultTask("testTask");
+  {
+    TaskRepository.threadLocalTask.set(testTask);
+  }
 
   @Test
   void convertToMbHandling() {
@@ -51,8 +70,6 @@ class DeployCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFoun
 
   @Test
   void mapRoutesShouldReturnTrueWhenRoutesIsNull() {
-    DefaultTask testTask = new DefaultTask("testTask");
-    TaskRepository.threadLocalTask.set(testTask);
     DeployCloudFoundryServerGroupDescription description = new DeployCloudFoundryServerGroupDescription();
     DeployCloudFoundryServerGroupAtomicOperation operation = new DeployCloudFoundryServerGroupAtomicOperation(null, description, null);
 
@@ -62,9 +79,6 @@ class DeployCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFoun
 
   @Test
   void mapRoutesShouldReturnTrueWhenRoutesAreValid() {
-    DefaultTask testTask = new DefaultTask("testTask");
-    TaskRepository.threadLocalTask.set(testTask);
-
     DeployCloudFoundryServerGroupDescription description = new DeployCloudFoundryServerGroupDescription();
     description.setClient(client);
     description.setServerGroupName("sg-name");
@@ -91,9 +105,6 @@ class DeployCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFoun
 
   @Test
   void mapRoutesShouldReturnFalseWhenInvalidRoutesAreFound() {
-    DefaultTask testTask = new DefaultTask("testTask");
-    TaskRepository.threadLocalTask.set(testTask);
-
     DeployCloudFoundryServerGroupDescription description = new DeployCloudFoundryServerGroupDescription();
     description.setClient(client);
     description.setServerGroupName("sg-name");
@@ -104,5 +115,68 @@ class DeployCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFoun
 
     assertThat(operation.mapRoutes(routeList, null, null)).isFalse();
     assertThat(testTask.getHistory()).has(status("Invalid format or domain for route 'road.to.nowhere'"), atIndex(2));
+  }
+
+  @Test
+  void executeOperation() {
+    // Given
+    final DeployCloudFoundryServerGroupDescription description = new DeployCloudFoundryServerGroupDescription()
+      .setAccountName("account1")
+      .setApplication("app1")
+      .setStack("stack1")
+      .setDetail("detail1")
+      .setArtifactCredentials(new ArtifactCredentialsFromString(
+        "test",
+        io.vavr.collection.List.of("a").asJava(),
+        ""
+      ))
+      .setSpace(CloudFoundrySpace.builder().id("space1Id").name("space1").build())
+      .setArtifact(Artifact.builder().reference("ref1").build())
+      .setApplicationAttributes(new DeployCloudFoundryServerGroupDescription.ApplicationAttributes()
+        .setInstances(7)
+        .setMemory("1G")
+        .setDiskQuota("2048M")
+        .setBuildpack("buildpack1")
+        .setServices(io.vavr.collection.List.of("service1").asJava())
+        .setEnv(HashMap.of(
+          "token", "ASDF"
+        ).toJavaMap()));
+    description.setClient(cloudFoundryClient);
+    description.setRegion("region1");
+    final CloudFoundryClusterProvider clusterProvider = mock(CloudFoundryClusterProvider.class);
+    final DeployCloudFoundryServerGroupAtomicOperation operation =
+      new DeployCloudFoundryServerGroupAtomicOperation(new PassThroughOperationPoller(), description, clusterProvider);
+
+    final Applications apps = cloudFoundryClient.getApplications();
+    when(clusterProvider.getClusters()).thenReturn(Collections.emptyMap());
+    when(apps.createApplication(any(), any(), any(), any()))
+      .thenReturn(CloudFoundryServerGroup.builder().id("serverGroupId").space(
+        CloudFoundrySpace.builder().id("spaceId").build()
+      ).build());
+    when(apps.getProcessState(any())).thenReturn(ProcessStats.State.RUNNING);
+    when(apps.createPackage(any()))
+      .thenAnswer((Answer<String>) invocation -> {
+        Object[] args = invocation.getArguments();
+        return args[0].toString() + "_package";
+      });
+
+    // When
+    final DeploymentResult result = operation.operate(Lists.emptyList());
+
+    // Then
+    final InOrder inOrder = Mockito.inOrder(apps, cloudFoundryClient.getServiceInstances());
+    inOrder.verify(apps).createApplication("app1-stack1-detail1-v000",
+      CloudFoundrySpace.builder().id("space1Id").name("space1").build(),
+      "buildpack1",
+      HashMap.of(
+        "token", "ASDF"
+      ).toJavaMap());
+    inOrder.verify(apps).uploadPackageBits(eq("serverGroupId_package"), any());
+    inOrder.verify(apps).createBuild("serverGroupId_package");
+    inOrder.verify(apps).scaleApplication("serverGroupId", 7, 1024, 2048);
+    inOrder.verify(cloudFoundryClient.getServiceInstances()).createServiceBindingsByName(any(), eq(Collections.singletonList("service1")));
+    inOrder.verify(apps).startApplication("serverGroupId");
+
+    assertThat(result.getServerGroupNames()).isEqualTo(Collections.singletonList("region1:app1-stack1-detail1-v000"));
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/PassThroughOperationPoller.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/PassThroughOperationPoller.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
+import groovy.lang.Closure;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class PassThroughOperationPoller extends OperationPoller {
+  public PassThroughOperationPoller() {
+    super(0, 0);
+  }
+
+  @Override
+  public Object waitForOperation(Closure operation, Closure ifDone, Long timeoutSeconds, Task task, String resourceString, String basePhase) {
+    return operation.call();
+  }
+
+  @Override
+  public <T> T waitForOperation(Supplier<T> operation, Function<T, Boolean> ifDone, Long timeoutSeconds, Task task, String resourceString, String basePhase) {
+    return operation.get();
+  }
+}


### PR DESCRIPTION
Added test for CF server group deploy operation execution.
Introduced PassThroughOperationPoller to execute logic without polling in tests.
Also added an attribute to the converter test.
