### PR TITLE
fix(edda): Better error message on edda lookup failures

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/EddaException.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/EddaException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.security.sdkclient;
+
+class EddaException extends Exception {
+  EddaException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
Previously, when edda lookup for a loadbalancer/target group would fail we would get
a useless stack trace with `UndeclaredThrowableException` at the top. This exception
would show up in deck causing lots of user confusion (and fail execution).
When in fact, such errors are often benign (we already ignore similar failures of direct AWS lookups)

This change plumbs through the 404 from edda so that it can be dealt with appropriately
(all other failure remain unchanged and re-throw the exception)
