### PR TITLE
feat(provider/cf): prefer "buildpacks" manifest attribute

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -248,12 +248,12 @@ public class Applications {
     safelyCall(() -> api.deleteAppInstance(guid, index));
   }
 
-  public CloudFoundryServerGroup createApplication(String appName, CloudFoundrySpace space, @Nullable String buildpack,
+  public CloudFoundryServerGroup createApplication(String appName, CloudFoundrySpace space, List<String> buildpacks,
                                                    @Nullable Map<String, String> environmentVariables) throws CloudFoundryApiException {
     Map<String, ToOneRelationship> relationships = new HashMap<>();
     relationships.put("space", new ToOneRelationship(new Relationship(space.getId())));
 
-    return safelyCall(() -> api.createApplication(new CreateApplication(appName, relationships, environmentVariables, buildpack)))
+    return safelyCall(() -> api.createApplication(new CreateApplication(appName, relationships, environmentVariables, buildpacks)))
       .map(this::map)
       .orElseThrow(() -> new CloudFoundryApiException("Cloud Foundry signaled that application creation succeeded but failed to provide a response."));
   }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateApplication.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateApplication.java
@@ -40,11 +40,11 @@ public class CreateApplication {
   private final BuildpackLifecycle lifecycle;
 
   public CreateApplication(String name, Map<String, ToOneRelationship> relationships, @Nullable Map<String, String> environmentVariables,
-                           String buildpack) {
+                           List<String> buildpacks) {
     this.name = name;
     this.relationships = relationships;
     this.environmentVariables = environmentVariables;
-    this.lifecycle = new BuildpackLifecycle(buildpack);
+    this.lifecycle = new BuildpackLifecycle(buildpacks);
   }
 
   @AllArgsConstructor
@@ -53,8 +53,8 @@ public class CreateApplication {
     private String type = "buildpack";
     private Map<String, List<String>> data;
 
-    BuildpackLifecycle(String buildpack) {
-      this.data = Collections.singletonMap("buildpacks", singletonList(buildpack != null && buildpack.length() > 0 ? buildpack : null));
+    BuildpackLifecycle(List<String> buildpacks) {
+      this.data = Collections.singletonMap("buildpacks", buildpacks);
     }
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
@@ -57,7 +57,7 @@ public class DeployCloudFoundryServerGroupDescription extends AbstractCloudFound
     private List<String> routes;
 
     @Nullable
-    private String buildpack;
+    private List<String> buildpacks;
 
     @Nullable
     private Map<String, String> env;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -110,7 +110,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation implements AtomicOpera
     getTask().updateStatus(PHASE, "Creating Cloud Foundry application '" + description.getServerGroupName() + "'");
 
     CloudFoundryServerGroup serverGroup = client.getApplications().createApplication(description.getServerGroupName(),
-      description.getSpace(), description.getApplicationAttributes().getBuildpack(), description.getApplicationAttributes().getEnv());
+      description.getSpace(), description.getApplicationAttributes().getBuildpacks(), description.getApplicationAttributes().getEnv());
     getTask().updateStatus(PHASE, "Created Cloud Foundry application '" + description.getServerGroupName() + "'");
 
     return serverGroup;

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -121,6 +122,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
         .setInstances(42)
         .setMemory("1024")
         .setDiskQuota("1024")
+        .setBuildpacks(Collections.emptyList())
     );
   }
 
@@ -132,7 +134,10 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
           "instances", 7,
           "memory", "1G",
           "disk_quota", "2048M",
-          "buildpack", "buildpack1",
+          "buildpacks", List.of(
+            "buildpack1",
+            "buildpack2"
+          ).asJava(),
           "services", List.of(
             "service1"
           ).asJava(),
@@ -155,7 +160,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
         .setInstances(7)
         .setMemory("1G")
         .setDiskQuota("2048M")
-        .setBuildpack("buildpack1")
+        .setBuildpacks(List.of("buildpack1", "buildpack2").asJava())
         .setServices(List.of("service1").asJava())
         .setRoutes(List.of(
           "www.example.com/foo"
@@ -163,6 +168,61 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
         .setEnv(HashMap.of(
           "token", "ASDF"
         ).toJavaMap())
+    );
+  }
+
+  @Test
+  void convertManifestMapToApplicationAttributesUsingDeprecatedBuildpackAttr() {
+    final Map input = HashMap.of(
+      "applications", List.of(
+        HashMap.of(
+          "buildpack", "buildpack1"
+        ).toJavaMap()
+      ).asJava()
+    ).toJavaMap();
+
+    assertThat(converter.convertManifest(input).get()).isEqualToComparingFieldByFieldRecursively(
+      new DeployCloudFoundryServerGroupDescription.ApplicationAttributes()
+        .setInstances(1)
+        .setMemory("1024")
+        .setDiskQuota("1024")
+        .setBuildpacks(List.of("buildpack1").asJava())
+    );
+  }
+
+  @Test
+  void convertManifestMapToApplicationAttributesUsingDeprecatedBuildpackAttrBlankStringValue() {
+    final Map input = HashMap.of(
+      "applications", List.of(
+        HashMap.of(
+          "buildpack", ""
+        ).toJavaMap()
+      ).asJava()
+    ).toJavaMap();
+
+    assertThat(converter.convertManifest(input).get()).isEqualToComparingFieldByFieldRecursively(
+      new DeployCloudFoundryServerGroupDescription.ApplicationAttributes()
+        .setInstances(1)
+        .setMemory("1024")
+        .setDiskQuota("1024")
+        .setBuildpacks(Collections.emptyList())
+    );
+  }
+
+  @Test
+  void convertManifestMapToApplicationAttributesUsingWithNoBuildpacks() {
+    final Map input = HashMap.of(
+      "applications", List.of(
+        Collections.EMPTY_MAP
+      ).asJava()
+    ).toJavaMap();
+
+    assertThat(converter.convertManifest(input).get()).isEqualToComparingFieldByFieldRecursively(
+      new DeployCloudFoundryServerGroupDescription.ApplicationAttributes()
+        .setInstances(1)
+        .setMemory("1024")
+        .setDiskQuota("1024")
+        .setBuildpacks(Collections.emptyList())
     );
   }
 

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
@@ -136,7 +136,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFoun
         .setInstances(7)
         .setMemory("1G")
         .setDiskQuota("2048M")
-        .setBuildpack("buildpack1")
+        .setBuildpacks(io.vavr.collection.List.of("buildpack1", "buildpack2").asJava())
         .setServices(io.vavr.collection.List.of("service1").asJava())
         .setEnv(HashMap.of(
           "token", "ASDF"
@@ -167,7 +167,7 @@ class DeployCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFoun
     final InOrder inOrder = Mockito.inOrder(apps, cloudFoundryClient.getServiceInstances());
     inOrder.verify(apps).createApplication("app1-stack1-detail1-v000",
       CloudFoundrySpace.builder().id("space1Id").name("space1").build(),
-      "buildpack1",
+      io.vavr.collection.List.of("buildpack1", "buildpack2").asJava(),
       HashMap.of(
         "token", "ASDF"
       ).toJavaMap());


### PR DESCRIPTION
“buildpack” will continue to work, but it is deprecated. So we should use “buildpacks” when available
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html

fixes pivotal-cf/cf-spinnaker-clouddriver#247