### PR TITLE
fix(search/cats): Avoid short-circuiting when filters are empty.

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -226,7 +226,7 @@ class CatsSearchProvider implements SearchProvider, Runnable {
 
   private List<String> findMatches(String q, List<String> cachesToQuery, Map<String, String> filters) {
 
-    if (!q && keyParsers) {
+    if (!q && keyParsers && filters) {
       // no keyword search so find sensible default value to set for searching
       Set<String> filterKeys = filters.keySet()
       keyParsers.find {


### PR DESCRIPTION
Avoids a bad path where cats tries to optimize the search q by looking for things in the filters. If filters are empty this always short-circuits and returns an empty result list.
