### PR TITLE
refactor(artifacts): Rewrite Maven artifact account with aether

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -78,6 +78,10 @@ dependencies {
   compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.7'
   compile "org.apache.ivy:ivy:2.4.0"
 
+  compile 'org.eclipse.aether:aether-api:1.1.0'
+  compile 'org.eclipse.aether:aether-impl:1.1.0'
+  compile 'org.apache.maven:maven-aether-provider:3.3.9'
+  
   compile fileTree(sdkLocation)
 
   testCompile('org.junit.jupiter:junit-jupiter-api:5.2.0')

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.maven;
 
+import com.squareup.okhttp.OkHttpClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -36,12 +37,12 @@ public class MavenArtifactConfiguration {
   private final MavenArtifactProviderProperties mavenArtifactProviderProperties;
 
   @Bean
-  List<? extends MavenArtifactCredentials> mavenArtifactCredentials() {
+  List<? extends MavenArtifactCredentials> mavenArtifactCredentials(OkHttpClient okHttpClient) {
     return mavenArtifactProviderProperties.getAccounts()
       .stream()
       .map(a -> {
         try {
-          return new MavenArtifactCredentials(a);
+          return new MavenArtifactCredentials(a, okHttpClient);
         } catch (Exception e) {
           log.warn("Failure instantiating maven artifact account {}: ", a, e);
           return null;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,51 +16,191 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.maven;
 
-import com.netflix.spinnaker.clouddriver.artifacts.ivy.IvyArtifactAccount;
-import com.netflix.spinnaker.clouddriver.artifacts.ivy.IvyArtifactCredentials;
-import com.netflix.spinnaker.clouddriver.artifacts.ivy.settings.IBiblioResolver;
-import com.netflix.spinnaker.clouddriver.artifacts.ivy.settings.IvySettings;
-import com.netflix.spinnaker.clouddriver.artifacts.ivy.settings.Resolvers;
+import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.internal.impl.DefaultRepositoryLayoutProvider;
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayout;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
+import org.eclipse.aether.transfer.NoRepositoryLayoutException;
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.Version;
+import org.eclipse.aether.version.VersionConstraint;
+import org.eclipse.aether.version.VersionScheme;
 
-import java.nio.file.Path;
-import java.util.Collections;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
 import java.util.List;
-import java.util.function.Supplier;
+import java.util.Optional;
 
-@Slf4j
-class MavenArtifactCredentials extends IvyArtifactCredentials {
+import static java.util.Collections.singletonList;
+
+public class MavenArtifactCredentials implements ArtifactCredentials {
+  private static final String RELEASE = "RELEASE";
+  private static final String SNAPSHOT = "SNAPSHOT";
+  private static final String LATEST = "LATEST";
+  private static final String MAVEN_METADATA_XML = "maven-metadata.xml";
+
+  private final MavenArtifactAccount account;
+  private final OkHttpClient okHttpClient;
+  private final RepositoryLayout repositoryLayout;
+
   @Getter
-  private final List<String> types = Collections.singletonList("maven/file");
+  private final List<String> types = singletonList("maven/file");
 
-  MavenArtifactCredentials(MavenArtifactAccount account) {
-    super(toIvyAccount(account));
+  public MavenArtifactCredentials(MavenArtifactAccount account, OkHttpClient okHttpClient) {
+    this.account = account;
+    this.okHttpClient = okHttpClient;
+
+    try {
+      RemoteRepository remoteRepository = new RemoteRepository.Builder(account.getName(), "default",
+        account.getRepositoryUrl()).build();
+      this.repositoryLayout = MavenRepositorySystemUtils.newServiceLocator()
+        .addService(RepositoryLayoutProvider.class, DefaultRepositoryLayoutProvider.class)
+        .getService(RepositoryLayoutProvider.class)
+        .newRepositoryLayout(MavenRepositorySystemUtils.newSession(), remoteRepository);
+    } catch (NoRepositoryLayoutException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
-  MavenArtifactCredentials(MavenArtifactAccount account, Supplier<Path> cacheBuilder) {
-    super(toIvyAccount(account), cacheBuilder);
+  @Override
+  public String getName() {
+    return account.getName();
   }
 
-  private static IvyArtifactAccount toIvyAccount(MavenArtifactAccount maven) {
-    IvyArtifactAccount ivy = new IvyArtifactAccount();
+  @Override
+  public InputStream download(Artifact artifact) {
+    try {
+      DefaultArtifact requestedArtifact = new DefaultArtifact(artifact.getReference());
+      String artifactPath = resolveVersion(requestedArtifact)
+        .map(version -> repositoryLayout.getLocation(withVersion(requestedArtifact, version), false))
+        .map(URI::getPath)
+        .orElseThrow(() -> new IllegalStateException("No versions matching constraint '" + artifact.getVersion() + "' for '" +
+          artifact.getReference() + "'"));
 
-    IBiblioResolver mavenResolver = new IBiblioResolver();
-    mavenResolver.setName("maven");
-    mavenResolver.setM2compatible(true);
-    mavenResolver.setUsepoms(true);
-    mavenResolver.setUseMavenMetadata(true);
-    mavenResolver.setRoot(maven.getRepositoryUrl());
+      Request artifactRequest = new Request.Builder()
+        .url(account.getRepositoryUrl() + "/" + artifactPath)
+        .get()
+        .build();
 
-    Resolvers resolvers = new Resolvers();
-    resolvers.setIbiblio(Collections.singletonList(mavenResolver));
+      Response artifactResponse = okHttpClient.newCall(artifactRequest).execute();
+      if (artifactResponse.isSuccessful()) {
+        return artifactResponse.body().byteStream();
+      }
+      throw new IllegalStateException("Unable to download artifact with reference '" + artifact.getReference() + "'. HTTP " +
+        artifactResponse.code());
+    } catch (IOException | ArtifactDownloadException e) {
+      throw new IllegalStateException("Unable to download artifact with reference '" + artifact.getReference() + "'", e);
+    }
+  }
 
-    IvySettings settings = new IvySettings();
-    settings.setResolvers(resolvers);
+  private Optional<String> resolveVersion(org.eclipse.aether.artifact.Artifact artifact) {
+    try {
+      String metadataPath = metadataUri(artifact).getPath();
+      Request metadataRequest = new Request.Builder()
+        .url(account.getRepositoryUrl() + "/" + metadataPath)
+        .get()
+        .build();
+      Response response = okHttpClient.newCall(metadataRequest).execute();
 
-    ivy.setName(maven.getName());
-    ivy.setSettings(settings);
+      if (response.isSuccessful()) {
+        VersionScheme versionScheme = new GenericVersionScheme();
+        VersionConstraint versionConstraint = versionScheme.parseVersionConstraint(artifact.getVersion());
+        Versioning versioning = new MetadataXpp3Reader().read(response.body().byteStream(), false).getVersioning();
 
-    return ivy;
+        if (isRelease(artifact)) {
+          return Optional.ofNullable(versioning.getRelease());
+        } else if (isLatestSnapshot(artifact)) {
+          return resolveVersion(withVersion(artifact, versioning.getLatest()));
+        } else if (isLatest(artifact)) {
+          String latestVersion = versioning.getLatest();
+          return latestVersion != null && latestVersion.endsWith("-SNAPSHOT") ?
+            resolveVersion(withVersion(artifact, latestVersion)) : Optional.ofNullable(latestVersion);
+        } else if (artifact.getVersion().endsWith("-SNAPSHOT")) {
+          String requestedClassifier = artifact.getClassifier() == null ? "" : artifact.getClassifier();
+          return versioning.getSnapshotVersions().stream()
+            .filter(v -> v.getClassifier().equals(requestedClassifier))
+            .map(SnapshotVersion::getVersion)
+            .findFirst();
+        } else {
+          return versioning
+            .getVersions()
+            .stream()
+            .map(v -> {
+              try {
+                return versionScheme.parseVersion(v);
+              } catch (InvalidVersionSpecificationException e) {
+                throw new ArtifactDownloadException(e);
+              }
+            })
+            .filter(versionConstraint::containsVersion)
+            .max(Version::compareTo)
+            .map(Version::toString);
+        }
+      } else {
+        throw new IOException("Unsuccessful response retrieving maven-metadata.xml " + response.code());
+      }
+    } catch (IOException | XmlPullParserException | InvalidVersionSpecificationException e) {
+      throw new ArtifactDownloadException(e);
+    }
+  }
+
+  private DefaultArtifact withVersion(org.eclipse.aether.artifact.Artifact artifact, String version) {
+    return new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(), artifact.getClassifier(),
+      artifact.getExtension(), version);
+  }
+
+  private URI metadataUri(org.eclipse.aether.artifact.Artifact artifact) {
+    String group = artifact.getGroupId();
+    String artifactId = artifact.getArtifactId();
+    String version = artifact.getVersion();
+
+    Metadata metadata;
+    if (artifact.getVersion().endsWith("-SNAPSHOT")) {
+      metadata = new DefaultMetadata(group, artifactId, version, MAVEN_METADATA_XML, Metadata.Nature.SNAPSHOT);
+    } else if (isRelease(artifact)) {
+      metadata = new DefaultMetadata(group, artifactId, MAVEN_METADATA_XML, Metadata.Nature.RELEASE);
+    } else if (isLatestSnapshot(artifact)) {
+      metadata = new DefaultMetadata(group, artifactId, MAVEN_METADATA_XML, Metadata.Nature.SNAPSHOT);
+    } else if (isLatest(artifact) || version.startsWith("[") || version.startsWith("(")) {
+      metadata = new DefaultMetadata(group, artifactId, MAVEN_METADATA_XML, Metadata.Nature.RELEASE_OR_SNAPSHOT);
+    } else {
+      metadata = new DefaultMetadata(group, artifactId, version, MAVEN_METADATA_XML, Metadata.Nature.RELEASE);
+    }
+
+    return repositoryLayout.getLocation(metadata, false);
+  }
+
+  private boolean isRelease(org.eclipse.aether.artifact.Artifact artifact) {
+    return RELEASE.equals(artifact.getVersion()) || "latest.release".equals(artifact.getVersion());
+  }
+
+  private boolean isLatestSnapshot(org.eclipse.aether.artifact.Artifact artifact) {
+    return SNAPSHOT.equals(artifact.getVersion()) || "latest.integration".equals(artifact.getVersion());
+  }
+
+  private boolean isLatest(org.eclipse.aether.artifact.Artifact artifact) {
+    return LATEST.equals(artifact.getVersion());
+  }
+
+  private static class ArtifactDownloadException extends RuntimeException {
+    ArtifactDownloadException(Throwable cause) {
+      super(cause);
+    }
   }
 }

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Pivotal, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,58 +18,153 @@ package com.netflix.spinnaker.clouddriver.artifacts.maven;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import org.apache.commons.io.Charsets;
+import com.squareup.okhttp.OkHttpClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
+import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith({WiremockResolver.class, TempDirectory.class})
+@ExtendWith(WiremockResolver.class)
 class MavenArtifactCredentialsTest {
   @Test
-  void downloadMavenBasedJar(@WiremockResolver.Wiremock WireMockServer server, @TempDirectory.TempDir Path tempDir) throws IOException {
-    server.stubFor(any(urlEqualTo("/com/test/app/1.0/app-1.0.jar"))
-      .willReturn(aResponse().withBody("contents")));
-
-    // only HEAD requests, should not be downloaded
-    server.stubFor(head(urlEqualTo("/com/test/app/1.0/app-1.0-sources.jar"))
-      .willReturn(aResponse().withBody("contents")));
-    server.stubFor(head(urlEqualTo("/com/test/app/1.0/app-1.0-javadoc.jar"))
-      .willReturn(aResponse().withBody("contents")));
-
-    server.stubFor(any(urlEqualTo("/com/test/app/1.0/app-1.0.pom"))
+  void release(@WiremockResolver.Wiremock WireMockServer server) {
+    server.stubFor(any(urlPathMatching("/com/test/app/(.*/)?maven-metadata.xml"))
       .willReturn(aResponse()
-        .withBody("<project>\n" +
-          "  <modelVersion>4.0.0</modelVersion>\n" +
+        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<metadata modelVersion=\"1.1.0\">\n" +
           "  <groupId>com.test</groupId>\n" +
-          "  <artifactId>app</artifactId  >\n" +
-          "  <version>1.0</version>\n" +
-          "</project>")));
+          "  <artifactId>app</artifactId>\n" +
+          "  <version>1.1</version>\n" +
+          "  <versioning>\n" +
+          "    <latest>1.1</latest>\n" +
+          "    <release>1.1</release>\n" +
+          "    <versions>\n" +
+          "      <version>1.0</version>\n" +
+          "      <version>1.1</version>\n" +
+          "    </versions>\n" +
+          "    <lastUpdated>20190322061505</lastUpdated>\n" +
+          "  </versioning>\n" +
+          "</metadata>")));
 
-    assertDownloadArtifact(tempDir, server);
-    assertThat(server.findUnmatchedRequests().getRequests()).isEmpty();
+    assertResolvable(server, "latest.release", "1.1");
+    assertResolvable(server, "RELEASE", "1.1");
+    assertResolvable(server, "LATEST", "1.1");
+    assertResolvable(server, "1.1", "1.1");
+    assertResolvable(server, "1.0", "1.0");
   }
 
-  private void assertDownloadArtifact(@TempDirectory.TempDir Path tempDir, @WiremockResolver.Wiremock WireMockServer server) throws IOException {
+  @Test
+  void snapshot(@WiremockResolver.Wiremock WireMockServer server) {
+    server.stubFor(any(urlPathMatching("/com/test/app/maven-metadata.xml"))
+      .willReturn(aResponse()
+        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<metadata modelVersion=\"1.1.0\">\n" +
+          "  <groupId>com.test</groupId>\n" +
+          "  <artifactId>app</artifactId>\n" +
+          "  <version>1.1-SNAPSHOT</version>\n" +
+          "  <versioning>\n" +
+          "    <latest>1.1-SNAPSHOT</latest>\n" +
+          "    <versions>\n" +
+          "      <version>1.0-SNAPSHOT</version>\n" +
+          "      <version>1.1-SNAPSHOT</version>\n" +
+          "    </versions>\n" +
+          "    <lastUpdated>20190322061505</lastUpdated>\n" +
+          "  </versioning>\n" +
+          "</metadata>")));
+
+    server.stubFor(any(urlPathMatching("/com/test/app/1.1-SNAPSHOT/maven-metadata.xml"))
+      .willReturn(aResponse()
+        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<metadata modelVersion=\"1.1.0\">\n" +
+          "  <groupId>com.test</groupId>\n" +
+          "  <artifactId>app</artifactId>\n" +
+          "  <version>1.1-SNAPSHOT</version>\n" +
+          "  <versioning>\n" +
+          "    <snapshot>\n" +
+          "      <timestamp>20190322.061344</timestamp>\n" +
+          "      <buildNumber>90</buildNumber>\n" +
+          "    </snapshot>\n" +
+          "    <lastUpdated>20190322061504</lastUpdated>\n" +
+          "    <snapshotVersions>\n" +
+          "      <snapshotVersion>\n" +
+          "        <classifier>sources</classifier>\n" +
+          "        <extension>jar</extension>\n" +
+          "        <value>1.1-20190322.061344-90</value>\n" +
+          "        <updated>20190322061344</updated>\n" +
+          "      </snapshotVersion>\n" +
+          "      <snapshotVersion>\n" +
+          "        <extension>jar</extension>\n" +
+          "        <value>1.1-20190322.061344-90</value>\n" +
+          "        <updated>20190322061344</updated>\n" +
+          "      </snapshotVersion>\n" +
+          "      <snapshotVersion>\n" +
+          "        <extension>pom</extension>\n" +
+          "        <value>1.1-20190322.061344-90</value>\n" +
+          "        <updated>20190322061344</updated>\n" +
+          "      </snapshotVersion>\n" +
+          "    </snapshotVersions>\n" +
+          "  </versioning>\n" +
+          "</metadata>")));
+
+    assertResolvable(server, "latest.integration", "1.1-20190322.061344-90", "1.1-SNAPSHOT");
+    assertResolvable(server, "LATEST", "1.1-20190322.061344-90", "1.1-SNAPSHOT");
+    assertResolvable(server, "SNAPSHOT", "1.1-20190322.061344-90", "1.1-SNAPSHOT");
+    assertResolvable(server, "1.1-SNAPSHOT", "1.1-20190322.061344-90", "1.1-SNAPSHOT");
+  }
+
+  @Test
+  void rangeVersion(@WiremockResolver.Wiremock WireMockServer server) {
+    server.stubFor(any(urlPathMatching("/com/test/app/maven-metadata.xml"))
+      .willReturn(aResponse()
+        .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<metadata modelVersion=\"1.1.0\">\n" +
+          "  <groupId>com.test</groupId>\n" +
+          "  <artifactId>app</artifactId>\n" +
+          "  <version>2.0</version>\n" +
+          "  <versioning>\n" +
+          "    <latest>2.0</latest>\n" +
+          "    <release>2.0</release>\n" +
+          "    <versions>\n" +
+          "      <version>1.0</version>\n" +
+          "      <version>1.1</version>\n" +
+          "      <version>2.0</version>\n" +
+          "    </versions>\n" +
+          "    <lastUpdated>20190322061505</lastUpdated>\n" +
+          "  </versioning>\n" +
+          "</metadata>")));
+
+    assertResolvable(server, "[1.0,)", "2.0");
+    assertResolvable(server, "[1.0,2.0)", "1.1");
+    assertResolvable(server, "(,2.0]", "2.0");
+  }
+
+  private void assertResolvable(WireMockServer server, String version, String expectedVersion) {
+    assertResolvable(server, version, expectedVersion, null);
+  }
+
+  private void assertResolvable(WireMockServer server, String version, String expectedVersion,
+                                @Nullable String expectedSnapshotVersion) {
+    String jarUrl = "/com/test/app/" +
+      (expectedSnapshotVersion == null ? expectedVersion : expectedSnapshotVersion) +
+      "/app-" + expectedVersion + ".jar";
+
+    server.stubFor(any(urlEqualTo(jarUrl)).willReturn(aResponse().withBody(expectedVersion)));
+
     MavenArtifactAccount account = new MavenArtifactAccount();
     account.setRepositoryUrl(server.baseUrl());
 
-    Path cache = tempDir.resolve("cache");
-    Files.createDirectories(cache);
-
     Artifact artifact = new Artifact();
-    artifact.setReference("com.test:app:1.0");
+    artifact.setReference("com.test:app:" + version);
 
-    assertThat(new MavenArtifactCredentials(account, () -> cache).download(artifact))
-      .hasSameContentAs(new ByteArrayInputStream("contents".getBytes(Charsets.UTF_8)));
-    assertThat(cache).doesNotExist();
+    assertThat(new MavenArtifactCredentials(account, new OkHttpClient()).download(artifact))
+      .hasSameContentAs(new ByteArrayInputStream(expectedVersion.getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(server.findUnmatchedRequests().getRequests()).isEmpty();
   }
 }


### PR DESCRIPTION
* Using the highest level of abstraction in aether possible such that resolving and downloading a Maven artifact does not require any disk access (for local cache).
* This rewrite relaxes the constraint that Maven artifact accounts be pointed at virtual repositories containing resolvable references to parent POMs and dependency management sections required previously by virtue of the way Ivy resolves artifacts. The aether approach is to look exclusively at `maven-metadata.xml`, which does not contain such references.
* The rewrite was caused by a need for [revision placeholders](https://maven.apache.org/maven-ci-friendly.html), which Ivy's Maven resolver does not support.

In some ways this is a move back to an implementation closer to what was originally proposed for the JAR artifact account in https://github.com/spinnaker/clouddriver/pull/3153, but with no local disk requirement and fewer dependencies.