### PR TITLE
fix(appengine): Allow gcloud path to be configured

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.groovy
@@ -49,9 +49,9 @@ class AppengineConfigurationProperties {
     List<String> omitVersions
     Long cachingIntervalSeconds
 
-    void initialize(AppengineJobExecutor jobExecutor) {
+    void initialize(AppengineJobExecutor jobExecutor, String gcloudPath) {
       if (this.jsonPath) {
-        jobExecutor.runCommand(["gcloud", "auth", "activate-service-account", "--key-file", this.jsonPath])
+        jobExecutor.runCommand([gcloudPath, "auth", "activate-service-account", "--key-file", this.jsonPath])
 
         def accountJson = new JsonSlurper().parse(new File(this.jsonPath))
         this.project = this.project ?: accountJson["project_id"]
@@ -99,4 +99,5 @@ class AppengineConfigurationProperties {
   }
 
   List<ManagedAccount> accounts = []
+  String gcloudPath
 }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineAtomicOperation.groovy
@@ -260,7 +260,7 @@ class DeployAppengineAtomicOperation implements AtomicOperation<DeploymentResult
     // runCommand expects a List<String> and will fail if some of the arguments are GStrings (as that is not a subclass
     // of String). It is thus important to only add Strings to deployCommand.  For example, adding a flag "--test=$testvalue"
     // below will cause deployments to fail unless you explicitly convert it to a String via "--test=$testvalue".toString()
-    def deployCommand = ["gcloud"]
+    def deployCommand = [description.credentials.gcloudPath]
     if (gcloudReleaseTrack != null && gcloudReleaseTrack != GcloudReleaseTrack.STABLE) {
       deployCommand << gcloudReleaseTrack.toString().toLowerCase()
     }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppengineCredentialsInitializer.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppengineCredentialsInitializer.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils
 import groovy.util.logging.Slf4j
+import org.apache.commons.lang3.StringUtils
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -62,7 +63,11 @@ class AppengineCredentialsInitializer implements CredentialsInitializerSynchroni
 
     accountsToAdd.each { AppengineConfigurationProperties.ManagedAccount managedAccount ->
       try {
-        managedAccount.initialize(jobExecutor)
+        String gcloudPath = appengineConfigurationProperties.gcloudPath
+        if (StringUtils.isEmpty(gcloudPath)) {
+          gcloudPath = "gcloud"
+        }
+        managedAccount.initialize(jobExecutor, gcloudPath)
 
         def jsonKey = AppengineCredentialsInitializer.getJsonKey(managedAccount)
         def appengineAccount = new AppengineNamedAccountCredentials.Builder()
@@ -72,6 +77,7 @@ class AppengineCredentialsInitializer implements CredentialsInitializerSynchroni
           .project(managedAccount.project)
           .jsonKey(jsonKey)
           .applicationName(clouddriverUserAgentApplicationName)
+          .gcloudPath(gcloudPath)
           .jsonPath(managedAccount.jsonPath)
           .requiredGroupMembership(managedAccount.requiredGroupMembership)
           .permissions(managedAccount.permissions.build())

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppengineNamedAccountCredentials.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/security/AppengineNamedAccountCredentials.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppengineGitCredent
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.fiat.model.resources.Permissions
 import groovy.transform.TupleConstructor
+import org.apache.commons.lang3.StringUtils
 
 import static com.netflix.spinnaker.clouddriver.appengine.config.AppengineConfigurationProperties.ManagedAccount.GcloudReleaseTrack
 
@@ -41,6 +42,8 @@ class AppengineNamedAccountCredentials implements AccountCredentials<AppengineCr
 
   @JsonIgnore
   final String jsonPath
+  @JsonIgnore
+  final String gcloudPath
   final AppengineCredentials credentials
   final String applicationName
   @JsonIgnore
@@ -72,6 +75,7 @@ class AppengineNamedAccountCredentials implements AccountCredentials<AppengineCr
     AppengineCredentials credentials
 
     String jsonKey
+    String gcloudPath
     String jsonPath
     String applicationName
     Appengine appengine
@@ -138,6 +142,11 @@ class AppengineNamedAccountCredentials implements AccountCredentials<AppengineCr
 
     Builder jsonPath(String jsonPath) {
       this.jsonPath = jsonPath
+      return this
+    }
+
+    Builder gcloudPath(String gcloudPath) {
+      this.gcloudPath = gcloudPath
       return this
     }
 
@@ -273,6 +282,7 @@ class AppengineNamedAccountCredentials implements AccountCredentials<AppengineCr
                                                   requiredGroupMembership,
                                                   permissions,
                                                   jsonPath,
+                                                  gcloudPath,
                                                   credentials,
                                                   applicationName,
                                                   appengine,


### PR DESCRIPTION
Fixes spinnaker/spinnaker#3349

Clouddriver searches the the PATH for the gcloud executible; in some cases it is easier to provide a direct path to the executable than to fully control the environment of clouddriver.

(One example is running it on Ubuntu 18.04 on GCE; gcloud is installed in /snap/bin, which is added to the path for login shells but is not in the path for systemd.)