### PR TITLE
fix(kubernetes): fix breaking api changes in kubernetes java client l…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy
@@ -211,11 +211,11 @@ class DeployKubernetesAtomicOperation implements AtomicOperation<DeploymentResul
         }
       } else {
         task.updateStatus BASE_PHASE, "Deployed stateful set ${controllerName}"
-        controllerSet = credentials.clientApiAdaptor.createStatfulSet(namespace, controllerSet)
+        controllerSet = credentials.clientApiAdaptor.createStatefulSet(namespace, controllerSet)
       }
     } else {
       task.updateStatus BASE_PHASE, "Deployed stateful set ${controllerName}"
-      controllerSet = credentials.clientApiAdaptor.createStatfulSet(namespace, controllerSet)
+      controllerSet = credentials.clientApiAdaptor.createStatefulSet(namespace, controllerSet)
     }
 
     if (description.scalingPolicy) {


### PR DESCRIPTION
…ibrary

- [This PR](https://github.com/spinnaker/clouddriver/pull/3784) upgraded our kubernetes client library from `1.0.0-beta1` to `5.0.0`, resulting in nearly every method signature requiring adjustment in our `KubernetesClientApiAdapter`.
- Also corrected spelling of `createStatefulSet` method and removed unused constants while I was in these files.