### PR TITLE
WIP feat(kubernetes): dynamic account config

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -23,6 +23,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation 'com.jayway.jsonpath:json-path:2.3.0'
   implementation "com.github.ben-manes.caffeine:guava"
+  implementation "org.springframework.cloud:spring-cloud-context"
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.groovy
@@ -20,9 +20,16 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import com.netflix.spinnaker.fiat.model.resources.Permissions
 import groovy.transform.ToString
+import lombok.Data
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.cloud.context.config.annotation.RefreshScope
+import org.springframework.stereotype.Component
 
+@Component
 @ToString(includeNames = true)
-class KubernetesConfigurationProperties {
+@ConfigurationProperties("kubernetes")
+class KubernetesConfigurationProperties implements DisposableBean {
   private static final Integer DEFAULT_CACHE_THREADS = 1
 
   @ToString(includeNames = true)
@@ -63,6 +70,11 @@ class KubernetesConfigurationProperties {
   }
 
   List<ManagedAccount> accounts = []
+
+  @Override
+  void destroy() {
+    this.accounts = []
+  }
 }
 
 @ToString(includeNames = true)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsSynchronizer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsSynchronizer.java
@@ -16,71 +16,66 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.security;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties.ManagedAccount;
+import static com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials.CredentialFactory;
+
 import com.netflix.spinnaker.cats.module.CatsModule;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable;
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.PostConstruct;
-
 import java.util.List;
-
-import static com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties.ManagedAccount;
-import static com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials.CredentialFactory;
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class KubernetesCredentialsSynchronizer implements CredentialsInitializerSynchronizable {
-
 
   private final AccountCredentialsRepository accountCredentialsRepository;
   private final KubernetesConfigurationProperties kubernetesConfigurationProperties;
   private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
   private final CredentialFactory credentialFactory;
+  private final CatsModule catsModule;
 
   public KubernetesCredentialsSynchronizer(
-    AccountCredentialsRepository accountCredentialsRepository,
-    KubernetesConfigurationProperties kubernetesConfigurationProperties,
-    KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-    CredentialFactory credentialFactory
-  ) {
+      AccountCredentialsRepository accountCredentialsRepository,
+      KubernetesConfigurationProperties kubernetesConfigurationProperties,
+      KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+      CredentialFactory credentialFactory,
+      CatsModule catsModule) {
     this.accountCredentialsRepository = accountCredentialsRepository;
     this.kubernetesConfigurationProperties = kubernetesConfigurationProperties;
     this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
     this.credentialFactory = credentialFactory;
+    this.catsModule = catsModule;
   }
 
   @Override
   @PostConstruct
-  public void synchronize(){
+  public void synchronize() {
 
-    List accountDelta = ProviderUtils.calculateAccountDeltas(
-      accountCredentialsRepository,
-      KubernetesNamedAccountCredentials.class,
-      kubernetesConfigurationProperties.getAccounts()
-    );
+    List accountDelta =
+        ProviderUtils.calculateAccountDeltas(
+            accountCredentialsRepository,
+            KubernetesNamedAccountCredentials.class,
+            kubernetesConfigurationProperties.getAccounts());
 
     List<ManagedAccount> accountsToAdd = (List<ManagedAccount>) accountDelta.get(0);
     List<String> deletedAccounts = (List<String>) accountDelta.get(1);
 
-    ProviderUtils.unscheduleAndDeregisterAgents(deletedAccounts, null);
+    ProviderUtils.unscheduleAndDeregisterAgents(deletedAccounts, catsModule);
 
-    accountsToAdd.forEach( managedAccount -> {
-      try {
-        KubernetesNamedAccountCredentials credentials = new KubernetesNamedAccountCredentials(
-          managedAccount,
-          kubernetesSpinnakerKindMap,
-          credentialFactory
-        );
-        accountCredentialsRepository.save(managedAccount.getName(), credentials);
-      } catch(Exception e) {
-        log.info("Could not load account {} for Kubernetes", managedAccount.getName());
-      }
-    });
-
+    accountsToAdd.forEach(
+        managedAccount -> {
+          try {
+            KubernetesNamedAccountCredentials credentials =
+                new KubernetesNamedAccountCredentials(
+                    managedAccount, kubernetesSpinnakerKindMap, credentialFactory);
+            accountCredentialsRepository.save(managedAccount.getName(), credentials);
+          } catch (Exception e) {
+            log.info("Could not load account {} for Kubernetes", managedAccount.getName());
+          }
+        });
   }
-
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsSynchronizer.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsSynchronizer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.security;
+
+import com.netflix.spinnaker.cats.module.CatsModule;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable;
+import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.PostConstruct;
+
+import java.util.List;
+
+import static com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties.ManagedAccount;
+import static com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials.CredentialFactory;
+
+@Slf4j
+public class KubernetesCredentialsSynchronizer implements CredentialsInitializerSynchronizable {
+
+
+  private final AccountCredentialsRepository accountCredentialsRepository;
+  private final KubernetesConfigurationProperties kubernetesConfigurationProperties;
+  private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
+  private final CredentialFactory credentialFactory;
+
+  public KubernetesCredentialsSynchronizer(
+    AccountCredentialsRepository accountCredentialsRepository,
+    KubernetesConfigurationProperties kubernetesConfigurationProperties,
+    KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
+    CredentialFactory credentialFactory
+  ) {
+    this.accountCredentialsRepository = accountCredentialsRepository;
+    this.kubernetesConfigurationProperties = kubernetesConfigurationProperties;
+    this.kubernetesSpinnakerKindMap = kubernetesSpinnakerKindMap;
+    this.credentialFactory = credentialFactory;
+  }
+
+  @Override
+  @PostConstruct
+  public void synchronize(){
+
+    List accountDelta = ProviderUtils.calculateAccountDeltas(
+      accountCredentialsRepository,
+      KubernetesNamedAccountCredentials.class,
+      kubernetesConfigurationProperties.getAccounts()
+    );
+
+    List<ManagedAccount> accountsToAdd = (List<ManagedAccount>) accountDelta.get(0);
+    List<String> deletedAccounts = (List<String>) accountDelta.get(1);
+
+    ProviderUtils.unscheduleAndDeregisterAgents(deletedAccounts, null);
+
+    accountsToAdd.forEach( managedAccount -> {
+      try {
+        KubernetesNamedAccountCredentials credentials = new KubernetesNamedAccountCredentials(
+          managedAccount,
+          kubernetesSpinnakerKindMap,
+          credentialFactory
+        );
+        accountCredentialsRepository.save(managedAccount.getName(), credentials);
+      } catch(Exception e) {
+        log.info("Could not load account {} for Kubernetes", managedAccount.getName());
+      }
+    });
+
+  }
+
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsInitializer.groovy
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Slf4j
-@Configuration
+//@Configuration
 class KubernetesNamedAccountCredentialsInitializer {
   @Autowired Registry spectatorRegistry
   @Autowired KubectlJobExecutor jobExecutor

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2Provider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2Provider.java
@@ -31,7 +31,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @Slf4j
 @Data
-class KubernetesV2Provider extends AgentSchedulerAware implements Provider {
+public class KubernetesV2Provider extends AgentSchedulerAware implements Provider {
   public static final String PROVIDER_NAME = KubernetesCloudProvider.getID();
 
   private Collection<Agent> agents = emptyAgentCollection();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderConfig.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderConfig.java
@@ -18,8 +18,6 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching;
 
 import com.netflix.spinnaker.cats.agent.Agent;
-import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
-import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentDispatcher;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
@@ -31,36 +29,24 @@ import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Component;
 
-@Configuration
+@Component
 @Slf4j
-class KubernetesV2ProviderConfig {
-  @Bean
-  @DependsOn("kubernetesNamedAccountCredentials")
-  KubernetesV2Provider kubernetesV2Provider(
-      KubernetesCloudProvider kubernetesCloudProvider,
-      AccountCredentialsRepository accountCredentialsRepository,
-      KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher,
-      KubernetesResourcePropertyRegistry kubernetesResourcePropertyRegistry) {
-    this.kubernetesV2Provider = new KubernetesV2Provider();
+public class KubernetesV2ProviderConfig {
+
+  public KubernetesV2ProviderConfig(
+    KubernetesV2Provider kubernetesV2Provider,
+    AccountCredentialsRepository accountCredentialsRepository,
+    KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher,
+    KubernetesResourcePropertyRegistry kubernetesResourcePropertyRegistry
+  ){
+    this.kubernetesV2Provider = kubernetesV2Provider;
     this.accountCredentialsRepository = accountCredentialsRepository;
     this.kubernetesV2CachingAgentDispatcher = kubernetesV2CachingAgentDispatcher;
     this.kubernetesResourcePropertyRegistry = kubernetesResourcePropertyRegistry;
-
-    ScheduledExecutorService poller =
-        Executors.newSingleThreadScheduledExecutor(
-            new NamedThreadFactory(KubernetesV2ProviderConfig.class.getSimpleName()));
-
-    synchronizeKubernetesV2Provider(kubernetesV2Provider, accountCredentialsRepository);
-
-    return kubernetesV2Provider;
   }
 
   private KubernetesV2Provider kubernetesV2Provider;
@@ -68,9 +54,7 @@ class KubernetesV2ProviderConfig {
   private KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher;
   private KubernetesResourcePropertyRegistry kubernetesResourcePropertyRegistry;
 
-  private void synchronizeKubernetesV2Provider(
-      KubernetesV2Provider kubernetesV2Provider,
-      AccountCredentialsRepository accountCredentialsRepository) {
+  public void synchronizeKubernetesV2Provider() {
     Set<KubernetesNamedAccountCredentials> allAccounts =
         ProviderUtils.buildThreadSafeSetOfAccounts(
             accountCredentialsRepository,

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/config/KubernetesConfiguration.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/config/KubernetesConfiguration.groovy
@@ -22,15 +22,11 @@ import com.netflix.spinnaker.clouddriver.kubernetes.health.KubernetesHealthIndic
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentialsSynchronizer
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials.CredentialFactory
-import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentialsInitializer
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.KubernetesUtil
-import com.netflix.spinnaker.clouddriver.kubernetes.v1.provider.KubernetesV1ProviderConfig
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.KubernetesV2ProviderConfig
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.cloud.context.config.annotation.RefreshScope
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
@@ -64,13 +60,15 @@ class KubernetesConfiguration {
     AccountCredentialsRepository accountCredentialsRepository,
     KubernetesConfigurationProperties kubernetesConfigurationProperties,
     KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-    CredentialFactory credentialFactory
+    CredentialFactory credentialFactory,
+    CatsModule catsModule
   ) {
     return new KubernetesCredentialsSynchronizer(
       accountCredentialsRepository,
       kubernetesConfigurationProperties,
       kubernetesSpinnakerKindMap,
-      credentialFactory
+      credentialFactory,
+      catsModule
     )
   }
 


### PR DESCRIPTION
☠️  DO NOT MERGE ☠️ 

Posting this to get initial feedback as it deals with areas of the codebase that I'm not super familiar with.

This PR aims to implement the work in the Cloud Foundry provider around dynamic configuration, particularly for accounts. Instead of using the `KubernetesNamedAccountInitializer`, `KubernetesCredentialsSynchronizer` is responsible for synchronizing the `AccountCredentialsRepository` with any added/changed/deleted accounts. This `@Bean` gets called whenever the `/refresh` endpoint is hit. Additionally, it will be called on a fixed interval. 

Some concerns I have about this refactor:
1. Credential instantiation for a large number of accounts takes a long time, even with `checkPermissionsOnStartup = false`. We've heard this from a number of users at scale. For example, I've heard reports of Clouddriver taking up to an hour to boot. With the way dynamic config works, we run the risk of that happening during account refresh as the same initialization process occurs when hitting the `/refresh` endpoint or when the periodic refresh triggers. Furthermore, calls to `/refresh` are not returned until this process finishes which will make integrating with it difficult (i.e. "how long should i wait before timeout"). Something to consider.

2. Previously, the `KubernetesV*Provider` classes were instantiated after the caching agents had been populated. In order to break the dependency loop between `CatsModule` and `KubernetesCredentialsSynchronizer` (described below) I had to instantiate those beans _before_ the synchronizer. I'm unsure if that will have any side effects or not. Additionally, there were instantiations of  `ScheduledExecutorService` in each of the `KubernetesV*ProviderConfig` classes which are unaccounted for in this patch. It'd be great to get some suggestions on how we might account for this i n the new setup.

3. In order for the `KubernetesCredentialsSynchronizer` to de-schedule any defunct caching agents it needs to depend on `CatsModule`. However, due to the way the `KubernetesV*Provider` instances were created this created a circular dependency between `CatsModule` and the synchronizer because `CatsModule` depends on `List<Provider>` and `KubernetesV*Provider` classes couldn't be created until _after_ the synchronizer had been created. In order to break this loop, I created the 2 provider beans _before_ the synchronizer. Again, I'm unsure of any consequences here. This change also turns the `KubernetesV*ProviderConfig` classes into `@Components` that we can call from the synchronizer to handle agent refreshing. 

It should be notes that Clouddriver does start and all of the logs look normal. Refresh behavior works as expected, too. As noted in point 2, i'm concerned that the agent polling isn't being setup properly. I _think_ the config refresh scheduler is taking care of that but that isn't really what we want.