### PR TITLE
chore(dependencies): externalize versions to gradle.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,6 @@
 
 buildscript {
   ext {
-    korkVersion = "5.3.0"
-    fiatVersion = "1.0.4"
     kotlinVersion = "1.3.10"
     junitPlatformVersion = "1.0.2"
   }
@@ -27,12 +25,15 @@ buildscript {
     jcenter()
     maven { url "https://spinnaker.bintray.com/gradle" }
     maven { url "https://plugins.gradle.org/m2/" }
+    if (spinnakerGradleVersion.endsWith("-SNAPSHOT")) {
+      mavenLocal()
+    }
   }
 
   dependencies {
-    classpath 'com.netflix.spinnaker.gradle:spinnaker-dev-plugin:6.3.0'
+    classpath "com.netflix.spinnaker.gradle:spinnaker-dev-plugin:$spinnakerGradleVersion"
     if (Boolean.valueOf(enablePublishing)) {
-      classpath "com.netflix.spinnaker.gradle:spinnaker-gradle-project:6.3.0"
+      classpath "com.netflix.spinnaker.gradle:spinnaker-gradle-project:$spinnakerGradleVersion"
     }
     classpath "com.netflix.nebula:nebula-kotlin-plugin:$kotlinVersion"
     classpath "org.junit.platform:junit-platform-gradle-plugin:${junitPlatformVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.parallel=true
 enablePublishing=false
 includeCloudProviders=all
+korkVersion=5.3.4
+fiatVersion=1.0.4
+spinnakerGradleVersion=6.5.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Compatibility with autobump.
Updates kork to 5.3.4
Updates spinnaker-gradle-plugin to 6.5.0
