### PR TITLE
fix(titus): Don't set default ZoneBalance during cloneServerGroup ope…

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.groovy
@@ -334,9 +334,6 @@ class TitusDeployHandler implements DeployHandler<TitusDeployDescription> {
             submitJobRequest.withConstraint(SubmitJobRequest.Constraint.soft(constraint))
           }
         }
-        if (description.jobType == "service" && !description.hardConstraints?.contains(SubmitJobRequest.Constraint.ZONE_BALANCE) && !description.softConstraints?.contains(SubmitJobRequest.Constraint.ZONE_BALANCE)) {
-          submitJobRequest.withConstraint(SubmitJobRequest.Constraint.soft(SubmitJobRequest.Constraint.ZONE_BALANCE))
-        }
     }
     if (description.jobType) {
       submitJobRequest.withJobType(description.jobType)


### PR DESCRIPTION
`ZoneBalance` was set `true` if the `cloneServerGroup` payload did not include `hardConstraints` and `softConstraints` , removing this logic and set only the values that are passed from the payload.

Tested the case with and without `hardConstraints` and `softConstraints` and looks fine from my tests.