### PR TITLE
fix(provider/kubernetes): fix v2 cronjob status

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCronJobHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCronJobHandler.java
@@ -86,10 +86,6 @@ public class KubernetesCronJobHandler extends KubernetesHandler implements
       return result;
     }
 
-    if (status.getActive() != null) {
-      return result.unstable(String.format("%s job(s) in progress", status.getActive().size()));
-    }
-
     return result;
   }
 


### PR DESCRIPTION
Currently Kubernetes only reports if a job scheduled by a cronjob has
completed without a success status. By checking if a job was running we
were only preventing potentially functioning cronjob specs from becoming
"stable", without correctly filtering out "unstable" cronjobs.
