### PR TITLE
fix(cache/introspection): sort by descending execution

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/AgentIntrospection.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/AgentIntrospection.java
@@ -31,6 +31,7 @@ public interface AgentIntrospection {
   int getTotalAdditions();
   int getTotalEvictions();
   Long getLastExecutionDurationMs();
+  Long getLastExecutionStartMs();
   Throwable getLastError();
   String getLastExecutionStartDate();
   void finishWithError(Throwable error, CacheResult result);

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
@@ -58,6 +58,8 @@ class CacheController {
   @RequestMapping(method = RequestMethod.GET, value = "/introspection")
   Collection <AgentIntrospection> getAgentIntrospections() {
     return CacheIntrospectionStore.getStore().listAgentIntrospections()
+        // sort by descending start time, so newest executions are first
+        .toSorted { a, b -> b.getLastExecutionStartMs() <=> a.getLastExecutionStartMs() }
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{cloudProvider}/{type}")


### PR DESCRIPTION
This makes the results a lot easier to read, as agents that are executed infrequently/on different nodes get pushed to the bottom

