### PR TITLE
feat(cf): Enable service sharing / unsharing

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
@@ -167,7 +167,7 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
     this.spaces = new Spaces(createService(SpaceService.class), organizations);
     this.applications = new Applications(account, appsManagerUri, metricsUri, createService(ApplicationService.class), spaces);
     this.domains = new Domains(createService(DomainService.class), organizations);
-    this.serviceInstances = new ServiceInstances(createService(ServiceInstanceService.class), organizations, spaces);
+    this.serviceInstances = new ServiceInstances(createService(ServiceInstanceService.class), createService(ConfigService.class), organizations, spaces);
     this.routes = new Routes(account, createService(RouteService.class), applications, domains, spaces);
   }
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ServiceInstances.java
@@ -16,14 +16,19 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.api.ConfigService;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.api.ServiceInstanceService;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.ServiceInstanceResponse;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.*;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.CreateSharedServiceInstances;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -32,20 +37,25 @@ import java.util.function.Supplier;
 
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.collectPageResources;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClientUtils.safelyCall;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ConfigFeatureFlag.ConfigFlag.SERVICE_INSTANCE_SHARING;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.State.*;
 import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.Type.*;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstance.Type.MANAGED_SERVICE_INSTANCE;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstance.Type.USER_PROVIDED_SERVICE_INSTANCE;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @RequiredArgsConstructor
 public class ServiceInstances {
   private static final String SPINNAKER_VERSION_V_D_3 = "spinnakerVersion-v\\d{3}";
   private final ServiceInstanceService api;
+  private final ConfigService configApi;
   private final Organizations orgs;
   private final Spaces spaces;
 
-  public Void createServiceBindingsByName(CloudFoundryServerGroup cloudFoundryServerGroup, @Nullable List<String> serviceInstanceNames) throws CloudFoundryApiException {
+  public Void createServiceBindingsByName(CloudFoundryServerGroup cloudFoundryServerGroup, @Nullable List<String> serviceInstanceNames) {
     if (serviceInstanceNames != null && !serviceInstanceNames.isEmpty()) {
       List<String> serviceInstanceQuery = getServiceQueryParams(serviceInstanceNames, cloudFoundryServerGroup.getSpace());
       List<Resource<? extends AbstractServiceInstance>> serviceInstances = new ArrayList<>();
@@ -108,25 +118,146 @@ public class ServiceInstances {
     return org.map(cfOrg -> spaces.findByName(cfOrg.getId(), space.getName())).orElse(null);
   }
 
-  @Nullable
-  public CloudFoundryServiceInstance getServiceInstance(String region, @Nullable String serviceInstanceName) throws CloudFoundryApiException {
-    CloudFoundrySpace space = getSpaceByRegionName(region);
-    Supplier<CloudFoundryServiceInstance> si = () -> Optional.ofNullable(getServiceInstance(space, serviceInstanceName))
+  // Visible for testing
+  CloudFoundryServiceInstance getOsbServiceInstanceByRegion(String region, String serviceInstanceName) {
+    CloudFoundrySpace space = Optional.ofNullable(getSpaceByRegionName(region))
+      .orElseThrow(() -> new CloudFoundryApiException("Cannot find region '" + region + "'"));
+    return Optional
+      .ofNullable(getOsbServiceInstance(space, serviceInstanceName))
+      .orElseThrow(() -> new CloudFoundryApiException("Cannot find service '" + serviceInstanceName + "' in region '" + space.getRegion() + "'"));
+  }
+
+  private Set<CloudFoundrySpace> vetSharingOfServicesArgumentsAndGetSharingSpaces(
+    String sharedFromRegion,
+    @Nullable String serviceInstanceName,
+    @Nullable Set<String> sharingRegions,
+    String gerund) {
+    if (isBlank(serviceInstanceName)) {
+      throw new CloudFoundryApiException("Please specify a name for the " + gerund + " service instance");
+    }
+    sharingRegions = Optional.ofNullable(sharingRegions).orElse(Collections.emptySet());
+    if (sharingRegions.size() == 0) {
+      throw new CloudFoundryApiException("Please specify a list of regions for " + gerund + " '" + serviceInstanceName + "'");
+    }
+
+    return sharingRegions.stream()
+      .map(r -> {
+        if (sharedFromRegion.equals(r)) {
+          throw new CloudFoundryApiException("Cannot specify 'org > space' as any of the " + gerund + " regions");
+        }
+        return Optional.ofNullable(getSpaceByRegionName(r))
+          .orElseThrow(() -> new CloudFoundryApiException("Cannot find region '" + r + "' for " + gerund));
+      })
+      .collect(toSet());
+  }
+
+  // Visible for testing
+  Set<CloudFoundrySpace> vetUnshareServiceArgumentsAndGetSharingSpaces(
+    @Nullable String serviceInstanceName,
+    @Nullable Set<String> sharingRegions) {
+    return vetSharingOfServicesArgumentsAndGetSharingSpaces("", serviceInstanceName, sharingRegions, "unsharing");
+  }
+
+  // Visible for testing
+  Set<CloudFoundrySpace> vetShareServiceArgumentsAndGetSharingSpaces(
+    @Nullable String sharedFromRegion,
+    @Nullable String serviceInstanceName,
+    @Nullable Set<String> sharingRegions) {
+    if (isBlank(sharedFromRegion)) {
+      throw new CloudFoundryApiException("Please specify a region for the sharing service instance");
+    }
+    return vetSharingOfServicesArgumentsAndGetSharingSpaces(sharedFromRegion, serviceInstanceName, sharingRegions, "sharing");
+  }
+
+  // Visible for testing
+  Void checkServiceShareable(String serviceInstanceName, CloudFoundryServiceInstance serviceInstance) {
+    ConfigFeatureFlag featureFlag =
+      Optional.ofNullable(configApi.getConfigFeatureFlags())
+        .orElse(Collections.emptySet())
+        .stream()
+        .filter(it -> it.getName() == SERVICE_INSTANCE_SHARING)
+        .findFirst()
+        .orElseThrow(() -> new CloudFoundryApiException("'service_instance_sharing' flag must be enabled in order to share services"));
+    if (!featureFlag.isEnabled()) {
+      throw new CloudFoundryApiException("'service_instance_sharing' flag must be enabled in order to share services");
+    }
+    ServicePlan plan = Optional.ofNullable(api.findServicePlanByServicePlanId(serviceInstance.getPlanId()))
       .map(Resource::getEntity)
-      .map(e -> CloudFoundryServiceInstance.builder()
-        .serviceInstanceName(serviceInstanceName)
-        .status(e.getLastOperation().getState().toString())
-        .build()
-      )
+      .orElseThrow(() -> new CloudFoundryApiException("The service plan for 'new-service-plan-name' was not found"));
+    String extraString = Optional.ofNullable(api.findServiceByServiceId(plan.getServiceGuid()))
+      .map(Resource::getEntity)
+      .map(s -> Optional.ofNullable(s.getExtra())
+        .orElseThrow(() -> new CloudFoundryApiException("The service broker must be configured as 'shareable' in order to share services")))
+      .orElseThrow(() -> new CloudFoundryApiException("The service broker for '" + serviceInstanceName + "' was not found"));
+
+    boolean isShareable;
+    try {
+      isShareable = !StringUtils.isEmpty(extraString) &&
+        new ObjectMapper().readValue(extraString, Map.class).get("shareable") == Boolean.TRUE;
+    } catch (IOException e) {
+      throw new CloudFoundryApiException(e);
+    }
+
+    if (!isShareable) {
+      throw new CloudFoundryApiException("The service broker must be configured as 'shareable' in order to share services");
+    }
+
+    return null;
+  }
+
+  public ServiceInstanceResponse shareServiceInstance(@Nullable String region, @Nullable String serviceInstanceName, @Nullable Set<String> shareToRegions) {
+    Set<CloudFoundrySpace> shareToSpaces = vetShareServiceArgumentsAndGetSharingSpaces(region, serviceInstanceName, shareToRegions);
+    CloudFoundryServiceInstance serviceInstance = getOsbServiceInstanceByRegion(region, serviceInstanceName);
+
+    if (MANAGED_SERVICE_INSTANCE.name().equalsIgnoreCase(serviceInstance.getType())) {
+      checkServiceShareable(serviceInstanceName, serviceInstance);
+    }
+
+    String serviceInstanceId = serviceInstance.getId();
+    SharedTo sharedTo = safelyCall(() -> api.getShareServiceInstanceSpaceIdsByServiceInstanceId(serviceInstanceId))
+      .orElseThrow(() -> new CloudFoundryApiException("Could not fetch spaces to which '" + serviceInstanceName + "' has been shared"));
+    Set<Map<String, String>> shareToIdsBody = shareToSpaces.stream()
+      .map(space -> Collections.singletonMap("guid", space.getId()))
+      .filter(idMap -> !sharedTo.getData().contains(idMap))
+      .collect(toSet());
+
+    if (shareToIdsBody.size() > 0) {
+      safelyCall(() -> api.shareServiceInstanceToSpaceIds(serviceInstanceId, new CreateSharedServiceInstances().setData(shareToIdsBody)));
+    }
+
+    return new ServiceInstanceResponse()
+      .setServiceInstanceName(serviceInstanceName)
+      .setType(SHARE)
+      .setState(SUCCEEDED);
+  }
+
+  public ServiceInstanceResponse unshareServiceInstance(
+    @Nullable String serviceInstanceName,
+    @Nullable Set<String> unshareFromRegions) {
+    Set<CloudFoundrySpace> unshareFromSpaces = vetUnshareServiceArgumentsAndGetSharingSpaces(serviceInstanceName, unshareFromRegions);
+
+    unshareFromSpaces
+      .forEach(s -> Optional.ofNullable(spaces.getSpaceSummaryById(s.getId()))
+        .map(SpaceSummary::getServices)
+        .ifPresent(set -> set.stream()
+          .filter(si -> serviceInstanceName.equals(si.getName()))
+          .forEach(si -> safelyCall(() -> api.unshareServiceInstanceFromSpaceId(si.getGuid(), s.getId())))
+        ));
+
+    return new ServiceInstanceResponse()
+      .setServiceInstanceName(serviceInstanceName)
+      .setType(UNSHARE)
+      .setState(SUCCEEDED);
+  }
+
+  @Nullable
+  public CloudFoundryServiceInstance getServiceInstance(String region, String serviceInstanceName) {
+    CloudFoundrySpace space = Optional.ofNullable(getSpaceByRegionName(region))
+      .orElseThrow(() -> new CloudFoundryApiException("Cannot find region '" + region + "'"));
+    Supplier<CloudFoundryServiceInstance> si = () -> Optional.ofNullable(getOsbServiceInstance(space, serviceInstanceName))
       .orElse(null);
 
     Supplier<CloudFoundryServiceInstance> up = () -> Optional.ofNullable(getUserProvidedServiceInstance(space, serviceInstanceName))
-      .map(Resource::getEntity)
-      .map(e -> CloudFoundryServiceInstance.builder()
-        .serviceInstanceName(serviceInstanceName)
-        .status(SUCCEEDED.toString())
-        .build()
-      )
       .orElse(null);
 
     return Optional.ofNullable(si.get()).orElseGet(up);
@@ -134,63 +265,76 @@ public class ServiceInstances {
 
   @Nullable
   @VisibleForTesting
-  Resource<ServiceInstance> getServiceInstance(CloudFoundrySpace space, @Nullable String serviceInstanceName) throws CloudFoundryApiException {
-    if (isBlank(serviceInstanceName)) {
-      throw new CloudFoundryApiException("Please specify a name for the service being sought");
-    }
-    List<Resource<ServiceInstance>> serviceInstances = collectPageResources("service instances by space and name",
-      pg -> api.all(pg, getServiceQueryParams(Collections.singletonList(serviceInstanceName), space)));
-
-    return getValidServiceInstance(space, serviceInstanceName, serviceInstances);
+  CloudFoundryServiceInstance getOsbServiceInstance(CloudFoundrySpace space, @Nullable String serviceInstanceName) {
+    return Optional.ofNullable(getServiceInstance(api::all, space, serviceInstanceName))
+      .map(r -> CloudFoundryServiceInstance.builder()
+        .serviceInstanceName(r.getEntity().getName())
+        .planId(r.getEntity().getServicePlanGuid())
+        .type(r.getEntity().getType().toString())
+        .status(r.getEntity().getLastOperation().getState().toString())
+        .id(r.getMetadata().getGuid())
+        .build()
+      )
+      .orElse(null);
   }
 
   @Nullable
-  private Resource<UserProvidedServiceInstance> getUserProvidedServiceInstance(CloudFoundrySpace space, @Nullable String serviceInstanceName) throws CloudFoundryApiException {
+  @VisibleForTesting
+  CloudFoundryServiceInstance getUserProvidedServiceInstance(CloudFoundrySpace space, @Nullable String serviceInstanceName) {
+    return Optional.ofNullable(getServiceInstance(api::allUserProvided, space, serviceInstanceName))
+      .map(r -> CloudFoundryServiceInstance.builder()
+        .serviceInstanceName(r.getEntity().getName())
+        .type(USER_PROVIDED_SERVICE_INSTANCE.toString())
+        .status(SUCCEEDED.toString())
+        .id(r.getMetadata().getGuid())
+        .build()
+      )
+      .orElse(null);
+  }
+
+  @Nullable
+  private <T> Resource<T>
+  getServiceInstance(BiFunction<Integer, List<String>, Page<T>> func, CloudFoundrySpace space, @Nullable String serviceInstanceName) {
     if (isBlank(serviceInstanceName)) {
       throw new CloudFoundryApiException("Please specify a name for the service being sought");
     }
-    List<Resource<UserProvidedServiceInstance>> services = collectPageResources("service instances by space and name",
-      pg -> api.allUserProvided(pg, getServiceQueryParams(Collections.singletonList(serviceInstanceName), space)));
 
-    return getValidServiceInstance(space, serviceInstanceName, services);
-  }
+    List<Resource<T>> serviceInstances = collectPageResources("service instances by space and name",
+      pg -> func.apply(pg, getServiceQueryParams(Collections.singletonList(serviceInstanceName), space)));
 
-  private <T> Resource<T> getValidServiceInstance(CloudFoundrySpace space, @Nullable String serviceInstanceName, List<Resource<T>> serviceInstances) {
     if (serviceInstances.isEmpty()) {
       return null;
     }
 
     if (serviceInstances.size() > 1) {
       throw new CloudFoundryApiException(serviceInstances.size() + " service instances found with name '" +
-        serviceInstanceName + "' in space " + space.getName() + ", but expected only 1");
+        serviceInstanceName + "' in space '" + space.getName() + "', but expected only 1");
     }
 
     return serviceInstances.get(0);
   }
 
-  public ServiceInstanceResponse destroyServiceInstance(CloudFoundrySpace space, String serviceInstanceName) throws CloudFoundryApiException {
-    Resource<ServiceInstance> serviceInstance = getServiceInstance(space, serviceInstanceName);
+  public ServiceInstanceResponse destroyServiceInstance(CloudFoundrySpace space, String serviceInstanceName) {
+    CloudFoundryServiceInstance serviceInstance = getOsbServiceInstance(space, serviceInstanceName);
     if (serviceInstance != null) {
-      String serviceInstanceId = serviceInstance.getMetadata().getGuid();
+      String serviceInstanceId = serviceInstance.getId();
       destroyServiceInstance(
         pg -> api.getBindingsForServiceInstance(serviceInstanceId, pg, null),
         () -> api.destroyServiceInstance(serviceInstanceId));
       return new ServiceInstanceResponse()
-        .setServiceInstanceId(serviceInstanceId)
         .setServiceInstanceName(serviceInstanceName)
         .setType(DELETE)
         .setState(IN_PROGRESS);
     } else {
-      Resource<UserProvidedServiceInstance> userProvidedServiceInstance = getUserProvidedServiceInstance(space, serviceInstanceName);
+      CloudFoundryServiceInstance userProvidedServiceInstance = getUserProvidedServiceInstance(space, serviceInstanceName);
       if (userProvidedServiceInstance == null) {
         throw new CloudFoundryApiException("No service instances with name '" + serviceInstanceName + "' found in space " + space.getName());
       }
-      String userProvidedServiceInstanceId = userProvidedServiceInstance.getMetadata().getGuid();
+      String userProvidedServiceInstanceId = userProvidedServiceInstance.getId();
       destroyServiceInstance(
         pg -> api.getBindingsForUserProvidedServiceInstance(userProvidedServiceInstanceId, pg, null),
         () -> api.destroyUserProvidedServiceInstance(userProvidedServiceInstanceId));
       return new ServiceInstanceResponse()
-        .setServiceInstanceId(userProvidedServiceInstanceId)
         .setServiceInstanceName(serviceInstanceName)
         .setType(DELETE)
         .setState(NOT_FOUND);
@@ -211,8 +355,7 @@ public class ServiceInstances {
     String servicePlanName,
     Set<String> tags,
     Map<String, Object> parameters,
-    CloudFoundrySpace space)
-    throws CloudFoundryApiException, ResourceNotFoundException {
+    CloudFoundrySpace space) {
     List<CloudFoundryServicePlan> cloudFoundryServicePlans = findAllServicePlansByServiceName(serviceName);
     if (cloudFoundryServicePlans.isEmpty()) {
       throw new ResourceNotFoundException("No plans available for service name '" + serviceName + "'");
@@ -235,9 +378,9 @@ public class ServiceInstances {
       command,
       api::createServiceInstance,
       api::updateServiceInstance,
-      c -> getServiceInstance(space, c.getName()),
+      c -> getOsbServiceInstance(space, c.getName()),
       (c, r) -> {
-        if (!r.getEntity().getServicePlanGuid().equals(c.getServicePlanGuid())) {
+        if (!r.getPlanId().equals(c.getServicePlanGuid())) {
           throw new CloudFoundryApiException("A service with name '" + c.getName() + "' exists but has a different plan");
         }
       },
@@ -254,7 +397,7 @@ public class ServiceInstances {
     Set<String> tags,
     Map<String, Object> credentials,
     String routeServiceUrl,
-    CloudFoundrySpace space) throws CloudFoundryApiException, ResourceNotFoundException {
+    CloudFoundrySpace space) {
     CreateUserProvidedServiceInstance command = new CreateUserProvidedServiceInstance();
     command.setName(newUserProvidedServiceInstanceName);
     command.setSyslogDrainUrl(syslogDrainUrl);
@@ -282,10 +425,9 @@ public class ServiceInstances {
   createServiceInstance(T command,
                         Function<T, Resource<S>> create,
                         BiFunction<String, T, Resource<S>> update,
-                        Function<T, Resource<S>> getServiceInstance,
-                        BiConsumer<T, Resource<S>> updateValidation,
+                        Function<T, CloudFoundryServiceInstance> getServiceInstance,
+                        BiConsumer<T, CloudFoundryServiceInstance> updateValidation,
                         CloudFoundrySpace space) {
-    String serviceInstanceId;
     LastOperation.Type operationType;
     List<String> serviceInstanceQuery = getServiceQueryParams(Collections.singletonList(command.getName()), space);
     List<Resource<? extends AbstractServiceInstance>> serviceInstances = new ArrayList<>();
@@ -294,11 +436,11 @@ public class ServiceInstances {
 
     if (serviceInstances.size() == 0) {
       operationType = CREATE;
-      serviceInstanceId = safelyCall(() -> create.apply(command)).map(res -> res.getMetadata().getGuid())
+      safelyCall(() -> create.apply(command)).map(res -> res.getMetadata().getGuid())
         .orElseThrow(() -> new CloudFoundryApiException("service instance '" + command.getName() + "' could not be created"));
     } else {
       operationType = UPDATE;
-      serviceInstanceId = serviceInstances.stream()
+      serviceInstances.stream()
         .findFirst()
         .map(r -> r.getMetadata().getGuid())
         .orElseThrow(() -> new CloudFoundryApiException("Service instance '" + command.getName() + "' not found"));
@@ -316,17 +458,16 @@ public class ServiceInstances {
         .min(Comparator.reverseOrder())
         .orElse("");
       if (newServiceInstanceVersionTag.isEmpty() || !existingServiceInstanceVersionTag.equals(newServiceInstanceVersionTag)) {
-        Resource<S> serviceInstance = getServiceInstance.apply(command);
+        CloudFoundryServiceInstance serviceInstance = getServiceInstance.apply(command);
         if (serviceInstance == null) {
           throw new CloudFoundryApiException("No service instances with name '" + command.getName() + "' found in space " + space.getName());
         }
         updateValidation.accept(command, serviceInstance);
-        safelyCall(() -> update.apply(serviceInstance.getMetadata().getGuid(), command));
+        safelyCall(() -> update.apply(serviceInstance.getId(), command));
       }
     }
 
     return new ServiceInstanceResponse()
-      .setServiceInstanceId(serviceInstanceId)
       .setServiceInstanceName(command.getName())
       .setType(operationType);
   }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Spaces.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Spaces.java
@@ -22,6 +22,7 @@ import com.google.common.cache.LoadingCache;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.api.SpaceService;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Resource;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Space;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.SpaceSummary;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import lombok.RequiredArgsConstructor;
 
@@ -66,6 +67,12 @@ public class Spaces {
   public List<CloudFoundrySpace> all() throws CloudFoundryApiException {
     return collectPageResources("spaces", pg -> api.all(pg, null))
       .stream().map(this::map).collect(toList());
+  }
+
+  @Nullable
+  public SpaceSummary getSpaceSummaryById(String spaceId) {
+    return safelyCall(() -> api.getSpaceSummaryById(spaceId))
+      .orElse(null);
   }
 
   @Nullable

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ConfigService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 
-import lombok.Data;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.*;
+import retrofit.client.Response;
+import retrofit.http.*;
 
-@Data
-public class ServicePlan {
-  private String id;
-  private String name;
-  private String serviceGuid;
+import java.util.List;
+import java.util.Set;
+
+public interface ConfigService {
+  @GET("/v2/config/feature_flags")
+  Set<ConfigFeatureFlag> getConfigFeatureFlags();
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ServiceInstanceService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ServiceInstanceService.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.*;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.CreateSharedServiceInstances;
 import retrofit.client.Response;
 import retrofit.http.*;
 
@@ -34,6 +35,12 @@ public interface ServiceInstanceService {
 
   @GET("/v2/services")
   Page<Service> findService(@Query("page") Integer page, @Query("q") List<String> queryParams);
+
+  @GET("/v2/service_plans/{guid}")
+  Resource<ServicePlan> findServicePlanByServicePlanId(@Path("guid") String servicePlanGuid);
+
+  @GET("/v2/services/{guid}")
+  Resource<Service> findServiceByServiceId(@Path("guid") String serviceGuid);
 
   @GET("/v2/spaces/{guid}/services")
   Page<Service> findServiceBySpaceId(@Path("guid") String spaceGuid, @Query("page") Integer page, @Query("q") List<String> queryParams);
@@ -65,7 +72,12 @@ public interface ServiceInstanceService {
   @DELETE("/v2/user_provided_service_instances/{guid}")
   Response destroyUserProvidedServiceInstance(@Path("guid") String serviceInstanceGuid);
 
-  @GET("/v2/service_instances/{guid}")
-  Resource<ServiceInstance> getServiceInstanceById(@Path("guid") String serviceInstanceGuid);
+  @POST("/v3/service_instances/{guid}/relationships/shared_spaces")
+  Response shareServiceInstanceToSpaceIds(@Path("guid") String serviceInstanceGuid, @Body CreateSharedServiceInstances body);
 
+  @GET("/v3/service_instances/{guid}/relationships/shared_spaces")
+  SharedTo getShareServiceInstanceSpaceIdsByServiceInstanceId(@Path("guid") String serviceInstanceGuid);
+
+  @DELETE("/v3/service_instances/{guid}/relationships/shared_spaces/{space_guid}")
+  Response unshareServiceInstanceFromSpaceId(@Path("guid") String serviceInstanceGuid, @Path("space_guid") String spaceGuid);
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/SpaceService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/SpaceService.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.client.api;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Page;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Resource;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Space;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.SpaceSummary;
 import retrofit.http.GET;
 import retrofit.http.Path;
 import retrofit.http.Query;
@@ -31,4 +32,7 @@ public interface SpaceService {
 
   @GET("/v2/spaces/{guid}")
   Resource<Space> findById(@Path("guid") String guid);
+
+  @GET("/v2/spaces/{guid}/summary")
+  SpaceSummary getSpaceSummaryById(@Path("guid") String guid);
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/ServiceInstanceResponse.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/ServiceInstanceResponse.java
@@ -21,7 +21,6 @@ import lombok.Data;
 
 @Data
 public class ServiceInstanceResponse {
-  private String serviceInstanceId;
   private String serviceInstanceName;
   private LastOperation.Type type;
   private LastOperation.State state;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ConfigFeatureFlag.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ConfigFeatureFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,31 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Data;
 
+import javax.annotation.Nullable;
+
+import static java.util.Arrays.stream;
+
 @Data
-public class ServicePlan {
-  private String id;
-  private String name;
-  private String serviceGuid;
+public class ConfigFeatureFlag {
+  ConfigFlag name;
+  boolean enabled;
+
+  public enum ConfigFlag {
+    SERVICE_INSTANCE_SHARING("service_instance_sharing");
+
+    private final String type;
+
+    ConfigFlag(String type) {
+      this.type = type;
+    }
+
+    @Nullable
+    @JsonCreator
+    public static ConfigFlag fromType(String type) {
+      return stream(ConfigFlag.values()).filter(st -> st.type.equalsIgnoreCase(type)).findFirst().orElse(null);
+    }
+  }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/LastOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/LastOperation.java
@@ -31,6 +31,8 @@ public class LastOperation {
   public enum Type {
     CREATE("create"),
     DELETE("delete"),
+    SHARE("share"),
+    UNSHARE("unshare"),
     UPDATE("update");
 
     private final String type;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/Service.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/Service.java
@@ -18,7 +18,12 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
 import lombok.Data;
 
+import javax.annotation.Nullable;
+
 @Data
 public class Service {
   private String label;
+
+  @Nullable
+  private String extra;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ServiceInstance.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/ServiceInstance.java
@@ -16,11 +16,34 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Data;
 
+import javax.annotation.Nullable;
+
+import static java.util.Arrays.stream;
+
 @Data
-public class ServiceInstance extends AbstractServiceInstance{
+public class ServiceInstance extends AbstractServiceInstance {
   private String plan;
   private String servicePlanGuid;
   private LastOperation lastOperation;
+  private Type type;
+
+  public enum Type {
+    MANAGED_SERVICE_INSTANCE("managed_service_instance"),
+    USER_PROVIDED_SERVICE_INSTANCE("user_provided_service_instance");
+
+    private final String type;
+
+    Type(String type) {
+      this.type = type;
+    }
+
+    @Nullable
+    @JsonCreator
+    public static Type fromType(String type) {
+      return stream(Type.values()).filter(st -> st.type.equalsIgnoreCase(type)).findFirst().orElse(null);
+    }
+  }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/SharedTo.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/SharedTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
 import lombok.Data;
 
+import java.util.Map;
+import java.util.Set;
+
 @Data
-public class ServicePlan {
-  private String id;
-  private String name;
-  private String serviceGuid;
+public class SharedTo {
+  private Set<Map<String, String>> data;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/SpaceSummary.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/SpaceSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,15 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
 import lombok.Data;
 
+import java.util.Set;
+
 @Data
-public class ServicePlan {
-  private String id;
-  private String name;
-  private String serviceGuid;
+public class SpaceSummary {
+  private Set<SummaryServiceInstance> services;
+
+  @Data
+  public static class SummaryServiceInstance {
+    String name;
+    String guid;
+  }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateSharedServiceInstances.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateSharedServiceInstances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3;
 
 import lombok.Data;
 
+import java.util.Map;
+import java.util.Set;
+
 @Data
-public class ServicePlan {
-  private String id;
-  private String name;
-  private String serviceGuid;
+public class CreateSharedServiceInstances {
+  private Set<Map<String, String>> data;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ShareCloudFoundryServiceAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ShareCloudFoundryServiceAtomicOperationConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.ShareCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.ShareCloudFoundryServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@CloudFoundryOperation(AtomicOperations.SHARE_SERVICE)
+@Component
+public class ShareCloudFoundryServiceAtomicOperationConverter extends AbstractCloudFoundryAtomicOperationConverter {
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new ShareCloudFoundryServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public ShareCloudFoundryServiceDescription convertDescription(Map input) {
+    ShareCloudFoundryServiceDescription converted = getObjectMapper().convertValue(input, ShareCloudFoundryServiceDescription.class);
+    converted.setClient(getClient(input));
+    return converted;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/UnshareCloudFoundryServiceAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/UnshareCloudFoundryServiceAtomicOperationConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.converters;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryOperation;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.UnshareCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.UnshareCloudFoundryServiceAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@CloudFoundryOperation(AtomicOperations.UNSHARE_SERVICE)
+@Component
+public class UnshareCloudFoundryServiceAtomicOperationConverter extends AbstractCloudFoundryAtomicOperationConverter {
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new UnshareCloudFoundryServiceAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public UnshareCloudFoundryServiceDescription convertDescription(Map input) {
+    UnshareCloudFoundryServiceDescription converted = getObjectMapper().convertValue(input, UnshareCloudFoundryServiceDescription.class);
+    converted.setClient(getClient(input));
+    return converted;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/ShareCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/ShareCloudFoundryServiceDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.Set;
 
 @Data
-public class ServicePlan {
-  private String id;
-  private String name;
-  private String serviceGuid;
+@EqualsAndHashCode(callSuper = true)
+public class ShareCloudFoundryServiceDescription extends AbstractCloudFoundryServiceDescription {
+  private String serviceInstanceName;
+  private Set<String> shareToRegions;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/UnshareCloudFoundryServiceDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/UnshareCloudFoundryServiceDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.Set;
 
 @Data
-public class ServicePlan {
-  private String id;
-  private String name;
-  private String serviceGuid;
+@EqualsAndHashCode(callSuper = true)
+public class UnshareCloudFoundryServiceDescription extends AbstractCloudFoundryServiceDescription {
+  private String serviceInstanceName;
+  private Set<String> unshareFromRegions;
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UnshareCloudFoundryServiceAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UnshareCloudFoundryServiceAtomicOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,21 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.ServiceInstanceResponse;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DestroyCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.UnshareCloudFoundryServiceDescription;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Set;
 
-import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.State.NOT_FOUND;
+import static java.util.stream.Collectors.toSet;
 
 @RequiredArgsConstructor
-public class DestroyCloudFoundryServiceAtomicOperation implements AtomicOperation<ServiceInstanceResponse> {
-  private static final String PHASE = "DELETE_SERVICE";
-  private final DestroyCloudFoundryServiceDescription description;
+public class UnshareCloudFoundryServiceAtomicOperation implements AtomicOperation<ServiceInstanceResponse> {
+  private static final String PHASE = "UNSHARE_SERVICE";
+  private final UnshareCloudFoundryServiceDescription description;
 
   private static Task getTask() {
     return TaskRepository.threadLocalTask.get();
@@ -40,15 +40,16 @@ public class DestroyCloudFoundryServiceAtomicOperation implements AtomicOperatio
   @Override
   public ServiceInstanceResponse operate(List priorOutputs) {
     Task task = getTask();
-    ServiceInstanceResponse response = description
-      .getClient()
-      .getServiceInstances()
-      .destroyServiceInstance(description.getSpace(), description.getServiceInstanceName());
-    task.updateStatus(PHASE, "Started removing service instance '" + description.getServiceInstanceName() + "' from space " + description.getSpace().getName());
-    LastOperation.State state = response.getState();
-    if(state == NOT_FOUND) {
-      task.updateStatus(PHASE, "Finished removing service instance '" + description.getServiceInstanceName() + "'");
-    }
-    return response;
+
+    String serviceInstanceName = description.getServiceInstanceName();
+    Set<String> unshareFromRegions = description.getUnshareFromRegions();
+    task.updateStatus(PHASE, "Unsharing service instance '" + serviceInstanceName +
+      "' from '" + String.join(", ", unshareFromRegions.stream().map(s -> "'" + s + "'").collect(toSet())));
+
+    ServiceInstanceResponse results = description.getClient().getServiceInstances().unshareServiceInstance(serviceInstanceName, unshareFromRegions);
+
+    task.updateStatus(PHASE, "Finished unsharing service instance '" + serviceInstanceName + "'");
+
+    return results;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServiceInstance.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServiceInstance.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.ServiceInstance.Type;
 import com.netflix.spinnaker.clouddriver.model.ServiceInstance;
 import lombok.Builder;
 import lombok.Value;
@@ -38,11 +39,20 @@ public class CloudFoundryServiceInstance implements ServiceInstance {
   String name;
 
   @JsonView(Views.Cache.class)
+  String id;
+
+  @JsonView(Views.Cache.class)
   String plan;
+
+  @JsonView(Views.Cache.class)
+  String planId;
 
   @JsonView(Views.Cache.class)
   String status;
 
   @JsonView(Views.Cache.class)
   Set<String> tags;
+
+  @JsonView(Views.Cache.class)
+  String type;
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/AbstractCloudFoundryAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/AbstractCloudFoundryAtomicOperationTest.java
@@ -39,13 +39,21 @@ class AbstractCloudFoundryAtomicOperationTest {
   Task runOperation(AtomicOperation<?> op) {
     Task task = new DefaultTask("test");
     TaskRepository.threadLocalTask.set(task);
-    Optional
-      .ofNullable(op.operate(emptyList()))
-      .ifPresent(o -> task.addResultObjects(Collections.singletonList(o)));
+    try {
+      Optional
+        .ofNullable(op.operate(emptyList()))
+        .ifPresent(o -> task.addResultObjects(Collections.singletonList(o)));
+    } catch (CloudFoundryApiException e) {
+      task.addResultObjects(Collections.singletonList(Collections.singletonMap("EXCEPTION", e)));
+    }
     return task;
   }
 
   static Condition<? super Status> status(String desc) {
     return new Condition<>(status -> status.getStatus().equals(desc), "description = '" + desc + "'");
+  }
+
+  static Condition<? super Status> statusStartsWith(String desc) {
+    return new Condition<>(status -> status.getStatus().startsWith(desc), "description = '" + desc + "'");
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeleteCloudFoundryLoadBalancerAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeleteCloudFoundryLoadBalancerAtomicOperationTest.java
@@ -20,7 +20,11 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiExce
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeleteCloudFoundryLoadBalancerDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryDomain;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryLoadBalancer;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Index.atIndex;
@@ -60,13 +64,13 @@ class DeleteCloudFoundryLoadBalancerAtomicOperationTest extends AbstractCloudFou
 
     DeleteCloudFoundryLoadBalancerAtomicOperation op = new DeleteCloudFoundryLoadBalancerAtomicOperation(desc);
 
-    Exception exception = null;
-    try {
-      runOperation(op);
-    } catch (CloudFoundryApiException cloudFoundryApiException) {
-      exception = cloudFoundryApiException;
-    }
-    assertThat(exception).isNotNull();
-    assertThat(exception.getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Load balancer does not exist");
+    Task task = runOperation(op);
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(Map.class);
+    Object ex = ((Map) o).get("EXCEPTION");
+    assertThat(ex).isInstanceOf(CloudFoundryApiException.class);
+    assertThat(((CloudFoundryApiException) ex).getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Load balancer does not exist");
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServiceAtomicOperationTest.java
@@ -46,7 +46,6 @@ class DeployCloudFoundryServiceAtomicOperationTest extends AbstractCloudFoundryA
 
     ServiceInstanceResponse serviceInstanceResponse = new ServiceInstanceResponse()
       .setServiceInstanceName("some-service-name")
-      .setServiceInstanceId("service-guid")
       .setType(UPDATE)
       .setState(IN_PROGRESS);
     when(client.getServiceInstances().createServiceInstance(any(), any(), any(), any(), any(), any()))
@@ -75,7 +74,6 @@ class DeployCloudFoundryServiceAtomicOperationTest extends AbstractCloudFoundryA
 
     ServiceInstanceResponse serviceInstanceResponse = new ServiceInstanceResponse()
       .setServiceInstanceName("some-up-service-name")
-      .setServiceInstanceId("up-service-guid")
       .setType(CREATE)
       .setState(SUCCEEDED);
     when(client.getServiceInstances().createUserProvidedServiceInstance(any(), any(), any(), any(), any(), any()))

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DestroyCloudFoundryServiceAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DestroyCloudFoundryServiceAtomicOperationTest.java
@@ -43,7 +43,6 @@ class DestroyCloudFoundryServiceAtomicOperationTest extends AbstractCloudFoundry
 
     ServiceInstanceResponse serviceInstanceResponse = new ServiceInstanceResponse()
       .setServiceInstanceName("service-instance-name")
-      .setServiceInstanceId("service-instance-guid")
       .setType(DELETE)
       .setState(IN_PROGRESS);
 
@@ -71,7 +70,6 @@ class DestroyCloudFoundryServiceAtomicOperationTest extends AbstractCloudFoundry
 
     ServiceInstanceResponse serviceInstanceResponse = new ServiceInstanceResponse()
       .setServiceInstanceName("up-service-instance-name")
-      .setServiceInstanceId("up-service-instance-guid")
       .setType(DELETE)
       .setState(NOT_FOUND);
 

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ScaleCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ScaleCloudFoundryServerGroupAtomicOperationTest.java
@@ -19,11 +19,14 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessStats;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.ScaleCloudFoundryServerGroupDescription;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,14 +69,14 @@ class ScaleCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFound
 
     ScaleCloudFoundryServerGroupAtomicOperation op = new ScaleCloudFoundryServerGroupAtomicOperation(poller, desc);
 
-    Exception exception = null;
-    try {
-      runOperation(op);
-    } catch (CloudFoundryApiException cloudFoundryApiException) {
-      exception = cloudFoundryApiException;
-    }
-    assertThat(exception).isNotNull();
-    assertThat(exception.getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Failed to start 'myapp' which instead crashed");
+    Task task = runOperation(op);
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(Map.class);
+    Object ex = ((Map) o).get("EXCEPTION");
+    assertThat(ex).isInstanceOf(CloudFoundryApiException.class);
+    assertThat(((CloudFoundryApiException) ex).getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Failed to start 'myapp' which instead crashed");
   }
 
   @Test

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ShareCloudFoundryServiceAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ShareCloudFoundryServiceAtomicOperationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.ServiceInstanceResponse;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.ShareCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.State.SUCCEEDED;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.Type.SHARE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.atIndex;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.*;
+
+class ShareCloudFoundryServiceAtomicOperationTest extends AbstractCloudFoundryAtomicOperationTest {
+  private ShareCloudFoundryServiceDescription desc = new ShareCloudFoundryServiceDescription();
+
+  @Test
+  void printsTwoStatusesWhenSharingSucceeds() {
+    desc.setRegion("org > space");
+    desc.setClient(client);
+    desc.setServiceInstanceName("service-instance-name");
+    Set<String> sharedToRegions = new HashSet<>();
+    sharedToRegions.add("org1 > region1");
+    sharedToRegions.add("org2 > region2");
+    sharedToRegions.add("org3 > region3");
+    desc.setShareToRegions(sharedToRegions);
+
+    ServiceInstanceResponse serviceInstanceResponse = new ServiceInstanceResponse()
+      .setServiceInstanceName("some-service-name")
+      .setType(SHARE)
+      .setState(SUCCEEDED);
+    when(client.getServiceInstances().shareServiceInstance(any(), any(), any()))
+      .thenReturn(serviceInstanceResponse);
+
+    ShareCloudFoundryServiceAtomicOperation op = new ShareCloudFoundryServiceAtomicOperation(desc);
+
+    Task task = runOperation(op);
+
+    verify(client.getServiceInstances(), times(1))
+      .shareServiceInstance(matches("org > space"), matches("service-instance-name"), same(sharedToRegions));
+    assertThat(task.getHistory())
+      .has(statusStartsWith("Sharing service instance 'service-instance-name' from 'org > space' into '"), atIndex(1));
+    assertThat(task.getHistory())
+      .has(status("Finished sharing service instance 'service-instance-name'"), atIndex(2));
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(ServiceInstanceResponse.class);
+    ServiceInstanceResponse response = (ServiceInstanceResponse) o;
+    assertThat(response).isEqualToComparingFieldByFieldRecursively(serviceInstanceResponse);
+  }
+
+  @Test
+  void printsOnlyOneStatusWhenSharingFails() {
+    desc.setRegion("org > space");
+    desc.setClient(client);
+    desc.setServiceInstanceName("service-instance-name");
+    Set<String> sharedToRegions = new HashSet<>();
+    sharedToRegions.add("org1 > region1");
+    sharedToRegions.add("org2 > region2");
+    sharedToRegions.add("org3 > region3");
+    desc.setShareToRegions(sharedToRegions);
+
+    when(client.getServiceInstances().shareServiceInstance(any(), any(), any()))
+      .thenThrow(new CloudFoundryApiException("Much fail"));
+
+    ShareCloudFoundryServiceAtomicOperation op = new ShareCloudFoundryServiceAtomicOperation(desc);
+
+    Task task = runOperation(op);
+
+    verify(client.getServiceInstances(), times(1))
+      .shareServiceInstance(matches("org > space"), matches("service-instance-name"), same(sharedToRegions));
+    assertThat(task.getHistory().size()).isEqualTo(2);
+    assertThat(task.getHistory())
+      .has(statusStartsWith("Sharing service instance 'service-instance-name' from 'org > space' into '"), atIndex(1));
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isNotInstanceOf(ServiceInstanceResponse.class);
+  }
+}

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/StartCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/StartCloudFoundryServerGroupAtomicOperationTest.java
@@ -19,10 +19,13 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessStats;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.StartCloudFoundryServerGroupDescription;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,13 +71,13 @@ class StartCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFound
 
     StartCloudFoundryServerGroupAtomicOperation op = new StartCloudFoundryServerGroupAtomicOperation(poller, desc);
 
-    Exception exception = null;
-    try {
-      runOperation(op);
-    } catch (CloudFoundryApiException cloudFoundryApiException) {
-      exception = cloudFoundryApiException;
-    }
-    assertThat(exception).isNotNull();
-    assertThat(exception.getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Failed to start 'myapp' which instead crashed");
+    Task task = runOperation(op);
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(Map.class);
+    Object ex = ((Map) o).get("EXCEPTION");
+    assertThat(ex).isInstanceOf(CloudFoundryApiException.class);
+    assertThat(((CloudFoundryApiException) ex).getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Failed to start 'myapp' which instead crashed");
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/StopCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/StopCloudFoundryServerGroupAtomicOperationTest.java
@@ -19,10 +19,13 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessStats;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.StopCloudFoundryServerGroupDescription;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,13 +71,13 @@ class StopCloudFoundryServerGroupAtomicOperationTest extends AbstractCloudFoundr
 
     StopCloudFoundryServerGroupAtomicOperation op = new StopCloudFoundryServerGroupAtomicOperation(poller, desc);
 
-    Exception exception = null;
-    try {
-      runOperation(op);
-    } catch (CloudFoundryApiException cloudFoundryApiException) {
-      exception = cloudFoundryApiException;
-    }
-    assertThat(exception).isNotNull();
-    assertThat(exception.getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Failed to stop 'myapp' which instead is running");
+    Task task = runOperation(op);
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(Map.class);
+    Object ex = ((Map) o).get("EXCEPTION");
+    assertThat(ex).isInstanceOf(CloudFoundryApiException.class);
+    assertThat(((CloudFoundryApiException) ex).getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Failed to stop 'myapp' which instead is running");
   }
 }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UnmapLoadBalancersAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UnmapLoadBalancersAtomicOperationTest.java
@@ -23,10 +23,12 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.LoadBal
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryDomain;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryLoadBalancer;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import io.vavr.collection.List;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
@@ -53,14 +55,14 @@ class UnmapLoadBalancersAtomicOperationTest extends AbstractCloudFoundryAtomicOp
   void operateWithNullRoutes() {
     UnmapLoadBalancersAtomicOperation op = new UnmapLoadBalancersAtomicOperation(desc);
 
-    Exception exception = null;
-    try {
-      runOperation(op);
-    } catch (CloudFoundryApiException cloudFoundryApiException) {
-      exception = cloudFoundryApiException;
-    }
-    assertThat(exception).isNotNull();
-    assertThat(exception.getMessage()).isEqualTo("Cloud Foundry API returned with error(s): No load balancer specified");
+    Task task = runOperation(op);
+    java.util.List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(Map.class);
+    Object ex = ((Map) o).get("EXCEPTION");
+    assertThat(ex).isInstanceOf(CloudFoundryApiException.class);
+    assertThat(((CloudFoundryApiException) ex).getMessage()).isEqualTo("Cloud Foundry API returned with error(s): No load balancer specified");
   }
 
   @Test
@@ -68,14 +70,14 @@ class UnmapLoadBalancersAtomicOperationTest extends AbstractCloudFoundryAtomicOp
     desc.setRoutes(Collections.emptyList());
     UnmapLoadBalancersAtomicOperation op = new UnmapLoadBalancersAtomicOperation(desc);
 
-    Exception exception = null;
-    try {
-      runOperation(op);
-    } catch (CloudFoundryApiException cloudFoundryApiException) {
-      exception = cloudFoundryApiException;
-    }
-    assertThat(exception).isNotNull();
-    assertThat(exception.getMessage()).isEqualTo("Cloud Foundry API returned with error(s): No load balancer specified");
+    Task task = runOperation(op);
+    java.util.List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(Map.class);
+    Object ex = ((Map) o).get("EXCEPTION");
+    assertThat(ex).isInstanceOf(CloudFoundryApiException.class);
+    assertThat(((CloudFoundryApiException) ex).getMessage()).isEqualTo("Cloud Foundry API returned with error(s): No load balancer specified");
   }
 
   @Test
@@ -85,14 +87,14 @@ class UnmapLoadBalancersAtomicOperationTest extends AbstractCloudFoundryAtomicOp
       "bad.route 2.example.com"
     ).asJava());
     UnmapLoadBalancersAtomicOperation op = new UnmapLoadBalancersAtomicOperation(desc);
-    Exception exception = null;
-    try {
-      runOperation(op);
-    } catch (CloudFoundryApiException cloudFoundryApiException) {
-      exception = cloudFoundryApiException;
-    }
-    assertThat(exception).isNotNull();
-    assertThat(exception.getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Load balancer 'bad.route-1.example.com' does not exist");
+    Task task = runOperation(op);
+    java.util.List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(Map.class);
+    Object ex = ((Map) o).get("EXCEPTION");
+    assertThat(ex).isInstanceOf(CloudFoundryApiException.class);
+    assertThat(((CloudFoundryApiException) ex).getMessage()).isEqualTo("Cloud Foundry API returned with error(s): Load balancer 'bad.route-1.example.com' does not exist");
   }
 
   @Test

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UnshareCloudFoundryServiceAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UnshareCloudFoundryServiceAtomicOperationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
+
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.ServiceInstanceResponse;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.UnshareCloudFoundryServiceDescription;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.State.SUCCEEDED;
+import static com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.LastOperation.Type.UNSHARE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.atIndex;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.*;
+
+class UnshareCloudFoundryServiceAtomicOperationTest extends AbstractCloudFoundryAtomicOperationTest {
+  private UnshareCloudFoundryServiceDescription desc = new UnshareCloudFoundryServiceDescription();
+
+  @Test
+  void deployService() {
+    desc.setRegion("org > space");
+    desc.setClient(client);
+    desc.setServiceInstanceName("service-instance-name");
+    Set<String> unsharedFromRegions = new HashSet<>();
+    unsharedFromRegions.add("org1 > region1");
+    unsharedFromRegions.add("org2 > region2");
+    unsharedFromRegions.add("org3 > region3");
+    desc.setUnshareFromRegions(unsharedFromRegions);
+
+    ServiceInstanceResponse serviceInstanceResponse = new ServiceInstanceResponse()
+      .setServiceInstanceName("some-service-name")
+      .setType(UNSHARE)
+      .setState(SUCCEEDED);
+    when(client.getServiceInstances().unshareServiceInstance(any(), any()))
+      .thenReturn(serviceInstanceResponse);
+
+    UnshareCloudFoundryServiceAtomicOperation op = new UnshareCloudFoundryServiceAtomicOperation(desc);
+
+    Task task = runOperation(op);
+
+    verify(client.getServiceInstances(), times(1))
+      .unshareServiceInstance(matches("service-instance-name"), same(unsharedFromRegions));
+    assertThat(task.getHistory())
+      .has(statusStartsWith("Unsharing service instance 'service-instance-name' from '"), atIndex(1));
+    assertThat(task.getHistory())
+      .has(status("Finished unsharing service instance 'service-instance-name'"), atIndex(2));
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(1).isEqualTo(resultObjects.size());
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(ServiceInstanceResponse.class);
+    ServiceInstanceResponse response = (ServiceInstanceResponse) o;
+    assertThat(response).isEqualToComparingFieldByFieldRecursively(serviceInstanceResponse);
+  }
+
+  @Test
+  void printsOnlyOneStatusWhenUnsharingFails() {
+    desc.setRegion("org > space");
+    desc.setClient(client);
+    desc.setServiceInstanceName("service-instance-name");
+    Set<String> unshareFromRegions = new HashSet<>();
+    unshareFromRegions.add("org1 > region1");
+    unshareFromRegions.add("org2 > region2");
+    unshareFromRegions.add("org3 > region3");
+    desc.setUnshareFromRegions(unshareFromRegions);
+
+    when(client.getServiceInstances().unshareServiceInstance(any(), any()))
+      .thenThrow(new CloudFoundryApiException("Much fail"));
+
+    UnshareCloudFoundryServiceAtomicOperation op = new UnshareCloudFoundryServiceAtomicOperation(desc);
+
+    Task task = runOperation(op);
+
+    verify(client.getServiceInstances(), times(1))
+      .unshareServiceInstance(matches("service-instance-name"), same(unshareFromRegions));
+    assertThat(task.getHistory().size()).isEqualTo(2);
+    assertThat(task.getHistory())
+      .has(statusStartsWith("Unsharing service instance 'service-instance-name' from '"), atIndex(1));
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isNotInstanceOf(ServiceInstanceResponse.class);
+  }
+}

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UpsertCloudFoundryLoadBalancerAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UpsertCloudFoundryLoadBalancerAtomicOperationTest.java
@@ -18,11 +18,16 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.Routes;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.ServiceInstanceResponse;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.UpsertCloudFoundryLoadBalancerDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryDomain;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryLoadBalancer;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
+import com.netflix.spinnaker.clouddriver.data.task.Task;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -62,13 +67,13 @@ class UpsertCloudFoundryLoadBalancerAtomicOperationTest extends AbstractCloudFou
 
     UpsertCloudFoundryLoadBalancerAtomicOperation op = new UpsertCloudFoundryLoadBalancerAtomicOperation(desc);
 
-    try {
-      runOperation(op);
-      failBecauseExceptionWasNotThrown(CloudFoundryApiException.class);
-    } catch (CloudFoundryApiException e) {
-      assertThat(e.getMessage()).contains("Load balancer already exists in another organization and space");
-    } catch (Throwable t) {
-      fail("Expected CloudFoundryApiException; got " + t);
-    }
+    Task task = runOperation(op);
+    List<Object> resultObjects = task.getResultObjects();
+    assertThat(resultObjects.size()).isEqualTo(1);
+    Object o = resultObjects.get(0);
+    assertThat(o).isInstanceOf(Map.class);
+    Object ex = ((Map) o).get("EXCEPTION");
+    assertThat(ex).isInstanceOf(CloudFoundryApiException.class);
+    assertThat(((CloudFoundryApiException) ex).getMessage()).contains("Load balancer already exists in another organization and space");
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperations.java
@@ -94,8 +94,9 @@ public final class AtomicOperations {
   // Service operations
   public static final String DEPLOY_SERVICE = "deployService";
   public static final String DESTROY_SERVICE = "destroyService";
+  public static final String SHARE_SERVICE = "shareService";
+  public static final String UNSHARE_SERVICE = "unshareService";
 
   // CloudFormation operations
   public static final String DEPLOY_CLOUDFORMATION_STACK = "deployCloudFormation";
-
 }


### PR DESCRIPTION
- Added CF API calls necessary for the sharing and unsharing of services
- Also removed unnecessary 'throws' statements from function declarations
- Augmented Cloud Foundry's testing framework for handling exceptions thrown by *AtomicOperation.operate()

spinnaker/spinnaker#4065

Co-Authored-By: Jammy Louie <jlouie@pivotal.io>
Co-Authored-By: Jason Chu <jchu@pivotal.io>