### PR TITLE
fix(appengine): Allow suppression of sequence in deployed servergroup names

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/description/DeployAppengineDescription.groovy
@@ -40,5 +40,6 @@ class DeployAppengineDescription extends AbstractAppengineCredentialsDescription
   List<Artifact> configArtifacts
   Boolean promote
   Boolean stopPreviousVersion
+  Boolean suppressVersionString
   String containerImageUrl // app engine flex only
 }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
@@ -33,13 +33,13 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact
 
 import com.netflix.spectator.api.Registry
 import groovy.util.logging.Slf4j
+
 import java.nio.file.Path
 import java.nio.file.Paths
 
 import org.springframework.beans.factory.annotation.Autowired
 import static com.netflix.spinnaker.clouddriver.appengine.config.AppengineConfigurationProperties.ManagedAccount.GcloudReleaseTrack
 import java.util.concurrent.TimeUnit
-
 
 class DeployAppengineAtomicOperation implements AtomicOperation<DeploymentResult> {
   private static final String BASE_PHASE = "DEPLOY"
@@ -247,9 +247,9 @@ class DeployAppengineAtomicOperation implements AtomicOperation<DeploymentResult
     def gcloudReleaseTrack = description.credentials.gcloudReleaseTrack
     def serverGroupNameResolver = new AppengineServerGroupNameResolver(project, region, description.credentials)
     def versionName = serverGroupNameResolver.resolveNextServerGroupName(description.application,
-                                                                         description.stack,
-                                                                         description.freeFormDetails,
-                                                                         false)
+      description.stack,
+      description.freeFormDetails,
+      description.suppressVersionString)
     def imageUrl = description.containerImageUrl
     def configFiles = description.configFiles
     def writtenFullConfigFilePaths = writeConfigFiles(configFiles, repositoryPath, applicationDirectoryRoot)


### PR DESCRIPTION
There are some specific use cases that require an appengine version's URL remain completely stable between deployments. Spinnaker normally adds sequence strings to names, which changes the URL that appengine exposes with each deployment. This fixes that.