### PR TITLE
feat(kuberenetes): v2 run job stage

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesModelUtil.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesModelUtil.java
@@ -30,8 +30,12 @@ import java.util.stream.Collectors;
 @Slf4j
 public class KubernetesModelUtil {
   public static long translateTime(String time) {
+    return KubernetesModelUtil.translateTime(time, "yyyy-MM-dd'T'HH:mm:ssX");
+  }
+
+  public static long translateTime(String time, String format) {
     try {
-      return StringUtils.isNotEmpty(time) ? (new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse(time)).getTime() : 0;
+      return StringUtils.isNotEmpty(time) ? (new SimpleDateFormat(format).parse(time)).getTime() : 0;
     } catch (ParseException e) {
       log.error("Failed to parse kubernetes timestamp", e);
       return 0;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/view/KubernetesJobProvider.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/view/KubernetesJobProvider.groovy
@@ -22,17 +22,19 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Cred
 import com.netflix.spinnaker.clouddriver.model.JobProvider
 import com.netflix.spinnaker.clouddriver.model.JobState
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.beans.factory.annotation.Autowired
+import io.fabric8.kubernetes.api.model.Pod
 import org.springframework.stereotype.Component
+
 
 @Component
 class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
   String platform = "kubernetes"
 
-  @Autowired
   AccountCredentialsProvider accountCredentialsProvider
 
-  KubernetesJobProvider() { }
+  KubernetesJobProvider(AccountCredentialsProvider accountCredentialsProvider) {
+    this.accountCredentialsProvider = accountCredentialsProvider
+  }
 
   @Override
   KubernetesJobStatus collectJob(String account, String location, String id) {
@@ -41,7 +43,7 @@ class KubernetesJobProvider implements JobProvider<KubernetesJobStatus> {
       return null
     }
     def trueCredentials = (credentials as KubernetesNamedAccountCredentials).credentials
-    def pod = trueCredentials.apiAdaptor.getPod(location, id)
+    Pod pod = trueCredentials.apiAdaptor.getPod(location, id)
     def status = new KubernetesJobStatus(pod, account)
 
     String podName = pod.getMetadata().getName()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/converter/job/KubernetesRunJobOperationConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/converter/job/KubernetesRunJobOperationConverter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.converter.job;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.converters.KubernetesAtomicOperationConverterHelper;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.KubernetesV2ArtifactProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.job.KubernetesRunJobOperationDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubernetesRunJobOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.RUN_JOB;
+
+@KubernetesOperation(RUN_JOB)
+@Component
+public class KubernetesRunJobOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+
+  private KubernetesResourcePropertyRegistry registry;
+
+  private KubernetesV2ArtifactProvider artifactProvider;
+
+  public KubernetesRunJobOperationConverter(KubernetesResourcePropertyRegistry registry, KubernetesV2ArtifactProvider artifactProvider) {
+    this.registry = registry;
+    this.artifactProvider = artifactProvider;
+  }
+
+  @Override
+  public AtomicOperation convertOperation(Map input){
+    return new KubernetesRunJobOperation(convertDescription(input), registry, artifactProvider);
+  }
+
+
+  @Override
+  public KubernetesRunJobOperationDescription convertDescription(Map input){
+    return (KubernetesRunJobOperationDescription) KubernetesAtomicOperationConverterHelper
+      .convertDescription(input, this, KubernetesRunJobOperationDescription.class);
+  }
+
+  @Override
+  public boolean acceptsVersion(ProviderVersion version) {
+    return version == ProviderVersion.v2;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/job/KubernetesRunJobOperationDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/job/KubernetesRunJobOperationDescription.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.job;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class KubernetesRunJobOperationDescription extends KubernetesAtomicOperationDescription {
+  String application;
+  String namespace = "";
+  KubernetesManifest manifest;
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/KubernetesV2JobStatus.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/KubernetesV2JobStatus.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesModelUtil;
+import com.netflix.spinnaker.clouddriver.model.JobState;
+import com.netflix.spinnaker.clouddriver.model.JobStatus;
+import io.kubernetes.client.models.V1Job;
+import io.kubernetes.client.models.V1JobCondition;
+import io.kubernetes.client.models.V1JobSpec;
+import io.kubernetes.client.models.V1JobStatus;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.*;
+
+@Data
+public class KubernetesV2JobStatus implements JobStatus, Serializable {
+
+  String name;
+  String cluster;
+  String account;
+  String id;
+  String location;
+  String provider = "kubernetes";
+  Long createdTime;
+  Long completedTime;
+  String message;
+  String reason;
+  Integer exitCode;
+  Integer signal;
+  String logs;
+  @JsonIgnore
+  V1Job job;
+
+  public KubernetesV2JobStatus(V1Job job, String account) {
+    this.job = job;
+    this.account = account;
+    this.name = job.getMetadata().getName();
+    this.location = job.getMetadata().getNamespace();
+    this.createdTime = KubernetesModelUtil.translateTime(
+      job.getMetadata().getCreationTimestamp().toString(), "yyyy-MM-dd'T'HH:mm:ss"
+    );
+  }
+
+  public Map<String, String> getCompletionDetails() {
+    Map<String, String> details = new HashMap<>();
+    details.put("exitCode", this.exitCode != null ? this.exitCode.toString() : "");
+    details.put("signal", this.signal != null ? this.signal.toString(): "");
+    details.put("message", this.message != null ? this.message : "");
+    details.put("reason", this.reason != null ? this.reason : "");
+    return details;
+  }
+
+  public JobState getJobState() {
+    V1JobStatus status = job.getStatus();
+    if (status == null) {
+      return JobState.Running;
+    }
+    int completions = Optional.of(job.getSpec()).map(V1JobSpec::getCompletions).orElse(1);
+    int succeeded = Optional.of(status).map(V1JobStatus::getSucceeded).orElse(0);
+
+    if (succeeded < completions) {
+      List<V1JobCondition> conditions = status.getConditions();
+      conditions = conditions != null ? conditions : Collections.emptyList();
+      Optional<V1JobCondition> condition = conditions.stream().filter(this::jobFailed).findFirst();
+      return condition.isPresent() ? JobState.Failed : JobState.Running;
+    }
+    return JobState.Succeeded;
+  }
+
+  private boolean jobFailed(V1JobCondition condition) {
+    return "Failed".equalsIgnoreCase(condition.getType()) && "True".equalsIgnoreCase(condition.getStatus());
+  }
+
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -118,6 +118,22 @@ public class KubectlJobExecutor {
     return status.getStdOut();
   }
 
+  public String jobLogs(KubernetesV2Credentials credentials, String namespace, String jobName) {
+    List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
+    command.add("logs");
+    command.add("job/"+jobName);
+
+    JobStatus status = jobExecutor.runJob(new JobRequest(command),
+      System.getenv(),
+      new ByteArrayInputStream(new byte[0]));
+
+    if (status.getResult() != JobStatus.Result.SUCCESS) {
+      throw new KubectlException("Failed to get logs from job/" + jobName + " in " + namespace + ": " + status.getStdErr());
+    }
+
+    return status.getStdOut();
+  }
+
   public List<String> delete(KubernetesV2Credentials credentials, KubernetesKind kind, String namespace, String name, KubernetesSelectorList labelSelectors, V1DeleteOptions deleteOptions) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubernetesRunJobOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubernetesRunJobOperation.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job;
+
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.job.KubernetesRunJobOperationDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesDeployManifestDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest.KubernetesDeployManifestOperation;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.moniker.Moniker;
+import com.netflix.spinnaker.moniker.Namer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+
+@Slf4j
+public class KubernetesRunJobOperation implements AtomicOperation<DeploymentResult> {
+  private static final String OP_NAME = "RUN_KUBERNETES_JOB";
+  private final KubernetesRunJobOperationDescription description;
+  private final KubernetesV2Credentials credentials;
+  private final KubernetesResourcePropertyRegistry registry;
+  private final Namer namer;
+  private final ArtifactProvider provider;
+
+  public KubernetesRunJobOperation(KubernetesRunJobOperationDescription description,
+                                   KubernetesResourcePropertyRegistry registry,
+                                   ArtifactProvider provider) {
+    this.description = description;
+    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.registry = registry;
+    this.provider = provider;
+    this.namer = NamerRegistry.lookup()
+      .withProvider(KubernetesCloudProvider.getID())
+      .withAccount(description.getCredentials().getName())
+      .withResource(KubernetesManifest.class);
+  }
+
+  private static Task getTask() {
+    return TaskRepository.threadLocalTask.get();
+  }
+
+  public DeploymentResult operate(List _unused) {
+    getTask().updateStatus(OP_NAME, "Running Kubernetes job...");
+    KubernetesManifest jobSpec = this.description.getManifest();
+    KubernetesKind kind = jobSpec.getKind();
+    if (kind != KubernetesKind.JOB) {
+      throw new IllegalArgumentException("Only kind of Job is accepted for the V2 Run Job operation.");
+    }
+
+    if (jobSpec.get("metadata") == null) {
+      jobSpec.put("metadata", new HashMap<>());
+    }
+
+    if (!this.description.getNamespace().isEmpty()){
+      jobSpec.setNamespace(this.description.getNamespace());
+    }
+    // append a random string to the job name to avoid collision
+    String currentName = jobSpec.getName();
+    String postfix = Long.toHexString(Double.doubleToLongBits(Math.random()));
+    jobSpec.setName(currentName + "-" + postfix);
+
+    KubernetesDeployManifestDescription deployManifestDescription = new KubernetesDeployManifestDescription();
+    // setup description
+    List<KubernetesManifest> manifests = new ArrayList<>();
+    manifests.add(jobSpec);
+
+    Moniker moniker = new Moniker();
+    moniker.setApp(description.getApplication());
+
+    deployManifestDescription.setManifests(manifests);
+    deployManifestDescription.setSource(KubernetesDeployManifestDescription.Source.text);
+    deployManifestDescription.setMoniker(moniker);
+    deployManifestDescription.setCredentials(description.getCredentials());
+
+    KubernetesDeployManifestOperation deployManifestOperation = new KubernetesDeployManifestOperation(deployManifestDescription, registry, provider);
+    OperationResult operationResult = deployManifestOperation.operate(new ArrayList());
+    DeploymentResult deploymentResult = new DeploymentResult();
+    Map<String, List<String>> deployedNames = deploymentResult.getDeployedNamesByLocation();
+    for (Map.Entry<String, Set<String>> e : operationResult.getManifestNamesByNamespace().entrySet()) {
+      deployedNames.put(e.getKey(), new ArrayList(e.getValue()));
+    }
+    deploymentResult.setDeployedNamesByLocation(deployedNames);
+    return deploymentResult;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.provider.view;
+
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.KubernetesV2JobStatus;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.model.JobProvider;
+import com.netflix.spinnaker.clouddriver.model.JobState;
+import com.netflix.spinnaker.clouddriver.model.Manifest;
+import com.netflix.spinnaker.clouddriver.model.ManifestProvider;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
+import io.kubernetes.client.models.V1DeleteOptions;
+import io.kubernetes.client.models.V1Job;
+import lombok.Data;
+import lombok.Getter;
+import org.apache.commons.lang.NotImplementedException;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatus> {
+  @Getter
+  private String platform = "kubernetes";
+  private AccountCredentialsProvider accountCredentialsProvider;
+  private List<ManifestProvider> manifestProviderList;
+
+  KubernetesV2JobProvider(AccountCredentialsProvider accountCredentialsProvider, List<ManifestProvider> manifestProviderList) {
+    this.accountCredentialsProvider = accountCredentialsProvider;
+    this.manifestProviderList = manifestProviderList;
+  }
+
+  public KubernetesV2JobStatus collectJob(String account, String location, String id) {
+
+    KubernetesV2Credentials credentials = (KubernetesV2Credentials) accountCredentialsProvider.getCredentials(account).getCredentials();
+    List<Manifest> manifests = manifestProviderList.stream()
+      .map(p -> p.getManifest(account, location, id))
+      .filter( m -> m != null)
+      .collect(Collectors.toList());
+
+    if (manifests.isEmpty()) {
+      throw new IllegalStateException("Could not find Kubernetes manifest " + id + " in namespace " + location);
+    }
+
+    KubernetesManifest jobManifest = ((KubernetesV2Manifest) manifests.get(0)).getManifest();
+    V1Job job = KubernetesCacheDataConverter.getResource(jobManifest, V1Job.class);
+    KubernetesV2JobStatus jobStatus = new KubernetesV2JobStatus(job, account);
+
+    StringBuilder logs = new StringBuilder();
+    job.getSpec().getTemplate().getSpec().getContainers().stream()
+      .forEach(c -> {
+        logs.append("=====" + c.getName() + "=======");
+        try {
+          logs.append(credentials.jobLogs(location, job.getMetadata().getName()));
+        } catch (Exception e) {
+          logs.append(e.getMessage());
+        }
+        logs.append("\n\n");
+      });
+
+    jobStatus.setLogs(logs.toString());
+
+    if (ImmutableList.of(JobState.Failed, JobState.Succeeded).contains(jobStatus.getJobState())) {
+      credentials.delete(jobManifest.getKind(), jobManifest.getNamespace(), jobManifest.getName(), new KubernetesSelectorList(), new V1DeleteOptions());
+    }
+
+    return jobStatus;
+  }
+
+  public Map<String, Object> getFileContents(String account, String location, String id, String filename) {
+    return new HashMap<>();
+  }
+
+  public void cancelJob(String account, String location, String id) {
+    throw new NotImplementedException("cancelJob is not implemented for the V2 Kubrenetes provider");
+  }
+
+
+
+
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -541,6 +541,10 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     return runAndRecordMetrics("logs", KubernetesKind.POD, namespace, () -> jobExecutor.logs(this, namespace, podName, containerName));
   }
 
+  public String jobLogs(String namespace, String jobName) {
+    return runAndRecordMetrics("logs", KubernetesKind.JOB, namespace, () -> jobExecutor.jobLogs(this, namespace, jobName));
+  }
+
   public void scale(KubernetesKind kind, String namespace, String name, int replicas) {
     runAndRecordMetrics("scale", kind, namespace, () -> jobExecutor.scale(this, kind, namespace, name, replicas));
   }


### PR DESCRIPTION
adds support for run job in kubernetes v2 provider. very similar to the
Deploy (Manifest) stage but only supports the Job kind. satisifies the
methods that are needed by the Run Job stage to start, monitor and
collect jobs.