### PR TITLE
fix(gce): fix waiting on regional operations from the new MIG compute wrapper

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/RegionalOperation.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/RegionalOperation.java
@@ -26,7 +26,7 @@ class RegionalOperation implements WaitableComputeOperation {
     return poller.waitForRegionalOperation(
         credentials.getCompute(),
         credentials.getProject(),
-        operation.getRegion(),
+        GCEUtil.getLocalName(operation.getRegion()),
         operation.getName(),
         /* timeoutSeconds= */ null,
         task,


### PR DESCRIPTION
I tested this locally with a ZonalOperation and fixed it there. I'm not
sure why it didn't occur to me to also make the same fix in
RegionalOperation.