### PR TITLE
fix(google): differentiate among autohealing health check kinds

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -396,12 +396,9 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
       description.autoscalingPolicy = GCEUtil.buildAutoscalingPolicyDescriptionFromAutoscalingPolicy(ancestorServerGroup.autoscalingPolicy)
     }
 
-    // Note: Cache queries for these health checks must occur in this order since queryHealthCheck() will make a live
-    // call that fails on a missing health check.
     def autoHealingHealthCheck = null
     if (description.autoHealingPolicy?.healthCheck) {
-      autoHealingHealthCheck = GCEUtil.queryNestedHealthCheck(project, description.accountName, description.autoHealingPolicy.healthCheck, compute, cacheView, task, BASE_PHASE, this) ?:
-        GCEUtil.queryHealthCheck(project, description.accountName, description.autoHealingPolicy.healthCheck, compute, cacheView, task, BASE_PHASE, this)
+      autoHealingHealthCheck = GCEUtil.queryHealthCheck(project, description.accountName, description.autoHealingPolicy.healthCheck, description.autoHealingPolicy.healthCheckKind, compute, cacheView, task, BASE_PHASE, this)
     }
 
     List<InstanceGroupManagerAutoHealingPolicy> autoHealingPolicy =

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -249,7 +249,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
       return newDescription
     }
 
-    ["healthCheck", "initialDelaySec"].each {
+    ["healthCheck", "initialDelaySec", "healthCheckKind"].each {
       if (update[it] != null) {
         newDescription[it] = update[it]
       }
@@ -278,10 +278,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
   }
 
   private buildAutoHealingPolicyFromAutoHealingPolicyDescription(GoogleAutoHealingPolicy autoHealingPolicyDescription, String project, Compute compute) {
-    // Note: Cache queries for these health checks must occur in this order since queryHealthCheck() will make a live
-    // call that fails on a missing health check.
-    def autoHealingHealthCheck = GCEUtil.queryNestedHealthCheck(project, description.accountName, autoHealingPolicyDescription.healthCheck, compute, cacheView, task, BASE_PHASE, this) ?:
-      GCEUtil.queryHealthCheck(project, description.accountName, autoHealingPolicyDescription.healthCheck, compute, cacheView, task, BASE_PHASE, this)
+    def autoHealingHealthCheck = GCEUtil.queryHealthCheck(project, description.accountName, autoHealingPolicyDescription.healthCheck, autoHealingPolicyDescription.healthCheckKind, compute, cacheView, task, BASE_PHASE, this)
 
     List<InstanceGroupManagerAutoHealingPolicy> autoHealingPolicy = autoHealingPolicyDescription?.healthCheck
       ? [new InstanceGroupManagerAutoHealingPolicy(

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleAutoHealingPolicy.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleAutoHealingPolicy.groovy
@@ -25,6 +25,7 @@ import groovy.transform.ToString
 @ToString(includeNames = true)
 class GoogleAutoHealingPolicy {
   String healthCheck
+  GoogleHealthCheck.HealthCheckKind healthCheckKind
   Integer initialDelaySec
   FixedOrPercent maxUnavailable
 


### PR DESCRIPTION
Previously when querying for a health check, we returned the first health check found by name when querying the following kinds in order: healthCheck --> httpHealthCheck --> httpsHealthCheck. However, it is possible to have up to three health checks with the same name (one of each kind), so we should specify `healthCheckKind` and only query for the specified kind, leaving the default querying logic in place if `healthCheckKind` is unspecified.