### PR TITLE
refactor(kubernetes): Move pod metrics to use KubernetesCacheData

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -338,6 +338,7 @@ public class Keys {
 
   @EqualsAndHashCode(callSuper = true)
   @Getter
+  @RequiredArgsConstructor
   public static class MetricCacheKey extends CacheKey {
     @Getter private static final Kind kind = KUBERNETES_METRIC;
     private final KubernetesKind kubernetesKind;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -150,9 +150,9 @@ public class KubernetesCacheDataConverter {
     return defaultCacheData(id, ttl, attributes, relationships);
   }
 
-  public static CacheData convertPodMetric(
-      String account, String namespace, KubernetesPodMetric podMetric) {
+  public static CacheData convertPodMetric(String account, KubernetesPodMetric podMetric) {
     String podName = podMetric.getPodName();
+    String namespace = podMetric.getNamespace();
     Map<String, Object> attributes =
         new ImmutableMap.Builder<String, Object>()
             .put("name", podName)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -102,10 +102,7 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
             KubernetesCacheDataConverter.convertPodMetric(
                 kubernetesCacheData, accountName, metric));
 
-    List<CacheData> cacheData = kubernetesCacheData.toCacheData();
-
-    Map<String, Collection<CacheData>> entries =
-        KubernetesCacheDataConverter.stratifyCacheDataByGroup(cacheData);
+    Map<String, Collection<CacheData>> entries = kubernetesCacheData.toStratifiedCacheData();
     KubernetesCacheDataConverter.logStratifiedCacheData(getAgentType(), entries);
 
     return new DefaultCacheResult(entries);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.Collection;
@@ -69,15 +70,13 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
     log.info(getAgentType() + ": agent is starting");
     reloadNamespaces();
 
-    KubernetesCacheData kubernetesCacheData = new KubernetesCacheData();
-    List<CacheData> cacheData =
+    List<KubernetesPodMetric> podMetrics =
         namespaces
             .parallelStream()
             .map(
                 n -> {
                   try {
-                    return credentials.topPod(n, null).stream()
-                        .map(m -> KubernetesCacheDataConverter.convertPodMetric(accountName, n, m));
+                    return credentials.topPod(n, null);
                   } catch (KubectlJobExecutor.KubectlException e) {
                     if (e.getMessage().contains("not available")) {
                       log.warn(
@@ -87,14 +86,19 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
                               + accountName
                               + "' have not been recorded yet.",
                           getAgentType());
-                      return null;
+                      return Collections.<KubernetesPodMetric>emptyList();
                     } else {
                       throw e;
                     }
                   }
                 })
+            .flatMap(Collection::stream)
             .filter(Objects::nonNull)
-            .flatMap(x -> x)
+            .collect(Collectors.toList());
+
+    List<CacheData> cacheData =
+        podMetrics.stream()
+            .map(m -> KubernetesCacheDataConverter.convertPodMetric(accountName, m))
             .collect(Collectors.toList());
 
     List<CacheData> invertedRelationships =

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -96,19 +96,16 @@ public class KubernetesMetricCachingAgent extends KubernetesCachingAgent<Kuberne
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
-    List<CacheData> cacheData =
-        podMetrics.stream()
-            .map(m -> KubernetesCacheDataConverter.convertPodMetric(accountName, m))
-            .collect(Collectors.toList());
+    KubernetesCacheData kubernetesCacheData = new KubernetesCacheData();
+    podMetrics.forEach(
+        metric ->
+            KubernetesCacheDataConverter.convertPodMetric(
+                kubernetesCacheData, accountName, metric));
 
-    List<CacheData> invertedRelationships =
-        KubernetesCacheDataConverter.invertRelationships(cacheData);
-
-    cacheData.addAll(invertedRelationships);
+    List<CacheData> cacheData = kubernetesCacheData.toCacheData();
 
     Map<String, Collection<CacheData>> entries =
-        KubernetesCacheDataConverter.stratifyCacheDataByGroup(
-            KubernetesCacheDataConverter.dedupCacheData(cacheData));
+        KubernetesCacheDataConverter.stratifyCacheDataByGroup(cacheData);
     KubernetesCacheDataConverter.logStratifiedCacheData(getAgentType(), entries);
 
     return new DefaultCacheResult(entries);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -175,10 +175,7 @@ public abstract class KubernetesV2CachingAgent
               }
             });
 
-    List<CacheData> resourceData = kubernetesCacheData.toCacheData();
-
-    Map<String, Collection<CacheData>> entries =
-        KubernetesCacheDataConverter.stratifyCacheDataByGroup(resourceData);
+    Map<String, Collection<CacheData>> entries = kubernetesCacheData.toStratifiedCacheData();
     KubernetesCacheDataConverter.logStratifiedCacheData(getAgentType(), entries);
 
     return new DefaultCacheResult(entries);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetric.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetric.java
