### PR TITLE
fix(kubernetes): Fail validation if account has no namespaces

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -64,7 +64,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final Clock clock;
   private final KubectlJobExecutor jobExecutor;
 
-  private final String accountName;
+  @Getter private final String accountName;
   @Getter private final List<String> namespaces;
   @Getter private final List<String> omitNamespaces;
   private final List<KubernetesKind> kinds;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
@@ -134,15 +134,12 @@ public class KubernetesValidationUtil {
   }
 
   protected boolean validateNamespace(String namespace, KubernetesV2Credentials credentials) {
-    final List<String> configuredNamespaces = credentials.getNamespaces();
-    if (configuredNamespaces != null && !configuredNamespaces.isEmpty() && !configuredNamespaces.contains(namespace)) {
-      reject("wrongNamespace", namespace);
-      return false;
-    }
-
-    final List<String> omitNamespaces = credentials.getOmitNamespaces();
-    if (omitNamespaces != null && omitNamespaces.contains(namespace)) {
-      reject("omittedNamespace", namespace);
+    final List<String> configuredNamespaces = credentials.getDeclaredNamespaces();
+    if (!configuredNamespaces.contains(namespace)) {
+      reject(
+        String.format("Account %s is not configured to deploy to namespace %s", credentials.getAccountName(), namespace),
+        namespace
+      );
       return false;
     }
     return true;


### PR DESCRIPTION
Before deploying a manifest, we check whether the namespace is one that the account is configured for. We do this by checking namespaces and omitNamespaces, but this fails in the case where an account is mis-configured and doesn't have any namespaces.

Instead, just use getDeclaredNamespaces which returns a fully resolved list of namespaces the account knows about (whether because of config or dynamically discovered).

Fixes spinnaker/spinnaker#4319