### PR TITLE
fix(SqlCache): modify typeSanitization regex to match unpermitted chars

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -65,7 +65,7 @@ class SqlCache(
     private val schemaVersion = SqlSchemaVersion.current()
     private val useRegexp = """.*[\?\[].*""".toRegex()
     private val cleanRegexp = """\.+\*""".toRegex()
-    private val typeSanitization = """[:/\-]""".toRegex()
+    private val typeSanitization = """[^A-Za-z0-9_]""".toRegex()
 
     private val log = LoggerFactory.getLogger(SqlCache::class.java)
   }

--- a/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/SqlCacheSpec.groovy
+++ b/cats/cats-sql/src/test/groovy/com/netflix/spinnaker/cats/sql/SqlCacheSpec.groovy
@@ -32,6 +32,19 @@ class SqlCacheSpec extends WriteableCacheSpec {
     SqlTestUtil.cleanupDb(context)
   }
 
+  def 'should handle invalid type'() {
+    given:
+    def data = createData('blerp', [a: 'b'])
+    ((SqlCache) cache).merge('foo.bar', data)
+
+    when:
+    def retrieved = ((SqlCache) cache).getAll('foo.bar')
+
+    then:
+    retrieved.size() == 1
+    retrieved.findAll { it.id == "blerp" }.size() == 1
+  }
+
   def 'should not write an item if it is unchanged'() {
     setup:
     def data = createData('blerp', [a: 'b'])


### PR DESCRIPTION
Fixes: https://github.com/spinnaker/spinnaker/issues/4591

Previously the type sanitization only had a limited set of matching characters, this creates bugs when encountering a cache type which included non-permitted mysql identifier characters. Change the regex to include the ASCII set of permitted chars outlined here: https://dev.mysql.com/doc/refman/5.7/en/identifiers.html

Added a test which previously failed to prove this fixes the problem.