### PR TITLE
fix(provider/kubernetes): Properly set unstable flag for deployment

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -120,7 +120,8 @@ public class KubernetesDeploymentHandler extends KubernetesHandler implements
     }
 
     if (available != null && available.getStatus().equalsIgnoreCase("false")) {
-      result.unavailable(available.getMessage());
+      result.unstable(available.getMessage())
+        .unavailable(available.getMessage());
     }
 
     V1beta2DeploymentCondition condition = status.getConditions()


### PR DESCRIPTION
If a deployment reports its "Available" deployment condition as false, we currently mark the manifest as unavailable but don't mark it as unstable, which means that downstream stages will continue before it stabilizes.

In most cases the logic below for comparing replica sets will end up marking the deployment as unstable as well as unavailable, but there are edge cases were Kubernetes (correctly) marks the deployment as unavailable but the Spinnaker logic does not.

One example is if the new replicas have not been created yet (such as if we poll quickly). In that case the replica counts will all match in the below logic and we'll mark the deployment stable.

It might make sense to just remove the logic below as it just duplicates what Kubernetes is doing to determine the status (though as noted here, does not completely account for all edge cases).