### PR TITLE
feat(titus): Jenkins build information for Titus Server Group

### DIFF
--- a/clouddriver-titus/clouddriver-titus.gradle
+++ b/clouddriver-titus/clouddriver-titus.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-eureka")
   implementation project(":clouddriver-security")
+  implementation project(":clouddriver-docker")
 
   annotationProcessor "org.projectlombok:lombok"
   compileOnly "org.projectlombok:lombok"
@@ -52,6 +53,8 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.yaml:snakeyaml:1.24"
+  implementation "com.squareup.retrofit:retrofit"
+  implementation "com.squareup.retrofit:converter-jackson"
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "junit:junit"

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
@@ -670,7 +670,6 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent {
       attributes.put("region", region.getName());
       attributes.put("account", account.getName());
       attributes.put("targetGroups", data.targetGroupNames);
-
       Map<String, Collection<String>> relationships = serverGroupCache.getRelationships();
       relationships.computeIfAbsent(APPLICATIONS.ns, key -> new HashSet<>()).add(data.appNameKey);
       relationships.computeIfAbsent(CLUSTERS.ns, key -> new HashSet<>()).add(data.clusterKey);

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/TitusRegistryService.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/utils/TitusRegistryService.java
@@ -1,0 +1,28 @@
+package com.netflix.spinnaker.clouddriver.titus.caching.utils;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Data;
+import retrofit.http.GET;
+import retrofit.http.Path;
+
+public interface TitusRegistryService {
+
+  @GET("/v2/{applicationName}/manifests/{version}")
+  BuildInfo getBuildInformation(
+      @Path(value = "applicationName", encode = false) String applicationName,
+      @Path("version") String version);
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  class BuildInfo {
+    String schemaVersion;
+    List<v1> history;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class v1 {
+      String v1Compatibility;
+    }
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/config/TitusRegistryConfig.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/config/TitusRegistryConfig.java
@@ -1,0 +1,45 @@
+package com.netflix.spinnaker.config;
+
+import static retrofit.Endpoints.newFixedEndpoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DefaultDockerOkClientProvider;
+import com.netflix.spinnaker.clouddriver.titus.caching.utils.TitusRegistryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import retrofit.Endpoint;
+import retrofit.RequestInterceptor;
+import retrofit.RestAdapter;
+import retrofit.converter.JacksonConverter;
+
+@Configuration
+public class TitusRegistryConfig {
+
+  @Autowired RestAdapter.LogLevel retrofitLogLevel;
+
+  @Autowired RequestInterceptor spinnakerRequestInterceptor;
+
+  @Bean
+  Endpoint titusRegistryEndpoint(@Value("${titus.titusRegistryUrl}") String titusRegistryBaseUrl) {
+    return newFixedEndpoint(titusRegistryBaseUrl);
+  }
+
+  @Bean
+  TitusRegistryService titusRegistryService(
+      Endpoint titusRegistryEndpoint,
+      ObjectMapper mapper,
+      @Value("${titus.titusRegistryUrl}") String registryBaseUrl,
+      @Value("${ok-http-client.read-timeout-ms:59000}") int readTimeoutMs) {
+    return new RestAdapter.Builder()
+        .setRequestInterceptor(spinnakerRequestInterceptor)
+        .setEndpoint(titusRegistryEndpoint)
+        .setClient(
+            new DefaultDockerOkClientProvider().provide(registryBaseUrl, readTimeoutMs, true))
+        .setLogLevel(retrofitLogLevel)
+        .setConverter(new JacksonConverter(mapper))
+        .build()
+        .create(TitusRegistryService.class);
+  }
+}


### PR DESCRIPTION
- We don't display `jenkins` build information for Titus server group today , this change will fetch the details from the titus registry and append it to the server group response.
- Following similar pattern that is used in aws , joining the data during the read time in `TitusClusterProvider`.