### PR TITLE
test(gce): Fix GCE upsert image tags test

### DIFF
--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleImageTagsAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleImageTagsAtomicOperationUnitSpec.groovy
@@ -117,9 +117,8 @@ class UpsertGoogleImageTagsAtomicOperationUnitSpec extends Specification impleme
       }
 
     then:
-      1 * imagesMock.setLabels(_, _, _) >> setLabelsMock
+      1 * imagesMock.setLabels(PROJECT_NAME, IMAGE_NAME, {it.labels == TAGS }) >> setLabelsMock
       1 * setLabelsMock.execute()
-//      globalSetLabelsRequest.labels == TAGS
   }
 
   void "should add to labels on image with existing labels"() {
@@ -188,9 +187,8 @@ class UpsertGoogleImageTagsAtomicOperationUnitSpec extends Specification impleme
       }
 
     then:
-      1 * imagesMock.setLabels(_, _, _) >> setLabelsMock
-      1 * setLabelsMock.execute()
-//      globalSetLabelsRequest.labels == LABELS + TAGS
+    1 * imagesMock.setLabels(PROJECT_NAME, IMAGE_NAME, {it.labels == LABELS + TAGS }) >> setLabelsMock
+    1 * setLabelsMock.execute()
   }
 
   void "should fail to create instance because image is invalid"() {


### PR DESCRIPTION
Some of the upgrades that came with boot2 made these tests have invalid syntax, so they were commented out to unblock the upgrade. Fixing the tests now here.