### PR TITLE
fix(ecs): If in "host" network mode, host and container port should b…

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -52,6 +52,7 @@ public class CreateServerGroupAtomicOperation
 
   private static final String NECESSARY_TRUSTED_SERVICE = "ecs-tasks.amazonaws.com";
   protected static final String AWSVPC_NETWORK_MODE = "awsvpc";
+  protected static final String HOST_NETWORK_MODE = "host";
   protected static final String FARGATE_LAUNCH_TYPE = "FARGATE";
   protected static final String NO_IAM_ROLE = "None (No IAM role)";
   protected static final String NO_IMAGE_CREDENTIALS = "None (No registry credentials)";
@@ -166,7 +167,8 @@ public class CreateServerGroupAtomicOperation
               .withProtocol(
                   description.getPortProtocol() != null ? description.getPortProtocol() : "tcp");
 
-      if (AWSVPC_NETWORK_MODE.equals(description.getNetworkMode())) {
+      if (AWSVPC_NETWORK_MODE.equals(description.getNetworkMode())
+          || HOST_NETWORK_MODE.equals(description.getNetworkMode())) {
         portMapping
             .withHostPort(description.getContainerPort())
             .withContainerPort(description.getContainerPort());

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -541,4 +541,21 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     environments.get("ENVIRONMENT_1") == "test1"
     environments.get("ENVIRONMENT_2") == "test2"
   }
+
+  def 'should use same port for host and container in host mode'() {
+    given:
+    def description = Mock(CreateServerGroupDescription)
+    description.getContainerPort() >> 10000
+    description.getNetworkMode() >> 'host'
+    def operation = new CreateServerGroupAtomicOperation(description)
+
+    when:
+    def request = operation.makeTaskDefinitionRequest('arn:aws:iam::test:test-role', 'mygreatapp-stack1-details2-v0011')
+
+    then:
+    def portMapping = request.getContainerDefinitions().get(0).getPortMappings().get(0)
+    portMapping.getHostPort() == 10000
+    portMapping.getContainerPort() == 10000
+    portMapping.getProtocol() == 'tcp'
+  }
 }


### PR DESCRIPTION
…e the same

When creating a task definition with the host network mode and specifying a containerPort, the containerPort should be used for both the host and container port.

Can be cherry-picked into 1.14.