### PR TITLE
fix(provider/kubernetes): Null boolean on KubernetesV2ServerGroup

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
@@ -255,7 +255,7 @@ public class ProjectClustersService {
         .flatMap(ac -> ac.getServerGroups().stream())
         .filter(serverGroup ->
           serverGroup != null &&
-            !serverGroup.isDisabled() &&
+            serverGroup.isDisabled() != null && !serverGroup.isDisabled() &&
             serverGroup.getInstanceCounts().getTotal() > 0)
         .forEach((ServerGroup serverGroup) -> {
           RegionClusterModel regionCluster = regionClusters.computeIfAbsent(


### PR DESCRIPTION
* KubernetesV2ServerGroup `disabled` flag is null and causes a NPE.
*`disabled` is set on https://github.com/spinnaker/clouddriver/pull/3060. This fix is just to get past the issue on 1.10.x. It doesn't show on later releases.
