### PR TITLE
fix(gce): TerminateGoogleInstancesDescription is not ServerGroupNameable

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/TerminateGoogleInstancesDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/TerminateGoogleInstancesDescription.groovy
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.description
 
-import com.netflix.spinnaker.clouddriver.security.resources.ServerGroupNameable
-
-class TerminateGoogleInstancesDescription extends AbstractGoogleCredentialsDescription implements ServerGroupNameable {
+class TerminateGoogleInstancesDescription extends AbstractGoogleCredentialsDescription {
   String serverGroupName
   List<String> instanceIds
   String region


### PR DESCRIPTION
@ttomsu 

Not sure if this is right or not, however this fixes google_kato_test terminate_instances.
Since https://github.com/spinnaker/clouddriver/commit/85a4901008322c9fba47065437b056d8cee2b0d2 the test was failing from a null pointer error. Note that test is deleting instances that are not bound to a server group.

It could be the bug is somewhere in the interface assuming that in fact there is a server group (i.e. server group is optional for this operation). I am not familiar with the semantics or implications here so am speculating with this and counting on your review.

See out of band email for more information about the failure details. 