### PR TITLE
fix(kubernetes): Infer API version when missing on patch manifest

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiGroup.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiGroup.java
@@ -58,8 +58,8 @@ public class KubernetesApiGroup {
     return name;
   }
 
-  public boolean isCustomResourceGroup() {
-    return !NATIVE_GROUPS.contains(this);
+  public boolean isNativeGroup() {
+    return NATIVE_GROUPS.contains(this);
   }
 
   @JsonCreator

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -19,57 +19,56 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Slf4j
 public class KubernetesKind {
-  public static KubernetesKind API_SERVICE = new KubernetesKind("apiService", false);
-  public static KubernetesKind CLUSTER_ROLE = new KubernetesKind("clusterRole", false);
-  public static KubernetesKind CLUSTER_ROLE_BINDING = new KubernetesKind("clusterRoleBinding", false);
-  public static KubernetesKind CONFIG_MAP = new KubernetesKind("configMap", "cm");
-  public static KubernetesKind CONTROLLER_REVISION = new KubernetesKind("controllerRevision");
-  public static KubernetesKind CUSTOM_RESOURCE_DEFINITION = new KubernetesKind("customResourceDefinition", "crd", false, false);
-  public static KubernetesKind CRON_JOB = new KubernetesKind("cronJob");
-  public static KubernetesKind DAEMON_SET = new KubernetesKind("daemonSet", "ds", true, true);
-  public static KubernetesKind DEPLOYMENT = new KubernetesKind("deployment", "deploy", true, true);
-  public static KubernetesKind EVENT = new KubernetesKind("event");
-  public static KubernetesKind HORIZONTAL_POD_AUTOSCALER = new KubernetesKind("horizontalpodautoscaler", "hpa");
-  public static KubernetesKind INGRESS = new KubernetesKind("ingress", "ing", true, true);
-  public static KubernetesKind JOB = new KubernetesKind("job");
-  public static KubernetesKind MUTATING_WEBHOOK_CONFIGURATION = new KubernetesKind("mutatingWebhookConfiguration", null, false, false);
-  public static KubernetesKind NAMESPACE = new KubernetesKind("namespace", "ns", false, false);
-  public static KubernetesKind NETWORK_POLICY = new KubernetesKind("networkPolicy", "netpol", true, true);
-  public static KubernetesKind PERSISTENT_VOLUME = new KubernetesKind("persistentVolume", "pv", false, false);
-  public static KubernetesKind PERSISTENT_VOLUME_CLAIM = new KubernetesKind("persistentVolumeClaim", "pvc");
-  public static KubernetesKind POD = new KubernetesKind("pod", "po", true, true);
-  public static KubernetesKind POD_PRESET = new KubernetesKind("podPreset");
-  public static KubernetesKind POD_SECURITY_POLICY = new KubernetesKind("podSecurityPolicy", false);
-  public static KubernetesKind POD_DISRUPTION_BUDGET = new KubernetesKind("podDisruptionBudget");
-  public static KubernetesKind REPLICA_SET = new KubernetesKind("replicaSet", "rs", true, true);
-  public static KubernetesKind ROLE = new KubernetesKind("role", true);
-  public static KubernetesKind ROLE_BINDING = new KubernetesKind("roleBinding", true);
-  public static KubernetesKind SECRET = new KubernetesKind("secret");
-  public static KubernetesKind SERVICE = new KubernetesKind("service", "svc", true, true);
-  public static KubernetesKind SERVICE_ACCOUNT = new KubernetesKind("serviceAccount", "sa");
-  public static KubernetesKind STATEFUL_SET = new KubernetesKind("statefulSet", null, true, true);
-  public static KubernetesKind STORAGE_CLASS = new KubernetesKind("storageClass", "sc", false, false);
-  public static KubernetesKind VALIDATING_WEBHOOK_CONFIGURATION = new KubernetesKind("validatingWebhookConfiguration", null, false, false);
+  public static KubernetesKind API_SERVICE = new KubernetesKind("apiService", KubernetesApiGroup.APIREGISTRATION_K8S_IO, false);
+  public static KubernetesKind CLUSTER_ROLE = new KubernetesKind("clusterRole", KubernetesApiGroup.RBAC_AUTHORIZATION_K8S_IO, false);
+  public static KubernetesKind CLUSTER_ROLE_BINDING = new KubernetesKind("clusterRoleBinding", KubernetesApiGroup.RBAC_AUTHORIZATION_K8S_IO, false);
+  public static KubernetesKind CONFIG_MAP = new KubernetesKind("configMap", KubernetesApiGroup.CORE, "cm");
+  public static KubernetesKind CONTROLLER_REVISION = new KubernetesKind("controllerRevision", KubernetesApiGroup.APPS);
+  public static KubernetesKind CUSTOM_RESOURCE_DEFINITION = new KubernetesKind("customResourceDefinition", KubernetesApiGroup.EXTENSIONS, "crd", false, false);
+  public static KubernetesKind CRON_JOB = new KubernetesKind("cronJob", KubernetesApiGroup.BATCH);
+  public static KubernetesKind DAEMON_SET = new KubernetesKind("daemonSet", KubernetesApiGroup.APPS, "ds", true, true);
+  public static KubernetesKind DEPLOYMENT = new KubernetesKind("deployment", KubernetesApiGroup.APPS, "deploy", true, true);
+  public static KubernetesKind EVENT = new KubernetesKind("event", KubernetesApiGroup.CORE);
+  public static KubernetesKind HORIZONTAL_POD_AUTOSCALER = new KubernetesKind("horizontalpodautoscaler", KubernetesApiGroup.AUTOSCALING, "hpa");
+  public static KubernetesKind INGRESS = new KubernetesKind("ingress", KubernetesApiGroup.EXTENSIONS, "ing", true, true);
+  public static KubernetesKind JOB = new KubernetesKind("job", KubernetesApiGroup.BATCH);
+  public static KubernetesKind MUTATING_WEBHOOK_CONFIGURATION = new KubernetesKind("mutatingWebhookConfiguration", KubernetesApiGroup.ADMISSIONREGISTRATION_K8S_IO, null, false, false);
+  public static KubernetesKind NAMESPACE = new KubernetesKind("namespace", KubernetesApiGroup.CORE, "ns", false, false);
+  public static KubernetesKind NETWORK_POLICY = new KubernetesKind("networkPolicy", KubernetesApiGroup.EXTENSIONS, "netpol", true, true);
+  public static KubernetesKind PERSISTENT_VOLUME = new KubernetesKind("persistentVolume", KubernetesApiGroup.CORE, "pv", false, false);
+  public static KubernetesKind PERSISTENT_VOLUME_CLAIM = new KubernetesKind("persistentVolumeClaim", KubernetesApiGroup.CORE, "pvc");
+  public static KubernetesKind POD = new KubernetesKind("pod", KubernetesApiGroup.CORE, "po", true, true);
+  public static KubernetesKind POD_PRESET = new KubernetesKind("podPreset", KubernetesApiGroup.SETTINGS_K8S_IO);
+  public static KubernetesKind POD_SECURITY_POLICY = new KubernetesKind("podSecurityPolicy", KubernetesApiGroup.EXTENSIONS, false);
+  public static KubernetesKind POD_DISRUPTION_BUDGET = new KubernetesKind("podDisruptionBudget", KubernetesApiGroup.POLICY);
+  public static KubernetesKind REPLICA_SET = new KubernetesKind("replicaSet", KubernetesApiGroup.APPS, "rs", true, true);
+  public static KubernetesKind ROLE = new KubernetesKind("role", KubernetesApiGroup.RBAC_AUTHORIZATION_K8S_IO, true);
+  public static KubernetesKind ROLE_BINDING = new KubernetesKind("roleBinding", KubernetesApiGroup.RBAC_AUTHORIZATION_K8S_IO, true);
+  public static KubernetesKind SECRET = new KubernetesKind("secret", KubernetesApiGroup.CORE);
+  public static KubernetesKind SERVICE = new KubernetesKind("service", KubernetesApiGroup.CORE, "svc", true, true);
+  public static KubernetesKind SERVICE_ACCOUNT = new KubernetesKind("serviceAccount", KubernetesApiGroup.CORE, "sa");
+  public static KubernetesKind STATEFUL_SET = new KubernetesKind("statefulSet", KubernetesApiGroup.APPS, null, true, true);
+  public static KubernetesKind STORAGE_CLASS = new KubernetesKind("storageClass", KubernetesApiGroup.STORAGE_K8S_IO, "sc", false, false);
+  public static KubernetesKind VALIDATING_WEBHOOK_CONFIGURATION = new KubernetesKind("validatingWebhookConfiguration", KubernetesApiGroup.ADMISSIONREGISTRATION_K8S_IO, null, false, false);
 
   // special kind that should never be assigned to a manifest, used only to represent objects whose kind is not in spinnaker's registry
-  public static KubernetesKind NONE = new KubernetesKind("none", null, true, false);
+  public static KubernetesKind NONE = new KubernetesKind("none", null, null, true, false);
 
   private final String name;
+  private final KubernetesApiGroup apiGroup;
   private final String alias;
   private boolean isNamespaced;
   // generally reserved for workloads, can be read as "does this belong to a spinnaker cluster?"
@@ -82,12 +81,13 @@ public class KubernetesKind {
   @Getter
   private static List<KubernetesKind> values;
 
-  protected KubernetesKind(String name, String alias, boolean isNamespaced, boolean hasClusterRelationship) {
+  protected KubernetesKind(String name, KubernetesApiGroup apiGroup, String alias, boolean isNamespaced, boolean hasClusterRelationship) {
     if (values == null) {
       values = Collections.synchronizedList(new ArrayList<>());
     }
 
     this.name = name;
+    this.apiGroup = apiGroup;
     this.alias = alias;
     this.isNamespaced = isNamespaced;
     this.hasClusterRelationship = hasClusterRelationship;
@@ -96,16 +96,16 @@ public class KubernetesKind {
     values.add(this);
   }
 
-  protected KubernetesKind(String name) {
-    this(name, null, true, false);
+  protected KubernetesKind(String name, KubernetesApiGroup apiGroup) {
+    this(name, apiGroup, null, true, false);
   }
 
-  protected KubernetesKind(String name, String alias) {
-    this(name, alias, true, false);
+  protected KubernetesKind(String name, KubernetesApiGroup apiGroup, String alias) {
+    this(name, apiGroup, alias, true, false);
   }
 
-  protected KubernetesKind(String name, boolean isNamespaced) {
-    this(name, null, isNamespaced, false);
+  protected KubernetesKind(String name, KubernetesApiGroup apiGroup, boolean isNamespaced) {
+    this(name, apiGroup, null, isNamespaced, false);
   }
 
   public boolean isNamespaced() {
@@ -127,7 +127,10 @@ public class KubernetesKind {
   @Override
   @JsonValue
   public String toString() {
-    return name;
+    if (apiGroup == null || apiGroup.isNativeGroup()) {
+      return name;
+    }
+    return name + "." + apiGroup.toString();
   }
 
   @JsonCreator
@@ -135,12 +138,21 @@ public class KubernetesKind {
     return fromString(name, true, true);
   }
 
-  public static KubernetesKind fromString(String name, KubernetesApiGroup apiGroup) {
-    return fromString(name, true, true, apiGroup);
+  public static KubernetesKind fromString(String name, boolean registered, boolean namespaced) {
+    KubernetesApiGroup apiGroup;
+    String kindName;
+    String[] parts = StringUtils.split(name, ".", 2);
+    if (parts.length == 2) {
+      kindName = parts[0];
+      apiGroup = KubernetesApiGroup.fromString(parts[1]);
+    } else {
+      kindName = name;
+      apiGroup = null;
+    }
+    return KubernetesKind.getOrRegisterKind(kindName, registered, namespaced, apiGroup);
   }
 
-  private static KubernetesKind fromString(final String name, final boolean registered, final boolean namespaced,
-      KubernetesApiGroup apiGroup) {
+  public static KubernetesKind getOrRegisterKind(final String name, final boolean registered, final boolean namespaced, final KubernetesApiGroup apiGroup) {
     if (StringUtils.isEmpty(name)) {
       return null;
     }
@@ -149,56 +161,41 @@ public class KubernetesKind {
       throw new IllegalArgumentException("The 'NONE' kind cannot be read.");
     }
 
-    String localName = name;
-    boolean localRegistered = registered;
-
-    if (Objects.isNull(apiGroup)) {
-      apiGroup = getApiGroup(name);
-    }
-
-    if (apiGroup.isCustomResourceGroup()) {
-      localRegistered = false;
-      if (!name.endsWith(apiGroup.toString())) {
-        localName = name + "." + apiGroup;
+    Predicate<KubernetesKind> groupMatches = kind -> {
+      // Exact match
+      if (kind.apiGroup == apiGroup) {
+        return true;
       }
-    }
 
-    final String finalName = localName;
-    final boolean finalRegistered = localRegistered;
+      // If we have not specified an API group, default to finding a native kind that matches
+      if (apiGroup == null || apiGroup.isNativeGroup()) {
+        return kind.apiGroup.isNativeGroup();
+      }
+
+      return false;
+    };
 
     synchronized (values) {
       Optional<KubernetesKind> kindOptional = values.stream()
-        .filter(v -> v.name.equalsIgnoreCase(finalName) || (v.alias != null && v.alias.equalsIgnoreCase(finalName)))
+        .filter(v -> v.name.equalsIgnoreCase(name) || (v.alias != null && v.alias.equalsIgnoreCase(name)))
+        .filter(groupMatches)
         .findAny();
 
       // separate from the above chain to avoid concurrent modification of the values list
       return kindOptional.orElseGet(() -> {
-        log.info("Dynamically registering {}, (namespaced: {}, registered: {})", finalName, namespaced, finalRegistered);
-        KubernetesKind result = new KubernetesKind(finalName);
+        log.info("Dynamically registering {}, (namespaced: {}, registered: {})", name, namespaced, registered);
+        KubernetesKind result = new KubernetesKind(name, Optional.ofNullable(apiGroup).orElse(KubernetesApiGroup.NONE));
         result.isDynamic = true;
-        result.isRegistered = finalRegistered;
+        result.isRegistered = registered;
         result.isNamespaced = namespaced;
         return result;
       });
     }
   }
 
-  public static KubernetesKind fromString(String name, boolean registered, boolean namespaced) {
-    return KubernetesKind.fromString(name, registered, namespaced, null);
-  }
-
   public static List<KubernetesKind> registeredStringList(List<String> names) {
     return names.stream()
         .map(KubernetesKind::fromString)
         .collect(Collectors.toList());
-  }
-
-  private static KubernetesApiGroup getApiGroup(String name) {
-    final String[] parts = name.split("\\.");
-    if (parts.length < 2) {
-      return KubernetesApiGroup.NONE;
-    }
-
-    return KubernetesApiGroup.fromString(StringUtils.joinWith(".", Arrays.stream(parts).skip(1).toArray()));
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -52,7 +52,13 @@ public class KubernetesManifest extends HashMap<String, Object> {
   public KubernetesKind getKind() {
     //using ApiVersion here allows a translation from a kind of NetworkPolicy in the manifest to something
     //like  NetworkPolicy.crd.projectcalico.org for custom resources
-    return KubernetesKind.fromString(getRequiredField(this, "kind"), getApiVersion().getApiGroup());
+    KubernetesApiGroup kubernetesApiGroup;
+    if (this.containsKey("apiVersion")) {
+      kubernetesApiGroup = getApiVersion().getApiGroup();
+    } else {
+      kubernetesApiGroup = null;
+    }
+    return KubernetesKind.fromString(getRequiredField(this, "kind"), kubernetesApiGroup);
   }
 
   @JsonIgnore

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -52,13 +52,14 @@ public class KubernetesManifest extends HashMap<String, Object> {
   public KubernetesKind getKind() {
     //using ApiVersion here allows a translation from a kind of NetworkPolicy in the manifest to something
     //like  NetworkPolicy.crd.projectcalico.org for custom resources
+    String kindName = getRequiredField(this, "kind");
     KubernetesApiGroup kubernetesApiGroup;
     if (this.containsKey("apiVersion")) {
       kubernetesApiGroup = getApiVersion().getApiGroup();
     } else {
       kubernetesApiGroup = null;
     }
-    return KubernetesKind.fromString(getRequiredField(this, "kind"), kubernetesApiGroup);
+    return KubernetesKind.getOrRegisterKind(kindName, true, true, kubernetesApiGroup);
   }
 
   @JsonIgnore

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentia
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.JsonPatch;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPatchOptions;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
@@ -414,9 +415,10 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
               String name = names.get("kind");
 
               String group = (String) spec.getOrDefault("group", "");
-              String scopedName = (!group.isEmpty()) ? name + "." + group : name;
+              KubernetesApiGroup kubernetesApiGroup = KubernetesApiGroup.fromString(group);
+              boolean isNamespaced = scope.equalsIgnoreCase("namespaced");
 
-              return KubernetesKind.fromString(scopedName, false, scope.equalsIgnoreCase("namespaced"));
+              return KubernetesKind.getOrRegisterKind(name, false, isNamespaced, kubernetesApiGroup);
             })
             .collect(Collectors.toList());
       } catch (KubectlException e) {


### PR DESCRIPTION
* fix(kubernetes): Infer API version when missing on patch manifest 

  The patch manifest stage is currently failing, because we're fetching the apiGroup as a required field. If there is no apiGroup specified, we should try to match the supplied kind against native groups.

* refactor(kubernetes): Add optional apiGroup to KubernetesKind 

  As I was working on the last commit, I found it a bit confusing knowing whether a given 'kind' string I was dealing with was a fully-qualified kind (with API group) or just the kind string.

  To make this less ambiguous, include 'apiGroup' as a field on the KubernetesKind object, and handle scoping as part of toString and fromString so this happens in one place.

  This adds the default api group for built-in kinds, but explicitly considers two built-in kinds as matching even if the API group doesn't to handle cases such as deployments which can exist in either apps or extensions.