### PR TITLE
fix(cf): CloudFoundryCredentials#getRegions NPE on using an uninitialized field

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
@@ -88,7 +88,7 @@ public class CloudFoundryCredentials implements AccountCredentials<CloudFoundryC
 
   public Collection<Map<String, String>> getRegions() {
     try {
-      return credentials.getSpaces().all().stream()
+      return getCredentials().getSpaces().all().stream()
           .map(space -> singletonMap("name", space.getRegion()))
           .collect(toList());
     } catch (CloudFoundryApiException e) {


### PR DESCRIPTION
A previous refactor moved the field initialization in the getter to make it lazy but `getRegions()` wasn't using the getter.