### PR TITLE
perf(kubernetes): Use a more efficient kind registry

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
@@ -74,13 +74,13 @@ public class KubernetesKindRegistry {
     Predicate<KubernetesKind> groupMatches =
         kind -> {
           // Exact match
-          if (Objects.equals(kind.getApiGroup(), apiGroup)) {
+          if (Objects.equals(kind.getScopedKind().getApiGroup(), apiGroup)) {
             return true;
           }
 
           // If we have not specified an API group, default to finding a native kind that matches
           if (apiGroup == null || apiGroup.isNativeGroup()) {
-            return kind.getApiGroup().isNativeGroup();
+            return kind.getScopedKind().getApiGroup().isNativeGroup();
           }
 
           return false;
@@ -89,7 +89,7 @@ public class KubernetesKindRegistry {
     return values.stream()
         .filter(
             v ->
-                v.getName().equalsIgnoreCase(name)
+                v.getScopedKind().getName().equalsIgnoreCase(name)
                     || (v.getAlias() != null && v.getAlias().equalsIgnoreCase(name)))
         .filter(groupMatches)
         .findAny();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
@@ -17,23 +17,27 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
 public class KubernetesKindRegistry {
-  private final List<KubernetesKind> values = Collections.synchronizedList(new ArrayList<>());
+  private final Map<KubernetesKind.ScopedKind, KubernetesKind> nameMap = new ConcurrentHashMap<>();
+  private final Map<KubernetesKind.ScopedKind, KubernetesKind> aliasMap = new ConcurrentHashMap<>();
 
   /** Registers a given {@link KubernetesKind} into the registry and returns the kind */
   @Nonnull
-  public KubernetesKind registerKind(@Nonnull KubernetesKind kind) {
-    values.add(kind);
+  public synchronized KubernetesKind registerKind(@Nonnull KubernetesKind kind) {
+    nameMap.put(kind.getScopedKind(), kind);
+    if (kind.getAlias() != null) {
+      aliasMap.put(
+          new KubernetesKind.ScopedKind(kind.getAlias(), kind.getScopedKind().getApiGroup()), kind);
+    }
     return kind;
   }
 
@@ -71,33 +75,23 @@ public class KubernetesKindRegistry {
       throw new IllegalArgumentException("The 'NONE' kind cannot be read.");
     }
 
-    Predicate<KubernetesKind> groupMatches =
-        kind -> {
-          // Exact match
-          if (Objects.equals(kind.getScopedKind().getApiGroup(), apiGroup)) {
-            return true;
-          }
+    KubernetesKind.ScopedKind searchKey = new KubernetesKind.ScopedKind(name, apiGroup);
+    KubernetesKind result = nameMap.get(searchKey);
+    if (result != null) {
+      return Optional.of(result);
+    }
 
-          // If we have not specified an API group, default to finding a native kind that matches
-          if (apiGroup == null || apiGroup.isNativeGroup()) {
-            return kind.getScopedKind().getApiGroup().isNativeGroup();
-          }
+    result = aliasMap.get(searchKey);
+    if (result != null) {
+      return Optional.of(result);
+    }
 
-          return false;
-        };
-
-    return values.stream()
-        .filter(
-            v ->
-                v.getScopedKind().getName().equalsIgnoreCase(name)
-                    || (v.getAlias() != null && v.getAlias().equalsIgnoreCase(name)))
-        .filter(groupMatches)
-        .findAny();
+    return Optional.empty();
   }
 
   /** Returns a list of all registered kinds */
   @Nonnull
   public List<KubernetesKind> getRegisteredKinds() {
-    return values;
+    return new ArrayList<>(nameMap.values());
   }
 }


### PR DESCRIPTION
* refactor(kubernetes): Pull kind identifying information to ScopedKind 

  I created ScopedKind as a helper class in KubernetesKind but it really represents the "key" for a given Kind (ie, the unique information that determines what kind we're talking about as opposed to other attributes).

  Move the name and apiGroup information to live in ScopedKind to encapsulate this.

* perf(kubernetes): Use a more efficient kind registry 

  We're always looking up kinds by either name or alias; instead of storing the kinds as an array and looping on every request, create a HashMap mapping the name -> KubernetesKind and another mapping alias -> KubernetesKind so it's easy to look up a kind by name or alias.
