### PR TITLE
fix(google): correctly filter instanceCacheData in GoogleClusterProvi…

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -181,7 +181,7 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
       def securityGroups = securityGroupProvider.getAllByAccount(false, clusterView.accountName)
 
       def instanceCacheData = instanceProvider.getInstanceCacheData(instanceKeySuperSet as List).findAll { instance ->
-        instance.relationships.get(CLUSTERS.ns)?.collect { Keys.parse(it).cluster }?.contains(clusterView.name)
+        instance.relationships.get(CLUSTERS.ns)?.collect { Keys.parse(it).cluster }?.any { it.contains(clusterView.name) }
       }
 
       def instances = instanceProvider.getInstancesFromCacheData(clusterView.accountName, instanceCacheData, securityGroups)


### PR DESCRIPTION
…der.clusterFromCacheData

Closes https://github.com/spinnaker/spinnaker/issues/4266

- When filtering `instanceCacheData` by cluster relationship, we need to check if any of the keys contain the cluster name, rather than checking if the list of keys contains an exact match for the cluster name.
- This fixes an issue where instance health is reported incorrectly in Deck's Clusters view.