### PR TITLE
fix(provider/cf): correct pagination logic when iterating

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryClientUtils.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryClientUtils.java
@@ -55,7 +55,7 @@ final class CloudFoundryClientUtils {
       .orElseThrow(() -> new CloudFoundryApiException("Unable to retrieve " + resourceNamePluralized));
 
     List<R> allResources = new ArrayList<>(firstPage.getResources());
-    for (int page = 2; page <= Math.max(2, firstPage.getPagination().getTotalPages()); page++) {
+    for (int page = 2; page <= firstPage.getPagination().getTotalPages(); page++) {
       final int p = page;
       allResources.addAll(safelyCall(() -> fetchPage.apply(p))
         .orElseThrow(() -> new CloudFoundryApiException("Unable to retrieve " + resourceNamePluralized))
@@ -70,7 +70,7 @@ final class CloudFoundryClientUtils {
       .orElseThrow(() -> new CloudFoundryApiException("Unable to retrieve " + resourceNamePluralized));
 
     List<Resource<R>> allResources = new ArrayList<>(firstPage.getResources());
-    for (int page = 2; page <= Math.max(2, firstPage.getTotalPages()); page++) {
+    for (int page = 2; page <= firstPage.getTotalPages(); page++) {
       final int p = page;
       allResources.addAll(safelyCall(() -> fetchPage.apply(p))
         .orElseThrow(() -> new CloudFoundryApiException("Unable to retrieve " + resourceNamePluralized))

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryClientUtilsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryClientUtilsTest.java
@@ -34,6 +34,22 @@ import static org.mockito.Mockito.when;
 class CloudFoundryClientUtilsTest {
 
   @Test
+  void collectPagesIteratesOverOnePage() {
+    ApplicationService applicationService = mock(ApplicationService.class);
+    Application applicationOne = new Application().setName("app-name-one");
+    List pageOneResources = Collections.singletonList(applicationOne);
+    Pagination<Application> pageOne = new Pagination<>();
+    pageOne.setPagination(new Pagination.Details().setTotalPages(1));
+    pageOne.setResources(pageOneResources);
+
+    when(applicationService.all(null, null, null)).thenReturn(pageOne);
+
+    List results = CloudFoundryClientUtils.collectPages("applications", page -> applicationService.all(page, null, null));
+
+    assertThat(results).containsExactly(applicationOne);
+  }
+
+  @Test
   void collectPagesIteratesOverMultiplePages() {
     ApplicationService applicationService = mock(ApplicationService.class);
     Application applicationOne = new Application().setName("app-name-one");
@@ -55,13 +71,27 @@ class CloudFoundryClientUtilsTest {
     assertThat(results).containsExactly(applicationOne, applicationTwo);
   }
 
+
+  @Test
+  void collectPageResourcesIteratesOverOnePage() {
+    DomainService domainService = mock(DomainService.class);
+    Domain domainOne = new Domain().setName("domain-name-one");
+    Page pageOne = Page.singleton(domainOne, "domain-one-guid").setTotalPages(1).setTotalResults(1);
+
+    when(domainService.allShared(null)).thenReturn(pageOne);
+
+    List results = CloudFoundryClientUtils.collectPageResources("shared domains",  domainService::allShared);
+
+    assertThat(results).containsExactly(pageOne.getResources().get(0));
+  }
+
   @Test
   void collectPageResourcesIteratesOverMultiplePages() {
     DomainService domainService = mock(DomainService.class);
     Domain domainOne = new Domain().setName("domain-name-one");
-    Page pageOne = Page.singleton(domainOne, "domain-one-guid");
+    Page pageOne = Page.singleton(domainOne, "domain-one-guid").setTotalPages(2).setTotalResults(2);
     Domain domainTwo = new Domain().setName("domain-name-two");
-    Page pageTwo = Page.singleton(domainTwo, "domain-two-guid");
+    Page pageTwo = Page.singleton(domainTwo, "domain-two-guid").setTotalPages(2).setTotalResults(2);
 
     when(domainService.allShared(null)).thenReturn(pageOne);
     when(domainService.allShared(2)).thenReturn(pageTwo);


### PR DESCRIPTION
Fix issue when collecting results from a single page and add a test for the scenario of a single page of results.

spinnaker/spinnaker#3662