### PR TITLE
fix(appengine): Properly account for GCS object version in deploy

### DIFF
--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
@@ -97,8 +97,12 @@ public class GcsStorageService {
     storage_ = storage;
   }
 
-  public InputStream openObjectStream(String bucketName, String path) throws IOException {
+  public InputStream openObjectStream(String bucketName, String path, Long generation)
+      throws IOException {
     Storage.Objects.Get get = storage_.objects().get(bucketName, path);
+    if (generation != null) {
+      get.setGeneration(generation);
+    }
     return get.executeMediaAsInputStream();
   }
 
@@ -143,7 +147,7 @@ public class GcsStorageService {
 
   public void downloadStorageObjectRelative(
       StorageObject obj, String ignorePrefix, String baseDirectory) throws IOException {
-    InputStream stream = openObjectStream(obj.getBucket(), obj.getName());
+    InputStream stream = openObjectStream(obj.getBucket(), obj.getName(), obj.getGeneration());
     String objPath = obj.getName();
     if (!ignorePrefix.isEmpty()) {
       ignorePrefix += File.separator;


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4530

The appengine deploy stage does not account for the fact that GCS objects can have a version (such as gs://bucket/file.tar#123). Currently sending a file such as the preceding breaks as the provider doesn't recognize it as a tar file (and also includes 123 as part of the file name rather than as an object generation).

Fix this so that the version is parsed out of the file path and is properly sent to the GCS API.