### PR TITLE
feat(event): Adding eventing lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ buildscript {
     }
     classpath "com.netflix.nebula:nebula-kotlin-plugin:$kotlinVersion"
     classpath "org.junit.platform:junit-platform-gradle-plugin:${junitPlatformVersion}"
-
+    classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
   }
 }
 
@@ -55,6 +55,7 @@ allprojects {
     apply plugin: 'java-library'
     apply plugin: 'groovy'
     apply plugin: 'nebula.kotlin'
+    apply plugin: "kotlin-allopen"
 
     sourceSets.main.java.srcDirs = []
     sourceSets.main.groovy.srcDirs += ["src/main/java"]

--- a/clouddriver-event/clouddriver-event.gradle
+++ b/clouddriver-event/clouddriver-event.gradle
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+  annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
+
+  implementation "com.netflix.spinnaker.kork:kork-core"
+  implementation "com.netflix.spinnaker.kork:kork-exceptions"
+  implementation "com.google.guava:guava"
+  implementation "com.google.code.findbugs:jsr305"
+  implementation "org.springframework.boot:spring-boot-actuator"
+  implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
+  implementation "javax.validation:validation-api"
+  implementation "org.hibernate.validator:hibernate-validator"
+
+  testImplementation "cglib:cglib-nodep"
+  testImplementation "org.objenesis:objenesis"
+  testImplementation "org.junit.platform:junit-platform-runner"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.springframework:spring-test"
+  testImplementation "org.springframework.boot:spring-boot-test"
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "io.strikt:strikt-core"
+  testImplementation "dev.minutest:minutest"
+  testImplementation "io.mockk:mockk"
+
+  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+}

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/Aggregate.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/Aggregate.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event
+
+/**
+ * The identifiable collection of an event log.
+ *
+ * Aggregates are grouped by a [type] which should be unique for each domain entity, with unique
+ * [id] values therein. A [version] field is used to ensure business logic is operating on the
+ * latest event state; any modification to an [Aggregate] event log will increment this value.
+ * When an operation is attempted on an [version] which is not head, the event framework will
+ * reject the change.
+ */
+class Aggregate(
+  val type: String,
+  val id: String,
+  var version: Long
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as Aggregate
+
+    if (type != other.type) return false
+    if (id != other.id) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = type.hashCode()
+    result = 31 * result + id.hashCode()
+    return result
+  }
+}

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/EventListener.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/EventListener.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event
+
+/**
+ * Interface for subscribing to Spinnaker events.
+ *
+ * An implementation must be responsible for filtering out the events that it doesn't care about.
+ */
+interface EventListener {
+  fun onEvent(event: SpinnakerEvent)
+}

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/EventMetadata.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/EventMetadata.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event
+
+import java.time.Instant
+
+/**
+ * Metadata for a [SpinnakerEvent].
+ *
+ * @param sequence Auto-incrementing number for event ordering
+ * @param originatingVersion The aggregate version that originated this event
+ * @param timestamp The time at which the event was created
+ * @param serviceVersion The version of the service (clouddriver) that created the event
+ * @param provenance Where the event was generated and by what
+ */
+data class EventMetadata(
+  val sequence: Long,
+  val originatingVersion: Long,
+  val timestamp: Instant = Instant.now(),
+  val serviceVersion: String = "unknown",
+  val provenance: String = "unknown"
+)

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/EventPublisher.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/EventPublisher.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event
+
+/**
+ * The event sourcing library event publisher.
+ *
+ * This library assumes that events are persisted first into a durable store and then propagated out
+ * to subscribers afterwards. There is no contract on immediacy or locality of events being delivered
+ * to subscribers: This is left entirely to the implementation.
+ */
+interface EventPublisher {
+  fun publish(event: SpinnakerEvent)
+}

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/SpinnakerEvent.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/SpinnakerEvent.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import java.util.UUID
+
+/**
+ * The base event class for the event sourcing library.
+ *
+ * @param aggregateType The type of aggregate the event is for
+ * @param aggregateId The id of the aggregate the event is for
+ * @property id A unique ID for the event. This value is for tracing, rather than loading events
+ * @property metadata Associated metadata about the event; not actually part of the "event proper"
+ */
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "spinEventType"
+)
+abstract class SpinnakerEvent(
+  val aggregateType: String,
+  val aggregateId: String
+) {
+  val id = UUID.randomUUID().toString()
+
+  lateinit var metadata: EventMetadata
+}

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/config/EventSourceAutoConfiguration.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/config/EventSourceAutoConfiguration.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+
+/**
+ * Auto-configures the event sourcing library.
+ */
+@Configuration
+@Import(MemoryEventRepositoryConfig::class)
+open class EventSourceAutoConfiguration

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/config/MemoryEventRepositoryConfig.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/config/MemoryEventRepositoryConfig.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event.config
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.event.persistence.EventRepository
+import com.netflix.spinnaker.clouddriver.event.persistence.InMemoryEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.validation.annotation.Validated
+import java.time.Duration
+import javax.validation.Constraint
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+import javax.validation.constraints.Min
+import kotlin.reflect.KClass
+
+@Configuration
+@ConditionalOnProperty("spinnaker.clouddriver.eventing.memory-repository.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(MemoryEventRepositoryConfigProperties::class)
+open class MemoryEventRepositoryConfig {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  init {
+    log.info("Configuring EventRepository: InMemoryEventRepository")
+  }
+
+  @Bean
+  open fun eventRepository(
+    properties: MemoryEventRepositoryConfigProperties,
+    applicationEventPublisher: ApplicationEventPublisher,
+    registry: Registry
+  ): EventRepository =
+    InMemoryEventRepository(properties, applicationEventPublisher, registry)
+}
+
+@MemoryEventRepositoryConfigProperties.SpinValidated
+@ConfigurationProperties("spinnaker.clouddriver.eventing.memory-repository")
+open class MemoryEventRepositoryConfigProperties {
+  /**
+   * The max age of an [Aggregate]. One of this and [maxAggregatesCount] must be set.
+   */
+  @Min(
+    message = "Event repository aggregate age cannot be less than 24 hours.",
+    value = 60 * 60 * 24 * 1000
+  )
+  var maxAggregateAgeMs: Long? = Duration.ofHours(24).toMillis()
+
+  /**
+   * The max number of [Aggregate] objects. One of this and [maxAggregateAgeMs] must be set.
+   */
+  var maxAggregatesCount: Int? = null
+
+  @Validated
+  @Constraint(validatedBy = [Validator::class])
+  @Target(AnnotationTarget.CLASS)
+  annotation class SpinValidated(
+    val message: String = "Invalid event repository configuration",
+    val groups: Array<KClass<out Any>> = [],
+    val payload: Array<KClass<out Any>> = []
+  )
+
+  class Validator : ConstraintValidator<SpinValidated, MemoryEventRepositoryConfigProperties> {
+    override fun isValid(
+      value: MemoryEventRepositoryConfigProperties,
+      context: ConstraintValidatorContext
+    ): Boolean {
+      if (value.maxAggregateAgeMs != null && value.maxAggregatesCount != null) {
+        context.buildConstraintViolationWithTemplate("Only one of 'maxAggregateAgeMs' and 'maxAggregatesCount' can be defined")
+          .addConstraintViolation()
+        return false
+      }
+      if (value.maxAggregateAgeMs == null && value.maxAggregatesCount == null) {
+        context.buildConstraintViolationWithTemplate("One of 'maxAggregateAgeMs' and 'maxAggregatesCount' must be set")
+          .addConstraintViolation()
+        return false
+      }
+      return true
+    }
+  }
+}

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/exceptions/AggregateChangeRejectedException.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/exceptions/AggregateChangeRejectedException.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event.exceptions
+
+import com.netflix.spinnaker.kork.exceptions.SystemException
+
+/**
+ * Thrown when one or more [SpinEvent] have been rejected from being committed to an [Aggregate].
+ *
+ * The process which originated the event must be retryable.
+ */
+class AggregateChangeRejectedException(message: String) : SystemException(message) {
+  override fun getRetryable() = true
+}

--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/persistence/EventRepository.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/persistence/EventRepository.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event.persistence
+
+import com.netflix.spinnaker.clouddriver.event.Aggregate
+import com.netflix.spinnaker.clouddriver.event.SpinnakerEvent
+
+/**
+ * The [EventRepository] is responsible for reading and writing immutable event logs from a persistent store.
+ *
+ * There's deliberately no eviction API. It's expected that each [EventRepository] implementation will implement
+ * that functionality on their own, including invocation apis and/or scheduling; tailoring to the operational
+ * needs of that backend.
+ */
+interface EventRepository {
+  /**
+   * Save [events] to an [Aggregate].
+   *
+   * @param aggregateType The aggregate collection name
+   * @param aggregateId The unique identifier of the event aggregate within the [aggregateType]
+   * @param originatingVersion The aggregate version that originated the [events]. This is used to ensure events are
+   *                           added only based off the latest aggregate state
+   * @param newEvents A list of events to be saved
+   */
+  fun save(aggregateType: String, aggregateId: String, originatingVersion: Long, newEvents: List<SpinnakerEvent>)
+
+  /**
+   * List all events for a given [Aggregate].
+   *
+   * @param aggregateType The aggregate collection name
+   * @param aggregateId The unique identifier of the event aggregate within the [aggregateType]
+   * @return An ordered list of events, oldest to newest
+   */
+  fun list(aggregateType: String, aggregateId: String): List<SpinnakerEvent>
+
+  /**
+   * List all aggregates for a given type.
+   *
+   * @param aggregateType The aggregate collection name. If not provided, all aggregates will be returned.
+   * @return An unordered list of matching aggregates.
+   */
+  fun listAggregates(aggregateType: String?): List<Aggregate>
+}

--- a/clouddriver-event/src/test/kotlin/com/netflix/spinnaker/clouddriver/event/EventSourceSystemTest.kt
+++ b/clouddriver-event/src/test/kotlin/com/netflix/spinnaker/clouddriver/event/EventSourceSystemTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.event.config.EventSourceAutoConfiguration
+import com.netflix.spinnaker.clouddriver.event.persistence.InMemoryEventRepository
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import strikt.api.expect
+import strikt.assertions.isA
+
+class EventSourceSystemTest : JUnit5Minutests {
+
+  fun tests() = rootContext<ApplicationContextRunner> {
+    fixture {
+      ApplicationContextRunner()
+      .withConfiguration(AutoConfigurations.of(
+        EventSourceAutoConfiguration::class.java
+      ))
+    }
+
+    test("supports no config") {
+      withUserConfiguration(EventSourceAutoConfiguration::class.java, DependencyConfiguration::class.java)
+        .run { ctx: AssertableApplicationContext ->
+          expect {
+            that(ctx.getBean("eventRepository")).describedAs("eventRepository").isA<InMemoryEventRepository>()
+          }
+        }
+    }
+  }
+
+  @Configuration
+  open class DependencyConfiguration {
+    @Bean
+    open fun registry(): Registry = NoopRegistry()
+  }
+}

--- a/clouddriver-event/src/test/kotlin/com/netflix/spinnaker/clouddriver/event/persistence/InMemoryEventRepositoryTest.kt
+++ b/clouddriver-event/src/test/kotlin/com/netflix/spinnaker/clouddriver/event/persistence/InMemoryEventRepositoryTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.event.persistence
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.clouddriver.event.SpinnakerEvent
+import com.netflix.spinnaker.clouddriver.event.config.MemoryEventRepositoryConfigProperties
+import com.netflix.spinnaker.clouddriver.event.exceptions.AggregateChangeRejectedException
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.assertThrows
+import org.springframework.context.ApplicationEventPublisher
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.get
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+import strikt.assertions.isSameInstanceAs
+import strikt.assertions.map
+
+class InMemoryEventRepositoryTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    test("no events returned for a non-existent aggregate") {
+      expectThat(subject.list("type", "noexist"))
+        .isEmpty()
+    }
+
+    test("save appends aggregate events") {
+      val event = MyEvent("agg", "id", "hello world")
+      subject.save(event.aggregateType, event.aggregateId, 0L, listOf(event))
+
+      expectThat(subject.list("agg", "id")) {
+        get { size }.isEqualTo(1)
+        get(0).and {
+          isSameInstanceAs(event)
+        }
+      }
+
+      val event2 = MyEvent("agg", "id", "hello rob")
+      subject.save(event2.aggregateType, event.aggregateId, 1L, listOf(event2))
+
+      expectThat(subject.list("agg", "id")) {
+        get { size }.isEqualTo(2)
+        get(0).and {
+          isSameInstanceAs(event)
+        }
+        get(1).and {
+          isSameInstanceAs(event2)
+        }
+      }
+    }
+
+    test("saving with a new aggregate with a non-zero originating version fails") {
+      val event = MyEvent("agg", "id", "hello")
+      assertThrows<AggregateChangeRejectedException> {
+        subject.save(event.aggregateType, event.aggregateId, 10L, listOf(event))
+      }
+    }
+
+    test("saving an aggregate with an old originating version fails") {
+      val event = MyEvent("agg", "id", "hello")
+      subject.save(event.aggregateType, event.aggregateId, 0L, listOf(event))
+
+      assertThrows<AggregateChangeRejectedException> {
+        subject.save(event.aggregateType, event.aggregateId, 0L, listOf(event))
+      }
+    }
+
+    test("newly saved events are published") {
+      val event = MyEvent("agg", "id", "hello")
+      subject.save(event.aggregateType, event.aggregateId, 0L, listOf(event))
+
+      verify { eventPublisher.publishEvent(event) }
+      confirmVerified(eventPublisher)
+    }
+
+    context("listing aggregates") {
+      val event1 = MyEvent("type1", "id", "one")
+      val event2 = MyEvent("type2", "id", "two")
+      val event3 = MyEvent("type3", "id", "three")
+
+      test("not providing a type") {
+        listOf(event1, event2, event3).forEach { subject.save(it.aggregateType, it.aggregateId, 0L, listOf(it)) }
+
+        expectThat(subject.listAggregates(null)) {
+          map { it.type }.containsExactly("type1", "type2", "type3")
+        }
+      }
+
+      test("providing a type") {
+        listOf(event1, event2, event3).forEach { subject.save(it.aggregateType, it.aggregateId, 0L, listOf(it)) }
+
+        expectThat(subject.listAggregates(event1.aggregateType)) {
+          map { it.type }.containsExactly("type1")
+        }
+      }
+
+      test("providing a non-existent type") {
+        listOf(event1, event2, event3).forEach { subject.save(it.aggregateType, it.aggregateId, 0L, listOf(it)) }
+
+        expectThat(subject.listAggregates("unknown")) {
+          isEmpty()
+        }
+      }
+    }
+  }
+
+  inner class Fixture {
+    var eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
+    var subject: EventRepository = InMemoryEventRepository(
+      MemoryEventRepositoryConfigProperties(),
+      eventPublisher,
+      NoopRegistry()
+    )
+  }
+
+  private inner class MyEvent(aggregateType: String, aggregateId: String, val value: String) : SpinnakerEvent(aggregateType, aggregateId)
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ includeCloudProviders=all
 fiatVersion=1.4.0
 enablePublishing=false
 korkVersion=5.10.3
