### PR TITLE
feat(kubernetes): Add support for excluding event loading on manifest…

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ManifestProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ManifestProvider.java
@@ -25,19 +25,8 @@ public interface ManifestProvider<T extends Manifest> {
     SIZE
   }
 
-  T getManifest(String account, String location, String name);
-
   T getManifest(String account, String location, String name, boolean includeEvents);
 
   List<T> getClusterAndSortAscending(
       String account, String location, String kind, String app, String cluster, Sort sort);
-
-  List<T> getClusterAndSortAscending(
-      String account,
-      String location,
-      String kind,
-      String app,
-      String cluster,
-      Sort sort,
-      boolean includeEvents);
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ManifestProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ManifestProvider.java
@@ -27,6 +27,17 @@ public interface ManifestProvider<T extends Manifest> {
 
   T getManifest(String account, String location, String name);
 
+  T getManifest(String account, String location, String name, boolean includeEvents);
+
   List<T> getClusterAndSortAscending(
       String account, String location, String kind, String app, String cluster, Sort sort);
+
+  List<T> getClusterAndSortAscending(
+      String account,
+      String location,
+      String kind,
+      String app,
+      String cluster,
+      Sort sort,
+      boolean includeEvents);
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopManifestProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopManifestProvider.java
@@ -21,11 +21,6 @@ import java.util.List;
 
 public class NoopManifestProvider implements ManifestProvider<Manifest> {
   @Override
-  public Manifest getManifest(String account, String location, String name) {
-    return null;
-  }
-
-  @Override
   public Manifest getManifest(String account, String location, String name, boolean includeEvents) {
     return null;
   }
@@ -33,18 +28,6 @@ public class NoopManifestProvider implements ManifestProvider<Manifest> {
   @Override
   public List<Manifest> getClusterAndSortAscending(
       String account, String location, String kind, String app, String cluster, Sort sort) {
-    return null;
-  }
-
-  @Override
-  public List<Manifest> getClusterAndSortAscending(
-      String account,
-      String location,
-      String kind,
-      String app,
-      String cluster,
-      Sort sort,
-      boolean includeEvents) {
     return null;
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopManifestProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/NoopManifestProvider.java
@@ -26,8 +26,25 @@ public class NoopManifestProvider implements ManifestProvider<Manifest> {
   }
 
   @Override
+  public Manifest getManifest(String account, String location, String name, boolean includeEvents) {
+    return null;
+  }
+
+  @Override
   public List<Manifest> getClusterAndSortAscending(
       String account, String location, String kind, String app, String cluster, Sort sort) {
+    return null;
+  }
+
+  @Override
+  public List<Manifest> getClusterAndSortAscending(
+      String account,
+      String location,
+      String kind,
+      String app,
+      String cluster,
+      Sort sort,
+      boolean includeEvents) {
     return null;
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -49,6 +49,12 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
 
   @Override
   public KubernetesV2Manifest getManifest(String account, String location, String name) {
+    return getManifest(account, location, name, true);
+  }
+
+  @Override
+  public KubernetesV2Manifest getManifest(
+      String account, String location, String name, boolean includeEvents) {
     if (!isAccountRelevant(account)) {
       return null;
     }
@@ -84,7 +90,10 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
     String namespace = manifest.getNamespace();
     KubernetesKind kind = manifest.getKind();
 
-    List<KubernetesManifest> events = credentials.eventsFor(kind, namespace, parsedName.getRight());
+    List<KubernetesManifest> events =
+        !includeEvents
+            ? Collections.emptyList()
+            : credentials.eventsFor(kind, namespace, parsedName.getRight());
 
     List<KubernetesPodMetric.ContainerMetric> metrics = Collections.emptyList();
     if (kind == KubernetesKind.POD && credentials.isMetrics()) {
@@ -101,6 +110,18 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
   @Override
   public List<KubernetesV2Manifest> getClusterAndSortAscending(
       String account, String location, String kind, String app, String cluster, Sort sort) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<KubernetesV2Manifest> getClusterAndSortAscending(
+      String account,
+      String location,
+      String kind,
+      String app,
+      String cluster,
+      Sort sort,
+      boolean includeEvents) {
     return Collections.emptyList();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -48,11 +48,6 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
   }
 
   @Override
-  public KubernetesV2Manifest getManifest(String account, String location, String name) {
-    return getManifest(account, location, name, true);
-  }
-
-  @Override
   public KubernetesV2Manifest getManifest(
       String account, String location, String name, boolean includeEvents) {
     if (!isAccountRelevant(account)) {
@@ -91,9 +86,9 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
     KubernetesKind kind = manifest.getKind();
 
     List<KubernetesManifest> events =
-        !includeEvents
-            ? Collections.emptyList()
-            : credentials.eventsFor(kind, namespace, parsedName.getRight());
+        includeEvents
+            ? credentials.eventsFor(kind, namespace, parsedName.getRight())
+            : Collections.emptyList();
 
     List<KubernetesPodMetric.ContainerMetric> metrics = Collections.emptyList();
     if (kind == KubernetesKind.POD && credentials.isMetrics()) {
@@ -110,18 +105,6 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
   @Override
   public List<KubernetesV2Manifest> getClusterAndSortAscending(
       String account, String location, String kind, String app, String cluster, Sort sort) {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public List<KubernetesV2Manifest> getClusterAndSortAscending(
-      String account,
-      String location,
-      String kind,
-      String app,
-      String cluster,
-      Sort sort,
-      boolean includeEvents) {
     return Collections.emptyList();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
@@ -106,7 +106,7 @@ public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatu
   private V1Job getKubernetesJob(String account, String location, String id) {
     List<Manifest> manifests =
         manifestProviderList.stream()
-            .map(p -> p.getManifest(account, location, id))
+            .map(p -> p.getManifest(account, location, id, false))
             .filter(m -> m != null)
             .collect(Collectors.toList());
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ManifestController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ManifestController.java
@@ -33,6 +33,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -52,15 +53,24 @@ public class ManifestController {
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
   @PostAuthorize("hasPermission(returnObject?.moniker?.app, 'APPLICATION', 'READ')")
   @RequestMapping(value = "/{account:.+}/_/{name:.+}", method = RequestMethod.GET)
-  Manifest getForAccountAndName(@PathVariable String account, @PathVariable String name) {
-    return getForAccountLocationAndName(account, "", name);
+  Manifest getForAccountAndName(
+      @PathVariable String account,
+      @PathVariable String name,
+      @RequestParam(value = "includeEvents", required = false, defaultValue = "true")
+          boolean includeEvents) {
+    return getForAccountLocationAndName(account, "", name, includeEvents);
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
   @PostAuthorize("hasPermission(returnObject?.moniker?.app, 'APPLICATION', 'READ')")
   @RequestMapping(value = "/{account:.+}/{location:.+}/{name:.+}", method = RequestMethod.GET)
   Manifest getForAccountLocationAndName(
-      @PathVariable String account, @PathVariable String location, @PathVariable String name) {
+      @PathVariable String account,
+      @PathVariable String location,
+      @PathVariable String name,
+      @RequestParam(value = "includeEvents", required = false, defaultValue = "true")
+          boolean includeEvents) {
+
     List<Manifest> manifests =
         manifestProviders.stream()
             .map(
@@ -89,8 +99,12 @@ public class ManifestController {
   }
 
   @RequestMapping(value = "/{account:.+}/{name:.+}", method = RequestMethod.GET)
-  Manifest getForAccountLocationAndName(@PathVariable String account, @PathVariable String name) {
-    return getForAccountLocationAndName(account, "", name);
+  Manifest getForAccountLocationAndName(
+      @PathVariable String account,
+      @PathVariable String name,
+      @RequestParam(value = "includeEvents", required = false, defaultValue = "true")
+          boolean includeEvents) {
+    return getForAccountLocationAndName(account, "", name, includeEvents);
   }
 
   @RequestMapping(
@@ -103,7 +117,9 @@ public class ManifestController {
       @PathVariable String kind,
       @PathVariable String app,
       @PathVariable String cluster,
-      @PathVariable Criteria criteria) {
+      @PathVariable Criteria criteria,
+      @RequestParam(value = "includeEvents", required = false, defaultValue = "true")
+          boolean includeEvents) {
     final String request =
         String.format(
             "(account: %s, location: %s, kind: %s, app %s, cluster: %s, criteria: %s)",
@@ -118,7 +134,13 @@ public class ManifestController {
                             account,
                             () ->
                                 p.getClusterAndSortAscending(
-                                    account, location, kind, app, cluster, criteria.getSort()));
+                                    account,
+                                    location,
+                                    kind,
+                                    app,
+                                    cluster,
+                                    criteria.getSort(),
+                                    includeEvents));
                   } catch (Throwable t) {
                     log.warn("Failed to read {}", request, t);
                     return null;

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ManifestController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ManifestController.java
@@ -77,7 +77,8 @@ public class ManifestController {
                 provider -> {
                   try {
                     return requestQueue.execute(
-                        account, () -> provider.getManifest(account, location, name));
+                        account,
+                        () -> provider.getManifest(account, location, name, includeEvents));
                   } catch (Throwable t) {
                     log.warn("Failed to read manifest ", t);
                     return null;
@@ -117,9 +118,7 @@ public class ManifestController {
       @PathVariable String kind,
       @PathVariable String app,
       @PathVariable String cluster,
-      @PathVariable Criteria criteria,
-      @RequestParam(value = "includeEvents", required = false, defaultValue = "true")
-          boolean includeEvents) {
+      @PathVariable Criteria criteria) {
     final String request =
         String.format(
             "(account: %s, location: %s, kind: %s, app %s, cluster: %s, criteria: %s)",
@@ -134,13 +133,7 @@ public class ManifestController {
                             account,
                             () ->
                                 p.getClusterAndSortAscending(
-                                    account,
-                                    location,
-                                    kind,
-                                    app,
-                                    cluster,
-                                    criteria.getSort(),
-                                    includeEvents));
+                                    account, location, kind, app, cluster, criteria.getSort()));
                   } catch (Throwable t) {
                     log.warn("Failed to read {}", request, t);
                     return null;


### PR DESCRIPTION
…s retrieval

This change allows optionally skipping kubernetes event retrieval when retrieving manifests. 

When live manifest mode is enabled, scenarios that result in a lot of manifests being loaded will put a lot of extra pressure on the kubernetes API server due to event loading. 

Specifically, we ran into this scenario when we had a lot of deployment pipelines running concurrently, and each deployment involved a decent number of manifests (~30). In Orca, the WaitForManifestStableTask (when live manifest mode is enabled) iterates through the manifests involved in the deployment and calls the retrieve manifest API for each one, which causes a lot of full event loads to occur, which tanks (in our case) the kubernetes API server. However, WaitForManifestStableTask does not actually need any event information to do its job, so in that particular case we can skip loading events entirely.

See https://github.com/spinnaker/orca/pull/2997 for the corresponding Orca change.