### PR TITLE
fix(provider/cf): Rectify scaling ASGs

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/ScaleCloudFoundryServerGroupDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/ScaleCloudFoundryServerGroupDescription.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -25,11 +26,11 @@ import javax.annotation.Nullable;
 @EqualsAndHashCode(callSuper = true)
 public class ScaleCloudFoundryServerGroupDescription extends AbstractCloudFoundryServerGroupDescription {
   @Nullable
-  private Integer instanceCount;
+  ServerGroup.Capacity capacity;
 
   @Nullable
-  private Integer memoryInMb;
+  private Integer memory;
 
   @Nullable
-  private Integer diskInMb;
+  private Integer diskQuota;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ScaleCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ScaleCloudFoundryServerGroupAtomicOperation.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.ScaleCl
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import lombok.RequiredArgsConstructor;
 
@@ -46,7 +47,12 @@ public class ScaleCloudFoundryServerGroupAtomicOperation implements AtomicOperat
 
     final CloudFoundryClient client = description.getClient();
 
-    client.getApplications().scaleApplication(description.getServerGroupId(), description.getInstanceCount(), description.getMemoryInMb(), description.getDiskInMb());
+    ServerGroup.Capacity capacity = description.getCapacity();
+    client.getApplications().scaleApplication(
+      description.getServerGroupId(),
+      capacity == null ? null : capacity.getDesired(),
+      description.getMemory(),
+      description.getDiskQuota());
 
     ProcessStats.State state = operationPoller.waitForOperation(
       () -> client.getApplications().getProcessState(description.getServerGroupId()),

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.converters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.MockCloudFoundryClient;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.ScaleCloudFoundryServerGroupDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryOrganization;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider;
+import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository;
+import io.vavr.collection.HashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+class ScaleCloudFoundryServerGroupAtomicOperationConverterTest {
+
+  private final CloudFoundryClient cloudFoundryClient = new MockCloudFoundryClient();
+  {
+    when(cloudFoundryClient.getOrganizations().findByName(any()))
+      .thenAnswer((Answer<Optional<CloudFoundryOrganization>>) invocation -> {
+        Object[] args = invocation.getArguments();
+        return Optional.of(CloudFoundryOrganization.builder()
+          .id(args[0].toString() + "ID").name(args[0].toString()).build());
+      });
+
+    when(cloudFoundryClient.getSpaces().findByName(any(), any())).thenAnswer((Answer<CloudFoundrySpace>) invocation -> {
+      Object[] args = invocation.getArguments();
+      return CloudFoundrySpace.builder().id(args[1].toString() + "ID").name(args[1].toString())
+        .organization(CloudFoundryOrganization.builder()
+          .id(args[0].toString()).name(args[0].toString().replace("ID", "")).build()).build();
+    });
+  }
+
+  private final CloudFoundryCredentials cloudFoundryCredentials = new CloudFoundryCredentials(
+    "test", "", "", "", "", "") {
+    public CloudFoundryClient getClient() {
+      return cloudFoundryClient;
+    }
+  };
+
+  private final AccountCredentialsRepository accountCredentialsRepository = new MapBackedAccountCredentialsRepository();
+  {
+    accountCredentialsRepository.update("test", cloudFoundryCredentials);
+  }
+
+  private final AccountCredentialsProvider accountCredentialsProvider =
+    new DefaultAccountCredentialsProvider(accountCredentialsRepository);
+
+  private final ScaleCloudFoundryServerGroupAtomicOperationConverter converter =
+    new ScaleCloudFoundryServerGroupAtomicOperationConverter(null);
+
+  @BeforeEach
+  void initializeClassUnderTest() {
+    converter.setAccountCredentialsProvider(accountCredentialsProvider);
+    converter.setObjectMapper(new ObjectMapper());
+  }
+
+  @Test
+  void convertDescription() {
+    final Map input = HashMap.of(
+      "credentials", "test",
+      "region", "org > space",
+      "capacity",  HashMap.of(
+        "desired", 15,
+        "min", 12,
+        "max", 61
+      ).toJavaMap(),
+      "diskQuota", 1027,
+      "memory", 10249
+    ).toJavaMap();
+
+    final ScaleCloudFoundryServerGroupDescription result = converter.convertDescription(input);
+
+    assertThat(result.getCapacity().getDesired()).isEqualTo(15);
+    assertThat(result.getDiskQuota()).isEqualTo(1027);
+    assertThat(result.getMemory()).isEqualTo(10249);
+  }
+
+  @Test
+  void convertDescriptionMissingFields() {
+    final Map input = HashMap.of(
+      "credentials", "test",
+      "region", "org > space",
+      "capacity",  HashMap.of(
+        "desired", 215,
+        "min", 12,
+        "max", 61
+      ).toJavaMap()
+    ).toJavaMap();
+
+    final ScaleCloudFoundryServerGroupDescription result = converter.convertDescription(input);
+
+    assertThat(result.getCapacity().getDesired()).isEqualTo(215);
+    assertThat(result.getDiskQuota()).isNull();
+    assertThat(result.getMemory()).isNull();
+  }
+}

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ScaleCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ScaleCloudFoundryServerGroupAtomicOperationTest.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessStats;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.ScaleCloudFoundryServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ class ScaleCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFound
   void before() {
     desc.setClient(client);
     desc.setServerGroupName("myapp");
-    desc.setInstanceCount(2);
+    desc.setCapacity(ServerGroup.Capacity.builder().desired(2).build());
   }
 
   @Test


### PR DESCRIPTION
Now CF uses the Capacity struct in clouddriver to handle the case of
scaling-down ASGs to 0 instances.

spinnaker/spinnaker#3670

Co-Authored-By: Joris Melchior <joris.melchior@gmail.com>