### PR TITLE
fix(cf): cacheTime should be stored as a long

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgent.java
@@ -297,7 +297,8 @@ public class CloudFoundryCachingAgent implements CachingAgent, OnDemandAgent, Ac
         new DefaultCacheData(
             Keys.getServerGroupKey(account, serverGroupName, region),
             (int) TimeUnit.MINUTES.toSeconds(10), // ttl
-            HashMap.<String, Object>of("cacheTime", Date.from(internalClock.instant())).toJavaMap(),
+            HashMap.<String, Object>of("cacheTime", internalClock.instant().toEpochMilli())
+                .toJavaMap(),
             emptyMap(),
             internalClock);
     providerCache.putCacheData(ON_DEMAND.getNs(), cacheData);

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgentTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgentTest.java
@@ -147,7 +147,8 @@ class CloudFoundryCachingAgentTest {
         new DefaultCacheData(
             Keys.getServerGroupKey(accountName, serverGroupName, region),
             (int) TimeUnit.MINUTES.toSeconds(10),
-            io.vavr.collection.HashMap.<String, Object>of("cacheTime", Date.from(now)).toJavaMap(),
+            io.vavr.collection.HashMap.<String, Object>of("cacheTime", now.toEpochMilli())
+                .toJavaMap(),
             emptyMap(),
             internalClock);
     Organizations mockOrganizations = mock(Organizations.class);


### PR DESCRIPTION
This will avoid exceptions this:
"Cannot compare java.lang.String with value '2019-05-22T03:51:57.222+0000' and java.lang.Long with value '1,558,496,930,016'"

That happen here:

https://github.com/spinnaker/orca/blob/fdc5f6a53affddc56051171accd97493fdc7b660/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy#L181

because cacheTime is expected to be a long.

![Screen Shot 2019-05-21 at 11 41 29 PM](https://user-images.githubusercontent.com/2743/58147894-2dc30a80-7c22-11e9-984f-c1ce981f944e.png)
