### PR TITLE
fix(kubernetes): include unclassified kinds in spinnakerKindMap so th…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
@@ -87,7 +87,7 @@ public class KubernetesSpinnakerKindMap {
 
   public Map<String, String> kubernetesToSpinnakerKindStringMap() {
     return kubernetesToSpinnaker.entrySet().stream().filter(
-      x -> x.getValue() != SpinnakerKind.UNCLASSIFIED && x.getKey() != KubernetesKind.NONE
+      x -> x.getKey() != KubernetesKind.NONE
     ).collect(
       Collectors.toMap(x -> x.getKey().toString(), x -> x.getValue().toString()));
   }


### PR DESCRIPTION
…ey can be surfaced for deletion

Closes https://github.com/spinnaker/spinnaker/issues/4240

- Removes filter so that Kubernetes kinds without a Spinnaker kind analog are included in the `spinnakerKindMap` surfaced by the credentials API. They map to `unclassified`.
- This allows us to pre-populate a kinds dropdown with all available kinds to delete for a given account. The Enable/Disable stage kind selection will be unaffected since we already filter those kinds such that the only included kinds map to Spinnaker kind `serverGroup`.
- @sbwsg since you originally added the `spinnakerKindMap`, let me know if you have any thoughts on this. From what I could tell, nothing in Clouddriver or Deck relies on it _not_ including `unclassified` kinds.
