### PR TITLE
fix(kubernetes): Use deterministic temp file names

### DIFF
--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/ConfigFileServiceTest.java
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/ConfigFileServiceTest.java
@@ -64,16 +64,14 @@ class ConfigFileServiceTest {
   void getLocalPathWhenFileExists() throws IOException {
     createExpectedFile();
 
-    String fileName = configFileService.getLocalPath(TEST_FILE_PATH, "test", ".file");
+    String fileName = configFileService.getLocalPath(TEST_FILE_PATH);
     assertThat(fileName).isEqualTo(TEST_FILE_PATH);
   }
 
   @Test
   void getLocalPathWhenFileDoesNotExist() {
     RuntimeException exception =
-        assertThrows(
-            RuntimeException.class,
-            () -> configFileService.getLocalPath(TEST_FILE_PATH, "test", ".file"));
+        assertThrows(RuntimeException.class, () -> configFileService.getLocalPath(TEST_FILE_PATH));
     assertThat(exception.getMessage()).contains(TEST_FILE_PATH);
   }
 
@@ -81,8 +79,8 @@ class ConfigFileServiceTest {
   void getLocalPathWhenFileInConfigServer() {
     expectFileInConfigServer();
 
-    String fileName = configFileService.getLocalPath(CLOUD_TEST_FILE_NAME, "test", ".file");
-    assertThat(baseName(fileName)).startsWith("test").endsWith(".file");
+    String fileName = configFileService.getLocalPath(CLOUD_TEST_FILE_NAME);
+    assertThat(fileName).isEqualTo(TEST_FILE_PATH);
   }
 
   @Test
@@ -91,8 +89,7 @@ class ConfigFileServiceTest {
 
     RuntimeException exception =
         assertThrows(
-            RuntimeException.class,
-            () -> configFileService.getLocalPath(CLOUD_TEST_FILE_NAME, "test", ".file"));
+            RuntimeException.class, () -> configFileService.getLocalPath(CLOUD_TEST_FILE_NAME));
     assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
   }
 
@@ -102,16 +99,14 @@ class ConfigFileServiceTest {
 
     RuntimeException exception =
         assertThrows(
-            RuntimeException.class,
-            () -> configFileService.getLocalPath(CLOUD_TEST_FILE_NAME, "test", ".file"));
+            RuntimeException.class, () -> configFileService.getLocalPath(CLOUD_TEST_FILE_NAME));
     assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
   }
 
   @Test
   void getLocalPathWhenContentProvided() {
-    String fileName =
-        configFileService.getLocalPathForContents(TEST_FILE_CONTENTS, "test", ".file");
-    assertThat(baseName(fileName)).startsWith("test").endsWith(".file");
+    String fileName = configFileService.getLocalPathForContents(TEST_FILE_CONTENTS, TEST_FILE_NAME);
+    assertThat(fileName).isEqualTo(TEST_FILE_PATH);
   }
 
   @Test
@@ -138,10 +133,6 @@ class ConfigFileServiceTest {
         assertThrows(
             RuntimeException.class, () -> configFileService.getContents(CLOUD_TEST_FILE_NAME));
     assertThat(exception.getMessage()).contains(CLOUD_TEST_FILE_NAME);
-  }
-
-  private String baseName(String fileName) {
-    return new File(fileName).getName();
   }
 
   private void createExpectedFile() throws IOException {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -180,12 +180,12 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials>
     private String getKubeconfigFile(
         KubernetesConfigurationProperties.ManagedAccount managedAccount) {
       if (StringUtils.isNotEmpty(managedAccount.getKubeconfigFile())) {
-        return configFileService.getLocalPath(managedAccount.getKubeconfigFile(), "kube", "config");
+        return configFileService.getLocalPath(managedAccount.getKubeconfigFile());
       }
 
       if (StringUtils.isNotEmpty(managedAccount.getKubeconfigContents())) {
         return configFileService.getLocalPathForContents(
-            managedAccount.getKubeconfigContents(), "kube", "config");
+            managedAccount.getKubeconfigContents(), managedAccount.getName());
       }
 
       return System.getProperty("user.home") + "/.kube/config";


### PR DESCRIPTION
When writing a temp kube config file from `kubeconfigContents` or from a `kubeconfigFile` that contains a config server reference like `configserver:kubeconfig`, a temp file with a randomly-generated and unique name was being generated. This causes problems when dynamic account refresh is introduced to the kubernetes provider in #3824. Every refresh will result in a new file being created with a non-deterministic name, making it difficult to determine of the `kubeconfigContents` or `kubeonfigFile` value actually changed and potentially filling the file system with temp files. 

This commit changes the behavior to create the temp file with a known name in the system temp directory, and overwrite the file contents on each refresh instead of creating a new file. 
