### PR TITLE
chore(cache): adds introspection to caching agents

### DIFF
--- a/cats/cats-core/cats-core.gradle
+++ b/cats/cats-core/cats-core.gradle
@@ -1,6 +1,7 @@
 dependencies {
   compile spinnaker.dependency('slf4jApi')
   compile spinnaker.dependency('jacksonAnnotations')
+  compileOnly spinnaker.dependency("lombok")
 
   testCompile project(":cats:cats-test")
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CacheResult.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CacheResult.java
@@ -40,4 +40,8 @@ public interface CacheResult {
    * @return The ids of items that should be explicitly evicted.
    */
   default Map<String, Collection<String>> getEvictions() { return Collections.emptyMap(); }
+
+  default Map<String, Object> getIntrospectionDetails() {
+    return Collections.emptyMap();
+  }
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CachingAgent.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/CachingAgent.java
@@ -16,7 +16,10 @@
 
 package com.netflix.spinnaker.cats.agent;
 
+import com.netflix.spinnaker.cats.cache.AgentIntrospection;
 import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.CacheIntrospectionStore;
+import com.netflix.spinnaker.cats.cache.DefaultAgentIntrospection;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.cats.provider.ProviderRegistry;
 import org.slf4j.Logger;
@@ -70,7 +73,11 @@ public interface CachingAgent extends Agent {
 
     @Override
     public void executeAgent(Agent agent) {
-      storeAgentResult(agent, executeAgentWithoutStore(agent));
+      AgentIntrospection introspection = new DefaultAgentIntrospection(agent);
+      CacheResult result = executeAgentWithoutStore(agent);
+      introspection.finish(result);
+      CacheIntrospectionStore.getStore().recordAgent(introspection);
+      storeAgentResult(agent, result);
     }
 
     public CacheResult executeAgentWithoutStore(Agent agent) {

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultCacheResult.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultCacheResult.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.cats.agent;
 
 import com.netflix.spinnaker.cats.cache.CacheData;
+import lombok.Getter;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -28,13 +29,20 @@ import java.util.Map;
 public class DefaultCacheResult implements CacheResult {
     private final Map<String, Collection<CacheData>> cacheResults;
     private final Map<String, Collection<String>> evictions;
+    @Getter
+    private final Map<String, Object> introspectionDetails;
 
     public DefaultCacheResult(Map<String, Collection<CacheData>> cacheResults) {
       this(cacheResults, new HashMap<>());
     }
     public DefaultCacheResult(Map<String, Collection<CacheData>> cacheResults, Map<String, Collection<String>> evictions) {
+      this(cacheResults, evictions, new HashMap<>());
+    }
+
+    public DefaultCacheResult(Map<String, Collection<CacheData>> cacheResults, Map<String, Collection<String>> evictions, Map<String, Object> introspectionDetails) {
         this.cacheResults = cacheResults;
         this.evictions = evictions;
+        this.introspectionDetails = introspectionDetails;
     }
 
     @Override

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/AgentIntrospection.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/AgentIntrospection.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.cache;
+
+import com.netflix.spinnaker.cats.agent.CacheResult;
+
+/**
+ * This is meant to store data about a single agent execution that _doesn't_ make sense to reasonably report to a
+ * monitoring system. Being able to inspect a single clouddriver node's use of these caching agents, having them report
+ * provider-specific details in the `details` field, (e.g. which namespaces/kinds are cached) and correlate that with
+ * details of how long the caching agents are executing, allowing users to both diagnose faulty/underprovisioned nodes, as
+ * well as tune their caching configuration by adjusting provider-specific fields.
+ */
+public interface AgentIntrospection {
+  String getId();
+  String getProvider();
+  int getTotalAdditions();
+  int getTotalEvictions();
+  Long getLastExecutionDurationMs();
+  Throwable getLastError();
+  String getLastExecutionStartDate();
+  void finishWithError(Throwable error, CacheResult result);
+  void finish(CacheResult result);
+}

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/CacheIntrospectionStore.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/CacheIntrospectionStore.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.cache;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CacheIntrospectionStore {
+  private static final CacheIntrospectionStore store = new CacheIntrospectionStore();
+
+  private Map<String, AgentIntrospection> agents = new ConcurrentHashMap<>();
+
+  public static CacheIntrospectionStore getStore() {
+    return store;
+  }
+
+  public Collection<AgentIntrospection> listAgentIntrospections() {
+    return agents.values();
+  }
+
+  public void recordAgent(AgentIntrospection agentIntrospection) {
+    agents.put(agentIntrospection.getId(), agentIntrospection);
+  }
+}

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/DefaultAgentIntrospection.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/DefaultAgentIntrospection.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.netflix.spinnaker.cats.cache;
+
+import com.netflix.spinnaker.cats.agent.Agent;
+import com.netflix.spinnaker.cats.agent.CacheResult;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.text.SimpleDateFormat;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+public class DefaultAgentIntrospection implements AgentIntrospection {
+  public DefaultAgentIntrospection(Agent agent) {
+    this.lastExecutionStartMs = System.currentTimeMillis();
+    this.id = agent.getAgentType();
+    this.provider = agent.getProviderName();
+  }
+
+  public void finishWithError(Throwable error, CacheResult result) {
+    lastError = error;
+    finish(result);
+  }
+
+  public void finish(CacheResult result) {
+    lastExecutionDurationMs = System.currentTimeMillis() - lastExecutionStartMs;
+    details = result.getIntrospectionDetails();
+    totalAdditions = result.getCacheResults().values().stream().reduce(0, (a, b) -> a + b.size(), (a, b) -> a + b);
+    totalEvictions = result.getEvictions().values().stream().reduce(0, (a, b) -> a + b.size(), (a, b) -> a + b);
+  }
+
+  private String id;
+  private String provider;
+  private int totalAdditions;
+  private int totalEvictions;
+  private Map<String, Object> details;
+  private Throwable lastError;
+  private Long lastExecutionStartMs;
+  private Long lastExecutionDurationMs;
+
+  public String getLastExecutionStartDate() {
+    return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(lastExecutionStartMs);
+  }
+}

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/DefaultCacheData.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/DefaultCacheData.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.cats.cache;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Clock;
 import java.util.Collection;
 import java.util.HashMap;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgent.java
@@ -39,6 +39,10 @@ public abstract class KubernetesCachingAgent<C extends KubernetesCredentials> im
 
   protected List<String> namespaces;
 
+  public List<String> getNamespaces() {
+    return namespaces;
+  }
+
   protected KubernetesCachingAgent(KubernetesNamedAccountCredentials<C> namedAccountCredentials,
       ObjectMapper objectMapper,
       Registry registry,

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -91,6 +91,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
   public CacheResult loadData(ProviderCache providerCache) {
     log.info(getAgentType() + " is starting");
     reloadNamespaces();
+    Map<String, Object> details = defaultIntrospectionDetails();
 
     Long start = System.currentTimeMillis();
     Map<KubernetesKind, List<KubernetesManifest>> primaryResource;
@@ -100,6 +101,8 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
       log.error(getAgentType() + ": resource for this caching agent is not supported for this cluster. This will cause problems, please remove it from caching using the `omitKinds` config parameter.");
       return new DefaultCacheResult(new HashMap<>());
     }
+
+    details.put("timeSpentInKubectlMs", System.currentTimeMillis() - start);
 
     List<String> primaryKeys = primaryResource.values()
         .stream()
@@ -157,7 +160,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
         .put(ON_DEMAND_TYPE, evictFromOnDemand.stream().map(CacheData::getId).collect(Collectors.toList()))
         .build();
 
-    return new DefaultCacheResult(cacheResults, evictionResults);
+    return new DefaultCacheResult(cacheResults, evictionResults, details);
   }
 
   protected void mergeCacheResults(Map<String, Collection<CacheData>> current, Map<String, Collection<CacheData>> added) {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.controllers
 
+import com.netflix.spinnaker.cats.cache.AgentIntrospection
+import com.netflix.spinnaker.cats.cache.CacheIntrospectionStore
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
@@ -50,6 +52,12 @@ class CacheController {
       ],
       httpStatus
     )
+  }
+
+
+  @RequestMapping(method = RequestMethod.GET, value = "/introspection")
+  Collection <AgentIntrospection> getAgentIntrospections() {
+    return CacheIntrospectionStore.getStore().listAgentIntrospections()
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{cloudProvider}/{type}")


### PR DESCRIPTION
Now by default, all recent caching agent run are displayed per-node
under `/cache/introspection`. Providers (shown in k8s v2 here) can
supply additional details such as namespaces & kinds cached, time spent
in kubectl, etc...
https://github.com/spinnaker/spinnaker/issues/3668