### PR TITLE
fix(provider/k8s): fix v2 run job cancel

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/converter/job/KubernetesDestroyJobAtomicOperationConverter.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/converter/job/KubernetesDestroyJobAtomicOperationConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.converter.job;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.converters.KubernetesAtomicOperationConverterHelper;
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.job.KubernetesJobDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubernetesDestroyJobAtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
+import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@KubernetesOperation(AtomicOperations.DESTROY_JOB)
+@Component
+public class KubernetesDestroyJobAtomicOperationConverter
+    extends AbstractAtomicOperationsCredentialsSupport {
+
+  @Override
+  public boolean acceptsVersion(ProviderVersion version) {
+    return version == ProviderVersion.v2;
+  }
+
+  @Override
+  public AtomicOperation convertOperation(Map input) {
+    return new KubernetesDestroyJobAtomicOperation(convertDescription(input));
+  }
+
+  @Override
+  public KubernetesJobDescription convertDescription(Map input) {
+    return (KubernetesJobDescription)
+        KubernetesAtomicOperationConverterHelper.convertDescription(
+            input, this, KubernetesJobDescription.class);
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/KubernetesV2JobStatus.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/KubernetesV2JobStatus.java
@@ -38,6 +38,7 @@ public class KubernetesV2JobStatus implements JobStatus, Serializable {
   String account;
   String id;
   String location;
+  String region;
   String provider = "kubernetes";
   Long createdTime;
   Long completedTime;
@@ -54,6 +55,7 @@ public class KubernetesV2JobStatus implements JobStatus, Serializable {
     this.account = account;
     this.name = job.getMetadata().getName();
     this.location = job.getMetadata().getNamespace();
+    this.region = job.getMetadata().getNamespace();
     this.createdTime =
         KubernetesModelUtil.translateTime(
             job.getMetadata().getCreationTimestamp().toString(), "yyyy-MM-dd'T'HH:mm:ss");

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubernetesDestroyJobAtomicOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubernetesDestroyJobAtomicOperation.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job;
+
+import com.netflix.spinnaker.clouddriver.data.task.Task;
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.job.KubernetesJobDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import io.kubernetes.client.models.V1DeleteOptions;
+import java.util.List;
+
+public class KubernetesDestroyJobAtomicOperation implements AtomicOperation<Void> {
+  private static final String BASE_PHASE = "DESTROY";
+  private final KubernetesJobDescription description;
+
+  public KubernetesDestroyJobAtomicOperation(KubernetesJobDescription jobDescription) {
+    this.description = jobDescription;
+  }
+
+  private static Task getTask() {
+    return TaskRepository.threadLocalTask.get();
+  }
+
+  @Override
+  public Void operate(List priorOutputs) {
+    Task task = getTask();
+    task.updateStatus(BASE_PHASE, "Initializing destroy of job.");
+    KubernetesNamedAccountCredentials namedAccountCredentials = description.getCredentials();
+
+    if (!(namedAccountCredentials.getCredentials() instanceof KubernetesV2Credentials)) {
+      throw new IllegalArgumentException("Only V2 credentials allowed");
+    }
+
+    KubernetesV2Credentials credentials =
+        (KubernetesV2Credentials) namedAccountCredentials.getCredentials();
+
+    task.updateStatus(BASE_PHASE, "Destroying job...");
+    credentials.delete(
+        KubernetesKind.JOB,
+        description.getNamespace(),
+        description.getJobName(),
+        new KubernetesSelectorList(),
+        new V1DeleteOptions());
+    task.updateStatus(
+        BASE_PHASE,
+        "Successfully destroyed job "
+            + description.getJobName()
+            + " in namespace "
+            + description.getNamespace());
+    return null;
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.NotImplementedException;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -98,10 +97,7 @@ public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatu
     return props;
   }
 
-  public void cancelJob(String account, String location, String id) {
-    throw new NotImplementedException(
-        "cancelJob is not implemented for the V2 Kubrenetes provider");
-  }
+  public void cancelJob(String account, String location, String id) {}
 
   private V1Job getKubernetesJob(String account, String location, String id) {
     List<Manifest> manifests =


### PR DESCRIPTION
implements the destroy operation for v2 jobs so that canceling the run
job stage actually works. adds an operation and converter. also adding
`region` to the job status so that the destroy op can be properly
created in orca.