### PR TITLE
feat(cats): initial support for indexing resource by application

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/Cache.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/Cache.java
@@ -19,11 +19,16 @@ package com.netflix.spinnaker.cats.cache;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * Cache provides view access to data keyed by type and identifier.
  */
 public interface Cache {
+  enum StoreType {
+    REDIS, IN_MEMORY, SQL
+  }
+
   /**
    * Gets a single item from the cache by type and id
    *
@@ -115,4 +120,55 @@ public interface Cache {
    * @return the items matching the type and identifiers
    */
   Collection<CacheData> getAll(String type, String... identifiers);
+
+  /**
+   * Retrieves all items for the specified type associated with the provided application.
+   * Requires a storeType with secondary indexes and support in the type's caching agent.
+   *
+   * @param type  the type for which to retrieve items
+   * @param application the application name
+   * @return the matching items, keyed by type
+   */
+  default Map<String, Collection<CacheData>> getAllByApplication(String type, String application) {
+    throw new UnsupportedCacheMethodException("Method only implemented for StoreType.SQL");
+  }
+
+  /**
+   * Retrieves all items for the specified type associated with the provided application.
+   * Requires a storeType with secondary indexes and support in the type's caching agent.
+   *
+   * @param type  the type for which to retrieve items
+   * @param application the application name
+   * @param cacheFilter the cacheFilter to govern which relationships to fetch
+   * @return the matching items, keyed by type
+   */
+  default Map<String, Collection<CacheData>> getAllByApplication(String type,
+                                                    String application,
+                                                    CacheFilter cacheFilter) {
+    throw new UnsupportedCacheMethodException("Method only implemented for StoreType.SQL");
+  }
+
+  /**
+   * Retrieves all items for the specified type associated with the provided application.
+   * Requires a storeType with secondary indexes and support in the type's caching agent.
+   *
+   * @param types  collection of types for which to retrieve items
+   * @param application the application name
+   * @param cacheFilters cacheFilters to govern which relationships to fetch, as type to filter
+   * @return the matching items, keyed by type
+   */
+  default Map<String, Collection<CacheData>> getAllByApplication(Collection<String> types,
+                                                                 String application,
+                                                                 Map<String, CacheFilter> cacheFilters) {
+    throw new UnsupportedCacheMethodException("Method only implemented for StoreType.SQL");
+  }
+
+  /**
+   * Get backing store type for Cache implementation
+   *
+   * @return the backing StoreType
+   */
+  default StoreType storeType() {
+    return StoreType.REDIS;
+  }
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/UnsupportedCacheMethodException.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/UnsupportedCacheMethodException.java
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.cats.cache;
+
+public class UnsupportedCacheMethodException extends RuntimeException {
+  public UnsupportedCacheMethodException(String message) {
+    super(message);
+  }
+}

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/mem/InMemoryCache.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/mem/InMemoryCache.java
@@ -42,6 +42,11 @@ public class InMemoryCache implements WriteableCache {
     private ConcurrentMap<String, ConcurrentMap<String, CacheData>> typeMap = new ConcurrentHashMap<>();
 
     @Override
+    public StoreType storeType() {
+        return StoreType.IN_MEMORY;
+    }
+
+    @Override
     public void merge(String type, CacheData cacheData) {
         merge(getOrCreate(type, cacheData.getId()), cacheData);
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerInstanceStateCachingAgent.groovy
@@ -122,7 +122,12 @@ class AmazonLoadBalancerInstanceStateCachingAgent implements CachingAgent, Healt
         for (InstanceLoadBalancers ilb in ilbs) {
           String instanceId = Keys.getInstanceKey(ilb.instanceId, account.name, region)
           String healthId = Keys.getInstanceHealthKey(ilb.instanceId, account.name, region, healthId)
+
           Map<String, Object> attributes = objectMapper.convertValue(ilb, ATTRIBUTES)
+          if (idObj.containsKey("application")) {
+            attributes.put("application", idObj.get("application"))
+          }
+
           Map<String, Collection<String>> relationships = [(INSTANCES.ns): [instanceId]]
           lbHealths.add(new DefaultCacheData(healthId, attributes, relationships))
           instances.add(new DefaultCacheData(instanceId, [:], [(HEALTH.ns): [healthId]]))

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/InstanceCachingAgent.groovy
@@ -196,6 +196,11 @@ class InstanceCachingAgent implements CachingAgent, AccountAware, DriftMetric {
       relationships[IMAGES.ns].add(data.imageId)
       if (data.serverGroup) {
         relationships[SERVER_GROUPS.ns].add(data.serverGroup)
+
+        def application = Keys.parse(data.serverGroup).get("application")
+        if (application != null) {
+          attributes.put("application", application)
+        }
       } else {
         relationships[SERVER_GROUPS.ns].clear()
       }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/LaunchConfigCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/LaunchConfigCachingAgent.groovy
@@ -105,9 +105,16 @@ class LaunchConfigCachingAgent implements CachingAgent, AccountAware, DriftMetri
     }
 
     Collection<CacheData> launchConfigData = launchConfigs.collect { LaunchConfiguration lc ->
+      String key = Keys.getLaunchConfigKey(lc.launchConfigurationName, account.name, region)
+      String application = Keys.parse(key).get("application")
       Map<String, Object> attributes = objectMapper.convertValue(lc, ATTRIBUTES);
+
+      if (application != null) {
+        attributes.put("application", application)
+      }
+
       Map<String, Collection<String>> relationships = [(IMAGES.ns):[Keys.getImageKey(lc.imageId, account.name, region)]]
-      new DefaultCacheData(Keys.getLaunchConfigKey(lc.launchConfigurationName, account.name, region), attributes, relationships)
+      new DefaultCacheData(key, attributes, relationships)
     }
 
     recordDrift(start)

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/agent/EurekaCachingAgent.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/provider/agent/EurekaCachingAgent.groovy
@@ -109,6 +109,8 @@ class EurekaCachingAgent implements CachingAgent, HealthProvidingCachingAgent, C
           Map<String, Object> attributes = convertedInstancesById[instance.instanceId]
           attributes.eurekaAccountName = eurekaAccountName
           attributes.allowMultipleEurekaPerAccount = allowMultipleEurekaPerAccount
+          attributes.application = application.name.toLowerCase()
+
           eurekaAwareProviderList.each { provider ->
             if (provider.isProviderForEurekaRecord(attributes)) {
               String instanceKey = provider.getInstanceKey(attributes, region)


### PR DESCRIPTION
The upcoming sql backed cache implementation adds support for indexing
and retrieving resources by application. This can provide significant
performance improvements for Spinnaker's application clusters view when
application contain >thousands of instances and associated health
objects.

The new CacheData.attributes.application value is used by SqlCache for
this purpose. This PR selectively implements this in several of the AWS
caching agents. AmazonClusterProvider will take advantage when serving
/applications/{application}/serverGroups requests when the SqlCache
implementation is in use.