### PR TITLE
perf(google): improve performance of /serverGroups endpoint

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.java
@@ -84,7 +84,7 @@ final class GoogleApplicationProvider implements ApplicationProvider {
     return getApplicationCacheData(cacheData);
   }
 
-  ApplicationCacheData getApplicationCacheData(CacheData cacheData) {
+  private ApplicationCacheData getApplicationCacheData(CacheData cacheData) {
     return new ApplicationCacheData(
         cacheData.getAttributes(),
         getRelationships(cacheData, CLUSTERS),

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -78,19 +78,19 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
   }
 
   Map<String, Set<GoogleCluster.View>> getClusters(String applicationName, boolean includeInstanceDetails) {
-    CacheData applicationCacheData = applicationProvider.getApplicationCacheData(applicationName)
+    GoogleApplicationProvider.ApplicationCacheData applicationCacheData = applicationProvider.getApplicationCacheData(applicationName)
 
-    Set<String> applicationClusterIdentifiers = applicationProvider.getApplicationClusterIdentifiers(applicationCacheData)
+    Set<String> clusterIdentifiers = applicationCacheData.getClusterIdentifiers();
     Collection<CacheData> clusterCacheData = cacheView.getAll(
       CLUSTERS.ns,
-      applicationClusterIdentifiers,
+      clusterIdentifiers,
       RelationshipCacheFilter.include(SERVER_GROUPS.ns)
     )
 
-    Set<String> applicationInstanceIdentifiers = includeInstanceDetails ?
-      applicationProvider.getApplicationInstanceIdentifiers(applicationCacheData) :
+    Set<String> instanceIdentifiers = includeInstanceDetails ?
+      applicationCacheData.getInstanceIdentifiers() :
       Collections.<String>emptySet()
-    Collection<CacheData> applicationInstanceCacheData = instanceProvider.getInstanceCacheData(applicationInstanceIdentifiers)
+    Collection<CacheData> instanceCacheData = instanceProvider.getInstanceCacheData(instanceIdentifiers)
 
     Map<String, Set<GoogleCluster.View>> clustersByAccount = new HashMap<>()
     Map<String, Set<GoogleSecurityGroup>> securityGroupsByAccount = new HashMap<>()
@@ -105,7 +105,7 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
         accountName,
         { a -> new HashSet<GoogleCluster.View>() }
       )
-      accountClusters.add(clusterFromCacheData(cacheData, applicationInstanceCacheData, accountSecurityGroups))
+      accountClusters.add(clusterFromCacheData(cacheData, instanceCacheData, accountSecurityGroups))
     }
 
     return clustersByAccount

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.provider.view
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.collect.ImmutableSet
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
@@ -77,26 +78,37 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
   }
 
   Map<String, Set<GoogleCluster.View>> getClusters(String applicationName, boolean includeInstanceDetails) {
-    GoogleApplication.View application = applicationProvider.getApplication(applicationName)
+    CacheData applicationCacheData = applicationProvider.getApplicationCacheData(applicationName)
 
-    def clusterKeys = []
-    application?.clusterNames?.each { String accountName, Set<String> clusterNames ->
-      clusterNames.each { String clusterName ->
-        clusterKeys << Keys.getClusterKey(accountName, applicationName, clusterName)
-      }
+    Set<String> applicationClusterIdentifiers = applicationProvider.getApplicationClusterIdentifiers(applicationCacheData)
+    Collection<CacheData> clusterCacheData = cacheView.getAll(
+      CLUSTERS.ns,
+      applicationClusterIdentifiers,
+      RelationshipCacheFilter.include(SERVER_GROUPS.ns)
+    )
+
+    Set<String> applicationInstanceIdentifiers = includeInstanceDetails ?
+      applicationProvider.getApplicationInstanceIdentifiers(applicationCacheData) :
+      Collections.<String>emptySet()
+    Collection<CacheData> applicationInstanceCacheData = instanceProvider.getInstanceCacheData(applicationInstanceIdentifiers)
+
+    Map<String, Set<GoogleCluster.View>> clustersByAccount = new HashMap<>()
+    Map<String, Set<GoogleSecurityGroup>> securityGroupsByAccount = new HashMap<>()
+
+    clusterCacheData.each { cacheData ->
+      String accountName = cacheData.getAttributes().get("accountName")
+      Set<GoogleSecurityGroup> accountSecurityGroups = securityGroupsByAccount.computeIfAbsent(
+        accountName,
+        { a -> securityGroupProvider.getAllByAccount(false, accountName) }
+      )
+      Set<GoogleCluster.View> accountClusters = clustersByAccount.computeIfAbsent(
+        accountName,
+        { a -> new HashSet<GoogleCluster.View>() }
+      )
+      accountClusters.add(clusterFromCacheData(cacheData, applicationInstanceCacheData, accountSecurityGroups))
     }
 
-    // TODO(jacobkiefer): Avoid parsing instance keys into map just to re-serialize?
-    Set<String> allApplicationInstanceKeys = includeInstanceDetails ? application?.instances?.collect { Keys.getInstanceKey(it.account, it.region, it.name) } : [] as Set
-
-    List<GoogleCluster.View> clusters = cacheView.getAll(
-        CLUSTERS.ns,
-        clusterKeys,
-        RelationshipCacheFilter.include(SERVER_GROUPS.ns)).collect { CacheData cacheData ->
-      clusterFromCacheData(cacheData, allApplicationInstanceKeys)
-    }
-
-    clusters?.groupBy { it.accountName } as Map<String, Set<GoogleCluster.View>>
+    return clustersByAccount
   }
 
   @Override
@@ -167,10 +179,22 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
     return false
   }
 
