### PR TITLE
feat(scattergather): Coroutine-backed scatter gather strategy

### DIFF
--- a/clouddriver-scattergather/clouddriver-scattergather.gradle
+++ b/clouddriver-scattergather/clouddriver-scattergather.gradle
@@ -9,6 +9,8 @@ dependencies {
   compile spinnaker.dependency("kork")
   compile spinnaker.dependency('korkWeb')
   compile spinnaker.dependency("okHttp3")
-//  compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:0.30.2"
-//  compile "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:0.30.2"
+  compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.1"
+  compile "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.0.1"
+
+  testCompile "com.squareup.okhttp3:mockwebserver:${spinnaker.version("okHttp3")}"
 }

--- a/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/config/ScatterGatherConfiguration.kt
+++ b/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/config/ScatterGatherConfiguration.kt
@@ -15,12 +15,12 @@
  */
 package com.netflix.spinnaker.clouddriver.config
 
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.scattergather.ScatterGather
+import com.netflix.spinnaker.clouddriver.scattergather.client.DefaultScatteredOkHttpCallFactory
 import com.netflix.spinnaker.clouddriver.scattergather.client.ScatteredOkHttpCallFactory
-import com.netflix.spinnaker.clouddriver.scattergather.naive.NaiveScatterGather
+import com.netflix.spinnaker.clouddriver.scattergather.coroutine.CoroutineScatterGather
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -29,11 +29,11 @@ open class ScatterGatherConfiguration {
 
   @Bean
   open fun scatteredOkHttpCallFactory(okHttp3ClientConfiguration: OkHttp3ClientConfiguration): ScatteredOkHttpCallFactory {
-    return ScatteredOkHttpCallFactory(okHttp3ClientConfiguration.create().build())
+    return DefaultScatteredOkHttpCallFactory(okHttp3ClientConfiguration.create().build())
   }
 
   @Bean
-  open fun scatterGather(callFactory: ScatteredOkHttpCallFactory): ScatterGather {
-    return NaiveScatterGather(callFactory)
+  open fun coroutineScatterGather(callFactory: ScatteredOkHttpCallFactory): ScatterGather {
+    return CoroutineScatterGather(callFactory)
   }
 }

--- a/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/scattergather/ScatterGatherException.kt
+++ b/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/scattergather/ScatterGatherException.kt
@@ -15,16 +15,8 @@
  */
 package com.netflix.spinnaker.clouddriver.scattergather
 
-import java.time.Duration
-import javax.servlet.http.HttpServletRequest
-
-/**
- * @param targets Target name (shard, etc) to base URL mapping
- * @param original The original servlet request that is initiating the scatter/gather operation
- * @param timeout The amount of time that scattered requests are given to complete
- */
-data class ServletScatterGatherRequest(
-  val targets: Map<String, String>,
-  val original: HttpServletRequest,
-  val timeout: Duration = Duration.ofSeconds(60)
-)
+class ScatterGatherException : RuntimeException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+  constructor(cause: Throwable) : super(cause)
+}

--- a/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/scattergather/client/DefaultScatteredOkHttpCallFactory.kt
+++ b/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/scattergather/client/DefaultScatteredOkHttpCallFactory.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.scattergather.client
+
+import okhttp3.Call
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * Creates a collection of OkHttp3 [Call] objects from a map of targets and
+ * an originating [HttpServletRequest].
+ */
+class DefaultScatteredOkHttpCallFactory(
+  private val okClient: OkHttpClient
+) : ScatteredOkHttpCallFactory {
+
+  /**
+   * Creates a collection of [Call] objects for a particular scatter request.
+   *
+   * The caller should provide a unique [workId] so that if a [Call] which can
+   * be used for request cancellation operations.
+   *
+   * The [targets] map expects a mapping of `shardName to shardBaseUrl`.
+   */
+  override fun createCalls(workId: String,
+                           targets: Map<String, String>,
+                           originalRequest: HttpServletRequest): List<Call> {
+    val requestBody = getRequestBody(originalRequest)
+
+    return targets.map { (targetName, baseUrl) ->
+      val okRequest = Request.Builder()
+        .tag("$workId:$targetName")
+        .url(originalRequest.toUrl(baseUrl))
+        .header(SCATTER_HEADER, "1")
+
+      originalRequest.headerNames.asSequence().forEach {
+        okRequest.header(it, originalRequest.getHeader(it))
+      }
+
+      okRequest.method(originalRequest.method, requestBody)
+
+      okClient.newCall(okRequest.build())
+    }
+  }
+
+  private fun getRequestBody(request: HttpServletRequest): RequestBody? =
+    if (request.contentLength == -1) {
+      null
+    } else {
+      RequestBody.create(
+        MediaType.parse(request.contentType),
+        request.reader.readText()
+      )
+    }
+
+  private fun HttpServletRequest.toUrl(baseUrl: String): String {
+    val url = "$baseUrl$requestURI"
+    return if (queryString == null) url else "$url?$queryString"
+  }
+
+  companion object {
+    const val SCATTER_HEADER = "X-Spinnaker-ScatteredRequest"
+  }
+}

