### PR TITLE
feat(core): Add DualTaskRepository

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/DualTaskRepositoryConfiguration.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/DualTaskRepositoryConfiguration.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.config;
+
+import com.netflix.spinnaker.clouddriver.data.task.DualTaskRepository;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.List;
+
+import static com.netflix.spinnaker.clouddriver.config.DualTaskRepositoryConfiguration.Properties;
+import static java.lang.String.format;
+
+@Configuration
+@ConditionalOnProperty("dualTaskRepository.enabled")
+@EnableConfigurationProperties(Properties.class)
+public class DualTaskRepositoryConfiguration {
+
+  @Primary
+  @Bean
+  TaskRepository dualExecutionRepository(Properties properties, List<TaskRepository> allRepositories) {
+    TaskRepository primary = findTaskRepositoryByClass(allRepositories, properties.primaryClass);
+    TaskRepository previous = findTaskRepositoryByClass(allRepositories, properties.previousClass);
+    return new DualTaskRepository(
+      primary,
+      previous,
+      properties.executorThreadPoolSize,
+      properties.executorTimeoutSeconds
+    );
+  }
+
+  private TaskRepository findTaskRepositoryByClass(List<TaskRepository> allRepositories, String className) {
+    Class repositoryClass;
+    try {
+      repositoryClass = Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new BeanCreationException("Could not find TaskRepository class", e);
+    }
+
+    return allRepositories
+      .stream()
+      .filter(repositoryClass::isInstance)
+      .findFirst()
+      .orElseThrow(() -> new IllegalStateException(format(
+        "No TaskRepository bean of class %s found", repositoryClass
+      )));
+  }
+
+  @ConfigurationProperties("dualTaskRepository")
+  public static class Properties {
+    /**
+     * The primary TaskRepository class.
+     */
+    String primaryClass;
+
+    /**
+     * The previous TaskRepository class.
+     */
+    String previousClass;
+
+    /**
+     * The number of threads that will be used for collating TaskRepository results from both primary and previous
+     * backends. For list operations, two threads will be used.
+     */
+    int executorThreadPoolSize = 10;
+
+    /**
+     * The amount of time in seconds that async tasks will have to complete before being timed out.
+     */
+    long executorTimeoutSeconds = 10;
+
+    public String getPrimaryClass() {
+      return primaryClass;
+    }
+
+    public void setPrimaryClass(String primaryClass) {
+      this.primaryClass = primaryClass;
+    }
+
+    public String getPreviousClass() {
+      return previousClass;
+    }
+
+    public void setPreviousClass(String previousClass) {
+      this.previousClass = previousClass;
+    }
+
+    public int getExecutorThreadPoolSize() {
+      return executorThreadPoolSize;
+    }
+
+    public void setExecutorThreadPoolSize(int executorThreadPoolSize) {
+      this.executorThreadPoolSize = executorThreadPoolSize;
+    }
+
+    public long getExecutorTimeoutSeconds() {
+      return executorTimeoutSeconds;
+    }
+
+    public void setExecutorTimeoutSeconds(long executorTimeoutSeconds) {
+      this.executorTimeoutSeconds = executorTimeoutSeconds;
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepository.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepository.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.data.task;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.*;
+
+public class DualTaskRepository implements TaskRepository {
+
+  private final static Logger log = LoggerFactory.getLogger(DualTaskRepository.class);
+
+  private final TaskRepository primary;
+  private final TaskRepository previous;
+  private final ExecutorService executorService;
+  private final long asyncTimeoutSeconds;
+
+  public DualTaskRepository(TaskRepository primary,
+                            TaskRepository previous,
+                            int threadPoolSize,
+                            long asyncTimeoutSeconds) {
+    this(primary, previous, Executors.newFixedThreadPool(threadPoolSize), asyncTimeoutSeconds);
+  }
+
+  public DualTaskRepository(TaskRepository primary,
+                            TaskRepository previous,
+                            ExecutorService executorService,
+                            long asyncTimeoutSeconds) {
+    this.primary = primary;
+    this.previous = previous;
+    this.executorService = executorService;
+    this.asyncTimeoutSeconds = asyncTimeoutSeconds;
+  }
+
+  @Override
+  public Task create(String phase, String status) {
+    return primary.create(phase, status);
+  }
+
+  @Override
+  public Task create(String phase, String status, String clientRequestId) {
+    return primary.create(phase, status, clientRequestId);
+  }
+
+  @Override
+  public Task get(String id) {
+    return Optional
+      .ofNullable(primary.get(id))
+      .orElse(previous.get(id));
+  }
+
+  @Override
+  public Task getByClientRequestId(String clientRequestId) {
+    return Optional
+      .ofNullable(primary.getByClientRequestId(clientRequestId))
+      .orElse(previous.getByClientRequestId(clientRequestId));
+  }
+
+  @Override
+  public List<Task> list() {
+    Future<List<Task>> primaryList = executorService.submit(primary::list);
+    Future<List<Task>> previousList = executorService.submit(previous::list);
+
+    List<Task> tasks = new ArrayList<>();
+    try {
+      tasks.addAll(primaryList.get(asyncTimeoutSeconds, TimeUnit.SECONDS));
+      tasks.addAll(previousList.get(asyncTimeoutSeconds, TimeUnit.SECONDS));
+    } catch (TimeoutException | InterruptedException | ExecutionException e) {
+      log.error("Could not retrieve list of tasks by timeout", e);
+      // Return tasks so we can still get data in partial failures
+    }
+
+    return tasks;
+  }
+
+  @Override
+  public List<Task> listByThisInstance() {
+    return primary.listByThisInstance();
+  }
+}

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepositorySpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepositorySpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.data.task
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DualTaskRepositorySpec extends Specification {
+
+  TaskRepository primary = Mock()
+  TaskRepository previous = Mock()
+
+  @Subject
+  TaskRepository subject = new DualTaskRepository(primary, previous, 4, 1)
+
+  void "always creates tasks from primary"() {
+    when:
+    subject.create("afternoon", "coffee")
+
+    then:
+    1 * primary.create(_, _)
+    0 * _
+
+    when:
+    subject.create("afternoon", "coffee", "needed")
+
+    then:
+    1 * primary.create(_, _, _)
+    0 * _
+  }
+
+  void "reads from previous if primary is missing a task"() {
+    given:
+    def expectedTask = new DefaultTask("1")
+
+    when:
+    def task = subject.get("1")
+
+    then:
+    task == expectedTask
+    1 * primary.get(_) >> null
+    1 * previous.get(_) >> expectedTask
+    0 * _
+  }
+
+  void "list collates results from both primary and previous"() {
+    when:
+    def result = subject.list()
+
+    then:
+    result*.id.sort() == ["1", "2", "3", "4"]
+    1 * primary.list() >> [
+      new DefaultTask("1"),
+      new DefaultTask("2")
+    ]
+    1 * previous.list() >> [
+      new DefaultTask("3"),
+      new DefaultTask("4")
+    ]
+    0 * _
+  }
+}


### PR DESCRIPTION
Simple little class to migrate task backends without interruption. 

I opted for not doing any special logic treatment around `clientRequestId`. I think this behavior will be fine?