### PR TITLE
feat(kubernetes v2):  Make logicalTtlSeconds configurable Kubernetes V2  #4178

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2CacheConfig.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2CacheConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching;
+
+import java.util.concurrent.TimeUnit;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import static java.lang.Math.toIntExact;
+
+@Component
+@Slf4j
+public class KubernetesV2CacheConfig {
+      //sudhakaropsmx:To make logical cache configurable
+	  private static int cacheTtlSeconds = toIntExact(TimeUnit.MINUTES.toSeconds(10));
+	
+	  @Value("${kubernetes.v2.cacheTtl}")
+	  public void setExternalLogicalTtlSeconds(String externalLogicalTtlSeconds) {
+		if(externalLogicalTtlSeconds != null) {
+			cacheTtlSeconds =  toIntExact(Integer.valueOf(externalLogicalTtlSeconds));
+		}
+	  }
+	  public static int getCacheTtlSeconds(){
+		  return cacheTtlSeconds;
+	  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2CacheConfig.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2CacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google, Inc.
+ * Copyright 2019 OpsMX, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching;
 
 import java.util.concurrent.TimeUnit;
+
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -27,12 +27,11 @@ import org.springframework.stereotype.Component;
 import static java.lang.Math.toIntExact;
 
 @Component
-@Slf4j
 public class KubernetesV2CacheConfig {
       //sudhakaropsmx:To make logical cache configurable
 	  private static int cacheTtlSeconds = toIntExact(TimeUnit.MINUTES.toSeconds(10));
 	
-	  @Value("${kubernetes.v2.cacheTtl}")
+	  @Value("${kubernetes.v2.cacheTtlSeconds}")
 	  public void setExternalLogicalTtlSeconds(String externalLogicalTtlSeconds) {
 		if(externalLogicalTtlSeconds != null) {
 			cacheTtlSeconds =  toIntExact(Integer.valueOf(externalLogicalTtlSeconds));

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.KubernetesV2CacheConfig;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesCachingProperties;
@@ -51,7 +52,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -60,14 +60,13 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.Logic
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.LogicalKind.CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.POD;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.SERVICE;
-import static java.lang.Math.toIntExact;
 
 @Slf4j
 public class KubernetesCacheDataConverter {
   private static ObjectMapper mapper = new ObjectMapper();
   private static final JSON json = new JSON();
   // TODO(lwander): make configurable
-  private static final int logicalTtlSeconds = toIntExact(TimeUnit.MINUTES.toSeconds(10));
+  private static final int logicalTtlSeconds = KubernetesV2CacheConfig.getCacheTtlSeconds();
   private static final int infrastructureTtlSeconds = -1;
   // These are kinds which are are frequently added/removed from other resources, and can sometimes
   // persist in the cache when no relationships are found.


### PR DESCRIPTION
This property is made configurable externally in clouddriver-local.yml and is being read from **com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.KubernetesV2CacheConfig**, e.g.
https://github.com/spinnaker/spinnaker/issues/4178
```yaml

kubernetes.v2.cacheTtl: 900

```
