### PR TITLE
fix(core): include instanceCounts when fetching project clusters, fix…

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppengineClusterProvider.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/view/AppengineClusterProvider.groovy
@@ -98,12 +98,12 @@ class AppengineClusterProvider implements ClusterProvider<AppengineCluster> {
 
   @Override
   Map<String, Set<AppengineCluster>> getClusterSummaries(String applicationName) {
-    translateClusters(getClusterData(applicationName), false)?.groupBy { it.accountName } as Map<String, Set<AppengineCluster>>
+    translateClusters(getClusterData(applicationName), false)?.groupBy { it.accountName }.collectEntries { k, v -> [k, new HashSet<>(v)] }
   }
 
   @Override
   Map<String, Set<AppengineCluster>> getClusterDetails(String applicationName) {
-    translateClusters(getClusterData(applicationName), true)?.groupBy { it.accountName } as Map<String, Set<AppengineCluster>>
+    translateClusters(getClusterData(applicationName), true)?.groupBy { it.accountName }.collectEntries { k, v -> [k, new HashSet<>(v)] }
   }
 
   Set<CacheData> getClusterData(String applicationName) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
@@ -222,12 +222,14 @@ public class ProjectClustersService {
     public String stack;
     public String detail;
     public List<ApplicationClusterModel> applications;
+    public ServerGroup.InstanceCounts instanceCounts;
 
     public ClusterModel(String account, String stack, String detail, List<ApplicationClusterModel> applications) {
       this.account = account;
       this.stack = stack;
       this.detail = detail;
       this.applications = applications;
+      this.instanceCounts = getInstanceCounts();
     }
 
     ServerGroup.InstanceCounts getInstanceCounts() {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -68,12 +68,12 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
 
   @Override
   Map<String, Set<GoogleCluster.View>> getClusterDetails(String applicationName) {
-    getClusters(applicationName, true /* detailed */)
+    getClusters(applicationName, true /* detailed */).collectEntries { k, v -> [k, new HashSet<>(v)] }
   }
 
   @Override
   Map<String, Set<GoogleCluster.View>> getClusterSummaries(String applicationName) {
-    getClusters(applicationName, false /* detailed */)
+    getClusters(applicationName, false /* detailed */).collectEntries { k, v -> [k, new HashSet<>(v)] }
   }
 
   Map<String, Set<GoogleCluster.View>> getClusters(String applicationName, boolean includeInstanceDetails) {


### PR DESCRIPTION
… ClassCastException for gce and appengine fetch cluster methods

While investigating https://github.com/spinnaker/spinnaker/issues/3490, I noticed that project clusters were also failing to populate for GCE and Appengine projects because ProjectClusterService.retrieveClusters was throwing the following error: `java.lang.ClassCastException: java.util.ArrayList cannot be cast to java.util.Set`. Additionally, `instanceCounts` was missing from the model for all providers.

(Will open a separate PR once I resolve the k8s issue in https://github.com/spinnaker/spinnaker/issues/3490)

Before:

![clusters_before](https://user-images.githubusercontent.com/15936279/50600307-aea18580-0e7e-11e9-9abe-0eed60d626fe.png)

After:

![clusters_after](https://user-images.githubusercontent.com/15936279/50600311-b2cda300-0e7e-11e9-97c5-8b97c2914bd7.png)
