### PR TITLE
fix(provider/titus): improve lookup of security group details

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProvider.groovy
@@ -112,6 +112,33 @@ class AmazonSecurityGroupProvider implements SecurityGroupProvider<AmazonSecurit
     getAllMatchingKeyPattern(Keys.getSecurityGroupKey(name, '*', region, account, vpcId), includeRules)[0]
   }
 
+  String getNameById(String account, String region, String securityGroupId, String vpcId) {
+    String key = getCacheIdentifier(Keys.getSecurityGroupKey('*', securityGroupId, region, account, vpcId))
+    if (key) {
+      return Keys.parse(key).name
+    } else {
+      return null
+    }
+  }
+
+  String getIdByName(String account, String region, String name, String vpcId) {
+    String key = getCacheIdentifier(Keys.getSecurityGroupKey(name, "*", region, account, vpcId))
+    if (key) {
+      return Keys.parse(key).id
+    } else {
+      return null
+    }
+  }
+
+  String getCacheIdentifier(String pattern) {
+    Set ids = cacheView.filterIdentifiers(SECURITY_GROUPS.ns, pattern)
+    if (ids.isEmpty()) {
+      return null
+    } else {
+      return ids.toArray()[0]
+    }
+  }
+
   AmazonSecurityGroup getById(String account, String region, String securityGroupId, String vpcId) {
     getAllMatchingKeyPattern(Keys.getSecurityGroupKey('*', securityGroupId, region, account, vpcId), true)[0]
   }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/AwsLookupUtil.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/AwsLookupUtil.groovy
@@ -71,7 +71,7 @@ class AwsLookupUtil {
     Map awsDetails = awsAccountLookup.find {
       it.titusAccount == account && it.region == region
     }
-    awsSecurityGroupProvider.get(false, awsDetails.awsAccount, region, providedSecurityGroup, awsDetails.vpcId)?.id
+    awsSecurityGroupProvider.getIdByName(awsDetails.awsAccount, region, providedSecurityGroup, awsDetails.vpcId)
   }
 
   String createSecurityGroupForApplication(account, region, application) {
@@ -187,12 +187,12 @@ class AwsLookupUtil {
       }
     }
 
-    [name      : awsSecurityGroupProvider.getById(false,
+    [name      : awsSecurityGroupProvider.getNameById(
       awsDetails.awsAccount,
       region,
       securityGroupId,
       awsDetails.vpcId
-    )?.name,
+     ),
      awsAccount: awsDetails.awsAccount,
      vpcId     : awsDetails.vpcId
     ]


### PR DESCRIPTION
Improve lookup of titus security groups from aws by not loading the entire security group object when not needed