### PR TITLE
feat(provider/azure): Apply network security group to a custom subnet

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
@@ -259,7 +259,4 @@ class AzureResourceManagerClient extends AzureBaseClient {
   String getProviderNamespace() {
     "Microsoft.Resources"
   }
-
-
-
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureAtomicOperationConverterHelper.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureAtomicOperationConverterHelper.groovy
@@ -37,7 +37,6 @@ class AzureAtomicOperationConverterHelper {
 
     // Save these to re-assign after ObjectMapper does its work.
     def credentials = input.remove("credentials")
-
     def converted = credentialsSupport.objectMapper
       .copy()
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
@@ -294,10 +294,13 @@ class AzureUtilities {
     Map<String, Object> map = new HashMap<>()
     if (sourceParameters.size() == 0) return mapper.writeValueAsString(sourceParameters)
     for(Map.Entry<String, Object> entry: sourceParameters.entrySet()) {
-      if(entry.value.class == String) {
-        map.put(entry.key, new ValueParameter(entry.value))
-      }else {
-        map.put(entry.key, new ReferenceParameter(entry.value))
+      // Avoid null reference by skipping null values. It still works for those mapping destination fields whose source values are skipped here since they will be assigned as null by default.
+      if(entry.value) {
+        if (entry.value.class == String) {
+          map.put(entry.key, new ValueParameter(entry.value))
+        } else {
+          map.put(entry.key, new ReferenceParameter(entry.value))
+        }
       }
     }
     mapper.writeValueAsString(map)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/model/AzureSecurityGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/model/AzureSecurityGroupDescription.groovy
@@ -31,6 +31,8 @@ class AzureSecurityGroupDescription extends AzureResourceOpsDescription {
   List<String> networkInterfaces = []
   List<String> subnets = []
   String subnet
+  String vnet
+  String vnetResourceGroup
 
   static class AzureSGRule {
     String id

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/UpsertAzureSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/UpsertAzureSecurityGroupAtomicOperation.groovy
@@ -61,12 +61,22 @@ class UpsertAzureSecurityGroupAtomicOperation implements AtomicOperation<Map> {
       // Create corresponding ResourceGroup if it's not created already
       description.credentials.resourceManagerClient.initializeResourceGroupAndVNet(resourceGroupName, null, description.region)
 
+      def templateParamMap = [
+        location : description.region,
+        networkSecurityGroupName : description.securityGroupName,
+        networkSecurityGroupResourceGroupName : resourceGroupName,
+        virtualNetworkName : description.vnet,
+        virtualNetworkResourceGroupName : description.vnetResourceGroup,
+        subnetName : description.subnet
+      ]
+
       Deployment deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(
         AzureSecurityGroupResourceTemplate.getTemplate(description),
         resourceGroupName,
         description.region,
         description.securityGroupName,
-        "securityGroup")
+        "securityGroup",
+        templateParamMap)
 
       errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task,BASE_PHASE, description.credentials, resourceGroupName, deployment.name())
     } catch (Throwable e) {

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureSecurityGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureSecurityGroupResourceTemplate.groovy
@@ -26,7 +26,6 @@ class AzureSecurityGroupResourceTemplate {
 
   static String getTemplate(UpsertAzureSecurityGroupDescription description) {
     SecurityGroupTemplate template = new SecurityGroupTemplate(description)
-
     mapper.writeValueAsString(template)
   }
 
@@ -44,8 +43,13 @@ class AzureSecurityGroupResourceTemplate {
       variables = new SecurityGroupTemplateVariables(description)
 
       SecurityGroup sg = new SecurityGroup(description)
-
       resources.add(sg)
+
+      // Apply NSG to subnet by using nested ARM template only when a subnet is pointed by users
+      if(description.subnet) {
+        SecurityGroupSubnet sg_subnet = new SecurityGroupSubnet()
+        resources.add(sg_subnet)
+      }
     }
   }
 
@@ -59,6 +63,11 @@ class AzureSecurityGroupResourceTemplate {
 
   static class SecurityGroupParameters{
     Location location = new Location()
+    NetworkSecurityGroupName networkSecurityGroupName = new NetworkSecurityGroupName()
+    NetworkSecurityGroupResourceGroupName networkSecurityGroupResourceGroupName = new NetworkSecurityGroupResourceGroupName()
+    VirtualNetworkName virtualNetworkName = new VirtualNetworkName()
+    VirtualNetworkResourceGroupName virtualNetworkResourceGroupName = new VirtualNetworkResourceGroupName()
+    SubnetName subnetName = new SubnetName()
   }
 
   static class Location{
@@ -66,12 +75,40 @@ class AzureSecurityGroupResourceTemplate {
     Map<String, String> metadata = ["description":"Location to deploy"]
   }
 
+  static class NetworkSecurityGroupName{
+    String type = "string"
+    Map<String, String> metadata = ["description":"The NSG name"]
+  }
+
+  static class NetworkSecurityGroupResourceGroupName{
+    String type = "string"
+    Map<String, String> metadata = ["description":"The resource group name of NSG"]
+  }
+
+  static class VirtualNetworkResourceGroupName{
+    String type = "string"
+    String defaultValue = ""
+    Map<String, String> metadata = ["description":"The resource group name of Virtual Network"]
+  }
+
+  static class VirtualNetworkName{
+    String type = "string"
+    String defaultValue = ""
+    Map<String, String> metadata = ["description":"The Virtual Network name"]
+  }
+
+  static class SubnetName{
+    String type = "string"
+    String defaultValue = ""
+    Map<String, String> metadata = ["description":"The subnet name"]
+  }
+
   static class SecurityGroup extends DependingResource{
     Map<String, String> tags
     SecurityGroupProperties properties
 
     SecurityGroup(UpsertAzureSecurityGroupDescription description) {
-      apiVersion = "2015-05-01-preview"
+      apiVersion = "2018-11-01"
       name = "[variables('securityGroupName')]"
       type = "Microsoft.Network/networkSecurityGroups"
       location = "[parameters('location')]"
@@ -126,6 +163,66 @@ class AzureSecurityGroupResourceTemplate {
       sourceAddressPrefix = rule.sourceAddressPrefix
       sourcePortRange = rule.sourcePortRange
     }
+  }
+
+  /*
+  Use ARM nested template to apply NSG to an existing subnet
+   */
+  static class SecurityGroupSubnet extends DependingResource{
+    String resourceGroup
+    SecurityGroupSubnetProperties properties
+
+    SecurityGroupSubnet() {
+      apiVersion = "2017-08-01"
+      name = "nestedTemplate_NSGSubnet"
+      type = "Microsoft.Resources/deployments"
+      resourceGroup = "[parameters('virtualNetworkResourceGroupName')]"
+      dependsOn.add("[parameters('networkSecurityGroupName')]")
+      properties = new SecurityGroupSubnetProperties()
+    }
+  }
+
+  static class SecurityGroupSubnetProperties {
+    String mode
+    SecurityGroupSubnetPropertiesNestedTemplate template
+
+    SecurityGroupSubnetProperties() {
+      mode = "Incremental"
+      template = new SecurityGroupSubnetPropertiesNestedTemplate()
+    }
+  }
+
+  static class SecurityGroupSubnetPropertiesNestedTemplate {
+    String $schema
+    String contentVersion
+    ArrayList<Resource> resources = []
+
+    SecurityGroupSubnetPropertiesNestedTemplate(){
+      $schema = "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
+      contentVersion = "1.0.0.0"
+      resources.add(new SecurityGroupSubnetPropertiesNestedTemplateSubnet())
+    }
+  }
+
+  static class SecurityGroupSubnetPropertiesNestedTemplateSubnet extends Resource {
+    SecurityGroupSubnetPropertiesNestedTemplateSubnetProperties properties
+
+    SecurityGroupSubnetPropertiesNestedTemplateSubnet(){
+      apiVersion = "2018-11-01"
+      type = "Microsoft.Network/virtualNetworks/subnets"
+      name = "[concat(parameters('virtualNetworkName'), '/', parameters('subnetName'))]"
+      location = "[parameters('location')]"
+      properties = new SecurityGroupSubnetPropertiesNestedTemplateSubnetProperties()
+    }
+  }
+
+  static class SecurityGroupSubnetPropertiesNestedTemplateSubnetProperties {
+    String addressPrefix = "[reference(resourceId(parameters('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName')), '2018-11-01').addressPrefix]"
+    SecurityGroupSubnetPropertiesNestedTemplateSubnetPropertiesNSG networkSecurityGroup = new SecurityGroupSubnetPropertiesNestedTemplateSubnetPropertiesNSG()
+  }
+
+  static class SecurityGroupSubnetPropertiesNestedTemplateSubnetPropertiesNSG {
+    String id = "[resourceId(parameters('networkSecurityGroupResourceGroupName'), 'Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]"
   }
 }
 

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/deploy/templates/AzureSecurityGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/deploy/templates/AzureSecurityGroupResourceTemplateSpec.groovy
@@ -88,13 +88,46 @@ class AzureSecurityGroupResourceTemplateSpec extends Specification {
       "metadata" : {
         "description" : "Location to deploy"
       }
+    },
+    "networkSecurityGroupName" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "The NSG name"
+      }
+    },
+    "networkSecurityGroupResourceGroupName" : {
+      "type" : "string",
+      "metadata" : {
+        "description" : "The resource group name of NSG"
+      }
+    },
+    "virtualNetworkName" : {
+      "type" : "string",
+      "defaultValue" : "",
+      "metadata" : {
+        "description" : "The Virtual Network name"
+      }
+    },
+    "virtualNetworkResourceGroupName" : {
+      "type" : "string",
+      "defaultValue" : "",
+      "metadata" : {
+        "description" : "The resource group name of Virtual Network"
+      }
+    },
+    "subnetName" : {
+      "type" : "string",
+      "defaultValue" : "",
+      "metadata" : {
+        "description" : "The subnet name"
+      }
     }
   },
   "variables" : {
     "securityGroupName" : "azuremasm-sg1-d11"
   },
   "resources" : [ {
-    "apiVersion" : "2015-05-01-preview",
+    "apiVersion" : "2018-11-01",
     "name" : "[variables('securityGroupName')]",
     "type" : "Microsoft.Network/networkSecurityGroups",
     "location" : "[parameters('location')]",


### PR DESCRIPTION
Azure network security group (NSG) needs to be applied to subnets within a virtual network or to Network Interface Controller (NIC) of VMs, otherwise it won't take effects.
ARM nested template is used here to implement above, which serves defining the template of binding the NSG to an existing subnet.