### PR TITLE
feat(provider/cf): display cf health check details for app

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/Process.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/Process.java
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3;
 
-import lombok.Data;
+import lombok.*;
+
+import javax.annotation.Nullable;
 
 @Data
 public class Process {
@@ -24,4 +26,23 @@ public class Process {
   private int instances;
   private int memoryInMb;
   private int diskInMb;
+
+  @Nullable
+  private HealthCheck healthCheck;
+
+  @Data
+  public static class HealthCheck {
+    @Nullable
+    private String type;
+
+    @Nullable
+    private HealthCheckData data;
+  }
+
+  @Data
+  public static class HealthCheckData {
+
+    @Nullable
+    private String endpoint;
+  }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/UpdateProcess.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/UpdateProcess.java
@@ -36,28 +36,5 @@ public class UpdateProcess {
   private final String command;
 
   @Nullable
-  private final HealthCheck healthCheck;
-
-  @Data
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  public static class HealthCheck {
-    @Nullable
-    private final String type;
-
-    @Nullable
-    private final HealthCheckData data;
-  }
-
-  @Data
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  public static class HealthCheckData {
-    @Nullable
-    private final Integer timeout;
-
-    @Nullable
-    private final Integer invocationTimeout;
-
-    @Nullable
-    private final String endpoint;
-  }
+  private final Process.HealthCheck healthCheck;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
@@ -74,6 +74,14 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
   Integer diskQuota;
 
   @JsonView(Views.Cache.class)
+  @Nullable
+  private String healthCheckType;
+
+  @JsonView(Views.Cache.class)
+  @Nullable
+  private String healthCheckHttpEndpoint;
+
+  @JsonView(Views.Cache.class)
   State state;
 
   @JsonView(Views.Cache.class)

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
@@ -134,14 +134,14 @@ class ApplicationsTest {
 
     apps.updateProcess("guid1", "command1", "http", "/endpoint");
     verify(applicationService).updateProcess("guid1", new UpdateProcess("command1",
-      new UpdateProcess.HealthCheck("http",
-        new UpdateProcess.HealthCheckData(null, null, "/endpoint")
+      new Process.HealthCheck().setType("http").setData(
+        new Process.HealthCheckData().setEndpoint("/endpoint")
       )
     ));
 
     apps.updateProcess("guid1", "command1", "http", null);
     verify(applicationService).updateProcess("guid1", new UpdateProcess("command1",
-      new UpdateProcess.HealthCheck("http", null)
+      new Process.HealthCheck().setType("http")
     ));
 
     apps.updateProcess("guid1", "command1", null, null);


### PR DESCRIPTION
Also changed the handling of a crashed instance to be down rather than out of service.
