### PR TITLE
 fix(provider/azure): Enable Azure Load Balancer from Azure VM Scale Set

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/AzureUtilities.groovy
@@ -35,6 +35,7 @@ class AzureUtilities {
   static final String IPCONFIG_NAME_PREFIX = "ipc-"
   static final String NETWORK_INTERFACE_PREFIX = "nic-"
   static final Pattern IPV4_PREFIX_REGEX = ~/^(?<addr3>\d+)\.(?<addr2>\d+)\.(?<addr1>\d+)\.(?<addr0>\d+)\/(?<length>\d+)$/
+  static final String LB_NAME_PREFIX = "lb-"
   static final String INBOUND_NATPOOL_PREFIX = "np-"
   static final String VNET_DEFAULT_ADDRESS_PREFIX = "10.0.0.0/8"
   static final int SUBNET_DEFAULT_ADDRESS_PREFIX_LENGTH = 24

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -67,7 +67,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   Boolean hasNewSubnet = false
   Boolean createNewSubnet = false
   AzureExtensionCustomScriptSettings customScriptsSettings
-  Boolean enableInboundNAT
+  Boolean enableInboundNAT = false
 
   static class AzureScaleSetSku {
     String name

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -67,6 +67,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   Boolean hasNewSubnet = false
   Boolean createNewSubnet = false
   AzureExtensionCustomScriptSettings customScriptsSettings
+  Boolean enableInboundNAT
 
   static class AzureScaleSetSku {
     String name
@@ -161,6 +162,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
     azureSG.clusterName = scaleSet.tags?.cluster ?: parsedName.cluster
     azureSG.securityGroupName = scaleSet.tags?.securityGroupName
     azureSG.loadBalancerName = scaleSet.tags?.loadBalancerName
+    azureSG.enableInboundNAT = scaleSet.tags?.enableInboundNAT
     azureSG.appGatewayName = scaleSet.tags?.appGatewayName
     azureSG.appGatewayBapId = scaleSet.tags?.appGatewayBapId
     // TODO: appGatewayBapId can be retrieved via scaleSet->networkProfile->networkInterfaceConfigurations->ipConfigurations->ApplicationGatewayBackendAddressPools

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -33,14 +33,16 @@ package com.netflix.spinnaker.clouddriver.azure.templates
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription.AzureInboundPortConfig
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
-
 import groovy.util.logging.Slf4j
 
 @Slf4j
 class AzureServerGroupResourceTemplate {
   static final String STORAGE_ACCOUNT_SUFFIX = "sa"
+
+  static String LB_NAME = null
 
   protected static ObjectMapper mapper = new ObjectMapper()
     .configure(SerializationFeature.INDENT_OUTPUT, true)
@@ -55,6 +57,14 @@ class AzureServerGroupResourceTemplate {
   static String getTemplate(AzureServerGroupDescription description) {
     ServerGroupTemplate template = new ServerGroupTemplate(description)
     mapper.writeValueAsString(template)
+  }
+
+  /**
+   * Initialize variables that will be used in mulitple places
+   * @param description Azure Server Group description object
+   */
+  private static void initializeCommonVariables(AzureServerGroupDescription description) {
+    LB_NAME = AzureUtilities.LB_NAME_PREFIX + description.name
   }
 
   /**
@@ -74,14 +84,23 @@ class AzureServerGroupResourceTemplate {
      * @param description
      */
     ServerGroupTemplate(AzureServerGroupDescription description) {
+      if (description.enableInboundNAT){
+        initializeCommonVariables(description)
+      }
+
       parameters = new ServerGroupTemplateParameters()
 
       //If it's custom,
       if (description.image.isCustom) {
-        variables = new CoreServerGroupTemplateVariables()
+          variables = new CoreServerGroupTemplateVariables(description)
       } else {
         variables = new ExtendedServerGroupTemplateVariables(description)
         resources.add(new StorageAccount(description))
+      }
+
+      if(description.enableInboundNAT){
+        resources.add(new PublicIpResource(properties: new PublicIPPropertiesWithDns()))
+        resources.add(new LoadBalancer(description))
       }
 
       resources.add(new VirtualMachineScaleSet(description))
@@ -93,7 +112,33 @@ class AzureServerGroupResourceTemplate {
 
   static class CoreServerGroupTemplateVariables implements TemplateVariables {
     final String apiVersion = "2018-10-01"
+    String publicIPAddressName = ""
+    String publicIPAddressID = ""
+    String publicIPAddressType = ""
+    String dnsNameForLBIP = ""
+    String loadBalancerBackend = ""
+    String loadBalancerFrontEnd = ""
+    String loadBalancerName = ""
+    String loadBalancerID = ""
+    String frontEndIPConfigID = ""
+    String inboundNatPoolName = ""
+
     CoreServerGroupTemplateVariables() {}
+
+    CoreServerGroupTemplateVariables(AzureServerGroupDescription description) {
+      if(description.enableInboundNAT){
+        publicIPAddressName = AzureUtilities.PUBLICIP_NAME_PREFIX + description.name
+        publicIPAddressID = "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+        publicIPAddressType = "Dynamic"
+        dnsNameForLBIP = AzureUtilities.DNS_NAME_PREFIX + description.name.toLowerCase()
+        frontEndIPConfigID = "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/', variables('loadBalancerName'), variables('loadBalancerFrontEnd'))]"
+        loadBalancerFrontEnd = AzureUtilities.LBFRONTEND_NAME_PREFIX + description.name
+        loadBalancerBackend = AzureUtilities.LBBACKEND_NAME_PREFIX + description.name
+        loadBalancerName = LB_NAME
+        loadBalancerID = "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]"
+        inboundNatPoolName = AzureUtilities.INBOUND_NATPOOL_PREFIX + description.name
+      }
+    }
   }
 
   /**
@@ -118,7 +163,8 @@ class AzureServerGroupResourceTemplate {
      * @param description
      */
     ExtendedServerGroupTemplateVariables(AzureServerGroupDescription description) {
-      super()
+      super(description)
+
       vhdContainerName = description.name.toLowerCase()
       osType = new OsType(description)
       imageReference = "[variables('osType')]"
@@ -304,6 +350,13 @@ class AzureServerGroupResourceTemplate {
       def currentTime = System.currentTimeMillis()
       tags = [:]
       tags.createdTime = currentTime.toString()
+      tags.subnetId = description.subnetId
+      tags.securityGroupName = description.securityGroupName
+      tags.enableInboundNAT = description.enableInboundNAT ? "true" : "false"
+      if(description.enableInboundNAT){
+        tags.loadBalancerName = LB_NAME
+      }
+
       if (description.instanceTags != null) {
         tags << description.instanceTags
       }
@@ -315,6 +368,10 @@ class AzureServerGroupResourceTemplate {
 
       if(description.zones != null && description.zones.size() != 0) {
         zones = description.zones.asList()
+      }
+
+      if(description.enableInboundNAT){
+        this.dependsOn.add("[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]")
       }
 
       properties = new VirtualMachineScaleSetProperty(description)
@@ -474,7 +531,7 @@ class AzureServerGroupResourceTemplate {
      */
     NetworkInterfaceIPConfiguration(AzureServerGroupDescription description) {
       name = AzureUtilities.IPCONFIG_NAME_PREFIX + description.getIdentifier()
-      properties = new NetworkInterfaceIPConfigurationsProperty()
+      properties = new NetworkInterfaceIPConfigurationsProperty(description)
     }
   }
 
@@ -484,13 +541,19 @@ class AzureServerGroupResourceTemplate {
   static class NetworkInterfaceIPConfigurationsProperty {
     NetworkInterfaceIPConfigurationSubnet subnet
     ArrayList<AppGatewayBackendAddressPool> ApplicationGatewayBackendAddressPools = []
+    ArrayList<LoadBalancerBackendAddressPool> loadBalancerBackendAddressPools = []
+    ArrayList<LoadBalancerInboundNatPoolId> loadBalancerInboundNatPools = []
 
     /**
      *
      * @param description
      */
-    NetworkInterfaceIPConfigurationsProperty() {
+    NetworkInterfaceIPConfigurationsProperty(AzureServerGroupDescription description) {
       subnet = new NetworkInterfaceIPConfigurationSubnet()
+      if(description.enableInboundNAT) {
+        loadBalancerBackendAddressPools.add(new LoadBalancerBackendAddressPool())
+        loadBalancerInboundNatPools.add(new LoadBalancerInboundNatPoolId())
+      }
       ApplicationGatewayBackendAddressPools.add(new AppGatewayBackendAddressPool())
     }
   }
@@ -503,6 +566,21 @@ class AzureServerGroupResourceTemplate {
 
     NetworkInterfaceIPConfigurationSubnet() {
       id = "[parameters('${subnetParameterName}')]"
+    }
+  }
+
+  static class LoadBalancerBackendAddressPool {
+    String id
+
+    LoadBalancerBackendAddressPool() {
+      id = "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('loadBalancerBackend'))]"
+    }
+  }
+
+  static class LoadBalancerInboundNatPoolId extends IdRef {
+
+    LoadBalancerInboundNatPoolId() {
+      id = "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('inboundNatPoolName'))]"
     }
   }
 
@@ -659,6 +737,98 @@ class AzureServerGroupResourceTemplate {
     CustomScriptExtensionSettings(AzureServerGroupDescription description) {
       commandToExecute = description.customScriptsSettings.commandToExecute
       fileUris = description.customScriptsSettings.fileUris
+    }
+  }
+
+  /**** Load Balancer Resource ****/
+  static class LoadBalancer extends DependingResource {
+    LoadBalancerProperties properties
+
+    LoadBalancer(AzureServerGroupDescription description) {
+      apiVersion = "[variables('apiVersion')]"
+      name = "[variables('loadBalancerName')]"
+      type = "Microsoft.Network/loadBalancers"
+      location = "[parameters('${locationParameterName}')]"
+      def currentTime = System.currentTimeMillis()
+      tags = [:]
+      tags.appName = description.application
+      tags.stack = description.stack
+      tags.detail = description.detail
+      tags.createdTime = currentTime.toString()
+      if (description.clusterName) tags.cluster = description.clusterName
+      if (description.name) tags.serverGroup = description.name
+      if (description.securityGroupName) tags.securityGroupName = description.securityGroupName
+
+      this.dependsOn.add("[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]")
+
+      properties = new LoadBalancerProperties(description)
+    }
+  }
+
+  static class LoadBalancerProperties {
+    ArrayList<FrontEndIpConfiguration> frontendIPConfigurations = []
+    ArrayList<BackEndAddressPool> backendAddressPools = []
+    ArrayList<InboundNatPool> inboundNatPools = []
+
+    LoadBalancerProperties(AzureServerGroupDescription description) {
+      frontendIPConfigurations.add(new FrontEndIpConfiguration())
+      backendAddressPools.add(new BackEndAddressPool())
+      description.inboundPortConfigs?.each {
+        inboundNatPools.add(new InboundNatPool(it))
+      }
+    }
+  }
+
+  static class FrontEndIpConfiguration {
+    String name
+    FrontEndIpProperties properties
+
+    FrontEndIpConfiguration() {
+      name = "[variables('loadBalancerFrontEnd')]"
+      properties = new FrontEndIpProperties("[variables('publicIPAddressID')]")
+    }
+  }
+
+  static class FrontEndIpProperties {
+    IdRef publicIpAddress
+
+    FrontEndIpProperties(String id) {
+      publicIpAddress = new IdRef(id)
+    }
+  }
+
+  static class BackEndAddressPool {
+    String name
+
+    BackEndAddressPool() {
+      name = "[variables('loadBalancerBackEnd')]"
+    }
+  }
+
+
+  static class InboundNatPool {
+    String name
+    InboundNatPoolProperties properties
+
+    InboundNatPool(AzureInboundPortConfig inboundPortConfig) {
+      name = inboundPortConfig.name
+      properties = new InboundNatPoolProperties(inboundPortConfig)
+    }
+  }
+
+  static class InboundNatPoolProperties {
+    IdRef frontendIPConfiguration
+    String protocol
+    int frontendPortRangeStart
+    int frontendPortRangeEnd
+    int backendPort
+
+    InboundNatPoolProperties(AzureInboundPortConfig inboundPortConfig) {
+      frontendIPConfiguration = new IdRef("[variables('frontEndIPConfigID')]")
+      protocol = inboundPortConfig.protocol
+      frontendPortRangeStart = inboundPortConfig.frontEndPortRangeStart
+      frontendPortRangeEnd = inboundPortConfig.frontEndPortRangeEnd
+      backendPort = inboundPortConfig.backendPort
     }
   }
 }

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
@@ -214,6 +214,16 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
+    "publicIPAddressName" : "",
+    "publicIPAddressID" : "",
+    "publicIPAddressType" : "",
+    "dnsNameForLBIP" : "",
+    "loadBalancerBackend" : "",
+    "loadBalancerFrontEnd" : "",
+    "loadBalancerName" : "",
+    "loadBalancerID" : "",
+    "frontEndIPConfigID" : "",
+    "inboundNatPoolName" : "",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -250,7 +260,10 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890"
+      "createdTime" : "1234567890",
+      "subnetId" : null,
+      "securityGroupName" : null,
+      "enableInboundNAT" : "false"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -289,6 +302,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
+                  "loadBalancerBackendAddressPools" : [ ],
+                  "loadBalancerInboundNatPools" : [ ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -354,7 +369,17 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     }
   },
   "variables" : {
-    "apiVersion" : "2018-10-01"
+    "apiVersion" : "2018-10-01",
+    "publicIPAddressName" : "",
+    "publicIPAddressID" : "",
+    "publicIPAddressType" : "",
+    "dnsNameForLBIP" : "",
+    "loadBalancerBackend" : "",
+    "loadBalancerFrontEnd" : "",
+    "loadBalancerName" : "",
+    "loadBalancerID" : "",
+    "frontEndIPConfigID" : "",
+    "inboundNatPoolName" : ""
   },
   "resources" : [ {
     "apiVersion" : "[variables('apiVersion')]",
@@ -362,7 +387,10 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890"
+      "createdTime" : "1234567890",
+      "subnetId" : null,
+      "securityGroupName" : null,
+      "enableInboundNAT" : "false"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -397,6 +425,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
+                  "loadBalancerBackendAddressPools" : [ ],
+                  "loadBalancerInboundNatPools" : [ ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -463,6 +493,16 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
+    "publicIPAddressName" : "",
+    "publicIPAddressID" : "",
+    "publicIPAddressType" : "",
+    "dnsNameForLBIP" : "",
+    "loadBalancerBackend" : "",
+    "loadBalancerFrontEnd" : "",
+    "loadBalancerName" : "",
+    "loadBalancerID" : "",
+    "frontEndIPConfigID" : "",
+    "inboundNatPoolName" : "",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -499,7 +539,10 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890"
+      "createdTime" : "1234567890",
+      "subnetId" : null,
+      "securityGroupName" : null,
+      "enableInboundNAT" : "false"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -538,6 +581,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
+                  "loadBalancerBackendAddressPools" : [ ],
+                  "loadBalancerInboundNatPools" : [ ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -619,6 +664,16 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
+    "publicIPAddressName" : "",
+    "publicIPAddressID" : "",
+    "publicIPAddressType" : "",
+    "dnsNameForLBIP" : "",
+    "loadBalancerBackend" : "",
+    "loadBalancerFrontEnd" : "",
+    "loadBalancerName" : "",
+    "loadBalancerID" : "",
+    "frontEndIPConfigID" : "",
+    "inboundNatPoolName" : "",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -655,7 +710,10 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890"
+      "createdTime" : "1234567890",
+      "subnetId" : null,
+      "securityGroupName" : null,
+      "enableInboundNAT" : "false"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -694,6 +752,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
+                  "loadBalancerBackendAddressPools" : [ ],
+                  "loadBalancerInboundNatPools" : [ ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -775,6 +835,16 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
+    "publicIPAddressName" : "",
+    "publicIPAddressID" : "",
+    "publicIPAddressType" : "",
+    "dnsNameForLBIP" : "",
+    "loadBalancerBackend" : "",
+    "loadBalancerFrontEnd" : "",
+    "loadBalancerName" : "",
+    "loadBalancerID" : "",
+    "frontEndIPConfigID" : "",
+    "inboundNatPoolName" : "",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -811,7 +881,10 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890"
+      "createdTime" : "1234567890",
+      "subnetId" : null,
+      "securityGroupName" : null,
+      "enableInboundNAT" : "false"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -850,6 +923,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
+                  "loadBalancerBackendAddressPools" : [ ],
+                  "loadBalancerInboundNatPools" : [ ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -932,6 +1007,16 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
+    "publicIPAddressName" : "",
+    "publicIPAddressID" : "",
+    "publicIPAddressType" : "",
+    "dnsNameForLBIP" : "",
+    "loadBalancerBackend" : "",
+    "loadBalancerFrontEnd" : "",
+    "loadBalancerName" : "",
+    "loadBalancerID" : "",
+    "frontEndIPConfigID" : "",
+    "inboundNatPoolName" : "",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -968,7 +1053,10 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890"
+      "createdTime" : "1234567890",
+      "subnetId" : null,
+      "securityGroupName" : null,
+      "enableInboundNAT" : "false"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -1007,6 +1095,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
+                  "loadBalancerBackendAddressPools" : [ ],
+                  "loadBalancerInboundNatPools" : [ ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]
@@ -1089,6 +1179,16 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
   },
   "variables" : {
     "apiVersion" : "2018-10-01",
+    "publicIPAddressName" : "",
+    "publicIPAddressID" : "",
+    "publicIPAddressType" : "",
+    "dnsNameForLBIP" : "",
+    "loadBalancerBackend" : "",
+    "loadBalancerFrontEnd" : "",
+    "loadBalancerName" : "",
+    "loadBalancerID" : "",
+    "frontEndIPConfigID" : "",
+    "inboundNatPoolName" : "",
     "vhdContainerName" : "azuremasm-st1-d11",
     "osType" : {
       "publisher" : "Canonical",
@@ -1126,6 +1226,9 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "location" : "[parameters('location')]",
     "tags" : {
       "createdTime" : "1234567890",
+      "subnetId" : null,
+      "securityGroupName" : null,
+      "enableInboundNAT" : "false",
       "key1" : "value1",
       "key2" : "value2"
     },
@@ -1166,6 +1269,8 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
                   "subnet" : {
                     "id" : "[parameters('subnetId')]"
                   },
+                  "loadBalancerBackendAddressPools" : [ ],
+                  "loadBalancerInboundNatPools" : [ ],
                   "applicationGatewayBackendAddressPools" : [ {
                     "id" : "[parameters('appGatewayAddressPoolId')]"
                   } ]

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/AzureServerGroupResourceTemplateSpec.groovy
@@ -260,10 +260,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890",
-      "subnetId" : null,
-      "securityGroupName" : null,
-      "enableInboundNAT" : "false"
+      "createdTime" : "1234567890"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -387,10 +384,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890",
-      "subnetId" : null,
-      "securityGroupName" : null,
-      "enableInboundNAT" : "false"
+      "createdTime" : "1234567890"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -539,10 +533,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890",
-      "subnetId" : null,
-      "securityGroupName" : null,
-      "enableInboundNAT" : "false"
+      "createdTime" : "1234567890"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -710,10 +701,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890",
-      "subnetId" : null,
-      "securityGroupName" : null,
-      "enableInboundNAT" : "false"
+      "createdTime" : "1234567890"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -881,10 +869,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890",
-      "subnetId" : null,
-      "securityGroupName" : null,
-      "enableInboundNAT" : "false"
+      "createdTime" : "1234567890"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -1053,10 +1038,7 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "type" : "Microsoft.Compute/virtualMachineScaleSets",
     "location" : "[parameters('location')]",
     "tags" : {
-      "createdTime" : "1234567890",
-      "subnetId" : null,
-      "securityGroupName" : null,
-      "enableInboundNAT" : "false"
+      "createdTime" : "1234567890"
     },
     "dependsOn" : [ ],
     "sku" : {
@@ -1226,9 +1208,6 @@ class AzureServerGroupResourceTemplateSpec extends Specification {
     "location" : "[parameters('location')]",
     "tags" : {
       "createdTime" : "1234567890",
-      "subnetId" : null,
-      "securityGroupName" : null,
-      "enableInboundNAT" : "false",
       "key1" : "value1",
       "key2" : "value2"
     },


### PR DESCRIPTION
Background:
Enable Azure Load Balancer which supports inbound NAT port-forwarding rules to connect to azure vm instances.
There is one another related PR (https://github.com/spinnaker/deck/pull/6829) in deck. Please also help to review.