### PR TITLE
feat(entitytags): a simple `deleteByNamespace` admin api

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTagsProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTagsProvider.java
@@ -67,6 +67,11 @@ public interface EntityTagsProvider {
   void delete(String id);
 
   /**
+   * Remove all entity tags within a particular namespace, optionally deleting from the source of truth (front50).
+   */
+  Map<String, Object> deleteByNamespace(String namespace, boolean dryRun, boolean deleteFromSource);
+
+  /**
    * Delete EntityTags
    */
   void bulkDelete(Collection<EntityTags> multipleEntityTags);

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/UpsertEntityTagsAtomicOperation.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/UpsertEntityTagsAtomicOperation.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.elasticsearch.ops;
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.elasticsearch.EntityRefIdBuilder;
 import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.BulkUpsertEntityTagsDescription;
 import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.UpsertEntityTagsDescription;
 import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
@@ -29,7 +30,10 @@ import com.netflix.spinnaker.kork.core.RetrySupport;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static com.netflix.spinnaker.clouddriver.elasticsearch.ops.BulkUpsertEntityTagsAtomicOperation.entityRefId;
 
 public class UpsertEntityTagsAtomicOperation implements AtomicOperation<Void> {
   private static final String BASE_PHASE = "ENTITY_TAGS";
@@ -61,7 +65,9 @@ public class UpsertEntityTagsAtomicOperation implements AtomicOperation<Void> {
       BASE_PHASE,
       String.format(
         "Updating entity tags for %s (isPartial: %s, tags: %s)",
-        entityTagsDescription.getId(),
+        Optional
+          .ofNullable(entityTagsDescription.getId())
+          .orElse(entityRefId(accountCredentialsProvider, entityTagsDescription).id),
         entityTagsDescription.isPartial,
         entityTagsDescription.getTags().stream().map(EntityTags.EntityTag::getName).collect(Collectors.joining(", "))
       )

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProviderSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProviderSpec.groovy
@@ -33,6 +33,8 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.util.function.Supplier
+
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder
 
 class ElasticSearchEntityTagsProviderSpec extends Specification {
@@ -250,7 +252,71 @@ class ElasticSearchEntityTagsProviderSpec extends Specification {
     verifyNotIndexed(allEntityTags[0])
     verifyNotIndexed(allEntityTags[1])
     verifyNotIndexed(allEntityTags[2])
+  }
 
+  def "should delete all entity tags in namespace"() {
+    given:
+    def allEntityTags = [
+      buildEntityTags("aws:servergroup:clouddriver-main-v001:myaccount:us-west-1", ["a": "1"], "my_namespace"),
+      buildEntityTags("aws:servergroup:clouddriver-main-v002:myaccount:us-west-1", ["b": "2"], "my_namespace"),
+      buildEntityTags("aws:servergroup:clouddriver-main-v003:myaccount:us-west-1", ["c": "3"]),
+    ]
+    allEntityTags.each {
+      entityTagsProvider.index(it)
+      entityTagsProvider.verifyIndex(it)
+    }
+
+    when:
+    entityTagsProvider.deleteByNamespace("my_namespace", true, false) // dry-run
+
+    then:
+    1 * front50Service.getAllEntityTags(false) >> {
+      return entityTagsProvider.getAll(
+        null, null, null, null, null, null, null, null, [:], 100
+      )
+    }
+    0 * _
+
+    when:
+    entityTagsProvider.deleteByNamespace("my_namespace", true, true) // dry-run
+
+    then:
+    1 * front50Service.getAllEntityTags(false) >> {
+      return entityTagsProvider.getAll(
+        null, null, null, null, null, null, null, null, [:], 100
+      )
+    }
+    0 * _
+
+    when:
+    entityTagsProvider.deleteByNamespace("my_namespace", false, false) // remove from elasticsearch (only!)
+    Thread.sleep(1000)
+
+    def allIndexedEntityTags = entityTagsProvider.getAll(
+      null, null, null, null, null, null, null, null, [:], 100
+    )
+
+    then:
+    1 * front50Service.getAllEntityTags(false) >> {
+      return entityTagsProvider.getAll(
+        null, null, null, null, null, null, null, null, [:], 100
+      )
+    }
+    _ * retrySupport.retry(_, _, _, _) >> { Supplier fn, int maxRetries, long retryBackoff, boolean exponential -> fn.get() }
+    0 * _
+
+    allIndexedEntityTags.findAll {
+      it.tags.any { it.namespace == "my_namespace"}
+    }.isEmpty()
+
+    when:
+    entityTagsProvider.deleteByNamespace("my_namespace", false, true) // remove from elasticsearch and front50
+
+    then:
+    1 * front50Service.getAllEntityTags(false) >> { return allEntityTags }
+    1 * front50Service.batchUpdate(_)
+    _ * retrySupport.retry(_, _, _, _) >> { Supplier fn, int maxRetries, long retryBackoff, boolean exponential -> fn.get() }
+    0 * _
   }
 
   boolean verifyNotIndexed(EntityTags entityTags) {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/admin/EntityTagsAdminController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/admin/EntityTagsAdminController.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.model.EntityTagsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -56,5 +57,16 @@ public class EntityTagsAdminController {
                 @RequestParam(name = "account", required = false) String account,
                 @RequestParam(name = "region", required = false) String region) {
     return entityTagsProvider.reconcile(cloudProvider, account, region, Optional.ofNullable(dryRun).orElse(true));
+  }
+
+  @RequestMapping(value = "/deleteByNamespace/{namespace}", method = RequestMethod.POST)
+  Map deleteByNamespace(@PathVariable("namespace") String namespace,
+                        @RequestParam(name = "dryRun", defaultValue = "true") Boolean dryRun,
+                        @RequestParam(name = "deleteFromSource", defaultValue = "false") Boolean deleteFromSource) {
+    return entityTagsProvider.deleteByNamespace(
+      namespace,
+      Optional.ofNullable(dryRun).orElse(true),
+      Optional.ofNullable(deleteFromSource).orElse(false)
+    );
   }
 }


### PR DESCRIPTION
Dry run (default):
```
curl -X POST 'https://localhost:8081/admin/tags/deleteByNamespace/{namespace}'
```

Remove from elasticsearch only:
```
curl -X POST 'https://localhost:8081/admin/tags/deleteByNamespace/{namespace}?dryRun=false'
```

Remove from elasticsearch and front50:
```
curl -X POST 'https://localhost:8081/admin/tags/deleteByNamespace/{namespace}?dryRun=false&deleteFromSource=true'
```
