### PR TITLE
refactor(kubernetes): A few minor refactors and perf fixes

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -199,12 +199,7 @@ public class KubernetesCacheDataConverter {
     logMalformedManifest(() -> "Converting " + manifest + " to a cached resource", manifest);
 
     KubernetesKind kind = manifest.getKind();
-    boolean hasClusterRelationship = false;
-    boolean isNamespaced = true;
-    if (kind != null) {
-      hasClusterRelationship = kind.hasClusterRelationship();
-      isNamespaced = kind.isNamespaced();
-    }
+    boolean hasClusterRelationship = kind != null && kind.hasClusterRelationship();
 
     KubernetesApiVersion apiVersion = manifest.getApiVersion();
     String name = manifest.getName();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -274,7 +274,7 @@ public class KubernetesCacheDataConverter {
     return mapper.convertValue(o, KubernetesManifest.class);
   }
 
-  public static <T> T getResource(KubernetesManifest manifest, Class<T> clazz) {
+  public static <T> T getResource(Object manifest, Class<T> clazz) {
     // A little hacky, but the only way to deserialize any timestamps using string constructors
     return json.deserialize(json.serialize(manifest), clazz);
   }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Instance.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2Instance.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.HealthState;
 import com.netflix.spinnaker.clouddriver.model.Instance;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance;
-import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodStatus;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,8 +50,8 @@ public class KubernetesV2Instance extends ManifestBasedModel implements Instance
     this.manifest = manifest;
     this.key = (Keys.InfrastructureCacheKey) Keys.parseKey(key).get();
 
-    V1Pod pod = KubernetesCacheDataConverter.getResource(this.manifest, V1Pod.class);
-    V1PodStatus status = pod.getStatus();
+    V1PodStatus status =
+        KubernetesCacheDataConverter.getResource(this.manifest.getStatus(), V1PodStatus.class);
     if (status != null) {
       health.add(new KubernetesV2Health(status).toMap());
       if (status.getContainerStatuses() != null) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ClusterProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ClusterProvider.java
@@ -321,36 +321,55 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
     }
 
     List<KubernetesV2ServerGroup> serverGroups =
-        serverGroupData.stream()
-            .map(
-                cd ->
-                    cacheUtils.<KubernetesV2ServerGroup>resourceModelFromCacheData(
-                        KubernetesV2ServerGroupCacheData.builder()
-                            .serverGroupData(cd)
-                            .instanceData(
-                                instanceDataByServerGroup.getOrDefault(
-                                    cd.getId(), new ArrayList<>()))
-                            .loadBalancerData(
-                                loadBalancerDataByServerGroup.getOrDefault(
-                                    cd.getId(), new ArrayList<>()))
-                            .serverGroupManagerKeys(
-                                serverGroupToServerGroupManagerKeys.getOrDefault(
-                                    cd.getId(), new ArrayList<>()))
-                            .build()))
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+        getServerGroups(
+            serverGroupData,
+            instanceDataByServerGroup,
+            loadBalancerDataByServerGroup,
+            serverGroupToServerGroupManagerKeys);
 
     List<KubernetesV2LoadBalancer> loadBalancers =
-        loadBalancerData.stream()
-            .map(
-                cd ->
-                    KubernetesV2LoadBalancer.fromCacheData(
-                        cd,
-                        serverGroupDataByLoadBalancer.getOrDefault(cd.getId(), new ArrayList<>()),
-                        instanceDataByServerGroup))
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+        getLoadBalancers(
+            loadBalancerData, instanceDataByServerGroup, serverGroupDataByLoadBalancer);
 
     return new KubernetesV2Cluster(clusterDatum.getId(), serverGroups, loadBalancers);
+  }
+
+  private List<KubernetesV2ServerGroup> getServerGroups(
+      List<CacheData> serverGroupData,
+      Map<String, List<CacheData>> instanceDataByServerGroup,
+      Map<String, List<CacheData>> loadBalancerDataByServerGroup,
+      Map<String, List<InfrastructureCacheKey>> serverGroupToServerGroupManagerKeys) {
+    return serverGroupData.stream()
+        .map(
+            cd ->
+                cacheUtils.<KubernetesV2ServerGroup>resourceModelFromCacheData(
+                    KubernetesV2ServerGroupCacheData.builder()
+                        .serverGroupData(cd)
+                        .instanceData(
+                            instanceDataByServerGroup.getOrDefault(cd.getId(), new ArrayList<>()))
+                        .loadBalancerData(
+                            loadBalancerDataByServerGroup.getOrDefault(
+                                cd.getId(), new ArrayList<>()))
+                        .serverGroupManagerKeys(
+                            serverGroupToServerGroupManagerKeys.getOrDefault(
+                                cd.getId(), new ArrayList<>()))
+                        .build()))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  private List<KubernetesV2LoadBalancer> getLoadBalancers(
+      List<CacheData> loadBalancerData,
+      Map<String, List<CacheData>> instanceDataByServerGroup,
+      Map<String, List<CacheData>> serverGroupDataByLoadBalancer) {
+    return loadBalancerData.stream()
+        .map(
+            cd ->
+                KubernetesV2LoadBalancer.fromCacheData(
+                    cd,
+                    serverGroupDataByLoadBalancer.getOrDefault(cd.getId(), new ArrayList<>()),
+                    instanceDataByServerGroup))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
These are all small changes I had on local branches while I was doing performance profiling.  The refactor commits have no performance effect, but I made them while trying to split up the code into smaller pieces that I could understand better so I think they're worth commiting for that reason.

* perf(kubernetes): Reduce deserialization of kubernetes pods 

  We're currently deserializing the entire kubernetes pod object when we actually only need the status. Given that pods are very common objects, it's worth only deserializing the status to speed up the server groups endpoint.

* refactor(kubernetes): Remove unused variable isNamespaced 

* refactor(kubernetes): Pull some logic from translateClusters 

  The translateCluster function gets both server groups and load balancers; it would be more clear to have separate functions to do each of these.

* refactor(kubernetes): Remove translateCluster function 

  Now that translateCluster has been split into two smaller functions, remove it and call the two smaller ones.