### PR TITLE
fix(ecs): allow sub-org ecr repos

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrImageProvider.java
@@ -43,11 +43,11 @@ import java.util.stream.Collectors;
 @Component
 public class EcrImageProvider implements ImageRepositoryProvider {
   private static final Pattern ACCOUNT_ID_PATTERN = Pattern.compile("^([0-9]{12})");
-  private static final Pattern REPOSITORY_NAME_PATTERN = Pattern.compile("\\/([a-z0-9._-]+)");
+  private static final Pattern REPOSITORY_NAME_PATTERN = Pattern.compile("\\/(((?:[a-z0-9]+(?:[._-][a-z0-9]+)*\\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*){2,})");
   private static final String IDENTIFIER_PATTERN = "(:([a-z0-9._-]+)|@(sha256:[0-9a-f]{64}))";
   private static final Pattern REGION_PATTERN = Pattern.compile("(\\w+-\\w+-\\d+)");
   static final Pattern ECR_REPOSITORY_URI_PATTERN = Pattern.compile(ACCOUNT_ID_PATTERN.toString() + "\\.dkr\\.ecr\\." +
-    REGION_PATTERN.toString() + ".+" +
+    REGION_PATTERN.toString() + ".+?" +
     REPOSITORY_NAME_PATTERN.toString() +
     IDENTIFIER_PATTERN);
 

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/view/EcrImageProviderSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/view/EcrImageProviderSpec.groovy
@@ -14,9 +14,57 @@ class EcrImageProviderSpec extends Specification {
 
     when:
     def canHandle = ecrImageProvider.handles(ecrRepositoryUrl)
+    def repoName = ecrImageProvider.extractEcrRepositoryName(ecrRepositoryUrl)
+    def accountId = ecrImageProvider.extractAwsAccountId(ecrRepositoryUrl)
+    def awsRegion = ecrImageProvider.extractAwsRegion(ecrRepositoryUrl)
+    def ecrIdentifier = ecrImageProvider.extractEcrIdentifier(repoName, ecrRepositoryUrl)
 
     then:
-    canHandle
+    canHandle &&
+    accountId == "123456789012" &&
+    repoName == "continuous-delivery" &&
+    awsRegion == "us-west-2" &&
+    ecrIdentifier == "latest"
+  }
+
+  @Test
+  void shouldHandleEcrSubOrgRepositoryUrl() {
+    given:
+    EcrImageProvider ecrImageProvider = new EcrImageProvider(null, null)
+    String ecrRepositoryUrl = "123456789012.dkr.ecr.us-west-2.amazonaws.com/sub-org/continuous-delivery:latest"
+
+    when:
+    def canHandle = ecrImageProvider.handles(ecrRepositoryUrl)
+    def repoName = ecrImageProvider.extractEcrRepositoryName(ecrRepositoryUrl)
+    def accountId = ecrImageProvider.extractAwsAccountId(ecrRepositoryUrl)
+    def awsRegion = ecrImageProvider.extractAwsRegion(ecrRepositoryUrl)
+    def ecrIdentifier = ecrImageProvider.extractEcrIdentifier(repoName, ecrRepositoryUrl)
+
+    then:
+    accountId == "123456789012" &&
+    repoName == "sub-org/continuous-delivery" &&
+    awsRegion == "us-west-2" &&
+    ecrIdentifier == "latest"
+  }
+
+  @Test
+  void shouldHandleEcrSha256RepositoryUrl() {
+    given:
+    EcrImageProvider ecrImageProvider = new EcrImageProvider(null, null)
+    String ecrRepositoryUrl = "123456789012.dkr.ecr.us-east-1.amazonaws.com/continuous-delivery@sha256:e87afa4e9a1b5b2b10b596526881acb6e7007dbff43f37270921ba84dbeda428"
+
+    when:
+    def canHandle = ecrImageProvider.handles(ecrRepositoryUrl)
+    def repoName = ecrImageProvider.extractEcrRepositoryName(ecrRepositoryUrl)
+    def accountId = ecrImageProvider.extractAwsAccountId(ecrRepositoryUrl)
+    def awsRegion = ecrImageProvider.extractAwsRegion(ecrRepositoryUrl)
+    def ecrIdentifier = ecrImageProvider.extractEcrIdentifier(repoName, ecrRepositoryUrl)
+
+    then:
+    accountId == "123456789012" &&
+    repoName == "continuous-delivery" &&
+    awsRegion == "us-east-1" &&
+    ecrIdentifier == "sha256:e87afa4e9a1b5b2b10b596526881acb6e7007dbff43f37270921ba84dbeda428"
   }
 
   @Test
@@ -30,5 +78,35 @@ class EcrImageProviderSpec extends Specification {
 
     then:
     !canHandle
+  }
+
+  @Test
+  void shouldNotHandleShortEcrRepoName() {
+    given:
+    EcrImageProvider ecrImageProvider = new EcrImageProvider(null, null)
+    String ecrRepositoryUrl = "123456789012.dkr.ecr.us-west-2.amazonaws.com/n:latest"
+
+    when:
+    boolean canHandle = ecrImageProvider.handles(ecrRepositoryUrl)
+
+    then:
+    !canHandle
+  }
+
+  @Test
+  void shouldNotHandleMissingRepoName() {
+    given:
+    EcrImageProvider ecrImageProvider = new EcrImageProvider(null, null)
+    String domainNameOnly = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+    String noRepoName = "123456789012.dkr.ecr.us-east-1.amazonaws.com/"
+    String subOrgNoRepoName = "123456789012.dkr.ecr.us-east-1.amazonaws.com/sub-org/"
+
+    when:
+    boolean canHandleDomainNameOnly = ecrImageProvider.handles(domainNameOnly)
+    boolean canHandleNoRepoName = ecrImageProvider.handles(noRepoName)
+    boolean canHandleSubOrgNoRepoName = ecrImageProvider.handles(subOrgNoRepoName)
+
+    then:
+    !canHandleDomainNameOnly && !canHandleNoRepoName && !canHandleSubOrgNoRepoName
   }
 }


### PR DESCRIPTION
The current regex match does not catch names like the following:
* `111111111111.dkr.ecr.us-east-1.amazonaws.com/sub-org/my-app-image:v0.0.0`