-spinnakerGradleVersion=7.0.1
+spinnakerGradleVersion=7.0.2
 org.gradle.parallel=true

--- a/gradle/spek.gradle
+++ b/gradle/spek.gradle
@@ -34,8 +34,6 @@ dependencies {
 
   testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin"
   testImplementation "io.strikt:strikt-core"
-
-  implementation "org.codehaus.groovy:groovy-all"
 }
 
 junitPlatform {

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,15 +40,16 @@ include 'cats:cats-core',
   'cats:cats-test',
   'cats:cats-sql',
   'clouddriver-artifacts',
+  'clouddriver-bom',
   'clouddriver-core',
   'clouddriver-core-tck',
   'clouddriver-elasticsearch',
+  'clouddriver-event',
+  'clouddriver-scattergather',
   'clouddriver-security',
   'clouddriver-sql',
   'clouddriver-sql-mysql',
-  'clouddriver-web',
-  'clouddriver-scattergather',
-  'clouddriver-bom'
+  'clouddriver-web'
 include(*gradle.ext.includedCloudProviderProjects)
 
 def setBuildFile(project) {


### PR DESCRIPTION
This is PR 1 of N for some new idempotency functionality in River. The implementation will be confined to the Titus provider only while we iterate ergonomics of the various components.

The idempotency functionality implements a Saga pattern that is backed by an immutable event log. While not strictly required for the design pattern, backing operations by an eventing system will make it more palatable for debugging and auditing functionality later on, as well as new interaction possibilities between clouddriver & orca in the future.

Current implementation targets an in-memory store only. Future contributions will add a SQL backend so that operations can be retried by Orca in the face of downstream cloud provider failures.

It is possible that this functionality could be lifted into kork at some point.