### PR TITLE
fix(google): return null guards to GoogleApplicationProvider

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import lombok.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -75,6 +76,7 @@ final class GoogleApplicationProvider implements ApplicationProvider {
     Set<String> instanceIdentifiers;
   }
 
+  @Nullable
   ApplicationCacheData getApplicationCacheData(String name) {
     CacheData cacheData =
         cacheView.get(

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleApplicationProvider.java
@@ -85,6 +85,9 @@ final class GoogleApplicationProvider implements ApplicationProvider {
   }
 
   private ApplicationCacheData getApplicationCacheData(CacheData cacheData) {
+    if (cacheData == null) {
+      return null;
+    }
     return new ApplicationCacheData(
         cacheData.getAttributes(),
         getRelationships(cacheData, CLUSTERS),
@@ -102,6 +105,9 @@ final class GoogleApplicationProvider implements ApplicationProvider {
 
   private GoogleApplication.View applicationFromCacheData(
       ApplicationCacheData applicationCacheData) {
+    if (applicationCacheData == null) {
+      return null;
+    }
     GoogleApplication application =
         objectMapper.convertValue(
             applicationCacheData.getApplicationAttributes(), GoogleApplication.class);

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/view/GoogleClusterProvider.groovy
@@ -80,6 +80,10 @@ class GoogleClusterProvider implements ClusterProvider<GoogleCluster.View> {
   Map<String, Set<GoogleCluster.View>> getClusters(String applicationName, boolean includeInstanceDetails) {
     GoogleApplicationProvider.ApplicationCacheData applicationCacheData = applicationProvider.getApplicationCacheData(applicationName)
 
+    if (applicationCacheData == null) {
+      return new HashMap<>()
+    }
+
     Set<String> clusterIdentifiers = applicationCacheData.getClusterIdentifiers();
     Collection<CacheData> clusterCacheData = cacheView.getAll(
       CLUSTERS.ns,


### PR DESCRIPTION
My bad! :see_no_evil: :sob: 
`GoogleApplicationProvider.getApplication` can be called with non-GCE application names, so we cannot assume 1) That we can build an instance of `ApplicationCacheData` (should default to null) or 2) That we will have a non-null instance of `ApplicationCacheData` downstream.