### PR TITLE
feat(titusserviceJobProcesses): Support serviceJobProcesses for creat…

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
@@ -66,6 +66,7 @@ public class JobDescription {
   private DisruptionBudget disruptionBudget;
 
   private SubmitJobRequest.Constraints constraints;
+  private ServiceJobProcesses serviceJobProcesses;
 
   // Soft/Hard constraints
 
@@ -120,6 +121,7 @@ public class JobDescription {
 
     disruptionBudget = request.getDisruptionBudget();
     constraints = request.getContainerConstraints();
+    serviceJobProcesses = request.getServiceJobProcesses();
   }
 
   public String getName() {
@@ -405,6 +407,14 @@ public class JobDescription {
     this.disruptionBudget = disruptionBudget;
   }
 
+  public ServiceJobProcesses getServiceJobProcesses() {
+    return serviceJobProcesses;
+  }
+
+  public void setServiceJobProcesses(ServiceJobProcesses serviceJobProcesses) {
+    this.serviceJobProcesses = serviceJobProcesses;
+  }
+
   @JsonIgnore
   public SubmitJobRequest.Constraints getConstraints() {
     return constraints;
@@ -566,12 +576,20 @@ public class JobDescription {
                         .build())
                 .build();
       }
-
+      com.netflix.titus.grpc.protogen.ServiceJobSpec.ServiceJobProcesses.Builder
+          titusServiceJobProcesses = ServiceJobSpec.ServiceJobProcesses.newBuilder();
+      if (serviceJobProcesses != null) {
+        titusServiceJobProcesses
+            .setDisableDecreaseDesired(serviceJobProcesses.isDisableDecreaseDesired())
+            .setDisableIncreaseDesired(serviceJobProcesses.isDisableIncreaseDesired())
+            .build();
+      }
       jobDescriptorBuilder.setService(
           ServiceJobSpec.newBuilder()
               .setEnabled(inService)
               .setCapacity(jobCapacity)
               .setMigrationPolicy(serviceMigrationPolicy)
+              .setServiceJobProcesses(titusServiceJobProcesses)
               .setRetryPolicy(
                   RetryPolicy.newBuilder()
                       .setExponentialBackOff(

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/SubmitJobRequest.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/SubmitJobRequest.java
@@ -100,6 +100,7 @@ public class SubmitJobRequest {
   private DisruptionBudget disruptionBudget = null;
 
   private Constraints containerConstraints = null;
+  private ServiceJobProcesses serviceJobProcesses = null;
 
   public DisruptionBudget getDisruptionBudget() {
     return disruptionBudget;
@@ -285,6 +286,11 @@ public class SubmitJobRequest {
     return this;
   }
 
+  public SubmitJobRequest withServiceJobProcesses(ServiceJobProcesses serviceJobProcesses) {
+    this.serviceJobProcesses = serviceJobProcesses;
+    return this;
+  }
+
   // Getters
 
   public String getJobType() {
@@ -425,5 +431,9 @@ public class SubmitJobRequest {
 
   public Constraints getContainerConstraints() {
     return containerConstraints;
+  }
+
+  public ServiceJobProcesses getServiceJobProcesses() {
+    return serviceJobProcesses;
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
 import com.netflix.spinnaker.clouddriver.titus.client.model.DisruptionBudget
 import com.netflix.spinnaker.clouddriver.titus.client.model.Efs
 import com.netflix.spinnaker.clouddriver.titus.client.model.MigrationPolicy
+import com.netflix.spinnaker.clouddriver.titus.client.model.ServiceJobProcesses
 import com.netflix.spinnaker.clouddriver.titus.client.model.SubmitJobRequest
 import groovy.transform.Canonical
 
@@ -56,6 +57,7 @@ class TitusDeployDescription extends AbstractTitusCredentialsDescription impleme
   Boolean copySourceScalingPoliciesAndActions = true
   Integer sequence
   DisruptionBudget disruptionBudget
+  ServiceJobProcesses serviceJobProcesses
 
   // constraints take precedence over list of soft / hard constraints when specified
   SubmitJobRequest.Constraints constraints = new SubmitJobRequest.Constraints()

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
@@ -306,6 +306,7 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
               [(it.key): it.value?.toString()]
             })
             .withDisruptionBudget(description.disruptionBudget)
+            .withServiceJobProcesses(description.serviceJobProcesses)
 
     if (dockerImage.imageDigest != null) {
       submitJobRequest = submitJobRequest.withDockerDigest(dockerImage.imageDigest)
@@ -393,6 +394,11 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
       description.capacity.min = sourceJob.instancesMin
       description.capacity.max = sourceJob.instancesMax
       description.capacity.desired = sourceJob.instancesDesired
+    }
+
+    if(description.serviceJobProcesses) {
+         description.serviceJobProcesses.disableDecreaseDesired = sourceJob.serviceJobProcesses.disableDecreaseDesired
+           description.serviceJobProcesses.disableIncreaseDesired = sourceJob.serviceJobProcesses.disableIncreaseDesired
     }
 
     description.resources.cpu = description.resources.cpu ?: sourceJob.cpu

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandlerSpec.groovy
@@ -84,6 +84,10 @@ class TitusDeployHandlerSpec extends Specification {
         'k1': 'value1',
         'k2': 123
       ],
+        serviceJobProcesses: [
+          "disableIncreaseDesired": true,
+          "disableDecreaseDesired": true
+        ],
       constraints: [
           soft: [
             "AvailabilityZone" : "us-east-1d",
@@ -136,6 +140,7 @@ class TitusDeployHandlerSpec extends Specification {
         it.allocateIpAddress == titusDeployDescription.resources.allocateIpAddress &&
         it.labels.get("interestingHealthProviderNames") == "Titus,Discovery" &&
         it.containerConstraints == constraints
+        it.serviceJobProcesses == titusDeployDescription.serviceJobProcesses
     } as SubmitJobRequest) >> "123456"
   }
 


### PR DESCRIPTION
- `ServiceJobProcesses` update operation was addressed as part of #3699. Adding support for `create` and `clone` operation which was missing.