### PR TITLE
fix(kubernetes/v1): re-add currentCpuUtilization

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesAutoscalerStatus.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesAutoscalerStatus.groovy
@@ -22,6 +22,7 @@ import groovy.util.logging.Slf4j
 
 @Slf4j
 class KubernetesAutoscalerStatus {
+  Integer currentCpuUtilization
   Integer currentReplicas
   Integer desiredReplicas
   Long lastScaleTime


### PR DESCRIPTION
@maggieneterval -- just realized I stripped out currentCpuUtilization from the class and forgot to add it back with my final commit on Friday.

Embarrassing -- but here's the fix! 