### PR TITLE
fix(titus): set default disruption interval to 10m

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
@@ -451,7 +451,7 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
   private DisruptionBudget getDefaultDisruptionBudget(Map application) {
     DisruptionBudget budget = new DisruptionBudget()
     budget.availabilityPercentageLimit = new AvailabilityPercentageLimit(95)
-    budget.ratePercentagePerInterval = new RatePercentagePerInterval(60000, 5)
+    budget.ratePercentagePerInterval = new RatePercentagePerInterval(600000, 5)
     budget.timeWindows = [
             new TimeWindow(
               ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],


### PR DESCRIPTION
60s is too aggressive; should be 600s