### PR TITLE
fix(kubernetes): Initialize credentials after CRDs are registered

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderConfig.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderConfig.java
@@ -103,6 +103,7 @@ class KubernetesV2ProviderConfig {
             log.warn("Error encountered registering {}: ", cr, e);
           }
         });
+        v2Credentials.initialize();
 
         List<Agent> newlyAddedAgents = kubernetesV2CachingAgentDispatcher.buildAllCachingAgents(credentials)
             .stream()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -69,6 +69,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final boolean onlySpinnakerManaged;
   @Getter
   private final boolean liveManifestCalls;
+  private final boolean checkPermissionsOnStartup;
 
   // TODO(lwander) make configurable
   private final static int namespaceExpirySeconds = 30;
@@ -398,6 +399,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       .collect(Collectors.toMap(k -> k, k -> InvalidKindReason.EXPLICITLY_OMITTED_BY_CONFIGURATION));
     this.onlySpinnakerManaged = onlySpinnakerManaged;
     this.liveManifestCalls = liveManifestCalls;
+    this.checkPermissionsOnStartup = checkPermissionsOnStartup;
 
     this.liveNamespaceSupplier = Suppliers.memoizeWithExpiration(() -> jobExecutor.list(this, Collections.singletonList(KubernetesKind.NAMESPACE), "", new KubernetesSelectorList())
         .stream()
@@ -426,7 +428,9 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         return new ArrayList<>();
       }
     }, crdExpirySeconds, TimeUnit.SECONDS);
+  }
 
+  public void initialize() {
     // ensure this is called at least once before the credentials object is created to ensure all crds are registered
     this.liveCrdSupplier.get();
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -38,6 +38,7 @@ class KubernetesV2CredentialsSpec extends Specification {
     KubernetesV2Credentials credentials = getBuilder()
       .checkPermissionsOnStartup(false)
       .build()
+    credentials.initialize()
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -50,6 +51,7 @@ class KubernetesV2CredentialsSpec extends Specification {
       .checkPermissionsOnStartup(false)
       .kinds([])
       .build()
+    credentials.initialize()
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -62,6 +64,7 @@ class KubernetesV2CredentialsSpec extends Specification {
       .checkPermissionsOnStartup(false)
       .kinds(["deployment"])
       .build()
+    credentials.initialize()
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -74,6 +77,7 @@ class KubernetesV2CredentialsSpec extends Specification {
       .checkPermissionsOnStartup(false)
       .omitKinds(["deployment"])
       .build()
+    credentials.initialize()
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == false
@@ -85,6 +89,7 @@ class KubernetesV2CredentialsSpec extends Specification {
     KubernetesV2Credentials credentials = getBuilder()
       .checkPermissionsOnStartup(true)
       .build()
+    credentials.initialize()
 
     then:
     kubectlJobExecutor.list(_, { it.contains(KubernetesKind.DEPLOYMENT) }, _, _) >> {


### PR DESCRIPTION
There are currently two mechanisms for Spinnaker to cache CRDs:
* Registered CRDs that are included in clouddriver's config and can set CRD-specific properties (such as a handler class)
* Unregistered CRDs that are discovered at startup by asking the cluster for all CRDs. These use default properties that are not overriden.

We are currently polling for CRDs in the cluster and configuring all found CRDs as unregistered before we register configured CRDs. Registration of a CRD is a no-op if the CRD has already been registered, so this means the user-configured registered CRD properties are being ignored.

We should instead wait until we've registered all configured CRDs before having the caching agent try to auto-discover CRDs.