### PR TITLE
fix(provider/azure): fail to destroy server group when there is only one server group.

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -85,21 +85,9 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
       it.attributes.processedCount = (it.attributes.processedCount ?: 0) + 1
     }
 
-    def cacheServerGroups = result.cacheResults[AZURE_SERVER_GROUPS.ns]
+    removeDeadCacheEntries(result, providerCache)
 
-    if (cacheServerGroups) {
-      cacheServerGroups.each { cacheServerGroup ->
-        if(!cacheServerGroup.relationships.containsKey(AZURE_INSTANCES.ns)) {
-          def serverGroupName = cacheServerGroup.attributes.serverGroup.name
-          removeDeadCacheEntries(result, providerCache, serverGroupName)
-        }
-      }
-
-      result
-    } else {
-      // run the cache cleanup routine on an empty server group list only for now
-      removeDeadCacheEntries(result, providerCache)
-    }
+    result
   }
 
   CacheResult removeDeadCacheEntries(CacheResult cacheResult, ProviderCache providerCache, String serverGroupName = "*") {
@@ -112,6 +100,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
         null
       }
     }
+    evictedSGList.removeAll(Collections.singleton(null))
     if (evictedSGList) {
       cacheResult.evictions[AZURE_SERVER_GROUPS.ns] = evictedSGList
     }
@@ -125,6 +114,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
         null
       }
     }
+    evictedInstanceList.removeAll(Collections.singleton(null))
     if (evictedInstanceList) {
       cacheResult.evictions[AZURE_INSTANCES.ns] = evictedInstanceList
     }


### PR DESCRIPTION
Background:
It failed to destroy server group at "WaitForDestroyedServerGroup" task when there is only one server group.
Root cause:
"WaitForDestroyedServerGroup" task will check whether the target server group is removed from redis. However, the target server group isn't removed from redis so that the task failed. The root cause is that "loaddata" function in "AzureServerGroupCachingAgent" only cache the data according by the server group in Azure side. When the last one server group is deleted from Azure side, the "loaddata" function doesn't get the target server group and cache it to redis so that this server group in redis becomes dead data. So it's a bug.
Fix:
Update code to remove dead data in each refresh task.