### PR TITLE
feat(provider/kubernetes): 'liveManifestCall' mode

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -56,6 +56,7 @@ class KubernetesConfigurationProperties {
     List<String> kinds
     List<String> omitKinds
     Boolean onlySpinnakerManaged
+    Boolean liveManifestCalls
   }
 
   List<ManagedAccount> accounts = []

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -71,6 +71,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
   private final AccountCredentialsRepository accountCredentialsRepository;
   private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
   private final Boolean onlySpinnakerManaged;
+  private final Boolean liveManifestCalls;
   KubernetesNamedAccountCredentials(String name,
                                     ProviderVersion providerVersion,
                                     AccountCredentialsRepository accountCredentialsRepository,
@@ -94,7 +95,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
                                     Registry spectatorRegistry,
                                     KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
                                     C credentials,
-                                    Boolean onlySpinnakerManaged) {
+                                    Boolean onlySpinnakerManaged,
+                                    Boolean liveManifestCalls) {
     this.name = name;
     this.providerVersion = providerVersion;
     this.environment = environment;
@@ -119,6 +121,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     this.credentials = credentials;
     this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
     this.onlySpinnakerManaged = onlySpinnakerManaged;
+    this.liveManifestCalls = liveManifestCalls;
   }
 
   public List<String> getNamespaces() {
@@ -235,6 +238,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     boolean checkPermissionsOnStartup;
     KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
     Boolean onlySpinnakerManaged;
+    Boolean liveManifestCalls;
 
     Builder kubernetesSpinnakerKindMap(KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
       this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
@@ -424,6 +428,11 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       return this;
     }
 
+    Builder liveManifestCalls(boolean liveManifestCalls) {
+      this.liveManifestCalls = liveManifestCalls;
+      return this;
+    }
+
     private C buildCredentials() {
       switch (providerVersion) {
         case v1:
@@ -469,6 +478,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
               .checkPermissionsOnStartup(checkPermissionsOnStartup)
               .jobExecutor(jobExecutor)
               .onlySpinnakerManaged(onlySpinnakerManaged)
+              .liveManifestCalls(liveManifestCalls)
               .build();
         default:
           throw new IllegalArgumentException("Unknown provider type: " + providerVersion);
@@ -559,7 +569,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
           spectatorRegistry,
           kubernetesSpinnakerKindMap,
           credentials,
-          onlySpinnakerManaged
+          onlySpinnakerManaged,
+          liveManifestCalls
       );
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -114,6 +114,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .checkPermissionsOnStartup(managedAccount.checkPermissionsOnStartup == null ? true : managedAccount.checkPermissionsOnStartup)
           .kubernetesSpinnakerKindMap(kubernetesSpinnakerKindMap)
           .onlySpinnakerManaged(managedAccount.onlySpinnakerManaged == null ? false : managedAccount.onlySpinnakerManaged)
+          .liveManifestCalls(managedAccount.liveManifestCalls ?: false)
           .build()
 
         accountCredentialsRepository.save(managedAccount.name, kubernetesAccount)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -275,6 +275,11 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
       return null;
     }
 
+    // No on-demand updates needed when live calls are used to check for status during orchestration
+    if (credentials.isLiveManifestCalls()) {
+      return null;
+    }
+
     if (!kind.isNamespaced() && StringUtils.isNotEmpty(namespace)) {
       log.warn("Kind {} is not namespace but namespace {} was provided, ignoring", kind, namespace);
       namespace = "";

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestAnnotater;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.model.ManifestProvider;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.moniker.Moniker;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public abstract class KubernetesV2AbstractManifestProvider implements ManifestProvider<KubernetesV2Manifest> {
+  protected abstract AccountCredentialsRepository getCredentialsRepository();
+  protected abstract KubernetesResourcePropertyRegistry getRegistry();
+
+  protected Optional<KubernetesV2Credentials> getCredentials(String account) {
+    AccountCredentials credentials = getCredentialsRepository().getOne(account);
+
+    if (credentials == null || !(credentials instanceof KubernetesNamedAccountCredentials)) {
+      return Optional.empty();
+    }
+
+    if (!(credentials.getCredentials() instanceof KubernetesV2Credentials)) {
+      return Optional.empty();
+    }
+
+    return Optional.ofNullable((KubernetesV2Credentials) credentials.getCredentials());
+  }
+
+  protected boolean isAccountRelevant(String account) {
+    return getCredentials(account).isPresent();
+  }
+
+  protected boolean makesLiveCalls(String account) {
+    return getCredentials(account).map(KubernetesV2Credentials::isLiveManifestCalls).orElseThrow(() -> new IllegalArgumentException("Account " + account + " is not a Kubernetess v2 account"));
+  }
+
+  protected KubernetesV2Manifest buildManifest(String account, KubernetesManifest manifest, List<KubernetesManifest> events, List<Map> metrics) {
+    String namespace = manifest.getNamespace();
+    KubernetesKind kind = manifest.getKind();
+
+    KubernetesResourceProperties properties = getRegistry().get(account, kind);
+    if (properties == null) {
+      return null;
+    }
+
+    Function<KubernetesManifest, String> lastEventTimestamp = (m) -> (String) m.getOrDefault("lastTimestamp", m.getOrDefault("firstTimestamp", "n/a"));
+
+    events = events.stream()
+        .sorted(Comparator.comparing(lastEventTimestamp))
+        .collect(Collectors.toList());
+
+    Moniker moniker = KubernetesManifestAnnotater.getMoniker(manifest);
+
+    KubernetesHandler handler = properties.getHandler();
+
+    return new KubernetesV2Manifest().builder()
+        .account(account)
+        .name(manifest.getFullResourceName())
+        .location(namespace)
+        .manifest(manifest)
+        .moniker(moniker)
+        .status(handler.status(manifest))
+        .artifacts(handler.listArtifacts(manifest))
+        .events(events)
+        .warnings(handler.listWarnings(manifest))
+        .metrics(metrics)
+        .build();
+
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManifestProvider {
+  @Getter
+  final private AccountCredentialsRepository credentialsRepository;
+  @Getter
+  final private KubernetesResourcePropertyRegistry registry;
+
+  @Autowired
+  public KubernetesV2LiveManifestProvider(AccountCredentialsRepository credentialsRepository, KubernetesResourcePropertyRegistry registry) {
+    this.credentialsRepository = credentialsRepository;
+    this.registry = registry;
+  }
+
+  @Override
+  public KubernetesV2Manifest getManifest(String account, String location, String name) {
+    if (!isAccountRelevant(account)) {
+      return null;
+    }
+
+    if (!makesLiveCalls(account)) {
+      return null;
+    }
+
+    Pair<KubernetesKind, String> parsedName;
+    try {
+      parsedName = KubernetesManifest.fromFullResourceName(name);
+    } catch (Exception e) {
+      return null;
+    }
+
+    // TODO(lwander): move to debug once early users have validated this
+    log.info("Live call to lookup manifest '{}:{}' in namespace '{}' under account '{}'", parsedName.getRight(), parsedName.getLeft(), location, account);
+    KubernetesV2Credentials credentials = getCredentials(account).orElseThrow(() -> new IllegalStateException("Already verified that credentials are relevant"));
+    KubernetesManifest manifest = credentials.get(parsedName.getLeft(), location, parsedName.getRight());
+    if (manifest == null) {
+      return null;
+    }
+
+    String namespace = manifest.getNamespace();
+    KubernetesKind kind = manifest.getKind();
+
+    List<KubernetesManifest> events = credentials.eventsFor(kind, namespace, parsedName.getRight());
+
+    // TODO kubectl top pod <name> -n <namespace>
+    // low-priority, pipeline-only mode doesn't need to see resource usage.
+    List<Map> metrics = Collections.emptyList();
+
+    return buildManifest(account, manifest, events, metrics);
+  }
+
+  @Override
+  public List<KubernetesV2Manifest> getClusterAndSortAscending(String account, String location, String kind, String app, String cluster, Sort sort) {
+    return Collections.emptyList();
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -72,6 +72,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   @Getter
   private final List<KubernetesCachingPolicy> cachingPolicies;
   private final boolean onlySpinnakerManaged;
+  @Getter
+  private final boolean liveManifestCalls;
 
   // TODO(lwander) make configurable
   private final static int namespaceExpirySeconds = 30;
@@ -194,6 +196,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     boolean serviceAccount;
     boolean metrics;
     boolean onlySpinnakerManaged;
+    boolean liveManifestCalls;
 
     public Builder accountName(String accountName) {
       this.accountName = accountName;
@@ -300,6 +303,11 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       return this;
     }
 
+    public Builder liveManifestCalls(boolean liveManifestCalls) {
+      this.liveManifestCalls = liveManifestCalls;
+      return this;
+    }
+
     public KubernetesV2Credentials build() {
       namespaces = namespaces == null ? new ArrayList<>() : namespaces;
       omitNamespaces = omitNamespaces == null ? new ArrayList<>() : omitNamespaces;
@@ -328,7 +336,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
           metrics,
           checkPermissionsOnStartup,
           debug,
-          onlySpinnakerManaged
+          onlySpinnakerManaged,
+          liveManifestCalls
       );
     }
   }
@@ -352,7 +361,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       boolean metrics,
       boolean checkPermissionsOnStartup,
       boolean debug,
-      boolean onlySpinnakerManaged) {
+      boolean onlySpinnakerManaged,
+      boolean liveManifestCalls) {
     this.registry = registry;
     this.clock = registry.clock();
     this.accountName = accountName;
@@ -373,6 +383,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.metrics = metrics;
     this.omitKinds = omitKinds;
     this.onlySpinnakerManaged = onlySpinnakerManaged;
+    this.liveManifestCalls = liveManifestCalls;
 
     this.liveNamespaceSupplier = Suppliers.memoizeWithExpiration(() -> jobExecutor.list(this, Collections.singletonList(KubernetesKind.NAMESPACE), "", new KubernetesSelectorList())
         .stream()
@@ -495,6 +506,10 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     } else {
       return runAndRecordMetrics("list", kinds, namespace, () -> jobExecutor.list(this, kinds, namespace, new KubernetesSelectorList()));
     }
+  }
+
+  public List<KubernetesManifest> eventsFor(KubernetesKind kind, String namespace, String name) {
+    return runAndRecordMetrics("list", KubernetesKind.EVENT, namespace, () -> jobExecutor.eventsFor(this, kind, namespace, name));
   }
 
   public String logs(String namespace, String podName, String containerName) {


### PR DESCRIPTION
Been meaning to submit this for us to try out:

This is in service of faster pipeline executions, which ignore force
cache refreshes, and only serve manifest status from live calls.

Need to find a cleaner top-level way to distinguish between object
providers that query the cache vs. live data.

Important to note: this leaves caching (& the clusters tab) intact for
now, those can be disabled separately in a future PR.