-  GoogleCluster.View clusterFromCacheData(CacheData cacheData, Set<String> instanceKeySuperSet) {
-    GoogleCluster.View clusterView = objectMapper.convertValue(cacheData.attributes, GoogleCluster)?.view
+  GoogleCluster.View clusterFromCacheData(CacheData clusterCacheData, Set<String> instanceKeySuperSet) {
+    return clusterFromCacheData(
+      clusterCacheData,
+      instanceProvider.getInstanceCacheData(instanceKeySuperSet),
+      securityGroupProvider.getAllByAccount(false, (String) clusterCacheData.getAttributes().get("accountName"))
+    )
+  }
 
-    def serverGroupKeys = cacheData.relationships[SERVER_GROUPS.ns]
+  GoogleCluster.View clusterFromCacheData(
+    CacheData clusterCacheData,
+    Collection<CacheData> instanceCacheDataSuperSet,
+    Set<GoogleSecurityGroup> securityGroups)
+  {
+    GoogleCluster.View clusterView = objectMapper.convertValue(clusterCacheData.attributes, GoogleCluster)?.view
+
+    def serverGroupKeys = clusterCacheData.relationships[SERVER_GROUPS.ns]
     if (serverGroupKeys) {
       log.debug("Server group keys from cluster relationships: ${serverGroupKeys}")
       def filter = RelationshipCacheFilter.include(LOAD_BALANCERS.ns)
@@ -178,9 +202,7 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
       def serverGroupData = cacheView.getAll(SERVER_GROUPS.ns, serverGroupKeys, filter)
       log.debug("Retrieved cache data for server groups: ${serverGroupData?.collect { it?.attributes?.name }}")
 
-      def securityGroups = securityGroupProvider.getAllByAccount(false, clusterView.accountName)
-
-      def instanceCacheData = instanceProvider.getInstanceCacheData(instanceKeySuperSet as List).findAll { instance ->
+      def instanceCacheData = instanceCacheDataSuperSet.findAll { instance ->
         instance.relationships.get(CLUSTERS.ns)?.collect { Keys.parse(it).cluster }?.any { it.contains(clusterView.name) }
       }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleInstanceProvider.groovy
@@ -81,7 +81,7 @@ class GoogleInstanceProvider implements InstanceProvider<GoogleInstance.View, St
     }
   }
 
-  Collection<CacheData> getInstanceCacheData(List<String> keys) {
+  Collection<CacheData> getInstanceCacheData(Collection<String> keys) {
     cacheView.getAll(INSTANCES.ns,
                      keys,
                      RelationshipCacheFilter.include(LOAD_BALANCERS.ns,


### PR DESCRIPTION
As the number of GCE resources increases, the `/serverGroups` request becomes unacceptably slow. Because I would like to cherry-pick this into 1.15, this is intended to be the least invasive refactor possible. Changes by class:

`GoogleApplicationProvider`
- Abstracts retrieving application cache data, and the identifiers of clusters and instances associated with an application, into reusable methods (to be used by `GoogleClusterProvider`).

`GoogleClusterProvider`
- Previously, `GoogleClusterProvider.getClusters` called `GoogleApplicationProvider.getApplication`, which retrieves the application cache data, maps it to a `GoogleApplication` object, transforms the related clusters into an account-to-cluster map, and transforms the related instances into a list of maps created by calling `Keys.parse`, which is expensive (more on that later). These transformations were unnecessary, because `getClusters` proceeded to transform the account-to-cluster map and the expensively parsed instance maps back into a list of keys of each. This change instead retrieves the raw application cache data and reads the list of related clusters and instances directly from its relationships.
- `GoogleClusterProvider.getClusters` calls `GoogleClusterProvider.clusterFromCacheData` for each cluster in the application. Previously, in each `clusterFromCacheData` call, we were calling `GoogleSecurityGroupProvider.getAllByAccount`, when in fact we should only need to fetch a given account's security groups once. This change lifts the security groups retrieval to the parent method, creating an account-to-security-groups map. We were also calling `GoogleInstanceProvider.getInstanceCacheData` on a list of every application instance for every cluster in the application, so this change also lifts that logic to the parent method and creates a second signature for `clusterFromCacheData` to preserve backwards compatibility with other consumers.

Next steps:
- Based on profiling a Clouddriver pod of a GCE installation with many resources, a non-trivial source of allocations is `Pattern.compile` calls in frigga utils, which is called by `Keys.parse`. I will investigate if any of the patterns can be made static.
