### PR TITLE
 feat(provider/kubernetes): Add traffic options to deploy description

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
@@ -38,6 +38,9 @@ public class KubernetesDeployManifestDescription extends KubernetesAtomicOperati
   private Source source;
   private Artifact manifestArtifact;
 
+  private boolean enableTraffic = true;
+  private List<String> services;
+
   public enum Source {
     artifact,
     text

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
@@ -29,14 +29,14 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class KubernetesDeployManifestDescription extends KubernetesAtomicOperationDescription {
   @Deprecated
-  KubernetesManifest manifest;
-  List<KubernetesManifest> manifests;
-  Moniker moniker;
-  List<Artifact> requiredArtifacts;
-  List<Artifact> optionalArtifacts;
-  Boolean versioned;
-  Source source;
-  Artifact manifestArtifact;
+  private KubernetesManifest manifest;
+  private List<KubernetesManifest> manifests;
+  private Moniker moniker;
+  private List<Artifact> requiredArtifacts;
+  private List<Artifact> optionalArtifacts;
+  private Boolean versioned;
+  private Source source;
+  private Artifact manifestArtifact;
 
   public enum Source {
     artifact,

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
@@ -205,9 +205,8 @@ public class KubernetesManifestAnnotater {
   public static KubernetesManifestTraffic getTraffic(KubernetesManifest manifest) {
     Map<String, String> annotations = manifest.getAnnotations();
 
-    return KubernetesManifestTraffic.builder()
-        .loadBalancers(getAnnotation(annotations, LOAD_BALANCERS, new TypeReference<List<String>>() {}, new ArrayList<>()))
-        .build();
+    List<String> loadBalancers = getAnnotation(annotations, LOAD_BALANCERS, new TypeReference<List<String>>() {}, new ArrayList<>());
+    return new KubernetesManifestTraffic(loadBalancers);
   }
 
   public static KubernetesCachingProperties getCachingProperties(KubernetesManifest manifest) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
@@ -209,6 +209,26 @@ public class KubernetesManifestAnnotater {
     return new KubernetesManifestTraffic(loadBalancers);
   }
 
+  public static void setTraffic(KubernetesManifest manifest, KubernetesManifestTraffic traffic) {
+    Map<String, String> annotations = manifest.getAnnotations();
+    List<String> loadBalancers = traffic.getLoadBalancers();
+
+    if (annotations.containsKey(LOAD_BALANCERS)) {
+      KubernetesManifestTraffic currentTraffic = getTraffic(manifest);
+      if (currentTraffic.getLoadBalancers().equals(loadBalancers)) {
+        return;
+      } else {
+        throw new RuntimeException(String.format(
+          "Manifest already has %s annotation set to %s. Failed attempting to set it to %s.",
+          LOAD_BALANCERS,
+          currentTraffic.getLoadBalancers(),
+          loadBalancers
+        ));
+      }
+    }
+    storeAnnotation(annotations, LOAD_BALANCERS, loadBalancers);
+  }
+
   public static KubernetesCachingProperties getCachingProperties(KubernetesManifest manifest) {
     Map<String, String> annotations = manifest.getAnnotations();
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestTraffic.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestTraffic.java
@@ -17,16 +17,14 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 import java.util.List;
 
-@Data
-@Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@EqualsAndHashCode
+@Getter
 public class KubernetesManifestTraffic {
-  List<String> loadBalancers;
+  private List<String> loadBalancers;
 }


### PR DESCRIPTION
* refactor(provider/kubernetes): Improve some encapsulation 

  KubernetesDeployManifestDescription is a Data class, so the member variables can be private.

  KubernetesManifestTraffic is simple enough that using a builder is less clear; give it a single-arg constructor and remove setters.

  Also lightly refactor KubernetesDeployManifestOperationSpec to make it easier to add tests in the next commit.

* feat(provider/kubernetes): Add traffic options to deploy description 

  In order to support better first-class deployment strategies in the Kubernetes V2 provider, add functionality to the deploy manifest stage.  In particular:
  * Allow the services to be specified on the deploy description, rather than only as an annotation on the manifest.
  * Add a boolean to control whether to send traffic to the new workload, defaulting to true.
