### PR TITLE
chore(provider/azure): Enable NSG source IP/CIDR filtering

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -621,7 +621,6 @@ class AzureNetworkClient extends AzureBaseClient {
 
   private static AzureSecurityGroupDescription getAzureSecurityGroupDescription(NetworkSecurityGroupInner item) {
     def sgItem = new AzureSecurityGroupDescription()
-
     sgItem.name = item.name()
     sgItem.id = item.name()
     sgItem.location = item.location()
@@ -649,9 +648,14 @@ class AzureNetworkClient extends AzureBaseClient {
         direction: rule.direction().toString(),
         destinationAddressPrefix: rule.destinationAddressPrefix(),
         destinationPortRange: rule.destinationPortRange(),
+        destinationPortRanges: rule.destinationPortRanges(),
+        destinationPortRangeModel: rule.destinationPortRange() ? rule.destinationPortRange() : rule.destinationPortRanges()?.toString()?.replaceAll("[^(0-9),-]", ""),
         sourceAddressPrefix: rule.sourceAddressPrefix(),
+        sourceAddressPrefixes: rule.sourceAddressPrefixes(),
+        sourceAddressPrefixModel: rule.sourceAddressPrefix() ? rule.sourceAddressPrefix() : rule.sourceAddressPrefixes()?.toString()?.replaceAll("[^(0-9a-zA-Z)./,:]", ""),
         sourcePortRange: rule.sourcePortRange())
     }
+
     sgItem.subnets = new ArrayList<String>()
     item.subnets()?.each { sgItem.subnets += AzureUtilities.getNameFromResourceId(it.id()) }
     sgItem.networkInterfaces = new ArrayList<String>()

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/model/AzureSecurityGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/model/AzureSecurityGroupDescription.groovy
@@ -41,12 +41,16 @@ class AzureSecurityGroupDescription extends AzureResourceOpsDescription {
     String resourceId /*Azure resource ID */
     String description /* restricted to 140 chars */
     String access /* gets or sets network traffic is allowed or denied; possible values are “Allow” and “Deny” */
-    String destinationAddressPrefix /* CIDR or destination IP range; asterix “*” can also be used to match all source IPs; default tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used */
-    String destinationPortRange /* Integer or range between 0 and 65535; asterix “*” can also be used to match all ports */
+    String destinationAddressPrefix /* CIDR or destination IP range; asterisk “*” can also be used to match all source IPs; default tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used */
+    String destinationPortRange /* Integer or range between 0 and 65535; asterisk “*” can also be used to match all ports */
+    List<String> destinationPortRanges /* List of integer or range between 0 and 65535 */
+    String destinationPortRangeModel /* The model destination port that is transparent whether it is from destinationPortRange or destinationPortRanges */
     String direction /* InBound or Outbound */
     Integer priority /* value can be between 100 and 4096 */
     String protocol /* Tcp, Udp or All(*) */
-    String sourceAddressPrefix /* CIDR or source IP range; asterix “*” can also be used to match all source IPs; default tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used */
-    String sourcePortRange /* Integer or range between 0 and 65535; asterix “*” can also be used to match all ports */
+    String sourceAddressPrefix /* CIDR or source IP range; asterisk “*” can also be used to match all source IPs; default tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used */
+    List<String> sourceAddressPrefixes /* List of CIDR or source IP range*/
+    String sourceAddressPrefixModel /* The model source IP/CIDR address that it transparent whether it is from sourceAddressPrefix or sourceAddressPrefixes */
+    String sourcePortRange /* Integer or range between 0 and 65535; asterisk “*” can also be used to match all ports */
   }
 }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureSecurityGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureSecurityGroupResourceTemplate.groovy
@@ -146,10 +146,12 @@ class AzureSecurityGroupResourceTemplate {
     String access /* gets or sets network traffic is allowed or denied; possible values are “Allow” and “Deny” */
     String destinationAddressPrefix /* CIDR or destination IP range; asterix “*” can also be used to match all source IPs; default tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used */
     String destinationPortRange /* Integer or range between 0 and 65535; asterix “*” can also be used to match all ports */
+    List<String> destinationPortRanges /* List of integer or range between 0 and 65535 */
     String direction /* InBound or Outbound */
     Integer priority /* value can be between 100 and 4096 */
     String protocol /* Tcp, Udp or All(*) */
     String sourceAddressPrefix /* CIDR or source IP range; asterix “*” can also be used to match all source IPs; default tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used */
+    List<String> sourceAddressPrefixes /* List of CIDR or source IP range */
     String sourcePortRange /* Integer or range between 0 and 65535; asterix “*” can also be used to match all ports */
 
     AzureNSGRuleProperties(AzureSGRule rule) {
@@ -157,10 +159,12 @@ class AzureSecurityGroupResourceTemplate {
       access = rule.access
       destinationAddressPrefix = rule.destinationAddressPrefix
       destinationPortRange = rule.destinationPortRange
+      destinationPortRanges = rule.destinationPortRanges
       direction = rule.direction
       priority = rule.priority
       protocol = rule.protocol
       sourceAddressPrefix = rule.sourceAddressPrefix
+      sourceAddressPrefixes = rule.sourceAddressPrefixes
       sourcePortRange = rule.sourcePortRange
     }
   }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/deploy/templates/AzureSecurityGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/deploy/templates/AzureSecurityGroupResourceTemplateSpec.groovy
@@ -146,10 +146,12 @@ class AzureSecurityGroupResourceTemplateSpec extends Specification {
           "access" : "Allow",
           "destinationAddressPrefix" : "*",
           "destinationPortRange" : "433",
+          "destinationPortRanges" : null,
           "direction" : "Inbound",
           "priority" : 100,
           "protocol" : "TCP",
           "sourceAddressPrefix" : "10.0.0.0/24",
+          "sourceAddressPrefixes" : null,
           "sourcePortRange" : "*"
         }
       }, {
@@ -159,10 +161,12 @@ class AzureSecurityGroupResourceTemplateSpec extends Specification {
           "access" : "Deny",
           "destinationAddressPrefix" : "*",
           "destinationPortRange" : "3389",
+          "destinationPortRanges" : null,
           "direction" : "Inbound",
           "priority" : 101,
           "protocol" : "TCP",
           "sourceAddressPrefix" : "Internet",
+          "sourceAddressPrefixes" : null,
           "sourcePortRange" : "*"
         }
       } ]


### PR DESCRIPTION
Add the source IP/CIDR filtering to Azure Network Security Group (NSG) that plays the role of Spinnaker firewall. There is a feature link PR on Deck: https://github.com/spinnaker/deck/pull/6657 