### PR TITLE
fix(cf): only create artifact metadata for Maven artifacts

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
@@ -54,11 +54,13 @@ public class MavenArtifactCredentials implements ArtifactCredentials {
   private static final String LATEST = "LATEST";
   private static final String MAVEN_METADATA_XML = "maven-metadata.xml";
 
+  public static final List<String> TYPES = singletonList("maven/file");
+
   private final MavenArtifactAccount account;
   private final OkHttpClient okHttpClient;
   private final RepositoryLayout repositoryLayout;
 
-  @Getter private final List<String> types = singletonList("maven/file");
+  @Getter private final List<String> types = TYPES;
 
   public MavenArtifactCredentials(MavenArtifactAccount account, OkHttpClient okHttpClient) {
     this.account = account;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -21,6 +21,7 @@ import static com.netflix.spinnaker.clouddriver.deploy.DeploymentResult.*;
 import static com.netflix.spinnaker.clouddriver.deploy.DeploymentResult.Deployment.*;
 import static java.util.stream.Collectors.toList;
 
+import com.netflix.spinnaker.clouddriver.artifacts.maven.MavenArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.CloudFoundryCloudProvider;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryApiException;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.CloudFoundryClient;
@@ -182,23 +183,25 @@ public class DeployCloudFoundryServerGroupAtomicOperation
             .map(HashMap::new)
             .orElse(new HashMap<>());
     final Artifact applicationArtifact = description.getApplicationArtifact();
-    if (applicationArtifact.getVersion() != null) {
-      environmentVars.put(
-          ServerGroupMetaDataEnvVar.ArtifactName.envVarName, applicationArtifact.getName());
-      environmentVars.put(
-          ServerGroupMetaDataEnvVar.ArtifactVersion.envVarName, applicationArtifact.getVersion());
-      environmentVars.put(
-          ServerGroupMetaDataEnvVar.ArtifactUrl.envVarName, applicationArtifact.getLocation());
-    }
-    final Map<String, Object> metadata = applicationArtifact.getMetadata();
-    if (metadata != null) {
-      final Map<String, String> buildInfo =
-          (Map<String, String>) applicationArtifact.getMetadata().get("build");
-      if (buildInfo != null) {
-        environmentVars.put(ServerGroupMetaDataEnvVar.JobName.envVarName, buildInfo.get("name"));
+    if (applicationArtifact != null && MavenArtifactCredentials.TYPES.contains(applicationArtifact.getType())) {
+      if (applicationArtifact.getVersion() != null) {
         environmentVars.put(
+          ServerGroupMetaDataEnvVar.ArtifactName.envVarName, applicationArtifact.getName());
+        environmentVars.put(
+          ServerGroupMetaDataEnvVar.ArtifactVersion.envVarName, applicationArtifact.getVersion());
+        environmentVars.put(
+          ServerGroupMetaDataEnvVar.ArtifactUrl.envVarName, applicationArtifact.getLocation());
+      }
+      final Map<String, Object> metadata = applicationArtifact.getMetadata();
+      if (metadata != null) {
+        final Map<String, String> buildInfo =
+          (Map<String, String>) applicationArtifact.getMetadata().get("build");
+        if (buildInfo != null) {
+          environmentVars.put(ServerGroupMetaDataEnvVar.JobName.envVarName, buildInfo.get("name"));
+          environmentVars.put(
             ServerGroupMetaDataEnvVar.JobNumber.envVarName, buildInfo.get("number"));
-        environmentVars.put(ServerGroupMetaDataEnvVar.JobUrl.envVarName, buildInfo.get("url"));
+          environmentVars.put(ServerGroupMetaDataEnvVar.JobUrl.envVarName, buildInfo.get("url"));
+        }
       }
     }
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -183,23 +183,24 @@ public class DeployCloudFoundryServerGroupAtomicOperation
             .map(HashMap::new)
             .orElse(new HashMap<>());
     final Artifact applicationArtifact = description.getApplicationArtifact();
-    if (applicationArtifact != null && MavenArtifactCredentials.TYPES.contains(applicationArtifact.getType())) {
+    if (applicationArtifact != null
+        && MavenArtifactCredentials.TYPES.contains(applicationArtifact.getType())) {
       if (applicationArtifact.getVersion() != null) {
         environmentVars.put(
-          ServerGroupMetaDataEnvVar.ArtifactName.envVarName, applicationArtifact.getName());
+            ServerGroupMetaDataEnvVar.ArtifactName.envVarName, applicationArtifact.getName());
         environmentVars.put(
-          ServerGroupMetaDataEnvVar.ArtifactVersion.envVarName, applicationArtifact.getVersion());
+            ServerGroupMetaDataEnvVar.ArtifactVersion.envVarName, applicationArtifact.getVersion());
         environmentVars.put(
-          ServerGroupMetaDataEnvVar.ArtifactUrl.envVarName, applicationArtifact.getLocation());
+            ServerGroupMetaDataEnvVar.ArtifactUrl.envVarName, applicationArtifact.getLocation());
       }
       final Map<String, Object> metadata = applicationArtifact.getMetadata();
       if (metadata != null) {
         final Map<String, String> buildInfo =
-          (Map<String, String>) applicationArtifact.getMetadata().get("build");
+            (Map<String, String>) applicationArtifact.getMetadata().get("build");
         if (buildInfo != null) {
           environmentVars.put(ServerGroupMetaDataEnvVar.JobName.envVarName, buildInfo.get("name"));
           environmentVars.put(
-            ServerGroupMetaDataEnvVar.JobNumber.envVarName, buildInfo.get("number"));
+              ServerGroupMetaDataEnvVar.JobNumber.envVarName, buildInfo.get("number"));
           environmentVars.put(ServerGroupMetaDataEnvVar.JobUrl.envVarName, buildInfo.get("url"));
         }
       }


### PR DESCRIPTION
All artifacts don’t use the Artifact fields consistently. For example, the Jenkins artifact uses the build number in the version field. It then looks incorrect when it is later displayed as a version.
