### PR TITLE
perf(redis): Replace String.format with String.join

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/AbstractRedisCache.java
@@ -215,23 +215,23 @@ public abstract class AbstractRedisCache implements WriteableCache {
   }
 
   protected String attributesId(String type, String id) {
-    return String.format("%s:%s:attributes:%s", prefix, type, id);
+    return String.join(":", prefix, type, "attributes", id);
   }
 
   protected String relationshipId(String type, String id, String relationship) {
-    return String.format("%s:%s:relationships:%s:%s", prefix, type, id, relationship);
+    return String.join(":", prefix, type, "relationships", id, relationship);
   }
 
   private String hashesDisabled(String type) {
-    return String.format("%s:%s:hashes.disabled", prefix, type);
+    return String.join(":", prefix, type, "hashes.disabled");
   }
 
   protected String allRelationshipsId(String type) {
-    return String.format("%s:%s:relationships", prefix, type);
+    return String.join(":", prefix, type, "relationships");
   }
 
   protected String allOfTypeId(String type) {
-    return String.format("%s:%s:members", prefix, type);
+    return String.join(":", prefix, type, "members");
   }
 
   protected TypeReference getRelationshipsTypeReference() {


### PR DESCRIPTION
When caching large Kubernetes clusters, ~25% of allocated objects per caching cycle are from calling String.format on cache keys.

String.format is significantly more expensive than String.join as it parses the input as a regular expression. In this case, we can replace the calls to .format() with calls to .join() while keeping exactly the same functionality.