### PR TITLE
fix(titus): Return job constraints with serverGroup details

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
@@ -71,6 +71,8 @@ public class Job {
   private String jobState;
   private ServiceJobProcesses serviceJobProcesses;
 
+  private SubmitJobRequest.Constraints constraints;
+
   public Job() {}
 
   public Job(
@@ -146,6 +148,17 @@ public class Job {
     iamProfile = grpcJob.getJobDescriptor().getContainer().getSecurityProfile().getIamRole();
     allocateIpAddress = true;
     submittedAt = new Date(grpcJob.getStatus().getTimestamp());
+    constraints = new SubmitJobRequest.Constraints();
+    if (grpcJob.getJobDescriptor().getContainer().getHardConstraints().getConstraintsMap()
+        != null) {
+      constraints.setHard(
+          grpcJob.getJobDescriptor().getContainer().getHardConstraints().getConstraintsMap());
+    }
+    if (grpcJob.getJobDescriptor().getContainer().getSoftConstraints().getConstraintsMap()
+        != null) {
+      constraints.setSoft(
+          grpcJob.getJobDescriptor().getContainer().getSoftConstraints().getConstraintsMap());
+    }
     softConstraints = new ArrayList<String>();
     softConstraints.addAll(
         grpcJob
@@ -570,5 +583,13 @@ public class Job {
 
   public void setServiceJobProcesses(ServiceJobProcesses serviceJobProcesses) {
     this.serviceJobProcesses = serviceJobProcesses;
+  }
+
+  public SubmitJobRequest.Constraints getConstraints() {
+    return constraints;
+  }
+
+  public void setConstraints(SubmitJobRequest.Constraints constraints) {
+    this.constraints = constraints;
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
@@ -149,15 +149,15 @@ public class Job {
     allocateIpAddress = true;
     submittedAt = new Date(grpcJob.getStatus().getTimestamp());
     constraints = new SubmitJobRequest.Constraints();
-    if (grpcJob.getJobDescriptor().getContainer().getHardConstraints().getConstraintsMap()
-        != null) {
-      constraints.setHard(
-          grpcJob.getJobDescriptor().getContainer().getHardConstraints().getConstraintsMap());
+    Map hardConstraintsMap =
+        grpcJob.getJobDescriptor().getContainer().getHardConstraints().getConstraintsMap();
+    if (hardConstraintsMap != null) {
+      constraints.setHard(hardConstraintsMap);
     }
-    if (grpcJob.getJobDescriptor().getContainer().getSoftConstraints().getConstraintsMap()
-        != null) {
-      constraints.setSoft(
-          grpcJob.getJobDescriptor().getContainer().getSoftConstraints().getConstraintsMap());
+    Map softConstraintsMap =
+        grpcJob.getJobDescriptor().getContainer().getSoftConstraints().getConstraintsMap();
+    if (softConstraintsMap != null) {
+      constraints.setSoft(softConstraintsMap);
     }
     softConstraints = new ArrayList<String>();
     softConstraints.addAll(

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.titus.client.model.Efs
 import com.netflix.spinnaker.clouddriver.titus.client.model.Job
 import com.netflix.spinnaker.clouddriver.titus.client.model.MigrationPolicy
 import com.netflix.spinnaker.clouddriver.titus.client.model.ServiceJobProcesses
+import com.netflix.spinnaker.clouddriver.titus.client.model.SubmitJobRequest
 
 /**
  * Equivalent of a Titus {@link com.netflix.spinnaker.clouddriver.titus.client.model.Job}
@@ -65,6 +66,7 @@ class TitusServerGroup implements ServerGroup, Serializable {
   Map buildInfo
   MigrationPolicy migrationPolicy
   ServiceJobProcesses serviceJobProcesses
+  SubmitJobRequest.Constraints constraints
 
   TitusServerGroup() {}
 
@@ -111,6 +113,7 @@ class TitusServerGroup implements ServerGroup, Serializable {
       ]
     ]
     serviceJobProcesses = job.serviceJobProcesses
+    constraints = job.constraints
   }
 
   @Override


### PR DESCRIPTION
- follow up to #3690, return `constraints` map as part for `TitusServerGroup` to keep it consistent.