### PR TITLE
fix(openstack): Fix openstack unit tests

### DIFF
--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackIdentityV3ProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackIdentityV3ProviderSpec.groovy
@@ -55,7 +55,6 @@ class OpenstackIdentityV3ProviderSpec extends Specification {
     mockClient = Mock(OSClient.OSClientV3) {
       getToken() >> { Mock(Token) }
     }
-    //IOSClientBuilder.V3.metaClass.authenticate = { mockClient }
     provider = Spy(OpenstackIdentityV3Provider, constructorArgs:[credentials]) {
       buildClient() >> { mockClient }
       getClient() >> { mockClient }


### PR DESCRIPTION
The openstack unit tests fail when run locally using gradle; the root cause is that the tests are not independent, as there is a test that does metaprogramming to change the behavior of a class.