### PR TITLE
fix(provider/azure): delink associated firewall from subnet while deleting firewall

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -472,6 +472,18 @@ class AzureNetworkClient extends AzureBaseClient {
    * @return a ServiceResponse object
    */
   ServiceResponse deleteSecurityGroup(String resourceGroupName, String securityGroupName) {
+    def associatedSubnets = azure.networkSecurityGroups().getByResourceGroup(resourceGroupName, securityGroupName).listAssociatedSubnets()
+
+    associatedSubnets?.each{ associatedSubnet ->
+      def subnetName = associatedSubnet.inner().name()
+      associatedSubnet
+        .parent()
+        .update()
+        .updateSubnet(subnetName)
+        .withoutNetworkSecurityGroup()
+        .parent()
+        .apply()
+    }
 
     deleteAzureResource(
       azure.networkSecurityGroups().&deleteByResourceGroup,


### PR DESCRIPTION
Background:
We cannot delete firewall associated with subnets.
Fix:
Remove links between firewall and subnet while deleting firewall.