### PR TITLE
feat(provider/kubernetes): namespace deployManifest

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
@@ -35,6 +35,7 @@ public class KubernetesDeployManifestDescription extends KubernetesAtomicOperati
   private Boolean versioned;
   private Source source;
   private Artifact manifestArtifact;
+  private String namespaceOverride;
 
   private boolean enableTraffic = true;
   private List<String> services;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -104,8 +104,13 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     validateManifestsForRolloutStrategies(inputManifests);
 
     for (KubernetesManifest manifest : inputManifests) {
-      if (StringUtils.isEmpty(manifest.getNamespace()) && manifest.getKind().isNamespaced()) {
-        manifest.setNamespace(credentials.getDefaultNamespace());
+
+      if (manifest.getKind().isNamespaced()) {
+        if (!StringUtils.isEmpty(description.getNamespaceOverride())) {
+          manifest.setNamespace(description.getNamespaceOverride());
+        } else if (StringUtils.isEmpty(manifest.getNamespace())) {
+          manifest.setNamespace(credentials.getDefaultNamespace());
+        }
       }
 
       KubernetesResourceProperties properties = findResourceProperties(manifest);

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
@@ -152,6 +152,24 @@ spec:
     result.manifestNamesByNamespace[DEFAULT_NAMESPACE][0] == "$KIND $NAME-$VERSION"
   }
 
+  void "replica set deployer uses namespace override when set"() {
+    setup:
+    def namespaceOverride = "overridden"
+    def credentialsMock = Mock(KubernetesV2Credentials)
+    credentialsMock.getDefaultNamespace() >> DEFAULT_NAMESPACE
+    def deployOp = getBaseDeployDescription(BASIC_REPLICA_SET_NO_NAMESPACE)
+      .setNamespaceOverride(namespaceOverride)
+    def mockDeployer= createMockDeployer(credentialsMock, deployOp)
+    
+    when:
+    def result = mockDeployer.operate([])
+
+    then:
+    result.manifestNamesByNamespace[namespaceOverride].size() == 1
+    result.manifestNamesByNamespace[namespaceOverride][0] == "$KIND $NAME-$VERSION"
+    !result.manifestNamesByNamespace.containsKey(DEFAULT_NAMESPACE)
+  }
+
   void "sends traffic to the specified service when enableTraffic is true"() {
     setup:
     def credentialsMock = Mock(KubernetesV2Credentials)


### PR DESCRIPTION
adds a `namespaceOverride` option to deployManifest which will set a
desired namespace on all manifests being deployed. this is the
equivilent of doing `kubectl apply --namespace {namespace}`. this
feature was primarily requested because it makes deploying stable helm
charts possible.

Closes spinnaker/spinnaker#2831