### PR TITLE
fix(deps): bump fabric8 to 4.1.1

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.moniker:moniker"
-  implementation "io.fabric8:kubernetes-client:4.0.0"
+  implementation "io.fabric8:kubernetes-client:4.1.1"
   implementation "io.kubernetes:client-java:1.0.0-beta1"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"


### PR DESCRIPTION
- Upgrades fabric8 to 4.1.1 for the same reasons detailed on [this PR](https://github.com/spinnaker/halyard/pull/1350).
- The fabric8 upgrade has some breaking changes for the HPA API, so we need to address these before cutting 1.15 so we don't break the Kubernetes V1 provider.