### PR TITLE
fix(runJob/kubernetes): defer cleanup to k8s

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
@@ -82,10 +82,6 @@ public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatu
 
     jobStatus.setLogs(logs.toString());
 
-    if (ImmutableList.of(JobState.Failed, JobState.Succeeded).contains(jobStatus.getJobState())) {
-      credentials.delete(jobManifest.getKind(), jobManifest.getNamespace(), jobManifest.getName(), new KubernetesSelectorList(), new V1DeleteOptions());
-    }
-
     return jobStatus;
   }
 


### PR DESCRIPTION
This is the beginning of some work to redo how logs are handled for Jobs
in the V2 provider. In order to implement the new approach we need to
prevent Jobs from being cleaned up by Spinnaker and defer to Kubernetes
to do that work. Versions >= 1.12 implement a `ttlSecondsAfterFinished`
field for Jobs that will tell Kubernetes to cleanup the Job after that
TTL has expired. We'll communicate this to customers via documentation.