### PR TITLE
fix(provider/cf): set the status to DOWN when no process stats returned

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -363,6 +363,6 @@ public class Applications {
   public ProcessStats.State getProcessState(String appGuid) throws CloudFoundryApiException {
     return safelyCall(() -> this.api.findProcessStatsById(appGuid))
       .flatMap(pr -> pr.getResources().stream().findAny().map(ProcessStats::getState))
-      .orElse(null);
+      .orElse(ProcessStats.State.DOWN);
   }
 }


### PR DESCRIPTION
Fix for an edge case where a server group in CF could return a 404 when trying to retrieve the process stats. When no process stats are found we should consider the status to be `DOWN` so that the app can be deleted otherwise the app will fail to be deleted.

spinnaker/spinnaker#3653