### PR TITLE
fix(kubernetes): fix image resolution for project clusters view

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
@@ -274,7 +274,17 @@ public class ProjectClustersService {
             .findFirst();
 
           new OptionalConsumer<>(
-            (DeployedBuild b) -> b.deployed = Math.max(b.deployed, serverGroup.getCreatedTime()),
+            (DeployedBuild b) -> {
+              b.deployed = Math.max(b.deployed, serverGroup.getCreatedTime());
+              List images = getServerGroupBuildInfoImages(imageSummaries);
+              if (images != null) {
+                images.forEach(image -> {
+                  if (image != null && !b.images.contains(image)) {
+                    b.images.add(image);
+                  }
+                });
+              }
+            },
             () -> regionCluster.builds.add(new DeployedBuild(
               buildInfo.host,
               buildInfo.name,

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java
@@ -50,6 +50,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.singletonList;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 @Slf4j
@@ -204,5 +206,47 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
       .region(getRegion())
       .isDisabled(isDisabled())
       .build();
+  }
+
+  @Override
+  public ImagesSummary getImagesSummary() {
+    Map<String, Object> buildInfo = getBuildInfo();
+    Set<String> images = (HashSet<String>) buildInfo.get("images");
+    return new ImagesSummary() {
+      @Override
+      public List<? extends ImageSummary> getSummaries() {
+        return singletonList(
+          new ImageSummary() {
+
+            @Override
+            public String getServerGroupName() {
+              return getManifest().getName();
+            }
+
+            @Override
+            public String getImageId() {
+              return null;
+            }
+
+            @Override
+            public String getImageName() {
+              return null;
+            }
+
+            @Override
+            public Map<String, Object> getImage() {
+              return null;
+            }
+
+            @Override
+            public Map<String, Object> getBuildInfo() {
+              return new ImmutableMap.Builder<String, Object>()
+                .put("images", new ArrayList<>(images))
+                .build();
+            }
+          }
+        );
+      }
+    };
   }
 }


### PR DESCRIPTION
As noted in comments on this issue (https://github.com/spinnaker/spinnaker/issues/3490), image names were not being resolved for Kubernetes v2 clusters. `KubernetesV2ServerGroup` was missing a `getImagesSummary` method, and the `ProjectClustersService.ApplicationClusterModel` was assuming only one image per cluster.

Before:
![before](https://user-images.githubusercontent.com/15936279/51349845-a5b2d580-1a74-11e9-9b32-005da8b6225d.png)

After:
![after](https://user-images.githubusercontent.com/15936279/51349848-a9465c80-1a74-11e9-954b-c321e372f402.png)



