### PR TITLE
fix(cf): capture build info for a manual trigger

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -263,8 +263,12 @@ public class DeployCloudFoundryServerGroupAtomicOperation
       final Map<String, Object> trigger = description.getTrigger();
       if (trigger != null) {
         final String triggerType = (String) trigger.get("type");
-        if (triggerType.equals("jenkins")) {
-          buildInfo = (Map<String, Object>) trigger.get("buildInfo");
+        if (triggerType.equals("jenkins") || triggerType.equals("manual")) {
+          final Map<String, Object> triggerBuildInfo =
+              (Map<String, Object>) trigger.get("buildInfo");
+          if (triggerBuildInfo != null) {
+            buildInfo = triggerBuildInfo;
+          }
         }
       }
     }


### PR DESCRIPTION
The Jenkins buildInfo is also populated on a manual trigger of a pipeline with a Jenkins trigger. We should use it.