### PR TITLE
feat(ecs): DRAFT: Add support for 'command' field and volume/mounts on ECS

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/description/CreateServerGroupDescription.java
@@ -16,8 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.deploy.description;
 
+import com.amazonaws.services.ecs.model.MountPoint;
 import com.amazonaws.services.ecs.model.PlacementConstraint;
 import com.amazonaws.services.ecs.model.PlacementStrategy;
+import com.amazonaws.services.ecs.model.Volume;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +43,8 @@ public class CreateServerGroupDescription extends AbstractECSDescription {
   Map<String, String> environmentVariables;
   Map<String, String> tags;
 
+  List<String> command;
+
   String dockerImageAddress;
   String dockerImageCredentialsSecret;
 
@@ -57,6 +61,9 @@ public class CreateServerGroupDescription extends AbstractECSDescription {
   String subnetType;
   Boolean associatePublicIpAddress;
   Integer healthCheckGracePeriodSeconds;
+
+  List<Volume> volumes;
+  List<MountPoint> mountPoints;
 
   String launchType;
   String platformVersion;

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -156,7 +156,13 @@ public class CreateServerGroupAtomicOperation
             .withEnvironment(containerEnvironment)
             .withCpu(description.getComputeUnits())
             .withMemoryReservation(description.getReservedMemory())
-            .withImage(description.getDockerImageAddress());
+            .withImage(description.getDockerImageAddress())
+            .withMountPoints(description.getMountPoints());
+
+    final Collection<String> containerCommand = description.getCommand();
+    if (containerCommand != null) {
+      containerDefinition.setCommand(containerCommand);
+    }
 
     Collection<PortMapping> portMappings = new LinkedList<>();
 
@@ -238,7 +244,8 @@ public class CreateServerGroupAtomicOperation
     RegisterTaskDefinitionRequest request =
         new RegisterTaskDefinitionRequest()
             .withContainerDefinitions(containerDefinitions)
-            .withFamily(EcsServerGroupNameResolver.getEcsFamilyName(newServerGroupName));
+            .withFamily(EcsServerGroupNameResolver.getEcsFamilyName(newServerGroupName))
+            .withVolumes(description.getVolumes());
     if (description.getNetworkMode() != null && !description.getNetworkMode().equals("default")) {
       request.withNetworkMode(description.getNetworkMode());
     }


### PR DESCRIPTION
Support specifying 'command', 'volume', and 'mountPoints' in an ECS deployment definition.

Does not yet have tests (these will be forthcoming).  PR to track work.

A bit of weirdness: Due to the fact that ECS is currently limited to a single container, 'volumes' goes to the task definition and 'mountPoints' goes to the container definition.