### PR TITLE
fix(core): Spring does not override default configuration files

### DIFF
--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -6,12 +6,12 @@ if (gradle.includedCloudProviderProjects.contains(':clouddriver-oracle')) {
 }
 
 ext {
-  springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
+  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/")
 }
 
 mainClassName = 'com.netflix.spinnaker.clouddriver.Main'
 run {
-  systemProperty('spring.config.location', project.springConfigLocation)
+  systemProperty('spring.config.additional-location', project.springConfigLocation)
 }
 
 configurations.all {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/Main.groovy
@@ -64,7 +64,7 @@ class Main extends SpringBootServletInitializer {
     'netflix.environment'    : 'test',
     'netflix.account'        : '${netflix.environment}',
     'netflix.stack'          : 'test',
-    'spring.config.location' : '${user.home}/.spinnaker/',
+    'spring.config.additional-location' : '${user.home}/.spinnaker/',
     'spring.application.name': 'clouddriver',
     'spring.config.name'     : 'spinnaker,${spring.application.name}',
     'spring.profiles.active' : '${netflix.environment},local'


### PR DESCRIPTION
In the Spring Boot 2 upgrade, spring.config.location overrides all other config locations. The equivalent property is now called spring.config.additional-location.
This fix allows the app the to run without additional config files.
