### PR TITLE
fix(provider/gce): Set device name on attached disks.

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -709,6 +709,12 @@ class GCEUtil {
                                  safeRetry,
                                  executor)
 
+    disks.findAll { it.isPersistent() }
+      .eachWithIndex { disk, i ->
+      def baseDeviceName = description.baseDeviceName ?: 'device'
+      disk.deviceName = "$baseDeviceName-$i"
+    }
+
     def firstPersistentDisk = disks.find { it.persistent }
     return disks.collect { disk ->
       def diskType = useDiskTypeUrl ? buildDiskTypeUrl(credentials.project, zone, disk.type) : disk.type
@@ -740,6 +746,7 @@ class GCEUtil {
 
       new AttachedDisk(boot: disk.is(firstPersistentDisk),
                        autoDelete: disk.autoDelete,
+                       deviceName: disk.deviceName,
                        type: disk.persistent ? DISK_TYPE_PERSISTENT : DISK_TYPE_SCRATCH,
                        initializeParams: attachedDiskInitializeParams)
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
@@ -43,6 +43,11 @@ class BaseGoogleInstanceDescription extends AbstractGoogleCredentialsDescription
   Boolean automaticRestart
   OnHostMaintenance onHostMaintenance
 
+  // Unique disk device name addressable by a Linux OS in /dev/disk/by-id/google-* in the running instance.
+  // Used to reference disk for mounting, resizing, etc.
+  // Only applicable for persistent disks.
+  String baseDeviceName
+
   // We support passing the image to deploy as either a string or an artifact, but default to
   // the string for backwards-compatibility
   ImageSource imageSource = ImageSource.STRING

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -193,6 +193,7 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
 
     task.updateStatus BASE_PHASE, "Composing server group $serverGroupName..."
 
+    description.baseDeviceName = serverGroupName
     def attachedDisks = GCEUtil.buildAttachedDisks(description,
                                                    null,
                                                    false,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
@@ -98,6 +98,7 @@ class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<Deployme
 
     task.updateStatus BASE_PHASE, "Composing instance..."
 
+    description.baseDeviceName = description.instanceName
     def attachedDisks = GCEUtil.buildAttachedDisks(description,
                                                    zone,
                                                    true,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
@@ -167,6 +167,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation extends GoogleAtomi
 
         clonedDescription.disks = overriddenProperties.disks
 
+        clonedDescription.baseDeviceName = description.serverGroupName
         def attachedDisks = GCEUtil.buildAttachedDisks(clonedDescription,
                                                        null,
                                                        false,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleDisk.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleDisk.groovy
@@ -30,6 +30,11 @@ class GoogleDisk {
   String sourceImage
   boolean autoDelete = true
 
+  // Unique disk device name addressable by a Linux OS in /dev/disk/by-id/google-* in the running instance.
+  // Used to reference disk for mounting, resizing, etc.
+  // Only applicable for persistent disks.
+  String deviceName
+
   void setType(String type) {
     this.type = GoogleDiskType.fromValue(type)
   }


### PR DESCRIPTION
This solves an issue where deleting MIGs with multiple disks would not delete the additional disks, leaving them orphaned.