### PR TITLE
fix(provider/kubernetes): ensure crds are registered before using creds

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -412,6 +412,9 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         return new ArrayList<>();
       }
     }, crdExpirySeconds, TimeUnit.SECONDS);
+
+    // ensure this is called at least once before the credentials object is created to ensure all crds are registered
+    this.liveCrdSupplier.get();
   }
 
   public List<KubernetesKind> getCrds() {


### PR DESCRIPTION
There is a race condition on startup where it is possible that a CRD is first encountered during a deployment, before a the CRD supplier (called in the code change) can register the CRDs with the correct flags. This prevents Spinnaker from correctly looking up which deployment handler to use, which is important for any kind that has custom logic during deployment (e.g. the `ReplicaSet` handler declares how images are substituted).

There is an outstanding issue (which I haven't been able to reproduce/encounter) where a similar bug manifests itself after clouddriver has been running for a while. This bug isn't fixed here, but the overall prevalence of this bug (esp when clouddriver pods are restarted/rescheduled) should be reduced.