### PR TITLE
fix(kubernetes): update fabric HPA model in v1 provider

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
@@ -92,6 +92,8 @@ import io.fabric8.kubernetes.api.model.HorizontalPodAutoscalerFluentImpl
 import io.fabric8.kubernetes.api.model.HostPathVolumeSourceBuilder
 import io.fabric8.kubernetes.api.model.IntOrString
 import io.fabric8.kubernetes.api.model.KeyToPath
+import io.fabric8.kubernetes.api.model.MetricSpec
+import io.fabric8.kubernetes.api.model.MetricSpecBuilder
 import io.fabric8.kubernetes.api.model.NFSVolumeSourceBuilder
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder
 import io.fabric8.kubernetes.api.model.PodTemplateSpec
@@ -818,7 +820,7 @@ class KubernetesApiConverter {
     description.capacity = new Capacity(min: autoscaler.spec.minReplicas,
                                         max: autoscaler.spec.maxReplicas,
                                         desired: description.targetSize)
-    def cpuUtilization = new KubernetesCpuUtilization(target: autoscaler.spec.targetCPUUtilizationPercentage)
+    def cpuUtilization = new KubernetesCpuUtilization(target: autoscaler.spec.metrics?.find { metric -> metric.resource.name == "cpu" }?.resource?.targetAverageUtilization)
     description.scalingPolicy = new KubernetesScalingPolicy(cpuUtilization: cpuUtilization)
   }
 
@@ -834,7 +836,13 @@ class KubernetesApiConverter {
       .withNewSpec()
       .withMinReplicas(description.capacity.min)
       .withMaxReplicas(description.capacity.max)
-      .withTargetCPUUtilizationPercentage(description.scalingPolicy.cpuUtilization.target)
+      .addToMetrics(new MetricSpecBuilder()
+        .withType("Resource")
+        .withNewResource()
+        .withName("cpu")
+        .withTargetAverageUtilization(description.scalingPolicy.cpuUtilization.target)
+        .endResource()
+        .build())
       .withNewScaleTargetRef()
       .withKind(resourceKind)
       .withName(resourceName)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/autoscaler/UpsertKubernetesAutoscalerAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/autoscaler/UpsertKubernetesAutoscalerAtomicOperation.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.exception.Kubernet
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import io.fabric8.kubernetes.api.model.DoneableHorizontalPodAutoscaler
 import io.fabric8.kubernetes.api.model.HorizontalPodAutoscalerBuilder
+import io.fabric8.kubernetes.api.model.MetricSpecBuilder
 
 class UpsertKubernetesAutoscalerAtomicOperation implements AtomicOperation<Void> {
   KubernetesAutoscalerDescription description
@@ -81,7 +82,7 @@ class UpsertKubernetesAutoscalerAtomicOperation implements AtomicOperation<Void>
       description.scalingPolicy.cpuUtilization = description.scalingPolicy.cpuUtilization ?: new KubernetesCpuUtilization()
       description.scalingPolicy.cpuUtilization.target = description.scalingPolicy.cpuUtilization.target != null ?
         description.scalingPolicy.cpuUtilization.target :
-        autoscaler.spec.targetCPUUtilizationPercentage
+        autoscaler.spec.metrics?.find { metric -> metric.resource.name == "cpu" }?.resource?.targetAverageUtilization
 
       ((DoneableHorizontalPodAutoscaler) KubernetesApiConverter.toAutoscaler(
         credentials.apiAdaptor.editAutoscaler(namespace, name), description, name, kind, version


### PR DESCRIPTION
- [This fabric8 commit](https://github.com/fabric8io/kubernetes-client/pull/1288/files) updated the Kubernetes HPA version from v1 to v2beta1, which includes a breaking change in the CPU Utilization model detailed in the docs [here](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/): `Notice that the targetCPUUtilizationPercentage field has been replaced with an array called metrics`.