### PR TITLE
fix(provider/kubernetes): bail out of caching on error

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -88,7 +88,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
             return credentials.list(primaryKinds(), n);
           } catch (KubectlException e) {
             log.warn("Failed to read kind {} from namespace {}: {}", primaryKinds(), n, e.getMessage());
-            return null;
+            throw e;
           }
         })
         .filter(Objects::nonNull)


### PR DESCRIPTION
By returning `null` we were deleting valid (but stale) cache entries
instead of forcing the caching agent to retry later.