--- a/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/scattergather/coroutine/CoroutineScatterGather.kt
+++ b/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/scattergather/coroutine/CoroutineScatterGather.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.scattergather.coroutine
+
+import com.netflix.spinnaker.clouddriver.scattergather.ReducedResponse
+import com.netflix.spinnaker.clouddriver.scattergather.ResponseReducer
+import com.netflix.spinnaker.clouddriver.scattergather.ScatterGather
+import com.netflix.spinnaker.clouddriver.scattergather.ScatterGatherException
+import com.netflix.spinnaker.clouddriver.scattergather.ServletScatterGatherRequest
+import com.netflix.spinnaker.clouddriver.scattergather.client.ScatteredOkHttpCallFactory
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.time.Duration
+import java.util.UUID
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Performs a scatter/gather request using coroutines.
+ *
+ * A requests for a particular scatter/gather operation will be given a timeout
+ * which they need to complete before failing the entire scatter operation.
+ * When a timeout happens, all on-going requests will be cancelled.
+ */
+class CoroutineScatterGather(
+  private val callFactory: ScatteredOkHttpCallFactory
+) : ScatterGather {
+
+  override fun request(request: ServletScatterGatherRequest, reducer: ResponseReducer): ReducedResponse {
+    val responses = performScatter(
+      callFactory.createCalls(
+        UUID.randomUUID().toString(),
+        request.targets,
+        request.original
+      ),
+      request.timeout
+    )
+
+    return reducer.reduce(responses)
+  }
+
+  private fun performScatter(calls: Collection<Call>, timeout: Duration): List<Response> {
+    // Could do `withTimeoutOrNull`, but we want to capture & wrap the timeout exception
+    try {
+      return runBlocking(Dispatchers.IO) {
+        withTimeout(timeout.toMillis()) {
+          calls
+            .map { call ->
+              async { call.await() }
+            }
+            .map { it.await() }
+        }
+      }
+    } catch (e: TimeoutCancellationException) {
+      throw ScatterGatherException("Scatter failed to complete all requests: ${e.message}", e)
+    }
+  }
+}
+
+private class ContinuationCallback(
+  private val continuation: CancellableContinuation<Response>
+) : Callback {
+
+  override fun onFailure(call: Call, e: IOException) {
+    if (e.isRetryable()) {
+      call.enqueue(this)
+    } else {
+      continuation.resumeWithException(e)
+    }
+  }
+
+  override fun onResponse(call: Call, response: Response) {
+    if (retryableCodes.contains(response.code())) {
+      call.enqueue(this)
+    } else {
+      continuation.resume(response)
+    }
+  }
+
+  private fun IOException.isRetryable(): Boolean {
+    return this is SocketTimeoutException
+  }
+
+  companion object {
+    private val retryableCodes = listOf(429, 503)
+  }
+}
+
+private suspend fun Call.await(): Response {
+  return suspendCancellableCoroutine { continuation ->
+    continuation.invokeOnCancellation {
+      cancel()
+    }
+    enqueue(ContinuationCallback(continuation))
+  }
+}

--- a/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/scattergather/naive/NaiveScatterGather.kt
+++ b/clouddriver-scattergather/src/main/kotlin/com/netflix/spinnaker/clouddriver/scattergather/naive/NaiveScatterGather.kt
@@ -27,12 +27,11 @@ import java.util.UUID
  *
  * This should be used only for development purposes, as it'll be crazy slow.
  * An async implementation should be used for non-development purposes.
