### PR TITLE
fix(titus): Map titus containerIp to privateIpAddress

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -47,6 +47,7 @@ class TitusInstance implements Instance {
   Set<TitusSecurityGroup> securityGroups
   final String providerType = TitusCloudProvider.ID
   final String cloudProvider = TitusCloudProvider.ID
+  String privateIpAddress
 
   TitusInstance() {}
 
@@ -80,6 +81,8 @@ class TitusInstance implements Instance {
     finishedAt = task.finishedAt ? task.finishedAt.time : null
     stdoutLive = task.stdoutLive
     logs = task.logs
+    // For Titus tasks map the privateIp to containerIp for consistency purpose
+    privateIpAddress = task.containerIp ?: task.data?.ipAddresses?.nfvpc
   }
 
   @Override

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -81,7 +81,8 @@ class TitusInstance implements Instance {
     finishedAt = task.finishedAt ? task.finishedAt.time : null
     stdoutLive = task.stdoutLive
     logs = task.logs
-    // For Titus tasks map the privateIp to containerIp for consistency purpose
+
+    // expose containerIp as privateIpAddress to remain consistent with aws
     privateIpAddress = task.containerIp ?: task.data?.ipAddresses?.nfvpc
   }
 

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
@@ -71,6 +71,7 @@ class TitusInstanceSpec extends Specification {
     titusInstance.env?.account == 'test'
     titusInstance.submittedAt == task.submittedAt.time
     titusInstance.finishedAt == null
+    titusInstance.privateIpAddress == task.data.ipAddresses.nfvpc
   }
 
   void 'can handle null ports'() {


### PR DESCRIPTION
Context : For titus instance we currently have only `containerIp` and this means we have to use something like this for links in application config `https://{{containerIp}}:port/link`. 
This change introduces the `privateIpAddress` field to titus instance so that there can be parity with AWS provider type applications and titus and we can use `https://{{privateIpAddress}}:port/link` across the board