### PR TITLE
fix(kubernetes): fix property parser exception

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/PropertyParser.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/PropertyParser.java
@@ -40,6 +40,11 @@ public class PropertyParser {
       if (MAGIC_SEARCH_PATTERN.matcher(line).find()) {
         log.debug("Identified: " + line);
         String[] splittedLine = line.split("=");
+        // if the split line doesn't match our expected length it cannot
+        // be parsed so we should skip it.
+        if (splittedLine.length != 2) {
+          continue;
+        }
         final String key = splittedLine[0].replaceFirst(MAGIC_SEARCH_STRING, "").toLowerCase();
         final String value = splittedLine[1].trim();
         log.debug(key + ":" + value);

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/PropertyParserSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/PropertyParserSpec.groovy
@@ -80,4 +80,14 @@ class PropertyParserSpec extends Specification {
         then:
         properties.size() == 0
     }
+
+    def "Does not attempt to parse properties with empty values"() {
+      String buildLog = "SPINNAKER_PROPERTY_FOO="
+
+      when:
+      Map<String, Object> properties = PropertyParser.extractPropertiesFromLog(buildLog)
+
+      then:
+      properties.size() == 0
+    }
 }


### PR DESCRIPTION
when the property parser exountered a malformed it would throw an out of
bounds exception and fail. we should just skip properties with empty
values.