### PR TITLE
fix(titus): Don't set default ZoneBalance during cloneServerGroup ope…

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
@@ -121,6 +121,13 @@ public class KubernetesV2InstanceProvider
 
     List<ContainerLog> result = new ArrayList();
 
+    // Short-circuit if pod cannot be found
+    if (pod == null) {
+      result.add(
+          new ContainerLog("Error", "Failed to retrieve pod data; pod may have been deleted."));
+      return result;
+    }
+
     // Make live calls rather than abuse the cache for storing all logs
     for (V1Container container : pod.getSpec().getContainers()) {
       ContainerLog log = new ContainerLog();


### PR DESCRIPTION
…ration (#3887)

Closes https://github.com/spinnaker/spinnaker/issues/4640

- Previously, when fetching logs from deleted pods we hit an NPE on line 132 of `KubernetesV2InstanceProvider.getConsoleOutput`.
- This surfaced a potentially confusing "Internal Server Error" in the "View Console Output (Raw)" modal of the UI, which can briefly appear in the time after deleting a resource manually but before Deck knows this. This change adds a more explicit error message when a pod cannot be found.

<details><summary>Before</summary>
<p>

![88ONQUR1B6J](https://user-images.githubusercontent.com/15936279/61485600-89361e00-a96f-11e9-9a63-8e5f974c3ac0.png)

</p>
</details>

<details><summary>After</summary>
<p>

![srcPp2QeU5m](https://user-images.githubusercontent.com/15936279/61485605-8a674b00-a96f-11e9-8a2e-f3e020a70b4e.png)

</p>
</details>



