### PR TITLE
chore(dependencies): manually bump korkVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,18 @@ allprojects {
     dependencies {
       implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
 
+      // This can be removed once there is a version of error-prone > 2.3.2. In 2.3.0, the
+      // @DoNotMock annotation was accidentally removed. It was put back, but hasn't made it into a
+      // release yet.
+      //
+      // In the meantime, kork depends on Guava 28.0, which depends on error-prone. There's no
+      // version listed, so Gradle resolves it to the newest version (2.3.2) which breaks the build
+      // because of that missing annotation. This block forces the build back to 2.2.0, the latest
+      // version that contains @DoNotMock.
+      implementation('com.google.errorprone:error_prone_annotations:2.2.0') {
+        force = true
+      }
+
       annotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor "org.projectlombok:lombok"
       testAnnotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 includeCloudProviders=all
 fiatVersion=1.4.0
 enablePublishing=false
-korkVersion=5.10.3
+korkVersion=5.11.0
 spinnakerGradleVersion=7.0.2
 org.gradle.parallel=true


### PR DESCRIPTION
Upgrading Guava in Kork also upgraded errorprone which caused a build
error, so this forces error-prone back to a version that works with our
build.