### PR TITLE
refactor(google): use Get instead of List to find a specific image

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/Images.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/Images.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.compute;
 
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.ComputeRequest;
-import com.google.api.services.compute.model.ImageList;
+import com.google.api.services.compute.model.Image;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.google.GoogleExecutor;
@@ -38,11 +38,10 @@ public class Images {
     this.registry = registry;
   }
 
-  public GoogleComputeRequest<Compute.Images.List, ImageList> list(String project)
+  public GoogleComputeRequest<Compute.Images.Get, Image> get(String project, String image)
       throws IOException {
-
-    Compute.Images.List request = credentials.getCompute().images().list(project);
-    return wrapRequest(request, "list");
+    Compute.Images.Get request = credentials.getCompute().images().get(project, image);
+    return wrapRequest(request, "get");
   }
 
   private <RequestT extends ComputeRequest<ResponseT>, ResponseT>

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/FakeGoogleComputeOperationRequest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/compute/FakeGoogleComputeOperationRequest.java
@@ -32,7 +32,7 @@ public class FakeGoogleComputeOperationRequest<RequestT extends ComputeRequest<O
   }
 
   public FakeGoogleComputeOperationRequest(Operation response) {
-    super(response);
+    super(response, /* request= */ null);
   }
 
   @Override

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/SetStatefulDiskAtomicOperationUnitSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/SetStatefulDiskAtomicOperationUnitSpec.groovy
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.ops
 
-
 import com.google.api.services.compute.model.InstanceGroupManager
-import com.google.api.services.compute.model.Operation
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.google.compute.FakeGoogleComputeOperationRequest
@@ -73,7 +71,7 @@ class SetStatefulDiskAtomicOperationUnitSpec extends Specification {
       credentials: CREDENTIALS)
     def operation = new SetStatefulDiskAtomicOperation(clusterProvider, computeApiFactory, description)
     def updateOp = new FakeGoogleComputeOperationRequest<>()
-    def getManagerRequest = new FakeGoogleComputeRequest<>(new InstanceGroupManager())
+    def getManagerRequest = FakeGoogleComputeRequest.createWithResponse(new InstanceGroupManager())
     _ * serverGroupManagers.get() >> getManagerRequest
 
     when:


### PR DESCRIPTION
I found this while looking for calls that needed pagination support. I
started to add pagination to the List call before I realized there was
really no point since we were applying a filter so that it would only
ever return a single image (or none).

I'm not sure why this didn't occur to me when I originally wrote the
code.