### PR TITLE
fix(metrics): strip the provider's package name in agent metrics

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/MetricInstrumentation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/MetricInstrumentation.groovy
@@ -43,8 +43,13 @@ class MetricInstrumentation implements ExecutionInstrumentation {
     counterId = registry.createId('executionCount').withTag('className', MetricInstrumentation.simpleName)
   }
 
+  private static String stripPackageName(String className) {
+    return className.substring(className.lastIndexOf(".")+1)
+  }
+
   private static String agentName(Agent agent) {
-    "$agent.providerName/$agent.agentType"
+    String simpleProviderName = stripPackageName(agent.providerName)
+    "$simpleProviderName/$agent.agentType"
   }
 
   @Override


### PR DESCRIPTION
Long tag values can cause issues for some time series systems. The
caching agents in particular are a bit too generous, as the provider
name often includes the full package path (typically 50-60 chars that
don't provide much value)