### PR TITLE
fix(provider/aws): change STS endpoints for GovCloud and China regions

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AssumeRoleAmazonCredentials.java
@@ -35,6 +35,14 @@ public class AssumeRoleAmazonCredentials extends AmazonCredentials {
     static AWSCredentialsProvider createSTSCredentialsProvider(AWSCredentialsProvider credentialsProvider, String accountId, String assumeRole, String sessionName) {
         String assumeRoleValue = Objects.requireNonNull(assumeRole, "assumeRole");
         if (!assumeRoleValue.startsWith("arn:")) {
+
+          /**
+           GovCloud and China regions need to have the full arn passed because of differing formats
+              Govcloud: arn:aws-us-gov:iam
+              China: arn:aws-cn:iam
+           Longer term fix is to have separate providers for aws-ec2-gov and aws-ec2-cn since their IAM realms are separate
+           from standard AWS cloud
+           */
           assumeRoleValue = String.format("arn:aws:iam::%s:%s", Objects.requireNonNull(accountId, "accountId"), assumeRoleValue);
         }
         return credentialsProvider == null ? null : new NetflixSTSAssumeRoleSessionCredentialsProvider(

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/NetflixSTSAssumeRoleSessionCredentialsProvider.java
@@ -28,6 +28,17 @@ public class NetflixSTSAssumeRoleSessionCredentialsProvider extends STSAssumeRol
                                                         String accountId) {
     super(longLivedCredentialsProvider, roleArn, roleSessionName);
     this.accountId = accountId;
+
+    /**
+     Need to explicitly set sts region if GovCloud or China as per
+     https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/STSAssumeRoleSessionCredentialsProvider.html
+     */
+    if (roleArn.contains("aws-us-gov")) {
+      setSTSClientEndpoint("sts.us-gov-west-1.amazonaws.com");
+    }
+    if (roleArn.contains("aws-cn")) {
+      setSTSClientEndpoint("sts.cn-north-1.amazonaws.com.cn");
+    }
   }
 
   public String getAccountId() {


### PR DESCRIPTION
Issue link: https://github.com/spinnaker/spinnaker/issues/3941

As detailed in https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/STSAssumeRoleSessionCredentialsProvider.html, STS has special endpoints for GovCloud and China regions.

At credential creation time, we don't have a way to easily check what region we are in, so I have it relying on the `arn` string being passed in. Clouddriver allows for a full arn, so we can check it for `aws-us-gov` or `aws-cn`.

I will also update the documentation as to point it passing in a full ARN is allowed.