### PR TITLE
feat(provider/kubernetes): allow v2 to set a cacheIntervalSeconds

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -57,6 +57,7 @@ class KubernetesConfigurationProperties {
     List<String> omitKinds
     Boolean onlySpinnakerManaged
     Boolean liveManifestCalls
+    Long cacheIntervalSeconds
   }
 
   List<ManagedAccount> accounts = []

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -72,6 +72,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
   private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
   private final Boolean onlySpinnakerManaged;
   private final Boolean liveManifestCalls;
+  private final Long cacheIntervalSeconds;
   KubernetesNamedAccountCredentials(String name,
                                     ProviderVersion providerVersion,
                                     AccountCredentialsRepository accountCredentialsRepository,
@@ -96,7 +97,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
                                     KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
                                     C credentials,
                                     Boolean onlySpinnakerManaged,
-                                    Boolean liveManifestCalls) {
+                                    Boolean liveManifestCalls,
+                                    Long cacheIntervalSeconds) {
     this.name = name;
     this.providerVersion = providerVersion;
     this.environment = environment;
@@ -122,6 +124,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
     this.onlySpinnakerManaged = onlySpinnakerManaged;
     this.liveManifestCalls = liveManifestCalls;
+    this.cacheIntervalSeconds = cacheIntervalSeconds;
   }
 
   public List<String> getNamespaces() {
@@ -177,6 +180,10 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
 
   public Permissions getPermissions() {
     return permissions;
+  }
+
+  public Long getCacheIntervalSeconds() {
+    return cacheIntervalSeconds;
   }
 
   public Map<String, String> getSpinnakerKindMap() {
@@ -239,6 +246,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
     Boolean onlySpinnakerManaged;
     Boolean liveManifestCalls;
+    Long cacheIntervalSeconds;
 
     Builder kubernetesSpinnakerKindMap(KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
       this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
@@ -433,6 +441,11 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       return this;
     }
 
+    Builder cacheIntervalSeconds(Long cacheIntervalSeconds) {
+      this.cacheIntervalSeconds = cacheIntervalSeconds;
+      return this;
+    }
+
     private C buildCredentials() {
       switch (providerVersion) {
         case v1:
@@ -570,7 +583,8 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
           kubernetesSpinnakerKindMap,
           credentials,
           onlySpinnakerManaged,
-          liveManifestCalls
+          liveManifestCalls,
+          cacheIntervalSeconds
       );
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -115,6 +115,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .kubernetesSpinnakerKindMap(kubernetesSpinnakerKindMap)
           .onlySpinnakerManaged(managedAccount.onlySpinnakerManaged == null ? false : managedAccount.onlySpinnakerManaged)
           .liveManifestCalls(managedAccount.liveManifestCalls ?: false)
+          .cacheIntervalSeconds(managedAccount.cacheIntervalSeconds)
           .build()
 
         accountCredentialsRepository.save(managedAccount.name, kubernetesAccount)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/CustomKubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/CustomKubernetesCachingAgentFactory.java
@@ -39,7 +39,8 @@ public class CustomKubernetesCachingAgentFactory {
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
-      int agentCount
+      int agentCount,
+      Long agentInterval
   ) {
     return new Agent(
         kind,
@@ -48,7 +49,8 @@ public class CustomKubernetesCachingAgentFactory {
         objectMapper,
         registry,
         agentIndex,
-        agentCount
+        agentCount,
+        agentInterval
     );
   }
 
@@ -62,9 +64,10 @@ public class CustomKubernetesCachingAgentFactory {
         ObjectMapper objectMapper,
         Registry registry,
         int agentIndex,
-        int agentCount
+        int agentCount,
+        Long agentInterval
     ) {
-      super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount);
+      super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount, agentInterval);
       this.kind = kind;
     }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCoreCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCoreCachingAgent.java
@@ -43,8 +43,9 @@ public class KubernetesCoreCachingAgent extends KubernetesV2OnDemandCachingAgent
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
-      int agentCount) {
-    super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount);
+      int agentCount,
+      Long agentInterval) {
+    super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount, agentInterval);
   }
 
   public Collection<AgentDataType> getProvidedDataTypes() {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.agent.AgentIntervalAware;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
 import com.netflix.spinnaker.cats.cache.CacheData;
@@ -42,9 +43,12 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.Kind.KUBERNETES_METRIC;
 
 @Slf4j
-public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<KubernetesV2Credentials> {
+public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<KubernetesV2Credentials> implements AgentIntervalAware {
   @Getter
   protected String providerName = KubernetesCloudProvider.getID();
+
+  @Getter
+  private final Long agentInterval;
 
   @Getter
   protected Collection<AgentDataType> providedDataTypes = Collections.unmodifiableCollection(
@@ -55,8 +59,10 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
-      int agentCount) {
+      int agentCount,
+      Long agentInterval) {
     super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
+    this.agentInterval = agentInterval;
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNamespaceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesNamespaceCachingAgent.java
@@ -48,8 +48,9 @@ public class KubernetesNamespaceCachingAgent extends KubernetesV2CachingAgent {
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
-      int agentCount) {
-    super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount);
+      int agentCount,
+      Long agentInterval) {
+    super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount, agentInterval);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -46,8 +46,9 @@ public class KubernetesUnregisteredCustomResourceCachingAgent extends Kubernetes
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
-      int agentCount) {
-    super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount);
+      int agentCount,
+      Long agentInterval) {
+    super(namedAccountCredentials, propertyRegistry, objectMapper, registry, agentIndex, agentCount, agentInterval);
 
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.agent.AgentIntervalAware;
 import com.netflix.spinnaker.cats.agent.CacheResult;
 import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
 import com.netflix.spinnaker.cats.cache.CacheData;
@@ -48,11 +49,14 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
-public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<KubernetesV2Credentials> {
+public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<KubernetesV2Credentials> implements AgentIntervalAware {
   protected KubectlJobExecutor jobExecutor;
 
   @Getter
   protected String providerName = KubernetesCloudProvider.getID();
+
+  @Getter
+  final protected Long agentInterval;
 
   private final KubernetesResourcePropertyRegistry propertyRegistry;
 
@@ -61,9 +65,11 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
-      int agentCount) {
+      int agentCount,
+      Long agentInterval) {
     super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount);
     this.propertyRegistry = propertyRegistry;
+    this.agentInterval = agentInterval;
   }
 
   protected KubernetesKind primaryKind() {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -77,8 +77,9 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
-      int agentCount) {
-    super(namedAccountCredentials, resourcePropertyRegistry, objectMapper, registry, agentIndex, agentCount);
+      int agentCount,
+      Long agentInterval) {
+    super(namedAccountCredentials, resourcePropertyRegistry, objectMapper, registry, agentIndex, agentCount, agentInterval);
     namer = NamerRegistry.lookup()
         .withProvider(KubernetesCloudProvider.getID())
         .withAccount(namedAccountCredentials.getName())

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CustomKubernetesHandlerFactory.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CustomKubernetesHandlerFactory.java
@@ -87,7 +87,8 @@ public class CustomKubernetesHandlerFactory {
         ObjectMapper objectMapper,
         Registry registry,
         int agentIndex,
-        int agentCount
+        int agentCount,
+        Long agentInterval
     ) {
       return CustomKubernetesCachingAgentFactory.create(
           kubernetesKind,
@@ -96,7 +97,8 @@ public class CustomKubernetesHandlerFactory {
           objectMapper,
           registry,
           agentIndex,
-          agentCount
+          agentCount,
+          agentInterval
       );
     }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHandler.java
@@ -93,7 +93,8 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
       ObjectMapper objectMapper,
       Registry registry,
       int agentIndex,
-      int agentCount
+      int agentCount,
+      Long agentInterval
   ) {
     Constructor constructor;
     Class<? extends KubernetesV2CachingAgent> clazz = cachingAgentClass();
@@ -109,7 +110,8 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
           ObjectMapper.class,
           Registry.class,
           int.class,
-          int.class
+          int.class,
+          Long.class
       );
     } catch (NoSuchMethodException e) {
       log.warn("Missing canonical constructor for {} caching agent", kind(), e);
@@ -124,7 +126,8 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
           objectMapper,
           registry,
           agentIndex,
-          agentCount
+          agentCount,
+          agentInterval
       );
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
       log.warn("Can't invoke caching agent constructor for {} caching agent", kind(), e);


### PR DESCRIPTION
This property is configurable on each k8s v2 account, e.g.

```yaml
kubernetes:
  accounts:
  - name: k8s-v2
    providerVersion: v2
    cacheIntervalSeconds: 60
```