### PR TITLE
feat(ecs): Migrate to standard server group name resolver

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/EcsServerGroupNameResolver.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/EcsServerGroupNameResolver.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy;
+
+import com.amazonaws.services.ecs.AmazonECS;
+import com.amazonaws.services.ecs.model.*;
+import com.google.common.collect.Lists;
+import com.netflix.frigga.Names;
+import com.netflix.spinnaker.clouddriver.helpers.AbstractServerGroupNameResolver;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class EcsServerGroupNameResolver extends AbstractServerGroupNameResolver {
+  private static final String PHASE = "ECS_DEPLOY";
+
+  String ecsClusterName;
+  AmazonECS ecs;
+  String region;
+
+  @Override
+  public String getPhase() {
+    return PHASE;
+  }
+
+  @Override
+  public String getRegion() {
+    return region;
+  }
+
+  @Override
+  public List<TakenSlot> getTakenSlots(String familyName) {
+    List<String> relevantServices = new ArrayList<>();
+    String nextToken = null;
+    do {
+      ListServicesRequest request = new ListServicesRequest().withCluster(ecsClusterName);
+      if (nextToken != null) {
+        request.setNextToken(nextToken);
+      }
+
+      ListServicesResult result = ecs.listServices(request);
+      for (String serviceArn : result.getServiceArns()) {
+        if (serviceArn.contains(familyName)) {
+          relevantServices.add(serviceArn);
+        }
+      }
+
+      nextToken = result.getNextToken();
+    } while (nextToken != null && nextToken.length() != 0);
+
+    List<TakenSlot> slots = new ArrayList<>();
+    List<List<String>> serviceBatches = Lists.partition(relevantServices, 10);
+    for (List<String> serviceBatch : serviceBatches) {
+      DescribeServicesRequest request = new DescribeServicesRequest().withCluster(ecsClusterName).withServices(serviceBatch);
+      DescribeServicesResult result = ecs.describeServices(request);
+      for (Service service : result.getServices()) {
+        Names names = Names.parseName(service.getServiceName());
+        slots.add(new TakenSlot(service.getServiceName(), names.getSequence(), service.getCreatedAt()));
+      }
+    }
+
+    return slots;
+  }
+
+  public static String getEcsFamilyName(String serverGroupName) {
+    // Format: family-name-v001
+    return serverGroupName.substring(0, serverGroupName.lastIndexOf('-'));
+  }
+
+  public static String getEcsContainerName(String serverGroupName) {
+    // Format: family-name-v001, container name = v001
+    return serverGroupName.substring(serverGroupName.lastIndexOf('-') + 1, serverGroupName.length());
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/EcsServerGroupNameResolverSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/EcsServerGroupNameResolverSpec.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package com.netflix.spinnaker.clouddriver.ecs.deploy
+
+
+import com.amazonaws.services.ecs.AmazonECS
+import com.amazonaws.services.ecs.model.*
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTask
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.helpers.AbstractServerGroupNameResolver
+import spock.lang.Specification
+
+class EcsServerGroupNameResolverSpec extends Specification {
+  def ecsClient = Mock(AmazonECS)
+
+  def ecsClusterName = 'default'
+  def region = 'us-west-1'
+
+  void setup() {
+    Task task = new DefaultTask("task")
+    TaskRepository.threadLocalTask.set(task)
+  }
+
+  void "should build TakenSlots based on existing ECS services"() {
+    given:
+    def resolver = new EcsServerGroupNameResolver(ecsClusterName, ecsClient, region)
+
+    when:
+    def takenSlots = resolver.getTakenSlots('application-stack-details')
+
+    then:
+    1 * ecsClient.listServices({ListServicesRequest request ->
+      request.cluster == ecsClusterName
+    }) >> new ListServicesResult().withServiceArns(
+      "arn:aws:ecs:region:account-id:service/cluster-name/application-stack-details-v000",
+      "arn:aws:ecs:region:account-id:service/cluster-name/hello-world-v000")
+    1 * ecsClient.describeServices({DescribeServicesRequest request ->
+      request.cluster == ecsClusterName
+      request.services == ["arn:aws:ecs:region:account-id:service/cluster-name/application-stack-details-v000"]
+    }) >> new DescribeServicesResult().withServices(
+      new Service(serviceName: "application-stack-details-v000", createdAt: new Date(1)))
+
+    takenSlots == [
+        new AbstractServerGroupNameResolver.TakenSlot('application-stack-details-v000', 0, new Date(1))
+    ]
+  }
+
+  void "should resolve task definition family name from service group name"() {
+    given:
+    def resolver = new EcsServerGroupNameResolver(ecsClusterName, ecsClient, region)
+    ecsClient.listServices(_) >> new ListServicesResult().withServiceArns("application-stack-details-v001")
+    ecsClient.describeServices(_) >> new DescribeServicesResult().withServices(
+      new Service(serviceName: "application-stack-details-v001", createdAt: new Date(1)))
+
+    when:
+    def nextServerGroupName = resolver.resolveNextServerGroupName('application', 'stack', 'details', false)
+    def familyName = EcsServerGroupNameResolver.getEcsFamilyName(nextServerGroupName)
+
+    then:
+    nextServerGroupName == "application-stack-details-v002".toString()
+    familyName == "application-stack-details"
+  }
+
+  void "should resolve task definition container name from service group name"() {
+    given:
+    def resolver = new EcsServerGroupNameResolver(ecsClusterName, ecsClient, region)
+    ecsClient.listServices(_) >> new ListServicesResult().withServiceArns("application-stack-details-v001", "application-stack-details-v002")
+    ecsClient.describeServices(_) >> new DescribeServicesResult().withServices(
+      new Service(serviceName: "application-stack-details-v001", createdAt: new Date(1)),
+      new Service(serviceName: "application-stack-details-v002", createdAt: new Date(2)))
+
+    when:
+    def nextServerGroupName = resolver.resolveNextServerGroupName('application', 'stack', 'details', false)
+    def containerName = EcsServerGroupNameResolver.getEcsContainerName(nextServerGroupName)
+
+    then:
+    nextServerGroupName == "application-stack-details-v003".toString()
+    containerName == "v003"
+  }
+}

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -107,6 +107,8 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
 
     then:
     1 * ecs.listServices(_) >> new ListServicesResult().withServiceArns("${serviceName}-v007")
+    1 * ecs.describeServices(_) >> new DescribeServicesResult().withServices(
+      new Service(serviceName: "${serviceName}-v007", createdAt: new Date()))
 
     1 * ecs.registerTaskDefinition({RegisterTaskDefinitionRequest request ->
       request.containerDefinitions.size() == 1
@@ -195,6 +197,8 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
 
     then:
     1 * ecs.listServices(_) >> new ListServicesResult().withServiceArns("${serviceName}-v007")
+    1 * ecs.describeServices(_) >> new DescribeServicesResult().withServices(
+      new Service(serviceName: "${serviceName}-v007", createdAt: new Date()))
 
     1 * ecs.registerTaskDefinition({RegisterTaskDefinitionRequest request ->
       request.networkMode == 'awsvpc'
@@ -241,7 +245,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'v0011')
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
 
     then:
     def labels = request.getContainerDefinitions().get(0).getDockerLabels()
@@ -262,7 +266,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'v0011')
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
 
     then:
     def labels = request.getContainerDefinitions().get(0).getDockerLabels()
@@ -285,7 +289,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'v0011')
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
 
     then:
     def labels = request.getContainerDefinitions().get(0).getDockerLabels()
@@ -301,7 +305,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'v0011')
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
 
     then:
     request.getContainerDefinitions().get(0).getLogConfiguration().getLogDriver() == 'some-log-driver'
@@ -314,7 +318,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'v0011')
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
 
     then:
     request.getContainerDefinitions().get(0).getLogConfiguration().getOptions() == null
@@ -330,7 +334,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'v0011')
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
 
     then:
     request.getContainerDefinitions().get(0).getLogConfiguration().getOptions() == logOptions
