### PR TITLE
fix(kubernetes): Fix compiler warnings

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
@@ -33,7 +33,6 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -44,9 +43,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 
@@ -128,10 +126,8 @@ public class ArtifactReplacer {
             .collect(Collectors.toSet());
 
     try {
-      return ReplaceResult.builder()
-          .manifest(mapper.readValue(document.jsonString(), KubernetesManifest.class))
-          .boundArtifacts(replacedArtifacts)
-          .build();
+      return new ReplaceResult(
+          mapper.readValue(document.jsonString(), KubernetesManifest.class), replacedArtifacts);
     } catch (IOException e) {
       log.error("Malformed Document Context", e);
       throw new RuntimeException(e);
@@ -257,12 +253,9 @@ public class ArtifactReplacer {
     }
   }
 
-  @Data
-  @NoArgsConstructor
-  @AllArgsConstructor
-  @Builder
+  @Value
   public static class ReplaceResult {
-    private KubernetesManifest manifest;
-    private Set<Artifact> boundArtifacts = new HashSet<>();
+    private final KubernetesManifest manifest;
+    private final Set<Artifact> boundArtifacts;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Application.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Application.java
@@ -19,21 +19,14 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model;
 
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.model.Application;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Value
 public class KubernetesV2Application implements Application {
-  private String name;
-  private Map<String, Set<String>> clusterNames = new HashMap<>();
+  private final String name;
+  private final Map<String, Set<String>> clusterNames;
 
   public Map<String, String> getAttributes() {
     return new ImmutableMap.Builder<String, String>().put("name", name).build();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Manifest.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Manifest.java
@@ -26,24 +26,22 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 
-@Data
+@Value
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class KubernetesV2Manifest implements Manifest {
-  private String account;
-  private String name;
-  private String location;
-  private Moniker moniker;
-  private KubernetesManifest manifest;
-  private Status status;
-  private Set<Artifact> artifacts = new HashSet<>();
-  private List<KubernetesManifest> events = new ArrayList<>();
-  private List<Warning> warnings = new ArrayList<>();
-  private List<KubernetesPodMetric.ContainerMetric> metrics = new ArrayList<>();
+  private final String account;
+  private final String name;
+  private final String location;
+  private final Moniker moniker;
+  private final KubernetesManifest manifest;
+  private final Status status;
+  @Builder.Default private final Set<Artifact> artifacts = new HashSet<>();
+  @Builder.Default private final List<KubernetesManifest> events = new ArrayList<>();
+  @Builder.Default private final List<Warning> warnings = new ArrayList<>();
+
+  @Builder.Default
+  private final List<KubernetesPodMetric.ContainerMetric> metrics = new ArrayList<>();
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
@@ -98,8 +98,7 @@ public abstract class KubernetesV2AbstractManifestProvider
 
     KubernetesHandler handler = properties.getHandler();
 
-    return new KubernetesV2Manifest()
-        .builder()
+    return KubernetesV2Manifest.builder()
         .account(account)
         .name(manifest.getFullResourceName())
         .location(namespace)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ApplicationProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ApplicationProvider.java
@@ -57,12 +57,7 @@ public class KubernetesV2ApplicationProvider implements ApplicationProvider {
             .collect(Collectors.groupingBy(ClusterCacheKey::getApplication, Collectors.toSet()));
 
     return keysByApplication.entrySet().stream()
-        .map(
-            e ->
-                KubernetesV2Application.builder()
-                    .name(e.getKey())
-                    .clusterNames(groupClustersByAccount(e.getValue()))
-                    .build())
+        .map(e -> new KubernetesV2Application(e.getKey(), groupClustersByAccount(e.getValue())))
         .collect(Collectors.toSet());
   }
 
@@ -82,10 +77,7 @@ public class KubernetesV2ApplicationProvider implements ApplicationProvider {
       return null;
     }
 
-    return KubernetesV2Application.builder()
-        .name(name)
-        .clusterNames(groupClustersByAccount(keys))
-        .build();
+    return new KubernetesV2Application(name, groupClustersByAccount(keys));
   }
 
   private Map<String, Set<String>> groupClustersByAccount(Collection<ClusterCacheKey> keys) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetric.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetric.java
@@ -30,8 +30,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class KubernetesPodMetric {
-  String podName;
-  List<ContainerMetric> containerMetrics = new ArrayList<>();
+  private String podName;
+  @Builder.Default private List<ContainerMetric> containerMetrics = new ArrayList<>();
 
   @Data
   @Builder
@@ -39,7 +39,7 @@ public class KubernetesPodMetric {
   @AllArgsConstructor
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class ContainerMetric {
-    String containerName;
-    Map<String, String> metrics;
+    private String containerName;
+    private Map<String, String> metrics;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/artifact/KubernetesCleanupArtifactsDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/artifact/KubernetesCleanupArtifactsDescription.java
@@ -23,11 +23,13 @@ import java.util.HashSet;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class KubernetesCleanupArtifactsDescription extends KubernetesAtomicOperationDescription {
   Set<KubernetesManifest> manifests = new HashSet<>();
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/OperationResult.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/OperationResult.java
@@ -25,20 +25,16 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 public class OperationResult {
-  Map<String, Set<String>> manifestNamesByNamespace = new HashMap<>();
-  Set<KubernetesManifest> manifests = new HashSet<>();
-  Set<Artifact> createdArtifacts = new HashSet<>();
-  Set<Artifact> boundArtifacts = new HashSet<>();
+  private Map<String, Set<String>> manifestNamesByNamespace = new HashMap<>();
+  private Set<KubernetesManifest> manifests = new HashSet<>();
+  private Set<Artifact> createdArtifacts = new HashSet<>();
+  private Set<Artifact> boundArtifacts = new HashSet<>();
 
   public void removeSensitiveKeys(
       KubernetesResourcePropertyRegistry propertyRegistry, String accountName) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -610,7 +610,8 @@ public class KubectlJobExecutor {
 
     if (header.length <= 2) {
       log.warn(
-          "Unexpected metric format -- no metrics to report based on table header {}.", header);
+          "Unexpected metric format -- no metrics to report based on table header {}.",
+          Arrays.asList(header));
       return new ArrayList<>();
     }
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProviderSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProviderSpec.groovy
@@ -49,11 +49,11 @@ class KubernetesV2JobProviderSpec extends Specification {
     ])
 
     def mockManifestProvider = Mock(KubernetesV2ManifestProvider) {
-      getManifest(*_) >> new KubernetesV2Manifest(
-        account: 'a',
-        name: 'a',
-        manifest: testManifest,
-      )
+      getManifest(*_) >> KubernetesV2Manifest.builder()
+        .account("a")
+        .name("a")
+        .manifest(testManifest)
+        .build()
     }
 
     when:


### PR DESCRIPTION
There are a few compiler warnings in clouddriver-kubernetes; fix these.

* Defaulting a field on a class that uses a `@Builder`, as `@Builder` ignores the default.  For these I either added `@Builder.Default` to tell the builder to use the default, or removed `@Builder` if it was not necessary (unused or for a simple class where all builders passed the same parameters).
* EqualsAndHashCode without calling the super class
* Passing an array instead of a list to a log call

Also, for some of the modified classes, took the opportunity to remove un-needed lombok annotations and clean up the interface (as well as make some fields final where possible).