### PR TITLE
fix(kubernetes): return only valid kinds from UnregisteredCrdCachingA…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -63,6 +63,8 @@ public class KubernetesUnregisteredCustomResourceCachingAgent extends Kubernetes
 
   @Override
   protected List<KubernetesKind> primaryKinds() {
-    return credentials.getCrds();
+    return credentials.getCrds().stream()
+      .filter(credentials::isValidKind)
+      .collect(Collectors.toList());
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -385,10 +385,6 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         .map(KubernetesManifest::getName)
         .collect(Collectors.toList()), namespaceExpirySeconds, TimeUnit.SECONDS);
 
-    if (checkPermissionsOnStartup) {
-      determineOmitKinds();
-    }
-
     this.liveCrdSupplier = Suppliers.memoizeWithExpiration(() -> {
       try {
         return this.list(KubernetesKind.CUSTOM_RESOURCE_DEFINITION, "")
@@ -410,6 +406,10 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
     // ensure this is called at least once before the credentials object is created to ensure all crds are registered
     this.liveCrdSupplier.get();
+
+    if (checkPermissionsOnStartup) {
+      determineOmitKinds();
+    }
   }
 
   public List<KubernetesKind> getCrds() {


### PR DESCRIPTION
…gent.primaryKinds

(Hopefully) closes https://github.com/spinnaker/spinnaker/issues/3972

I attempted to reproduce #3972 by enabling a service account w/ RBAC that excluded permissions for a CRD I had previously deployed to a cluster I manage with Spinnaker, and not added to the whitelisted `kinds` in my hal config. Since I could not reproduce the exact errors specified in #3972, my best guess is that at least the first error originated from the following sequence of events in Clouddriver:
`KubernetesV2CachingAgent.loadPrimaryResourceList` calls `KubernetesV2Credentials.list` with the kinds returned from `KubernetesUnregisteredCustomResourceCachingAgent.primaryKinds`, which does not filter by valid kinds. Since we _do_ filter by valid kinds in `KubernetesCoreCachingAgent.primaryKinds`, my guess is that we should do the same here and not be doing anything with non-whitelisted CRDs.

Apologies for bothering you @lwander but since the issue mentions that you had believed this issue to already be resolved, would love your input if you have a second. Thanks!