### PR TITLE
feat(core): `DeploymentResult` support for returning target capacity

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.kork.core.RetrySupport
 import groovy.util.logging.Slf4j
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
@@ -55,10 +55,10 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult> {
     task.updateStatus TASK_PHASE, "Found handler: ${deployHandler.getClass().simpleName}"
 
     task.updateStatus TASK_PHASE, "Invoking Handler."
-    def deploymentResult = deployHandler.handle(description, priorOutputs)
 
-    task.updateStatus TASK_PHASE, "Server Groups: ${deploymentResult.serverGroupNames} created."
+    DeploymentResult deploymentResult = deployHandler.handle(description, priorOutputs).normalize()
+    task.updateStatus TASK_PHASE, "Server Groups: ${deploymentResult.getDeployments()} created."
 
-    deploymentResult
+    return deploymentResult
   }
 }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperationUnitSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperationUnitSpec.groovy
@@ -39,6 +39,7 @@ class DeployAtomicOperationUnitSpec extends Specification {
     }
 
     and:
+    def deploymentResult = Mock(DeploymentResult)
     def deployHandlerRegistry = Mock(DeployHandlerRegistry)
     def testDeployHandler = Mock(DeployHandler)
     def deployAtomicOperation = new DeployAtomicOperation(deployDescription)
@@ -49,7 +50,8 @@ class DeployAtomicOperationUnitSpec extends Specification {
 
     then:
     1 * deployHandlerRegistry.findHandler(_) >> testDeployHandler
-    1 * testDeployHandler.handle(_, _) >> { Mock(DeploymentResult) }
+    1 * testDeployHandler.handle(_, _) >> { deploymentResult }
+    1 * deploymentResult.normalize() >> { return deploymentResult }
 
     deployAtomicOperation.getEvents() == [ createServerGroupEvent ]
   }

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DeploymentResultSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DeploymentResultSpec.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.deploy
+
+import spock.lang.Specification;
+
+class DeploymentResultSpec extends Specification {
+
+  def "should no-op if `deployments` is non-null"() {
+    given:
+    def deploymentResult = new DeploymentResult(
+        deployments: [new DeploymentResult.Deployment()],
+        serverGroupNameByRegion: ["us-east-1": "app-v001"]
+    )
+
+    expect:
+    deploymentResult.normalize().deployments.size() == 1
+  }
+
+  def "should normalize `serverGroupNameByRegion` and `deployedNamesByLocation`"() {
+    given:
+    def deploymentResult = new DeploymentResult(
+        serverGroupNameByRegion: ["us-east-1": "app-v001"],
+        deployedNamesByLocation: ["us-west-2": ["app-v002", "app-v003"]]
+    )
+
+    when:
+    deploymentResult.normalize()
+
+    then:
+    (deploymentResult.deployments as List) == [
+        new DeploymentResult.Deployment(location: "us-east-1", serverGroupName: "app-v001"),
+        new DeploymentResult.Deployment(location: "us-west-2", serverGroupName: "app-v002"),
+        new DeploymentResult.Deployment(location: "us-west-2", serverGroupName: "app-v003")
+    ]
+  }
+}


### PR DESCRIPTION
AWS deployments are somewhat special in that they create an initial
asg of size 0/0/0 and then subsequently resize it to the target
capacity.

This causes problems if the `ForceCacheRefresh` task as part of a deploy
were to ever be removed from `orca` as it's possible for the 0/0/0 asg
to be cached and the `WaitForUpInstances` task to prematurely complete.

I'd like to remove the `ForceCacheRefresh` task as part of a deploy,
hence this PR and a follow-up in `orca` that makes it aware of the
capacity being passed back from `clouddriver`.
