### PR TITLE
fix(redis): Clean up embedded redis in tests

### DIFF
--- a/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactorySpec.groovy
+++ b/cats/cats-redis/src/test/groovy/com/netflix/spinnaker/cats/redis/cache/RedisNamedCacheFactorySpec.groovy
@@ -32,7 +32,6 @@ class RedisNamedCacheFactorySpec extends Specification {
     @Subject
     RedisNamedCacheFactory factory
 
-    @Shared
     @AutoCleanup("destroy")
     EmbeddedRedis embeddedRedis
 

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/RedisTaskRepositorySpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/RedisTaskRepositorySpec.groovy
@@ -71,5 +71,9 @@ class RedisTaskRepositorySpec extends Specification {
     fromOldPool.id == oldPoolTask.id
     fromOldPool.startTimeMs == oldPoolTask.startTimeMs
     fromOldPool.status.status == oldPoolTask.status.status
+
+    cleanup:
+    embeddedRedis1.destroy()
+    embeddedRedis2.destroy()
   }
 }


### PR DESCRIPTION
These tests are leaking a total of three embedded redis instances, which build up over time on a machine used to run the tests frequently.