### PR TITLE
fix(titus): Don't copy migrationPolicy from source during job creation

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.handlers
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.TargetGroupLookupHelper
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.TargetGroupLookupHelper.TargetGroupLookupResult
@@ -172,7 +173,9 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
         if (description.inService == null) {
           description.inService = sourceJob.inService
         }
-        description.migrationPolicy = description.migrationPolicy ?: sourceJob.migrationPolicy
+        if(description.disruptionBudget == null) {
+          description.migrationPolicy = description.migrationPolicy ?: sourceJob.migrationPolicy
+        }
         description.jobType = description.jobType ?: "service"
         if (!description.hardConstraints) description.hardConstraints = []
         if (!description.softConstraints) description.softConstraints = []

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.handlers
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.frigga.Names
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.TargetGroupLookupHelper
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer.TargetGroupLookupHelper.TargetGroupLookupResult
@@ -173,7 +172,8 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
         if (description.inService == null) {
           description.inService = sourceJob.inService
         }
-        if(description.disruptionBudget == null) {
+        if (description.disruptionBudget == null) {
+          //migrationPolicy should only be used when the disruptionBudget has not been specified
           description.migrationPolicy = description.migrationPolicy ?: sourceJob.migrationPolicy
         }
         description.jobType = description.jobType ?: "service"


### PR DESCRIPTION
- We use to copy the `migrationPolicy` from source even when it was not specified in the payload and `jobDisruptionBudget` was set as part of the payload, this fix it to ignore the source `migrationPolicy` when `jobDisruptioBuget` is set and copy only when its not specified.
