### PR TITLE
fix(provider/openstack): Make the openstack provider compatible wit hthe latest openstack releases.

### DIFF
--- a/clouddriver-openstack/clouddriver-openstack.gradle
+++ b/clouddriver-openstack/clouddriver-openstack.gradle
@@ -15,7 +15,7 @@
  */
 
 ext {
-  openstack4jVersion = '3.1.0'
+  openstack4jVersion = '3.2.0'
   commonsNetVersion = '3.5'
   commonsIOVersion = '1.3.2'
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackLoadBalancerProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackLoadBalancerProvider.groovy
@@ -18,12 +18,12 @@ package com.netflix.spinnaker.clouddriver.openstack.client
 
 import com.netflix.spinnaker.clouddriver.openstack.domain.HealthMonitor
 import org.openstack4j.model.common.ActionResponse
-import org.openstack4j.model.network.ext.HealthMonitorV2
-import org.openstack4j.model.network.ext.LbPoolV2
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2StatusTree
-import org.openstack4j.model.network.ext.MemberV2
+import org.openstack4j.model.octavia.HealthMonitorV2
+import org.openstack4j.model.octavia.LbPoolV2
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
+import org.openstack4j.model.octavia.LoadBalancerV2StatusTree
+import org.openstack4j.model.octavia.MemberV2
 
 /**
  * Operations associated to load balancer and relevant building blocks.

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackLoadBalancerV2Provider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackLoadBalancerV2Provider.groovy
@@ -23,17 +23,17 @@ import com.netflix.spinnaker.clouddriver.openstack.domain.LoadBalancerResolver
 import org.apache.commons.lang.StringUtils
 import org.openstack4j.api.Builders
 import org.openstack4j.model.common.ActionResponse
-import org.openstack4j.model.network.ext.HealthMonitorType
-import org.openstack4j.model.network.ext.HealthMonitorV2
-import org.openstack4j.model.network.ext.LbMethod
-import org.openstack4j.model.network.ext.LbPoolV2
-import org.openstack4j.model.network.ext.ListenerProtocol
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2StatusTree
-import org.openstack4j.model.network.ext.MemberV2
-import org.openstack4j.model.network.ext.MemberV2Update
-import org.openstack4j.model.network.ext.Protocol
+import org.openstack4j.model.octavia.HealthMonitorType
+import org.openstack4j.model.octavia.HealthMonitorV2
+import org.openstack4j.model.octavia.LbMethod
+import org.openstack4j.model.octavia.LbPoolV2
+import org.openstack4j.model.octavia.ListenerProtocol
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
+import org.openstack4j.model.octavia.LoadBalancerV2StatusTree
+import org.openstack4j.model.octavia.MemberV2
+import org.openstack4j.model.octavia.MemberV2Update
+import org.openstack4j.model.octavia.Protocol
 
 class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, OpenstackRequestHandler, OpenstackIdentityAware, LoadBalancerResolver {
 
@@ -49,14 +49,14 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   List<? extends LoadBalancerV2> getLoadBalancers(final String region) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().loadbalancer().list()
+      getRegionClient(region).octavia().loadBalancerV2().list()
     }
   }
 
   @Override
   LoadBalancerV2 createLoadBalancer(final String region, final String name, final String description, final String subnetId) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().loadbalancer().create(Builders.loadbalancerV2()
+      getRegionClient(region).octavia().loadBalancerV2().create(Builders.octavia().loadBalancerV2()
         .name(name)
         .description(description)
         .subnetId(subnetId)
@@ -67,21 +67,21 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   LoadBalancerV2 getLoadBalancer(final String region, final String id) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().loadbalancer().get(id)
+      getRegionClient(region).octavia().loadBalancerV2().get(id)
     }
   }
 
   @Override
   ActionResponse deleteLoadBalancer(String region, String id) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().loadbalancer().delete(id)
+      getRegionClient(region).octavia().loadBalancerV2().delete(id)
     }
   }
 
   @Override
   LoadBalancerV2 getLoadBalancerByName(final String region, final String name) {
     handleRequest {
-      List<? extends LoadBalancerV2> lbs = getRegionClient(region).networking().lbaasV2().loadbalancer().list(['name':name])
+      List<? extends LoadBalancerV2> lbs = getRegionClient(region).octavia().loadBalancerV2().list(['name':name])
       lbs.size() > 0 ? lbs.first() : null
     }
   }
@@ -89,14 +89,14 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   List<? extends ListenerV2> getListeners(final String region) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().listener().list()
+      getRegionClient(region).octavia().listenerV2().list()
     }
   }
 
   @Override
   ListenerV2 createListener(final String region, final String name, final String externalProtocol, final Integer externalPort, final String description, final String loadBalancerId) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().listener().create(Builders.listenerV2()
+      getRegionClient(region).octavia().listenerV2().create(Builders.octavia().listenerV2()
         .name(name)
         .description(description)
         .loadBalancerId(loadBalancerId)
@@ -110,7 +110,7 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   ListenerV2 getListener(final String region, final String id) {
     ListenerV2 result = handleRequest {
-      getRegionClient(region).networking().lbaasV2().listener().get(id)
+      getRegionClient(region).octavia().listenerV2().get(id)
     }
 
     if (!result) {
@@ -122,21 +122,21 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   ActionResponse deleteListener(final String region, final String id) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().listener().delete(id)
+      getRegionClient(region).octavia().listenerV2().delete(id)
     }
   }
 
   @Override
   List<? extends LbPoolV2> getPools(final String region) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().lbPool().list()
+      getRegionClient(region).octavia().lbPoolV2().list()
     }
   }
 
   @Override
   LbPoolV2 createPool(final String region, final String name, final String internalProtocol, final String method, final String listenerId) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().lbPool().create(Builders.lbpoolV2()
+      getRegionClient(region).octavia().lbPoolV2().create(Builders.octavia().lbPoolV2()
         .name(name)
         .lbMethod(LbMethod.forValue(method))
         .listenerId(listenerId)
@@ -149,7 +149,7 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   LbPoolV2 getPool(final String region, final String id) {
     LbPoolV2 result = handleRequest {
-      getRegionClient(region).networking().lbaasV2().lbPool().get(id)
+      getRegionClient(region).octavia().lbPoolV2().get(id)
     }
 
     if (!result) {
@@ -161,7 +161,7 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   LbPoolV2 updatePool(final String region, final String id, final String method) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().lbPool().update(id, Builders.lbPoolV2Update()
+      getRegionClient(region).octavia().lbPoolV2().update(id, Builders.octavia().lbPoolV2Update()
         .lbMethod(LbMethod.forValue(method))
         .adminStateUp(Boolean.TRUE)
         .build())
@@ -171,35 +171,35 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   ActionResponse deletePool(final String region, final String id) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().lbPool().delete(id)
+      getRegionClient(region).octavia().lbPoolV2().delete(id)
     }
   }
 
   @Override
   List<? extends HealthMonitorV2> getHealthMonitors(final String region) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().healthMonitor().list()
+      getRegionClient(region).octavia().healthMonitorV2().list()
     }
   }
 
   @Override
   ActionResponse deleteMonitor(final String region, final String id) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().healthMonitor().delete(id)
+      getRegionClient(region).octavia().healthMonitorV2().delete(id)
     }
   }
 
   @Override
   HealthMonitorV2 getMonitor(final String region, final String id) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().healthMonitor().get(id)
+      getRegionClient(region).octavia().healthMonitorV2().get(id)
     }
   }
 
   @Override
   HealthMonitorV2 createMonitor(final String region, final String poolId, final HealthMonitor healthMonitor) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().healthMonitor().create(Builders.healthmonitorV2()
+      getRegionClient(region).octavia().healthMonitorV2().create(Builders.octavia().healthMonitorV2()
         .poolId(poolId)
         .type(HealthMonitorType.forValue(healthMonitor.type?.name()))
         .delay(healthMonitor.delay)
@@ -216,7 +216,7 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   HealthMonitorV2 updateMonitor(final String region, final String id, final HealthMonitor healthMonitor) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().healthMonitor().update(id, Builders.healthMonitorV2Update()
+      getRegionClient(region).octavia().healthMonitorV2().update(id, Builders.octavia().healthMonitorV2Update()
         .delay(healthMonitor.delay)
         .expectedCodes(healthMonitor.expectedCodes?.join(','))
         .httpMethod(healthMonitor.httpMethod)
@@ -243,7 +243,7 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   String getMemberIdForInstance(String region, String ip, String lbPoolId) {
     String memberId = handleRequest {
-      client.useRegion(region).networking().lbaasV2().lbPool().listMembers(lbPoolId)?.find { m -> m.address == ip }?.id
+      client.useRegion(region).octavia().lbPoolV2().listMembers(lbPoolId)?.find { m -> m.address == ip }?.id
     }
     if (StringUtils.isEmpty(memberId)) {
       throw new OpenstackProviderException("Instance with ip ${ip} is not associated with any load balancer memberships")
@@ -254,9 +254,9 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   MemberV2 addMemberToLoadBalancerPool(String region, String ip, String lbPoolId, String subnetId, Integer internalPort, int weight) {
     MemberV2 member = handleRequest {
-      client.useRegion(region).networking().lbaasV2().lbPool().createMember(
+      client.useRegion(region).octavia().lbPoolV2().createMember(
         lbPoolId,
-        Builders.memberV2().address(ip).subnetId(subnetId).protocolPort(internalPort).weight(weight).build()
+        Builders.octavia().memberV2().address(ip).subnetId(subnetId).protocolPort(internalPort).weight(weight).build()
       )
     }
     if (!member) {
@@ -268,22 +268,22 @@ class OpenstackLoadBalancerV2Provider implements OpenstackLoadBalancerProvider, 
   @Override
   ActionResponse removeMemberFromLoadBalancerPool(String region, String lbPoolId, String memberId) {
     handleRequest {
-      client.useRegion(region).networking().lbaasV2().lbPool().deleteMember(lbPoolId, memberId)
+      client.useRegion(region).octavia().lbPoolV2().deleteMember(lbPoolId, memberId)
     }
   }
 
   @Override
   LoadBalancerV2StatusTree getLoadBalancerStatusTree(final String region, final String id) {
     handleRequest {
-      getRegionClient(region).networking().lbaasV2().loadbalancer().statusTree(id)
+      getRegionClient(region).octavia().loadBalancerV2().statusTree(id)
     }
   }
 
   @Override
   MemberV2 updatePoolMemberStatus(final String region, final String poolId, final String memberId, final boolean status) {
     handleRequest {
-      MemberV2Update update = Builders.memberV2Update().adminStateUp(status).build()
-      getRegionClient(region).networking().lbaasV2().lbPool().updateMember(poolId, memberId, update)
+      MemberV2Update update = Builders.octavia().memberV2Update().adminStateUp(status).build()
+      getRegionClient(region).octavia().lbPoolV2().updateMember(poolId, memberId, update)
     }
   }
 }

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationV1Provider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationV1Provider.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.openstack.client
 
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.ServerGroupParameters
-import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
 import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.servergroup.ServerGroupConstants
 import org.openstack4j.api.Builders
 import org.openstack4j.model.heat.Resource

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/MemberData.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/MemberData.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergro
 import groovy.transform.Canonical
 
 /**
- * This is used to represent an OS::Neutron::LBaaS::PoolMember resource. These resources
+ * This is used to represent an OS::Octavia::PoolMember resource. These resources
  * are dynamically added to the heat template servergroup_resource_member.yaml.
  */
 @Canonical

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/StackPoolMemberAware.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/StackPoolMemberAware.groovy
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.clouddriver.openstack.deploy.ops
 import com.netflix.spinnaker.clouddriver.openstack.deploy.description.servergroup.MemberData
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
 
 trait StackPoolMemberAware {
 
@@ -77,7 +77,7 @@ trait StackPoolMemberAware {
     Map<String, Object> resources = memberData.collectEntries {
       [
         ("member-$it.loadBalancerName-$it.listenerShortId-$it.externalPort-$it.internalPort".toString()): [
-          type      : "OS::Neutron::LBaaS::PoolMember",
+          type      : "OS::Octavia::PoolMember",
           properties: [
             address      : [get_param: "address"],
             pool         : it.poolId,

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/AbstractRegistrationOpenstackInstancesAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/AbstractRegistrationOpenstackInstancesAtomicOperation.groovy
@@ -26,8 +26,8 @@ import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackPro
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.loadbalancer.LoadBalancerChecker
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
 
 /**
  * Base class that will handle both load balancer registration and deregistration.

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/AbstractOpenstackLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/AbstractOpenstackLoadBalancerAtomicOperation.groovy
@@ -27,10 +27,10 @@ import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
 import com.netflix.spinnaker.clouddriver.openstack.task.TaskStatusAware
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.openstack4j.model.heat.Stack
-import org.openstack4j.model.network.ext.LbPoolV2
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
-import org.openstack4j.openstack.networking.domain.ext.ListItem
+import org.openstack4j.model.octavia.LbPoolV2
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
+import org.openstack4j.openstack.octavia.domain.ListItem
 
 abstract class AbstractOpenstackLoadBalancerAtomicOperation implements TaskStatusAware, StackPoolMemberAware, LoadBalancerResolver {
 

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/DeleteOpenstackLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/DeleteOpenstackLoadBalancerAtomicOperation.groovy
@@ -24,8 +24,8 @@ import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.StackPoolMemberAwa
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import groovy.util.logging.Slf4j
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
 
 /**
  * Removes an openstack load balancer.

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/LoadBalancerChecker.java
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/LoadBalancerChecker.java
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.clouddriver.openstack.client.BlockingStatusChecker;
 import com.netflix.spinnaker.clouddriver.openstack.config.OpenstackConfigurationProperties.LbaasConfig;
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException;
 import org.openstack4j.model.common.ActionResponse;
-import org.openstack4j.model.network.ext.LbProvisioningStatus;
-import org.openstack4j.model.network.ext.LoadBalancerV2;
+import org.openstack4j.model.octavia.LbProvisioningStatus;
+import org.openstack4j.model.octavia.LoadBalancerV2;
 
 class LoadBalancerChecker implements BlockingStatusChecker.StatusChecker<LoadBalancerV2> {
   Operation operation;

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/UpsertOpenstackLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/UpsertOpenstackLoadBalancerAtomicOperation.groovy
@@ -32,10 +32,10 @@ import org.openstack4j.model.compute.FloatingIP
 import org.openstack4j.model.network.NetFloatingIP
 import org.openstack4j.model.network.Network
 import org.openstack4j.model.network.Port
-import org.openstack4j.model.network.ext.HealthMonitorV2
-import org.openstack4j.model.network.ext.LbPoolV2
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
+import org.openstack4j.model.octavia.HealthMonitorV2
+import org.openstack4j.model.octavia.LbPoolV2
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
 
 class UpsertOpenstackLoadBalancerAtomicOperation extends AbstractOpenstackLoadBalancerAtomicOperation implements AtomicOperation<Map>, TaskStatusAware {
   OpenstackLoadBalancerDescription description

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/AbstractEnableDisableOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/AbstractEnableDisableOpenstackAtomicOperation.groovy
@@ -30,7 +30,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import groovy.util.logging.Slf4j
 import org.openstack4j.model.compute.Server
 import org.openstack4j.model.heat.Stack
-import org.openstack4j.model.network.ext.LoadBalancerV2StatusTree
+import org.openstack4j.model.octavia.LoadBalancerV2StatusTree
 import retrofit.RetrofitError
 
 import java.util.concurrent.CompletableFuture

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackLoadBalancer.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackLoadBalancer.groovy
@@ -25,10 +25,10 @@ import com.netflix.spinnaker.clouddriver.openstack.OpenstackCloudProvider
 import com.netflix.spinnaker.clouddriver.openstack.domain.LoadBalancerResolver
 import com.netflix.spinnaker.moniker.Moniker
 import groovy.transform.Canonical
-import org.openstack4j.model.network.ext.HealthMonitorV2
-import org.openstack4j.model.network.ext.LbPoolV2
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
+import org.openstack4j.model.octavia.HealthMonitorV2
+import org.openstack4j.model.octavia.LbPoolV2
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
 
 @Canonical
 @JsonIgnoreProperties(['createdRegex', 'createdPattern'])

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackLoadBalancerHealth.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/model/OpenstackLoadBalancerHealth.groovy
@@ -31,7 +31,8 @@ class OpenstackLoadBalancerHealth {
   enum PlatformStatus {
     ONLINE,
     OFFLINE,
-    DISABLED
+    DISABLED,
+    ERROR
 
     HealthState toHealthState() {
       this == ONLINE ? HealthState.Up : HealthState.Down

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackLoadBalancerCachingAgent.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackLoadBalancerCachingAgent.groovy
@@ -36,14 +36,14 @@ import com.netflix.spinnaker.clouddriver.openstack.model.OpenstackLoadBalancerHe
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
 import groovy.util.logging.Slf4j
 import org.openstack4j.model.network.Port
-import org.openstack4j.model.network.ext.HealthMonitorV2
-import org.openstack4j.model.network.ext.LbPoolV2
-import org.openstack4j.model.network.ext.ListenerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2
-import org.openstack4j.model.network.ext.LoadBalancerV2StatusTree
-import org.openstack4j.model.network.ext.status.LbPoolV2Status
-import org.openstack4j.model.network.ext.status.ListenerV2Status
-import org.openstack4j.model.network.ext.status.MemberV2Status
+import org.openstack4j.model.octavia.HealthMonitorV2
+import org.openstack4j.model.octavia.LbPoolV2
+import org.openstack4j.model.octavia.ListenerV2
+import org.openstack4j.model.octavia.LoadBalancerV2
+import org.openstack4j.model.octavia.LoadBalancerV2StatusTree
+import org.openstack4j.model.octavia.status.LbPoolV2Status
+import org.openstack4j.model.octavia.status.ListenerV2Status
+import org.openstack4j.model.octavia.status.MemberV2Status
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgent.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackServerGroupCachingAgent.groovy
@@ -39,7 +39,7 @@ import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccoun
 import com.netflix.spinnaker.clouddriver.openstack.utils.DateUtils
 import groovy.util.logging.Slf4j
 import org.openstack4j.model.heat.Stack
-import org.openstack4j.model.network.ext.status.LoadBalancerV2Status
+import org.openstack4j.model.octavia.status.LoadBalancerV2Status
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future

--- a/clouddriver-openstack/src/main/resources/servergroup.yaml
+++ b/clouddriver-openstack/src/main/resources/servergroup.yaml
@@ -128,30 +128,40 @@ resources:
       cooldown: {get_param: scaledown_cooldown}
       scaling_adjustment: {get_param: scaledown_adjustment}
   meter_alarm_high:
-    type: OS::Ceilometer::Alarm
+    type: OS::Aodh::GnocchiAggregationByResourcesAlarm
     properties:
       description: Scale up if the average meter_name > scaleup_threshold for scaleup_period seconds
-      meter_name: {get_param: autoscaling_type}
-      statistic: avg
-      period: {get_param: scaleup_period}
+      metric: {get_param: autoscaling_type}
+      aggregation_method: mean
+      granularity: {get_param: scaleup_period}
       evaluation_periods: 1
+      resource_type: instance
       threshold: {get_param: scaleup_threshold}
       alarm_actions:
         - {get_attr: [web_server_scaleup_policy, alarm_url]}
-      matching_metadata: {'metadata.user_metadata.stack': {get_param: "OS::stack_id"}}
+      ## matching_metadata: {'metadata.user_metadata.stack': {get_param: "OS::stack_id"}}
+      query:
+        list_join:
+          - ''
+          - - {'=': {server_group: {get_param: "OS::stack_id"}}}
       comparison_operator: gt
   meter_alarm_low:
-    type: OS::Ceilometer::Alarm
+    type: OS::Aodh::GnocchiAggregationByResourcesAlarm
     properties:
       description: Scale up if the average meter_name < scaledown_threshold for scaledown_period seconds
-      meter_name: {get_param: autoscaling_type}
-      statistic: avg
-      period: {get_param: scaledown_period}
+      metric: {get_param: autoscaling_type}
+      aggregation_method: mean
+      granularity: {get_param: scaledown_period}
       evaluation_periods: 1
+      resource_type: instance
       threshold: {get_param: scaledown_threshold}
       alarm_actions:
         - {get_attr: [web_server_scaledown_policy, alarm_url]}
-      matching_metadata: {'metadata.user_metadata.stack': {get_param: "OS::stack_id"}}
+      ## matching_metadata: {'metadata.user_metadata.stack': {get_param: "OS::stack_id"}}
+      query:
+        list_join:
+          - ''
+          - - {'=': {server_group: {get_param: "OS::stack_id"}}}
       comparison_operator: lt
 outputs:
   OS::stack_id:

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/AbstractRegistrationOpenstackInstancesAtomicOperationUnitSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/instance/AbstractRegistrationOpenstackInstancesAtomicOperationUnitSpec.groovy
@@ -30,7 +30,7 @@ import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccoun
 import org.openstack4j.model.network.ext.LbProvisioningStatus
 import org.openstack4j.model.network.ext.ListenerV2
 import org.openstack4j.model.network.ext.LoadBalancerV2
-import org.openstack4j.openstack.networking.domain.ext.ListItem
+import org.openstack4j.openstack.octavia.domain.ListItem
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/AbstractOpenstackLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/AbstractOpenstackLoadBalancerAtomicOperationSpec.groovy
@@ -36,7 +36,7 @@ import org.openstack4j.model.network.ext.LbPoolV2
 import org.openstack4j.model.network.ext.LbProvisioningStatus
 import org.openstack4j.model.network.ext.ListenerV2
 import org.openstack4j.model.network.ext.LoadBalancerV2
-import org.openstack4j.openstack.networking.domain.ext.ListItem
+import org.openstack4j.openstack.octavia.domain.ListItem
 import spock.lang.Shared
 import spock.lang.Specification
 

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/UpsertOpenstackLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/loadbalancer/UpsertOpenstackLoadBalancerAtomicOperationSpec.groovy
@@ -46,7 +46,7 @@ import org.openstack4j.model.network.ext.LbPoolV2
 import org.openstack4j.model.network.ext.LbProvisioningStatus
 import org.openstack4j.model.network.ext.ListenerV2
 import org.openstack4j.model.network.ext.LoadBalancerV2
-import org.openstack4j.openstack.networking.domain.ext.ListItem
+import org.openstack4j.openstack.octavia.domain.ListItem
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperationSpec.groovy
@@ -35,7 +35,7 @@ import org.openstack4j.model.network.Subnet
 import org.openstack4j.model.network.ext.ListenerV2
 import org.openstack4j.model.network.ext.LoadBalancerV2
 import org.openstack4j.openstack.heat.domain.HeatStack
-import org.openstack4j.openstack.networking.domain.ext.ListItem
+import org.openstack4j.openstack.octavia.domain.ListItem
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -332,7 +332,7 @@ parameters:
     description: "Server address for autoscaling group resource"
 resources:
   member-mockpool-99-null-null:
-    type: "OS::Neutron::LBaaS::PoolMember"
+    type: "OS::Octavia::PoolMember"
     properties:
       address:
         get_param: "address"

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackLoadBalancerCachingAgentSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/provider/agent/OpenstackLoadBalancerCachingAgentSpec.groovy
@@ -46,7 +46,7 @@ import org.openstack4j.model.network.ext.status.LbPoolV2Status
 import org.openstack4j.model.network.ext.status.ListenerV2Status
 import org.openstack4j.model.network.ext.status.LoadBalancerV2Status
 import org.openstack4j.model.network.ext.status.MemberV2Status
-import org.openstack4j.openstack.networking.domain.ext.ListItem
+import org.openstack4j.openstack.octavia.domain.ListItem
 import spock.lang.Shared
 import spock.lang.Specification
 


### PR DESCRIPTION
The pull request includes the following changes:

- Upgrade to Openstack4j 3.2.0; this library allows to parse the description of some newer OpenStack objects, like the Octavia load balancers. The old library failed to deserialize their content.
- Replace the deprecated LoadBalance V2 interface of Neutron with the newer Octavia interface. The latest version of Openstack use Octavia directly, without having Neutron to intermediate the load balancer operations.
- Replace references to the deprecated ceilometer interface. The heat templates refer to Ceilometer that has been deprecated and removed; replaced with Gnocchi.

I know that the Openstack Clouddriver has been deprecated and removed from Spinnaker starting with version 1.14, but I would like to have fixed the 1.13 code, that still supports Openstack, and then evaluate if it is worth reintroduce support in 1.14.