### PR TITLE
fix(cf): Fix server group name resolver

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ApplicationService.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/api/ApplicationService.java
@@ -20,9 +20,9 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Applicatio
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.InstanceStatus;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.MapRoute;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Page;
-import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.*;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Package;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Process;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.*;
 import retrofit.client.Response;
 import retrofit.http.*;
 import retrofit.mime.TypedFile;
@@ -47,9 +47,10 @@ public interface ApplicationService {
   Map<String, InstanceStatus> instances(@Path("guid") String guid);
 
   @GET("/v2/apps")
-  Page<com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Application> appsLessThanName(@Query("q") String q,
-                                                                                                    @Query("order-direction") String orderDirection,
-                                                                                                    @Query("results-per-page") Integer resultsPerPage);
+  Page<com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Application> listAppsFiltered(
+    @Query("page") Integer page,
+    @Query("q") List<String> q,
+    @Query("results-per-page") Integer resultsPerPage);
 
   /**
    * Requires an empty body.

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/Page.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v2/Page.java
@@ -18,8 +18,11 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2;
 
 import lombok.Data;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Data
 public class Page<R> {
@@ -40,6 +43,27 @@ public class Page<R> {
     resource.setEntity(data);
 
     page.setResources(Collections.singletonList(resource));
+
+    return page;
+  }
+
+  public static <R> Page<R> asPage(R... data) {
+    Page<R> page = new Page<>();
+    page.setTotalPages(1);
+    page.setTotalResults(data.length);
+
+    page.setResources(Arrays.stream(data)
+      .map(d -> {
+        Resource.Metadata metadata = new Resource.Metadata();
+        metadata.setGuid(UUID.randomUUID().toString());
+
+        Resource<R> resource = new Resource<>();
+        resource.setMetadata(metadata);
+        resource.setEntity(d);
+        return resource;
+      })
+      .collect(Collectors.toList())
+    );
 
     return page;
   }


### PR DESCRIPTION
The previous criteria selected server groups lexicographically less than `clusterName-v9999`, but this  selected `clusterName-prod-v046` because `p` < `v`.

We're now doing `<clusterName-v9999` and `>=clusterName`, selecting more than one result, filtering on matching cluster names, and returning all the taken server groups in the cluster.

Additionally, now filtering on `space_guid`.

cc / @ciberkleid