### PR TITLE
feat(kubernetes): allow multi-manifest with rollout strategies

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -262,11 +262,11 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
   }
 
   private void validateManifestsForRolloutStrategies(List<KubernetesManifest> manifests) {
-    if (description.getStrategy() != null
-        && (manifests.size() != 1
-            || !manifests.get(0).getKind().equals(KubernetesKind.REPLICA_SET))) {
+    long numReplicaSets =
+        manifests.stream().filter(m -> m.getKind().equals(KubernetesKind.REPLICA_SET)).count();
+    if (description.getStrategy() != null && numReplicaSets != 1) {
       throw new RuntimeException(
-          "Spinnaker can manage traffic for ReplicaSets only. Please deploy exactly one ReplicaSet manifest or disable rollout strategies.");
+          "Spinnaker can manage traffic for one ReplicaSet only. Please deploy one ReplicaSet manifest or disable rollout strategies.");
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/4446

- Removes validation preventing multi-manifests to be deployed as part of a Spinnaker-coordinated rollout strategy. Still expects exactly one ReplicaSet, but now permits other resources to be deployed alongside the ReplicaSet. (Also, the designated Service must still be deployed prior to the rollout.)

Related PRs:
Deck: spinnaker/deck#7219
Orca: https://github.com/spinnaker/orca/pull/3034