### PR TITLE
refactor(artifacts): Clean up Spring dependency injection

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
@@ -33,7 +33,7 @@ public class ArtifactCredentialsRepository {
   @Getter
   private final List<ArtifactCredentials> allCredentials;
 
-  ArtifactCredentialsRepository(List<List<? extends ArtifactCredentials>> allCredentials) {
+  public ArtifactCredentialsRepository(List<List<? extends ArtifactCredentials>> allCredentials) {
     this.allCredentials = Collections.unmodifiableList(
       allCredentials.stream()
         .filter(Objects::nonNull)

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
@@ -18,21 +18,48 @@
 package com.netflix.spinnaker.clouddriver.artifacts;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Component
 public class ArtifactCredentialsRepository {
-  private final List<ArtifactCredentials> allCredentials = new CopyOnWriteArrayList<>();
+  @Getter
+  private final List<ArtifactCredentials> allCredentials;
 
-  public void save(ArtifactCredentials credentials) {
-    allCredentials.add(credentials);
+  ArtifactCredentialsRepository(List<List<? extends ArtifactCredentials>> allCredentials) {
+    this.allCredentials = Collections.unmodifiableList(
+      allCredentials.stream()
+        .filter(Objects::nonNull)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList())
+    );
   }
 
-  public List<ArtifactCredentials> getAllCredentials() {
-    return Collections.unmodifiableList(allCredentials);
+  public ArtifactCredentials getCredentials(String accountName) {
+    return getAllCredentials()
+      .stream()
+      .filter(e -> e.getName().equals(accountName))
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("No credentials with name '" + accountName + "' could be found."));
+  }
+
+  public ArtifactCredentials getCredentials(String accountName, String type) {
+    if (StringUtils.isEmpty(accountName)) {
+      throw new IllegalArgumentException("An artifact account must be supplied to download this artifact: " + accountName);
+    }
+
+    ArtifactCredentials credentials = getCredentials(accountName);
+    if (!credentials.handlesType(type)) {
+      throw new IllegalArgumentException("Artifact credentials '" + accountName + "' cannot handle artifacts of type '" + type + "'");
+    }
+
+    return credentials;
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactDownloader.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactDownloader.java
@@ -17,42 +17,21 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 @Component
+@RequiredArgsConstructor
 public class ArtifactDownloader {
   final private ArtifactCredentialsRepository artifactCredentialsRepository;
 
-  @Autowired
-  public ArtifactDownloader(ArtifactCredentialsRepository artifactCredentialsRepository, ObjectMapper objectMapper) {
-    this.artifactCredentialsRepository = artifactCredentialsRepository;
-  }
-
   public InputStream download(Artifact artifact) throws IOException {
-    String artifactAccount = artifact.getArtifactAccount();
-    if (StringUtils.isEmpty(artifactAccount)) {
-      throw new IllegalArgumentException("An artifact account must be supplied to download this artifact: " + artifactAccount);
-    }
-
-    ArtifactCredentials credentials = artifactCredentialsRepository.getAllCredentials()
-        .stream()
-        .filter(c -> c.getName().equals(artifactAccount))
-        .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("No credentials with name '" + artifactAccount + "' could be found."));
-
-    if (!credentials.handlesType(artifact.getType())) {
-      throw new IllegalArgumentException("Artifact credentials '" + artifactAccount + "' cannot handle artifacts of type '" + artifact.getType() + "'");
-    }
-
-    return credentials.download(artifact);
+    return artifactCredentialsRepository
+      .getCredentials(artifact.getArtifactAccount(), artifact.getType())
+      .download(artifact);
   }
-
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactConfiguration.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.bitbucket;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import com.squareup.okhttp.OkHttpClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,22 +36,14 @@ import java.util.stream.Collectors;
 @Slf4j
 public class BitbucketArtifactConfiguration {
   private final BitbucketArtifactProviderProperties bitbucketArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Bean
-  OkHttpClient bitbucketOkHttpClient() {
-    return new OkHttpClient();
-  }
-
-  @Bean
-  List<? extends BitbucketArtifactCredentials> bitbucketArtifactCredentials(OkHttpClient bitbucketOkHttpClient) {
+  List<? extends BitbucketArtifactCredentials> bitbucketArtifactCredentials(OkHttpClient okHttpClient) {
     return bitbucketArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {
         try {
-          BitbucketArtifactCredentials c = new BitbucketArtifactCredentials(a, bitbucketOkHttpClient);
-          artifactCredentialsRepository.save(c);
-          return c;
+          return new BitbucketArtifactCredentials(a, okHttpClient);
         } catch (Exception e) {
           log.warn("Failure instantiating Bitbucket artifact account {}: ", a, e);
           return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactConfiguration.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.embedded;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -30,14 +29,10 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class EmbeddedArtifactConfiguration {
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
-
   @Bean
-  List<? extends EmbeddedArtifactAccount> embeddedArtifactAccounts() {
+  List<? extends EmbeddedArtifactCredentials> embeddedArtifactCredentials() {
     EmbeddedArtifactAccount account = new EmbeddedArtifactAccount();
     EmbeddedArtifactCredentials credentials = new EmbeddedArtifactCredentials(account);
-    artifactCredentialsRepository.save(credentials);
-
-    return Collections.singletonList(account);
+    return Collections.singletonList(credentials);
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactConfiguration.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.artifacts.front50;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,13 +30,9 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class Front50ArtifactConfiguration {
-
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
-
   @Bean
   List<? extends Front50ArtifactCredentials> front50ArtifactCredentials(ObjectMapper objectMapper, Front50Service front50Service) {
     Front50ArtifactCredentials c = new Front50ArtifactCredentials(objectMapper, front50Service);
-    artifactCredentialsRepository.save(c);
     return Collections.singletonList(c);
   }
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactConfiguration.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.gcs;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -38,7 +37,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class GcsArtifactConfiguration {
   private final GcsArtifactProviderProperties gcsArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Bean
   List<? extends GcsArtifactCredentials> gcsArtifactCredentials(String clouddriverUserAgentApplicationName) {
@@ -46,9 +44,7 @@ public class GcsArtifactConfiguration {
         .stream()
         .map(a -> {
           try {
-            GcsArtifactCredentials c = new GcsArtifactCredentials(clouddriverUserAgentApplicationName, a);
-            artifactCredentialsRepository.save(c);
-            return c;
+            return new GcsArtifactCredentials(clouddriverUserAgentApplicationName, a);
           } catch (IOException | GeneralSecurityException e) {
             log.warn("Failure instantiating gcs artifact account {}: ", a, e);
             return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactConfiguration.java
@@ -18,7 +18,6 @@
 package com.netflix.spinnaker.clouddriver.artifacts.github;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import com.squareup.okhttp.OkHttpClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,23 +37,15 @@ import java.util.stream.Collectors;
 @Slf4j
 public class GitHubArtifactConfiguration {
   private final GitHubArtifactProviderProperties gitHubArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
   private final ObjectMapper objectMapper;
 
   @Bean
-  OkHttpClient gitHubOkHttpClient() {
-    return new OkHttpClient();
-  }
-
-  @Bean
-  List<? extends GitHubArtifactCredentials> gitHubArtifactCredentials(OkHttpClient gitHubOkHttpClient) {
+  List<? extends GitHubArtifactCredentials> gitHubArtifactCredentials(OkHttpClient okHttpClient) {
     return gitHubArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {
         try {
-          GitHubArtifactCredentials c = new GitHubArtifactCredentials(a, gitHubOkHttpClient, objectMapper);
-          artifactCredentialsRepository.save(c);
-          return c;
+          return new GitHubArtifactCredentials(a, okHttpClient, objectMapper);
         } catch (Exception e) {
           log.warn("Failure instantiating GitHub artifact account {}: ", a, e);
           return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactConfiguration.java
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.gitlab;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import com.squareup.okhttp.OkHttpClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,23 +35,14 @@ import java.util.stream.Collectors;
 @Slf4j
 public class GitlabArtifactConfiguration {
   private final GitlabArtifactProviderProperties gitlabArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
-  private final ObjectMapper objectMapper;
 
   @Bean
-  OkHttpClient gitlabOkHttpClient() {
-    return new OkHttpClient();
-  }
-
-  @Bean
-  List<? extends GitlabArtifactCredentials> gitlabArtifactCredentials(OkHttpClient gitlabOkHttpClient) {
+  List<? extends GitlabArtifactCredentials> gitlabArtifactCredentials(OkHttpClient okHttpClient) {
     return gitlabArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {
         try {
-          GitlabArtifactCredentials c = new GitlabArtifactCredentials(a, gitlabOkHttpClient);
-          artifactCredentialsRepository.save(c);
-          return c;
+          return new GitlabArtifactCredentials(a, okHttpClient);
         } catch (Exception e) {
           log.warn("Failure instantiating Gitlab artifact account {}: ", a, e);
           return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactConfiguration.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.helm;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import com.squareup.okhttp.OkHttpClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,23 +36,15 @@ import java.util.stream.Collectors;
 @Slf4j
 public class HelmArtifactConfiguration {
   private final HelmArtifactProviderProperties helmArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Bean
-  OkHttpClient helmOkHttpClient() {
-    return new OkHttpClient();
-  }
-
-  @Bean
-  List<? extends HelmArtifactCredentials> helmArtifactCredentials(OkHttpClient helmOkHttpClient) {
+  List<? extends HelmArtifactCredentials> helmArtifactCredentials(OkHttpClient okHttpClient) {
 
     return helmArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {
         try {
-          HelmArtifactCredentials c = new HelmArtifactCredentials(a, helmOkHttpClient);
-          artifactCredentialsRepository.save(c);
-          return c;
+          return new HelmArtifactCredentials(a, okHttpClient);
         } catch (Exception e) {
           log.warn("Failure instantiating Helm artifact account {}: ", a, e);
           return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.ivy;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,7 +34,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class IvyArtifactConfiguration {
   private final IvyArtifactProviderProperties ivyArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Bean
   List<? extends IvyArtifactCredentials> ivyArtifactCredentials() {
@@ -43,9 +41,7 @@ public class IvyArtifactConfiguration {
       .stream()
       .map(a -> {
         try {
-          IvyArtifactCredentials c = new IvyArtifactCredentials(a);
-          artifactCredentialsRepository.save(c);
-          return c;
+          return new IvyArtifactCredentials(a);
         } catch (Exception e) {
           log.warn("Failure instantiating ivy artifact account {}: ", a, e);
           return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.maven;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,7 +34,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class MavenArtifactConfiguration {
   private final MavenArtifactProviderProperties mavenArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Bean
   List<? extends MavenArtifactCredentials> mavenArtifactCredentials() {
@@ -43,9 +41,7 @@ public class MavenArtifactConfiguration {
       .stream()
       .map(a -> {
         try {
-          MavenArtifactCredentials c = new MavenArtifactCredentials(a);
-          artifactCredentialsRepository.save(c);
-          return c;
+          return new MavenArtifactCredentials(a);
         } catch (Exception e) {
           log.warn("Failure instantiating maven artifact account {}: ", a, e);
           return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactConfiguration.java
@@ -9,7 +9,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.oracle;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,7 +27,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class OracleArtifactConfiguration {
   private  final OracleArtifactProviderProperties oracleArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Bean
   List<? extends OracleArtifactCredentials> oracleArtifactCredentials(String clouddriverUserAgentApplicationName) {
@@ -36,9 +34,7 @@ public class OracleArtifactConfiguration {
             .stream()
             .map(a -> {
               try {
-                OracleArtifactCredentials c = new OracleArtifactCredentials(clouddriverUserAgentApplicationName, a);
-                artifactCredentialsRepository.save(c);
-                return c;
+                return new OracleArtifactCredentials(clouddriverUserAgentApplicationName, a);
               } catch (Exception e) {
                 log.warn("Failure instantiating oracle artifact account {}: ", a, e);
                 return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.s3;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,7 +34,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class S3ArtifactConfiguration {
   private final S3ArtifactProviderProperties s3ArtifactProviderProperties;
-  private final ArtifactCredentialsRepository artifactCredentialsRepository;
 
   @Bean
   List<? extends S3ArtifactCredentials> s3ArtifactCredentials() {
@@ -43,9 +41,7 @@ public class S3ArtifactConfiguration {
       .stream()
       .map(a -> {
         try {
-          S3ArtifactCredentials c = new S3ArtifactCredentials(a);
-          artifactCredentialsRepository.save(c);
-          return c;
+          return new S3ArtifactCredentials(a);
         } catch (IllegalArgumentException e) {
           log.warn("Failure instantiating s3 artifact account {}: ", a, e);
           return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/config/ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/config/ArtifactConfiguration.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.config;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactCredentialsRepository;
+import com.squareup.okhttp.OkHttpClient;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 @ComponentScan("com.netflix.spinnaker.clouddriver.artifacts")
 public class ArtifactConfiguration {
   @Bean
-  ArtifactCredentialsRepository artifactCredentialsRepository() {
-    return new ArtifactCredentialsRepository();
+  OkHttpClient okHttpClient() {
+    return new OkHttpClient();
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -70,15 +70,16 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
   }
 
   private List<String> accounts = List.of("test", "sourceAccount", "sourceAccount1", "sourceAccount2", "destinationAccount");
-  private final ArtifactCredentialsRepository artifactCredentialsRepository = new ArtifactCredentialsRepository();
 
-  {
-    accounts.toStream().forEach(account -> artifactCredentialsRepository.save(new ArtifactCredentialsFromString(
-      account,
-      List.of("a").asJava(),
-      "applications: [{instances: 42}]"
-    )));
-  }
+  private final ArtifactCredentialsRepository artifactCredentialsRepository = new ArtifactCredentialsRepository(
+    Collections.singletonList(
+      accounts.map(account -> new ArtifactCredentialsFromString(
+        account,
+        List.of("a").asJava(),
+        "applications: [{instances: 42}]"
+      )).asJava()
+    )
+  );
 
   private final AccountCredentialsRepository accountCredentialsRepository = new MapBackedAccountCredentialsRepository();
 

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
@@ -71,21 +71,21 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
     }
   };
 
-  private final ArtifactCredentialsRepository artifactCredentialsRepository = new ArtifactCredentialsRepository();
-
-  {
-    artifactCredentialsRepository.save(new ArtifactCredentialsFromString(
-      "test",
-      List.of("a").asJava(),
-      "service_instance_name: my-service-instance-name\n" +
-        "service: my-service\n" +
-        "service_plan: my-service-plan\n" +
-        "tags:\n" +
-        "- tag1\n" +
-        "parameters: |\n" +
-        "  { \"foo\": \"bar\" }\n"
-    ));
-  }
+  private final ArtifactCredentialsRepository artifactCredentialsRepository = new ArtifactCredentialsRepository(
+    Collections.singletonList(
+      Collections.singletonList(new ArtifactCredentialsFromString(
+        "test",
+        List.of("a").asJava(),
+        "service_instance_name: my-service-instance-name\n" +
+          "service: my-service\n" +
+          "service_plan: my-service-plan\n" +
+          "tags:\n" +
+          "- tag1\n" +
+          "parameters: |\n" +
+          "  { \"foo\": \"bar\" }\n"
+      ))
+    )
+  );
 
   private final AccountCredentialsRepository accountCredentialsRepository = new MapBackedAccountCredentialsRepository();
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
@@ -68,10 +68,7 @@ public class ArtifactController {
   @RequestMapping(method = RequestMethod.GET, value = "/account/{accountName}/names")
   List<String> getNames(@PathVariable("accountName") String accountName,
                         @RequestParam(value = "type") String type) {
-    ArtifactCredentials credentials = findArtifactCredentials(accountName);
-    if (!credentials.handlesType(type)) {
-      throw new IllegalArgumentException("Artifact credentials '" + accountName + "' cannot handle artifacts of type '" + type + "'");
-    }
+    ArtifactCredentials credentials = artifactCredentialsRepository.getCredentials(accountName, type);
     return credentials.getArtifactNames();
   }
 
@@ -79,18 +76,7 @@ public class ArtifactController {
   List<String> getVersions(@PathVariable("accountName") String accountName,
                            @RequestParam(value = "type") String type,
                            @RequestParam(value = "artifactName") String artifactName) {
-    ArtifactCredentials credentials = findArtifactCredentials(accountName);
-    if (!credentials.handlesType(type)) {
-      throw new IllegalArgumentException("Artifact credentials '" + accountName + "' cannot handle artifacts of type '" + type + "'");
-    }
+    ArtifactCredentials credentials = artifactCredentialsRepository.getCredentials(accountName, type);
     return credentials.getArtifactVersions(artifactName);
-  }
-
-  private ArtifactCredentials findArtifactCredentials(String accountName) {
-    return artifactCredentialsRepository.getAllCredentials()
-      .stream()
-      .filter(e -> e.getName().equals(accountName))
-      .findFirst()
-      .orElseThrow(() -> new IllegalArgumentException("No credentials with name '" + accountName + "' could be found."));
   }
 }


### PR DESCRIPTION
Each artifact type creates its own okHttpClient; just create a single one that is autowired into each.

Instead of having the individual types depend on the repository and modify it, have the repository depend on the individual artifact types. It can then just create a list from these injected types.

Improve the interface of artifactCredentialsRepository. Most calls to getAllCredentials filter based on name and/or type; add this filtering as a supported function in the interface and clean up the calling code.