### PR TITLE
feat(eureka): store instance to eureka health relationships

### DIFF
--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/agent/EurekaCachingAgent.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/agent/EurekaCachingAgent.groovy
@@ -114,8 +114,10 @@ class EurekaCachingAgent implements CachingAgent, HealthProvidingCachingAgent, C
               String instanceKey = provider.getInstanceKey(attributes, region)
               if (instanceKey) {
                 String instanceHealthKey = provider.getInstanceHealthKey(attributes, region, healthId)
-                Map<String, Collection<String>> relationships = [(INSTANCES.ns): [instanceKey]]
-                eurekaCacheData.add(new DefaultCacheData(instanceHealthKey, attributes, relationships))
+                Map<String, Collection<String>> healthRelationship = [(INSTANCES.ns): [instanceKey]]
+                Map<String, Collection<String>> instanceRelationship = [(HEALTH.ns): [instanceHealthKey]]
+                eurekaCacheData.add(new DefaultCacheData(instanceHealthKey, attributes, healthRelationship))
+                instanceCacheData.add(new DefaultCacheData(instanceKey, Collections.emptyMap(), instanceRelationship))
               }
             }
           }


### PR DESCRIPTION
- with a relational cache provider, storing instance -> health relationships (as is already done by other HealthProvidingCachingAgent's) allows loading serverGroups with instance and health data without having to predetermine instance or health keys.
