### PR TITLE
fix(provider/azure): Failed to edit load balancer

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
@@ -85,6 +85,7 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
         description.subnetResourceId = appGatewayDescription.subnetResourceId
         description.serverGroups = appGatewayDescription.serverGroups
         description.trafficEnabledSG = appGatewayDescription.trafficEnabledSG
+        description.vnetResourceGroup = appGatewayDescription.vnetResourceGroup
 
         Deployment deployment = description.credentials.resourceManagerClient.createResourceFromTemplate(
           AzureAppGatewayResourceTemplate.getTemplate(description),


### PR DESCRIPTION
Background:
Currently it throws exception "Async operation failed with provisioning state: Failed" after clicked update button for editing load balancer.
Fix:
After investigated, the root cause is the 'vnetResourceGroup' field in tags to be passed to azure is null while updating. So bind the vnetResourceGroup value before pass to azure. After tested, it edits load balancer successfully.