### PR TITLE
refactor(kubernetes): Simplify account creation code

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -23,10 +23,12 @@ import groovy.transform.ToString
 
 @ToString(includeNames = true)
 class KubernetesConfigurationProperties {
+  private static final Integer DEFAULT_CACHE_THREADS = 1
+
   @ToString(includeNames = true)
   static class ManagedAccount {
     String name
-    ProviderVersion providerVersion
+    ProviderVersion providerVersion = ProviderVersion.v1
     String environment
     String accountType
     String context
@@ -37,26 +39,26 @@ class KubernetesConfigurationProperties {
     String kubeconfigFile
     String kubeconfigContents
     String kubectlExecutable
-    Integer kubectlRequestTimeoutSeconds;
-    Boolean serviceAccount
-    Boolean configureImagePullSecrets
+    Integer kubectlRequestTimeoutSeconds
+    boolean serviceAccount = false
+    boolean configureImagePullSecrets = true
     List<String> namespaces
     List<String> omitNamespaces
     String skin
-    Integer cacheThreads
+    int cacheThreads = DEFAULT_CACHE_THREADS
     List<LinkedDockerRegistryConfiguration> dockerRegistries
     List<String> requiredGroupMembership
     Permissions.Builder permissions = new Permissions.Builder()
     String namingStrategy = "kubernetesAnnotations"
-    Boolean debug = false
-    Boolean metrics = true
-    Boolean checkPermissionsOnStartup = true
+    boolean debug = false
+    boolean metrics = true
+    boolean checkPermissionsOnStartup = true
     List<CustomKubernetesResource> customResources;
     List<KubernetesCachingPolicy> cachingPolicies;
     List<String> kinds
     List<String> omitKinds
-    Boolean onlySpinnakerManaged
-    Boolean liveManifestCalls
+    boolean onlySpinnakerManaged = false
+    boolean liveManifestCalls = false
     Long cacheIntervalSeconds
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -18,11 +18,8 @@ package com.netflix.spinnaker.clouddriver.kubernetes.security;
 
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
-import com.netflix.spinnaker.clouddriver.kubernetes.config.CustomKubernetesResource;
-import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesCachingPolicy;
-import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
@@ -31,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
-import com.netflix.spinnaker.moniker.Namer;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
@@ -85,167 +81,20 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
   }
 
   static class Builder<C extends KubernetesCredentials> {
-    String name;
-    ProviderVersion providerVersion;
-    String environment;
-    String accountType;
-    String context;
-    String cluster;
-    String oAuthServiceAccount;
-    List<String> oAuthScopes;
-    String user;
+    KubernetesConfigurationProperties.ManagedAccount managedAccount;
     String userAgent;
-    String kubeconfigFile;
-    String kubeconfigContents;
-    String kubectlExecutable;
-    Integer kubectlRequestTimeoutSeconds;
-    Boolean serviceAccount;
-    Boolean metrics;
-    Boolean configureImagePullSecrets;
-    List<String> namespaces;
-    List<String> omitNamespaces;
-    String skin;
-    int cacheThreads;
-    List<String> requiredGroupMembership;
-    Permissions permissions;
-    List<LinkedDockerRegistryConfiguration> dockerRegistries;
     Registry spectatorRegistry;
+    NamerRegistry namerRegistry;
     AccountCredentialsRepository accountCredentialsRepository;
     KubectlJobExecutor jobExecutor;
-    Namer namer;
-    List<CustomKubernetesResource> customResources;
-    List<KubernetesCachingPolicy> cachingPolicies;
-    List<String> kinds;
-    List<String> omitKinds;
-    boolean debug;
-    boolean checkPermissionsOnStartup;
-    KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
-    Boolean onlySpinnakerManaged;
-    Boolean liveManifestCalls;
-    Long cacheIntervalSeconds;
 
-    Builder kubernetesSpinnakerKindMap(KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap) {
-      this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
-      return this;
-    }
-
-    Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    Builder providerVersion(ProviderVersion providerVersion) {
-      this.providerVersion = providerVersion;
-      return this;
-    }
-
-    Builder environment(String environment) {
-      this.environment = environment;
-      return this;
-    }
-
-    Builder accountType(String accountType) {
-      this.accountType = accountType;
-      return this;
-    }
-
-    Builder context(String context) {
-      this.context = context;
-      return this;
-    }
-
-    Builder cluster(String cluster) {
-      this.cluster = cluster;
-      return this;
-    }
-
-    Builder oAuthServiceAccount(String oAuthServiceAccount) {
-      this.oAuthServiceAccount = oAuthServiceAccount;
-      return this;
-    }
-
-    Builder oAuthScopes(List<String> oAuthScopes) {
-      this.oAuthScopes = oAuthScopes;
-      return this;
-    }
-
-    Builder user(String user) {
-      this.user = user;
+    Builder managedAccount(KubernetesConfigurationProperties.ManagedAccount managedAccount) {
+      this.managedAccount = managedAccount;
       return this;
     }
 
     Builder userAgent(String userAgent) {
       this.userAgent = userAgent;
-      return this;
-    }
-
-    Builder kubeconfigFile(String kubeconfigFile) {
-      this.kubeconfigFile = kubeconfigFile;
-      return this;
-    }
-
-    Builder kubeconfigContents(String kubeconfigContents) {
-      this.kubeconfigContents = kubeconfigContents;
-      return this;
-    }
-
-    Builder kubectlExecutable(String kubectlExecutable) {
-      this.kubectlExecutable = kubectlExecutable;
-      return this;
-    }
-
-    Builder kubectlRequestTimeoutSeconds(Integer kubectlRequestTimeoutSeconds) {
-      this.kubectlRequestTimeoutSeconds = kubectlRequestTimeoutSeconds;
-      return this;
-    }
-
-    Builder serviceAccount(Boolean serviceAccount) {
-      this.serviceAccount = serviceAccount;
-      return this;
-    }
-
-    Builder metrics(Boolean metrics) {
-      this.metrics = metrics;
-      return this;
-    }
-
-    Builder configureImagePullSecrets(Boolean configureImagePullSecrets) {
-      this.configureImagePullSecrets = configureImagePullSecrets;
-      return this;
-    }
-
-    Builder requiredGroupMembership(List<String> requiredGroupMembership) {
-      this.requiredGroupMembership = requiredGroupMembership;
-      return this;
-    }
-
-    Builder permissions(Permissions permissions) {
-      this.permissions = permissions;
-      return this;
-    }
-
-    Builder dockerRegistries(List<LinkedDockerRegistryConfiguration> dockerRegistries) {
-      this.dockerRegistries = dockerRegistries;
-      return this;
-    }
-
-    Builder namespaces(List<String> namespaces) {
-      this.namespaces = namespaces;
-      return this;
-    }
-
-    Builder omitNamespaces(List<String> omitNamespaces) {
-      this.omitNamespaces = omitNamespaces;
-      return this;
-    }
-
-    Builder skin(String skin) {
-      this.skin = skin;
-      return this;
-    }
-
-    Builder cacheThreads(int cacheThreads) {
-      this.cacheThreads = cacheThreads;
       return this;
     }
 
@@ -264,83 +113,39 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       return this;
     }
 
-    Builder debug(boolean debug) {
-      this.debug = debug;
-      return this;
-    }
-
-    Builder checkPermissionsOnStartup(boolean checkPermissionsOnStartup) {
-      this.checkPermissionsOnStartup = checkPermissionsOnStartup;
-      return this;
-    }
-
-    Builder namer(Namer namer) {
-      this.namer = namer;
-      return this;
-    }
-
-    Builder cachingPolicies(List<KubernetesCachingPolicy> cachingPolicies) {
-      this.cachingPolicies = cachingPolicies;
-      return this;
-    }
-
-    Builder customResources(List<CustomKubernetesResource> customResources) {
-      this.customResources = customResources;
-      return this;
-    }
-
-    Builder kinds(List<String> kinds) {
-      this.kinds = kinds;
-      return this;
-    }
-
-    Builder omitKinds(List<String> omitKinds) {
-      this.omitKinds = omitKinds;
-      return this;
-    }
-
-    Builder onlySpinnakerManaged(Boolean onlySpinnakerManaged) {
-      this.onlySpinnakerManaged = onlySpinnakerManaged;
-      return this;
-    }
-
-    Builder liveManifestCalls(boolean liveManifestCalls) {
-      this.liveManifestCalls = liveManifestCalls;
-      return this;
-    }
-
-    Builder cacheIntervalSeconds(Long cacheIntervalSeconds) {
-      this.cacheIntervalSeconds = cacheIntervalSeconds;
+    Builder namerRegistry(NamerRegistry namerRegistry) {
+      this.namerRegistry = namerRegistry;
       return this;
     }
 
     private C buildCredentials() {
       if (
-        omitNamespaces != null
-          && !omitNamespaces.isEmpty()
-          && namespaces != null
-          && !namespaces.isEmpty()
+        managedAccount.getOmitNamespaces() != null
+          && !managedAccount.getOmitNamespaces().isEmpty()
+          && managedAccount.getNamespaces() != null
+          && !managedAccount.getNamespaces().isEmpty()
         ) {
         throw new IllegalArgumentException("At most one of 'namespaces' and 'omitNamespaces' can be specified");
       }
 
       if (
-        omitKinds != null
-          && !omitKinds.isEmpty()
-          && kinds != null
-          && !kinds.isEmpty()
+        managedAccount.getOmitKinds() != null
+          && !managedAccount.getOmitKinds().isEmpty()
+          && managedAccount.getKinds() != null
+          && !managedAccount.getKinds().isEmpty()
         ) {
         throw new IllegalArgumentException("At most one of 'kinds' and 'omitKinds' can be specified");
       }
 
+      String kubeconfigFile = managedAccount.getKubeconfigFile();
       if (StringUtils.isEmpty(kubeconfigFile)){
-        if (StringUtils.isEmpty(kubeconfigContents)) {
+        if (StringUtils.isEmpty(managedAccount.getKubeconfigContents())) {
           kubeconfigFile = System.getProperty("user.home") + "/.kube/config";
         } else {
           try {
             File temp = File.createTempFile("kube", "config");
             BufferedWriter writer = new BufferedWriter(new FileWriter(temp));
-            writer.write(kubeconfigContents);
+            writer.write(managedAccount.getKubeconfigContents());
             writer.close();
             kubeconfigFile = temp.getAbsolutePath();
           } catch (IOException e) {
@@ -348,75 +153,73 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
           }
         }
       }
-      switch (providerVersion) {
+      switch (managedAccount.getProviderVersion()) {
         case v1:
           return (C) new KubernetesV1Credentials(
-              name,
+              managedAccount.getName(),
               kubeconfigFile,
-              context,
-              cluster,
-              user,
+              managedAccount.getContext(),
+              managedAccount.getCluster(),
+              managedAccount.getUser(),
               userAgent,
-              serviceAccount,
-              configureImagePullSecrets,
-              namespaces,
-              omitNamespaces,
-              dockerRegistries,
+              managedAccount.getServiceAccount(),
+              managedAccount.getConfigureImagePullSecrets(),
+              managedAccount.getNamespaces(),
+              managedAccount.getOmitNamespaces(),
+              managedAccount.getDockerRegistries(),
               spectatorRegistry,
               accountCredentialsRepository
           );
         case v2:
           NamerRegistry.lookup()
               .withProvider(KubernetesCloudProvider.getID())
-              .withAccount(name)
-              .setNamer(KubernetesManifest.class, namer);
+              .withAccount(managedAccount.getName())
+              .setNamer(KubernetesManifest.class, namerRegistry.getNamingStrategy(managedAccount.getNamingStrategy()));
           return (C) new KubernetesV2Credentials.Builder()
-              .accountName(name)
+              .accountName(managedAccount.getName())
               .kubeconfigFile(kubeconfigFile)
-              .kubectlExecutable(kubectlExecutable)
-              .kubectlRequestTimeoutSeconds(kubectlRequestTimeoutSeconds)
-              .context(context)
-              .oAuthServiceAccount(oAuthServiceAccount)
-              .oAuthScopes(oAuthScopes)
-              .serviceAccount(serviceAccount)
+              .kubectlExecutable(managedAccount.getKubectlExecutable())
+              .kubectlRequestTimeoutSeconds(managedAccount.getKubectlRequestTimeoutSeconds())
+              .context(managedAccount.getContext())
+              .oAuthServiceAccount(managedAccount.getoAuthServiceAccount())
+              .oAuthScopes(managedAccount.getoAuthScopes())
+              .serviceAccount(managedAccount.getServiceAccount())
               .userAgent(userAgent)
-              .namespaces(namespaces)
-              .omitNamespaces(omitNamespaces)
+              .namespaces(managedAccount.getNamespaces())
+              .omitNamespaces(managedAccount.getOmitNamespaces())
               .registry(spectatorRegistry)
-              .customResources(customResources)
-              .cachingPolicies(cachingPolicies)
-              .kinds(kinds)
-              .omitKinds(omitKinds)
-              .metrics(metrics)
-              .debug(debug)
-              .checkPermissionsOnStartup(checkPermissionsOnStartup)
+              .customResources(managedAccount.getCustomResources())
+              .cachingPolicies(managedAccount.getCachingPolicies())
+              .kinds(managedAccount.getKinds())
+              .omitKinds(managedAccount.getOmitKinds())
+              .metrics(managedAccount.getMetrics())
+              .debug(managedAccount.getDebug())
+              .checkPermissionsOnStartup(managedAccount.getCheckPermissionsOnStartup())
               .jobExecutor(jobExecutor)
-              .onlySpinnakerManaged(onlySpinnakerManaged)
-              .liveManifestCalls(liveManifestCalls)
+              .onlySpinnakerManaged(managedAccount.getOnlySpinnakerManaged())
+              .liveManifestCalls(managedAccount.getLiveManifestCalls())
               .build();
         default:
-          throw new IllegalArgumentException("Unknown provider type: " + providerVersion);
+          throw new IllegalArgumentException("Unknown provider type: " + managedAccount.getProviderVersion());
       }
     }
 
     KubernetesNamedAccountCredentials build() {
-      if (StringUtils.isEmpty(name)) {
+      if (StringUtils.isEmpty(managedAccount.getName())) {
         throw new IllegalArgumentException("Account name for Kubernetes provider missing.");
       }
 
-      C credentials = buildCredentials();
-
       return new KubernetesNamedAccountCredentials(
-        name,
-        providerVersion,
-        environment,
-        accountType,
-        skin,
-        cacheThreads,
-        requiredGroupMembership,
-        permissions,
-        credentials,
-        cacheIntervalSeconds
+        managedAccount.getName(),
+        managedAccount.getProviderVersion(),
+        managedAccount.getEnvironment(),
+        managedAccount.getAccountType(),
+        managedAccount.getSkin(),
+        managedAccount.getCacheThreads(),
+        managedAccount.getRequiredGroupMembership(),
+        managedAccount.getPermissions().build(),
+        buildCredentials(),
+        managedAccount.getCacheIntervalSeconds()
       );
     }
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -20,7 +20,6 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.module.CatsModule
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
@@ -40,7 +39,6 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
   @Autowired Registry spectatorRegistry
   @Autowired KubectlJobExecutor jobExecutor
   @Autowired NamerRegistry namerRegistry
-  @Autowired KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap
 
   @Bean
   List<? extends KubernetesNamedAccountCredentials> kubernetesNamedAccountCredentials(
@@ -76,44 +74,12 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
     accountsToAdd.each { KubernetesConfigurationProperties.ManagedAccount managedAccount ->
       try {
         def kubernetesAccount = new KubernetesNamedAccountCredentials.Builder()
+          .managedAccount(managedAccount)
           .accountCredentialsRepository(accountCredentialsRepository)
           .userAgent(clouddriverUserAgentApplicationName)
-          .name(managedAccount.name)
-          .providerVersion(managedAccount.providerVersion)
-          .environment(managedAccount.environment)
-          .accountType(managedAccount.accountType)
-          .context(managedAccount.context)
-          .cluster(managedAccount.cluster)
-          .oAuthServiceAccount(managedAccount.oAuthServiceAccount)
-          .oAuthScopes(managedAccount.oAuthScopes)
-          .user(managedAccount.user)
-          .kubeconfigFile(managedAccount.kubeconfigFile)
-          .kubeconfigContents(managedAccount.kubeconfigContents)
-          .kubectlExecutable(managedAccount.kubectlExecutable)
-          .kubectlRequestTimeoutSeconds(managedAccount.kubectlRequestTimeoutSeconds)
-          .serviceAccount(managedAccount.serviceAccount)
-          .configureImagePullSecrets(managedAccount.configureImagePullSecrets)
-          .namespaces(managedAccount.namespaces)
-          .omitNamespaces(managedAccount.omitNamespaces)
-          .skin(managedAccount.skin)
-          .cacheThreads(managedAccount.cacheThreads)
-          .dockerRegistries(managedAccount.dockerRegistries)
-          .requiredGroupMembership(managedAccount.requiredGroupMembership)
-          .permissions(managedAccount.permissions.build())
           .spectatorRegistry(spectatorRegistry)
           .jobExecutor(jobExecutor)
-          .namer(namerRegistry.getNamingStrategy(managedAccount.namingStrategy))
-          .customResources(managedAccount.customResources)
-          .cachingPolicies(managedAccount.cachingPolicies)
-          .kinds(managedAccount.kinds)
-          .omitKinds(managedAccount.omitKinds)
-          .metrics(managedAccount.metrics)
-          .debug(managedAccount.debug)
-          .checkPermissionsOnStartup(managedAccount.checkPermissionsOnStartup)
-          .kubernetesSpinnakerKindMap(kubernetesSpinnakerKindMap)
-          .onlySpinnakerManaged(managedAccount.onlySpinnakerManaged)
-          .liveManifestCalls(managedAccount.liveManifestCalls)
-          .cacheIntervalSeconds(managedAccount.cacheIntervalSeconds)
+          .namerRegistry(namerRegistry)
           .build()
 
         accountCredentialsRepository.save(managedAccount.name, kubernetesAccount)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.module.CatsModule
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable
@@ -37,6 +38,7 @@ import org.springframework.context.annotation.Scope
 class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitializerSynchronizable {
   @Autowired Registry spectatorRegistry
   @Autowired KubectlJobExecutor jobExecutor
+  @Autowired KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap
 
   @Bean
   List<? extends KubernetesNamedAccountCredentials> kubernetesNamedAccountCredentials(
@@ -71,7 +73,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
     // TODO(lwander): Modify accounts when their dockerRegistries attribute is updated as well -- need to ask @duftler.
     accountsToAdd.each { KubernetesConfigurationProperties.ManagedAccount managedAccount ->
       try {
-        def kubernetesAccount = new KubernetesNamedAccountCredentials(managedAccount, credentialFactory)
+        def kubernetesAccount = new KubernetesNamedAccountCredentials(managedAccount, kubernetesSpinnakerKindMap, credentialFactory)
 
         accountCredentialsRepository.save(managedAccount.name, kubernetesAccount)
       } catch (e) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -37,8 +37,6 @@ import org.springframework.context.annotation.Scope
 @Slf4j
 @Configuration
 class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitializerSynchronizable {
-  private static final Integer DEFAULT_CACHE_THREADS = 1
-
   @Autowired Registry spectatorRegistry
   @Autowired KubectlJobExecutor jobExecutor
   @Autowired NamerRegistry namerRegistry
@@ -82,8 +80,8 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .userAgent(clouddriverUserAgentApplicationName)
           .name(managedAccount.name)
           .providerVersion(managedAccount.providerVersion)
-          .environment(managedAccount.environment ?: managedAccount.name)
-          .accountType(managedAccount.accountType ?: managedAccount.name)
+          .environment(managedAccount.environment)
+          .accountType(managedAccount.accountType)
           .context(managedAccount.context)
           .cluster(managedAccount.cluster)
           .oAuthServiceAccount(managedAccount.oAuthServiceAccount)
@@ -98,7 +96,7 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .namespaces(managedAccount.namespaces)
           .omitNamespaces(managedAccount.omitNamespaces)
           .skin(managedAccount.skin)
-          .cacheThreads(managedAccount.cacheThreads ?: DEFAULT_CACHE_THREADS)
+          .cacheThreads(managedAccount.cacheThreads)
           .dockerRegistries(managedAccount.dockerRegistries)
           .requiredGroupMembership(managedAccount.requiredGroupMembership)
           .permissions(managedAccount.permissions.build())
@@ -111,10 +109,10 @@ class KubernetesNamedAccountCredentialsInitializer implements CredentialsInitial
           .omitKinds(managedAccount.omitKinds)
           .metrics(managedAccount.metrics)
           .debug(managedAccount.debug)
-          .checkPermissionsOnStartup(managedAccount.checkPermissionsOnStartup == null ? true : managedAccount.checkPermissionsOnStartup)
+          .checkPermissionsOnStartup(managedAccount.checkPermissionsOnStartup)
           .kubernetesSpinnakerKindMap(kubernetesSpinnakerKindMap)
-          .onlySpinnakerManaged(managedAccount.onlySpinnakerManaged == null ? false : managedAccount.onlySpinnakerManaged)
-          .liveManifestCalls(managedAccount.liveManifestCalls ?: false)
+          .onlySpinnakerManaged(managedAccount.onlySpinnakerManaged)
+          .liveManifestCalls(managedAccount.liveManifestCalls)
           .cacheIntervalSeconds(managedAccount.cacheIntervalSeconds)
           .build()
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
@@ -69,12 +69,9 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
     dockerRegistries = [dockerRegistry]
     accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
     credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock)
-    namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name("accountName")
-        .credentials(credentials)
-        .dockerRegistries(dockerRegistries)
-        .spectatorRegistry(spectatorRegistry)
-        .build()
+    namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
+      getCredentials() >> credentials
+    }
 
     namedPort1 = new KubernetesNamedServicePort(name: VALID_NAME1, port: VALID_PORT1, targetPort: VALID_PORT1, nodePort: VALID_PORT1, protocol: VALID_PROTOCOL1)
   }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/securitygroup/UpsertKubernetesV1SecurityGroupAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/securitygroup/UpsertKubernetesV1SecurityGroupAtomicOperationSpec.groovy
@@ -61,12 +61,9 @@ class UpsertKubernetesV1SecurityGroupAtomicOperationSpec extends Specification {
     dockerRegistries = [dockerRegistry]
     accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
     credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock)
-    namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name("accountName")
-        .credentials(credentials)
-        .dockerRegistries(dockerRegistries)
-        .spectatorRegistry(spectatorRegistry)
-        .build()
+    namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
+      getCredentials() >> credentials
+    }
 
     testTLS = [new KubernetesIngressTlS([TLS_HOST], TLS_SECRET)].asList()
     resultTLS = [new IngressTLS([TLS_HOST], TLS_SECRET)].asList()

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -113,19 +113,13 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
     credentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock)
-    namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name("name")
-        .dockerRegistries(dockerRegistries)
-        .spectatorRegistry(spectatorRegistry)
-        .credentials(credentials)
-        .build()
+    namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
+      getCredentials() >> credentials
+    }
 
-    sourceNamedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name("name")
-        .dockerRegistries(dockerRegistries)
-        .spectatorRegistry(spectatorRegistry)
-        .credentials(credentials)
-        .build()
+    sourceNamedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
+      getCredentials() >> credentials
+    }
 
     objectMetadata.setLabels(LABELS)
     podTemplateSpec.setMetadata(objectMetadata)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
@@ -133,12 +133,9 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
     credentials = new KubernetesV1Credentials(apiMock, [NAMESPACE], [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock,)
-    namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name("name")
-        .dockerRegistries(dockerRegistries)
-        .credentials(credentials)
-        .spectatorRegistry(spectatorRegistry)
-        .build()
+    namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
+      getCredentials() >> credentials
+    }
     clusterName = KubernetesUtil.combineAppStackDetail(APPLICATION, STACK, DETAILS)
     replicationControllerName = String.format("%s-v%s", clusterName, SEQUENCE)
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
@@ -59,14 +59,11 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       })
     })
 
-    def dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
-    def dockerRegistries = [dockerRegistry]
     credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock)
-    def namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name(ACCOUNT_NAME)
-        .dockerRegistries(dockerRegistries)
-        .credentials(credentials)
-        .build()
+    def namedAccountCredentials =Mock(KubernetesNamedAccountCredentials) {
+      getName() >> ACCOUNT_NAME
+      getCredentials() >> credentials
+    }
     credentialsRepo.save(ACCOUNT_NAME, namedAccountCredentials)
   }
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
@@ -69,12 +69,10 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
     credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock)
