### PR TITLE
fix(provider/azure): The cache data of firewall hasn't been removed after deleting firewall successfully

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
@@ -134,6 +134,7 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
         return buildCacheResult(providerCache, null, 0, updatedSecurityGroup, null)
       } else {
         evictedSecurityGroup = new AzureSecurityGroupDescription(
+          id: securityGroupName,
           name: securityGroupName,
           region: region,
           appName: AzureUtilities.getAppNameFromAzureResourceName(securityGroupName),


### PR DESCRIPTION
Background:
Currently, the cache data of firewall hasn't been removed after deleting firewall successfully so that user still can see the firewall in UI.
Fix:
After investigated, it seems that the id isn't specified in eviction list so that the firewall can not be found in cache.