### PR TITLE
fix(provider/kubernetes): hold entries in on-demand longer

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -97,7 +97,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     try {
       primaryResource = loadPrimaryResourceList();
     } catch (KubectlJobExecutor.NoResourceTypeException e) {
-      log.warn(getAgentType() + ": resource for this caching agent is not supported for this cluster");
+      log.error(getAgentType() + ": resource for this caching agent is not supported for this cluster. This will cause problems, please remove it from caching using the `omitKinds` config parameter.");
       return new DefaultCacheResult(new HashMap<>());
     }
 
@@ -210,7 +210,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     cacheTime = cacheTime == null ? 0L : cacheTime;
     processedCount = processedCount == null ? 0 : processedCount;
 
-    return cacheTime >= lastFullRefresh || processedCount == 0;
+    return cacheTime >= lastFullRefresh || processedCount < 2;
   }
 
   private OnDemandAgent.OnDemandResult evictEntry(ProviderCache providerCache, KubernetesKind kind, String key) {


### PR DESCRIPTION
This should help prevent the force cache refresh task from having to query the on demand cache as often, as processed entries will be kept for an additional cycle (30s)

@benjaminws @davidxia, I think this should speed up executions that seem hung on ForceCacheRefresh tasks