### PR TITLE
fix(provider/azure): Add more filter condition to just remove instances which are associated with server group is succeeded status

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -89,7 +89,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
 
     if (cacheServerGroups) {
       cacheServerGroups.each { cacheServerGroup ->
-        if(!cacheServerGroup.relationships.containsKey(AZURE_INSTANCES.ns)) {
+        if(cacheServerGroup.attributes.serverGroup.provisioningState == 'Succeeded' && !cacheServerGroup.relationships.containsKey(AZURE_INSTANCES.ns)) {
           def serverGroupName = cacheServerGroup.attributes.serverGroup.name
           removeDeadCacheEntries(result, providerCache, serverGroupName)
         }


### PR DESCRIPTION
Background:
Add more filter condition to just remove instances which are associated with server group is succeeded status. The server group with other status doesn't need to be processed.