### PR TITLE
perf(kubernetes): Improve performance of kubernetes search

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -178,6 +178,11 @@ public class Keys {
     @Getter private static final Kind kind = Kind.LOGICAL;
 
     public abstract LogicalKind getLogicalKind();
+
+    @Override
+    public final String getGroup() {
+      return getLogicalKind().toString();
+    }
   }
 
   @EqualsAndHashCode(callSuper = true)
@@ -244,11 +249,6 @@ public class Keys {
     public String toString() {
       return createKeyFromParts(getKind(), logicalKind, name);
     }
-
-    @Override
-    public String getGroup() {
-      return logicalKind.toString();
-    }
   }
 
   @EqualsAndHashCode(callSuper = true)
@@ -282,11 +282,6 @@ public class Keys {
     @Override
     public String toString() {
       return createKeyFromParts(getKind(), logicalKind, account, application, name);
-    }
-
-    @Override
-    public String getGroup() {
-      return logicalKind.toString();
     }
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
@@ -207,7 +207,7 @@ public class KubernetesV2SearchProvider implements SearchProvider {
                     return null;
                   }
                 })
-            .filter(Objects::nonNull)
+            .filter(k -> k != null && k != KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED)
             .map(kindMap::translateSpinnakerKind)
             .flatMap(Collection::stream)
             .map(KubernetesKind::toString)


### PR DESCRIPTION
* perf(kubernetes): Filter unclassified kinds from search query 

  When performing searches, we attempt to interpret the input type as a Spinnaker kind and to search the corresponding Kubernetes kinds. For example, if a user inputs serverGroups, we'll translate that to add replicaSets and daemonSets to the types to search.

  If the input type is *not* a Spinnaker kind, it gets mapped to KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED. Currently this is causing the search logic to search *every* Kubernetes kind that is also unclassified which is expensive and not what we want.

  If the input string is not a Spinnaker kind, just skip adding any extra kubernetes kinds to search.

* refactor(kubernetes): Simplify relationship code 

  The code to look up keys related to an application/cluster that matches the search query is overly complex. Simplify it by:
  * Simplifying the stream operations
  * Replacing the use of a Pair<> with a helper class
  * Parsing the logical key as we read it from the cache rather than later.

* refactor(kubernetes): Minor style changes 

  * Push the getGroup function that's identically overriden in both subclasses of LogicalKey up to the base class
  * Use the more specific logicalKey that was just cast when converting a key to a map
  * Instead of creating a List from each search result separately, then combining them, just concatenate the streams. Also move the identical isNull check to the combined stream instead of having it on each separate one.

* perf(kubernetes): Improve performance of kubernetes search 

  Instead of processing all relationships of applications/clusters that match, and later filtering to those that are of types of interest, push the filtering logic down. Only fetch relationships that point to a kind of interest.

  We can also simplify the post-filtering logic; the only time the result's type and group will differ is when the group is a KubernetesKind and the type is the corresponding SpinnakerKind. But if we're searching for a SpinnakerKind, the typesToSearch will already have all mapped KubernetesKind's so it's redundant to also check if the SpinnakerKind is in typesToMatch.

  This also removes the need to separately keep track of typesToSearch and typesToMatch.
