### PR TITLE
fix(titus): set adjustmentType when copying scaling policies on clone

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/UpsertTitusScalingPolicyDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/UpsertTitusScalingPolicyDescription.groovy
@@ -163,6 +163,7 @@ class UpsertTitusScalingPolicyDescription extends AbstractTitusCredentialsDescri
       StepScalingPolicy stepPolicy = stepDescriptor.scalingPolicy
       Step step = new Step()
       description.step = step
+      description.adjustmentType = stepPolicy.adjustmentType
       step.cooldown = stepPolicy.cooldownSec.value
       step.metricAggregationType = stepPolicy.metricAggregationType
       step.stepAdjustments = []


### PR DESCRIPTION
Apparently AWS will default this to "add", so we should probably set it to whatever the old value was.