### PR TITLE
feat(aws/ecs): map ContainerDefinition secrets to TaskDefinition

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/TaskDefinition.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/model/TaskDefinition.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.ecs.model;
 
 import com.amazonaws.services.ecs.model.KeyValuePair;
+import com.amazonaws.services.ecs.model.Secret;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -34,5 +35,6 @@ public class TaskDefinition {
   int memoryLimit;
 
   Collection<KeyValuePair> environmentVariables;
+  Collection<Secret> secrets;
 
 }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -222,7 +222,8 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
       .setMemoryLimit(memoryLimit)
       .setIamRole(iamRole)
       .setTaskName(StringUtils.substringAfterLast(taskDefinition.getTaskDefinitionArn(), "/"))
-      .setEnvironmentVariables(containerDefinition.getEnvironment());
+      .setEnvironmentVariables(containerDefinition.getEnvironment())
+      .setSecrets(containerDefinition.getSecrets());
   }
 
   private ServerGroup.Capacity buildServerGroupCapacity(int desiredCount, ScalableTarget target) {

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProviderSpec.groovy
@@ -353,6 +353,7 @@ class EcsServerClusterProviderSpec extends Specification {
         cpuUnits: 123,
         memoryReservation: 256,
         environmentVariables: [],
+        secrets: [],
         iamRole: 'None'
       ),
       metricAlarms: [],


### PR DESCRIPTION
ContainerDefinition allows for secrets to be defined.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html

Not sure how we can get this to be mapped from deck or what other work this would require

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
