### PR TITLE
fix(appengine): Fix threading bugs in AppengineMutexRepository

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/AppengineMutexRepository.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/AppengineMutexRepository.groovy
@@ -18,45 +18,34 @@ package com.netflix.spinnaker.clouddriver.appengine.deploy
 
 import java.util.concurrent.Semaphore
 
-class AppengineMutexRepository {
-  static HashMap<String, Mutex> mutexRepository = new HashMap<>()
+public class AppengineMutexRepository {
+  private static HashMap<String, Mutex> mutexRepository = new HashMap<>()
 
-  static <T> T atomicWrapper(String mutexKey, Closure<T> doOperation) {
+  public static <T> T atomicWrapper(String mutexKey, Closure<T> doOperation) {
     if (!mutexRepository.containsKey(mutexKey)) {
       mutexRepository.put(mutexKey, new Mutex())
     }
     Mutex mutex = mutexRepository.get(mutexKey)
 
-    // Outside the try {} block, because in the case of an exception being thrown here, we don't want to try unlocking
-    // the mutex in the finally block.
     mutex.lock()
-    T result = null
-    Exception failure
     try {
-      result = doOperation()
-    } catch (Exception e) {
-      failure = e
+      return doOperation()
     } finally {
       mutex.unlock()
-      if (failure) {
-        throw failure
-      } else {
-        return result
-      }
     }
   }
 
-  static class Mutex {
-    Semaphore sem
+  private static class Mutex {
+    private Semaphore sem
 
-    void lock() {
+    public void lock() {
       if (sem == null) {
         sem = new Semaphore(1)
       }
       sem.acquire()
     }
 
-    void unlock() {
+    public void unlock() {
       if (sem == null) {
         throw new IllegalStateException("Attempt made to unlock mutex that was never locked")
       }
@@ -64,4 +53,3 @@ class AppengineMutexRepository {
     }
   }
 }
-


### PR DESCRIPTION
I found these bugs while looking into spinnaker/spinnaker#4574.  I'm not sure if this is the root cause of those issues, but it certainly could be and is worth fixing.

* refactor(appengine): Remove unnecessary catch block 

  There's no need to catch an exception only to re-throw it in the finally block. Replace with an idiomatic try/finally.

  Also add some public/private modifiers that will make conversion to java in the next commit easier.

* refactor(appengine): Convert mutex repository to java 

* fix(appengine): Fix threading bugs in AppengineMutexRepository 

  There are a couple of threading bugs here:
  (1) We do an unsyncronized containsKey + put to generate the mutex for a given String, which can lead to two threads holding different Mutexes for the same String.
  (2) The Mutex itself has a bug whereby two threads calling lock can actually acquire different semaphores.

  Remove the Mutex class entirely and replace it with a ReentrantLock which supports the same operations. Use a ConcurrentHashMap and the atomic computeIfAbsent to store the mappings from keys to locks.
