### PR TITLE
fix(provider/k8s): return operation result data

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubernetesRunJobDeploymentResult.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubernetesRunJobDeploymentResult.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class KubernetesRunJobDeploymentResult extends OperationResult {
+  Map<String, List<String>> deployedNamesByLocation = new HashMap<>();
+
+  public KubernetesRunJobDeploymentResult(OperationResult result) {
+    this.setManifestNamesByNamespace(result.getManifestNamesByNamespace());
+    this.setManifests(result.getManifests());
+    this.setCreatedArtifacts(result.getCreatedArtifacts());
+    this.setBoundArtifacts(result.getBoundArtifacts());
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubernetesRunJobOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubernetesRunJobOperation.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job;
 
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
-import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.job.KubernetesRunJobOperationDescription;
@@ -37,7 +36,8 @@ import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class KubernetesRunJobOperation implements AtomicOperation<DeploymentResult> {
+public class KubernetesRunJobOperation
+    implements AtomicOperation<KubernetesRunJobDeploymentResult> {
   private static final String OP_NAME = "RUN_KUBERNETES_JOB";
   private final KubernetesRunJobOperationDescription description;
   private final KubernetesV2Credentials credentials;
@@ -64,7 +64,7 @@ public class KubernetesRunJobOperation implements AtomicOperation<DeploymentResu
     return TaskRepository.threadLocalTask.get();
   }
 
-  public DeploymentResult operate(List _unused) {
+  public KubernetesRunJobDeploymentResult operate(List _unused) {
     getTask().updateStatus(OP_NAME, "Running Kubernetes job...");
     KubernetesManifest jobSpec = this.description.getManifest();
     KubernetesKind kind = jobSpec.getKind();
@@ -105,7 +105,8 @@ public class KubernetesRunJobOperation implements AtomicOperation<DeploymentResu
     KubernetesDeployManifestOperation deployManifestOperation =
         new KubernetesDeployManifestOperation(deployManifestDescription, registry, provider);
     OperationResult operationResult = deployManifestOperation.operate(new ArrayList());
-    DeploymentResult deploymentResult = new DeploymentResult();
+    KubernetesRunJobDeploymentResult deploymentResult =
+        new KubernetesRunJobDeploymentResult(operationResult);
     Map<String, List<String>> deployedNames = deploymentResult.getDeployedNamesByLocation();
     for (Map.Entry<String, Set<String>> e :
         operationResult.getManifestNamesByNamespace().entrySet()) {


### PR DESCRIPTION
return the operation result data alongside the data required by the run
job task. the operation result data will be used when refreshing the
cached manifests in downstream refresh tasks