- *
- * TODO(rz): Add CoroutinesScatterGather
  */
 class NaiveScatterGather(
   private val callFactory: ScatteredOkHttpCallFactory
 ) : ScatterGather {
+
   override fun request(request: ServletScatterGatherRequest, reducer: ResponseReducer): ReducedResponse {
     val calls = callFactory.createCalls(
       UUID.randomUUID().toString(),

--- a/clouddriver-scattergather/src/test/kotlin/com/netflix/spinnaker/clouddriver/scattergather/client/DefaultScatteredOkHttpCallFactorySpec.kt
+++ b/clouddriver-scattergather/src/test/kotlin/com/netflix/spinnaker/clouddriver/scattergather/client/DefaultScatteredOkHttpCallFactorySpec.kt
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.clouddriver.scattergather.client
 
-import com.netflix.spinnaker.clouddriver.scattergather.client.ScatteredOkHttpCallFactory.Companion.SCATTER_HEADER
+import com.netflix.spinnaker.clouddriver.scattergather.client.DefaultScatteredOkHttpCallFactory.Companion.SCATTER_HEADER
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okio.Buffer
@@ -29,7 +29,7 @@ import strikt.assertions.get
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNull
 
-internal object ScatteredOkHttpCallFactorySpec : Spek({
+internal object DefaultScatteredOkHttpCallFactorySpec : Spek({
 
   describe("creating a scattered request") {
     val okClient = OkHttpClient()
@@ -44,7 +44,7 @@ internal object ScatteredOkHttpCallFactorySpec : Spek({
       }
 
       it("creates two requests") {
-        val result = ScatteredOkHttpCallFactory(okClient).createCalls("workid", targets, servletRequest)
+        val result = DefaultScatteredOkHttpCallFactory(okClient).createCalls("workid", targets, servletRequest)
 
         expectThat(result) {
           get { size }.isEqualTo(2)
@@ -76,7 +76,7 @@ internal object ScatteredOkHttpCallFactorySpec : Spek({
       }
 
       it("creates two requests with bodies") {
-        val result = ScatteredOkHttpCallFactory(okClient).createCalls("workid", targets, servletRequest)
+        val result = DefaultScatteredOkHttpCallFactory(okClient).createCalls("workid", targets, servletRequest)
 
         expectThat(result) {
           get { size }.isEqualTo(2)

--- a/clouddriver-scattergather/src/test/kotlin/com/netflix/spinnaker/clouddriver/scattergather/coroutine/CoroutineScatterGatherSpec.kt
+++ b/clouddriver-scattergather/src/test/kotlin/com/netflix/spinnaker/clouddriver/scattergather/coroutine/CoroutineScatterGatherSpec.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.scattergather.coroutine
+
+import com.netflix.spinnaker.clouddriver.scattergather.ServletScatterGatherRequest
+import com.netflix.spinnaker.clouddriver.scattergather.client.DefaultScatteredOkHttpCallFactory
+import com.netflix.spinnaker.clouddriver.scattergather.reducer.DeepMergeResponseReducer
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.springframework.mock.web.MockHttpServletRequest
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.isEqualTo
+
+internal object CoroutineScatterGatherSpec : Spek({
+
+  describe("calling multiple targets with coroutines") {
+    val server = MockWebServer()
+
+    beforeGroup {
+      server.enqueue(MockResponse().setBody("""{"one": 1}"""))
+      server.enqueue(MockResponse().setBody("""{"two": 2}"""))
+      server.start()
+    }
+
+    given("two requests") {
+      val subject = CoroutineScatterGather(DefaultScatteredOkHttpCallFactory(
+        OkHttpClient()
+      ))
+
+      it("completes the requests") {
+        val result = subject.request(
+          ServletScatterGatherRequest(
+            mapOf(
+              "shard1" to server.url("").toString(),
+              "shard2" to server.url("").toString()
+            ),
+            MockHttpServletRequest("GET", "hello").apply {
+              addHeader("Accept", "application/json")
+            }
+          ),
+          DeepMergeResponseReducer()
+        )
+
+        expectThat(result) {
+          get { status }.isEqualTo(200)
+          get { body!! }.contains("two")
+          get { body!! }.contains("one")
+        }
+      }
+    }
+
+    afterGroup {
+      server.shutdown()
+    }
+  }
+})


### PR DESCRIPTION
Adds a coroutine-backed scatter/gather implementation.

Two main benefits of this one over the current naive implementation:

1. Timeouts will cancel any unfinished, in-flight work.
2. Requests are performed in parallel.

The parallelism of requests is limited by the size of the OkHttp connection pool.

This also has some extra noise because I made the `ScatteredOkHttpCallFactory` an interface. I was initially going to mock everything out, but realized that'd be more brittle than an embedded server.