### PR TITLE
test(core): Simple startup integration test

### DIFF
--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/MainSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/MainSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import spock.lang.Specification
+
+@EnableAutoConfiguration
+@SpringBootTest(classes = [WebConfig])
+class MainSpec extends Specification {
+  def "Ensure clouddriver starts with the default profile"() {
+    when:
+    true
+
+    then:
+    noExceptionThrown()
+  }
+}


### PR DESCRIPTION
It's very common for one of our microservices to fail to start because of a missing autowire dependency. Often this is because someone changes autowiring such that it only works with a particular feature enabled, but fails with it disabled.

To prevent these issues, add an extremely simple integration test that just checks that clouddriver starts up with the default spring profile. This won't catch everything, but should catch most of the common cases I've seen. (We can always add test for other common profiles later if desired.)