### PR TITLE
fix(provider/cf): correct manifest for env vars

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
@@ -157,7 +157,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter extends Abstr
       attrs.setBuildpacks(buildpacks);
       attrs.setServices(app.getServices());
       attrs.setRoutes(app.getRoutes() == null ? null : app.getRoutes().stream().flatMap(route -> route.values().stream()).collect(toList()));
-      attrs.setEnv(app.getEnv() == null ? null : app.getEnv().stream().flatMap(env -> env.entrySet().stream()).collect(toMap(Map.Entry::getKey, Map.Entry::getValue)));
+      attrs.setEnv(app.getEnv());
       return attrs;
     });
   }
@@ -193,7 +193,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter extends Abstr
     private List<Map<String, String>> routes;
 
     @Nullable
-    private List<Map<String, String>> env;
+    private Map<String, String> env;
   }
 
   private Artifact convertToArtifact(String account, String reference) {

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -85,7 +85,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
     new DefaultAccountCredentialsProvider(accountCredentialsRepository);
 
   private final DeployCloudFoundryServerGroupAtomicOperationConverter converter =
-    new DeployCloudFoundryServerGroupAtomicOperationConverter(null, artifactCredentialsRepository,null);
+    new DeployCloudFoundryServerGroupAtomicOperationConverter(null, artifactCredentialsRepository, null);
 
   @BeforeEach
   void initializeClassUnderTest() {
@@ -148,11 +148,9 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
               "route", "www.example.com/foo"
             ).toJavaMap()
           ).asJava(),
-          "env", List.of(
-            HashMap.of(
-              "token", "ASDF"
-            ).toJavaMap()
-          ).asJava()
+          "env", HashMap.of(
+            "token", "ASDF"
+          ).toJavaMap()
         ).toJavaMap()
       ).asJava()
     ).toJavaMap();


### PR DESCRIPTION
The implementation of manifest parsing had previously assumed a list of single-entry hashmaps instead of a single hashmap.

- spinnaker/spinnaker#3609