### PR TITLE
fix(artifacts): Maven release artifact resolution by version results in 404

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
@@ -180,7 +180,7 @@ public class MavenArtifactCredentials implements ArtifactCredentials {
     } else if (isLatest(artifact) || version.startsWith("[") || version.startsWith("(")) {
       metadata = new DefaultMetadata(group, artifactId, MAVEN_METADATA_XML, Metadata.Nature.RELEASE_OR_SNAPSHOT);
     } else {
-      metadata = new DefaultMetadata(group, artifactId, version, MAVEN_METADATA_XML, Metadata.Nature.RELEASE);
+      metadata = new DefaultMetadata(group, artifactId, MAVEN_METADATA_XML, Metadata.Nature.RELEASE);
     }
 
     return repositoryLayout.getLocation(metadata, false);

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentialsTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MavenArtifactCredentialsTest {
   @Test
   void release(@WiremockResolver.Wiremock WireMockServer server) {
-    server.stubFor(any(urlPathMatching("/com/test/app/(.*/)?maven-metadata.xml"))
+    server.stubFor(any(urlPathMatching("/com/test/app/maven-metadata.xml"))
       .willReturn(aResponse()
         .withBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
           "<metadata modelVersion=\"1.1.0\">\n" +


### PR DESCRIPTION
In order to fetch a maven artifact with coordinates `com.example:example-app:0.0.1-build.10` the version resolving logic should not fetch the metadata by version instead it should fetch the metadata for the artifact and the resolve the version released version from the `maven-metadata.xml`.

```
2019-04-17 02:55:30.974 ERROR 1 --- [ool-4-thread-10] c.n.s.c.o.DefaultOrchestrationProcessor  : java.lang.IllegalStateException: Unable to download artifact with reference 'com.example:example-app:[com.example:example-app:0.0.1-build.17]'
        at com.netflix.spinnaker.clouddriver.artifacts.maven.MavenArtifactCredentials.download(MavenArtifactCredentials.java:108)
        at com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeployCloudFoundryServerGroupAtomicOperation.downloadPackageArtifact(DeployCloudFoundryServerGroupAtomicOperation.java:161)
        at com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeployCloudFoundryServerGroupAtomicOperation.operate(DeployCloudFoundryServerGroupAtomicOperation.java:72)
        at com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.ops.DeployCloudFoundryServerGroupAtomicOperation.operate(DeployCloudFoundryServerGroupAtomicOperation.java:43)
        at com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation$operate.call(Unknown Source)
        at com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor$_process_closure1$_closure2.doCall(DefaultOrchestrationProcessor.groovy:89)
        at com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor$_process_closure1$_closure2.doCall(DefaultOrchestrationProcessor.groovy)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:98)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:264)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1034)
        at groovy.lang.Closure.call(Closure.java:418)
        at groovy.lang.Closure.call(Closure.java:412)
        at com.netflix.spinnaker.clouddriver.metrics.TimedCallable$ClosureWrapper.call(TimedCallable.groovy:55)
        at com.netflix.spinnaker.clouddriver.metrics.TimedCallable.call(TimedCallable.groovy:82)
        at java_util_concurrent_Callable$call.call(Unknown Source)
        at com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor$_process_closure1.doCall(DefaultOrchestrationProcessor.groovy:88)
        at com.netflix.spinnaker.clouddriver.orchestration.DefaultOrchestrationProcessor$_process_closure1.doCall(DefaultOrchestrationProcessor.groovy)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:98)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:264)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1034)
        at groovy.lang.Closure.call(Closure.java:418)
        at groovy.lang.Closure.call(Closure.java:412)
        at com.netflix.spinnaker.security.AuthenticatedRequest.lambda$propagate$0(AuthenticatedRequest.java:97)
        at com.netflix.spinnaker.clouddriver.metrics.TimedCallable.call(TimedCallable.groovy:82)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: com.netflix.spinnaker.clouddriver.artifacts.maven.MavenArtifactCredentials$ArtifactDownloadException: java.io.IOException: Unsuccessful response retrieving maven-metadata.xml 404
        at com.netflix.spinnaker.clouddriver.artifacts.maven.MavenArtifactCredentials.resolveVersion(MavenArtifactCredentials.java:159)
        at com.netflix.spinnaker.clouddriver.artifacts.maven.MavenArtifactCredentials.download(MavenArtifactCredentials.java:90)
        ... 37 more
Caused by: java.io.IOException: Unsuccessful response retrieving maven-metadata.xml 404
        at com.netflix.spinnaker.clouddriver.artifacts.maven.MavenArtifactCredentials.resolveVersion(MavenArtifactCredentials.java:156)
        ... 38 more
```