### PR TITLE
feat(provider/google): Support service account security groups

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleSecurityGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleSecurityGroup.groovy
@@ -54,6 +54,15 @@ class GoogleSecurityGroup implements SecurityGroup {
 
   @Override
   SecurityGroupSummary getSummary() {
-    new GoogleSecurityGroupSummary(name: name, id: id, network: network, selfLink: selfLink, sourceTags: sourceTags, targetTags: targetTags)
+    new GoogleSecurityGroupSummary(
+      name: name,
+      id: id,
+      network: network,
+      selfLink: selfLink,
+      sourceTags: sourceTags,
+      targetTags: targetTags,
+      sourceServiceAccounts: sourceServiceAccounts,
+      targetServiceAccounts: targetServiceAccounts
+    )
   }
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleSecurityGroupSummary.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleSecurityGroupSummary.groovy
@@ -31,4 +31,6 @@ class GoogleSecurityGroupSummary implements SecurityGroupSummary {
   String selfLink
   String sourceTags
   String targetTags
+  String sourceServiceAccounts
+  String targetServiceAccounts
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleServerGroup.groovy
@@ -60,6 +60,7 @@ class GoogleServerGroup implements GoogleLabeledResource {
   Boolean enableVtpm = false
   Boolean enableIntegrityMonitoring = false
   Set<String> instanceTemplateTags = []
+  Set<String> instanceTemplateServiceAccounts = []
   Map<String, String> instanceTemplateLabels = [:]
   String selfLink
   InstanceGroupManagerActionsSummary currentActions
@@ -116,6 +117,7 @@ class GoogleServerGroup implements GoogleLabeledResource {
     Boolean enableVtpm = GoogleServerGroup.this.enableVtpm
     Boolean enableIntegrityMonitoring = GoogleServerGroup.this.enableIntegrityMonitoring
     Set<String> instanceTemplateTags = GoogleServerGroup.this.instanceTemplateTags
+    Set<String> instanceTemplateServiceAccounts = GoogleServerGroup.this.instanceTemplateServiceAccounts
     Map<String, String> instanceTemplateLabels = GoogleServerGroup.this.instanceTemplateLabels
     String selfLink = GoogleServerGroup.this.selfLink
     Boolean discovery = GoogleServerGroup.this.discovery
@@ -224,6 +226,7 @@ class GoogleServerGroup implements GoogleLabeledResource {
     Map getProviderMetadata() {
       [
         tags: GoogleServerGroup.this.launchConfig?.instanceTemplate?.properties?.tags?.items,
+        serviceAccounts: GoogleServerGroup.this.launchConfig?.instanceTemplate?.properties?.serviceAccounts,
         networkName: GoogleServerGroup.this.networkName
       ]
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
@@ -501,6 +501,7 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
       networkName = Utils.decorateXpnResourceIdIfNeeded(project, instanceTemplate?.properties?.networkInterfaces?.getAt(0)?.network)
       canIpForward = instanceTemplate?.properties?.canIpForward
       instanceTemplateTags = instanceTemplate?.properties?.tags?.items
+      instanceTemplateServiceAccounts = instanceTemplate?.properties?.serviceAccounts
       instanceTemplateLabels = instanceTemplate?.properties?.labels
       launchConfig.with {
         launchConfigurationName = instanceTemplate?.name

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -248,6 +248,7 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
         account,
         securityGroups,
         serverGroup.instanceTemplateTags,
+        serverGroup.instanceTemplateServiceAccounts,
         serverGroup.networkName)
 
     if (instances) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
@@ -145,6 +145,7 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance.View, St
         account,
         securityGroups,
         instance.tags.items as Set<String>,
+        instance.serviceAccounts as Set<String>,
         instance.networkName)
 
     instance

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProviderSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleSecurityGroupProviderSpec.groovy
@@ -325,6 +325,7 @@ class GoogleSecurityGroupProviderSpec extends Specification {
           name: 'a',
           id: 6614377178691015953,
           network: 'https://compute.googleapis.com/compute/v1/projects/my-project/global/networks/default',
+          targetServiceAccounts: ['user@test.iam.gserviceaccount.com'],
           selfLink: 'https://compute.googleapis.com/compute/v1/projects/my-project/global/firewalls/a'
         ),
         new Firewall(


### PR DESCRIPTION
This PR adds support for existing serviceAccount based firewall rules. 

For any rules that exist, the `application/appname/serverGroups` endpoint will now successfully return the service account of the instance that is running, in addition to the `/securityGroups` endpoint now properly returning firewall rules that DO NOT have tags (`targetTags` or `sourceTags`) but instead use serviceAccounts.

For example, if a firewall rule already exists using a service account, you will see the object in `/securityGroups`:

```
{
  id: "host/sampleapp-internal-test",
  moniker: {
    app: "sampleapp",
    cluster: "sampleapp-internal-test",
    detail: "internal-test",
    stack: "app"
  },
  name: "sampleapp-internal-test",
  network: "host/host-network",
  selfLink: "https://www.googleapis.com/compute/beta/projects/host/global/firewalls/sampleapp-internal-test",
  sourceServiceAccounts: "[sampleapp-nginx-internal@prod-app.iam.gserviceaccount.com]",
  targetServiceAccounts: "[sampleapp-testt@prod-app.iam.gserviceaccount.com]"
}
```

There is still work to. be done to support creating new security groups with service accounts, and changing deck to view these security groups, but this is the first step.

Issue: https://github.com/spinnaker/spinnaker/issues/4332