### PR TITLE
Revert "chore(clouddriver/oracle): Get the Oracle API jar from Maven."

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -2,6 +2,63 @@ test {
   useJUnitPlatform()
 }
 
+class DownloadTask extends DefaultTask {
+  @Input
+  String sourceUrl
+
+  @OutputFile
+  File target
+
+  @TaskAction
+  void download() {
+    ant.get(src: sourceUrl, dest: target)
+  }
+}
+
+final File sdkDownloadLocation = project.file('build/sdkdownload')
+final File sdkLocation = project.file('build/oci-java-sdk')
+
+// Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile/runtime deps
+// https://github.com/oracle/oci-java-sdk/issues/25
+task fetchSdk(type: DownloadTask) {
+  sourceUrl = 'https://github.com/oracle/oci-java-sdk/releases/download/v1.3.2/oci-java-sdk.zip'
+  target = sdkDownloadLocation
+}
+
+task unpackSdk(type: Sync) {
+  dependsOn('fetchSdk')
+  from zipTree(tasks.fetchSdk.target)
+  into sdkLocation
+  include "**/*.jar"
+  exclude "**/*-sources.jar"
+  exclude "**/*-javadoc.jar"
+  exclude "apidocs/**"
+  exclude "examples/**"
+
+  // Scary but works. I think clouddriver deps in general need cleaning at some point
+  // Even without the oracle bmc sdk 3rd party deps there's still multiple javax.inject and commons-X JARs
+  exclude "**/*jackson*.jar"
+  exclude "**/*jersey*.jar"
+  exclude "**/hk2*.jar"
+  exclude "**/*guava*.jar"
+  exclude "**/commons*.jar"
+  exclude "**/aopalliance*.jar"
+  exclude "**/javassist*.jar"
+  exclude "**/slf*.jar"
+  exclude "**/osgi*.jar"
+  exclude "**/validation*.jar"
+  exclude "**/jsr305*.jar"
+  exclude "**/json-smart*.jar"
+  exclude "**/oci-java-sdk-full-shaded-*.jar"
+}
+
+task cleanSdk(type: Delete) {
+  delete sdkLocation, sdkDownloadLocation
+}
+
+tasks.clean.dependsOn('cleanSdk')
+tasks.compileJava.dependsOn('unpackSdk')
+
 dependencies {
   implementation project(":clouddriver-core")
 
@@ -16,7 +73,6 @@ dependencies {
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
-  implementation "com.oracle.oci.sdk:oci-java-sdk-core:1.5.2"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.sun.jersey:jersey-client:1.9.1"
   implementation "org.apache.commons:commons-compress:1.14"
@@ -27,6 +83,8 @@ dependencies {
   implementation "org.eclipse.aether:aether-impl:1.1.0"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
+
+  implementation fileTree(sdkLocation)
 
   testImplementation "com.github.tomakehurst:wiremock:latest.release"
   testImplementation "org.assertj:assertj-core"

--- a/clouddriver-oracle/clouddriver-oracle.gradle
+++ b/clouddriver-oracle/clouddriver-oracle.gradle
@@ -1,7 +1,67 @@
+
+class DownloadTask extends DefaultTask {
+  @Input
+  String sourceUrl
+
+  @OutputFile
+  File target
+
+  @TaskAction
+  void download() {
+    ant.get(src: sourceUrl, dest: target)
+  }
+}
+
+final File sdkDownloadLocation = project.file('build/sdkdownload')
+final File sdkLocation = project.file('build/oci-java-sdk')
+
+// Oracle BMCS SDK isn't published to any maven repo (yet!), so we manually download, unpack and add to compile/runtime deps
+// https://github.com/oracle/oci-java-sdk/issues/25
+task fetchSdk(type: DownloadTask) {
+  sourceUrl = 'https://github.com/oracle/oci-java-sdk/releases/download/v1.3.2/oci-java-sdk.zip'
+  target = sdkDownloadLocation
+}
+
+task unpackSdk(type: Sync) {
+  dependsOn('fetchSdk')
+  from zipTree(tasks.fetchSdk.target)
+  into sdkLocation
+  include "**/*.jar"
+  exclude "**/*-sources.jar"
+  exclude "**/*-javadoc.jar"
+  exclude "apidocs/**"
+  exclude "examples/**"
+
+  // Scary but works. I think clouddriver deps in general need cleaning at some point
+  // Even without the oracle bmc sdk 3rd party deps there's still multiple javax.inject and commons-X JARs
+  exclude "**/*jackson*.jar"
+  exclude "**/*jersey*.jar"
+  exclude "**/hk2*.jar"
+  exclude "**/*guava*.jar"
+  exclude "**/commons*.jar"
+  exclude "**/aopalliance*.jar"
+  exclude "**/javassist*.jar"
+  exclude "**/slf*.jar"
+  exclude "**/osgi*.jar"
+  exclude "**/validation*.jar"
+  exclude "**/jsr305*.jar"
+  exclude "**/json-smart*.jar"
+  exclude "**/oci-java-sdk-full-shaded-*.jar"
+}
+
+task cleanSdk(type: Delete) {
+  delete sdkLocation, sdkDownloadLocation
+}
+
+tasks.clean.dependsOn('cleanSdk')
+tasks.compileJava.dependsOn('unpackSdk')
+
 dependencies {
   implementation project(":clouddriver-core")
   implementation project(":cats:cats-core")
   implementation project(":clouddriver-security")
+
+  implementation fileTree(sdkLocation)
 
   compileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"
@@ -13,10 +73,6 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.moniker:moniker"
-  implementation "com.oracle.oci.sdk:oci-java-sdk-core:1.5.2"
-  implementation "com.oracle.oci.sdk:oci-java-sdk-identity:1.5.2"
-  implementation "com.oracle.oci.sdk:oci-java-sdk-loadbalancer:1.5.2"
-  implementation "com.oracle.oci.sdk:oci-java-sdk-objectstorage:1.5.2"
   implementation "org.codehaus.groovy:groovy-all"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'spinnaker.application'
 
+if (gradle.includedCloudProviderProjects.contains(':clouddriver-oracle')) {
+  tasks.startScripts.dependsOn(':clouddriver-oracle:unpackSdk')
+  tasks.startScripts.mustRunAfter(':clouddriver-oracle:unpackSdk')
+}
+
 ext {
   springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/")
 }


### PR DESCRIPTION
Reverts spinnaker/clouddriver#3695

https://github.com/spinnaker/spinnaker/issues/4488
https://github.com/spinnaker/spinnaker/issues/4484

This will get Clouddriver as it exists today back to a working runtime state (albeit a painful dev / build experience thanks to Oracle). The @spinnaker/toc will add to the agenda to more clearly define what it takes to:

1. Requirements for adding a new core cloud provider.
2. Requirements for continued core cloud provider support.
3. Process for removal of cloud providers.

It's my opinion that Oracle should be responsible for maintaining their cloud provider and if they're unable to do so, their cloud provider should be deprecated and removed.

cc @andrewbackes @plumpy @shihchang @guoyongzhang