### PR TITLE
fix(elasticsearch): Fix connection string for elasticsearch tests

### DIFF
--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProviderSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProviderSpec.groovy
@@ -74,7 +74,7 @@ class ElasticSearchEntityTagsProviderSpec extends Specification {
 
     elasticSearchConfigProperties = new ElasticSearchConfigProperties(
       activeIndex: "tags_v1",
-      connection: "http://localhost:9200"
+      connection: getConnectionString(node)
     )
     def config = new ElasticSearchConfig()
     jestClient = config.jestClient(elasticSearchConfigProperties)
@@ -343,5 +343,13 @@ class ElasticSearchEntityTagsProviderSpec extends Specification {
         entityId: idSplit[2]
       )
     )
+  }
+
+  // The Node object does not store its connection string, so we need to make a request to the cluster
+  // to get it using the Node's client.
+  private static String getConnectionString(Node node) {
+    def nodeName = node.settings().get("name")
+    def nodeInfoResponse = node.client().admin().cluster().prepareNodesInfo(nodeName).execute().get()
+    return "http://" + nodeInfoResponse[0].serviceAttributes.http_address
   }
 }


### PR DESCRIPTION
The elasticsearch tests spin up a new local node agains which to run the tests; this node defaults to port 9200, but will pick another port if that port is not available. The tests currently always send requests to port 9200 (which could be an unrelated node); update them to send requests to the node created by the tests.