### PR TITLE
chore(dependencies): Bump spinnaker-dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = '1.17.0'
+    spinnakerDependenciesVersion = '1.17.0-patch1'
     if (project.hasProperty('spinnakerDependenciesVersion')) {
       spinnakerDependenciesVersion = project.property('spinnakerDependenciesVersion')
     }


### PR DESCRIPTION
Cherry-pick an update to spinnaker-dependencies into 1.12 to roll back the fabric8 library update, which was causing issues due to a breaking change in the library.