### PR TITLE
 feat(kubernetes): Add metrics support to live manifest mode

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -241,8 +241,10 @@ public class KubernetesCacheDataConverter {
     return defaultCacheData(key, infrastructureTtlSeconds, attributes, cacheRelationships);
   }
 
-  public static List<Map> getMetrics(CacheData cacheData) {
-    return mapper.convertValue(cacheData.getAttributes().get("metrics"), new TypeReference<List<Map>>() { });
+  public static List<KubernetesPodMetric.ContainerMetric> getMetrics(CacheData cacheData) {
+    return mapper.convertValue(
+      cacheData.getAttributes().get("metrics"),
+      new TypeReference<List<KubernetesPodMetric.ContainerMetric>>() {});
   }
 
   public static KubernetesManifest getManifest(CacheData cacheData) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -73,7 +73,7 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
     List<CacheData> cacheData = namespaces.parallelStream()
         .map(n -> {
               try {
-                return credentials.topPod(n)
+                return credentials.topPod(n, null)
                     .stream()
                     .map(m -> KubernetesCacheDataConverter.convertPodMetric(accountName, n, m));
               } catch (KubectlJobExecutor.KubectlException e) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Manifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Manifest.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
@@ -29,7 +30,6 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 @Data
@@ -46,5 +46,5 @@ public class KubernetesV2Manifest implements Manifest {
   private Set<Artifact> artifacts = new HashSet<>();
   private List<KubernetesManifest> events = new ArrayList<>();
   private List<Warning> warnings = new ArrayList<>();
-  private List<Map> metrics = new ArrayList<>();
+  private List<KubernetesPodMetric.ContainerMetric> metrics = new ArrayList<>();
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
@@ -34,7 +35,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -67,7 +67,7 @@ public abstract class KubernetesV2AbstractManifestProvider implements ManifestPr
     return getCredentials(account).map(KubernetesV2Credentials::isLiveManifestCalls).orElseThrow(() -> new IllegalArgumentException("Account " + account + " is not a Kubernetess v2 account"));
   }
 
-  protected KubernetesV2Manifest buildManifest(String account, KubernetesManifest manifest, List<KubernetesManifest> events, List<Map> metrics) {
+  protected KubernetesV2Manifest buildManifest(String account, KubernetesManifest manifest, List<KubernetesManifest> events, List<KubernetesPodMetric.ContainerMetric> metrics) {
     String namespace = manifest.getNamespace();
     KubernetesKind kind = manifest.getKind();
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
@@ -30,7 +31,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 @Component
 @Slf4j
@@ -78,7 +78,7 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
 
     // TODO kubectl top pod <name> -n <namespace>
     // low-priority, pipeline-only mode doesn't need to see resource usage.
-    List<Map> metrics = Collections.emptyList();
+    List<KubernetesPodMetric.ContainerMetric> metrics = Collections.emptyList();
 
     return buildManifest(account, manifest, events, metrics);
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -29,8 +29,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -76,9 +78,15 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
 
     List<KubernetesManifest> events = credentials.eventsFor(kind, namespace, parsedName.getRight());
 
-    // TODO kubectl top pod <name> -n <namespace>
-    // low-priority, pipeline-only mode doesn't need to see resource usage.
     List<KubernetesPodMetric.ContainerMetric> metrics = Collections.emptyList();
+    if (kind == KubernetesKind.POD && credentials.isMetrics()) {
+      metrics = credentials
+        .topPod(namespace, parsedName.getRight())
+        .stream()
+        .map(KubernetesPodMetric::getContainerMetrics)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+    }
 
     return buildManifest(account, manifest, events, metrics);
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
@@ -37,7 +38,6 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -129,7 +129,7 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
         .collect(Collectors.toList());
 
     String metricKey = Keys.metric(kind, account, namespace, manifest.getName());
-    List<Map> metrics = cacheUtils.getSingleEntry(Keys.Kind.KUBERNETES_METRIC.toString(), metricKey)
+    List<KubernetesPodMetric.ContainerMetric> metrics = cacheUtils.getSingleEntry(Keys.Kind.KUBERNETES_METRIC.toString(), metricKey)
         .map(KubernetesCacheDataConverter::getMetrics)
         .orElse(Collections.emptyList());
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetric.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetric.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -37,6 +38,7 @@ public class KubernetesPodMetric {
   @Builder
   @NoArgsConstructor
   @AllArgsConstructor
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class ContainerMetric {
     String containerName;
     Map<String, String> metrics;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -489,10 +489,14 @@ public class KubectlJobExecutor {
     return status.getOutput();
   }
 
-  public Collection<KubernetesPodMetric> topPod(KubernetesV2Credentials credentials, String namespace) {
+  public Collection<KubernetesPodMetric> topPod(KubernetesV2Credentials credentials,
+    String namespace, String pod) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
     command.add("top");
     command.add("po");
+    if (pod != null) {
+      command.add(pod);
+    }
     command.add("--containers");
 
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -287,7 +287,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     if (metrics) {
       try {
         log.info("Checking if pod metrics are readable...");
-        topPod(checkNamespace);
+        topPod(checkNamespace, null);
       } catch (Exception e) {
         log.warn("Could not read pod metrics in account '{}' for reason: {}", accountName, e.getMessage());
         log.debug("Reading logs failed with exception: ", e);
@@ -352,8 +352,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     return runAndRecordMetrics("delete", kind, namespace, () -> jobExecutor.delete(this, kind, namespace, name, labelSelectors, options));
   }
 
-  public Collection<KubernetesPodMetric> topPod(String namespace) {
-    return runAndRecordMetrics("top", KubernetesKind.POD, namespace, () -> jobExecutor.topPod(this, namespace));
+  public Collection<KubernetesPodMetric> topPod(String namespace, String pod) {
+    return runAndRecordMetrics("top", KubernetesKind.POD, namespace, () -> jobExecutor.topPod(this, namespace, pod));
   }
 
   public void deploy(KubernetesManifest manifest) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -17,10 +17,12 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest
@@ -141,6 +143,52 @@ metadata:
     KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["deployment": [Keys.infrastructure(KubernetesKind.DEPLOYMENT, "account", "namespace", "a-name")]]
     KubernetesKind.SERVICE     | KubernetesApiVersion.V1           | ["cluster": [Keys.cluster("account", "app", "name")], "application": [Keys.application("blarg")]]
     KubernetesKind.SERVICE     | KubernetesApiVersion.V1           | ["cluster": [Keys.cluster("account", "app", "name")], "application": [Keys.application("blarg"), Keys.application("asdfasdf")]]
+  }
+
+  @Unroll
+  def "correctly builds cache data entry for pod metrics"() {
+    setup:
+    def account = "my-account"
+    def namespace = "my-namespace"
+    def podName = "pod-name"
+    def podMetric = KubernetesPodMetric.builder()
+      .podName(podName)
+      .containerMetrics(containerMetrics)
+      .build()
+
+    when:
+    def cacheData = KubernetesCacheDataConverter.convertPodMetric(account, namespace, podMetric)
+
+    then:
+    cacheData.attributes == [
+      name: podName,
+      namespace: namespace,
+      metrics: containerMetrics
+    ]
+
+    when:
+    def metrics = KubernetesCacheDataConverter.getMetrics(cacheData)
+
+    then:
+    // Once getMetrics is updated to directly return a List<KubernetesPodMetric.ContainerMetric> we can remove this
+    // type conversion
+    metrics == mapper.convertValue(containerMetrics, new TypeReference<List<Map<String, Object>>>() {})
+
+    where:
+    containerMetrics << [
+      [containerMetric("container-a")],
+      [containerMetric("container-a"), containerMetric("container-b")],
+      []
+    ]
+  }
+
+  def containerMetric(String containerName) {
+    return KubernetesPodMetric.ContainerMetric.builder()
+      .containerName(containerName)
+      .metrics([
+        "CPU(cores)": "10m",
+        "MEMORY(bytes)": "2Mi"
+      ]).build()
   }
 
   def filterRelationships(Collection<String> keys, List<Pair<KubernetesKind, String>> existingResources) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
@@ -170,9 +169,7 @@ metadata:
     def metrics = KubernetesCacheDataConverter.getMetrics(cacheData)
 
     then:
-    // Once getMetrics is updated to directly return a List<KubernetesPodMetric.ContainerMetric> we can remove this
-    // type conversion
-    metrics == mapper.convertValue(containerMetrics, new TypeReference<List<Map<String, Object>>>() {})
+    metrics == containerMetrics
 
     where:
     containerMetrics << [


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4243

* test(kubernetes): Add tests to pod metrics caching 

* refactor(kubernetes): Improve typing of pod metrics 

  The pod metrics code converts the metrics to Maps before using them, which makes it more difficult to use these metrics. Simplify this code by using the KubernetesPodMetric class that already exists.

  In order to preserve the serialized version stored in the cache, rename some fields to match what we're currently using to serialize. Then serialize/deserialize to/from that object when we write/read from the cache.

* feat(kubernetes): Add metrics support to live manifest mode 

  The live manifest supplier does not currently support returning metrics, so users with it enabled can't see metrics on the clusters tab. Add support for this.
