### PR TITLE
fix(provider/kubernetes): fix NPE on KubernetesV2ServerGroup disabled…

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
@@ -255,8 +255,7 @@ public class ProjectClustersService {
         .flatMap(ac -> ac.getServerGroups().stream())
         .filter(serverGroup ->
           serverGroup != null &&
-            serverGroup.isDisabled() != null &&
-            !serverGroup.isDisabled().booleanValue() &&
+            (serverGroup.isDisabled() == null || !serverGroup.isDisabled()) &&
             serverGroup.getInstanceCounts().getTotal() > 0)
         .forEach((ServerGroup serverGroup) -> {
           RegionClusterModel regionCluster = regionClusters.computeIfAbsent(

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/core/ProjectClustersService.java
@@ -255,7 +255,8 @@ public class ProjectClustersService {
         .flatMap(ac -> ac.getServerGroups().stream())
         .filter(serverGroup ->
           serverGroup != null &&
-            !serverGroup.isDisabled() &&
+            serverGroup.isDisabled() != null &&
+            !serverGroup.isDisabled().booleanValue() &&
             serverGroup.getInstanceCounts().getTotal() > 0)
         .forEach((ServerGroup serverGroup) -> {
           RegionClusterModel regionCluster = regionClusters.computeIfAbsent(


### PR DESCRIPTION
KubernetesV2ServerGroup disabled flag is null and causes a NPE.
Related to spinnaker/spinnaker#3490 and cherry picked PRs: #3292, #3293,  #3294