### PR TITLE
perf(google): when fetching lbs, only load every sg if needed

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.google.provider.view
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.base.Strings
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
@@ -54,13 +55,13 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
   @Override
   Set<GoogleLoadBalancerView> getApplicationLoadBalancers(String application) {
     String pattern = Keys.getLoadBalancerKey("*", "*", "${application}*")
-    Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, pattern)
+    Set<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, pattern).toSet()
 
     // It is possible to configure a server group in application A to use a load balancer from
     // application B. Therefore, if (and only if) we have not already retrieved load balancer
     // identifiers for all applications, we need to retrieve identifiers for every load balancer
     // associated with a server group from this application.
-    if (application != null && !application.isEmpty()) {
+    if (!Strings.isNullOrEmpty(application)) {
       Collection<CacheData> applicationServerGroups = cacheView.getAll(
         SERVER_GROUPS.ns,
         cacheView.filterIdentifiers(SERVER_GROUPS.ns, "${GoogleCloudProvider.ID}:*:${application}-*")
@@ -68,9 +69,7 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
       applicationServerGroups.each { CacheData serverGroup ->
         Collection<String> relatedLoadBalancers = serverGroup.relationships[LOAD_BALANCERS.ns] ?: []
         relatedLoadBalancers.each { String lb ->
-          if (!identifiers.contains(lb)) {
-            identifiers.add(lb)
-          }
+          identifiers.add(lb)
         }
       }
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleLoadBalancerProvider.groovy
@@ -53,21 +53,32 @@ class GoogleLoadBalancerProvider implements LoadBalancerProvider<GoogleLoadBalan
 
   @Override
   Set<GoogleLoadBalancerView> getApplicationLoadBalancers(String application) {
-    def pattern = Keys.getLoadBalancerKey("*", "*", "${application}*")
-    def identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, pattern)
+    String pattern = Keys.getLoadBalancerKey("*", "*", "${application}*")
+    Collection<String> identifiers = cacheView.filterIdentifiers(LOAD_BALANCERS.ns, pattern)
 
-    def applicationServerGroups = cacheView.getAll(
+    // It is possible to configure a server group in application A to use a load balancer from
+    // application B. Therefore, if (and only if) we have not already retrieved load balancer
+    // identifiers for all applications, we need to retrieve identifiers for every load balancer
+    // associated with a server group from this application.
+    if (application != null && !application.isEmpty()) {
+      Collection<CacheData> applicationServerGroups = cacheView.getAll(
         SERVER_GROUPS.ns,
         cacheView.filterIdentifiers(SERVER_GROUPS.ns, "${GoogleCloudProvider.ID}:*:${application}-*")
-    )
-    applicationServerGroups.each { CacheData serverGroup ->
-      identifiers.addAll(serverGroup.relationships[LOAD_BALANCERS.ns] ?: [])
+      )
+      applicationServerGroups.each { CacheData serverGroup ->
+        Collection<String> relatedLoadBalancers = serverGroup.relationships[LOAD_BALANCERS.ns] ?: []
+        relatedLoadBalancers.each { String lb ->
+          if (!identifiers.contains(lb)) {
+            identifiers.add(lb)
+          }
+        }
+      }
     }
 
     // TODO(duftler): De-frigga this.
 
     cacheView.getAll(LOAD_BALANCERS.ns,
-                     identifiers.unique(),
+                     identifiers,
                      RelationshipCacheFilter.include(SERVER_GROUPS.ns, INSTANCES.ns)).collect { CacheData loadBalancerCacheData ->
       loadBalancersFromCacheData(loadBalancerCacheData, (loadBalancerCacheData?.relationships?.get(INSTANCES.ns) ?: []) as Set)
     } as Set


### PR DESCRIPTION
- Some GCE users have reported that it can take about ten seconds to open the clone server group modal. The slowest request that must complete before the model loads is to `/loadBalancers?provider=gce`. Based on profiling, `GoogleLoadBalancerProvider.getApplicationLoadBalancers` seems to be the main culprit in terms of allocations.
- This method first retrieves every LB ID associated with the given application. Then, since you can attach other applications' LBs to a SG, it grabs every single server group in the given application and grabs every associated LB's ID. Then it dedupes all the LB IDs.
- This gets really bad because we are calling this method from `GoogleLoadBalancerProvider.list` with _no_ application specified, so we were grabbing _every_ load balancer from the cache, and then grabbing _every_ server group from the cache, grabbing every related LB from each of those SGs, and then de-duping the LBs. Instead, since we're already grabbing every LB if we're not filtering by application, let's skip the step where we grab every single server group to read their LBs.
-  Open question / next steps: should we add application name as a query param when we make this request from deck? (Would that even help in applications with many more application-SGs than total-LBs?) More importantly, do we really need to read this much stuff from the cache on load of the clone server modal or can we defer to just in time when the LB dropdown is selected? To be continued...