### PR TITLE
fix(ecs): Fix incorrect de-duping of clusters

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsServerClusterProvider.java
@@ -175,7 +175,8 @@ public class EcsServerClusterProvider implements ClusterProvider<EcsServerCluste
         boolean found = false;
 
         for (EcsServerCluster cluster : clusterMap.get(applicationName)) {
-          if (cluster.getName().equals(escClusterName)) {
+          if (cluster.getName().equals(escClusterName)
+              && cluster.getAccountName().equals(credentials.getName())) {
             cluster.getServerGroups().add(ecsServerGroup);
             found = true;
             break;


### PR DESCRIPTION
Fix incorrect de-duping of clusters with same name, but different accounts

Fixes spinnaker/spinnaker#4448

Can be cherry-picked into 1.14