### PR TITLE
feat(provider/google): Support Shielded VM policies

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -196,17 +196,19 @@ class GCEUtil {
 
     boolean isUefiCompatible = false;
     boolean isSecureBootCompatible = false;
-    for (def feature : guestOsFeatureList) {
+
+    guestOsFeatureList.each { feature ->
       if (feature.getType() == "UEFI_COMPATIBLE") {
         isUefiCompatible= true
-        continue
+        return
       }
 
       if (feature.getType() == "SECURE_BOOT") {
         isSecureBootCompatible = true
-        continue
+        return
       }
     }
+
     return isUefiCompatible && isSecureBootCompatible
   }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -188,6 +188,28 @@ class GCEUtil {
     }
   }
 
+  static boolean isShieldedVmCompatible(Image image) {
+    java.util.List<GuestOsFeature> guestOsFeatureList = image.getGuestOsFeatures()
+    if (guestOsFeatureList == null || guestOsFeatureList.size() == 0) {
+      return false
+    }
+
+    boolean isUefiCompatible = false;
+    boolean isSecureBootCompatible = false;
+    for (def feature : guestOsFeatureList) {
+      if (feature.getType() == "UEFI_COMPATIBLE") {
+        isUefiCompatible= true
+        continue
+      }
+
+      if (feature.getType() == "SECURE_BOOT") {
+        isSecureBootCompatible = true
+        continue
+      }
+    }
+    return isUefiCompatible && isSecureBootCompatible
+  }
+
   static GoogleNetwork queryNetwork(String accountName, String networkName, Task task, String phase, GoogleNetworkProvider googleNetworkProvider) {
     task.updateStatus phase, "Looking up network $networkName..."
 
@@ -612,6 +634,7 @@ class GCEUtil {
 
     def networkInterface = instanceTemplateProperties.networkInterfaces[0]
     def serviceAccountEmail = instanceTemplateProperties.serviceAccounts?.getAt(0)?.email
+    def shieldedVmConfig = instanceTemplateProperties.shieldedVmConfig
 
     return new BaseGoogleInstanceDescription(
       image: image,
@@ -625,7 +648,10 @@ class GCEUtil {
       network: Utils.decorateXpnResourceIdIfNeeded(project, networkInterface.network),
       subnet: Utils.decorateXpnResourceIdIfNeeded(project, networkInterface.subnet),
       serviceAccountEmail: serviceAccountEmail,
-      authScopes: retrieveScopesFromServiceAccount(serviceAccountEmail, instanceTemplateProperties.serviceAccounts)
+      authScopes: retrieveScopesFromServiceAccount(serviceAccountEmail, instanceTemplateProperties.serviceAccounts),
+      enableSecureBoot: shieldedVmConfig?.enableSecureBoot,
+      enableVtpm: shieldedVmConfig?.enableVtpm,
+      enableIntegrityMonitoring: shieldedVmConfig?.enableIntegrityMonitoring
     )
   }
 
@@ -741,6 +767,7 @@ class GCEUtil {
                                                String phase,
                                                String clouddriverUserAgentApplicationName,
                                                List<String> baseImageProjects,
+                                               Image bootImage,
                                                SafeRetry safeRetry,
                                                GoogleExecutorTraits executor) {
     def credentials = description.credentials
@@ -754,14 +781,6 @@ class GCEUtil {
     if (!disks) {
       throw new GoogleOperationException("Unable to determine disks for instance type $instanceType.")
     }
-
-    def bootImage = getBootImage(description,
-                                 task,
-                                 phase,
-                                 clouddriverUserAgentApplicationName,
-                                 baseImageProjects,
-                                 safeRetry,
-                                 executor)
 
     disks.findAll { it.isPersistent() }
       .eachWithIndex { disk, i ->
@@ -920,6 +939,24 @@ class GCEUtil {
     }
 
     return scheduling
+  }
+
+  static ShieldedVmConfig buildShieldedVmConfig(BaseGoogleInstanceDescription description) {
+    def shieldedVmConfig = new ShieldedVmConfig()
+
+    if (description.enableSecureBoot != null) {
+      shieldedVmConfig.enableSecureBoot = description.enableSecureBoot
+    }
+
+    if (description.enableVtpm != null) {
+      shieldedVmConfig.enableVtpm = description.enableVtpm
+    }
+
+    if (description.enableIntegrityMonitoring != null) {
+      shieldedVmConfig.enableIntegrityMonitoring = description.enableIntegrityMonitoring
+    }
+
+    return shieldedVmConfig
   }
 
   static void updateStatusAndThrowNotFoundException(String errorMsg, Task task, String phase) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
@@ -43,6 +43,9 @@ class BaseGoogleInstanceDescription extends AbstractGoogleCredentialsDescription
   Boolean preemptible
   Boolean automaticRestart
   OnHostMaintenance onHostMaintenance
+  Boolean enableSecureBoot;
+  Boolean enableVtpm;
+  Boolean enableIntegrityMonitoring;
 
   // Unique disk device name addressable by a Linux OS in /dev/disk/by-id/google-* in the running instance.
   // Used to reference disk for mounting, resizing, etc.

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BaseGoogleInstanceDescription.groovy
@@ -43,8 +43,16 @@ class BaseGoogleInstanceDescription extends AbstractGoogleCredentialsDescription
   Boolean preemptible
   Boolean automaticRestart
   OnHostMaintenance onHostMaintenance
+  // Secure boot helps protect your VM instances against boot-level and kernel-level malware and rootkits.
+  // Supported only for Shielded VMs
   Boolean enableSecureBoot;
+  // Virtual Trusted Platform Module (vTPM) validates your guest VM pre-boot and boot integrity,
+  // and offers key generation and protection.
+  // Supported only for Shielded VMs
   Boolean enableVtpm;
+  // Integrity monitoring lets you monitor and verify the runtime boot integrity of your shielded VM instances using Stackdriver reports.
+  // Note: requires vTPM to be enabled.
+  // Supported only for Shielded VMs
   Boolean enableIntegrityMonitoring;
 
   // Unique disk device name addressable by a Linux OS in /dev/disk/by-id/google-* in the running instance.

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -220,6 +220,13 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
     task.updateStatus BASE_PHASE, "Composing server group $serverGroupName..."
 
     description.baseDeviceName = serverGroupName
+    def bootImage = GCEUtil.getBootImage(description,
+      task,
+      BASE_PHASE,
+      clouddriverUserAgentApplicationName,
+      googleConfigurationProperties.baseImageProjects,
+      safeRetry,
+      this)
     def attachedDisks = GCEUtil.buildAttachedDisks(description,
                                                    null,
                                                    false,
@@ -228,6 +235,7 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
                                                    BASE_PHASE,
                                                    clouddriverUserAgentApplicationName,
                                                    googleConfigurationProperties.baseImageProjects,
+                                                   bootImage,
                                                    safeRetry,
                                                    this)
 
@@ -394,6 +402,11 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
                                                     labels: labels,
                                                     scheduling: scheduling,
                                                     serviceAccounts: serviceAccount)
+
+    if (GCEUtil.isShieldedVmCompatible(bootImage)) {
+      def shieldedVmConfig = GCEUtil.buildShieldedVmConfig(description)
+      instanceProperties.setShieldedVmConfig(shieldedVmConfig)
+    }
 
     if (description.minCpuPlatform) {
       instanceProperties.minCpuPlatform = description.minCpuPlatform

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/handlers/BasicGoogleDeployHandler.groovy
@@ -220,6 +220,7 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
     task.updateStatus BASE_PHASE, "Composing server group $serverGroupName..."
 
     description.baseDeviceName = serverGroupName
+
     def bootImage = GCEUtil.getBootImage(description,
       task,
       BASE_PHASE,
@@ -227,6 +228,10 @@ class BasicGoogleDeployHandler implements DeployHandler<BasicGoogleDeployDescrip
       googleConfigurationProperties.baseImageProjects,
       safeRetry,
       this)
+
+    // We include a subset of the image's attributes and a reference in the disks.
+    // Furthermore, we're using the underlying raw compute model classes
+    // so we can't simply change the representation to support what we need for shielded VMs.
     def attachedDisks = GCEUtil.buildAttachedDisks(description,
                                                    null,
                                                    false,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CopyLastGoogleServerGroupAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CopyLastGoogleServerGroupAtomicOperation.groovy
@@ -245,6 +245,25 @@ class CopyLastGoogleServerGroupAtomicOperation extends GoogleAtomicOperation<Dep
           description.canIpForward != null
           ? description.canIpForward
           : ancestorInstanceProperties.canIpForward
+
+      def shieldedVmConfig = ancestorInstanceProperties.shieldedVmConfig
+
+      if (shieldedVmConfig) {
+        newDescription.enableSecureBoot =
+          description.enableSecureBoot != null
+            ? description.enableSecureBoot
+            : shieldedVmConfig.enableSecureBoot
+
+        newDescription.enableVtpm =
+          description.enableVtpm != null
+            ? description.enableVtpm
+            : shieldedVmConfig.enableVtpm
+
+        newDescription.enableIntegrityMonitoring =
+          description.enableIntegrityMonitoring != null
+            ? description.enableIntegrityMonitoring
+            : shieldedVmConfig.enableIntegrityMonitoring
+      }
     }
 
     AutoscalingPolicy ancestorAutoscalingPolicy = ancestorServerGroup.autoscalingPolicy

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
@@ -20,6 +20,8 @@ import com.google.api.services.compute.model.Instance
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
+import com.netflix.spinnaker.clouddriver.google.GoogleExecutorTraits
+import com.netflix.spinnaker.clouddriver.google.deploy.description.BaseGoogleInstanceDescription
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.config.GoogleConfigurationProperties
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
@@ -99,6 +101,13 @@ class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<Deployme
     task.updateStatus BASE_PHASE, "Composing instance..."
 
     description.baseDeviceName = description.instanceName
+    def bootImage = GCEUtil.getBootImage(description,
+      task,
+      BASE_PHASE,
+      clouddriverUserAgentApplicationName,
+      googleConfigurationProperties.baseImageProjects,
+      safeRetry,
+      this)
     def attachedDisks = GCEUtil.buildAttachedDisks(description,
                                                    zone,
                                                    true,
@@ -107,6 +116,7 @@ class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<Deployme
                                                    BASE_PHASE,
                                                    clouddriverUserAgentApplicationName,
                                                    googleConfigurationProperties.baseImageProjects,
+                                                   bootImage,
                                                    safeRetry,
                                                    this)
 
@@ -134,6 +144,11 @@ class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<Deployme
                                 labels: description.labels,
                                 scheduling: scheduling,
                                 serviceAccounts: serviceAccount)
+
+    if (GCEUtil.isShieldedVmCompatible(bootImage)) {
+      def shieldedVmConfig = GCEUtil.buildShieldedVmConfig(description)
+      instance.setShieldedVmConfig(shieldedVmConfig)
+    }
 
     if (description.minCpuPlatform) {
       instance.minCpuPlatform = description.minCpuPlatform

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CreateGoogleInstanceAtomicOperation.groovy
@@ -101,6 +101,7 @@ class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<Deployme
     task.updateStatus BASE_PHASE, "Composing instance..."
 
     description.baseDeviceName = description.instanceName
+
     def bootImage = GCEUtil.getBootImage(description,
       task,
       BASE_PHASE,
@@ -108,6 +109,10 @@ class CreateGoogleInstanceAtomicOperation extends GoogleAtomicOperation<Deployme
       googleConfigurationProperties.baseImageProjects,
       safeRetry,
       this)
+
+    // We include a subset of the image's attributes and a reference in the disks.
+    // Furthermore, we're using the underlying raw compute model classes
+    // so we can't simply change the representation to support what we need for shielded VMs.
     def attachedDisks = GCEUtil.buildAttachedDisks(description,
                                                    zone,
                                                    true,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
@@ -168,6 +168,14 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation extends GoogleAtomi
         clonedDescription.disks = overriddenProperties.disks
 
         clonedDescription.baseDeviceName = description.serverGroupName
+
+        def bootImage = GCEUtil.getBootImage(description,
+          task,
+          BASE_PHASE,
+          clouddriverUserAgentApplicationName,
+          googleConfigurationProperties.baseImageProjects,
+          safeRetry,
+          this)
         def attachedDisks = GCEUtil.buildAttachedDisks(clonedDescription,
                                                        null,
                                                        false,
@@ -176,6 +184,7 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation extends GoogleAtomi
                                                        BASE_PHASE,
                                                        clouddriverUserAgentApplicationName,
                                                        googleConfigurationProperties.baseImageProjects,
+                                                       bootImage,
                                                        safeRetry,
                                                        this)
 
@@ -203,6 +212,10 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation extends GoogleAtomi
       // Override the instance template's canIpForward property if it was specified.
       if (overriddenProperties.canIpForward) {
         instanceTemplateProperties.setCanIpForward(canIpForward)
+      }
+
+      if (overriddenProperties.shieldedVmConfig) {
+        instanceTemplateProperties.setShieldedVmConfig(description.shieldedVmConfig)
       }
 
       // Override the instance template's metadata if instanceMetadata was specified.

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/ModifyGoogleServerGroupInstanceTemplateAtomicOperation.groovy
@@ -176,6 +176,10 @@ class ModifyGoogleServerGroupInstanceTemplateAtomicOperation extends GoogleAtomi
           googleConfigurationProperties.baseImageProjects,
           safeRetry,
           this)
+
+        // We include a subset of the image's attributes and a reference in the disks.
+        // Furthermore, we're using the underlying raw compute model classes
+        // so we can't simply change the representation to support what we need for shielded VMs.
         def attachedDisks = GCEUtil.buildAttachedDisks(clonedDescription,
                                                        null,
                                                        false,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/snapshot/SaveSnapshotAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/snapshot/SaveSnapshotAtomicOperation.groovy
@@ -262,6 +262,9 @@ class SaveSnapshotAtomicOperation implements AtomicOperation<Void> {
         instanceTemplateMap.metadata[item.key] = item.value
       }
     }
+    if (instanceTemplate.properties.shieldedVmConfig) {
+      addShieldedVmConfigToInstanceTemplateMap(instanceTemplate.properties.shieldedVmConfig as ShieldedVmConfig, instanceTemplateMap)
+    }
     numInstanceTemplates++
     resourceMap.google_compute_instance_template[instanceTemplate.name as String] = instanceTemplateMap
 
@@ -278,6 +281,20 @@ class SaveSnapshotAtomicOperation implements AtomicOperation<Void> {
     }
     if (scheduling.preemptible != null) {
       instanceTemplateMap.scheduling.preemptible = scheduling.preemptible
+    }
+    return null
+  }
+
+  private Void addShieldedVmConfigToInstanceTemplateMap(ShieldedVmConfig shieldedVmConfig, Map instanceTemplateMap) {
+    instanceTemplateMap.shielded_vm_config = [:]
+    if (shieldedVmConfig.enableSecureBoot != null) {
+      instanceTemplateMap.shielded_vm_config.enable_secure_boot = shieldedVmConfig.enableSecureBoot
+    }
+    if (shieldedVmConfig.enableVtpm != null) {
+      instanceTemplateMap.shielded_vm_config.enable_vtpm = shieldedVmConfig.enableVtpm
+    }
+    if (shieldedVmConfig.enableIntegrityMonitoring != null) {
+      instanceTemplateMap.shielded_vm_config.enable_integrity_monitoring = shieldedVmConfig.enableIntegrityMonitoring
     }
     return null
   }
@@ -612,6 +629,9 @@ class SaveSnapshotAtomicOperation implements AtomicOperation<Void> {
         instanceProperties.serviceAccounts.add(convertMapToServiceAccount(serviceAccountMap))
       }
     }
+    if (instancePropertiesMap.shieldedVmConfig) {
+      instanceProperties.shieldedVmConfig = convertMapToShieldedVmConfig(instancePropertiesMap.shieldedVmConfig as Map)
+    }
     return instanceProperties
   }
 
@@ -645,6 +665,16 @@ class SaveSnapshotAtomicOperation implements AtomicOperation<Void> {
     scheduling.onHostMaintenance = schedulingMap.onHostMaintenance as String
     scheduling.preemptible = schedulingMap.preemptible as Boolean
     return scheduling
+  }
+
+  private ShieldedVmConfig convertMapToShieldedVmConfig(Map shieldedVmConfigMap) {
+    
+    ShieldedVmConfig shieldedVmConfig = new ShieldedVmConfig()
+
+    shieldedVmConfig.enableSecureBoot = shieldedVmConfigMap.enableSecureBoot as Boolean
+    shieldedVmConfig.enableVtpm = shieldedVmConfigMap.enableVtpm as Boolean
+    shieldedVmConfig.enableIntegrityMonitoring = shieldedVmConfigMap.enableIntegrityMonitoring as Boolean
+    return shieldedVmConfig
   }
 
   private NetworkInterface convertMapToNetworkInterface(Map networkInterfaceMap) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
@@ -56,6 +56,9 @@ class GoogleServerGroup implements GoogleLabeledResource {
   Boolean discovery = false
   String networkName
   Boolean canIpForward = false
+  Boolean enableSecureBoot = false
+  Boolean enableVtpm = false
+  Boolean enableIntegrityMonitoring = false
   Set<String> instanceTemplateTags = []
   Map<String, String> instanceTemplateLabels = [:]
   String selfLink
@@ -109,6 +112,9 @@ class GoogleServerGroup implements GoogleLabeledResource {
     Boolean disabled = GoogleServerGroup.this.disabled
     String networkName = GoogleServerGroup.this.networkName
     Boolean canIpForward = GoogleServerGroup.this.canIpForward
+    Boolean enableSecureBoot = GoogleServerGroup.this.enableSecureBoot
+    Boolean enableVtpm = GoogleServerGroup.this.enableVtpm
+    Boolean enableIntegrityMonitoring = GoogleServerGroup.this.enableIntegrityMonitoring
     Set<String> instanceTemplateTags = GoogleServerGroup.this.instanceTemplateTags
     Map<String, String> instanceTemplateLabels = GoogleServerGroup.this.instanceTemplateLabels
     String selfLink = GoogleServerGroup.this.selfLink

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CopyLastGoogleServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/CopyLastGoogleServerGroupAtomicOperationUnitSpec.groovy
@@ -23,6 +23,7 @@ import com.google.api.services.compute.model.Image
 import com.google.api.services.compute.model.InstanceProperties
 import com.google.api.services.compute.model.InstanceTemplate
 import com.google.api.services.compute.model.Scheduling
+import com.google.api.services.compute.model.ShieldedVmConfig
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -96,6 +97,7 @@ class CopyLastGoogleServerGroupAtomicOperationUnitSpec extends Specification {
   private def instanceMetadata
   private def tags
   private def scheduling
+  private def shieldedVmConfig
   private def serviceAccount
   private def instanceProperties
   private def instanceTemplate

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/SerializeApplicationAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/SerializeApplicationAtomicOperationUnitSpec.groovy
@@ -48,6 +48,10 @@ class SerializeApplicationAtomicOperationUnitSpec extends Specification {
   private static final SCHEDULING_ON_HOST_MAINTENANCE = "MIGRATE"
   private static final SCHEDULING_PREEMPTIBLE = false
 
+  private static final SHIELDEDVMCONFIG_ENABLE_SECURE_BOOT = false
+  private static final SHIELDEDVMCONFIG_ENABLE_VTPM = false
+  private static final SHIELDEDVMCONFIG_ENABLE_INTEGRITY_MONITORING = false
+
   private static final DISK_AUTO_DELETE = true
   private static final DISK_BOOT = false
   private static final DISK_DEVICE_NAME = "test_device_name"
@@ -101,6 +105,9 @@ class SerializeApplicationAtomicOperationUnitSpec extends Specification {
       def scheduling = new Scheduling(automaticRestart: SCHEDULING_AUTOMATIC_RESTART,
                                       onHostMaintenance: SCHEDULING_ON_HOST_MAINTENANCE,
                                       preemptible: SCHEDULING_PREEMPTIBLE)
+      def shieldedVmConfig = new ShieldedVmConfig(enableSecureBoot: SHIELDEDVMCONFIG_ENABLE_SECURE_BOOT,
+                                                  enableVtpm: SHIELDEDVMCONFIG_ENABLE_VTPM,
+                                                  enableIntegrityMonitoring: SHIELDEDVMCONFIG_ENABLE_INTEGRITY_MONITORING)
       def disk = new AttachedDisk(autoDelete: DISK_AUTO_DELETE,
                                   boot: DISK_BOOT,
                                   deviceName: DISK_DEVICE_NAME,
@@ -122,7 +129,8 @@ class SerializeApplicationAtomicOperationUnitSpec extends Specification {
                                                       metadata: INSTANCE_TEMPLATE_METADATA,
                                                       scheduling: scheduling,
                                                       disks: [disk],
-                                                      networkInterfaces: [networkInterface])
+                                                      networkInterfaces: [networkInterface],
+                                                      shieldedVmConfig: shieldedVmConfig)
       def instanceTemplate = new InstanceTemplate(description: INSTANCE_TEMPLATE_DESCRIPTION,
                                                   name: INSTANCE_TEMPLATE_NAME,
                                                   properties: instanceProperties)
@@ -159,6 +167,9 @@ class SerializeApplicationAtomicOperationUnitSpec extends Specification {
       def schedulingMap = [automatic_restart: SCHEDULING_AUTOMATIC_RESTART,
                            on_host_maintenance: SCHEDULING_ON_HOST_MAINTENANCE,
                            preemptible: SCHEDULING_PREEMPTIBLE]
+      def shieldedVmConfigMap = [enable_secure_boot: SHIELDEDVMCONFIG_ENABLE_SECURE_BOOT,
+                                  enable_vtpm: SHIELDEDVMCONFIG_ENABLE_VTPM,
+                                  enable_integrity_monitoring: SHIELDEDVMCONFIG_ENABLE_INTEGRITY_MONITORING]
       def autoscalingPolicyMap = [max_replicas: AUTOSCALING_MAX_NUM_REPLICAS,
                                   min_replicas: AUTOSCALING_MIN_NUM_REPLICAS,
                                   cooldown_period: AUTOSCALING_COOL_DOWN_PERIOD,
@@ -186,7 +197,8 @@ class SerializeApplicationAtomicOperationUnitSpec extends Specification {
                                  project: null,
                                  network_interface: [networkInterfaceMap],
                                  scheduling: schedulingMap,
-                                 metadata: metadataMap]
+                                 metadata: metadataMap,
+                                 shielded_vm_config: shieldedVmConfigMap]
       def targetPools = []
       SERVER_GROUP_LOAD_BALANCERS.each {String loadBalancer ->
         targetPools.add("\${google_compute_target_pool.${loadBalancer}.self_link}")


### PR DESCRIPTION
Shielded VMs are virtual machines (VMs) on Google Cloud Platform hardened by a set of security controls that help defend against rootkits and bootkits. Using Shielded VMs helps protect enterprise workloads from threats like remote attacks, privilege escalation, and malicious insiders. Shielded VMs leverage advanced platform security capabilities such as secure and measured boot, a virtual trusted platform module (vTPM), UEFI firmware, and integrity monitoring. Please see more details and screenshots using the link below.


https://github.com/spinnaker/spinnaker/issues/4281
