### PR TITLE
fix(kubernetes): Properly handle empty kubectl input stream

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Cred
 import io.kubernetes.client.models.V1DeleteOptions;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -718,7 +719,12 @@ public class KubectlJobExecutor {
     return (BufferedReader r) -> {
       try (JsonReader reader = new JsonReader(r)) {
         List<KubernetesManifest> manifestList = new ArrayList<>();
-        reader.beginObject();
+        try {
+          reader.beginObject();
+        } catch (EOFException e) {
+          // If the stream we're parsing is empty, just return an empty list
+          return manifestList;
+        }
         while (reader.hasNext()) {
           if (reader.nextName().equals("items")) {
             reader.beginArray();


### PR DESCRIPTION
If kubectl throws an error, it will generaly return a nonzero status, an empty stdout, and the error in stderr. The streaming manifest parsing logic fails when the output stream is empty, so we're propagating the error parsing the empty input stream instead of the actual error message.

If the output of kubectl is empty, just return an empty list of manifests. The calling code will the properly look at the return code and stderr to determine whether the call succeeded and what message to show the user.