@@ -344,7 +348,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'v0011')
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
 
     then:
     request.getContainerDefinitions().get(0).getRepositoryCredentials().getCredentialsParameter() == 'my-secret'
@@ -357,7 +361,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'v0011')
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
 
     then:
     request.getContainerDefinitions().get(0).getRepositoryCredentials() == null
@@ -385,7 +389,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    RegisterTaskDefinitionRequest result = operation.makeTaskDefinitionRequest("test-role", "v1")
+    RegisterTaskDefinitionRequest result = operation.makeTaskDefinitionRequest("test-role", "v1-kcats-liated-v001")
 
     then:
     result.getTaskRoleArn() == null
@@ -393,7 +397,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
 
     result.getContainerDefinitions().size() == 1
     def containerDefinition = result.getContainerDefinitions().first()
-    containerDefinition.name == 'v1'
+    containerDefinition.name == 'v001'
     containerDefinition.image == 'docker-image-url'
     containerDefinition.cpu == 9001
     containerDefinition.memoryReservation == 9001
@@ -409,7 +413,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     for(elem in containerDefinition.environment){
       environments.put(elem.getName(), elem.getValue())
     }
-    environments.get("SERVER_GROUP") == "v1"
+    environments.get("SERVER_GROUP") == "v1-kcats-liated-v001"
     environments.get("CLOUD_STACK") == "kcats"
     environments.get("CLOUD_DETAIL") == "liated"
   }
@@ -424,7 +428,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     def operation = new CreateServerGroupAtomicOperation(description)
 
     when:
-    RegisterTaskDefinitionRequest result = operation.makeTaskDefinitionRequest("test-role", "v1")
+    RegisterTaskDefinitionRequest result = operation.makeTaskDefinitionRequest("test-role", "v1-kcats-liated-v001")
 
     then:
     result.getContainerDefinitions().size() == 1
@@ -434,7 +438,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     for(elem in containerDefinition.environment){
       environments.put(elem.getName(), elem.getValue())
     }
-    environments.get("SERVER_GROUP") == "v1"
+    environments.get("SERVER_GROUP") == "v1-kcats-liated-v001"
     environments.get("CLOUD_STACK") == "kcats"
     environments.get("CLOUD_DETAIL") == "liated"
     environments.get("ENVIRONMENT_1") == "test1"


### PR DESCRIPTION
This makes it slightly easier to implement https://github.com/spinnaker/spinnaker/issues/3733, by standardizing on the same logic that determines the 'next' and 'current' server groups.

This does change the format of the server group names, from basename-v0001 to basename-v001.  It's not a breaking change because the sequence number parses the same in both formats.