### PR TITLE
fix(kubernetes): Allow namespaces that don't exist in validation

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -65,7 +65,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final Clock clock;
   private final KubectlJobExecutor jobExecutor;
 
-  @Getter private final String accountName;
+  private final String accountName;
   @Getter private final List<String> namespaces;
   @Getter private final List<String> omitNamespaces;
   private final List<KubernetesKind> kinds;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
@@ -139,13 +139,17 @@ public class KubernetesValidationUtil {
   }
 
   protected boolean validateNamespace(String namespace, KubernetesV2Credentials credentials) {
-    final List<String> configuredNamespaces = credentials.getDeclaredNamespaces();
-    if (!configuredNamespaces.contains(namespace)) {
-      reject(
-          String.format(
-              "Account %s is not configured to deploy to namespace %s",
-              credentials.getAccountName(), namespace),
-          namespace);
+    final List<String> configuredNamespaces = credentials.getNamespaces();
+    if (configuredNamespaces != null
+        && !configuredNamespaces.isEmpty()
+        && !configuredNamespaces.contains(namespace)) {
+      reject("wrongNamespace", namespace);
+      return false;
+    }
+
+    final List<String> omitNamespaces = credentials.getOmitNamespaces();
+    if (omitNamespaces != null && omitNamespaces.contains(namespace)) {
+      reject("omittedNamespace", namespace);
       return false;
     }
     return true;


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4482

In 1.14, we tried to improve the failure mode for users with misconfigured accounts by using the actual live list of namespaces while validating accounts.

This fails when users are creating a namespace and deploying something to the namespace as part of the same operation; in that case the live list does not know about the namespace (but will by the time the deployment completes).

This reverts spinnaker/clouddriver#3639 (and adds a comment and test to make sure this subtle bug is not re-introduced).