### PR TITLE
feat(appengine): add configurable caching agent interval

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.groovy
@@ -47,6 +47,7 @@ class AppengineConfigurationProperties {
     List<String> versions
     List<String> omitServices
     List<String> omitVersions
+    Long cachingIntervalSeconds
 
     void initialize(AppengineJobExecutor jobExecutor) {
       if (this.jsonPath) {

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AbstractAppengineCachingAgent.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AbstractAppengineCachingAgent.groovy
@@ -19,13 +19,16 @@ package com.netflix.spinnaker.clouddriver.appengine.provider.agent
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.netflix.spinnaker.cats.agent.AccountAware
+import com.netflix.spinnaker.cats.agent.AgentIntervalAware
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.clouddriver.appengine.AppengineCloudProvider
 import com.netflix.spinnaker.clouddriver.appengine.provider.AppengineProvider
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
 
-abstract class AbstractAppengineCachingAgent implements CachingAgent, AccountAware {
+import java.util.concurrent.TimeUnit
+
+abstract class AbstractAppengineCachingAgent implements CachingAgent, AccountAware, AgentIntervalAware {
   final String accountName
   final String providerName = AppengineProvider.PROVIDER_NAME
   final AppengineCloudProvider appengineCloudProvider = new AppengineCloudProvider()
@@ -84,6 +87,13 @@ abstract class AbstractAppengineCachingAgent implements CachingAgent, AccountAwa
     if (batch.size()) {
       batch.execute()
     }
+  }
+
+  Long getAgentInterval() {
+    if (this.credentials.cachingIntervalSeconds == null) {
+      return TimeUnit.SECONDS.toMillis(60)
+    }
+    return TimeUnit.SECONDS.toMillis(this.credentials.cachingIntervalSeconds)
   }
 
   abstract String getSimpleName()

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppengineCredentialsInitializer.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppengineCredentialsInitializer.groovy
@@ -89,6 +89,7 @@ class AppengineCredentialsInitializer implements CredentialsInitializerSynchroni
           .versions(managedAccount.versions)
           .omitServices(managedAccount.omitServices)
           .omitVersions(managedAccount.omitVersions)
+          .cachingIntervalSeconds(managedAccount.cachingIntervalSeconds)
           .build()
 
         accountCredentialsRepository.save(managedAccount.name, appengineAccount)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppengineNamedAccountCredentials.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppengineNamedAccountCredentials.groovy
@@ -59,6 +59,8 @@ class AppengineNamedAccountCredentials implements AccountCredentials<AppengineCr
   final List<String> omitServices
   final List<String> omitVersions
 
+  final Long cachingIntervalSeconds
+
   static class Builder {
     String name
     String environment
@@ -88,6 +90,7 @@ class AppengineNamedAccountCredentials implements AccountCredentials<AppengineCr
     List<String> versions
     List<String> omitServices
     List<String> omitVersions
+    Long cachingIntervalSeconds
 
     /*
     * If true, the builder will overwrite region with a value from the platform.
@@ -233,6 +236,11 @@ class AppengineNamedAccountCredentials implements AccountCredentials<AppengineCr
       return this
     }
 
+    Builder cachingIntervalSeconds(Long interval) {
+      this.cachingIntervalSeconds = interval
+      return this
+    }
+
     AppengineNamedAccountCredentials build() {
       credentials = credentials ?:
         jsonKey ?
@@ -276,7 +284,8 @@ class AppengineNamedAccountCredentials implements AccountCredentials<AppengineCr
                                                   services,
                                                   versions,
                                                   omitServices,
-                                                  omitVersions)
+                                                  omitVersions,
+                                                  cachingIntervalSeconds)
     }
   }
 }


### PR DESCRIPTION
Allows a user to configure Spinnaker to hit the AppEngine Admin API less often, thereby reducing the risk of hitting quotas.

See halyard PR where the flag to configure this is exposed: https://github.com/spinnaker/halyard/pull/1235