### PR TITLE
fix(appengine): check for null versions in servergroup caching agent

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineServerGroupCachingAgent.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineServerGroupCachingAgent.groovy
@@ -318,9 +318,11 @@ class AppengineServerGroupCachingAgent extends AbstractAppengineCachingAgent imp
       def callback = new AppengineCallback<ListVersionsResponse>()
         .success { ListVersionsResponse versionsResponse, HttpHeaders responseHeaders ->
           def versions = versionsResponse.getVersions()
-          versions.removeIf { shouldIgnoreServerGroup(it.getId()) }
           if (versions) {
-            serverGroupsByLoadBalancer[loadBalancer].addAll(versions)
+            versions.removeIf { shouldIgnoreServerGroup(it.getId()) }
+            if(versions) {
+              serverGroupsByLoadBalancer[loadBalancer].addAll(versions)
+            }
           }
         }
 


### PR DESCRIPTION
Appengine always requires that a service have at least 1 version, except for the `default` version which is not deletable. This causes an NPE when the caching agent attempts to cache a `default` service with 0 versions. Put the removeIf inside of the version check to fix this NPE