### PR TITLE
refactor(kubernetes): Create KubernetesKindRegistry

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCoreCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCoreCachingAgent.java
@@ -70,11 +70,9 @@ public class KubernetesCoreCachingAgent extends KubernetesV2OnDemandCachingAgent
 
   @Override
   protected List<KubernetesKind> primaryKinds() {
-    synchronized (KubernetesKind.getValues()) {
-      return KubernetesKind.getValues().stream()
-          .filter(credentials::isValidKind)
-          .filter(k -> !k.isDynamic())
-          .collect(Collectors.toList());
-    }
+    return KubernetesKind.getRegisteredKinds().stream()
+        .filter(credentials::isValidKind)
+        .filter(k -> !k.isDynamic())
+        .collect(Collectors.toList());
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+
+public class KubernetesKindRegistry {
+  private final List<KubernetesKind> values = Collections.synchronizedList(new ArrayList<>());
+
+  /** Registers a given {@link KubernetesKind} into the registry and returns the kind */
+  @Nonnull
+  public KubernetesKind registerKind(@Nonnull KubernetesKind kind) {
+    values.add(kind);
+    return kind;
+  }
+
+  /**
+   * Searches the registry for a {@link KubernetesKind} with the supplied name and apiGroup. If a
+   * kind is found, it is returned. If no kind is found, the provided {@link
+   * Supplier<KubernetesKind>} is invoked and the resulting kind is registered.
+   *
+   * <p>This method is guaranteed to atomically check and register the kind.
+   */
+  @Nonnull
+  public synchronized KubernetesKind getOrRegisterKind(
+      @Nonnull final String name,
+      @Nullable final KubernetesApiGroup apiGroup,
+      @Nonnull Supplier<KubernetesKind> supplier) {
+    return getRegisteredKind(name, apiGroup).orElseGet(() -> registerKind(supplier.get()));
+  }
+
+  /**
+   * Searches the registry for a {@link KubernetesKind} with the supplied name and apiGroup. Returns
+   * an {@link Optional<KubernetesKind>} containing the kind, or an empty {@link Optional} if no
+   * kind is found.
+   *
+   * <p>Kinds whose API groups are different but are both is a native API groups (see {@link
+   * KubernetesApiGroup#isNativeGroup()}) are considered to match.
+   */
+  @Nonnull
+  public Optional<KubernetesKind> getRegisteredKind(
+      @Nonnull final String name, @Nullable final KubernetesApiGroup apiGroup) {
+    if (StringUtils.isEmpty(name)) {
+      return Optional.of(KubernetesKind.NONE);
+    }
+
+    if (name.equalsIgnoreCase(KubernetesKind.NONE.toString())) {
+      throw new IllegalArgumentException("The 'NONE' kind cannot be read.");
+    }
+
+    Predicate<KubernetesKind> groupMatches =
+        kind -> {
+          // Exact match
+          if (Objects.equals(kind.getApiGroup(), apiGroup)) {
+            return true;
+          }
+
+          // If we have not specified an API group, default to finding a native kind that matches
+          if (apiGroup == null || apiGroup.isNativeGroup()) {
+            return kind.getApiGroup().isNativeGroup();
+          }
+
+          return false;
+        };
+
+    return values.stream()
+        .filter(
+            v ->
+                v.getName().equalsIgnoreCase(name)
+                    || (v.getAlias() != null && v.getAlias().equalsIgnoreCase(name)))
+        .filter(groupMatches)
+        .findAny();
+  }
+
+  /** Returns a list of all registered kinds */
+  @Nonnull
+  public List<KubernetesKind> getRegisteredKinds() {
+    return values;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -334,7 +334,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     // otherwise, checking all namespaces for all kinds is too expensive in large clusters (imagine
     // a cluster with 100s of namespaces).
     String checkNamespace = namespaces.get(0);
-    List<KubernetesKind> allKinds = KubernetesKind.getValues();
+    List<KubernetesKind> allKinds = KubernetesKind.getRegisteredKinds();
 
     log.info(
         "Checking permissions on configured kinds for account {}... {}", accountName, allKinds);

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKindRegistrySpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKindRegistrySpec.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindRegistry
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class KubernetesKindRegistrySpec extends Specification {
+  static final KubernetesApiGroup CUSTOM_API_GROUP =  KubernetesApiGroup.fromString("test")
+  static final KubernetesKind CUSTOM_KIND = KubernetesKind.fromString("customKind", CUSTOM_API_GROUP)
+
+  @Unroll
+  void "kinds from core API groups are returned if any core API group is input"() {
+    given:
+    @Subject KubernetesKindRegistry kindRegistry = new KubernetesKindRegistry()
+    kindRegistry.registerKind(KubernetesKind.REPLICA_SET)
+
+    when:
+    def kind = kindRegistry.getRegisteredKind(name, apiGroup)
+
+    then:
+    result == kind.orElse(null)
+
+    where:
+    name         | apiGroup                      | result
+    "replicaSet" | null                          | KubernetesKind.REPLICA_SET
+    "replicaSet" | KubernetesApiGroup.APPS       | KubernetesKind.REPLICA_SET
+    "replicaSet" | KubernetesApiGroup.EXTENSIONS | KubernetesKind.REPLICA_SET
+    "replicaSet" | CUSTOM_API_GROUP              | null
+    "rs"         | null                          | KubernetesKind.REPLICA_SET
+    "rs"         | KubernetesApiGroup.APPS       | KubernetesKind.REPLICA_SET
+    "replicaSet" | KubernetesApiGroup.EXTENSIONS | KubernetesKind.REPLICA_SET
+    "replicaSet" | CUSTOM_API_GROUP              | null
+
+  }
+
+  @Unroll
+  void "getRegisteredKind returns kinds that have been registered"() {
+    given:
+    @Subject KubernetesKindRegistry kindRegistry = new KubernetesKindRegistry()
+    KubernetesKind result
+
+    when:
+    result = kindRegistry.getRegisteredKind("customKind", CUSTOM_API_GROUP).orElse(null)
+
+    then:
+    result == null
+
+    when:
+    kindRegistry.registerKind(CUSTOM_KIND)
+    result = kindRegistry.getRegisteredKind("customKind", CUSTOM_API_GROUP).orElse(null)
+
+    then:
+    result == CUSTOM_KIND
+  }
+
+  @Unroll
+  void "getOrRegisterKind registers kinds that are not in the registry"() {
+    given:
+    @Subject KubernetesKindRegistry kindRegistry = new KubernetesKindRegistry()
+    KubernetesKind result
+
+    when:
+    result = kindRegistry.getOrRegisterKind("customKind", CUSTOM_API_GROUP, {CUSTOM_KIND})
+
+    then:
+    result == CUSTOM_KIND
+
+    when:
+    result = kindRegistry.getRegisteredKind("customKind", CUSTOM_API_GROUP).orElse(null)
+
+    then:
+    result == CUSTOM_KIND
+  }
+
+  @Unroll
+  void "getOrRegisterKind does not call the supplier for a kind that is already registered"() {
+    given:
+    @Subject KubernetesKindRegistry kindRegistry = new KubernetesKindRegistry()
+    kindRegistry.registerKind(CUSTOM_KIND)
+
+    when:
+    def result = kindRegistry.getOrRegisterKind("customKind", CUSTOM_API_GROUP, {
+      throw new Exception("Should not have called supplier")
+    })
+
+    then:
+    result == CUSTOM_KIND
+    noExceptionThrown()
+  }
+
+  @Unroll
+  void "getRegisteredKinds returns all kinds that are registered"() {
+    given:
+    @Subject KubernetesKindRegistry kindRegistry = new KubernetesKindRegistry()
+    Collection<KubernetesKind> kinds
+
+    when:
+    kinds = kindRegistry.getRegisteredKinds()
+
+    then:
+    kinds.isEmpty()
+
+    when:
+    kindRegistry.registerKind(KubernetesKind.REPLICA_SET)
+    kindRegistry.registerKind(CUSTOM_KIND)
+    kinds = kindRegistry.getRegisteredKinds()
+
+    then:
+    kinds.size() == 2
+    kinds.contains(KubernetesKind.REPLICA_SET)
+    kinds.contains(CUSTOM_KIND)
+  }
+}


### PR DESCRIPTION
The KubernetesKind class is responsible for both providing information about a given KubernetesKind and for keeping a registry of all registered kinds.  The registry of all kinds is stored as a list which is very inefficient to search.

In preparation for making this logic more efficient, create a KubernetesKindRegistry that supports registering kind or getting registered kinds. The implementation will be the exact same (inefficient) one that is currently directly in KubernetesKind but we have now defined an API and can write tests against it, and in a future commit replace it with a more efficient implementation.