### PR TITLE
fix(kubernetes): Fix a few other bugs from client library upgrade

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
@@ -124,7 +124,7 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
   }
 
   private static Rule fromPolicyPort(V1NetworkPolicyPort policyPort) {
-    String port = policyPort.getPort().getStrValue();
+    String port = policyPort.getPort().toString();
     return new PortRule()
         .setProtocol(policyPort.getProtocol())
         .setPortRanges(new TreeSet<>(Collections.singletonList(new StringPortRange(port))));


### PR DESCRIPTION
V1HTTPGetAction.getPort() now returns an IntOrString. This supports .toString() to always convert to a string, but does not support .toInt() so we need to handle parsing as an int if desired.

The logic to serialize an IntOrString needs to know that it should only dump either getString() or getInt() depending if it's a string or integer, which our ObjectMapper doesn't know about. The Yaml object that comes with the kubernetes API is configured to handle this, so just use that instead to handle serializing.