### PR TITLE
perf(kubernetes): Reduce memory allocation during caching cycles

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -97,10 +97,7 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
             .collect(Collectors.toList());
 
     List<CacheData> invertedRelationships =
-        cacheData.stream()
-            .map(KubernetesCacheDataConverter::invertRelationships)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
+        KubernetesCacheDataConverter.invertRelationships(cacheData);
 
     cacheData.addAll(invertedRelationships);
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -183,11 +183,7 @@ public abstract class KubernetesV2CachingAgent
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
-    List<CacheData> invertedRelationships =
-        resourceData.stream()
-            .map(KubernetesCacheDataConverter::invertRelationships)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
+    resourceData.addAll(KubernetesCacheDataConverter.invertRelationships(resourceData));
 
     resourceData.addAll(
         resources.values().stream()
@@ -196,13 +192,8 @@ public abstract class KubernetesV2CachingAgent
             .filter(Objects::nonNull)
             .collect(Collectors.toList()));
 
-    resourceData.addAll(invertedRelationships);
-
     resourceData.addAll(
-        resourceData.stream()
-            .map(rs -> KubernetesCacheDataConverter.getClusterRelationships(accountName, rs))
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList()));
+        KubernetesCacheDataConverter.getClusterRelationships(accountName, resourceData));
 
     Map<String, Collection<CacheData>> entries =
         KubernetesCacheDataConverter.stratifyCacheDataByGroup(

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -123,13 +123,13 @@ metadata:
     def cacheData = new DefaultCacheData(id, null, relationships)
 
     when:
-    def result = KubernetesCacheDataConverter.invertRelationships(cacheData)
+    def result = KubernetesCacheDataConverter.invertRelationships([cacheData])
 
     then:
     relationships.every {
       group, keys -> keys.every {
         key -> result.find {
-          data -> data.id == key && data.relationships.get(kind.toString()) == [id]
+          data -> data.id == key && data.relationships.get(kind.toString()) == [id] as Set
         } != null
       }
     }
@@ -159,13 +159,14 @@ metadata:
     def cacheData = new DefaultCacheData(id, attributes, [:])
 
     when:
-    def result = KubernetesCacheDataConverter.getClusterRelationships(account, cacheData)
+    def result = KubernetesCacheDataConverter.getClusterRelationships(account, [cacheData])
 
     then:
-    result.id == Keys.application(application)
-    result.relationships.clusters == [
+    result.size() == 1
+    result[0].id == Keys.application(application)
+    result[0].relationships.clusters == [
         Keys.cluster(account, application, cluster)
-    ]
+    ] as Set
 
     where:
     kind                       | cluster


### PR DESCRIPTION
* test(kubernetes): Add tests to getClusterRelationships 

  Also simplify the logic in the invertRelationships test

* perf(kubernetes): Reduce memory allocation during caching cycles 

  The caching logic for the kubernetes v2 provider allocates a lot of short-term memory during each caching cycle, putting pressure on the garbage collector, in some cases exceeding the garbage collection overhead.

  A significant contributor is the logic to compute relationships between kubernetes objects. We currently create a CacheData object to hold each relationship and rely on downstream (and inefficient) logic to merge these into one CacheData per object, containing all of its relationships.

  Improve this by having invertRelationships return one CacheData per object (containing all of its relationships) rather than on CacheData per relationship. Likewise, have getClusterRelationships return a single CacheData for each application, rather than a separate one for each
 application-object relationship.
