### PR TITLE
refactor(kubernetes): Simplify v2 account creation code

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -42,21 +42,21 @@ class KubernetesConfigurationProperties {
     Integer kubectlRequestTimeoutSeconds
     boolean serviceAccount = false
     boolean configureImagePullSecrets = true
-    List<String> namespaces
-    List<String> omitNamespaces
+    List<String> namespaces = new ArrayList<>()
+    List<String> omitNamespaces = new ArrayList<>()
     String skin
     int cacheThreads = DEFAULT_CACHE_THREADS
     List<LinkedDockerRegistryConfiguration> dockerRegistries
-    List<String> requiredGroupMembership
+    List<String> requiredGroupMembership = new ArrayList<>()
     Permissions.Builder permissions = new Permissions.Builder()
     String namingStrategy = "kubernetesAnnotations"
     boolean debug = false
     boolean metrics = true
     boolean checkPermissionsOnStartup = true
-    List<CustomKubernetesResource> customResources;
-    List<KubernetesCachingPolicy> cachingPolicies;
-    List<String> kinds
-    List<String> omitKinds
+    List<CustomKubernetesResource> customResources = new ArrayList<>()
+    List<KubernetesCachingPolicy> cachingPolicies = new ArrayList<>()
+    List<String> kinds = new ArrayList<>()
+    List<String> omitKinds = new ArrayList<>()
     boolean onlySpinnakerManaged = false
     boolean liveManifestCalls = false
     Long cacheIntervalSeconds

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -145,7 +145,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
         .withProvider(KubernetesCloudProvider.getID())
         .withAccount(managedAccount.getName())
         .setNamer(KubernetesManifest.class, namerRegistry.getNamingStrategy(managedAccount.getNamingStrategy()));
-      return new KubernetesV2Credentials.Builder()
+      return KubernetesV2Credentials.builder()
         .accountName(managedAccount.getName())
         .kubeconfigFile(getKubeconfigFile(managedAccount))
         .kubectlExecutable(managedAccount.getKubectlExecutable())
@@ -154,7 +154,6 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
         .oAuthServiceAccount(managedAccount.getoAuthServiceAccount())
         .oAuthScopes(managedAccount.getoAuthScopes())
         .serviceAccount(managedAccount.getServiceAccount())
-        .userAgent(userAgent)
         .namespaces(managedAccount.getNamespaces())
         .omitNamespaces(managedAccount.getOmitNamespaces())
         .registry(spectatorRegistry)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -145,29 +145,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
         .withProvider(KubernetesCloudProvider.getID())
         .withAccount(managedAccount.getName())
         .setNamer(KubernetesManifest.class, namerRegistry.getNamingStrategy(managedAccount.getNamingStrategy()));
-      return KubernetesV2Credentials.builder()
-        .accountName(managedAccount.getName())
-        .kubeconfigFile(getKubeconfigFile(managedAccount))
-        .kubectlExecutable(managedAccount.getKubectlExecutable())
-        .kubectlRequestTimeoutSeconds(managedAccount.getKubectlRequestTimeoutSeconds())
-        .context(managedAccount.getContext())
-        .oAuthServiceAccount(managedAccount.getoAuthServiceAccount())
-        .oAuthScopes(managedAccount.getoAuthScopes())
-        .serviceAccount(managedAccount.getServiceAccount())
-        .namespaces(managedAccount.getNamespaces())
-        .omitNamespaces(managedAccount.getOmitNamespaces())
-        .registry(spectatorRegistry)
-        .customResources(managedAccount.getCustomResources())
-        .cachingPolicies(managedAccount.getCachingPolicies())
-        .kinds(managedAccount.getKinds())
-        .omitKinds(managedAccount.getOmitKinds())
-        .metrics(managedAccount.getMetrics())
-        .debug(managedAccount.getDebug())
-        .checkPermissionsOnStartup(managedAccount.getCheckPermissionsOnStartup())
-        .jobExecutor(jobExecutor)
-        .onlySpinnakerManaged(managedAccount.getOnlySpinnakerManaged())
-        .liveManifestCalls(managedAccount.getLiveManifestCalls())
-        .build();
+      return new KubernetesV2Credentials(spectatorRegistry, jobExecutor, managedAccount);
     }
 
     private void validateAccount(KubernetesConfigurationProperties.ManagedAccount managedAccount) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -78,7 +78,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
       this.requiredGroupMembership = Collections.emptyList();
     } else {
       this.permissions = null;
-      this.requiredGroupMembership = Optional.ofNullable(managedAccount.getRequiredGroupMembership()).map(Collections::unmodifiableList).orElse(Collections.emptyList());
+      this.requiredGroupMembership = Collections.unmodifiableList(managedAccount.getRequiredGroupMembership());
     }
 
     switch (managedAccount.getProviderVersion()) {
@@ -149,21 +149,15 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials> 
     }
 
     private void validateAccount(KubernetesConfigurationProperties.ManagedAccount managedAccount) {
-      if (
-        managedAccount.getOmitNamespaces() != null
-          && !managedAccount.getOmitNamespaces().isEmpty()
-          && managedAccount.getNamespaces() != null
-          && !managedAccount.getNamespaces().isEmpty()
-        ) {
+      if (StringUtils.isEmpty(managedAccount.getName())) {
+        throw new IllegalArgumentException("Account name for Kubernetes provider missing.");
+      }
+
+      if (!managedAccount.getOmitNamespaces().isEmpty() && !managedAccount.getNamespaces().isEmpty()) {
         throw new IllegalArgumentException("At most one of 'namespaces' and 'omitNamespaces' can be specified");
       }
 
-      if (
-        managedAccount.getOmitKinds() != null
-          && !managedAccount.getOmitKinds().isEmpty()
-          && managedAccount.getKinds() != null
-          && !managedAccount.getKinds().isEmpty()
-        ) {
+      if (!managedAccount.getOmitKinds().isEmpty() && !managedAccount.getKinds().isEmpty()) {
         throw new IllegalArgumentException("At most one of 'kinds' and 'omitKinds' can be specified");
       }
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -150,7 +150,7 @@ public abstract class KubernetesV2CachingAgent extends KubernetesCachingAgent<Ku
         .map(rs -> {
           try {
             CacheData cacheData = KubernetesCacheDataConverter.convertAsResource(accountName, rs, relationships.get(rs));
-            if (credentials.getOnlySpinnakerManaged() && StringUtils.isEmpty((String) cacheData.getAttributes().get("application"))) {
+            if (credentials.isOnlySpinnakerManaged() && StringUtils.isEmpty((String) cacheData.getAttributes().get("application"))) {
               return null;
             } else {
               return cacheData;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -33,20 +33,26 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor.KubectlException;
 import io.kubernetes.client.models.V1DeleteOptions;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 public class KubernetesV2Credentials implements KubernetesCredentials {
@@ -188,174 +194,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   @Getter
   private final boolean debug;
 
-  public static class Builder {
-    String accountName;
-    String kubeconfigFile;
-    String context;
-    String kubectlExecutable;
-    Integer kubectlRequestTimeoutSeconds;
-    String oAuthServiceAccount;
-    List<String> oAuthScopes;
-    String userAgent;
-    List<String> namespaces = new ArrayList<>();
-    List<String> omitNamespaces = new ArrayList<>();
-    Registry registry;
-    KubectlJobExecutor jobExecutor;
-    List<CustomKubernetesResource> customResources;
-    List<KubernetesCachingPolicy> cachingPolicies;
-    List<String> kinds;
-    List<String> omitKinds;
-    boolean debug;
-    boolean checkPermissionsOnStartup;
-    boolean serviceAccount;
-    boolean metrics;
-    boolean onlySpinnakerManaged;
-    boolean liveManifestCalls;
-
-    public Builder accountName(String accountName) {
-      this.accountName = accountName;
-      return this;
-    }
-
-    public Builder kubeconfigFile(String kubeconfigFile) {
-      this.kubeconfigFile = kubeconfigFile;
-      return this;
-    }
-
-    public Builder kubectlExecutable(String kubectlExecutable) {
-      this.kubectlExecutable = kubectlExecutable;
-      return this;
-    }
-
-    public Builder kubectlRequestTimeoutSeconds(Integer kubectlRequestTimeoutSeconds) {
-      this.kubectlRequestTimeoutSeconds = kubectlRequestTimeoutSeconds;
-      return this;
-    }
-
-    public Builder context(String context) {
-      this.context = context;
-      return this;
-    }
-
-    public Builder userAgent(String userAgent) {
-      this.userAgent = userAgent;
-      return this;
-    }
-
-    public Builder namespaces(List<String> namespaces) {
-      this.namespaces = namespaces;
-      return this;
-    }
-
-    public Builder omitNamespaces(List<String> omitNamespaces) {
-      this.omitNamespaces = omitNamespaces;
-      return this;
-    }
-
-    public Builder registry(Registry registry) {
-      this.registry = registry;
-      return this;
-    }
-
-    public Builder jobExecutor(KubectlJobExecutor jobExecutor) {
-      this.jobExecutor = jobExecutor;
-      return this;
-    }
-
-    public Builder cachingPolicies(List<KubernetesCachingPolicy> cachingPolicies) {
-      this.cachingPolicies = cachingPolicies;
-      return this;
-    }
-
-    public Builder customResources(List<CustomKubernetesResource> customResources) {
-      this.customResources = customResources;
-      return this;
-    }
-
-    public Builder debug(boolean debug) {
-      this.debug = debug;
-      return this;
-    }
-
-    public Builder checkPermissionsOnStartup(boolean checkPermissionsOnStartup) {
-      this.checkPermissionsOnStartup = checkPermissionsOnStartup;
-      return this;
-    }
-
-    public Builder serviceAccount(boolean serviceAccount) {
-      this.serviceAccount = serviceAccount;
-      return this;
-    }
-
-    public Builder oAuthServiceAccount(String oAuthServiceAccount) {
-      this.oAuthServiceAccount = oAuthServiceAccount;
-      return this;
-    }
-
-    public Builder oAuthScopes(List<String> oAuthScopes) {
-      this.oAuthScopes = oAuthScopes;
-      return this;
-    }
-
-    public Builder kinds(List<String> kinds) {
-      this.kinds = kinds;
-      return this;
-    }
-
-    public Builder omitKinds(List<String> omitKinds) {
-      this.omitKinds = omitKinds;
-      return this;
-    }
-
-    public Builder metrics(boolean metrics) {
-      this.metrics = metrics;
-      return this;
-    }
-
-    public Builder onlySpinnakerManaged(boolean onlySpinnakerManaged) {
-      this.onlySpinnakerManaged = onlySpinnakerManaged;
-      return this;
-    }
-
-    public Builder liveManifestCalls(boolean liveManifestCalls) {
-      this.liveManifestCalls = liveManifestCalls;
-      return this;
-    }
-
-    public KubernetesV2Credentials build() {
-      namespaces = namespaces == null ? new ArrayList<>() : namespaces;
-      omitNamespaces = omitNamespaces == null ? new ArrayList<>() : omitNamespaces;
-      customResources = customResources == null ? new ArrayList<>() : customResources;
-      kinds = kinds == null ? new ArrayList<>() : kinds;
-      omitKinds = omitKinds == null ? new ArrayList<>() : omitKinds;
-      cachingPolicies = cachingPolicies == null ? new ArrayList<>() : cachingPolicies;
-
-      return new KubernetesV2Credentials(
-          accountName,
-          jobExecutor,
-          namespaces,
-          omitNamespaces,
-          registry,
-          kubeconfigFile,
-          kubectlExecutable,
-          kubectlRequestTimeoutSeconds,
-          context,
-          oAuthServiceAccount,
-          oAuthScopes,
-          serviceAccount,
-          customResources,
-          cachingPolicies,
-          KubernetesKind.registeredStringList(kinds),
-          KubernetesKind.registeredStringList(omitKinds),
-          metrics,
-          checkPermissionsOnStartup,
-          debug,
-          onlySpinnakerManaged,
-          liveManifestCalls
-      );
-    }
-  }
-
+  @Builder
   private KubernetesV2Credentials(@NotNull String accountName,
       @NotNull KubectlJobExecutor jobExecutor,
       @NotNull List<String> namespaces,
@@ -370,8 +209,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       boolean serviceAccount,
       @NotNull List<CustomKubernetesResource> customResources,
       @NotNull List<KubernetesCachingPolicy> cachingPolicies,
-      @NotNull List<KubernetesKind> kinds,
-      @NotNull List<KubernetesKind> omitKinds,
+      @NotNull List<String> kinds,
+      @NotNull List<String> omitKinds,
       boolean metrics,
       boolean checkPermissionsOnStartup,
       boolean debug,
@@ -380,8 +219,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.registry = registry;
     this.clock = registry.clock();
     this.accountName = accountName;
-    this.namespaces = namespaces;
-    this.omitNamespaces = omitNamespaces;
+    this.namespaces = Optional.ofNullable(namespaces).orElse(new ArrayList<>());
+    this.omitNamespaces = Optional.ofNullable(omitNamespaces).orElse(new ArrayList<>());
     this.jobExecutor = jobExecutor;
     this.debug = debug;
     this.kubectlExecutable = kubectlExecutable;
@@ -391,11 +230,11 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.oAuthServiceAccount = oAuthServiceAccount;
     this.oAuthScopes = oAuthScopes;
     this.serviceAccount = serviceAccount;
-    this.customResources = customResources;
-    this.cachingPolicies = cachingPolicies;
-    this.kinds = kinds;
+    this.customResources = Optional.ofNullable(customResources).orElse(new ArrayList<>());;
+    this.cachingPolicies = Optional.ofNullable(cachingPolicies).orElse(new ArrayList<>());;
+    this.kinds = Optional.ofNullable(kinds).map(KubernetesKind::registeredStringList).orElse(new ArrayList<>());
     this.metrics = metrics;
-    this.omitKinds = omitKinds.stream()
+    this.omitKinds = Optional.ofNullable(omitKinds).orElse(new ArrayList<>()).stream().map(KubernetesKind::fromString)
       .collect(Collectors.toMap(k -> k, k -> InvalidKindReason.EXPLICITLY_OMITTED_BY_CONFIGURATION));
     this.onlySpinnakerManaged = onlySpinnakerManaged;
     this.liveManifestCalls = liveManifestCalls;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -120,8 +120,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.registry = registry;
     this.clock = registry.clock();
     this.accountName = managedAccount.getName();
-    this.namespaces = Optional.ofNullable(managedAccount.getNamespaces()).orElse(new ArrayList<>());
-    this.omitNamespaces = Optional.ofNullable(managedAccount.getOmitNamespaces()).orElse(new ArrayList<>());
+    this.namespaces = managedAccount.getNamespaces();
+    this.omitNamespaces = managedAccount.getOmitNamespaces();
     this.jobExecutor = jobExecutor;
     this.debug = managedAccount.getDebug();
     this.kubectlExecutable = managedAccount.getKubectlExecutable();
@@ -131,11 +131,11 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.oAuthServiceAccount = managedAccount.getoAuthServiceAccount();
     this.oAuthScopes = managedAccount.getoAuthScopes();
     this.serviceAccount = managedAccount.getServiceAccount();
-    this.customResources = Optional.ofNullable(managedAccount.getCustomResources()).orElse(new ArrayList<>());;
-    this.cachingPolicies = Optional.ofNullable(managedAccount.getCachingPolicies()).orElse(new ArrayList<>());;
-    this.kinds = Optional.ofNullable(managedAccount.getKinds()).map(KubernetesKind::registeredStringList).orElse(new ArrayList<>());
+    this.customResources = managedAccount.getCustomResources();
+    this.cachingPolicies = managedAccount.getCachingPolicies();
+    this.kinds = KubernetesKind.registeredStringList(managedAccount.getKinds());
     this.metrics = managedAccount.getMetrics();
-    this.omitKinds = Optional.ofNullable(managedAccount.getOmitKinds()).orElse(new ArrayList<>()).stream().map(KubernetesKind::fromString)
+    this.omitKinds = managedAccount.getOmitKinds().stream().map(KubernetesKind::fromString)
       .collect(Collectors.toMap(k -> k, k -> InvalidKindReason.EXPLICITLY_OMITTED_BY_CONFIGURATION));
     this.onlySpinnakerManaged = managedAccount.getOnlySpinnakerManaged();
     this.liveManifestCalls = managedAccount.getLiveManifestCalls();

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesNamedAccountCredentialsInitializerSpec.groovy
@@ -97,7 +97,7 @@ class KubernetesNamedAccountCredentialsInitializerSpec extends Specification {
     credentials.getCredentials() instanceof KubernetesV2Credentials
     KubernetesV2Credentials accountCredentials = (KubernetesV2Credentials) credentials.getCredentials()
     accountCredentials.isServiceAccount() == false
-    accountCredentials.getOnlySpinnakerManaged() == false
+    accountCredentials.isOnlySpinnakerManaged() == false
     accountCredentials.isDebug() == false
     accountCredentials.isMetrics() == true
     accountCredentials.isLiveManifestCalls() == false

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.security
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import spock.lang.Specification
@@ -26,18 +27,18 @@ class KubernetesV2CredentialsSpec extends Specification {
   KubectlJobExecutor kubectlJobExecutor = Stub(KubectlJobExecutor)
   String NAMESPACE = "my-namespace"
 
-  private getBuilder() {
-    return KubernetesV2Credentials.builder()
-      .registry(registry)
-      .jobExecutor(kubectlJobExecutor)
-      .namespaces([NAMESPACE])
+  private buildCredentials(KubernetesConfigurationProperties.ManagedAccount managedAccount) {
+    return new KubernetesV2Credentials(registry, kubectlJobExecutor, managedAccount)
   }
 
   void "Built-in Kubernetes kinds are considered valid by default"() {
     when:
-    KubernetesV2Credentials credentials = getBuilder()
-      .checkPermissionsOnStartup(false)
-      .build()
+    KubernetesV2Credentials credentials = buildCredentials(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        namespaces: [NAMESPACE],
+        checkPermissionsOnStartup: false,
+      )
+    )
     credentials.initialize()
 
     then:
@@ -47,10 +48,13 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Built-in Kubernetes kinds are considered valid by default when kinds is empty"() {
     when:
-    KubernetesV2Credentials credentials = getBuilder()
-      .checkPermissionsOnStartup(false)
-      .kinds([])
-      .build()
+    KubernetesV2Credentials credentials = buildCredentials(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        namespaces: [NAMESPACE],
+        checkPermissionsOnStartup: false,
+        kinds: []
+      )
+    )
     credentials.initialize()
 
     then:
@@ -60,10 +64,13 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Only explicitly listed kinds are valid when kinds is not empty"() {
     when:
-    KubernetesV2Credentials credentials = getBuilder()
-      .checkPermissionsOnStartup(false)
-      .kinds(["deployment"])
-      .build()
+    KubernetesV2Credentials credentials = buildCredentials(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        namespaces: [NAMESPACE],
+        checkPermissionsOnStartup: false,
+        kinds: ["deployment"]
+      )
+    )
     credentials.initialize()
 
     then:
@@ -73,10 +80,13 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Explicitly omitted kinds are not valid"() {
     when:
-    KubernetesV2Credentials credentials = getBuilder()
-      .checkPermissionsOnStartup(false)
-      .omitKinds(["deployment"])
-      .build()
+    KubernetesV2Credentials credentials = buildCredentials(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        namespaces: [NAMESPACE],
+        checkPermissionsOnStartup: false,
+        omitKinds: ["deployment"]
+      )
+    )
     credentials.initialize()
 
     then:
@@ -86,9 +96,12 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Kinds that are not readable are considered invalid"() {
     when:
-    KubernetesV2Credentials credentials = getBuilder()
-      .checkPermissionsOnStartup(true)
-      .build()
+    KubernetesV2Credentials credentials = buildCredentials(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        namespaces: [NAMESPACE],
+        checkPermissionsOnStartup: true,
+      )
+    )
     credentials.initialize()
 
     then:

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -27,7 +27,7 @@ class KubernetesV2CredentialsSpec extends Specification {
   String NAMESPACE = "my-namespace"
 
   private getBuilder() {
-    return new KubernetesV2Credentials.Builder()
+    return KubernetesV2Credentials.builder()
       .registry(registry)
       .jobExecutor(kubectlJobExecutor)
       .namespaces([NAMESPACE])


### PR DESCRIPTION
As a follow-up to #3630, do the same kind of simplification in `KubernetesV2Credentials`.  Now it should be much easier to see how each of the fields are defaulted, and to understand where they are used.

* refactor(kubernetes): Use a builder in KubernetesV2Credentials 

  KubernetesV2Credentials implements its own builder that does a bit of defaulting; push this defaulting into the constructor and use a @Builder annotation to get a builder that does not do any defaulting itself.

* refactor(kubernetes): Pass ManagedAccount to constructor 

  Rather than use a builder, we can just use the existing ManagedAccount object that we already have and pass it to the constructor for KubernetesV2Credentials.

* refactor(kubernetes): Move defaulting to ManagedAccount 

  Some of the defaulting and null checks in KubernetesV2Credentials can be avoided if we just default directly on the ManagedAccount class.

* refactor(kubernetes): Rearrange fields in kubernetes account 

  KubernetesV2Credentials has a lot of fields; clean up the class by arraging the fields to all be first and matching the order of fields in the constructor with the order the fields are defined.
