### PR TITLE
fix(ecs): Handle container instances no longer being cached

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -241,6 +241,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
 
     for (LoadBalancer loadBalancer : loadBalancers) {
       if (loadBalancer.getTargetGroupArn() == null
+          || containerInstance == null
           || containerInstance.getEc2InstanceId() == null) {
         continue;
       }

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
@@ -169,6 +169,29 @@ class TaskHealthCachingAgentSpec extends Specification {
     taskHealth.getTaskId() == CommonCachingAgent.TASK_ID_1
   }
 
+  def 'should skip tasks with a non-cached container instance'() {
+    given:
+    ObjectMapper mapper = new ObjectMapper()
+    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(new NetworkBinding().withHostPort(1337)), Map.class)
+    def taskAttributes = [
+      taskId              : CommonCachingAgent.TASK_ID_1,
+      taskArn             : CommonCachingAgent.TASK_ARN_1,
+      startedAt           : new Date().getTime(),
+      containerInstanceArn: CommonCachingAgent.CONTAINER_INSTANCE_ARN_2,
+      group               : 'service:' + CommonCachingAgent.SERVICE_NAME_1,
+      containers          : Collections.singletonList(containerMap)
+    ]
+    def taskKey = Keys.getTaskKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_ID_1)
+    def taskCacheData = new DefaultCacheData(taskKey, taskAttributes, Collections.emptyMap())
+    providerCache.getAll(TASKS.toString(), _) >> Collections.singletonList(taskCacheData)
+
+    when:
+    def taskHealthList = agent.getItems(ecs, providerCache)
+
+    then:
+    taskHealthList == []
+  }
+
   def 'should get a list of task health for aws-vpc mode'() {
     given:
     ObjectMapper mapper = new ObjectMapper()


### PR DESCRIPTION
Handle container instances no longer being cached, but showing up in stopped ECS tasks in the account.  This seems to happen when there is a high rate of change among container instances, for example when using a Spot fleet.

This can be cherry-picked into 1.14.

Fixes spinnaker/spinnaker#4466