### PR TITLE
fix(amazon): use source credentials when retrieving scaling policies …

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -306,10 +306,10 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
       deploymentResult.serverGroupNames << "${region}:${asgName}".toString()
       deploymentResult.serverGroupNameByRegion[region] = asgName
 
-      if (description.copySourceScalingPoliciesAndActions) {
+      if (description.copySourceScalingPoliciesAndActions && sourceRegionScopedProvider) {
         copyScalingPoliciesAndScheduledActions(
           task, sourceRegionScopedProvider,
-          regionScopedProvider.amazonCredentials, description.credentials,
+          sourceRegionScopedProvider.amazonCredentials, description.credentials,
           description.source.asgName, asgName,
           description.source.region, region
         )


### PR DESCRIPTION
…to copy

For at least a year and a half, this bug has prevented users from cloning a server group from one account into another, as the method is expecting that third argument (of eight!) to be the credentials of the source ASG.

It doesn't fully prevent cloning - it just fails to copy scaling policies and scheduled actions, and then Orca leaves the target cluster in whatever state in happened to be in when the failure happens (which is normally mostly fine, right?)