### PR TITLE
chore(core): Decouple scheduler backend from cache backend

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/AgentSchedulerConfig.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/AgentSchedulerConfig.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.cache;
+
+import com.netflix.spinnaker.cats.agent.AgentScheduler;
+import com.netflix.spinnaker.cats.cluster.AgentIntervalProvider;
+import com.netflix.spinnaker.cats.cluster.DefaultNodeIdentity;
+import com.netflix.spinnaker.cats.cluster.NodeStatusProvider;
+import com.netflix.spinnaker.cats.dynomite.cluster.DynoClusteredAgentScheduler;
+import com.netflix.spinnaker.cats.dynomite.cluster.DynoClusteredSortAgentScheduler;
+import com.netflix.spinnaker.cats.redis.cluster.ClusteredAgentScheduler;
+import com.netflix.spinnaker.cats.redis.cluster.ClusteredSortAgentScheduler;
+import com.netflix.spinnaker.clouddriver.core.RedisConfigurationProperties;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import com.netflix.spinnaker.kork.dynomite.DynomiteClientDelegate;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import redis.clients.jedis.JedisPool;
+
+import java.net.URI;
+import java.time.Clock;
+
+@Configuration
+@ConditionalOnProperty(value = "caching.writeEnabled", matchIfMissing = true)
+public class AgentSchedulerConfig {
+
+  @Bean
+  @ConditionalOnExpression("${redis.enabled:true} && ${redis.scheduler.enabled:true}")
+  AgentScheduler redisAgentScheduler(RedisConfigurationProperties redisConfigurationProperties,
+                                RedisClientDelegate redisClientDelegate,
+                                JedisPool jedisPool,
+                                AgentIntervalProvider agentIntervalProvider,
+                                NodeStatusProvider nodeStatusProvider,
+                                DynamicConfigService dynamicConfigService) {
+    if (redisConfigurationProperties.getScheduler().equalsIgnoreCase("default")) {
+      URI redisUri = URI.create(redisConfigurationProperties.getConnection());
+      String redisHost = redisUri.getHost();
+      int redisPort = redisUri.getPort();
+      if (redisPort == -1) {
+        redisPort = 6379;
+      }
+      return new ClusteredAgentScheduler(
+        redisClientDelegate,
+        new DefaultNodeIdentity(redisHost, redisPort),
+        agentIntervalProvider,
+        nodeStatusProvider,
+        redisConfigurationProperties.getAgent().getEnabledPattern(),
+        redisConfigurationProperties.getAgent().getAgentLockAcquisitionIntervalSeconds(),
+        dynamicConfigService
+      );
+    } else if (redisConfigurationProperties.getScheduler().equalsIgnoreCase("sort")) {
+      return new ClusteredSortAgentScheduler(
+        jedisPool,
+        nodeStatusProvider,
+        agentIntervalProvider,
+        redisConfigurationProperties.getParallelism()
+      );
+    } else {
+      throw new IllegalStateException("redis.scheduler must be one of 'default', 'sort', or ''.");
+    }
+  }
+
+  @Bean
+  @ConditionalOnExpression("${dynomite.enabled:false} && ${dynomite.scheduler.enabled:false}")
+  AgentScheduler dynomiteAgentScheduler(Clock clock,
+                                RedisConfigurationProperties redisConfigurationProperties,
+                                RedisClientDelegate redisClientDelegate,
+                                AgentIntervalProvider agentIntervalProvider,
+                                NodeStatusProvider nodeStatusProvider) {
+    if (redisConfigurationProperties.getScheduler().equalsIgnoreCase("default")) {
+      return new DynoClusteredAgentScheduler(
+        (DynomiteClientDelegate) redisClientDelegate,
+        new DefaultNodeIdentity(),
+        agentIntervalProvider,
+        nodeStatusProvider
+      );
+    } else if (redisConfigurationProperties.getScheduler().equalsIgnoreCase("sort")) {
+      return new DynoClusteredSortAgentScheduler(
+        clock,
+        redisClientDelegate,
+        nodeStatusProvider,
+        agentIntervalProvider,
+        redisConfigurationProperties.getParallelism()
+      );
+    } else {
+      throw new IllegalStateException("redis.scheduler must be one of 'default', 'sort', or ''.");
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteCacheConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/DynomiteCacheConfig.groovy
@@ -25,37 +25,30 @@ import com.netflix.dyno.connectionpool.impl.ConnectionPoolConfigurationImpl
 import com.netflix.dyno.connectionpool.impl.lb.HostToken
 import com.netflix.dyno.jedis.DynoJedisClient
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.cats.agent.AgentScheduler
 import com.netflix.spinnaker.cats.cache.NamedCacheFactory
+import com.netflix.spinnaker.cats.cluster.AgentIntervalProvider
+import com.netflix.spinnaker.cats.cluster.DefaultNodeStatusProvider
+import com.netflix.spinnaker.cats.cluster.NodeStatusProvider
 import com.netflix.spinnaker.cats.compression.CompressionStrategy
 import com.netflix.spinnaker.cats.compression.GZipCompression
 import com.netflix.spinnaker.cats.compression.NoopCompression
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteCache.CacheMetrics
 import com.netflix.spinnaker.cats.dynomite.cache.DynomiteNamedCacheFactory
-import com.netflix.spinnaker.cats.dynomite.cluster.DynoClusteredAgentScheduler
-import com.netflix.spinnaker.cats.dynomite.cluster.DynoClusteredSortAgentScheduler
 import com.netflix.spinnaker.cats.redis.cache.RedisCacheOptions
-import com.netflix.spinnaker.cats.cluster.AgentIntervalProvider
-import com.netflix.spinnaker.cats.cluster.DefaultNodeIdentity
-import com.netflix.spinnaker.cats.cluster.DefaultNodeStatusProvider
-import com.netflix.spinnaker.cats.cluster.NodeStatusProvider
 import com.netflix.spinnaker.clouddriver.core.RedisConfigurationProperties
 import com.netflix.spinnaker.kork.dynomite.DynomiteClientDelegate
-import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-import java.time.Clock
 import java.util.concurrent.TimeUnit
 
 @Configuration
-@ConditionalOnExpression('${dynomite.enabled:false}')
+@ConditionalOnExpression("\${dynomite.enabled:false} && \${dynomite.cache.enabled:false}")
 @EnableConfigurationProperties([DynomiteConfigurationProperties, RedisConfigurationProperties, GZipCompressionStrategyProperties])
 class DynomiteCacheConfig {
 
@@ -143,27 +136,6 @@ class DynomiteCacheConfig {
       TimeUnit.SECONDS.toMillis(redisConfigurationProperties.poll.errorIntervalSeconds),
       TimeUnit.SECONDS.toMillis(redisConfigurationProperties.poll.timeoutSeconds)
     );
-  }
-
-  @Bean
-  @ConditionalOnProperty(value = "caching.writeEnabled", matchIfMissing = true)
-  AgentScheduler agentScheduler(Clock clock,
-                                RedisConfigurationProperties redisConfigurationProperties,
-                                RedisClientDelegate redisClientDelegate,
-                                AgentIntervalProvider agentIntervalProvider,
-                                NodeStatusProvider nodeStatusProvider) {
-    if (redisConfigurationProperties.scheduler.equalsIgnoreCase("default")) {
-      new DynoClusteredAgentScheduler(
-        (DynomiteClientDelegate) redisClientDelegate,
-        new DefaultNodeIdentity(),
-        agentIntervalProvider,
-        nodeStatusProvider
-      );
-    } else if (redisConfigurationProperties.scheduler.equalsIgnoreCase("sort")) {
-      new DynoClusteredSortAgentScheduler(clock, redisClientDelegate, nodeStatusProvider, agentIntervalProvider, redisConfigurationProperties.parallelism ?: -1);
-    } else {
-      throw new IllegalStateException("redis.scheduler must be one of 'default', 'sort', or ''.");
-    }
   }
 
   static class StaticHostSupplier implements HostSupplier {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/RedisConfig.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.data.task.jedis.RedisTaskRepository
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
-import com.netflix.spinnaker.kork.jedis.telemetry.InstrumentedJedis
 import com.netflix.spinnaker.kork.jedis.telemetry.InstrumentedJedisPool
 import org.apache.commons.pool2.impl.GenericObjectPool
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig
@@ -47,6 +46,7 @@ class RedisConfig {
   }
 
   @Bean
+  @ConditionalOnExpression('${redis.taskRepository.enabled:true}')
   TaskRepository taskRepository(RedisClientDelegate redisClientDelegate, Optional<RedisClientDelegate> redisClientDelegatePrevious) {
     new RedisTaskRepository(redisClientDelegate, redisClientDelegatePrevious)
   }


### PR DESCRIPTION
Some spring config refactoring, this allows us to have different backends for the cache scheduler and cache. While the SQL backend does support a SQL-based scheduler, it's not nearly as resource efficient as the Redis schedulers.