### PR TITLE
fix(appengine): Fix appengine deployments

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
@@ -257,6 +257,9 @@ class DeployAppengineAtomicOperation implements AtomicOperation<DeploymentResult
       (description.configFilepaths?.collect { Paths.get(repositoryPath, applicationDirectoryRoot ?: '.', it).toString() } ?: []) as List<String>
     def configArtifactPaths = fetchConfigArtifacts(description.configArtifacts, repositoryPath, applicationDirectoryRoot)
 
+    // runCommand expects a List<String> and will fail if some of the arguments are GStrings (as that is not a subclass
+    // of String). It is thus important to only add Strings to deployCommand.  For example, adding a flag "--test=$testvalue"
+    // below will cause deployments to fail unless you explicitly convert it to a String via "--test=$testvalue".toString()
     def deployCommand = ["gcloud"]
     if (gcloudReleaseTrack != null && gcloudReleaseTrack != GcloudReleaseTrack.STABLE) {
       deployCommand << gcloudReleaseTrack.toString().toLowerCase()

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
@@ -262,13 +262,13 @@ class DeployAppengineAtomicOperation implements AtomicOperation<DeploymentResult
       deployCommand << gcloudReleaseTrack.toString().toLowerCase()
     }
     deployCommand += ["app", "deploy", *(repositoryFullConfigFilePaths + writtenFullConfigFilePaths + configArtifactPaths)]
-    deployCommand << "--version=$versionName"
+    deployCommand << "--version=" + versionName
     deployCommand << (description.promote ? "--promote" : "--no-promote")
     deployCommand << (description.stopPreviousVersion ? "--stop-previous-version": "--no-stop-previous-version")
-    deployCommand << "--project=$project"
-    deployCommand << "--account=$accountEmail"
+    deployCommand << "--project=" + project
+    deployCommand << "--account=" + accountEmail
     if (containerDeployment) {
-      deployCommand << "--image-url=$imageUrl"
+      deployCommand << "--image-url=" + imageUrl
     }
 
     task.updateStatus BASE_PHASE, "Deploying version $versionName..."

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/snapshot/RestoreSnapshotAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/snapshot/RestoreSnapshotAtomicOperation.groovy
@@ -142,6 +142,9 @@ class RestoreSnapshotAtomicOperation implements AtomicOperation<Void> {
 
     task.updateStatus BASE_PHASE, "Restoring snapshot with timestamp ${snapshotTimestamp} for application ${applicationName} in account ${accountName}"
     createTerraformConfig()
+    // JobRequest expects a List<String> and will fail if some of the arguments are GStrings (as that is not a subclass
+    // of String). It is thus important to only add Strings to command.  For example, adding a flag "--test=$testvalue"
+    // below will cause the job to fail unless you explicitly convert it to a String via "--test=$testvalue".toString()
     ArrayList<String> command = ["terraform", "apply", "-state=" + directory + "/terraform.tfstate", directory]
     JobStatus jobStatus = jobExecutor.runJob(new JobRequest(command), System.getenv(), new ByteArrayInputStream())
     cleanUpDirectory()
@@ -223,6 +226,9 @@ class RestoreSnapshotAtomicOperation implements AtomicOperation<Void> {
       inputStream = new ByteArrayInputStream()
       env.GOOGLE_REGION = region
     }
+    // JobRequest expects a List<String> and will fail if some of the arguments are GStrings (as that is not a subclass
+    // of String). It is thus important to only add Strings to command.  For example, adding a flag "--test=$testvalue"
+    // below will cause the job to fail unless you explicitly convert it to a String via "--test=$testvalue".toString()
     ArrayList<String> command = ["terraform", "import", "-state=" + directory + "/terraform.tfstate", resource + "." + name, id]
     JobStatus jobStatus = jobExecutor.runJob(new JobRequest(command), env, inputStream)
     if (jobStatus.getResult() == JobStatus.Result.FAILURE && jobStatus.stdOut) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/snapshot/RestoreSnapshotAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/snapshot/RestoreSnapshotAtomicOperation.groovy
@@ -142,7 +142,7 @@ class RestoreSnapshotAtomicOperation implements AtomicOperation<Void> {
 
     task.updateStatus BASE_PHASE, "Restoring snapshot with timestamp ${snapshotTimestamp} for application ${applicationName} in account ${accountName}"
     createTerraformConfig()
-    ArrayList<String> command = ["terraform", "apply", "-state=$directory/terraform.tfstate", "$directory"]
+    ArrayList<String> command = ["terraform", "apply", "-state=" + directory + "/terraform.tfstate", directory]
     JobStatus jobStatus = jobExecutor.runJob(new JobRequest(command), System.getenv(), new ByteArrayInputStream())
     cleanUpDirectory()
     if (jobStatus.getResult() == JobStatus.Result.FAILURE && jobStatus.getStdOut()) {
@@ -223,7 +223,7 @@ class RestoreSnapshotAtomicOperation implements AtomicOperation<Void> {
       inputStream = new ByteArrayInputStream()
       env.GOOGLE_REGION = region
     }
-    ArrayList<String> command = ["terraform", "import", "-state=$directory/terraform.tfstate", "$resource.$name", id]
+    ArrayList<String> command = ["terraform", "import", "-state=" + directory + "/terraform.tfstate", resource + "." + name, id]
     JobStatus jobStatus = jobExecutor.runJob(new JobRequest(command), env, inputStream)
     if (jobStatus.getResult() == JobStatus.Result.FAILURE && jobStatus.stdOut) {
       cleanUpDirectory()


### PR DESCRIPTION
The new JobExecutorLocal is in Java, and fails when passed an array containing a mixture of Strings and GStrings.  As a GString is not a subclass of String (which is final) it is incorrect to create a collection containing a mixture (and generates a warning). Fix this at the source by not creating arrays that mix String and Gstring.