### PR TITLE
refactor(kubernetes): Make cache keys immutable

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -225,7 +225,7 @@ public class Keys {
 
     @Override
     public String toString() {
-      return createKey(kind, type, name, version);
+      return createKey(kind, type, name, location, version);
     }
 
     @Override
@@ -289,7 +289,7 @@ public class Keys {
 
     @Override
     public String toString() {
-      return createKey(getKind(), logicalKind, account, name);
+      return createKey(getKind(), logicalKind, account, application, name);
     }
 
     @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -104,7 +104,7 @@ public class Keys {
     List<String> components =
         Arrays.stream(elems)
             .map(s -> s == null ? "" : s.toString())
-            .map(s -> s.replaceAll(":", ";"))
+            .map(s -> s.contains(":") ? s.replaceAll(":", ";") : s)
             .collect(Collectors.toList());
     components.add(0, provider);
     return String.join(":", components);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -100,7 +100,7 @@ public class Keys {
 
   private static final String provider = "kubernetes.v2";
 
-  private static String createKey(Object... elems) {
+  private static String createKeyFromParts(Object... elems) {
     List<String> components =
         Arrays.stream(elems)
             .map(s -> s == null ? "" : s.toString())
@@ -108,31 +108,6 @@ public class Keys {
             .collect(Collectors.toList());
     components.add(0, provider);
     return String.join(":", components);
-  }
-
-  public static String artifact(String type, String name, String location, String version) {
-    return createKey(Kind.ARTIFACT, type, name, location, version);
-  }
-
-  public static String application(String name) {
-    return createKey(Kind.LOGICAL, LogicalKind.APPLICATIONS, name);
-  }
-
-  public static String cluster(String account, String application, String name) {
-    return createKey(Kind.LOGICAL, LogicalKind.CLUSTERS, account, application, name);
-  }
-
-  public static String infrastructure(
-      KubernetesKind kind, String account, String namespace, String name) {
-    return createKey(Kind.INFRASTRUCTURE, kind, account, namespace, name);
-  }
-
-  public static String infrastructure(KubernetesManifest manifest, String account) {
-    return infrastructure(manifest.getKind(), account, manifest.getNamespace(), manifest.getName());
-  }
-
-  public static String metric(KubernetesKind kind, String account, String namespace, String name) {
-    return createKey(KUBERNETES_METRIC, kind, account, namespace, name);
   }
 
   public static Optional<CacheKey> parseKey(String key) {
@@ -223,9 +198,13 @@ public class Keys {
       version = parts[5];
     }
 
+    public static String createKey(String type, String name, String location, String version) {
+      return createKeyFromParts(kind, type, name, location, version);
+    }
+
     @Override
     public String toString() {
-      return createKey(kind, type, name, location, version);
+      return createKeyFromParts(kind, type, name, location, version);
     }
 
     @Override
@@ -248,6 +227,10 @@ public class Keys {
       name = parts[3];
     }
 
+    public static String createKey(String name) {
+      return createKeyFromParts(getKind(), logicalKind, name);
+    }
+
     @Override
     public LogicalKind getLogicalKind() {
       return logicalKind;
@@ -255,7 +238,7 @@ public class Keys {
 
     @Override
     public String toString() {
-      return createKey(getKind(), logicalKind, name);
+      return createKeyFromParts(getKind(), logicalKind, name);
     }
 
     @Override
@@ -282,6 +265,10 @@ public class Keys {
       name = parts[5];
     }
 
+    public static String createKey(String account, String application, String name) {
+      return createKeyFromParts(getKind(), logicalKind, account, application, name);
+    }
+
     @Override
     public LogicalKind getLogicalKind() {
       return logicalKind;
@@ -289,7 +276,7 @@ public class Keys {
 
     @Override
     public String toString() {
-      return createKey(getKind(), logicalKind, account, application, name);
+      return createKeyFromParts(getKind(), logicalKind, account, application, name);
     }
 
     @Override
@@ -319,9 +306,18 @@ public class Keys {
       name = parts[5];
     }
 
+    public static String createKey(
+        KubernetesKind kubernetesKind, String account, String namespace, String name) {
+      return createKeyFromParts(kind, kubernetesKind, account, namespace, name);
+    }
+
+    public static String createKey(KubernetesManifest manifest, String account) {
+      return createKey(manifest.getKind(), account, manifest.getNamespace(), manifest.getName());
+    }
+
     @Override
     public String toString() {
-      return createKey(kind, kubernetesKind, account, namespace, name);
+      return createKeyFromParts(kind, kubernetesKind, account, namespace, name);
     }
 
     @Override
@@ -350,9 +346,14 @@ public class Keys {
       name = parts[5];
     }
 
+    public static String createKey(
+        KubernetesKind kubernetesKind, String account, String namespace, String name) {
+      return createKeyFromParts(kind, kubernetesKind, account, namespace, name);
+    }
+
     @Override
     public String toString() {
-      return createKey(kind, kubernetesKind, account, namespace, name);
+      return createKeyFromParts(kind, kubernetesKind, account, namespace, name);
     }
 
     @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -20,15 +20,14 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.Kind.KUBERNETES_METRIC;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -188,11 +187,8 @@ public class Keys {
     }
   }
 
-  @Data
   public abstract static class CacheKey {
-    private Kind kind;
-    private String provider = KubernetesCloudProvider.getID();
-    private String type;
+    private static final String provider = "kubernetes.v2";
 
     public abstract String getGroup();
 
@@ -200,21 +196,21 @@ public class Keys {
   }
 
   @EqualsAndHashCode(callSuper = true)
-  @Data
+  @Getter
   public abstract static class LogicalKey extends CacheKey {
-    private Kind kind = Kind.LOGICAL;
+    @Getter private static final Kind kind = Kind.LOGICAL;
 
     public abstract LogicalKind getLogicalKind();
   }
 
   @EqualsAndHashCode(callSuper = true)
-  @Data
+  @Getter
   public static class ArtifactCacheKey extends CacheKey {
-    private Kind kind = Kind.ARTIFACT;
-    private String type;
-    private String name;
-    private String location;
-    private String version;
+    @Getter private static final Kind kind = Kind.ARTIFACT;
+    private final String type;
+    private final String name;
+    private final String location;
+    private final String version;
 
     public ArtifactCacheKey(String[] parts) {
       if (parts.length != 6) {
@@ -239,10 +235,10 @@ public class Keys {
   }
 
   @EqualsAndHashCode(callSuper = true)
-  @Data
+  @Getter
   public static class ApplicationCacheKey extends LogicalKey {
-    private LogicalKind logicalKind = LogicalKind.APPLICATIONS;
-    private String name;
+    private static final LogicalKind logicalKind = LogicalKind.APPLICATIONS;
+    private final String name;
 
     public ApplicationCacheKey(String[] parts) {
       if (parts.length != 4) {
@@ -250,6 +246,11 @@ public class Keys {
       }
 
       name = parts[3];
+    }
+
+    @Override
+    public LogicalKind getLogicalKind() {
+      return logicalKind;
     }
 
     @Override
@@ -264,12 +265,12 @@ public class Keys {
   }
 
   @EqualsAndHashCode(callSuper = true)
-  @Data
+  @Getter
   public static class ClusterCacheKey extends LogicalKey {
-    private LogicalKind logicalKind = LogicalKind.CLUSTERS;
-    private String account;
-    private String application;
-    private String name;
+    private static final LogicalKind logicalKind = LogicalKind.CLUSTERS;
+    private final String account;
+    private final String application;
+    private final String name;
 
     public ClusterCacheKey(String[] parts) {
       if (parts.length != 6) {
@@ -279,6 +280,11 @@ public class Keys {
       account = parts[3];
       application = parts[4];
       name = parts[5];
+    }
+
+    @Override
+    public LogicalKind getLogicalKind() {
+      return logicalKind;
     }
 
     @Override
@@ -293,13 +299,13 @@ public class Keys {
   }
 
   @EqualsAndHashCode(callSuper = true)
-  @Data
+  @Getter
   public static class InfrastructureCacheKey extends CacheKey {
-    private Kind kind = Kind.INFRASTRUCTURE;
-    private KubernetesKind kubernetesKind;
-    private String account;
-    private String namespace;
-    private String name;
+    @Getter private static final Kind kind = Kind.INFRASTRUCTURE;
+    private final KubernetesKind kubernetesKind;
+    private final String account;
+    private final String namespace;
+    private final String name;
 
     public InfrastructureCacheKey(String[] parts) {
       if (parts.length != 6) {
@@ -325,13 +331,13 @@ public class Keys {
   }
 
   @EqualsAndHashCode(callSuper = true)
-  @Data
+  @Getter
   public static class MetricCacheKey extends CacheKey {
-    private Kind kind = KUBERNETES_METRIC;
-    private KubernetesKind kubernetesKind;
-    private String account;
-    private String namespace;
-    private String name;
+    @Getter private static final Kind kind = KUBERNETES_METRIC;
+    private final KubernetesKind kubernetesKind;
+    private final String account;
+    private final String namespace;
+    private final String name;
 
     public MetricCacheKey(String[] parts) {
       if (parts.length != 6) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -115,9 +115,9 @@ public class KubernetesCacheDataConverter {
     Map<String, Collection<String>> cacheRelationships = new HashMap<>();
 
     String key =
-        Keys.artifact(
+        Keys.ArtifactCacheKey.createKey(
             artifact.getType(), artifact.getName(), artifact.getLocation(), artifact.getVersion());
-    String owner = Keys.infrastructure(manifest, account);
+    String owner = Keys.InfrastructureCacheKey.createKey(manifest, account);
     cacheRelationships.put(manifest.getKind().toString(), Collections.singletonList(owner));
 
     return defaultCacheData(key, logicalTtlSeconds, attributes, cacheRelationships);
@@ -180,10 +180,10 @@ public class KubernetesCacheDataConverter {
                 .put(
                     POD.toString(),
                     Collections.singletonList(
-                        Keys.infrastructure(POD, account, namespace, podName)))
+                        Keys.InfrastructureCacheKey.createKey(POD, account, namespace, podName)))
                 .build());
 
-    String id = Keys.metric(POD, account, namespace, podName);
+    String id = Keys.MetricCacheKey.createKey(POD, account, namespace, podName);
 
     return defaultCacheData(id, infrastructureTtlSeconds, attributes, relationships);
   }
@@ -247,7 +247,7 @@ public class KubernetesCacheDataConverter {
         ownerReferenceRelationships(account, namespace, manifest.getOwnerReferences()));
     cacheRelationships.putAll(implicitRelationships(manifest, account, resourceRelationships));
 
-    String key = Keys.infrastructure(kind, account, namespace, name);
+    String key = Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name);
     return defaultCacheData(key, infrastructureTtlSeconds, attributes, cacheRelationships);
   }
 
@@ -301,7 +301,7 @@ public class KubernetesCacheDataConverter {
       cacheRelationships.put(
           ARTIFACT.toString(),
           Collections.singletonList(
-              Keys.artifact(
+              Keys.ArtifactCacheKey.createKey(
                   artifact.getType(),
                   artifact.getName(),
                   artifact.getLocation(),
@@ -310,12 +310,14 @@ public class KubernetesCacheDataConverter {
 
     if (hasClusterRelationship) {
       cacheRelationships.put(
-          APPLICATIONS.toString(), Collections.singletonList(Keys.application(application)));
+          APPLICATIONS.toString(),
+          Collections.singletonList(Keys.ApplicationCacheKey.createKey(application)));
       String cluster = moniker.getCluster();
       if (StringUtils.isNotEmpty(cluster)) {
         cacheRelationships.put(
             CLUSTERS.toString(),
-            Collections.singletonList(Keys.cluster(account, application, cluster)));
+            Collections.singletonList(
+                Keys.ClusterCacheKey.createKey(account, application, cluster)));
       }
     }
 
@@ -337,7 +339,7 @@ public class KubernetesCacheDataConverter {
       keys = new ArrayList<>();
     }
 
-    keys.add(Keys.infrastructure(kind, account, namespace, name));
+    keys.add(Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name));
 
     relationships.put(kind.toString(), keys);
   }
@@ -357,7 +359,7 @@ public class KubernetesCacheDataConverter {
         keys = new ArrayList<>();
       }
 
-      keys.add(Keys.infrastructure(kind, account, namespace, name));
+      keys.add(Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name));
       relationships.put(kind.toString(), keys);
     }
 
@@ -376,7 +378,7 @@ public class KubernetesCacheDataConverter {
         keys = new ArrayList<>();
       }
 
-      keys.add(Keys.infrastructure(kind, account, namespace, name));
+      keys.add(Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name));
       relationships.put(kind.toString(), keys);
     }
 
@@ -461,14 +463,17 @@ public class KubernetesCacheDataConverter {
       String account, String application, List<Moniker> monikers) {
     Set<String> clusterRelationships =
         monikers.stream()
-            .map(m -> Keys.cluster(account, application, m.getCluster()))
+            .map(m -> Keys.ClusterCacheKey.createKey(account, application, m.getCluster()))
             .collect(Collectors.toSet());
 
     Map<String, Object> attributes = new HashMap<>();
     Map<String, Collection<String>> relationships = new HashMap<>();
     relationships.put(CLUSTERS.toString(), clusterRelationships);
     return defaultCacheData(
-        Keys.application(application), logicalTtlSeconds, attributes, relationships);
+        Keys.ApplicationCacheKey.createKey(application),
+        logicalTtlSeconds,
+        attributes,
+        relationships);
   }
 
   static void logStratifiedCacheData(

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -113,7 +113,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
         primaryResource.values().stream()
             .flatMap(Collection::stream)
             .map(rs -> objectMapper.convertValue(rs, KubernetesManifest.class))
-            .map(mf -> Keys.infrastructure(mf, accountName))
+            .map(mf -> Keys.InfrastructureCacheKey.createKey(mf, accountName))
             .collect(Collectors.toList());
 
     List<CacheData> keepInOnDemand = new ArrayList<>();
@@ -329,7 +329,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     log.info("{}: Accepted on demand refresh of '{}'", getAgentType(), data);
     OnDemandAgent.OnDemandResult result;
     KubernetesManifest manifest = loadPrimaryResource(kind, namespace, name);
-    String resourceKey = Keys.infrastructure(kind, account, namespace, name);
+    String resourceKey = Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name);
     try {
       result =
           manifest == null

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ApplicationProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ApplicationProvider.java
@@ -46,7 +46,7 @@ public class KubernetesV2ApplicationProvider implements ApplicationProvider {
   public Set<? extends Application> getApplications(boolean expand) {
     // TODO(lwander) performance optimization: rely on expand parameter to make a more
     // cache-efficient call
-    String clusterGlobKey = Keys.cluster("*", "*", "*");
+    String clusterGlobKey = ClusterCacheKey.createKey("*", "*", "*");
     Map<String, Set<ClusterCacheKey>> keysByApplication =
         cacheUtils.getAllKeysMatchingPattern(CLUSTERS.toString(), clusterGlobKey).stream()
             .map(Keys::parseKey)
@@ -63,7 +63,7 @@ public class KubernetesV2ApplicationProvider implements ApplicationProvider {
 
   @Override
   public Application getApplication(String name) {
-    String clusterGlobKey = Keys.cluster("*", name, "*");
+    String clusterGlobKey = ClusterCacheKey.createKey("*", name, "*");
     List<ClusterCacheKey> keys =
         cacheUtils.getAllKeysMatchingPattern(CLUSTERS.toString(), clusterGlobKey).stream()
             .map(Keys::parseKey)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ArtifactProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ArtifactProvider.java
@@ -41,7 +41,7 @@ public class KubernetesV2ArtifactProvider implements ArtifactProvider {
 
   @Override
   public List<Artifact> getArtifacts(String type, String name, String location) {
-    String key = Keys.artifact(type, name, location, "*");
+    String key = Keys.ArtifactCacheKey.createKey(type, name, location, "*");
     return cacheUtils.getAllDataMatchingPattern(Keys.Kind.ARTIFACT.toString(), key).stream()
         .sorted(
             Comparator.comparing(

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ClusterProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ClusterProvider.java
@@ -72,7 +72,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
 
   @Override
   public Map<String, Set<KubernetesV2Cluster>> getClusterSummaries(String application) {
-    String applicationKey = Keys.application(application);
+    String applicationKey = Keys.ApplicationCacheKey.createKey(application);
     return groupByAccountName(
         translateClusters(
             cacheUtils.getTransitiveRelationship(
@@ -83,7 +83,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
 
   @Override
   public Map<String, Set<KubernetesV2Cluster>> getClusterDetails(String application) {
-    String clusterGlobKey = Keys.cluster("*", application, "*");
+    String clusterGlobKey = Keys.ClusterCacheKey.createKey("*", application, "*");
     return groupByAccountName(
         translateClustersWithRelationships(
             cacheUtils.getAllDataMatchingPattern(CLUSTERS.toString(), clusterGlobKey)));
@@ -91,7 +91,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
 
   @Override
   public Set<KubernetesV2Cluster> getClusters(String application, String account) {
-    String globKey = Keys.cluster(account, application, "*");
+    String globKey = Keys.ClusterCacheKey.createKey(account, application, "*");
     return translateClustersWithRelationships(
         cacheUtils.getAllDataMatchingPattern(CLUSTERS.toString(), globKey));
   }
@@ -105,7 +105,8 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
   public KubernetesV2Cluster getCluster(
       String application, String account, String name, boolean includeDetails) {
     return cacheUtils
-        .getSingleEntry(CLUSTERS.toString(), Keys.cluster(account, application, name))
+        .getSingleEntry(
+            CLUSTERS.toString(), Keys.ClusterCacheKey.createKey(account, application, name))
         .map(
             entry -> {
               Collection<CacheData> clusterData = Collections.singletonList(entry);
@@ -130,7 +131,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
 
     KubernetesKind kind = parsedName.getLeft();
     String shortName = parsedName.getRight();
-    String key = Keys.infrastructure(kind, account, namespace, shortName);
+    String key = InfrastructureCacheKey.createKey(kind, account, namespace, shortName);
     List<String> relatedTypes =
         kindMap.translateSpinnakerKind(INSTANCES).stream()
             .map(KubernetesKind::toString)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
@@ -79,7 +79,7 @@ public class KubernetesV2InstanceProvider
 
     KubernetesKind kind = parsedName.getLeft();
     String name = parsedName.getRight();
-    String key = Keys.infrastructure(kind, account, location, name);
+    String key = Keys.InfrastructureCacheKey.createKey(kind, account, location, name);
 
     Optional<CacheData> optionalInstanceData = cacheUtils.getSingleEntry(kind.toString(), key);
     if (!optionalInstanceData.isPresent()) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -87,7 +87,7 @@ public class KubernetesV2LoadBalancerProvider
 
     KubernetesKind kind = parsedName.getLeft();
     String name = parsedName.getRight();
-    String key = Keys.infrastructure(kind, account, name, name);
+    String key = Keys.InfrastructureCacheKey.createKey(kind, account, name, name);
 
     Optional<CacheData> optionalLoadBalancerData = cacheUtils.getSingleEntry(kind.toString(), key);
     if (!optionalLoadBalancerData.isPresent()) {
@@ -107,7 +107,7 @@ public class KubernetesV2LoadBalancerProvider
                 kind ->
                     cacheUtils.getTransitiveRelationship(
                         APPLICATIONS.toString(),
-                        Collections.singletonList(Keys.application(application)),
+                        Collections.singletonList(Keys.ApplicationCacheKey.createKey(application)),
                         kind.toString()))
             .flatMap(Collection::stream)
             .collect(Collectors.toList());

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -85,7 +85,8 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
       location = "";
     }
 
-    String key = Keys.infrastructure(kind, account, location, parsedName.getRight());
+    String key =
+        Keys.InfrastructureCacheKey.createKey(kind, account, location, parsedName.getRight());
 
     Optional<CacheData> dataOptional = cacheUtils.getSingleEntry(kind.toString(), key);
     if (!dataOptional.isPresent()) {
@@ -109,7 +110,7 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
     KubernetesHandler handler = properties.getHandler();
 
     return cacheUtils
-        .getSingleEntry(CLUSTERS.toString(), Keys.cluster(account, app, cluster))
+        .getSingleEntry(CLUSTERS.toString(), Keys.ClusterCacheKey.createKey(account, app, cluster))
         .map(
             c ->
                 cacheUtils.loadRelationshipsFromCache(c, kind).stream()
@@ -147,7 +148,7 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
                 .collect(Collectors.toList())
             : Collections.emptyList();
 
-    String metricKey = Keys.metric(kind, account, namespace, manifest.getName());
+    String metricKey = Keys.MetricCacheKey.createKey(kind, account, namespace, manifest.getName());
     List<KubernetesPodMetric.ContainerMetric> metrics =
         cacheUtils
             .getSingleEntry(Keys.Kind.KUBERNETES_METRIC.toString(), metricKey)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2SecurityGroupProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2SecurityGroupProvider.java
@@ -68,7 +68,7 @@ public class KubernetesV2SecurityGroupProvider
         .stream()
         .map(
             k -> {
-              String key = Keys.infrastructure(k, "*", namespace, "*");
+              String key = Keys.InfrastructureCacheKey.createKey(k, "*", namespace, "*");
               return cacheUtils.getAllDataMatchingPattern(k.toString(), key);
             })
         .flatMap(Collection::stream)
@@ -82,7 +82,7 @@ public class KubernetesV2SecurityGroupProvider
         .stream()
         .map(
             k -> {
-              String key = Keys.infrastructure(k, account, "*", "*");
+              String key = Keys.InfrastructureCacheKey.createKey(k, account, "*", "*");
               return cacheUtils.getAllDataMatchingPattern(k.toString(), key);
             })
         .flatMap(Collection::stream)
@@ -104,7 +104,7 @@ public class KubernetesV2SecurityGroupProvider
         .stream()
         .map(
             k -> {
-              String key = Keys.infrastructure(k, account, "*", name);
+              String key = Keys.InfrastructureCacheKey.createKey(k, account, "*", name);
               return cacheUtils.getAllDataMatchingPattern(k.toString(), key);
             })
         .flatMap(Collection::stream)
@@ -119,7 +119,7 @@ public class KubernetesV2SecurityGroupProvider
         .stream()
         .map(
             k -> {
-              String key = Keys.infrastructure(k, account, namespace, "*");
+              String key = Keys.InfrastructureCacheKey.createKey(k, account, namespace, "*");
               return cacheUtils.getAllDataMatchingPattern(k.toString(), key);
             })
         .flatMap(Collection::stream)
@@ -141,7 +141,7 @@ public class KubernetesV2SecurityGroupProvider
         .stream()
         .map(
             k -> {
-              String key = Keys.infrastructure(k, account, namespace, name);
+              String key = Keys.InfrastructureCacheKey.createKey(k, account, namespace, name);
               return cacheUtils.getSingleEntry(k.toString(), key).orElse(null);
             })
         .filter(Objects::nonNull)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ServerGroupManagerProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ServerGroupManagerProvider.java
@@ -55,7 +55,8 @@ public class KubernetesV2ServerGroupManagerProvider
       String application) {
     CacheData applicationDatum =
         cacheUtils
-            .getSingleEntry(APPLICATIONS.toString(), Keys.application(application))
+            .getSingleEntry(
+                APPLICATIONS.toString(), Keys.ApplicationCacheKey.createKey(application))
             .orElse(null);
     if (applicationDatum == null) {
       return null;

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KeysSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KeysSpec.groovy
@@ -31,7 +31,7 @@ class KeysSpec extends Specification {
   @Unroll
   def "produces correct app keys #key"() {
     expect:
-    Keys.application(application) == key
+    Keys.ApplicationCacheKey.createKey(application) == key
 
     where:
     application || key
@@ -42,7 +42,7 @@ class KeysSpec extends Specification {
   @Unroll
   def "produces correct cluster keys #key"() {
     expect:
-    Keys.cluster(account, application, cluster) == key
+    Keys.ClusterCacheKey.createKey(account, application, cluster) == key
 
     where:
     account | application | cluster   || key
@@ -53,7 +53,7 @@ class KeysSpec extends Specification {
   @Unroll
   def "produces correct infra keys #key"() {
     expect:
-    Keys.infrastructure(kind, account, namespace, name) == key
+    Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name) == key
 
     where:
     kind                       | apiVersion                              | account | namespace   | name      || key

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KeysSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KeysSpec.groovy
@@ -191,4 +191,20 @@ class KeysSpec extends Specification {
     Keys.LogicalKind.APPLICATIONS | "applications"
     Keys.LogicalKind.CLUSTERS     | "clusters"
   }
+
+  def "serialization and deserialization are inverses"() {
+    when:
+    def parsed = Keys.parseKey(key).get()
+
+    then:
+    parsed.toString() == key
+
+    where:
+    key << [
+      "kubernetes.v2:artifact:kubernetes/replicaSet:spinnaker-io:docs-site:v046",
+      "kubernetes.v2:infrastructure:secret:k8s:spin:spinnaker",
+      "kubernetes.v2:logical:applications:spinnaker",
+      "kubernetes.v2:logical:clusters:k8s:docs:docs-site"
+    ]
+  }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -77,16 +77,16 @@ metadata:
     if (application == null) {
       true
     } else {
-      cacheData.relationships.get(Keys.LogicalKind.APPLICATIONS.toString()) == [Keys.application(application)]
+      cacheData.relationships.get(Keys.LogicalKind.APPLICATIONS.toString()) == [Keys.ApplicationCacheKey.createKey(application)]
       if (cluster) {
-        cacheData.relationships.get(Keys.LogicalKind.CLUSTERS.toString()) == [Keys.cluster(account, application, cluster)]
+        cacheData.relationships.get(Keys.LogicalKind.CLUSTERS.toString()) == [Keys.ClusterCacheKey.createKey(account, application, cluster)]
       } else {
         cacheData.relationships.get(Keys.LogicalKind.CLUSTERS.toString()) == null
       }
       cacheData.attributes.get("name") == name
       cacheData.attributes.get("namespace") == namespace
       cacheData.attributes.get("kind") == kind
-      cacheData.id == Keys.infrastructure(kind, account, namespace, name)
+      cacheData.id == Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name)
     }
 
     where:
@@ -106,7 +106,7 @@ metadata:
     def result = KubernetesCacheDataConverter.ownerReferenceRelationships(account, namespace, ownerRefs)
 
     then:
-    result.get(kind.toString()) == [Keys.infrastructure(kind, account, namespace, name)]
+    result.get(kind.toString()) == [Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name)]
 
     where:
     kind                       | apiVersion                              | account           | cluster       | namespace        | name
@@ -119,7 +119,7 @@ metadata:
   @Unroll
   def "given a cache data entry, invert its relationships"() {
     setup:
-    def id = Keys.infrastructure(kind, "account", "namespace", "version")
+    def id = Keys.InfrastructureCacheKey.createKey(kind, "account", "namespace", "version")
     def cacheData = new DefaultCacheData(id, null, relationships)
 
     when:
@@ -136,12 +136,12 @@ metadata:
 
     where:
     kind                       | version                           | relationships
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["application": [Keys.application("app")]]
+    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["application": [Keys.ApplicationCacheKey.createKey("app")]]
     KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["application": []]
     KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | [:]
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["deployment": [Keys.infrastructure(KubernetesKind.DEPLOYMENT, "account", "namespace", "a-name")]]
-    KubernetesKind.SERVICE     | KubernetesApiVersion.V1           | ["cluster": [Keys.cluster("account", "app", "name")], "application": [Keys.application("blarg")]]
-    KubernetesKind.SERVICE     | KubernetesApiVersion.V1           | ["cluster": [Keys.cluster("account", "app", "name")], "application": [Keys.application("blarg"), Keys.application("asdfasdf")]]
+    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["deployment": [Keys.InfrastructureCacheKey.createKey(KubernetesKind.DEPLOYMENT, "account", "namespace", "a-name")]]
+    KubernetesKind.SERVICE     | KubernetesApiVersion.V1           | ["cluster": [Keys.ClusterCacheKey.createKey("account", "app", "name")], "application": [Keys.ApplicationCacheKey.createKey("blarg")]]
+    KubernetesKind.SERVICE     | KubernetesApiVersion.V1           | ["cluster": [Keys.ClusterCacheKey.createKey("account", "app", "name")], "application": [Keys.ApplicationCacheKey.createKey("blarg"), Keys.ApplicationCacheKey.createKey("asdfasdf")]]
   }
 
   @Unroll
@@ -149,7 +149,7 @@ metadata:
     setup:
     def account = "account"
     def application = "app"
-    def id = Keys.infrastructure(kind, account, "namespace", cluster)
+    def id = Keys.InfrastructureCacheKey.createKey(kind, account, "namespace", cluster)
     def attributes = [
       moniker: [
         app: application,
@@ -163,9 +163,9 @@ metadata:
 
     then:
     result.size() == 1
-    result[0].id == Keys.application(application)
+    result[0].id == Keys.ApplicationCacheKey.createKey(application)
     result[0].relationships.clusters == [
-        Keys.cluster(account, application, cluster)
+      Keys.ClusterCacheKey.createKey(account, application, cluster)
     ] as Set
 
     where:


### PR DESCRIPTION
* refactor(kubernetes): Make cache keys immutable 

  We don't ever change cache keys after construction, but they still support (unused) setters.  Make these keys immutable so we can safely use them as keys in sets/maps.

* fix(kubernetes): Fix serialization of cache keys 

  Some cache key types don't have symmetry between serialization and deserialization logic.  Fix them so that they do so we can create a key and call toString() and get the same result as if we directly created the string key.

* refactor(kubernetes): Move key constructors into inner classes 

  The top-level Keys class supports a number of methods for creating a String representation of various key types. Move these methods into the relevant inner classes and rename them createKey.

* perf(kubernetes): Short-circuit string replacement 

  As a performance improvement, don't allocate a new string for every key part we're processing via the replaceAll(). Instead check whether they key has a ':' first which is relatively cheap compared to alwyas allocating a new string.
