### PR TITLE
fix(titus): serialize empty RateUnlimited field in DisruptionBudget

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/DisruptionBudget.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/DisruptionBudget.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.client.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.netflix.spinnaker.clouddriver.titus.client.model.disruption.*;
 import lombok.Data;
 
@@ -28,6 +29,8 @@ public class DisruptionBudget implements Serializable {
   UnhealthyTasksLimit unhealthyTasksLimit;
   RelocationLimit relocationLimit;
   RatePercentagePerHour ratePercentagePerHour;
+
+  @JsonSerialize
   RateUnlimited rateUnlimited;
   List<TimeWindow> timeWindows;
   List<ContainerHealthProvider> containerHealthProviders;


### PR DESCRIPTION
This field is a marker, so it has no body (consistent with the gRPC model). 

I'm debating whether we should stay true to the gRPC model, or make it a boolean to avoid this weirdness. For now, I'd like to leave it as an empty Object, unless that's against any other conventions in our codebase.

I didn't catch this in my testing because I was hitting the serverGroups endpoint with the browser and getting XML instead of JSON.