### PR TITLE
fix(provider/azure): re-add resource names to the deployment name

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
@@ -56,10 +56,11 @@ class AzureResourceManagerClient extends AzureBaseClient {
   Deployment createResourceFromTemplate(String template,
                                         String resourceGroupName,
                                         String region,
+                                        String resourceName,
                                         String resourceType,
                                         Map<String, Object> templateParams = [:]) {
 
-    String deploymentName = [resourceType, "deployment"].join(AzureUtilities.NAME_SEPARATOR)
+    String deploymentName = [resourceName, resourceType, "deployment"].join(AzureUtilities.NAME_SEPARATOR)
     if (!templateParams['location']) {
       templateParams['location'] = region
     }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/UpsertAzureAppGatewayAtomicOperation.groovy
@@ -91,6 +91,7 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
           AzureAppGatewayResourceTemplate.getTemplate(description),
           resourceGroupName,
           description.region,
+          description.loadBalancerName,
           "appGateway")
 
         errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name())
@@ -167,6 +168,7 @@ class UpsertAzureAppGatewayAtomicOperation implements AtomicOperation<Map> {
           AzureAppGatewayResourceTemplate.getTemplate(description),
           resourceGroupName,
           description.region,
+          description.loadBalancerName,
           "appGateway")
 
         errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name())

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/UpsertAzureLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/UpsertAzureLoadBalancerAtomicOperation.groovy
@@ -62,6 +62,7 @@ class UpsertAzureLoadBalancerAtomicOperation implements AtomicOperation<Map> {
         AzureLoadBalancerResourceTemplate.getTemplate(description),
         resourceGroupName,
         description.region,
+        description.loadBalancerName,
         "loadBalancer")
 
       errList = AzureDeploymentOperation.checkDeploymentOperationStatus(task, BASE_PHASE, description.credentials, resourceGroupName, deployment.name())

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/UpsertAzureSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/UpsertAzureSecurityGroupAtomicOperation.groovy
@@ -74,6 +74,7 @@ class UpsertAzureSecurityGroupAtomicOperation implements AtomicOperation<Map> {
         AzureSecurityGroupResourceTemplate.getTemplate(description),
         resourceGroupName,
         description.region,
+        description.securityGroupName,
         "securityGroup",
         templateParamMap)
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
@@ -211,6 +211,7 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
           AzureServerGroupResourceTemplate.getTemplate(description),
           resourceGroupName,
           description.region,
+          description.name,
           "serverGroup",
           templateParameters)
 


### PR DESCRIPTION
This PR is to partially revert a previous [PR](https://github.com/spinnaker/clouddriver/pull/3473) covering the logic of removing unnecessary info in the name of the resource deployment. While we find those removed info could be useful in tracking deployment, so I add it back.