### PR TITLE
fix(kubernetes): Fix daemonset stability condition

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
@@ -105,6 +105,12 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
       return result;
     }
 
+    Long observedGeneration = status.getObservedGeneration();
+    if (observedGeneration != null
+        && !observedGeneration.equals(daemonSet.getMetadata().getGeneration())) {
+      return result.unstable("Waiting for daemonset spec update to be observed");
+    }
+
     int desiredReplicas = status.getDesiredNumberScheduled();
     Integer existing = status.getCurrentNumberScheduled();
     if (existing == null || desiredReplicas > existing) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -103,7 +103,7 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
 
     Long observedGeneration = status.getObservedGeneration();
     if (observedGeneration != null
-        && observedGeneration != replicaSet.getMetadata().getGeneration()) {
+        && !observedGeneration.equals(replicaSet.getMetadata().getGeneration())) {
       result.unstable("Waiting for replicaset spec update to be observed");
     }
 


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4571.

Currently we'll consider a daemonset stable if it has the correct number of replicas, even if they are of the wrong generation. Fix this by adding a check for the generation, just as we do for replica sets.

Also, fix a bug in the replica set implementation where we are comparing Integers using == instead of using .equals.