### PR TITLE
feat(cf): add build info to server group

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -258,6 +258,9 @@ public class Applications {
 
     Map<String, String> environmentVars = applicationEnv == null || applicationEnv.getEnvironmentJson() == null ? emptyMap() : applicationEnv.getEnvironmentJson();
 
+    final CloudFoundryBuildInfo buildInfo = getBuildInfoFromEnvVars(environmentVars);
+    Arrays.asList(BuildEnvVar.values()).forEach(envVar -> environmentVars.remove(envVar.envVarName));
+
     String healthCheckType = null;
     String healthCheckHttpEndpoint = null;
     if (process != null && process.getHealthCheck() != null) {
@@ -296,6 +299,16 @@ public class Applications {
       .instances(instances)
       .state(state)
       .env(environmentVars)
+      .ciBuild(buildInfo)
+      .build();
+  }
+
+  private CloudFoundryBuildInfo getBuildInfoFromEnvVars(Map<String, String> environmentVars) {
+    return CloudFoundryBuildInfo.builder()
+      .jobName(environmentVars.get(BuildEnvVar.JobName.envVarName))
+      .jobNumber(environmentVars.get(BuildEnvVar.JobNumber.envVarName))
+      .jobUrl(environmentVars.get(BuildEnvVar.JobUrl.envVarName))
+      .version(environmentVars.get(BuildEnvVar.Version.envVarName))
       .build();
   }
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -22,10 +22,12 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.ProcessStats;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.CloudFoundryServerGroupNameResolver;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.model.BuildEnvVar;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryServerGroup;
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
 import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -145,10 +147,20 @@ public class DeployCloudFoundryServerGroupAtomicOperation
     CloudFoundryClient client = description.getClient();
     getTask().updateStatus(PHASE, "Creating Cloud Foundry application '" + description.getServerGroupName() + "'");
 
+    Map<String, String> environmentVars = new HashMap<>(description.getApplicationAttributes().getEnv());
+    final Artifact applicationArtifact = description.getApplicationArtifact();
+    environmentVars.put(BuildEnvVar.Version.envVarName, applicationArtifact.getVersion());
+    final Map<String, String> buildInfo = (Map<String, String>) applicationArtifact.getMetadata().get("build");
+    if (buildInfo != null) {
+      environmentVars.put(BuildEnvVar.JobName.envVarName, buildInfo.get("name"));
+      environmentVars.put(BuildEnvVar.JobNumber.envVarName, buildInfo.get("number"));
+      environmentVars.put(BuildEnvVar.JobUrl.envVarName, buildInfo.get("url"));
+    }
+
     CloudFoundryServerGroup serverGroup = client.getApplications().createApplication(description.getServerGroupName(),
       description.getSpace(),
       description.getApplicationAttributes().getBuildpacks(),
-      description.getApplicationAttributes().getEnv());
+      environmentVars);
     getTask().updateStatus(PHASE, "Created Cloud Foundry application '" + description.getServerGroupName() + "'");
 
     return serverGroup;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -149,12 +149,17 @@ public class DeployCloudFoundryServerGroupAtomicOperation
 
     Map<String, String> environmentVars = new HashMap<>(description.getApplicationAttributes().getEnv());
     final Artifact applicationArtifact = description.getApplicationArtifact();
-    environmentVars.put(BuildEnvVar.Version.envVarName, applicationArtifact.getVersion());
-    final Map<String, String> buildInfo = (Map<String, String>) applicationArtifact.getMetadata().get("build");
-    if (buildInfo != null) {
-      environmentVars.put(BuildEnvVar.JobName.envVarName, buildInfo.get("name"));
-      environmentVars.put(BuildEnvVar.JobNumber.envVarName, buildInfo.get("number"));
-      environmentVars.put(BuildEnvVar.JobUrl.envVarName, buildInfo.get("url"));
+    if (applicationArtifact.getVersion() != null) {
+      environmentVars.put(BuildEnvVar.Version.envVarName, applicationArtifact.getVersion());
+    }
+    final Map<String, Object> metadata = applicationArtifact.getMetadata();
+    if (metadata != null) {
+      final Map<String, String> buildInfo = (Map<String, String>) applicationArtifact.getMetadata().get("build");
+      if (buildInfo != null) {
+        environmentVars.put(BuildEnvVar.JobName.envVarName, buildInfo.get("name"));
+        environmentVars.put(BuildEnvVar.JobNumber.envVarName, buildInfo.get("number"));
+        environmentVars.put(BuildEnvVar.JobUrl.envVarName, buildInfo.get("url"));
+      }
     }
 
     CloudFoundryServerGroup serverGroup = client.getApplications().createApplication(description.getServerGroupName(),

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/BuildEnvVar.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/BuildEnvVar.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/BuildEnvVar.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/BuildEnvVar.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+public enum BuildEnvVar {
+
+  JobName(BuildEnvVar.PREFIX + "BUILD_JOB_NAME"),
+  JobNumber(BuildEnvVar.PREFIX + "BUILD_JOB_NUMBER"),
+  JobUrl(BuildEnvVar.PREFIX + "BUILD_JOB_URL"),
+  Version(BuildEnvVar.PREFIX + "BUILD_VERSION");
+
+  public static final String PREFIX = "__SPINNAKER_";
+  public final String envVarName;
+
+  BuildEnvVar(String envVarName) {
+    this.envVarName = envVarName;
+  }
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryBuildInfo.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryBuildInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.cloudfoundry.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * The CI build metadata for an app artifact based on the build info produced by Artifactory
+ */
+@Value
+@Builder
+@JsonDeserialize(builder = CloudFoundryBuildInfo.CloudFoundryBuildInfoBuilder.class)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class CloudFoundryBuildInfo {
+
+  @JsonView(Views.Cache.class)
+  String jobName;
+
+  @JsonView(Views.Cache.class)
+  String jobNumber;
+
+  @JsonView(Views.Cache.class)
+  String jobUrl;
+
+  @JsonView(Views.Cache.class)
+  String version;
+}

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryBuildInfo.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryBuildInfo.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2019 Pivotal, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
@@ -100,6 +100,9 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
   @JsonView(Views.Cache.class)
   List<CloudFoundryServiceInstance> serviceInstances;
 
+  @JsonView(Views.Cache.class)
+  CloudFoundryBuildInfo ciBuild;
+
   @Wither
   @JsonView(Views.Relationship.class)
   Set<CloudFoundryInstance> instances;

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
@@ -331,6 +331,7 @@ class ApplicationsTest {
       .name(serverGroupName)
       .appsManagerUri("some-apps-man-uri/organizations/org-id/spaces/space-guid/applications/server-group-guid")
       .metricsUri("some-metrics-uri/apps/server-group-guid")
+      .ciBuild(CloudFoundryBuildInfo.builder().build())
       .build();
 
     CloudFoundryServerGroup serverGroup = apps.findServerGroupByNameAndSpaceId(serverGroupName, spaceId);


### PR DESCRIPTION
Every cloud provider will have a different way to put metadata on their server group. Here we use app environment variables because we don’t have resource tagging yet.
The builds are not cloud provider specific so it makes sense to have more consistency here. The CFBuildInfo could be more general purpose than just CF. It could be moved to the core model as part of a server group and a consistent way to represent ci build reference info. It is basic build metadata that is produced by Artifactory build info and relevant attributes to just about any CI system.
