### PR TITLE
feat(cf): Cloudfoundry API endpoint server certificate now validated by default

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryClientUtils.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryClientUtils.java
@@ -43,6 +43,8 @@ final class CloudFoundryClientUtils {
       return Optional.of(r.call());
     } catch (RetrofitError retrofitError) {
       if (retrofitError.getResponse() != null && retrofitError.getResponse().getStatus() == 404) {
+        // FIXME: The oauthInterceptor could use a misconfigured endpoint and return 404 and
+        //        this code would mask the issue.
         return Optional.empty();
       } else {
         ErrorDescription errorDescription =

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/config/CloudFoundryConfigurationProperties.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/config/CloudFoundryConfigurationProperties.java
@@ -59,5 +59,6 @@ public class CloudFoundryConfigurationProperties implements DisposableBean {
     private String user;
     private String password;
     private String environment;
+    private boolean skipSslValidation;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizer.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizer.java
@@ -84,7 +84,8 @@ public class CloudFoundryCredentialsSynchronizer implements CredentialsInitializ
                   managedAccount.getApi(),
                   managedAccount.getUser(),
                   managedAccount.getPassword(),
-                  managedAccount.getEnvironment());
+                  managedAccount.getEnvironment(),
+                  managedAccount.isSkipSslValidation());
 
           AccountCredentials existingCredentials =
               accountCredentialsRepository.getOne(credentials.getName());

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
@@ -64,7 +64,8 @@ class ApplicationsTest {
             "some-metrics-uri",
             "api.run.pivotal.io",
             "baduser",
-            "badpassword");
+            "badpassword",
+            false);
 
     assertThatThrownBy(() -> client.getApplications().all())
         .isInstanceOf(CloudFoundryApiException.class);

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClientTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClientTest.java
@@ -53,7 +53,7 @@ class HttpCloudFoundryClientTest {
 
     HttpCloudFoundryClient cloudFoundryClient =
         new HttpCloudFoundryClient(
-            "account", "appsManUri", "metricsUri", "host", "user", "password");
+            "account", "appsManUri", "metricsUri", "host", "user", "password", false);
     Response response = cloudFoundryClient.createRetryInterceptor(chain);
 
     try {
@@ -82,7 +82,7 @@ class HttpCloudFoundryClientTest {
 
     HttpCloudFoundryClient cloudFoundryClient =
         new HttpCloudFoundryClient(
-            "account", "appsManUri", "metricsUri", "host", "user", "password");
+            "account", "appsManUri", "metricsUri", "host", "user", "password", false);
     Response response = cloudFoundryClient.createRetryInterceptor(chain);
 
     try {
@@ -111,7 +111,7 @@ class HttpCloudFoundryClientTest {
 
     HttpCloudFoundryClient cloudFoundryClient =
         new HttpCloudFoundryClient(
-            "account", "appsManUri", "metricsUri", "host", "user", "password");
+            "account", "appsManUri", "metricsUri", "host", "user", "password", false);
     Response response = cloudFoundryClient.createRetryInterceptor(chain);
 
     try {

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractLoadBalancersAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractLoadBalancersAtomicOperationConverterTest.java
@@ -85,7 +85,7 @@ class AbstractLoadBalancersAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("test", "", "", "", "", "", "") {
+      new CloudFoundryCredentials("test", "", "", "", "", "", "", false) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/CreateCloudFoundryServiceKeyAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/CreateCloudFoundryServiceKeyAtomicOperationConverterTest.java
@@ -52,7 +52,7 @@ class CreateCloudFoundryServiceKeyAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("my-account", "", "", "", "", "", "") {
+      new CloudFoundryCredentials("my-account", "", "", "", "", "", "", false) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceKeyAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceKeyAtomicOperationConverterTest.java
@@ -57,7 +57,7 @@ class DeleteCloudFoundryServiceKeyAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("my-account", "", "", "", "", "", "") {
+      new CloudFoundryCredentials("my-account", "", "", "", "", "", "", false) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -70,7 +70,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                       .build()));
     }
 
-    return new CloudFoundryCredentials(name, "", "", "", "", "", "") {
+    return new CloudFoundryCredentials(name, "", "", "", "", "", "", false) {
       public CloudFoundryClient getClient() {
         return cloudFoundryClient;
       }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
@@ -72,7 +72,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("test", "", "", "", "", "", "") {
+      new CloudFoundryCredentials("test", "", "", "", "", "", "", false) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -60,7 +60,7 @@ class ScaleCloudFoundryServerGroupAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("test", "", "", "", "", "", "") {
+      new CloudFoundryCredentials("test", "", "", "", "", "", "", false) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizerTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizerTest.java
@@ -115,7 +115,7 @@ class CloudFoundryCredentialsSynchronizerTest {
 
   private CloudFoundryCredentials createCredentials(String name) {
     return new CloudFoundryCredentials(
-        name, null, null, "api." + name, "user-" + name, "pwd-" + name, null);
+        name, null, null, "api." + name, "user-" + name, "pwd-" + name, null, false);
   }
 
   private void loadProviderFromRepository() {


### PR DESCRIPTION
The HTTPS endpoint for a CloudFoundry account's apiHost field now has its server certificate validated by default.

BREAKING CHANGE: The previous default behaviour used to be skipping the certificate validation. The change might break environments where the certificate or the certificate of its issuers are not in the JVM's trust store.
Skipping the certificate validation for CloudFoundry accounts can be enabled with this `hal` command: `hal config provider cloudfoundry account edit ACCOUNT_NAME --skip-ssl-validation=true`