### PR TITLE
feat(kubernetes): validate manifests for spinnaker-managed rollout st…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
@@ -40,9 +40,16 @@ public class KubernetesDeployManifestDescription extends KubernetesAtomicOperati
 
   private boolean enableTraffic = true;
   private List<String> services;
+  private Strategy strategy;
 
   public enum Source {
     artifact,
     text
+  }
+
+  public enum Strategy {
+    RED_BLACK,
+    HIGHLANDER,
+    NONE
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
@@ -229,6 +229,17 @@ public class KubernetesManifestAnnotater {
     storeAnnotation(annotations, LOAD_BALANCERS, loadBalancers);
   }
 
+  public static void validateAnnotationsForRolloutStrategies(KubernetesManifest manifest, KubernetesDeployManifestDescription.Strategy strategy) {
+    Map<String, String> annotations = manifest.getAnnotations();
+    Integer maxVersionHistory = getAnnotation(annotations, MAX_VERSION_HISTORY, new TypeReference<Integer>() {});
+    if (strategy == KubernetesDeployManifestDescription.Strategy.RED_BLACK && maxVersionHistory != null && maxVersionHistory < 2) {
+      throw new RuntimeException(String.format(
+        "The max version history specified in your manifest conflicts with the behavior of the Red/Black rollout strategy. Please update your %s annotation to a value greater than or equal to 2.",
+        MAX_VERSION_HISTORY
+      ));
+    }
+  }
+
   public static KubernetesCachingProperties getCachingProperties(KubernetesManifest manifest) {
     Map<String, String> annotations = manifest.getAnnotations();
 


### PR DESCRIPTION
…rategies

Handles two anticipated failure modes:
- Attempting to enable rollout strategies for non-ReplicaSet kinds, or attempting to deploy another resource alongside a ReplicaSet:

![replicaSet](https://user-images.githubusercontent.com/15936279/56443249-cf70d800-62c1-11e9-801d-89c7d3afd719.png)


- Attempting to enact a Red/Black rollout with a ReplicaSet containing a [`strategy.spinnaker.io/max-version-history`](https://www.spinnaker.io/reference/providers/kubernetes-v2/#strategy) annotation set to 1, which would interfere with the expected behavior of a Red/Black rollout:

![maxVersionHistoryError](https://user-images.githubusercontent.com/15936279/56443252-d1d33200-62c1-11e9-8b24-26c48758a765.png)
