### PR TITLE
refactor(cloudformation): rename cf model and use accountName instead of accountId

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
@@ -35,7 +35,7 @@ class Keys implements KeyParser {
     KEY_PAIRS,
     INSTANCE_TYPES,
     ELASTIC_IPS,
-    CLOUDFORMATION,
+    STACKS,
     ON_DEMAND
 
     final String ns
@@ -109,7 +109,7 @@ class Keys implements KeyParser {
       case Namespace.ELASTIC_IPS.ns:
         result << [address: parts[2], account: parts[3], region: parts[4]]
         break
-      case Namespace.CLOUDFORMATION.ns:
+      case Namespace.STACKS.ns:
         result << [id: parts[2], account: parts[3], region: parts[4]]
         break;
       default:
@@ -168,6 +168,6 @@ class Keys implements KeyParser {
   static String getCloudFormationKey(String stackId,
                                      String region,
                                      String accountName) {
-    "$ID:${Namespace.CLOUDFORMATION}:${accountName}:${region}:${stackId}"
+    "$ID:${Namespace.STACKS}:${accountName}:${region}:${stackId}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/cache/Keys.groovy
@@ -167,7 +167,7 @@ class Keys implements KeyParser {
 
   static String getCloudFormationKey(String stackId,
                                      String region,
-                                     String account) {
-    "$ID:${Namespace.CLOUDFORMATION}:${account}:${region}:${stackId}"
+                                     String accountName) {
+    "$ID:${Namespace.CLOUDFORMATION}:${accountName}:${region}:${stackId}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/CloudFormationController.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/CloudFormationController.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.controllers;
 
 import com.netflix.spinnaker.clouddriver.aws.model.CloudFormationStack;
-import com.netflix.spinnaker.clouddriver.aws.model.CloudFormationProvider;
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonCloudFormationProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -29,10 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.HandlerMapping;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RequestMapping("/aws/cloudFormation/stacks")
@@ -40,13 +37,13 @@ import java.util.stream.Collectors;
 class CloudFormationController {
 
   @Autowired
-  private CloudFormationProvider<CloudFormationStack> cloudFormationProvider;
+  private AmazonCloudFormationProvider cloudFormationProvider;
 
   @RequestMapping(method = RequestMethod.GET)
-  List<CloudFormationStack> list(@RequestParam String accountId,
+  List<CloudFormationStack> list(@RequestParam String accountName,
                                  @RequestParam(required = false, defaultValue = "*") String region) {
-    log.debug("Cloud formation list stacks for account {}", accountId);
-    return cloudFormationProvider.list(accountId, region);
+    log.debug("Cloud formation list stacks for account {}", accountName);
+    return cloudFormationProvider.list(accountName, region);
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/**")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -194,7 +194,7 @@ class Keys implements KeyParser {
     "${ID}:${Namespace.RESERVED_INSTANCES}:${account}:${region}:${reservedInstancesId}"
   }
 
-  static String getCloudFormationKey(String stackId, String account, String region) {
-    "${ID}:${Namespace.CLOUDFORMATION}:${account}:${region}:${stackId}"
+  static String getCloudFormationKey(String stackId, String accountName, String region) {
+    "${ID}:${Namespace.CLOUDFORMATION}:${accountName}:${region}:${stackId}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/data/Keys.groovy
@@ -40,7 +40,7 @@ class Keys implements KeyParser {
       .put(Namespace.TARGET_GROUPS.ns, "targetGroup")
       .put(Namespace.CLUSTERS.ns, "cluster")
       .put(Namespace.APPLICATIONS.ns, "application")
-      .put(Namespace.CLOUDFORMATION.ns, "cloudformation")
+      .put(Namespace.STACKS.ns, "stacks")
       .build()
 
   private static final Set<String> PARSEABLE_FIELDS =
@@ -127,7 +127,7 @@ class Keys implements KeyParser {
       case Namespace.HEALTH.ns:
         result << [instanceId: parts[2], account: parts[3], region: parts[4], provider: parts[5]]
         break
-      case Namespace.CLOUDFORMATION.ns:
+      case Namespace.STACKS.ns:
         result << [stackId: parts[2], account: parts[3], region: parts[4]]
         break
       default:
@@ -195,6 +195,6 @@ class Keys implements KeyParser {
   }
 
   static String getCloudFormationKey(String stackId, String accountName, String region) {
-    "${ID}:${Namespace.CLOUDFORMATION}:${accountName}:${region}:${stackId}"
+    "${ID}:${Namespace.STACKS}:${accountName}:${region}:${stackId}"
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonCloudFormationStack.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonCloudFormationStack.java
@@ -21,7 +21,7 @@ import java.util.Date;
 import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class AmazonCloudFormation implements CloudFormation {
+public class AmazonCloudFormationStack implements CloudFormationStack {
   final String type = "aws";
   private String stackId;
   private Map<String, String> tags;
@@ -86,8 +86,8 @@ public class AmazonCloudFormation implements CloudFormation {
 
   @Override
   public boolean equals(Object cf) {
-    if (cf instanceof AmazonCloudFormation) {
-      return stackId.equals(((AmazonCloudFormation) cf).stackId);
+    if (cf instanceof AmazonCloudFormationStack) {
+      return stackId.equals(((AmazonCloudFormationStack) cf).stackId);
     } else {
       return false;
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/CloudFormationProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/CloudFormationProvider.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.model;
 import java.util.List;
 import java.util.Optional;
 
-public interface CloudFormationProvider<T extends CloudFormation> {
+public interface CloudFormationProvider<T extends CloudFormationStack> {
 
   List<T> list(String account, String region);
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/CloudFormationStack.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/CloudFormationStack.java
@@ -22,7 +22,7 @@ import java.util.Map;
 /**
  * A representation of a CloudFormation stack
  */
-public interface CloudFormation {
+public interface CloudFormationStack {
 
   String getStackId();
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgent.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.CLOUDFORMATION;
+import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.STACKS;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 
 @Slf4j
@@ -45,7 +45,7 @@ public class AmazonCloudFormationCachingAgent implements CachingAgent, AccountAw
   private final String region;
 
   static final Set<AgentDataType> types = new HashSet<>(
-    Collections.singletonList(AUTHORITATIVE.forType(CLOUDFORMATION.getNs()))
+    Collections.singletonList(AUTHORITATIVE.forType(STACKS.getNs()))
   );
 
   public AmazonCloudFormationCachingAgent(AmazonClientProvider amazonClientProvider,
@@ -111,16 +111,16 @@ public class AmazonCloudFormationCachingAgent implements CachingAgent, AccountAw
         }
         String stackCacheKey = Keys.getCloudFormationKey(stack.getStackId(), region, account.getName());
         Map<String, Collection<String>> relationships = new HashMap<>();
-        relationships.put(CLOUDFORMATION.getNs(), Collections.singletonList(stackCacheKey));
+        relationships.put(STACKS.getNs(), Collections.singletonList(stackCacheKey));
         stackCacheData.add(new DefaultCacheData(stackCacheKey, stackAttributes, relationships));
       }
-    } catch (Exception e) {
-      log.info("Error retrieving stacks, ignoring error: {}", e.getMessage());
+    } catch (AmazonCloudFormationException e) {
+      log.error("Error retrieving stacks", e);
     }
 
     log.info("Caching {} items in {}", stackCacheData.size(), getAgentType());
     HashMap<String, Collection<CacheData>> result = new HashMap<>();
-    result.put(CLOUDFORMATION.getNs(), stackCacheData);
+    result.put(STACKS.getNs(), stackCacheData);
     return new DefaultCacheResult(result);
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgent.java
@@ -108,7 +108,7 @@ public class AmazonCloudFormationCachingAgent implements CachingAgent, AccountAw
           .map(StackEvent::getResourceStatusReason)
           .map(statusReason -> stackAttributes.put("stackStatusReason", statusReason));
       }
-      String stackCacheKey = Keys.getCloudFormationKey(stack.getStackId(), region, account.getAccountId());
+      String stackCacheKey = Keys.getCloudFormationKey(stack.getStackId(), region, account.getName());
       Map<String, Collection<String>> relationships = new HashMap<>();
       relationships.put(CLOUDFORMATION.getNs(), Collections.singletonList(stackCacheKey));
       stackCacheData.add(new DefaultCacheData(stackCacheKey, stackAttributes, relationships));

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProvider.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter;
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys;
-import com.netflix.spinnaker.clouddriver.aws.model.AmazonCloudFormation;
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonCloudFormationStack;
 import com.netflix.spinnaker.clouddriver.aws.model.CloudFormationProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +35,7 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.CLOUDFO
 
 @Slf4j
 @Component
-class AmazonCloudFormationProvider implements CloudFormationProvider<AmazonCloudFormation> {
+class AmazonCloudFormationProvider implements CloudFormationProvider<AmazonCloudFormationStack> {
 
   private final Cache cacheView;
   private final ObjectMapper objectMapper;
@@ -46,25 +46,25 @@ class AmazonCloudFormationProvider implements CloudFormationProvider<AmazonCloud
     this.objectMapper = objectMapper;
   }
 
-  public List<AmazonCloudFormation> list(String account, String region) {
+  public List<AmazonCloudFormationStack> list(String account, String region) {
     String filter = Keys.getCloudFormationKey("*", region, account);
     log.debug("List all stacks with filter {}", filter);
     return loadResults(cacheView.filterIdentifiers(CLOUDFORMATION.getNs(), filter));
   }
 
   @Override
-  public Optional<AmazonCloudFormation> get(String stackId) {
+  public Optional<AmazonCloudFormationStack> get(String stackId) {
     String filter = Keys.getCloudFormationKey(stackId, "*", "*");
     log.debug("Get stack with filter {}", filter);
     return loadResults(cacheView.filterIdentifiers(CLOUDFORMATION.getNs(), filter)).stream().findFirst();
   }
 
-  List<AmazonCloudFormation> loadResults(Collection<String> identifiers) {
+  List<AmazonCloudFormationStack> loadResults(Collection<String> identifiers) {
     return cacheView.getAll(CLOUDFORMATION.getNs(), identifiers, RelationshipCacheFilter.none())
       .stream()
       .map(data -> {
         log.debug("Cloud formation cached properties {}", data.getAttributes());
-        return objectMapper.convertValue(data.getAttributes(), AmazonCloudFormation.class);
+        return objectMapper.convertValue(data.getAttributes(), AmazonCloudFormationStack.class);
       })
       .collect(Collectors.toList());
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProvider.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter;
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys;
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonCloudFormationStack;
 import com.netflix.spinnaker.clouddriver.aws.model.CloudFormationProvider;
+import com.netflix.spinnaker.clouddriver.aws.model.CloudFormationStack;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -35,31 +36,31 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.CLOUDFO
 
 @Slf4j
 @Component
-class AmazonCloudFormationProvider implements CloudFormationProvider<AmazonCloudFormationStack> {
+public class AmazonCloudFormationProvider implements CloudFormationProvider<CloudFormationStack> {
 
   private final Cache cacheView;
   private final ObjectMapper objectMapper;
 
   @Autowired
-  AmazonCloudFormationProvider(Cache cacheView, ObjectMapper objectMapper) {
+  public AmazonCloudFormationProvider(Cache cacheView, ObjectMapper objectMapper) {
     this.cacheView = cacheView;
     this.objectMapper = objectMapper;
   }
 
-  public List<AmazonCloudFormationStack> list(String account, String region) {
-    String filter = Keys.getCloudFormationKey("*", region, account);
+  public List<CloudFormationStack> list(String accountName, String region) {
+    String filter = Keys.getCloudFormationKey("*", region, accountName);
     log.debug("List all stacks with filter {}", filter);
     return loadResults(cacheView.filterIdentifiers(CLOUDFORMATION.getNs(), filter));
   }
 
   @Override
-  public Optional<AmazonCloudFormationStack> get(String stackId) {
+  public Optional<CloudFormationStack> get(String stackId) {
     String filter = Keys.getCloudFormationKey(stackId, "*", "*");
     log.debug("Get stack with filter {}", filter);
     return loadResults(cacheView.filterIdentifiers(CLOUDFORMATION.getNs(), filter)).stream().findFirst();
   }
 
-  List<AmazonCloudFormationStack> loadResults(Collection<String> identifiers) {
+  List<CloudFormationStack> loadResults(Collection<String> identifiers) {
     return cacheView.getAll(CLOUDFORMATION.getNs(), identifiers, RelationshipCacheFilter.none())
       .stream()
       .map(data -> {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProvider.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.CLOUDFORMATION;
+import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.STACKS;
 
 @Slf4j
 @Component
@@ -50,18 +50,18 @@ public class AmazonCloudFormationProvider implements CloudFormationProvider<Clou
   public List<CloudFormationStack> list(String accountName, String region) {
     String filter = Keys.getCloudFormationKey("*", region, accountName);
     log.debug("List all stacks with filter {}", filter);
-    return loadResults(cacheView.filterIdentifiers(CLOUDFORMATION.getNs(), filter));
+    return loadResults(cacheView.filterIdentifiers(STACKS.getNs(), filter));
   }
 
   @Override
   public Optional<CloudFormationStack> get(String stackId) {
     String filter = Keys.getCloudFormationKey(stackId, "*", "*");
     log.debug("Get stack with filter {}", filter);
-    return loadResults(cacheView.filterIdentifiers(CLOUDFORMATION.getNs(), filter)).stream().findFirst();
+    return loadResults(cacheView.filterIdentifiers(STACKS.getNs(), filter)).stream().findFirst();
   }
 
   List<CloudFormationStack> loadResults(Collection<String> identifiers) {
-    return cacheView.getAll(CLOUDFORMATION.getNs(), identifiers, RelationshipCacheFilter.none())
+    return cacheView.getAll(STACKS.getNs(), identifiers, RelationshipCacheFilter.none())
       .stream()
       .map(data -> {
         log.debug("Cloud formation cached properties {}", data.getAttributes());

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/CloudFormationControllerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/CloudFormationControllerSpec.groovy
@@ -16,9 +16,8 @@
 package com.netflix.spinnaker.clouddriver.aws.controllers
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.netflix.spinnaker.clouddriver.aws.controllers.CloudFormationController
-import com.netflix.spinnaker.clouddriver.aws.model.CloudFormation
-import com.netflix.spinnaker.clouddriver.aws.model.CloudFormationProvider
+import com.netflix.spinnaker.clouddriver.aws.model.CloudFormationStack
+import com.netflix.spinnaker.clouddriver.aws.provider.view.AmazonCloudFormationProvider
 import groovy.transform.Immutable
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -44,12 +43,12 @@ class CloudFormationControllerSpec extends Specification {
   protected MockMvc mvc
 
   @Autowired
-  CloudFormationProvider<CloudFormation> cloudFormationProvider
+  AmazonCloudFormationProvider cloudFormationProvider
 
   def "request a list of stacks returns all the stacks for a given account (any region)"() {
     given:
     def accountId = '123456789'
-    cloudFormationProvider.list(accountId, '*') >> [ new CloudFormationTest(accountId: accountId) ]
+    cloudFormationProvider.list(accountId, '*') >> [ new CloudFormationStackTest(accountId: accountId) ]
 
     when:
     def results = mvc.perform(get("/aws/cloudFormation/stacks?accountId=$accountId"))
@@ -63,7 +62,7 @@ class CloudFormationControllerSpec extends Specification {
     given:
     def accountId = '123456789'
     def region = 'region'
-    cloudFormationProvider.list(accountId, region) >> [ new CloudFormationTest(accountId: accountId, region: region) ]
+    cloudFormationProvider.list(accountId, region) >> [ new CloudFormationStackTest(accountId: accountId, region: region) ]
 
     when:
     def results = mvc.perform(get("/aws/cloudFormation/stacks?accountId=$accountId&region=$region"))
@@ -77,7 +76,7 @@ class CloudFormationControllerSpec extends Specification {
   def "requesting a single stack by stackId"() {
     given:
     def stackId = "arn:cloudformation:stack/name"
-    cloudFormationProvider.get(stackId) >> Optional.of(new CloudFormationTest(stackId: stackId))
+    cloudFormationProvider.get(stackId) >> Optional.of(new CloudFormationStackTest(stackId: stackId))
 
     when:
     def results = mvc.perform(get("/aws/cloudFormation/stacks/$stackId"))
@@ -101,7 +100,7 @@ class CloudFormationControllerSpec extends Specification {
 
   @Immutable
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
-  class CloudFormationTest implements CloudFormation {
+  class CloudFormationStackTest implements CloudFormationStack {
     final String stackId
     final Map<String, String> tags
     final Map<String, String> outputs
@@ -120,8 +119,8 @@ class CloudFormationControllerSpec extends Specification {
     DetachedMockFactory detachedMockFactory = new DetachedMockFactory()
 
     @Bean
-    CloudFormationProvider provider() {
-      detachedMockFactory.Stub(CloudFormationProvider)
+    AmazonCloudFormationProvider provider() {
+      detachedMockFactory.Stub(AmazonCloudFormationProvider)
     }
   }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/CloudFormationControllerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/controllers/CloudFormationControllerSpec.groovy
@@ -47,29 +47,29 @@ class CloudFormationControllerSpec extends Specification {
 
   def "request a list of stacks returns all the stacks for a given account (any region)"() {
     given:
-    def accountId = '123456789'
-    cloudFormationProvider.list(accountId, '*') >> [ new CloudFormationStackTest(accountId: accountId) ]
+    def accountName = 'aws-account-name'
+    cloudFormationProvider.list(accountName, '*') >> [ new CloudFormationStackTest(accountName: accountName) ]
 
     when:
-    def results = mvc.perform(get("/aws/cloudFormation/stacks?accountId=$accountId"))
+    def results = mvc.perform(get("/aws/cloudFormation/stacks?accountName=$accountName"))
 
     then:
     results.andExpect(status().is2xxSuccessful())
-    results.andExpect(jsonPath('$[0].accountId').value(accountId))
+    results.andExpect(jsonPath('$[0].accountName').value(accountName))
   }
 
   def "request a list of stacks returns all the stacks for a given account filtering by region (if specified)"() {
     given:
-    def accountId = '123456789'
+    def accountName = 'aws-account-name'
     def region = 'region'
-    cloudFormationProvider.list(accountId, region) >> [ new CloudFormationStackTest(accountId: accountId, region: region) ]
+    cloudFormationProvider.list(accountName, region) >> [ new CloudFormationStackTest(accountName: accountName, region: region) ]
 
     when:
-    def results = mvc.perform(get("/aws/cloudFormation/stacks?accountId=$accountId&region=$region"))
+    def results = mvc.perform(get("/aws/cloudFormation/stacks?accountName=$accountName&region=$region"))
 
     then:
     results.andExpect(status().is2xxSuccessful())
-    results.andExpect(jsonPath('$[0].accountId').value(accountId))
+    results.andExpect(jsonPath('$[0].accountName').value(accountName))
     results.andExpect(jsonPath('$[0].region').value(region))
   }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonCloudFormationStackSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonCloudFormationStackSpec.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.model
 import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Specification
 
-class AmazonCloudFormationSpec extends Specification {
+class AmazonCloudFormationStackSpec extends Specification {
 
   def objectMapper = new ObjectMapper()
 
@@ -38,10 +38,10 @@ class AmazonCloudFormationSpec extends Specification {
     ]
 
     when:
-    def cf = objectMapper.convertValue(attributes, AmazonCloudFormation)
+    def cf = objectMapper.convertValue(attributes, AmazonCloudFormationStack)
 
     then:
-    assert cf instanceof AmazonCloudFormation
+    assert cf instanceof AmazonCloudFormationStack
     with(cf) {
       stackId == "stackId"
       tags == [tag1: "tag1", tag2: "tag2"]
@@ -60,10 +60,10 @@ class AmazonCloudFormationSpec extends Specification {
     def attributes = [stackId: "stackId"]
 
     when:
-    def cf = objectMapper.convertValue(attributes, AmazonCloudFormation)
+    def cf = objectMapper.convertValue(attributes, AmazonCloudFormationStack)
 
     then:
-    assert cf instanceof AmazonCloudFormation
+    assert cf instanceof AmazonCloudFormationStack
     with(cf) {
       stackId == "stackId"
       tags == null

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgentSpec.groovy
@@ -32,7 +32,7 @@ import spock.lang.Subject
 
 class AmazonCloudFormationCachingAgentSpec extends Specification {
   static String region = 'region'
-  static String account = 'account'
+  static String accountName = 'accountName'
 
   @Subject
   AmazonCloudFormationCachingAgent agent
@@ -49,7 +49,7 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
   def setup() {
     ec2 = Mock(AmazonEC2)
     def creds = Stub(NetflixAmazonCredentials) {
-      getAccountId() >> account
+      getName() >> accountName
     }
     acp = Mock(AmazonClientProvider)
     agent = new AmazonCloudFormationCachingAgent(acp, creds, region)
@@ -71,8 +71,8 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
     1 * amazonCloudFormation.describeStacks() >> stackResults
     1 * stackResults.stacks >> [ stack1, stack2 ]
 
-    results.find { it.id == Keys.getCloudFormationKey("stack1", "region", "account") }.attributes.'stackId' == stack1.stackId
-    results.find { it.id == Keys.getCloudFormationKey("stack2", "region", "account") }.attributes.'stackId' == stack2.stackId
+    results.find { it.id == Keys.getCloudFormationKey("stack1", "region", "accountName") }.attributes.'stackId' == stack1.stackId
+    results.find { it.id == Keys.getCloudFormationKey("stack2", "region", "accountName") }.attributes.'stackId' == stack2.stackId
   }
 
   void "should evict cloudformations when not found on subsequent runs"() {
@@ -91,8 +91,8 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
     1 * amazonCloudFormation.describeStacks() >> stackResults
     1 * stackResults.stacks >> [ stack1, stack2 ]
 
-    results.find { it.id == Keys.getCloudFormationKey("stack1", "region", "account") }.attributes.'stackId' == stack1.stackId
-    results.find { it.id == Keys.getCloudFormationKey("stack2", "region", "account") }.attributes.'stackId' == stack2.stackId
+    results.find { it.id == Keys.getCloudFormationKey("stack1", "region", "accountName") }.attributes.'stackId' == stack1.stackId
+    results.find { it.id == Keys.getCloudFormationKey("stack2", "region", "accountName") }.attributes.'stackId' == stack2.stackId
 
     when:
     cache = agent.loadData(providerCache)
@@ -103,8 +103,8 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
     1 * amazonCloudFormation.describeStacks() >> stackResults
     1 * stackResults.stacks >> [ stack1 ]
 
-    results.find { it.id == Keys.getCloudFormationKey("stack1", "region", "account") }.attributes.'stackId' == stack1.stackId
-    results.find { it.id == Keys.getCloudFormationKey("stack2", "region", "account") } == null
+    results.find { it.id == Keys.getCloudFormationKey("stack1", "region", "accountName") }.attributes.'stackId' == stack1.stackId
+    results.find { it.id == Keys.getCloudFormationKey("stack2", "region", "accountName") } == null
   }
 
   void "should include stack status reason when state is ROLLBACK_COMPLETE (failed)"() {
@@ -126,6 +126,6 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
     1 * amazonCloudFormation.describeStackEvents(_) >> stackEventResults
     1 * stackEventResults.getStackEvents() >> [ stackEvent ]
 
-    results.find { it.id == Keys.getCloudFormationKey("stack1", "region", "account") }.attributes.'stackStatusReason' == 'who knows'
+    results.find { it.id == Keys.getCloudFormationKey("stack1", "region", "accountName") }.attributes.'stackStatusReason' == 'who knows'
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgentSpec.groovy
@@ -64,7 +64,7 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
 
     when:
     def cache = agent.loadData(providerCache)
-    def results = cache.cacheResults[Keys.Namespace.CLOUDFORMATION.ns]
+    def results = cache.cacheResults[Keys.Namespace.STACKS.ns]
 
     then:
     1 * acp.getAmazonCloudFormation(_, _) >> amazonCloudFormation
@@ -84,7 +84,7 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
 
     when:
     def cache = agent.loadData(providerCache)
-    def results = cache.cacheResults[Keys.Namespace.CLOUDFORMATION.ns]
+    def results = cache.cacheResults[Keys.Namespace.STACKS.ns]
 
     then:
     1 * acp.getAmazonCloudFormation(_, _) >> amazonCloudFormation
@@ -96,7 +96,7 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
 
     when:
     cache = agent.loadData(providerCache)
-    results = cache.cacheResults[Keys.Namespace.CLOUDFORMATION.ns]
+    results = cache.cacheResults[Keys.Namespace.STACKS.ns]
 
     then:
     1 * acp.getAmazonCloudFormation(_, _) >> amazonCloudFormation
@@ -117,7 +117,7 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
 
     when:
     def cache = agent.loadData(providerCache)
-    def results = cache.cacheResults[Keys.Namespace.CLOUDFORMATION.ns]
+    def results = cache.cacheResults[Keys.Namespace.STACKS.ns]
 
     then:
     1 * acp.getAmazonCloudFormation(_, _) >> amazonCloudFormation

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProviderSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
-import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.CLOUDFORMATION
+import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.STACKS
 
 class AmazonCloudFormationProviderSpec extends Specification {
   static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
@@ -40,7 +40,7 @@ class AmazonCloudFormationProviderSpec extends Specification {
   def setup() {
     def cache = new InMemoryCache()
     cloudFormations.each {
-      cache.merge(CLOUDFORMATION.ns,
+      cache.merge(STACKS.ns,
           new DefaultCacheData(makeKey(it), objectMapper.convertValue(it, ATTRIBUTES), [:]))
     }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonCloudFormationProviderSpec.groovy
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.mem.InMemoryCache
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
-import com.netflix.spinnaker.clouddriver.aws.model.AmazonCloudFormation
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonCloudFormationStack
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -99,16 +99,16 @@ class AmazonCloudFormationProviderSpec extends Specification {
   }
 
   @Shared
-  def stack1 = new AmazonCloudFormation(stackId: "stack1", region: "region1", accountId: "account1")
+  def stack1 = new AmazonCloudFormationStack(stackId: "stack1", region: "region1", accountId: "account1")
   @Shared
-  def stack2 = new AmazonCloudFormation(stackId: "stack2", region: "region2", accountId: "account1")
+  def stack2 = new AmazonCloudFormationStack(stackId: "stack2", region: "region2", accountId: "account1")
   @Shared
-  def stack3 = new AmazonCloudFormation(stackId: "stack3", region: "region1", accountId: "account2")
+  def stack3 = new AmazonCloudFormationStack(stackId: "stack3", region: "region1", accountId: "account2")
 
   @Shared
-  Set<AmazonCloudFormation> cloudFormations = [stack1, stack2, stack3]
+  Set<AmazonCloudFormationStack> cloudFormations = [stack1, stack2, stack3]
 
-  private static String makeKey(AmazonCloudFormation stack) {
+  private static String makeKey(AmazonCloudFormationStack stack) {
     Keys.getCloudFormationKey(stack.stackId, stack.region, stack.accountId)
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/Namespace.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/provider/agent/Namespace.groovy
@@ -38,7 +38,7 @@ enum Namespace {
   RESERVATION_REPORTS,
   RESERVED_INSTANCES,
   PROJECT_CLUSTERS,
-  CLOUDFORMATION
+  STACKS
 
   public final String ns
   final Set<String> fields


### PR DESCRIPTION
This patch renames the cloud formation model to CloudFormationStack to better reflect its meaning. This change also uses the aws account name instead of the account id on the controller and cloud formation caching agent as suggested in https://github.com/spinnaker/clouddriver/pull/3320#issuecomment-458314739. It also makes the cloud formation caching agent resilient to permission errors, so it doesn't fail if the role assumed by spinnaker cannot list cloud formation stacks.