### PR TITLE
chore(provider/kubernetes): add agent type to caching logs

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -67,7 +67,7 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    log.info(getAgentType() + " is starting");
+    log.info(getAgentType() + ": agent is starting");
     reloadNamespaces();
 
     List<CacheData> cacheData = namespaces.parallelStream()
@@ -78,7 +78,7 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
                     .map(m -> KubernetesCacheDataConverter.convertPodMetric(accountName, n, m));
               } catch (KubectlJobExecutor.KubectlException e) {
                 if (e.getMessage().contains("not available")) {
-                  log.warn("Metrics for namespace '" + n + "' in account '" + accountName + "' have not been recorded yet.");
+                  log.warn("{}: Metrics for namespace '" + n + "' in account '" + accountName + "' have not been recorded yet.", getAgentType());
                   return null;
                 } else {
                   throw e;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -93,7 +93,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
           try {
             return credentials.list(primaryKinds(), n);
           } catch (KubectlException e) {
-            log.warn("Failed to read kind {} from namespace {}: {}", primaryKinds(), n, e.getMessage());
+            log.warn("{}: Failed to read kind {} from namespace {}: {}", getAgentType(), primaryKinds(), n, e.getMessage());
             throw e;
           }
         })
@@ -128,7 +128,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    log.info(getAgentType() + " is starting");
+    log.info(getAgentType() + ": agent is starting");
     reloadNamespaces();
     Map<String, Object> details = defaultIntrospectionDetails();
 
@@ -163,7 +163,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
               return cacheData;
             }
           } catch (Exception e) {
-            log.warn("Failure converting {} as resource", rs, e);
+            log.warn("{}: Failure converting {} as resource", getAgentType(), rs, e);
             return null;
           }
         })
@@ -201,7 +201,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
       try {
         RegistryUtils.addRelationships(propertyRegistry, accountName, k, allResources, result);
       } catch (Exception e) {
-        log.warn("Failure adding relationships for {}", k, e);
+        log.warn("{}: Failure adding relationships for {}", getAgentType(), k, e);
       }
     });
     return result;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -90,7 +90,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    log.info(getAgentType() + " is starting");
+    log.info(getAgentType() + ": agent is starting");
     reloadNamespaces();
     Map<String, Object> details = defaultIntrospectionDetails();
 
@@ -221,7 +221,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     Map<String, Collection<String>> evictions = new HashMap<>();
     CacheResult cacheResult = new DefaultCacheResult(new HashMap<>());
 
-    log.info("Evicting on demand '{}'", key);
+    log.info("{}: Evicting on demand '{}'", getAgentType(), key);
     providerCache.evictDeletedItems(ON_DEMAND_TYPE, Collections.singletonList(key));
     evictions.put(kind.toString(), Collections.singletonList(key));
 
@@ -260,9 +260,6 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     String name;
     KubernetesKind kind;
 
-    // todo(lwander): this can be removed
-    log.debug("Queried for on demand cache refresh of '{}'", data);
-
     if (!getAccountName().equals(account)) {
       return null;
     }
@@ -286,7 +283,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     }
 
     if (!kind.isNamespaced() && StringUtils.isNotEmpty(namespace)) {
-      log.warn("Kind {} is not namespace but namespace {} was provided, ignoring", kind, namespace);
+      log.warn("{}: Kind {} is not namespace but namespace {} was provided, ignoring", getAgentType(), kind, namespace);
       namespace = "";
     }
 
@@ -297,7 +294,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
       return null;
     }
 
-    log.info("Accepted on demand refresh of '{}'", data);
+    log.info("{}: Accepted on demand refresh of '{}'", getAgentType(), data);
     OnDemandAgent.OnDemandResult result;
     KubernetesManifest manifest = loadPrimaryResource(kind, namespace, name);
     String resourceKey = Keys.infrastructure(kind, account, namespace, name);
@@ -308,7 +305,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
       return null;
     }
 
-    log.info("On demand cache refresh of (data: {}) succeeded", data);
+    log.info("{}: On demand cache refresh of (data: {}) succeeded", getAgentType(), data);
     return result;
   }
 


### PR DESCRIPTION
Now all caching entries start with:
```
$account/$agentClass[$index/$threads]: ...
```
closes https://github.com/spinnaker/spinnaker/issues/3877