### PR TITLE
feat(artifacts): Add ivy/maven artifact account support

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -1,3 +1,6 @@
+test {
+  useJUnitPlatform()
+}
 
 class DownloadTask extends DefaultTask {
   @Input
@@ -67,7 +70,17 @@ dependencies {
   compile spinnaker.dependency("googleStorage")
   compile spinnaker.dependency("awsS3")
   compile "org.apache.commons:commons-compress:1.14"
-  compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.6"
+  compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.7"
+  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.7'
+  compile "org.apache.ivy:ivy:2.4.0"
 
   compile fileTree(sdkLocation)
+
+  testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')
+  testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
+  testCompile 'org.assertj:assertj-core:3.8.0'
+  testCompile 'org.junit-pioneer:junit-pioneer:latest.release'
+
+  testCompile 'ru.lanwen.wiremock:wiremock-junit5:1.2.0'
+  testCompile 'com.github.tomakehurst:wiremock:latest.release'
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/DiskFreeingInputStream.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/DiskFreeingInputStream.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+/**
+ * An {@link java.io.InputStream} that frees local disk resources when closed.
+ */
+public class DiskFreeingInputStream extends InputStream {
+  private final InputStream delegate;
+  private final Path deleteOnClose;
+
+  public DiskFreeingInputStream(InputStream delegate, Path deleteOnClose) {
+    this.delegate = delegate;
+    this.deleteOnClose = deleteOnClose;
+  }
+
+  @Override
+  public int read() throws IOException {
+    return delegate.read();
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+    if (Files.exists(deleteOnClose)) {
+      Files.walk(deleteOnClose)
+        .map(Path::toFile)
+        .sorted(Comparator.reverseOrder())
+        .forEach(File::delete);
+    }
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactAccount.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy;
+
+import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
+import com.netflix.spinnaker.clouddriver.artifacts.ivy.settings.IvySettings;
+import lombok.Data;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+@Data
+public class IvyArtifactAccount implements ArtifactAccount {
+  private String name;
+  private IvySettings settings;
+  private List<String> resolveConfigurations = singletonList("master");
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy;
+
+import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Configuration
+@ConditionalOnProperty("artifacts.ivy.enabled")
+@EnableConfigurationProperties(IvyArtifactProviderProperties.class)
+@RequiredArgsConstructor
+@Slf4j
+public class IvyArtifactConfiguration {
+  private final IvyArtifactProviderProperties ivyArtifactProviderProperties;
+  private final ArtifactCredentialsRepository artifactCredentialsRepository;
+
+  @Bean
+  List<? extends IvyArtifactCredentials> ivyArtifactCredentials() {
+    return ivyArtifactProviderProperties.getAccounts()
+      .stream()
+      .map(a -> {
+        try {
+          IvyArtifactCredentials c = new IvyArtifactCredentials(a);
+          artifactCredentialsRepository.save(c);
+          return c;
+        } catch (Exception e) {
+          log.warn("Failure instantiating ivy artifact account {}: ", a, e);
+          return null;
+        }
+      })
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList());
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentials.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy;
+
+import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ivy.Ivy;
+import org.apache.ivy.core.module.id.ModuleId;
+import org.apache.ivy.core.module.id.ModuleRevisionId;
+import org.apache.ivy.core.report.ResolveReport;
+import org.apache.ivy.core.resolve.ResolveOptions;
+import org.apache.ivy.util.AbstractMessageLogger;
+import org.apache.ivy.util.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+@Slf4j
+@Data
+public class IvyArtifactCredentials implements ArtifactCredentials {
+  private final List<String> types = Collections.singletonList("ivy/file");
+  private final IvyArtifactAccount account;
+  private final Supplier<Path> cacheBuilder;
+
+  public IvyArtifactCredentials(IvyArtifactAccount account) {
+    this(account, () -> Paths.get(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString()));
+  }
+
+  public IvyArtifactCredentials(IvyArtifactAccount account, Supplier<Path> cacheBuilder) {
+    this.cacheBuilder = cacheBuilder;
+    redirectIvyLogsToSlf4j();
+    this.account = account;
+  }
+
+  private static void redirectIvyLogsToSlf4j() {
+    Message.setDefaultLogger(new AbstractMessageLogger() {
+      private final Logger logger = LoggerFactory.getLogger("org.apache.ivy");
+
+      @Override
+      protected void doProgress() {
+      }
+
+      @Override
+      protected void doEndProgress(String msg) {
+        log(msg, Message.MSG_INFO);
+      }
+
+      @Override
+      public void log(String msg, int level) {
+        switch (level) {
+          case Message.MSG_ERR:
+            logger.error(msg);
+            break;
+          case Message.MSG_WARN:
+            logger.warn(msg);
+            break;
+          case Message.MSG_INFO:
+            logger.info(msg);
+            break;
+          case Message.MSG_DEBUG:
+            logger.debug(msg);
+            break;
+          case Message.MSG_VERBOSE:
+            logger.trace(msg);
+          default:
+            // do nothing
+        }
+      }
+
+      @Override
+      public void rawlog(String msg, int level) {
+        log(msg, level);
+      }
+    });
+  }
+
+  public InputStream download(Artifact artifact) {
+    Path cacheDir = cacheBuilder.get();
+    Ivy ivy = account.getSettings().toIvy(cacheDir);
+
+    String[] parts = artifact.getReference().split(":");
+    if (parts.length < 3) {
+      throw new IllegalArgumentException("Ivy artifact reference must have a group, artifact, and version separated by ':'");
+    }
+
+    ModuleRevisionId mrid = new ModuleRevisionId(new ModuleId(parts[0], parts[1]), parts[2]);
+
+    try {
+      ResolveReport report = ivy.resolve(mrid, (ResolveOptions) new ResolveOptions()
+        .setTransitive(false)
+        .setConfs(account.getResolveConfigurations().toArray(new String[0]))
+        .setLog("download-only"), true);
+      return Arrays.stream(report.getAllArtifactsReports())
+        .findFirst()
+        .map(rep -> {
+          try {
+            return new DiskFreeingInputStream(new FileInputStream(rep.getLocalFile()), cacheDir);
+          } catch (FileNotFoundException e) {
+            throw new UncheckedIOException(e);
+          }
+        })
+        .orElseThrow(() -> new IllegalArgumentException("Unable to resolve artifact for reference '" + artifact.getReference() + "'"));
+    } catch (ParseException | IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return account.getName();
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactProviderProperties.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@ConfigurationProperties("artifacts.ivy")
+public class IvyArtifactProviderProperties {
+  private boolean enabled;
+  private List<IvyArtifactAccount> accounts = new ArrayList<>();
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/BintrayResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/BintrayResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.annotation.Nullable;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class BintrayResolver extends Resolver<org.apache.ivy.plugins.resolver.BintrayResolver> {
+  /**
+   * Bintray username of a repository owner.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private String subject;
+
+  /**
+   * User’s repository name.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private String repo;
+
+  @Override
+  public org.apache.ivy.plugins.resolver.BintrayResolver toIvyModel() {
+    org.apache.ivy.plugins.resolver.BintrayResolver bintrayResolver = new org.apache.ivy.plugins.resolver.BintrayResolver();
+    bintrayResolver.setRepo(repo);
+    bintrayResolver.setSubject(subject);
+    return super.toIvyModel(bintrayResolver);
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/ChainResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/ChainResolver.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ChainResolver extends Resolver<org.apache.ivy.plugins.resolver.ChainResolver> {
+  @JsonIgnore
+  private final Resolvers resolvers = new Resolvers();
+  /**
+   * If the first found should be returned.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private Boolean returnFirst;
+  /**
+   * If the chain should behave like a dual chain.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private Boolean dual;
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public void setBintray(@Nullable List<BintrayResolver> bintray) {
+    this.resolvers.setBintray(bintray);
+  }
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public void setUrl(@Nullable List<UrlResolver> url) {
+    this.resolvers.setUrl(url);
+  }
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public void setIbiblio(@Nullable List<IBiblioResolver> ibiblio) {
+    this.resolvers.setIbiblio(ibiblio);
+  }
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  public void setSsh(@Nullable List<SshResolver> ssh) {
+    this.resolvers.setSsh(ssh);
+  }
+
+  @Override
+  public org.apache.ivy.plugins.resolver.ChainResolver toIvyModel() {
+    org.apache.ivy.plugins.resolver.ChainResolver chainResolver = new org.apache.ivy.plugins.resolver.ChainResolver();
+    if (returnFirst != null) {
+      chainResolver.setReturnFirst(returnFirst);
+    }
+    if (dual != null) {
+      chainResolver.setDual(dual);
+    }
+    resolvers.toDependencyResolvers().forEach(chainResolver::add);
+    return super.toIvyModel(chainResolver);
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Credentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Credentials.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+
+import javax.annotation.Nullable;
+
+@Data
+public class Credentials {
+  @JacksonXmlProperty(isAttribute = true)
+  private String host;
+
+  @Nullable
+  @JacksonXmlProperty(isAttribute = true)
+  private String realm;
+
+  @JacksonXmlProperty(isAttribute = true)
+  private String username;
+
+  @JacksonXmlProperty(isAttribute = true)
+  private String password;
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IBiblioResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IBiblioResolver.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.annotation.Nullable;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class IBiblioResolver extends Resolver<org.apache.ivy.plugins.resolver.IBiblioResolver> {
+  /**
+   * The root of the artifact repository.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private String root;
+
+  /**
+   * A pattern describing the layout of the artifact repository. For example:
+   * {@code https://repo1.maven.org/maven2/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]}
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private String pattern;
+
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private Boolean m2compatible;
+
+  /**
+   * If this resolver should use Maven POMs when it is already in {@link #m2compatible} mode.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private Boolean useMavenMetadata;
+
+  /**
+   * If this resolver should use maven-metadata.xml files to list available revisions, otherwise use directory listing.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private Boolean usepoms;
+
+  @Override
+  public org.apache.ivy.plugins.resolver.IBiblioResolver toIvyModel() {
+    org.apache.ivy.plugins.resolver.IBiblioResolver biblioResolver = new org.apache.ivy.plugins.resolver.IBiblioResolver();
+    if (pattern != null) {
+      biblioResolver.setPattern(pattern);
+    }
+    if (root != null) {
+      biblioResolver.setRoot(root);
+    }
+    if (m2compatible != null) {
+      biblioResolver.setM2compatible(m2compatible);
+    }
+    if (useMavenMetadata != null) {
+      biblioResolver.setUseMavenMetadata(useMavenMetadata);
+    }
+    if (usepoms != null) {
+      biblioResolver.setUsepoms(usepoms);
+    }
+    return super.toIvyModel(biblioResolver);
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IvySettings.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IvySettings.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.Data;
+import org.apache.ivy.Ivy;
+import org.apache.ivy.plugins.resolver.DependencyResolver;
+import org.apache.ivy.util.url.CredentialsStore;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.List;
+
+@JacksonXmlRootElement(localName = "ivysettings")
+@Data
+public class IvySettings {
+  private Resolvers resolvers = new Resolvers();
+  private Settings settings = new Settings();
+
+  @Nullable
+  private Credentials credentials;
+
+  public static IvySettings parse(String xml) {
+    try {
+      return new XmlMapper()
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .readValue(xml, IvySettings.class);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Unable to read Ivy settings", e);
+    }
+  }
+
+  public Ivy toIvy(Path cache) {
+    return Ivy.newInstance(toIvySettings(cache));
+  }
+
+  org.apache.ivy.core.settings.IvySettings toIvySettings(Path cache) {
+    org.apache.ivy.core.settings.IvySettings ivySettings = new org.apache.ivy.core.settings.IvySettings();
+    List<DependencyResolver> dependencyResolvers = resolvers.toDependencyResolvers();
+    if (dependencyResolvers.isEmpty()) {
+      throw new IllegalArgumentException("At least one ivy resolver is required");
+    }
+
+    dependencyResolvers.forEach(ivySettings::addResolver);
+    String defaultResolver = settings.getDefaultResolver();
+    ivySettings.setDefaultResolver(defaultResolver == null ? dependencyResolvers.iterator().next().getName() : defaultResolver);
+    if (credentials != null) {
+      CredentialsStore.INSTANCE.addCredentials(credentials.getRealm(), credentials.getHost(),
+        credentials.getUsername(), credentials.getPassword());
+    }
+    ivySettings.setDefaultCache(cache.toFile());
+    ivySettings.validate();
+    return ivySettings;
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Pattern.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Pattern.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import lombok.Data;
+
+@Data
+public class Pattern {
+  private String pattern;
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Resolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Resolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+import org.apache.ivy.plugins.resolver.DependencyResolver;
+
+@Data
+public abstract class Resolver<M extends DependencyResolver> {
+  /**
+   * The name which identifies the resolver.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  private String name;
+
+  public abstract M toIvyModel();
+
+  protected M toIvyModel(M partial) {
+    partial.setName(name);
+    return partial;
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Resolvers.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Resolvers.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import lombok.Data;
+import org.apache.ivy.plugins.resolver.DependencyResolver;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class Resolvers {
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @Nullable
+  private List<BintrayResolver> bintray;
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @Nullable
+  private List<UrlResolver> url;
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @Nullable
+  private List<IBiblioResolver> ibiblio;
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @Nullable
+  private List<SshResolver> ssh;
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @Nullable
+  private List<ChainResolver> chain;
+
+  public List<DependencyResolver> toDependencyResolvers() {
+    List<DependencyResolver> resolvers = new ArrayList<>();
+    if (bintray != null) {
+      bintray.forEach(r -> resolvers.add(r.toIvyModel()));
+    }
+    if (url != null) {
+      url.forEach(r -> resolvers.add(r.toIvyModel()));
+    }
+    if (ibiblio != null) {
+      ibiblio.forEach(r -> resolvers.add(r.toIvyModel()));
+    }
+    if (ssh != null) {
+      ssh.forEach(r -> resolvers.add(r.toIvyModel()));
+    }
+    if (chain != null) {
+      chain.forEach(r -> resolvers.add(r.toIvyModel()));
+    }
+    return resolvers;
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Settings.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Settings.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+
+import javax.annotation.Nullable;
+
+@Data
+public class Settings {
+  @Nullable
+  @JacksonXmlProperty(isAttribute = true)
+  private String defaultResolver;
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/SshResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/SshResolver.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class SshResolver extends Resolver<org.apache.ivy.plugins.resolver.SshResolver> {
+  /**
+   * The username to provide as a credential.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  private String user;
+
+  /**
+   * The password to provide as a credential.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  private String password;
+
+  /**
+   * The host to connect to. Defaults to host given on the patterns, failing if none is set.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private String host;
+
+  /**
+   * The port to connect to.
+   */
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private Integer port;
+
+  /**
+   * Defines a pattern for Ivy files, using the pattern attribute.
+   */
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @Nullable
+  private List<Pattern> ivy;
+
+  /**
+   * Defines a pattern for artifacts, using the pattern attribute
+   */
+  @JacksonXmlElementWrapper(useWrapping = false)
+  private List<Pattern> artifact;
+
+  @Override
+  public org.apache.ivy.plugins.resolver.SshResolver toIvyModel() {
+    org.apache.ivy.plugins.resolver.SshResolver sshResolver = new org.apache.ivy.plugins.resolver.SshResolver();
+    sshResolver.setHost(host);
+    if (port != null) {
+      sshResolver.setPort(port);
+    }
+    sshResolver.setUser(user);
+    sshResolver.setUserPassword(password);
+    if (ivy != null) {
+      ivy.forEach(pattern -> sshResolver.addIvyPattern(pattern.getPattern()));
+    }
+    artifact.forEach(pattern -> sshResolver.addArtifactPattern(pattern.getPattern()));
+    return super.toIvyModel(sshResolver);
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/UrlResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/UrlResolver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.ivy.plugins.resolver.URLResolver;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class UrlResolver extends Resolver<URLResolver> {
+  @JacksonXmlProperty(isAttribute = true)
+  @Nullable
+  private Boolean m2compatible;
+
+  /**
+   * Defines a pattern for Ivy files, using the pattern attribute.
+   */
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @Nullable
+  private List<Pattern> ivy;
+
+  /**
+   * Defines a pattern for artifacts, using the pattern attribute
+   */
+  @JacksonXmlElementWrapper(useWrapping = false)
+  private List<Pattern> artifact;
+
+  @Override
+  public URLResolver toIvyModel() {
+    URLResolver urlResolver = new URLResolver();
+    if (m2compatible != null) {
+      urlResolver.setM2compatible(m2compatible);
+    }
+    if (ivy != null) {
+      ivy.forEach(pattern -> urlResolver.addIvyPattern(pattern.getPattern()));
+    }
+    artifact.forEach(pattern -> urlResolver.addArtifactPattern(pattern.getPattern()));
+    return super.toIvyModel(urlResolver);
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactAccount.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.maven;
+
+import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
+import lombok.Data;
+
+@Data
+public class MavenArtifactAccount implements ArtifactAccount {
+  private String name;
+  private String repositoryUrl;
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.maven;
+
+import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Configuration
+@ConditionalOnProperty("artifacts.maven.enabled")
+@EnableConfigurationProperties(MavenArtifactProviderProperties.class)
+@RequiredArgsConstructor
+@Slf4j
+public class MavenArtifactConfiguration {
+  private final MavenArtifactProviderProperties mavenArtifactProviderProperties;
+  private final ArtifactCredentialsRepository artifactCredentialsRepository;
+
+  @Bean
+  List<? extends MavenArtifactCredentials> mavenArtifactCredentials() {
+    return mavenArtifactProviderProperties.getAccounts()
+      .stream()
+      .map(a -> {
+        try {
+          MavenArtifactCredentials c = new MavenArtifactCredentials(a);
+          artifactCredentialsRepository.save(c);
+          return c;
+        } catch (Exception e) {
+          log.warn("Failure instantiating maven artifact account {}: ", a, e);
+          return null;
+        }
+      })
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList());
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.maven;
+
+import com.netflix.spinnaker.clouddriver.artifacts.ivy.IvyArtifactAccount;
+import com.netflix.spinnaker.clouddriver.artifacts.ivy.IvyArtifactCredentials;
+import com.netflix.spinnaker.clouddriver.artifacts.ivy.settings.IBiblioResolver;
+import com.netflix.spinnaker.clouddriver.artifacts.ivy.settings.IvySettings;
+import com.netflix.spinnaker.clouddriver.artifacts.ivy.settings.Resolvers;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+@Slf4j
+@Data
+public class MavenArtifactCredentials extends IvyArtifactCredentials {
+  private final List<String> types = Collections.singletonList("maven/file");
+
+  public MavenArtifactCredentials(MavenArtifactAccount account) {
+    super(toIvyAccount(account));
+  }
+
+  public MavenArtifactCredentials(MavenArtifactAccount account, Supplier<Path> cacheBuilder) {
+    super(toIvyAccount(account), cacheBuilder);
+  }
+
+  private static IvyArtifactAccount toIvyAccount(MavenArtifactAccount maven) {
+    IvyArtifactAccount ivy = new IvyArtifactAccount();
+
+    IBiblioResolver mavenResolver = new IBiblioResolver();
+    mavenResolver.setName("maven");
+    mavenResolver.setM2compatible(true);
+    mavenResolver.setUsepoms(true);
+    mavenResolver.setUseMavenMetadata(true);
+    mavenResolver.setRoot(maven.getRepositoryUrl());
+
+    Resolvers resolvers = new Resolvers();
+    resolvers.setIbiblio(Collections.singletonList(mavenResolver));
+
+    IvySettings settings = new IvySettings();
+    settings.setResolvers(resolvers);
+
+    ivy.setSettings(settings);
+
+    return ivy;
+  }
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactProviderProperties.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.maven;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@ConfigurationProperties("artifacts.ivy")
+public class MavenArtifactProviderProperties {
+  private boolean enabled;
+  private List<MavenArtifactAccount> accounts = new ArrayList<>();
+}

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/config/ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/config/ArtifactConfiguration.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.gcs.GcsArtifactConfiguration;
 import com.netflix.spinnaker.clouddriver.artifacts.github.GitHubArtifactConfiguration;
 import com.netflix.spinnaker.clouddriver.artifacts.helm.HelmArtifactConfiguration;
 import com.netflix.spinnaker.clouddriver.artifacts.http.HttpArtifactConfiguration;
+import com.netflix.spinnaker.clouddriver.artifacts.ivy.IvyArtifactConfiguration;
 import com.netflix.spinnaker.clouddriver.artifacts.oracle.OracleArtifactConfiguration;
 import com.netflix.spinnaker.clouddriver.artifacts.s3.S3ArtifactConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -38,16 +39,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 @EnableConfigurationProperties
 @EnableScheduling
 @Component
-@ComponentScan({"com.netflix.spinnaker.clouddriver.artifacts"})
-@Import({
-  EmbeddedArtifactConfiguration.class,
-  GcsArtifactConfiguration.class,
-  OracleArtifactConfiguration.class,
-  GitHubArtifactConfiguration.class,
-  HttpArtifactConfiguration.class,
-  HelmArtifactConfiguration.class,
-  S3ArtifactConfiguration.class
-})
+@ComponentScan("com.netflix.spinnaker.clouddriver.artifacts")
 public class ArtifactConfiguration {
   @Bean
   ArtifactCredentialsRepository artifactCredentialsRepository() {

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/DiskFreeingInputStreamTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/DiskFreeingInputStreamTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.TempDirectory;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(TempDirectory.class)
+class DiskFreeingInputStreamTest {
+  @Test
+  void onlyFreeResourcesOnce(@TempDirectory.TempDir Path tempDir) throws IOException {
+    Path test = tempDir.resolve("test.txt");
+    Files.write(test, "hello world".getBytes());
+    FileInputStream fis = new FileInputStream(test.toFile());
+
+    assertThat(fis).hasSameContentAs(new ByteArrayInputStream("hello world".getBytes())); // closes once
+    fis.close();
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/DiskFreeingInputStreamTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/DiskFreeingInputStreamTest.java
@@ -32,11 +32,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DiskFreeingInputStreamTest {
   @Test
   void onlyFreeResourcesOnce(@TempDirectory.TempDir Path tempDir) throws IOException {
-    Path test = tempDir.resolve("test.txt");
+    Path temp = tempDir.resolve("temp");
+    Files.createDirectories(temp);
+    Path test = temp.resolve("test.txt");
     Files.write(test, "hello world".getBytes());
     FileInputStream fis = new FileInputStream(test.toFile());
-
-    assertThat(fis).hasSameContentAs(new ByteArrayInputStream("hello world".getBytes())); // closes once
-    fis.close();
+    DiskFreeingInputStream dfis = new DiskFreeingInputStream(fis, temp);
+    assertThat(dfis).hasSameContentAs(new ByteArrayInputStream("hello world".getBytes())); // closes once
+    dfis.close();
   }
 }

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentialsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.netflix.spinnaker.clouddriver.artifacts.ivy.settings.IvySettings;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import org.apache.commons.io.Charsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.TempDirectory;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith({WiremockResolver.class, TempDirectory.class})
+class IvyArtifactCredentialsTest {
+  @Test
+  void downloadIvyBasedJar(@WiremockResolver.Wiremock WireMockServer server, @TempDirectory.TempDir Path tempDir) throws IOException {
+    server.stubFor(any(urlEqualTo("/com/test/app/1.0/app-1.0.jar"))
+      .willReturn(aResponse()
+        .withBody("contents")));
+    server.stubFor(any(urlEqualTo("/com/test/app/1.0/app-1.0.xml"))
+      .willReturn(aResponse()
+        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<ivy-module version=\"2.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://ant.apache.org/ivy/schemas/ivy.xsd\">\n" +
+          "  <info organisation=\"com.test\" module=\"app\" revision=\"1.0\" status=\"release\"/>\n" +
+          "  <configurations defaultconf=\"master\">\n" +
+          "    <conf name=\"master\"/>\n" +
+          "  </configurations>\n" +
+          "  <publications>\n" +
+          "    <artifact/>\n" +
+          "  </publications>\n" +
+          "</ivy-module>")));
+
+    String ivySettingsXml = "<ivy-settings>\n" +
+      "  <settings defaultResolver=\"main\" />\n" +
+      "  <resolvers>\n" +
+      "    <url name=\"main\">\n" +
+      "      <ivy pattern=\"" + server.baseUrl() + "/[orgPath]/[module]/[revision]/[module]-[revision].xml\"/>\n" +
+      "      <artifact pattern=\"" + server.baseUrl() + "/[orgPath]/[module]/[revision]/[module]-[revision].[ext]\"/>\n" +
+      "    </url>\n" +
+      "  </resolvers>\n" +
+      "</ivy-settings>";
+
+    assertDownloadArtifact(tempDir, ivySettingsXml);
+    assertThat(server.findUnmatchedRequests().getRequests()).isEmpty();
+  }
+
+  @Test
+  void downloadMavenBasedJarFromIvySettings(@WiremockResolver.Wiremock WireMockServer server, @TempDirectory.TempDir Path tempDir) throws IOException {
+    server.stubFor(any(urlEqualTo("/com/test/app/1.0/app-1.0.jar"))
+      .willReturn(aResponse().withBody("contents")));
+
+    // only HEAD requests, should not be downloaded
+    server.stubFor(head(urlEqualTo("/com/test/app/1.0/app-1.0-sources.jar"))
+      .willReturn(aResponse().withBody("contents")));
+    server.stubFor(head(urlEqualTo("/com/test/app/1.0/app-1.0-javadoc.jar"))
+      .willReturn(aResponse().withBody("contents")));
+
+    server.stubFor(any(urlEqualTo("/com/test/app/1.0/app-1.0.pom"))
+      .willReturn(aResponse()
+        .withBody("<project>\n" +
+          "  <modelVersion>4.0.0</modelVersion>\n" +
+          "  <groupId>com.test</groupId>\n" +
+          "  <artifactId>app</artifactId  >\n" +
+          "  <version>1.0</version>\n" +
+          "</project>")));
+
+    String ivySettingsXml = "<ivy-settings>\n" +
+      "  <settings defaultResolver=\"main\" />\n" +
+      "  <resolvers>\n" +
+      "    <chain name=\"main\">\n" +
+      "      <ibiblio name=\"public\" m2compatible=\"true\" root=\"" + server.baseUrl() + "\" />\n" +
+      "    </chain>\n" +
+      "  </resolvers>\n" +
+      "</ivy-settings>";
+
+    assertDownloadArtifact(tempDir, ivySettingsXml);
+    assertThat(server.findUnmatchedRequests().getRequests()).isEmpty();
+  }
+
+  private void assertDownloadArtifact(@TempDirectory.TempDir Path tempDir, String ivySettingsXml) throws IOException {
+    IvyArtifactAccount account = new IvyArtifactAccount();
+    account.setSettings(IvySettings.parse(ivySettingsXml));
+
+    Path cache = tempDir.resolve("cache");
+    Files.createDirectories(cache);
+
+    Artifact artifact = new Artifact();
+    artifact.setReference("com.test:app:1.0");
+
+    assertThat(new IvyArtifactCredentials(account, () -> cache).download(artifact))
+      .hasSameContentAs(new ByteArrayInputStream("contents".getBytes(Charsets.UTF_8)));
+    assertThat(cache).doesNotExist();
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactProviderPropertiesTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactProviderPropertiesTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+class IvyArtifactProviderPropertiesTest {
+  @Test
+  void deserializeIvySettings() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.readValue("{\n" +
+      "  \"accounts\": [{\n" +
+      "    \"name\": \"mavenCentral\",\n" +
+      "    \"settings\": {\n" +
+      "      \"settings\": { \"defaultResolver\": \"mavenCentral\" },\n" +
+      "      \"resolvers\": {\n" +
+      "        \"ibiblio\": [{\n" +
+      "          \"name\": \"mavenCentral\",\n" +
+      "          \"m2compatible\": \"true\"\n" +
+      "        }]\n" +
+      "      }\n" +
+      "    }\n" +
+      "  }]\n" +
+      "}", IvyArtifactProviderProperties.class);
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/ChainResolverTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/ChainResolverTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+class ChainResolverTest {
+  @Test
+  void resolversAreUnwrapped() throws IOException {
+    ChainResolver chainResolver = new XmlMapper().readValue(
+      "<chain name=\"main\">\n" +
+        "  <ibiblio name=\"public\" m2compatible=\"true\" root=\"https://repo.spring.io/libs-release\" />\n" +
+        "</chain>", ChainResolver.class);
+
+    assertThat(chainResolver.getResolvers().getIbiblio()).hasSize(1);
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IvySettingsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IvySettingsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.TempDirectory;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(TempDirectory.class)
+class IvySettingsTest {
+  @Test
+  void minimalJCenterSettings(@TempDirectory.TempDir Path tempDir) {
+    BintrayResolver bintray = new BintrayResolver();
+    bintray.setName("jcenter");
+
+    Resolvers resolvers = new Resolvers();
+    resolvers.setBintray(Collections.singletonList(bintray));
+
+    IvySettings settings = new IvySettings();
+    settings.setResolvers(resolvers);
+
+    settings.toIvy(tempDir);
+  }
+
+  @Test
+  void parseIvySettingsGeneratedForMavenRepositoryInArtifactory(@TempDirectory.TempDir Path tempDir) {
+    String ivySettingsXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+      "<ivy-settings>\n" +
+      "  <settings defaultResolver=\"main\" />\n" +
+      "  <resolvers>\n" +
+      "    <chain name=\"main\">\n" +
+      "      <ibiblio name=\"public\" m2compatible=\"true\" root=\"https://repo.spring.io/libs-release\" />\n" +
+      "    </chain>\n" +
+      "  </resolvers>\n" +
+      "</ivy-settings>";
+
+    IvySettings settings = IvySettings.parse(ivySettingsXml);
+    settings.toIvy(tempDir);
+
+    assertThat(settings.getSettings().getDefaultResolver()).isEqualTo("main");
+  }
+
+  @Test
+  void atLeastOneResolverIsRequired() {
+    IvySettings settings = new IvySettings();
+    assertThatThrownBy(() -> settings.toIvySettings(Paths.get("./"))).isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/SshResolverTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/SshResolverTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SshResolverTest {
+  @Test
+  void patternsAreDeserialized() throws IOException {
+    SshResolver sshResolver = new XmlMapper().readValue(
+      "<ssh name=\"main\">\n" +
+        "  <ivy pattern=\"http://repo/[module]/[revision]/ivy-[revision].xml\"/>\n" +
+        "  <artifact pattern=\"http://repo/[module]/[revision]/[artifact]-[revision].[ext]\"/>\n" +
+        "</ssh>", SshResolver.class);
+
+    assertThat(sshResolver.getIvy()).hasSize(1);
+    assertThat(sshResolver.getArtifact()).hasSize(1);
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/UrlResolverTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/UrlResolverTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UrlResolverTest {
+  @Test
+  void patternsAreDeserialized() throws IOException {
+    UrlResolver urlResolver = new XmlMapper().readValue(
+      "<url name=\"main\">\n" +
+        "  <ivy pattern=\"http://repo/[module]/[revision]/ivy-[revision].xml\"/>\n" +
+        "  <artifact pattern=\"http://repo/[module]/[revision]/[artifact]-[revision].[ext]\"/>\n" +
+        "</url>", UrlResolver.class);
+
+    assertThat(urlResolver.getIvy()).hasSize(1);
+    assertThat(urlResolver.getArtifact()).hasSize(1);
+  }
+}

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentialsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.artifacts.maven;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import org.apache.commons.io.Charsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.TempDirectory;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith({WiremockResolver.class, TempDirectory.class})
+class MavenArtifactCredentialsTest {
+  @Test
+  void downloadMavenBasedJar(@WiremockResolver.Wiremock WireMockServer server, @TempDirectory.TempDir Path tempDir) throws IOException {
+    server.stubFor(any(urlEqualTo("/com/test/app/1.0/app-1.0.jar"))
+      .willReturn(aResponse().withBody("contents")));
+
+    // only HEAD requests, should not be downloaded
+    server.stubFor(head(urlEqualTo("/com/test/app/1.0/app-1.0-sources.jar"))
+      .willReturn(aResponse().withBody("contents")));
+    server.stubFor(head(urlEqualTo("/com/test/app/1.0/app-1.0-javadoc.jar"))
+      .willReturn(aResponse().withBody("contents")));
+
+    server.stubFor(any(urlEqualTo("/com/test/app/1.0/app-1.0.pom"))
+      .willReturn(aResponse()
+        .withBody("<project>\n" +
+          "  <modelVersion>4.0.0</modelVersion>\n" +
+          "  <groupId>com.test</groupId>\n" +
+          "  <artifactId>app</artifactId  >\n" +
+          "  <version>1.0</version>\n" +
+          "</project>")));
+
+    assertDownloadArtifact(tempDir, server);
+    assertThat(server.findUnmatchedRequests().getRequests()).isEmpty();
+  }
+
+  private void assertDownloadArtifact(@TempDirectory.TempDir Path tempDir, @WiremockResolver.Wiremock WireMockServer server) throws IOException {
+    MavenArtifactAccount account = new MavenArtifactAccount();
+    account.setRepositoryUrl(server.baseUrl());
+
+    Path cache = tempDir.resolve("cache");
+    Files.createDirectories(cache);
+
+    Artifact artifact = new Artifact();
+    artifact.setReference("com.test:app:1.0");
+
+    assertThat(new MavenArtifactCredentials(account, () -> cache).download(artifact))
+      .hasSameContentAs(new ByteArrayInputStream("contents".getBytes(Charsets.UTF_8)));
+    assertThat(cache).doesNotExist();
+  }
+}

--- a/clouddriver-artifacts/src/test/resources/logback.xml
+++ b/clouddriver-artifacts/src/test/resources/logback.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright 2018 Pivotal Software, Inc.
+    <p>
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    <p>
+    http://www.apache.org/licenses/LICENSE-2.0
+    <p>
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!-- WireMock related logging -->
+    <logger name="/" level="warn"/>
+    <logger name="WireMock" level="warn"/>
+    <logger name="ru.lanwen.wiremock" level="warn"/>
+    <logger name="org.eclipse.jetty" level="error"/>
+</configuration>


### PR DESCRIPTION
Adds support for Maven and Ivy expected artifact accounts. Generalizes #3153.

* Files are resolved to disk, and cleaned up automatically when the `InputStream` resulting from a `download` is closed.
* Does not download transitives.
* Does not download sources and javadocs.
* Multiple, chained Ivy/Maven repositories are possible using the Ivy provider.
* `IvySettings`, a field of `IvyArtifactAccount` is a mirror of the relevant bits of Ivy's settings file, and contains the relevant Jackson XML annotations necessary to make `IvySettings` deserializable directly from an Ivy settings XML.
  - Ivy settings XML can be [generated from Artifactory](https://www.jfrog.com/confluence/display/RTF/Working+with+Ivy#WorkingwithIvy-AutomaticSettingswithArtifactory'sIvySettingsGenerator).