### PR TITLE
fix(provider/docker): No longer depend on service in authentication

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
@@ -174,7 +174,8 @@ class DockerBearerTokenService {
       throw new DockerRegistryAuthenticationException("Www-Authenticate header must provide 'realm' parameter.")
     }
     if (!result.service) {
-      throw new DockerRegistryAuthenticationException("Www-Authenticate header must provide 'service' parameter.")
+      // This e.g. is the case for OpenShift Container Registry
+      result.service = null
     }
 
     return result

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenServiceSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenServiceSpec.groovy
@@ -50,6 +50,19 @@ class DockerBearerTokenServiceSpec extends Specification {
       result.scope == SCOPE1
   }
 
+  void "should parse Www-Authenticate header with missing service and path."() {
+    setup:
+      def input = "realm=\"${REALM1}/${PATH1}\",scope=\"${SCOPE1}\""
+    when:
+      def result = tokenService.parseBearerAuthenticateHeader(input)
+
+    then:
+      result.path == PATH1
+      result.realm == REALM1
+      result.service == null
+      result.scope == SCOPE1
+  }
+
   void "should parse Www-Authenticate header with some privileges and path."() {
     setup:
       def input = "realm=\"${REALM1}/${PATH1}\",service=\"${SERVICE1}\",scope=\"${SCOPE2}\""
@@ -73,6 +86,19 @@ class DockerBearerTokenServiceSpec extends Specification {
       !result.path
       result.realm == REALM1
       result.service == SERVICE1
+      result.scope == SCOPE2
+  }
+
+  void "should parse Www-Authenticate header with missing service and no path."() {
+    setup:
+      def input = "realm=\"${REALM1}\",scope=\"${SCOPE2}\""
+    when:
+      def result = tokenService.parseBearerAuthenticateHeader(input)
+
+    then:
+      !result.path
+      result.realm == REALM1
+      result.service == null
       result.scope == SCOPE2
   }
 


### PR DESCRIPTION
Should fix #3772

Depending on the structure of the service URIs, there may be no Service in
the Authentication (see https://tools.ietf.org/html/rfc6750#section-3).
This is actually true for OpenShift OKR structure.
As such, ignore missing `service` and ensure that it gets ignored later on
as query parameter.