### PR TITLE
fix(kubernetes): Improve error message on kubectl failure

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
@@ -87,8 +87,13 @@ public class JobExecutorLocal implements JobExecutor {
     DefaultExecuteResultHandler resultHandler = new DefaultExecuteResultHandler();
     executor.execute(jobRequest.getCommandLine(), jobRequest.getEnvironment(), resultHandler);
 
-    T result =
-        consumer.consume(new BufferedReader(new InputStreamReader(new PipedInputStream(stdOut))));
+    T result;
+    try {
+      result =
+          consumer.consume(new BufferedReader(new InputStreamReader(new PipedInputStream(stdOut))));
+    } catch (IOException e) {
+      return JobResult.<T>builder().result(JobResult.Result.FAILURE).error(e.toString()).build();
+    }
 
     try {
       resultHandler.waitFor();


### PR DESCRIPTION
If a call to kubectl fails to parse the output, we'll return a parsing failure directly to the user. Instead, return a
failed job with the error message and let the caller handle the exception as it would any other failed job.