### PR TITLE
fix(jobcontroller): better error message if property file not found on job

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/JobController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/JobController.groovy
@@ -71,14 +71,20 @@ class JobController {
   @ApiOperation(value = "Collect a file from a job", notes = "Collects the file result of a job.")
   @RequestMapping(value = "/{account}/{location}/{id}/{fileName:.+}", method = RequestMethod.GET)
   Map<String, Object> getFileContents(
-                       @ApiParam(value = "Application name", required = true) @PathVariable String application,
-                       @ApiParam(value = "Account job was created by", required = true) @PathVariable String account,
-                       @ApiParam(value = "Namespace, region, or zone job is running in", required = true) @PathVariable String location,
-                       @ApiParam(value = "Unique identifier of job being looked up", required = true) @PathVariable String id,
-                       @ApiParam(value = "File name to look up", required = true) @PathVariable String fileName
+    @ApiParam(value = "Application name", required = true) @PathVariable String application,
+    @ApiParam(value = "Account job was created by", required = true) @PathVariable String account,
+    @ApiParam(value = "Namespace, region, or zone job is running in", required = true) @PathVariable String location,
+    @ApiParam(value = "Unique identifier of job being looked up", required = true) @PathVariable String id,
+    @ApiParam(value = "File name to look up", required = true) @PathVariable String fileName
   ) {
-    jobProviders.findResults {
+    Collection<Map<String, Object>> results = jobProviders.findResults {
       it.getFileContents(account, location, id, fileName)
-    }.first()
+    }
+
+    if (!results.isEmpty()) {
+      return results.first()
+    }
+
+    return Collections.emptyMap()
   }
 }


### PR DESCRIPTION
When we fail to find the props file specified for a titus task we get a cryptic
error message "cannot access first() element of empty list"
Propagate the actual error when the properties file can't be found