@@ -20,18 +20,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
+@Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class KubernetesPodMetric {
-  private String podName;
-  @Builder.Default private List<ContainerMetric> containerMetrics = new ArrayList<>();
+  private final String podName;
+  private final String namespace;
+  @Builder.Default private final List<ContainerMetric> containerMetrics = new ArrayList<>();
 
   @Data
   @Builder

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -640,6 +640,7 @@ public class KubectlJobExecutor {
               podName,
               KubernetesPodMetric.builder()
                   .podName(podName)
+                  .namespace(namespace)
                   .containerMetrics(new ArrayList<>())
                   .build());
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -158,11 +158,12 @@ metadata:
     def podName = "pod-name"
     def podMetric = KubernetesPodMetric.builder()
       .podName(podName)
+      .namespace(namespace)
       .containerMetrics(containerMetrics)
       .build()
 
     when:
-    def cacheData = KubernetesCacheDataConverter.convertPodMetric(account, namespace, podMetric)
+    def cacheData = KubernetesCacheDataConverter.convertPodMetric(account, podMetric)
 
     then:
     cacheData.attributes == [

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys
@@ -123,36 +124,9 @@ metadata:
   }
 
   @Unroll
-  def "given a cache data entry, invert its relationships"() {
-    setup:
-    def id = Keys.InfrastructureCacheKey.createKey(kind, "account", "namespace", "version")
-    def cacheData = new DefaultCacheData(id, null, relationships)
-
-    when:
-    def result = KubernetesCacheDataConverter.invertRelationships([cacheData])
-
-    then:
-    relationships.every {
-      group, keys -> keys.every {
-        key -> result.find {
-          data -> data.id == key && data.relationships.get(kind.toString()) == [id] as Set
-        } != null
-      }
-    }
-
-    where:
-    kind                       | version                           | relationships
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["application": [Keys.ApplicationCacheKey.createKey("app")]]
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["application": []]
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | [:]
-    KubernetesKind.REPLICA_SET | KubernetesApiVersion.APPS_V1BETA1 | ["deployment": [Keys.InfrastructureCacheKey.createKey(KubernetesKind.DEPLOYMENT, "account", "namespace", "a-name")]]
-    KubernetesKind.SERVICE     | KubernetesApiVersion.V1           | ["cluster": [Keys.ClusterCacheKey.createKey("account", "app", "name")], "application": [Keys.ApplicationCacheKey.createKey("blarg")]]
-    KubernetesKind.SERVICE     | KubernetesApiVersion.V1           | ["cluster": [Keys.ClusterCacheKey.createKey("account", "app", "name")], "application": [Keys.ApplicationCacheKey.createKey("blarg"), Keys.ApplicationCacheKey.createKey("asdfasdf")]]
-  }
-
-  @Unroll
   def "correctly builds cache data entry for pod metrics"() {
     setup:
+    KubernetesCacheData kubernetesCacheData = new KubernetesCacheData()
     def account = "my-account"
     def namespace = "my-namespace"
     def podName = "pod-name"
@@ -161,11 +135,17 @@ metadata:
       .namespace(namespace)
       .containerMetrics(containerMetrics)
       .build()
+    def metricKey = new Keys.MetricCacheKey(KubernetesKind.POD, account, namespace, podName)
 
     when:
-    def cacheData = KubernetesCacheDataConverter.convertPodMetric(account, podMetric)
+    KubernetesCacheDataConverter.convertPodMetric(kubernetesCacheData, account, podMetric)
+    List<CacheData> cacheDataList = kubernetesCacheData.toCacheData()
 
     then:
+    CacheData cacheData = cacheDataList
+      .stream()
+      .filter({cd -> cd.id == metricKey.toString()})
+      .findFirst().get()
     cacheData.attributes == [
       name: podName,
       namespace: namespace,


### PR DESCRIPTION
This is a follow-up to #3829, using the newly created class in a few more places and deleting a lot of now-obsolete code.

* refactor(kubernetes): Process pod metrics outside of parallel loop 

  We currently fetch pod metrics in a parallel stream because most of the time is spent in IO waiting for kubectl to return the metrics. We're also processing the metrics in parallel, which blocks moving to the new KubernetesCacheData object as it is not threadsafe.

  Rather than make it threadsafe (which would add some overhead and complexity) just move the processing of the received metrics out of the parallel stream and into a sequential stream. We'll still fetch the metrics in a parallel stream, it's just the relatively fast post-processing that will now be sequential.

* refactor(kubernetes): Move pod metrics to use KubernetesCacheData 

  Remove invertRelationships and dedupCacheData from the KubernetesMetricCachingAgent by having it use KubernetesCacheData. This removes that last two uses of these functions, which can now be deleted.

* perf(kubernetes): Replace stratify function 

  After generating a Collection<CacheData> of kubernetes cache data, we always then group this data by the CacheData's group and perform some filtering of the data.

  The grouping and filtering requires parsing the cache key again, so it would be more efficient if we did this as part of KubernetesCacheData before writing out the CacheData entries.
