### PR TITLE
fix(cf): Unmap LBs too aggressive

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UnmapLoadBalancersAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/UnmapLoadBalancersAtomicOperation.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops;
 
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.Routes;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.LoadBalancersDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryLoadBalancer;
@@ -61,10 +62,10 @@ public class UnmapLoadBalancersAtomicOperation
         }
       });
 
-
+      CloudFoundryClient client = description.getClient();
       lbMap.forEach((uri, o) -> {
         getTask().updateStatus(PHASE, "Unmapping load balancer '" + uri + "'");
-        o.ifPresent(lb -> routes.deleteRoute(lb.getId()));
+        o.ifPresent(lb -> client.getApplications().unmapRoute(description.getServerGroupId(), lb.getId()));
         getTask().updateStatus(PHASE, "Unmapped load balancer '" + uri + "'");
       });
     }


### PR DESCRIPTION
Attempting to unmap a load balancer from a single server group would remove it universally.  It should be limited to a single version of an application.

spinnaker/spinnaker#4164