### PR TITLE
fix(entitytags): Handle non-deserializable entity tags

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/EntityTags.groovy
@@ -167,7 +167,11 @@ class EntityTags {
 
       switch (valueType) {
         case EntityTagValueType.object:
-          return objectMapper.readValue(value.toString(), Map.class)
+          try {
+            return objectMapper.readValue(value.toString(), Map.class)
+          } catch (Exception e) {
+            return value
+          }
         default:
           return value
       }


### PR DESCRIPTION
Specifically situations where a tag identifies itself as an object but
is actually a `String`.
