### PR TITLE
fix(auth): s/applicationName/appName when determining application name

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/converters/UpsertTitusScalingPolicyAtomicOperationConverter.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/converters/UpsertTitusScalingPolicyAtomicOperationConverter.groovy
@@ -54,7 +54,7 @@ class UpsertTitusScalingPolicyAtomicOperationConverter extends AbstractAtomicOpe
     try {
       def titusClient = titusClientProvider.getTitusClient(converted.credentials, converted.region)
       def titusJob = titusClient.getJobAndAllRunningAndCompletedTasks(converted.jobId)
-      converted.application = titusJob.applicationName
+      converted.application = titusJob.appName
     } catch (Exception e) {
       converted.application = null
       log.error("Unable to determine application for titus job (jobId: {})", converted.jobId, e)


### PR DESCRIPTION
Turns out that `applicationName` on a titus job is the container name.

For authorization purposes, we need to be looking at `appName`.
