### PR TITLE
fix(core): add `cloudProvider` to `LoadBalancerServerGroup` as expect…

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppengineLoadBalancer.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/model/AppengineLoadBalancer.groovy
@@ -75,7 +75,8 @@ class AppengineLoadBalancer implements LoadBalancer, Serializable {
         isDisabled: serverGroup.isDisabled(),
         allowsGradualTrafficMigration: serverGroup.allowsGradualTrafficMigration,
         instances: instances as Set,
-        detachedInstances: detachedInstances as Set
+        detachedInstances: detachedInstances as Set,
+        cloudProvider: AppengineCloudProvider.ID
       )
     } as Set<LoadBalancerServerGroup>
     null

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
@@ -198,7 +198,8 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
             ]
         )
       } : [],
-      detachedInstances: serverGroup.any().detachedInstances
+      detachedInstances: serverGroup.any().detachedInstances,
+      cloudProvider: AmazonCloudProvider.ID
     )
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/view/AzureAppGatewayProvider.groovy
@@ -95,7 +95,8 @@ class AzureAppGatewayProvider implements LoadBalancerProvider<AzureLoadBalancer>
         name: serverGroup,
         isDisabled: false,
         detachedInstances: [],
-        instances: []
+        instances: [],
+        cloudProvider: AzureCloudProvider.ID
       ))
     }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/view/AzureLoadBalancerProvider.groovy
