### PR TITLE
fix(provider/appengine): Fix NPE thrown when deploying GCS object usi…

### DIFF
--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
@@ -75,7 +75,7 @@ public class GcsStorageService {
 
     private GoogleCredential loadCredential(String credentialsPath) throws IOException {
       GoogleCredential credential;
-      if (!credentialsPath.isEmpty()) {
+      if (credentialsPath != null && !credentialsPath.isEmpty()) {
         FileInputStream stream = new FileInputStream(credentialsPath);
         credential = GoogleCredential.fromStream(stream, transport_, jsonFactory_)
           .createScoped(Collections.singleton(StorageScopes.DEVSTORAGE_READ_ONLY));


### PR DESCRIPTION
…ng default creds

Fixes https://github.com/spinnaker/spinnaker/issues/3975