### PR TITLE
fix(deps): bump fiat to 1.0.4-patch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@
 buildscript {
   ext {
     korkVersion = "5.2.6"
-    fiatVersion = "1.0.4"
+    fiatVersion = "1.0.9"
     kotlinVersion = "1.3.10"
     junitPlatformVersion = "1.0.2"
   }


### PR DESCRIPTION
Updates version of Fiat consumed to 1.0.9 (really a patch of 1.0.4), which includes [these commits](https://github.com/spinnaker/fiat/releases/tag/v1.0.9).