### PR TITLE
fix(kubernetes): Improve error message on unbound artifact

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -147,9 +147,11 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     getTask().updateStatus(OP_NAME, "Checking if all requested artifacts were bound...");
     if (!unboundArtifacts.isEmpty()) {
       throw new IllegalArgumentException(
-          "The following artifacts could not be bound: '"
-              + unboundArtifacts
-              + "' . Failing the stage as this is likely a configuration error.");
+          String.format(
+              "The following required artifacts could not be bound: '%s'."
+                  + "Check that the Docker image name above matches the name used in the image field of your manifest."
+                  + "Failing the stage as this is likely a configuration error.",
+              unboundArtifacts));
     }
 
     getTask().updateStatus(OP_NAME, "Sorting manifests by priority...");

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
@@ -130,9 +130,11 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
               new HashSet<>(description.getRequiredArtifacts()), replaceResult.getBoundArtifacts());
       if (!unboundArtifacts.isEmpty()) {
         throw new IllegalArgumentException(
-            "The following required artifacts could not be bound: '"
-                + unboundArtifacts
-                + "' . Failing the stage as this is likely a configuration error.");
+            String.format(
+                "The following required artifacts could not be bound: '%s'."
+                    + "Check that the Docker image name above matches the name used in the image field of your manifest."
+                    + "Failing the stage as this is likely a configuration error.",
+                unboundArtifacts));
       }
     }
     return replaceResult;


### PR DESCRIPTION
Fixes spinnaker/spinnaker#3571

The error message when a required artifact is not bound in a Kubernetes deploy or patch stage is confusing. Make this clearer so that users get more actionable feedback when they misconfigure a stage.