-    namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name(VALID_ACCOUNT)
-        .dockerRegistries(dockerRegistries)
-        .spectatorRegistry(spectatorRegistry)
-        .credentials(credentials)
-        .build()
+    namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
+      getName() >> VALID_ACCOUNT
+      getCredentials() >> credentials
+    }
     credentialsRepo.save(VALID_ACCOUNT, namedAccountCredentials)
     validator.accountCredentialsProvider = credentialsProvider
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
@@ -91,15 +91,11 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
       })
     })
 
-    def dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
-    def dockerRegistries = [dockerRegistry]
     def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock)
-    def namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name(VALID_ACCOUNT)
-        .dockerRegistries(dockerRegistries)
-        .credentials(credentials)
-        .spectatorRegistry(spectatorRegistry)
-        .build()
+    def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
+      getName() >> VALID_ACCOUNT
+      getCredentials() >> credentials
+    }
     credentialsRepo.save(VALID_ACCOUNT, namedAccountCredentials)
     validator.accountCredentialsProvider = credentialsProvider
   }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
@@ -97,15 +97,11 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
       })
     })
 
-    def dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
-    def dockerRegistries = [dockerRegistry]
     def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock)
-    def namedAccountCredentials = new KubernetesNamedAccountCredentials.Builder()
-        .name(VALID_ACCOUNT)
-        .dockerRegistries(dockerRegistries)
-        .spectatorRegistry(spectatorRegistry)
-        .credentials(credentials)
-        .build()
+    def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
+      getName() >> VALID_ACCOUNT
+      getCredentials() >> credentials
+    }
     credentialsRepo.save(VALID_ACCOUNT, namedAccountCredentials)
     validator.accountCredentialsProvider = credentialsProvider
   }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
