### PR TITLE
chore(cf): rename serviceName to serviceInstanceName

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -198,7 +198,7 @@ public class Applications {
         .stream()
         .flatMap(vcap -> vcap.getValue().stream()
           .map(instance -> CloudFoundryServiceInstance.builder()
-            .serviceName(vcap.getKey())
+            .serviceInstanceName(vcap.getKey())
             .name(instance.getName())
             .plan(instance.getPlan())
             .tags(instance.getTags())

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverter.java
@@ -94,14 +94,14 @@ public class DeployCloudFoundryServiceAtomicOperationConverter extends AbstractC
       });
     if (manifest.getService() == null) {
       throw new IllegalArgumentException("Manifest is missing the service");
-    } else if (manifest.getServiceName() == null) {
-      throw new IllegalArgumentException("Manifest is missing the service name");
+    } else if (manifest.getServiceInstanceName() == null) {
+      throw new IllegalArgumentException("Manifest is missing the service instance name");
     } else if(manifest.getServicePlan() == null) {
       throw new IllegalArgumentException("Manifest is missing the service plan");
     }
     DeployCloudFoundryServiceDescription.ServiceAttributes attrs = new DeployCloudFoundryServiceDescription.ServiceAttributes();
     attrs.setService(manifest.getService());
-    attrs.setServiceName(manifest.getServiceName());
+    attrs.setServiceInstanceName(manifest.getServiceInstanceName());
     attrs.setServicePlan(manifest.getServicePlan());
     attrs.setTags(manifest.getTags());
     attrs.setParameterMap(parseParameters(manifest.getParameters()));
@@ -115,11 +115,11 @@ public class DeployCloudFoundryServiceAtomicOperationConverter extends AbstractC
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
       .convertValue(manifestMap, new TypeReference<UserProvidedServiceManifest>() {
       });
-    if (manifest.getServiceName() == null) {
+    if (manifest.getServiceInstanceName() == null) {
       throw new IllegalArgumentException("Manifest is missing the service name");
     }
     DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes attrs = new DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes();
-    attrs.setServiceName(manifest.getServiceName());
+    attrs.setServiceInstanceName(manifest.getServiceInstanceName());
     attrs.setSyslogDrainUrl(manifest.getSyslogDrainUrl());
     attrs.setRouteServiceUrl(manifest.getRouteServiceUrl());
     attrs.setTags(manifest.getTags());
@@ -144,7 +144,7 @@ public class DeployCloudFoundryServiceAtomicOperationConverter extends AbstractC
   private static class ServiceManifest {
     private String service;
 
-    private String serviceName;
+    private String serviceInstanceName;
 
     private String servicePlan;
 
@@ -157,7 +157,7 @@ public class DeployCloudFoundryServiceAtomicOperationConverter extends AbstractC
 
   @Data
   private static class UserProvidedServiceManifest {
-    private String serviceName;
+    private String serviceInstanceName;
 
     @Nullable
     private String syslogDrainUrl;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServiceDescription.java
@@ -46,7 +46,7 @@ public class DeployCloudFoundryServiceDescription extends AbstractCloudFoundrySe
   @Data
   public static class ServiceAttributes {
     String service;
-    String serviceName;
+    String serviceInstanceName;
     String servicePlan;
 
     @Nullable
@@ -58,7 +58,7 @@ public class DeployCloudFoundryServiceDescription extends AbstractCloudFoundrySe
 
   @Data
   public static class UserProvidedServiceAttributes {
-    String serviceName;
+    String serviceInstanceName;
 
     @Nullable
     Set<String> tags;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DestroyCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DestroyCloudFoundryServiceDescription.java
@@ -22,5 +22,5 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class DestroyCloudFoundryServiceDescription extends AbstractCloudFoundryServiceDescription {
-  private String serviceName;
+  private String serviceInstanceName;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperation.java
@@ -39,35 +39,35 @@ public class DeployCloudFoundryServiceAtomicOperation implements AtomicOperation
     switch (description.getServiceType()) {
       case "service":
         DeployCloudFoundryServiceDescription.ServiceAttributes serviceAttributes = description.getServiceAttributes();
-        task.updateStatus(PHASE, "Creating service instance '" + serviceAttributes.getServiceName() + "' from service " + serviceAttributes.getService() + " and service plan " + serviceAttributes.getServicePlan());
+        task.updateStatus(PHASE, "Creating service instance '" + serviceAttributes.getServiceInstanceName() + "' from service " + serviceAttributes.getService() + " and service plan " + serviceAttributes.getServicePlan());
         description
           .getClient()
           .getServiceInstances()
           .createServiceInstance(
-            serviceAttributes.getServiceName(),
+            serviceAttributes.getServiceInstanceName(),
             serviceAttributes.getService(),
             serviceAttributes.getServicePlan(),
             serviceAttributes.getTags(),
             serviceAttributes.getParameterMap(),
             description.getSpace(),
             description.getTimeout());
-        task.updateStatus(PHASE, "Created service instance '" + serviceAttributes.getServiceName() + "'");
+        task.updateStatus(PHASE, "Created service instance '" + serviceAttributes.getServiceInstanceName() + "'");
         break;
       case "userProvided":
         DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes userProvidedServiceAttributes = description.getUserProvidedServiceAttributes();
-        task.updateStatus(PHASE, "Creating user provided service instance '" + userProvidedServiceAttributes.getServiceName() + "'");
+        task.updateStatus(PHASE, "Creating user provided service instance '" + userProvidedServiceAttributes.getServiceInstanceName() + "'");
         description
           .getClient()
           .getServiceInstances()
           .createUserProvidedServiceInstance(
-            userProvidedServiceAttributes.getServiceName(),
+            userProvidedServiceAttributes.getServiceInstanceName(),
             userProvidedServiceAttributes.getSyslogDrainUrl(),
             userProvidedServiceAttributes.getTags(),
             userProvidedServiceAttributes.getCredentialsMap(),
             userProvidedServiceAttributes.getRouteServiceUrl(),
             description.getSpace()
           );
-        task.updateStatus(PHASE, "Created user provided service instance '" + userProvidedServiceAttributes.getServiceName() + "'");
+        task.updateStatus(PHASE, "Created user provided service instance '" + userProvidedServiceAttributes.getServiceInstanceName() + "'");
         break;
     }
     return null;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DestroyCloudFoundryServiceAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DestroyCloudFoundryServiceAtomicOperation.java
@@ -36,11 +36,11 @@ public class DestroyCloudFoundryServiceAtomicOperation implements AtomicOperatio
   @Override
   public Void operate(List priorOutputs) {
     Task task = getTask();
-    task.updateStatus(PHASE, "Initializing the removal of service instance '" + description.getServiceName() + "' from space " + description.getSpace().getName());
+    task.updateStatus(PHASE, "Initializing the removal of service instance '" + description.getServiceInstanceName() + "' from space " + description.getSpace().getName());
     description.getClient()
       .getServiceInstances()
-      .destroyServiceInstance(description.getSpace(), description.getServiceName(), description.getTimeout());
-    task.updateStatus(PHASE, "Done removing service instance '" + description.getServiceName() + "'");
+      .destroyServiceInstance(description.getSpace(), description.getServiceInstanceName(), description.getTimeout());
+    task.updateStatus(PHASE, "Done removing service instance '" + description.getServiceInstanceName() + "'");
     return null;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServiceInstance.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServiceInstance.java
@@ -31,7 +31,7 @@ import java.util.Set;
 @JsonDeserialize(builder = CloudFoundryServiceInstance.CloudFoundryServiceInstanceBuilder.class)
 public class CloudFoundryServiceInstance {
   @JsonView(Views.Cache.class)
-  String serviceName;
+  String serviceInstanceName;
 
   @JsonView(Views.Cache.class)
   String name;

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstancesTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstancesTest.java
@@ -151,7 +151,7 @@ class ServiceInstancesTest {
     when(serviceInstanceService.getServiceInstanceById(any())).thenReturn(succeededServiceInstanceResource);
 
     serviceInstances.createServiceInstance("new-service-instance-name",
-      "serviceName",
+      "serviceInstanceName",
       "ServicePlan1",
       Collections.emptySet(),
       null,
@@ -173,7 +173,7 @@ class ServiceInstancesTest {
 
     assertThrows(CloudFoundryApiException.class, () ->
       serviceInstances.createServiceInstance("newServiceInstanceName",
-        "serviceName",
+        "serviceInstanceName",
         "ServicePlan1",
         Collections.emptySet(),
         null,
@@ -196,7 +196,7 @@ class ServiceInstancesTest {
 
     assertThrows(ResourceNotFoundException.class, () ->
       serviceInstances.createServiceInstance("newServiceInstanceName",
-        "serviceName",
+        "serviceInstanceName",
         "servicePlanName",
         Collections.emptySet(),
         null,
@@ -219,7 +219,7 @@ class ServiceInstancesTest {
     when(serviceInstanceService.getServiceInstanceById(any())).thenReturn(polledServiceInstanceResource);
 
     serviceInstances.createServiceInstance("newServiceInstanceName",
-      "serviceName",
+      "serviceInstanceName",
       "ServicePlan1",
       Collections.emptySet(),
       null,
@@ -246,7 +246,7 @@ class ServiceInstancesTest {
 
     assertThrows(CloudFoundryApiException.class, () ->
       serviceInstances.createServiceInstance("newServiceInstanceName",
-        "serviceName",
+        "serviceInstanceName",
         "ServicePlan1",
         Collections.emptySet(),
         null,
@@ -282,7 +282,7 @@ class ServiceInstancesTest {
 
     assertThrows(CloudFoundryApiException.class, () ->
       serviceInstances.createServiceInstance("newServiceInstanceName",
-        "serviceName",
+        "serviceInstanceName",
         "ServicePlan1",
         Collections.emptySet(),
         null,

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
@@ -77,7 +77,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
     artifactCredentialsRepository.save(new ArtifactCredentialsFromString(
       "test",
       List.of("a").asJava(),
-      "service_name: my-service-name\n" +
+      "service_instance_name: my-service-instance-name\n" +
         "service: my-service\n" +
         "service_plan: my-service-plan\n" +
         "tags:\n" +
@@ -108,7 +108,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
   void convertManifestMapToServiceAttributes() {
     final Map input = HashMap.of(
       "service", "my-service",
-      "service_name", "my-service-name",
+      "service_instance_name", "my-service-instance-name",
       "service_plan", "my-service-plan",
       "tags", List.of(
         "my-tag"
@@ -119,7 +119,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
     assertThat(converter.convertManifest(input)).isEqualToComparingFieldByFieldRecursively(
       new DeployCloudFoundryServiceDescription.ServiceAttributes()
         .setService("my-service")
-        .setServiceName("my-service-name")
+        .setServiceInstanceName("my-service-instance-name")
         .setServicePlan("my-service-plan")
         .setTags(Collections.singleton("my-tag"))
         .setParameterMap(HashMap.<String, Object>of(
@@ -131,7 +131,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
   @Test
   void convertManifestMapToServiceAttributesMissingServiceThrowsException() {
     final Map input = HashMap.of(
-      "service_name", "my-service-name",
+      "service_instance_name", "my-service-instance-name",
       "service_plan", "my-service-plan",
       "tags", List.of(
         "my-tag"
@@ -145,7 +145,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
   @Test
   void convertManifestMapToServiceAttributesMissingServiceNameThrowsException() {
     final Map input = HashMap.of(
-      "service_name", "my-service-name",
+      "service_instance_name", "my-service-instance-name",
       "service_plan", "my-service-plan",
       "tags", List.of(
         "my-tag"
@@ -160,7 +160,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
   void convertManifestMapToServiceAttributesMissingServicePlanThrowsException() {
     final Map input = HashMap.of(
       "service", "my-service",
-      "service_name", "my-service-name",
+      "service_instance_name", "my-service-instance-name",
       "tags", List.of(
         "my-tag"
       ).asJava(),
@@ -173,7 +173,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
   @Test
   void convertCupsManifestMapToUserProvidedServiceAttributes() {
     final Map input = HashMap.of(
-      "service_name", "my-service-name",
+      "service_instance_name", "my-service-instance-name",
       "syslog_drain_url", "test-syslog-drain-url",
       "route_service_url", "test-route-service-url",
       "tags", List.of(
@@ -184,7 +184,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
 
     assertThat(converter.convertUserProvidedServiceManifest(input)).isEqualToComparingFieldByFieldRecursively(
       new DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes()
-        .setServiceName("my-service-name")
+        .setServiceInstanceName("my-service-instance-name")
         .setSyslogDrainUrl("test-syslog-drain-url")
         .setRouteServiceUrl("test-route-service-url")
         .setTags(Collections.singleton("my-tag"))
@@ -212,7 +212,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
   void convertManifestMapToServiceAttributesEmptyParamString() {
     final Map input = HashMap.of(
       "service", "my-service",
-      "service_name", "my-service-name",
+      "service_instance_name", "my-service-instance-name",
       "service_plan", "my-service-plan",
       "tags", List.of(
         "my-tag"
@@ -223,7 +223,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
     assertThat(converter.convertManifest(input)).isEqualToComparingFieldByFieldRecursively(
       new DeployCloudFoundryServiceDescription.ServiceAttributes()
         .setService("my-service")
-        .setServiceName("my-service-name")
+        .setServiceInstanceName("my-service-instance-name")
         .setServicePlan("my-service-plan")
         .setTags(Collections.singleton("my-tag"))
     );
@@ -260,7 +260,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
     assertThat(result.getServiceAttributes()).isEqualToComparingFieldByFieldRecursively(
       new DeployCloudFoundryServiceDescription.ServiceAttributes()
         .setService("my-service")
-        .setServiceName("my-service-name")
+        .setServiceInstanceName("my-service-instance-name")
         .setServicePlan("my-service-plan")
         .setTags(Collections.singleton("tag1"))
         .setParameterMap(HashMap.<String, Object>of(
@@ -276,7 +276,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
       "region", "org > space",
       "manifest", HashMap.of(
         "type", "userProvided",
-        "serviceName", "userProvidedServiceName",
+        "serviceInstanceName", "userProvidedServiceName",
         "tags", List.of(
           "my-tag"
         ).asJava(),
@@ -290,7 +290,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
     assertThat(result.getServiceAttributes()).isNull();
     assertThat(result.getUserProvidedServiceAttributes()).isEqualToComparingFieldByFieldRecursively(
       new DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes()
-        .setServiceName("userProvidedServiceName")
+        .setServiceInstanceName("userProvidedServiceName")
         .setSyslogDrainUrl("http://syslogDrainUrl.io")
         .setRouteServiceUrl("http://routeServiceUrl.io")
         .setTags(Collections.singleton("my-tag"))
@@ -307,7 +307,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
       "region", "org > space",
       "manifest", HashMap.of(
         "type", "userProvided",
-        "serviceName", "userProvidedServiceName",
+        "serviceInstanceName", "userProvidedServiceName",
         "tags", List.of(
           "my-tag"
         ).asJava(),
@@ -320,7 +320,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
     assertThat(result.getServiceAttributes()).isNull();
     assertThat(result.getUserProvidedServiceAttributes()).isEqualToComparingFieldByFieldRecursively(
       new DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes()
-        .setServiceName("userProvidedServiceName")
+        .setServiceInstanceName("userProvidedServiceName")
         .setSyslogDrainUrl("http://syslogDrainUrl.io")
         .setRouteServiceUrl("http://routeServiceUrl.io")
         .setTags(Collections.singleton("my-tag"))

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperationTest.java
@@ -30,7 +30,7 @@ class DeployCloudFoundryServiceAtomicOperationTest extends AbstractCloudFoundryA
     desc.setServiceType("service");
     desc.setClient(client);
     desc.setServiceAttributes(new DeployCloudFoundryServiceDescription.ServiceAttributes()
-      .setServiceName("some-service-name")
+      .setServiceInstanceName("some-service-name")
       .setService("some-service")
       .setServicePlan("some-service-plan")
     );
@@ -47,7 +47,7 @@ class DeployCloudFoundryServiceAtomicOperationTest extends AbstractCloudFoundryA
     desc.setServiceType("userProvided");
     desc.setClient(client);
     desc.setUserProvidedServiceAttributes(new DeployCloudFoundryServiceDescription.UserProvidedServiceAttributes()
-      .setServiceName("some-service-name")
+      .setServiceInstanceName("some-service-name")
     );
 
     DeployCloudFoundryServiceAtomicOperation op = new DeployCloudFoundryServiceAtomicOperation(desc);


### PR DESCRIPTION
renaming `serviceName` to `serviceInstanceName` so it is clear that `serviceInstanceName` represents the new service instance and not the name of the Service