@@ -84,7 +84,7 @@ class AzureLoadBalancerProvider /*implements LoadBalancerProvider<AzureLoadBalan
       region: loadBalancerDescription.region,
       vnet: loadBalancerDescription.vnet ?: "vnet-unassigned",
       subnet: loadBalancerDescription.subnet ?: "subnet-unassigned",
-      serverGroups: [new LoadBalancerServerGroup(name: loadBalancerDescription.serverGroup, isDisabled: false, detachedInstances: [], instances: [])]
+      serverGroups: [new LoadBalancerServerGroup(name: loadBalancerDescription.serverGroup, isDisabled: false, detachedInstances: [], instances: [], cloudProvider: AzureCloudProvider.ID)]
     )
   }
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryLoadBalancer.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryLoadBalancer.java
@@ -94,7 +94,8 @@ public class CloudFoundryLoadBalancer extends CloudFoundryModel implements LoadB
         app.getInstances()
           .stream()
           .map(it -> new LoadBalancerInstance(it.getId(), it.getName(), null, it.getHealth().get(0)))
-          .collect(toSet())
+          .collect(toSet()),
+        CloudFoundryCloudProvider.ID
       )
     ).collect(toSet());
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerServerGroup.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerServerGroup.java
@@ -34,4 +34,5 @@ public class LoadBalancerServerGroup {
   Boolean isDisabled;
   Set<String> detachedInstances;
   Set<LoadBalancerInstance> instances;
+  String cloudProvider;
 }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosLoadBalancer.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/model/DcosLoadBalancer.groovy
@@ -90,7 +90,9 @@ class DcosLoadBalancer implements LoadBalancer, Serializable, LoadBalancerProvid
           //}
         } as Set,
         // TODO once we can do this
-        detachedInstances: [])
+        detachedInstances: [],
+        cloudProvider: DcosCloudProvider.ID
+      )
     } as Set
   }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
@@ -146,6 +146,7 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
           isDisabled: isDisabled,
           detachedInstances: [],
           instances: [],
+          cloudProvider: GoogleCloudProvider.ID,
       )
 
       // TODO(duftler): De-frigga this.

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesV1LoadBalancer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesV1LoadBalancer.groovy
@@ -85,7 +85,9 @@ class KubernetesV1LoadBalancer implements LoadBalancer, Serializable, LoadBalanc
           } else {
             return (String) null
           }
-        } as Set)
+        } as Set,
+        cloudProvider: KubernetesCloudProvider.ID
+      )
     } as Set
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacerFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
@@ -205,6 +206,7 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
       .name(getName())
       .region(getRegion())
       .isDisabled(isDisabled())
+      .cloudProvider(KubernetesCloudProvider.getID())
       .build();
   }
 

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackLoadBalancerProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackLoadBalancerProvider.groovy
@@ -115,7 +115,7 @@ class OpenstackLoadBalancerProvider implements LoadBalancerProvider<OpenstackLoa
       LoadBalancerServerGroup loadBalancerServerGroup = null
       ServerGroup serverGroup = clusterProvider.getServerGroup(loadBalancer.account, loadBalancer.region, Keys.parse(key)['serverGroup'])
       if (serverGroup) {
-        loadBalancerServerGroup = new LoadBalancerServerGroup(name: serverGroup.name, isDisabled: serverGroup.isDisabled())
+        loadBalancerServerGroup = new LoadBalancerServerGroup(name: serverGroup.name, isDisabled: serverGroup.isDisabled(), cloudProvider: OpenstackCloudProvider.ID)
         loadBalancerServerGroup.instances = serverGroup.instances?.collect { instance ->
           new LoadBalancerInstance(id: instance.name, health: [state: instance.healthState?.toString()])
         }?.toSet()

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackLoadBalancerProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/view/OpenstackLoadBalancerProviderSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import com.netflix.spinnaker.clouddriver.openstack.OpenstackCloudProvider
 import com.netflix.spinnaker.clouddriver.openstack.cache.Keys
 import com.netflix.spinnaker.clouddriver.openstack.model.OpenstackFloatingIP
 import com.netflix.spinnaker.clouddriver.openstack.model.OpenstackLoadBalancer
@@ -329,7 +330,7 @@ class OpenstackLoadBalancerProviderSpec extends Specification {
     def healthMonitor = new OpenstackLoadBalancer.OpenstackHealthMonitor(id: "health$i", httpMethod: 'GET',
                                                                          maxRetries: 5, adminStateUp: 'UP', delay: 5, expectedCodes: [200])
     def serverGroups = [new LoadBalancerServerGroup(name: 'sg1', isDisabled: false,
-                                                    instances: [new LoadBalancerInstance(id: 'id', zone: "zone$i", health: [state:'up', zone: "zone$i"])])]
+                                                    instances: [new LoadBalancerInstance(id: 'id', zone: "zone$i", health: [state:'up', zone: "zone$i"])], cloudProvider: OpenstackCloudProvider.ID)]
     new OpenstackLoadBalancer.View(account: account, region: region, id: id, name: name, description: description,
                                    status: status, algorithm: algorithm, ip: ip, subnetId: subnet, subnetName: subnet, networkId: network, networkName: network,
                                    healthMonitor: healthMonitor, serverGroups: serverGroups)

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusTargetGroupServerGroupProvider.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusTargetGroupServerGroupProvider.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.aws.model.AmazonTargetGroup;
 import com.netflix.spinnaker.clouddriver.aws.model.TargetGroupServerGroupProvider;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
+import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider;
 import com.netflix.spinnaker.clouddriver.titus.caching.Keys;
 import com.netflix.spinnaker.clouddriver.titus.caching.utils.AwsLookupUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -118,7 +119,8 @@ public class TitusTargetGroupServerGroupProvider implements TargetGroupServerGro
             attributes.get("region").toString(),
             !(Boolean) job.get("inService"),
             Collections.emptySet(),
-            targetGroupInstances
+            targetGroupInstances,
+            TitusCloudProvider.ID
           );
 
           if (allTargetGroups.containsKey(targetGroup)) {


### PR DESCRIPTION
…ed by deck

Closes https://github.com/spinnaker/spinnaker/issues/4074

Before:
![1748bd74-20a7-4400-be97-58550867a49e](https://user-images.githubusercontent.com/15936279/55177278-3da9fb00-5159-11e9-947a-d66802712af0.gif)

After:
![c7c2c2c1-85ac-491b-a307-44a7dc31adb2](https://user-images.githubusercontent.com/15936279/55177144-e86de980-5158-11e9-90f0-22c48c3be06c.gif)


Deck expects `LoadBalancerServerGroup`s to have a `cloudProvider` field in order to correctly route to the Server Group side-view from the Load Balancers tab (per code [here](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/loadBalancer/LoadBalancerServerGroup.tsx#L56)). 