### PR TITLE
fix(cf): add ci build info under build info

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryServerGroup.java
@@ -168,7 +168,8 @@ public class CloudFoundryServerGroup extends CloudFoundryModel implements Server
       "metricsUri", metricsUri,
       "droplet", droplet,
       "id", id,
-      "serviceInstances", serviceInstances)
+      "serviceInstances", serviceInstances,
+      "ciBuild", ciBuild)
       .toJavaMap();
   }
 


### PR DESCRIPTION
CI build info can sit under here with the droplet build info. It isn’t ideal because it is not typed or shared more widely than CF, but it tags along for the ride everywhere that buildinfo goes.
