### PR TITLE
fix(titus): handle additional task states

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/TaskState.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/TaskState.java
@@ -59,11 +59,18 @@ public enum TaskState {
         case "normal":
           return TaskState.FINISHED;
         case "killed":
+        case "scaledDown":
+        case "stuckInState":
           return TaskState.STOPPED;
         case "crashed":
         case "lost":
           return TaskState.CRASHED;
         case "failed":
+        case "invalidRequest":
+        case "runtimeLimitExceeded":
+        case "transientSystemError":
+        case "localSystemError":
+        case "unknownSystemError":
           return TaskState.FAILED;
         default:
           return TaskState.FINISHED;


### PR DESCRIPTION
These are reason codes that can happen, and we should not consider a job that ends with them successful.