### PR TITLE
fix(artifacts): resolve version of artifacts

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/ArtifactCredentials.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.NotImplementedException;
 
 public interface ArtifactCredentials {
@@ -30,6 +31,14 @@ public interface ArtifactCredentials {
   List<String> getTypes();
 
   InputStream download(Artifact artifact) throws IOException;
+
+  default Optional<String> resolveArtifactName(Artifact artifact) {
+    return Optional.ofNullable(artifact.getName());
+  }
+
+  default Optional<String> resolveArtifactVersion(Artifact artifact) {
+    return Optional.ofNullable(artifact.getVersion());
+  }
 
   @JsonIgnore
   default List<String> getArtifactNames() {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
@@ -122,6 +122,23 @@ public class MavenArtifactCredentials implements ArtifactCredentials {
     }
   }
 
+  public Optional<String> resolveArtifactName(Artifact artifact) {
+    try {
+      final DefaultArtifact aetherArtifact = new DefaultArtifact(artifact.getReference());
+      return Optional.of(aetherArtifact.getGroupId() + ":" + aetherArtifact.getArtifactId());
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  public Optional<String> resolveArtifactVersion(Artifact artifact) {
+    try {
+      return resolveVersion(new DefaultArtifact(artifact.getReference()));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
   private Optional<String> resolveVersion(org.eclipse.aether.artifact.Artifact artifact) {
     try {
       String metadataPath = metadataUri(artifact).getPath();

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -185,14 +185,20 @@ public class DeployCloudFoundryServerGroupAtomicOperation
     final Artifact applicationArtifact = description.getApplicationArtifact();
     if (applicationArtifact != null
         && MavenArtifactCredentials.TYPES.contains(applicationArtifact.getType())) {
-      if (applicationArtifact.getVersion() != null) {
-        environmentVars.put(
-            ServerGroupMetaDataEnvVar.ArtifactName.envVarName, applicationArtifact.getName());
-        environmentVars.put(
-            ServerGroupMetaDataEnvVar.ArtifactVersion.envVarName, applicationArtifact.getVersion());
-        environmentVars.put(
-            ServerGroupMetaDataEnvVar.ArtifactUrl.envVarName, applicationArtifact.getLocation());
-      }
+      description
+          .getArtifactCredentials()
+          .resolveArtifactName(applicationArtifact)
+          .map(
+              resolvedName ->
+                  environmentVars.put(
+                      ServerGroupMetaDataEnvVar.ArtifactName.envVarName, resolvedName));
+      description
+          .getArtifactCredentials()
+          .resolveArtifactVersion(applicationArtifact)
+          .map(
+              resolvedVersion ->
+                  environmentVars.put(
+                      ServerGroupMetaDataEnvVar.ArtifactVersion.envVarName, resolvedVersion));
       final Map<String, Object> metadata = applicationArtifact.getMetadata();
       if (metadata != null) {
         final Map<String, String> buildInfo =


### PR DESCRIPTION
Sometimes Artifacts don’t have the version populated. For example, a default Maven artifact in a pipeline may have a reference with a ‘latest.release’ suffix. This allows us a way to look up the actual version used. Name is often unpopulated along with version.
This also finds specific snapshot versions.
Artifact Url was purposefully left out of the CF server group env vars because we don’t actually have enough information to construct it and put it in artifact.location upstream.
