### PR TITLE
fix(titus): fix and hydrate titus instance search results

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
@@ -115,7 +115,7 @@ class Keys implements KeyParser {
           result << [application: names.app.toLowerCase(), cluster: parts[2], account: parts[3], region: parts[4], serverGroup: parts[5], stack: names.stack, detail: names.detail, sequence: names.sequence?.toString()]
           break
         case Namespace.INSTANCES.ns:
-            result << [id: parts[2], region: parts[3], instanceId: parts[5]]
+          result << [id: parts[2], region: parts[3], instanceId: parts[5]]
           break
         case Namespace.CLUSTERS.ns:
           def names = Names.parseName(parts[4])


### PR DESCRIPTION
Titus tasks (i.e. instances) show up in search results in an unclickable way right now because they're not hydrated. This hydrates them so we can show valid links in the UI