@@ -117,7 +117,6 @@ class KubernetesNamedAccountCredentialsInitializerSpec extends Specification {
     1 * accountCredentialsRepository.save("test-account", _ as KubernetesNamedAccountCredentials) >> { _, creds ->
       credentials = creds
     }
-    1 * namerRegistry.getNamingStrategy("kubernetesAnnotations") >> Mock(KubernetesManifestNamer)
 
     credentials.getName() == "test-account"
     credentials.getProviderVersion() == ProviderVersion.v1

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAcco
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentialsInitializer
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion
@@ -32,22 +33,26 @@ import org.springframework.context.ApplicationContext
 import spock.lang.Specification
 
 class KubernetesNamedAccountCredentialsInitializerSpec extends Specification {
-  String clouddriverUserAgentApplicationName = "userAgent"
   CatsModule catsModule = Mock(CatsModule)
   ApplicationContext applicationContext = Mock(ApplicationContext)
   AccountCredentialsRepository accountCredentialsRepository = Mock(AccountCredentialsRepository)
   List<ProviderSynchronizerTypeWrapper> providerSynchronizerTypeWrapper = Collections.emptyList()
-
   NamerRegistry namerRegistry = Mock(NamerRegistry)
+  KubernetesNamedAccountCredentials.CredentialFactory credentialFactory = new KubernetesNamedAccountCredentials.CredentialFactory(
+    "userAgent",
+    new NoopRegistry(),
+    namerRegistry,
+    accountCredentialsRepository,
+    Mock(KubectlJobExecutor)
+  )
 
   KubernetesNamedAccountCredentialsInitializer kubernetesNamedAccountCredentialsInitializer = new KubernetesNamedAccountCredentialsInitializer(
-    namerRegistry: namerRegistry,
     spectatorRegistry: new NoopRegistry()
   )
 
   def synchronizeAccounts(KubernetesConfigurationProperties kubernetesConfigurationProperties) {
     return kubernetesNamedAccountCredentialsInitializer.synchronizeKubernetesAccounts(
-      clouddriverUserAgentApplicationName, kubernetesConfigurationProperties, catsModule, applicationContext, accountCredentialsRepository, providerSynchronizerTypeWrapper
+      credentialFactory, kubernetesConfigurationProperties, catsModule, applicationContext, accountCredentialsRepository, providerSynchronizerTypeWrapper
     )
   }
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.security
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.cats.module.CatsModule
+import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
+import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentialsInitializer
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
+import org.springframework.context.ApplicationContext
+import spock.lang.Specification
+
+class KubernetesNamedAccountCredentialsInitializerSpec extends Specification {
+  String clouddriverUserAgentApplicationName = "userAgent"
+  CatsModule catsModule = Mock(CatsModule)
+  ApplicationContext applicationContext = Mock(ApplicationContext)
+  AccountCredentialsRepository accountCredentialsRepository = Mock(AccountCredentialsRepository)
+  List<ProviderSynchronizerTypeWrapper> providerSynchronizerTypeWrapper = Collections.emptyList()
+
+  NamerRegistry namerRegistry = Mock(NamerRegistry)
+
+  KubernetesNamedAccountCredentialsInitializer kubernetesNamedAccountCredentialsInitializer = new KubernetesNamedAccountCredentialsInitializer(
+    namerRegistry: namerRegistry,
+    spectatorRegistry: new NoopRegistry()
+  )
+
+  def synchronizeAccounts(KubernetesConfigurationProperties kubernetesConfigurationProperties) {
+    return kubernetesNamedAccountCredentialsInitializer.synchronizeKubernetesAccounts(
+      clouddriverUserAgentApplicationName, kubernetesConfigurationProperties, catsModule, applicationContext, accountCredentialsRepository, providerSynchronizerTypeWrapper
+    )
+  }
+
+  void "is a no-op when there are no configured accounts"() {
+    when:
+    KubernetesConfigurationProperties kubernetesConfigurationProperties = new KubernetesConfigurationProperties()
+    synchronizeAccounts(kubernetesConfigurationProperties)
+
+    then:
+    0 * accountCredentialsRepository.save(*_)
+  }
+
+  void "correctly creates a v2 account and defaults properties"() {
+    given:
+    KubernetesNamedAccountCredentials credentials
+
+    when:
+    KubernetesConfigurationProperties kubernetesConfigurationProperties = new KubernetesConfigurationProperties()
+    kubernetesConfigurationProperties.setAccounts([
+      new KubernetesConfigurationProperties.ManagedAccount(
+        name: "test-account",
+        namespaces: ["default"],
+        providerVersion: ProviderVersion.v2)
+    ])
+    synchronizeAccounts(kubernetesConfigurationProperties)
+
+
+    then:
+    1 * accountCredentialsRepository.save("test-account", _ as KubernetesNamedAccountCredentials) >> { _, creds ->
+      credentials = creds
+    }
+    1 * namerRegistry.getNamingStrategy("kubernetesAnnotations") >> Mock(KubernetesManifestNamer)
+
+    credentials.getName() == "test-account"
+    credentials.getProviderVersion() == ProviderVersion.v2
+    credentials.getEnvironment() == "test-account"
+    credentials.getAccountType() == "test-account"
+    credentials.getSkin() == "v2"
+    credentials.getCacheThreads() == 1
+    credentials.getCacheIntervalSeconds() == null
+
+    credentials.getCredentials() instanceof KubernetesV2Credentials
+    KubernetesV2Credentials accountCredentials = (KubernetesV2Credentials) credentials.getCredentials()
+    accountCredentials.isServiceAccount() == false
+    accountCredentials.getOnlySpinnakerManaged() == false
+    accountCredentials.isDebug() == false
+    accountCredentials.isMetrics() == true
+    accountCredentials.isLiveManifestCalls() == false
+  }
+
+  void "correctly creates a v1 account and defaults properties"() {
+    given:
+    KubernetesNamedAccountCredentials credentials
+
+    when:
+    KubernetesConfigurationProperties kubernetesConfigurationProperties = new KubernetesConfigurationProperties()
+    kubernetesConfigurationProperties.setAccounts([
+      new KubernetesConfigurationProperties.ManagedAccount(
+        name: "test-account",
+        namespaces: ["default"],
+        dockerRegistries: [new LinkedDockerRegistryConfiguration(accountName: "docker-account")]
+      )
+    ])
+    synchronizeAccounts(kubernetesConfigurationProperties)
+
+    then:
+    1 * accountCredentialsRepository.save("test-account", _ as KubernetesNamedAccountCredentials) >> { _, creds ->
+      credentials = creds
+    }
+    1 * namerRegistry.getNamingStrategy("kubernetesAnnotations") >> Mock(KubernetesManifestNamer)
+
+    credentials.getName() == "test-account"
+    credentials.getProviderVersion() == ProviderVersion.v1
+    credentials.getEnvironment() == "test-account"
+    credentials.getAccountType() == "test-account"
+    credentials.getSkin() == "v1"
+    credentials.getCacheThreads() == 1
+    credentials.getCacheIntervalSeconds() == null
+
+    credentials.getCredentials() instanceof KubernetesV1Credentials
+    KubernetesV1Credentials accountCredentials = (KubernetesV1Credentials) credentials.getCredentials()
+    accountCredentials.getDeclaredNamespaces() == ["default"]
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
@@ -112,6 +112,15 @@ class KubernetesNamedAccountCredentialsInitializerSpec extends Specification {
     kubernetesConfigurationProperties.setAccounts([
       new KubernetesConfigurationProperties.ManagedAccount(
         name: "test-account",
+        kubeconfigContents: """
+apiVersion: v1
+contexts:
+- name: default
+  context:
+    cluster: test
+    user: test
+current-context: default
+""",
         namespaces: ["default"],
         dockerRegistries: [new LinkedDockerRegistryConfiguration(accountName: "docker-account")]
       )


### PR DESCRIPTION
The code to translate Kubernetes account properties into accounts uses multiple levels of `Builder` classes, each of which do a bit of defaulting/initialization.  This makes it difficult to understand where configured account properties are defaulted, and where they are actually used.

As a first pass to simplifying this, clean up the interface between `KubernetesNamedAccountInitializer` and `KubernetesNamedAccountCredentials`.  Remove the builder class and have defaulting either occur directly on the `KubernetesConfigurationProperties.ManagedAccount` class (for simple defaults) or in the constructor (for more complex cases that aren't just setting a single default value.)

* test(kubernetes): Add tests to credentials initializing 

  There are currently no tests on initializing credentials; before refactoring this code, add some tests.

  Also, a number of the Kubernetes tests depend on being able to explicitly pass credentials to a builder for KubernetesNamedAccountCredentials, which will be removed. Instead just use a mock object and specify the desired properties.

* refactor(kubernetes): Remove unused fields from account credentials 

  Most of the fields on KubernetesNamedAccountCredentials are just copies of the fields on the contained KubernetesCredentials object. There's no need to also have these on the parent class (and in fact we never look these up on the parent class).  Remove all of the redundant fields.

  For the remaining fields:
  - Apply 'private final' consistently
  - Replace the accessors with a @Getter annotation

* refactor(kubernetes): Consolidate defaulting of account parameters 

  Defaulting of account paramters is scattered across a few different classes; consolidate this to the definition of the properties class so it's easier to see the values of these properties.

* refactor(kubernetes): Pass ManagedAccount to builder 

  Rather than pass each property of the ManagedAccount individually to the Builder for KubernetesNamedAccountCredentials, just pass the entire object.

* refactor(kubernetes): Use a factory class instead of a builder 

  Now that we're passing the entire ManagedAccount class to the builder rather than the properties individually, there are no optional parameters, so a builder class is less optimal. Other than the ManagedAccount, all properties of the builder are beans that can be autowired. Create a factory bean that autowires in these other beans, and exposes methods to create a v1 or a v2 account from a supplied ManagedAccount.

  Ideally most of the logic in CredentialFactory would actually live in as factories in the credential classes themselves; I'll likely make this change in a future PR, but for now this is a reasonable shim to avoid making this PR too large.
