### PR TITLE
fix(provider/azure): Remove Azure Load Balancer from Azure VM Scale Set

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
@@ -34,7 +34,6 @@ class AzureUtilities {
   static final String IPCONFIG_NAME_PREFIX = "ipc-"
   static final String NETWORK_INTERFACE_PREFIX = "nic-"
   static final Pattern IPV4_PREFIX_REGEX = ~/^(?<addr3>\d+)\.(?<addr2>\d+)\.(?<addr1>\d+)\.(?<addr0>\d+)\/(?<length>\d+)$/
-  static final String LB_NAME_PREFIX = "lb-"
   static final String INBOUND_NATPOOL_PREFIX = "np-"
   static final String VNET_DEFAULT_ADDRESS_PREFIX = "10.0.0.0/8"
   static final int SUBNET_DEFAULT_ADDRESS_PREFIX_LENGTH = 24

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -32,16 +32,14 @@ package com.netflix.spinnaker.clouddriver.azure.templates
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
-import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription.AzureInboundPortConfig
-import groovy.util.logging.Slf4j
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
+
+import groovy.util.logging.Slf4j
 
 @Slf4j
 class AzureServerGroupResourceTemplate {
   static final String STORAGE_ACCOUNT_SUFFIX = "sa"
-
-  static String LB_NAME = null
 
   protected static ObjectMapper mapper = new ObjectMapper()
     .configure(SerializationFeature.INDENT_OUTPUT, true)
@@ -56,14 +54,6 @@ class AzureServerGroupResourceTemplate {
   static String getTemplate(AzureServerGroupDescription description) {
     ServerGroupTemplate template = new ServerGroupTemplate(description)
     mapper.writeValueAsString(template)
-  }
-
-  /**
-   * Initialize variables that will be used in mulitple places
-   * @param description Azure Server Group description object
-   */
-  private static void initializeCommonVariables(AzureServerGroupDescription description) {
-    LB_NAME = AzureUtilities.LB_NAME_PREFIX + description.name
   }
 
   /**
@@ -82,19 +72,16 @@ class AzureServerGroupResourceTemplate {
      * @param description
      */
     ServerGroupTemplate(AzureServerGroupDescription description) {
-      initializeCommonVariables(description)
       parameters = new ServerGroupTemplateParameters()
 
       //If it's custom,
       if (description.image.isCustom) {
-        variables = new CoreServerGroupTemplateVariables(description)
+        variables = new CoreServerGroupTemplateVariables()
       } else {
         variables = new ExtendedServerGroupTemplateVariables(description)
         resources.add(new StorageAccount(description))
       }
 
-      resources.add(new PublicIpResource(properties: new PublicIPPropertiesWithDns()))
-      resources.add(new LoadBalancer(description))
       resources.add(new VirtualMachineScaleSet(description))
     }
 
@@ -104,31 +91,7 @@ class AzureServerGroupResourceTemplate {
 
   static class CoreServerGroupTemplateVariables implements TemplateVariables {
     final String apiVersion = "2018-10-01"
-    String publicIPAddressName
-    String publicIPAddressID
-    String publicIPAddressType
-    String dnsNameForLBIP
-    String loadBalancerBackend
-    String loadBalancerFrontEnd
-    String loadBalancerName
-    String loadBalancerID
-    String frontEndIPConfigID
-    String inboundNatPoolName
-
     CoreServerGroupTemplateVariables() {}
-
-    CoreServerGroupTemplateVariables(AzureServerGroupDescription description) {
-      publicIPAddressName = AzureUtilities.PUBLICIP_NAME_PREFIX + description.name
-      publicIPAddressID = "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
-      publicIPAddressType = "Dynamic"
-      dnsNameForLBIP = AzureUtilities.DNS_NAME_PREFIX + description.name.toLowerCase()
-      frontEndIPConfigID = "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/', variables('loadBalancerName'), variables('loadBalancerFrontEnd'))]"
-      loadBalancerFrontEnd = AzureUtilities.LBFRONTEND_NAME_PREFIX + description.name
-      loadBalancerBackend = AzureUtilities.LBBACKEND_NAME_PREFIX + description.name
-      loadBalancerName = LB_NAME
-      loadBalancerID = "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]"
-      inboundNatPoolName = AzureUtilities.INBOUND_NATPOOL_PREFIX + description.name
-    }
   }
 
   /**
@@ -153,7 +116,7 @@ class AzureServerGroupResourceTemplate {
      * @param description
      */
     ExtendedServerGroupTemplateVariables(AzureServerGroupDescription description) {
-      super(description)
+      super()
       vhdContainerName = description.name.toLowerCase()
       osType = new OsType(description)
       imageReference = "[variables('osType')]"
@@ -330,7 +293,6 @@ class AzureServerGroupResourceTemplate {
       tags.detail = description.detail
       tags.cluster = description.clusterName
       tags.createdTime = currentTime.toString()
-      tags.loadBalancerName = LB_NAME
       tags.hasNewSubnet = description.hasNewSubnet.toString()
 
       // debug only; can be removed as part of the tags cleanup
@@ -354,8 +316,6 @@ class AzureServerGroupResourceTemplate {
           tags.storageAccountNames = tags.storageAccountNames ? "${tags.storageAccountNames},${uniqueName}" : uniqueName
         }
       }
-
-      this.dependsOn.add("[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]")
 
       properties = new VirtualMachineScaleSetProperty(description)
       sku = new ScaleSetSkuProperty(description)
@@ -486,8 +446,6 @@ class AzureServerGroupResourceTemplate {
   static class NetworkInterfaceIPConfigurationsProperty {
     NetworkInterfaceIPConfigurationSubnet subnet
     ArrayList<AppGatewayBackendAddressPool> ApplicationGatewayBackendAddressPools = []
-    ArrayList<LoadBalancerBackendAddressPool> loadBalancerBackendAddressPools = []
-    ArrayList<LoadBalancerInboundNatPoolId> loadBalancerInboundNatPools = []
 
     /**
      *
@@ -495,9 +453,7 @@ class AzureServerGroupResourceTemplate {
      */
     NetworkInterfaceIPConfigurationsProperty() {
       subnet = new NetworkInterfaceIPConfigurationSubnet()
-      loadBalancerBackendAddressPools.add(new LoadBalancerBackendAddressPool())
       ApplicationGatewayBackendAddressPools.add(new AppGatewayBackendAddressPool())
-      loadBalancerInboundNatPools.add(new LoadBalancerInboundNatPoolId())
     }
   }
 
@@ -509,21 +465,6 @@ class AzureServerGroupResourceTemplate {
 
     NetworkInterfaceIPConfigurationSubnet() {
       id = "[parameters('${subnetParameterName}')]"
-    }
-  }
-
-  static class LoadBalancerBackendAddressPool {
-    String id
-
-    LoadBalancerBackendAddressPool() {
-      id = "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('loadBalancerBackend'))]"
-    }
-  }
-
-  static class LoadBalancerInboundNatPoolId extends IdRef {
-
-    LoadBalancerInboundNatPoolId() {
-      id = "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('inboundNatPoolName'))]"
     }
   }
 
@@ -592,6 +533,7 @@ class AzureServerGroupResourceTemplate {
     }
   }
 
+
   static class ImageReference {
     String id
 
@@ -604,7 +546,6 @@ class AzureServerGroupResourceTemplate {
    *
    */
   static class ScaleSetCustomManagedImageStorageProfile implements StorageProfile {
-
     ImageReference imageReference
     /**
      *
@@ -634,7 +575,6 @@ class AzureServerGroupResourceTemplate {
       }
     }
   }
-
 
   /**** VMSS extensionsProfile ****/
   static class ScaleSetExtensionProfileProperty {
@@ -679,118 +619,4 @@ class AzureServerGroupResourceTemplate {
       fileUris = description.customScriptsSettings.fileUris
     }
   }
-
-
-  /**** Load Balancer Resource ****/
-  static class LoadBalancer extends DependingResource {
-    LoadBalancerProperties properties
-
-    LoadBalancer(AzureServerGroupDescription description) {
-      apiVersion = "[variables('apiVersion')]"
-      name = "[variables('loadBalancerName')]"
-      type = "Microsoft.Network/loadBalancers"
-      location = "[parameters('${locationParameterName}')]"
-      def currentTime = System.currentTimeMillis()
-      tags = [:]
-      tags.appName = description.application
-      tags.stack = description.stack
-      tags.detail = description.detail
-      tags.createdTime = currentTime.toString()
-      if (description.clusterName) tags.cluster = description.clusterName
-      if (description.name) tags.serverGroup = description.name
-      if (description.securityGroupName) tags.securityGroupName = description.securityGroupName
-
-      this.dependsOn.add("[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]")
-
-      properties = new LoadBalancerProperties(description)
-    }
-  }
-
-  static class LoadBalancerProperties {
-    ArrayList<FrontEndIpConfiguration> frontendIPConfigurations = []
-    ArrayList<BackEndAddressPool> backendAddressPools = []
-    ArrayList<InboundNatPool> inboundNatPools = []
-
-    LoadBalancerProperties(AzureServerGroupDescription description) {
-      frontendIPConfigurations.add(new FrontEndIpConfiguration())
-      backendAddressPools.add(new BackEndAddressPool())
-      description.inboundPortConfigs?.each {
-        inboundNatPools.add(new InboundNatPool(it))
-      }
-    }
-  }
-
-  static class FrontEndIpConfiguration {
-    String name
-    FrontEndIpProperties properties
-
-    FrontEndIpConfiguration() {
-      name = "[variables('loadBalancerFrontEnd')]"
-      properties = new FrontEndIpProperties("[variables('publicIPAddressID')]")
-    }
-  }
-
-  static class FrontEndIpProperties {
-    IdRef publicIpAddress
-
-    FrontEndIpProperties(String id) {
-      publicIpAddress = new IdRef(id)
-    }
-  }
-
-  static class BackEndAddressPool {
-    String name
-
-    BackEndAddressPool() {
-      name = "[variables('loadBalancerBackEnd')]"
-    }
-  }
-
-
-  static class InboundNatPool {
-    String name
-    InboundNatPoolProperties properties
-
-    InboundNatPool(AzureInboundPortConfig inboundPortConfig) {
-      name = inboundPortConfig.name
-      properties = new InboundNatPoolProperties(inboundPortConfig)
-    }
-  }
-
-  static class InboundNatPoolProperties {
-    IdRef frontendIPConfiguration
-    String protocol
-    int frontendPortRangeStart
-    int frontendPortRangeEnd
-    int backendPort
-
-    InboundNatPoolProperties(AzureInboundPortConfig inboundPortConfig) {
-      frontendIPConfiguration = new IdRef("[variables('frontEndIPConfigID')]")
-      protocol = inboundPortConfig.protocol
-      frontendPortRangeStart = inboundPortConfig.frontEndPortRangeStart
-      frontendPortRangeEnd = inboundPortConfig.frontEndPortRangeEnd
-      backendPort = inboundPortConfig.backendPort
-    }
-  }
-/*
-  static class PublicIpResource extends Resource {
-
-    PublicIpResource() {
-      apiVersion = '2015-06-15'
-      name = '''[variables('publicIpAddressName')]'''
-      type = '''Microsoft.Network/publicIPAddresses'''
-      location = "[parameters('${locationParameterName}')]"
-    }
-    PublicIPPropertiesWithDns properties = new PublicIPPropertiesWithDns()
-  }
-
-  static class PublicIPProperties {
-    String publicIPAllocationMethod = '''[variables('publicIpAddressType')]'''
-    DnsSettings dnsSettings = new DnsSettings()
-  }
-
-  static class DnsSettings {
-    String domainNameLabel = '''[variables('dnsNameForLBIP')]'''
-  }
-*/
 }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/AzureServerGroupResourceTemplateSpec.groovy
@@ -188,16 +188,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
-    "publicIPAddressName" : "pip-azureMASM-st1-d11",
-    "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
-    "publicIPAddressType" : "Dynamic",
-    "dnsNameForLBIP" : "dns-azuremasm-st1-d11",
-    "loadBalancerBackend" : "be-azureMASM-st1-d11",
-    "loadBalancerFrontEnd" : "fe-azureMASM-st1-d11",
-    "loadBalancerName" : "lb-azureMASM-st1-d11",
-    "loadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
-    "frontEndIPConfigID" : "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/', variables('loadBalancerName'), variables('loadBalancerFrontEnd'))]",
-    "inboundNatPoolName" : "np-azureMASM-st1-d11",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -230,57 +220,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   }, {
     "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('publicIPAddressName')]",
-    "type" : "Microsoft.Network/publicIPAddresses",
-    "location" : "[parameters('location')]",
-    "tags" : null,
-    "properties" : {
-      "publicIPAllocationMethod" : "[variables('publicIPAddressType')]",
-      "dnsSettings" : {
-        "domainNameLabel" : "[variables('dnsNameForLBIP')]"
-      }
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('loadBalancerName')]",
-    "type" : "Microsoft.Network/loadBalancers",
-    "location" : "[parameters('location')]",
-    "tags" : {
-      "appName" : "azureMASM",
-      "stack" : "st1",
-      "detail" : "d11",
-      "createdTime" : "1234567890",
-      "cluster" : "azureMASM-st1-d11",
-      "serverGroup" : "azureMASM-st1-d11"
-    },
-    "dependsOn" : [ "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]" ],
-    "properties" : {
-      "frontendIPConfigurations" : [ {
-        "name" : "[variables('loadBalancerFrontEnd')]",
-        "properties" : {
-          "publicIpAddress" : {
-            "id" : "[variables('publicIPAddressID')]"
-          }
-        }
-      } ],
-      "backendAddressPools" : [ {
-        "name" : "[variables('loadBalancerBackEnd')]"
-      } ],
-      "inboundNatPools" : [ {
-        "name" : "InboundPortConfig",
-        "properties" : {
-          "frontendIPConfiguration" : {
-            "id" : "[variables('frontEndIPConfigID')]"
-          },
-          "protocol" : "tcp",
-          "frontendPortRangeStart" : 50000,
-          "frontendPortRangeEnd" : 50099,
-          "backendPort" : 3389
-        }
-      } ]
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
     "name" : "azureMASM-st1-d11",
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
@@ -290,12 +229,11 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "detail" : "d11",
       "cluster" : "azureMASM-st1-d11",
       "createdTime" : "1234567890",
-      "loadBalancerName" : "lb-azureMASM-st1-d11",
       "hasNewSubnet" : "false",
       "imageIsCustom" : "false",
       "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]"
     },
-    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]", "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]" ],
+    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]" ],
     "sku" : {
       "name" : "Standard_A1",
       "tier" : "Standard",
@@ -331,12 +269,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
-                  "loadBalancerBackendAddressPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('loadBalancerBackend'))]"
-                  } ],
-                  "loadBalancerInboundNatPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('inboundNatPoolName'))]"
-                  } ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -393,70 +325,9 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01",
-    "publicIPAddressName" : "pip-azureMASM-st1-d11",
-    "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
-    "publicIPAddressType" : "Dynamic",
-    "dnsNameForLBIP" : "dns-azuremasm-st1-d11",
-    "loadBalancerBackend" : "be-azureMASM-st1-d11",
-    "loadBalancerFrontEnd" : "fe-azureMASM-st1-d11",
-    "loadBalancerName" : "lb-azureMASM-st1-d11",
-    "loadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
-    "frontEndIPConfigID" : "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/', variables('loadBalancerName'), variables('loadBalancerFrontEnd'))]",
-    "inboundNatPoolName" : "np-azureMASM-st1-d11"
+    "apiVersion" : "2018-10-01"
   },
   "resources" : [ {
-    "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('publicIPAddressName')]",
-    "type" : "Microsoft.Network/publicIPAddresses",
-    "location" : "[parameters('location')]",
-    "tags" : null,
-    "properties" : {
-      "publicIPAllocationMethod" : "[variables('publicIPAddressType')]",
-      "dnsSettings" : {
-        "domainNameLabel" : "[variables('dnsNameForLBIP')]"
-      }
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('loadBalancerName')]",
-    "type" : "Microsoft.Network/loadBalancers",
-    "location" : "[parameters('location')]",
-    "tags" : {
-      "appName" : "azureMASM",
-      "stack" : "st1",
-      "detail" : "d11",
-      "createdTime" : "1234567890",
-      "cluster" : "azureMASM-st1-d11",
-      "serverGroup" : "azureMASM-st1-d11"
-    },
-    "dependsOn" : [ "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]" ],
-    "properties" : {
-      "frontendIPConfigurations" : [ {
-        "name" : "[variables('loadBalancerFrontEnd')]",
-        "properties" : {
-          "publicIpAddress" : {
-            "id" : "[variables('publicIPAddressID')]"
-          }
-        }
-      } ],
-      "backendAddressPools" : [ {
-        "name" : "[variables('loadBalancerBackEnd')]"
-      } ],
-      "inboundNatPools" : [ {
-        "name" : "InboundPortConfig",
-        "properties" : {
-          "frontendIPConfiguration" : {
-            "id" : "[variables('frontEndIPConfigID')]"
-          },
-          "protocol" : "tcp",
-          "frontendPortRangeStart" : 50000,
-          "frontendPortRangeEnd" : 50099,
-          "backendPort" : 22
-        }
-      } ]
-    }
-  }, {
     "apiVersion" : "[variables('apiVersion')]",
     "name" : "azureMASM-st1-d11",
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
@@ -467,11 +338,10 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "detail" : "d11",
       "cluster" : "azureMASM-st1-d11",
       "createdTime" : "1234567890",
-      "loadBalancerName" : "lb-azureMASM-st1-d11",
       "hasNewSubnet" : "false",
       "imageIsCustom" : "true"
     },
-    "dependsOn" : [ "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]" ],
+    "dependsOn" : [ ],
     "sku" : {
       "name" : "Standard_A1",
       "tier" : "Standard",
@@ -503,12 +373,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
-                  "loadBalancerBackendAddressPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('loadBalancerBackend'))]"
-                  } ],
-                  "loadBalancerInboundNatPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('inboundNatPoolName'))]"
-                  } ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -566,16 +430,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
-    "publicIPAddressName" : "pip-azureMASM-st1-d11",
-    "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
-    "publicIPAddressType" : "Dynamic",
-    "dnsNameForLBIP" : "dns-azuremasm-st1-d11",
-    "loadBalancerBackend" : "be-azureMASM-st1-d11",
-    "loadBalancerFrontEnd" : "fe-azureMASM-st1-d11",
-    "loadBalancerName" : "lb-azureMASM-st1-d11",
-    "loadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
-    "frontEndIPConfigID" : "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/', variables('loadBalancerName'), variables('loadBalancerFrontEnd'))]",
-    "inboundNatPoolName" : "np-azureMASM-st1-d11",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -608,57 +462,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   }, {
     "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('publicIPAddressName')]",
-    "type" : "Microsoft.Network/publicIPAddresses",
-    "location" : "[parameters('location')]",
-    "tags" : null,
-    "properties" : {
-      "publicIPAllocationMethod" : "[variables('publicIPAddressType')]",
-      "dnsSettings" : {
-        "domainNameLabel" : "[variables('dnsNameForLBIP')]"
-      }
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('loadBalancerName')]",
-    "type" : "Microsoft.Network/loadBalancers",
-    "location" : "[parameters('location')]",
-    "tags" : {
-      "appName" : "azureMASM",
-      "stack" : "st1",
-      "detail" : "d11",
-      "createdTime" : "1234567890",
-      "cluster" : "azureMASM-st1-d11",
-      "serverGroup" : "azureMASM-st1-d11"
-    },
-    "dependsOn" : [ "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]" ],
-    "properties" : {
-      "frontendIPConfigurations" : [ {
-        "name" : "[variables('loadBalancerFrontEnd')]",
-        "properties" : {
-          "publicIpAddress" : {
-            "id" : "[variables('publicIPAddressID')]"
-          }
-        }
-      } ],
-      "backendAddressPools" : [ {
-        "name" : "[variables('loadBalancerBackEnd')]"
-      } ],
-      "inboundNatPools" : [ {
-        "name" : "InboundPortConfig",
-        "properties" : {
-          "frontendIPConfiguration" : {
-            "id" : "[variables('frontEndIPConfigID')]"
-          },
-          "protocol" : "tcp",
-          "frontendPortRangeStart" : 50000,
-          "frontendPortRangeEnd" : 50099,
-          "backendPort" : 22
-        }
-      } ]
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
     "name" : "azureMASM-st1-d11",
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
@@ -668,12 +471,11 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "detail" : "d11",
       "cluster" : "azureMASM-st1-d11",
       "createdTime" : "1234567890",
-      "loadBalancerName" : "lb-azureMASM-st1-d11",
       "hasNewSubnet" : "false",
       "imageIsCustom" : "false",
       "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]"
     },
-    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]", "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]" ],
+    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]" ],
     "sku" : {
       "name" : "Standard_A1",
       "tier" : "Standard",
@@ -709,12 +511,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
-                  "loadBalancerBackendAddressPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('loadBalancerBackend'))]"
-                  } ],
-                  "loadBalancerInboundNatPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('inboundNatPoolName'))]"
-                  } ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -787,16 +583,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
-    "publicIPAddressName" : "pip-azureMASM-st1-d11",
-    "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
-    "publicIPAddressType" : "Dynamic",
-    "dnsNameForLBIP" : "dns-azuremasm-st1-d11",
-    "loadBalancerBackend" : "be-azureMASM-st1-d11",
-    "loadBalancerFrontEnd" : "fe-azureMASM-st1-d11",
-    "loadBalancerName" : "lb-azureMASM-st1-d11",
-    "loadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
-    "frontEndIPConfigID" : "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/', variables('loadBalancerName'), variables('loadBalancerFrontEnd'))]",
-    "inboundNatPoolName" : "np-azureMASM-st1-d11",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -829,57 +615,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   }, {
     "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('publicIPAddressName')]",
-    "type" : "Microsoft.Network/publicIPAddresses",
-    "location" : "[parameters('location')]",
-    "tags" : null,
-    "properties" : {
-      "publicIPAllocationMethod" : "[variables('publicIPAddressType')]",
-      "dnsSettings" : {
-        "domainNameLabel" : "[variables('dnsNameForLBIP')]"
-      }
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('loadBalancerName')]",
-    "type" : "Microsoft.Network/loadBalancers",
-    "location" : "[parameters('location')]",
-    "tags" : {
-      "appName" : "azureMASM",
-      "stack" : "st1",
-      "detail" : "d11",
-      "createdTime" : "1234567890",
-      "cluster" : "azureMASM-st1-d11",
-      "serverGroup" : "azureMASM-st1-d11"
-    },
-    "dependsOn" : [ "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]" ],
-    "properties" : {
-      "frontendIPConfigurations" : [ {
-        "name" : "[variables('loadBalancerFrontEnd')]",
-        "properties" : {
-          "publicIpAddress" : {
-            "id" : "[variables('publicIPAddressID')]"
-          }
-        }
-      } ],
-      "backendAddressPools" : [ {
-        "name" : "[variables('loadBalancerBackEnd')]"
-      } ],
-      "inboundNatPools" : [ {
-        "name" : "InboundPortConfig",
-        "properties" : {
-          "frontendIPConfiguration" : {
-            "id" : "[variables('frontEndIPConfigID')]"
-          },
-          "protocol" : "tcp",
-          "frontendPortRangeStart" : 50000,
-          "frontendPortRangeEnd" : 50099,
-          "backendPort" : 3389
-        }
-      } ]
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
     "name" : "azureMASM-st1-d11",
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
@@ -889,12 +624,11 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "detail" : "d11",
       "cluster" : "azureMASM-st1-d11",
       "createdTime" : "1234567890",
-      "loadBalancerName" : "lb-azureMASM-st1-d11",
       "hasNewSubnet" : "false",
       "imageIsCustom" : "false",
       "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]"
     },
-    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]", "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]" ],
+    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]" ],
     "sku" : {
       "name" : "Standard_A1",
       "tier" : "Standard",
@@ -930,12 +664,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
-                  "loadBalancerBackendAddressPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('loadBalancerBackend'))]"
-                  } ],
-                  "loadBalancerInboundNatPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('inboundNatPoolName'))]"
-                  } ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -1008,16 +736,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
-    "publicIPAddressName" : "pip-azureMASM-st1-d11",
-    "publicIPAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
-    "publicIPAddressType" : "Dynamic",
-    "dnsNameForLBIP" : "dns-azuremasm-st1-d11",
-    "loadBalancerBackend" : "be-azureMASM-st1-d11",
-    "loadBalancerFrontEnd" : "fe-azureMASM-st1-d11",
-    "loadBalancerName" : "lb-azureMASM-st1-d11",
-    "loadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
-    "frontEndIPConfigID" : "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/', variables('loadBalancerName'), variables('loadBalancerFrontEnd'))]",
-    "inboundNatPoolName" : "np-azureMASM-st1-d11",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -1050,57 +768,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   }, {
     "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('publicIPAddressName')]",
-    "type" : "Microsoft.Network/publicIPAddresses",
-    "location" : "[parameters('location')]",
-    "tags" : null,
-    "properties" : {
-      "publicIPAllocationMethod" : "[variables('publicIPAddressType')]",
-      "dnsSettings" : {
-        "domainNameLabel" : "[variables('dnsNameForLBIP')]"
-      }
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
-    "name" : "[variables('loadBalancerName')]",
-    "type" : "Microsoft.Network/loadBalancers",
-    "location" : "[parameters('location')]",
-    "tags" : {
-      "appName" : "azureMASM",
-      "stack" : "st1",
-      "detail" : "d11",
-      "createdTime" : "1234567890",
-      "cluster" : "azureMASM-st1-d11",
-      "serverGroup" : "azureMASM-st1-d11"
-    },
-    "dependsOn" : [ "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]" ],
-    "properties" : {
-      "frontendIPConfigurations" : [ {
-        "name" : "[variables('loadBalancerFrontEnd')]",
-        "properties" : {
-          "publicIpAddress" : {
-            "id" : "[variables('publicIPAddressID')]"
-          }
-        }
-      } ],
-      "backendAddressPools" : [ {
-        "name" : "[variables('loadBalancerBackEnd')]"
-      } ],
-      "inboundNatPools" : [ {
-        "name" : "InboundPortConfig",
-        "properties" : {
-          "frontendIPConfiguration" : {
-            "id" : "[variables('frontEndIPConfigID')]"
-          },
-          "protocol" : "tcp",
-          "frontendPortRangeStart" : 50000,
-          "frontendPortRangeEnd" : 50099,
-          "backendPort" : 22
-        }
-      } ]
-    }
-  }, {
-    "apiVersion" : "[variables('apiVersion')]",
     "name" : "azureMASM-st1-d11",
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
@@ -1110,12 +777,11 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
       "detail" : "d11",
       "cluster" : "azureMASM-st1-d11",
       "createdTime" : "1234567890",
-      "loadBalancerName" : "lb-azureMASM-st1-d11",
       "hasNewSubnet" : "false",
       "imageIsCustom" : "false",
       "storageAccountNames" : "[concat(uniqueString(concat(resourceGroup().id, subscription().id, 'azuremasmst1d11', '0')), 'sa')]"
     },
-    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]", "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]" ],
+    "dependsOn" : [ "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageNameArray')[0])]" ],
     "sku" : {
       "name" : "Standard_A1",
       "tier" : "Standard",
@@ -1152,12 +818,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
-                  "loadBalancerBackendAddressPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('loadBalancerBackend'))]"
-                  } ],
-                  "loadBalancerInboundNatPools" : [ {
-                    "id" : "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('inboundNatPoolName'))]"
-                  } ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]


### PR DESCRIPTION
Currently Azure Application Gateway is already playing the role of Spinnaker Load Balancer, so it means the App Gateway can directly point to Server Groups (Azure VM Scale Set). While currently within the VMSS there is still Azure Load Balancer created, which we believe is redundant so we remove it. 