### PR TITLE
perf(redis): Don't re-encode string when computing hash

### DIFF
--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cache/RedisCache.java
@@ -15,8 +15,6 @@
  */
 package com.netflix.spinnaker.cats.redis.cache;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
@@ -442,7 +440,7 @@ public class RedisCache extends AbstractRedisCache {
       boolean hasTtl) {
     if (options.isHashingEnabled() && !hasTtl) {
       final String hash =
-          Hashing.sha1().newHasher().putString(serializedValue, UTF_8).hash().toString();
+          Hashing.sha1().newHasher().putUnencodedChars(serializedValue).hash().toString();
       final String existingHash = hashes.get(id);
       if (hash.equals(existingHash)) {
         return true;


### PR DESCRIPTION
When caching values in redis, we compare the hash of the value we're about to write against the value already in the cache to avoid writing unchanged values again.

The hash function we're using is expensive as it encodes the string to bytes before hashing it. Per the documentation of the putString function, it is only useful for cross-language compatibility and we should instead use putUnencodedChars for much better performance when this is not needed.

Link to header block:
https://github.com/google/guava/blob/af57f19e99110695d2b1329ae313aa5158580417/guava/src/com/google/common/hash/Hasher.java#L110