### PR TITLE
fix(titus): Consolidate & verify security group assignment behavior

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/JobType.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/JobType.java
@@ -36,8 +36,14 @@ public enum JobType {
     return JobType.valueOf(value.toUpperCase());
   }
 
+  /** Use {@code isEqual(String)} instead. */
+  @Deprecated
   public static boolean isEqual(@Nullable String value, @Nonnull JobType expectedType) {
     return from(value).equals(expectedType);
+  }
+
+  public boolean isEqual(@Nullable String value) {
+    return from(value).equals(this);
   }
 
   @Nonnull

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
@@ -49,7 +49,6 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
   private String jobType;
   private int retries;
   private int runtimeLimitSecs;
-  private Boolean useApplicationDefaultSecurityGroup = true;
   private List<String> interestingHealthProviderNames = new ArrayList<>();
   private MigrationPolicy migrationPolicy;
   private Boolean copySourceScalingPoliciesAndActions = true;

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
@@ -105,6 +105,10 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
             .withDisruptionBudget(disruptionBudget)
             .withServiceJobProcesses(serviceJobProcesses);
 
+    if (!securityGroups.isEmpty()) {
+      submitJobRequest.withSecurityGroups(securityGroups);
+    }
+
     if (dockerImage.getImageDigest() != null) {
       submitJobRequest.withDockerDigest(dockerImage.getImageDigest());
     } else {

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/actions/PrepareTitusDeployActionSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/actions/PrepareTitusDeployActionSpec.groovy
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.clouddriver.titus.deploy.description.TitusDeployDes
 import com.netflix.spinnaker.config.AwsConfiguration
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 class PrepareTitusDeployActionSpec extends Specification {
 
@@ -126,8 +127,43 @@ class PrepareTitusDeployActionSpec extends Specification {
     }
   }
 
-  def "uses description only when no source asg is provided"() {
+  def "security groups are resolved"() {
+    given:
+    TitusDeployDescription description = createTitusDeployDescription()
+    description.securityGroups = ["sg-1", "fancyname"]
 
+    when:
+    subject.resolveSecurityGroups(saga, description)
+
+    then:
+    awsLookupUtil.securityGroupIdExists(_, _, "sg-1") >> true
+    awsLookupUtil.securityGroupIdExists(_, _, "fancyname") >> false
+    awsLookupUtil.convertSecurityGroupNameToId(_, _, "fancyname") >> "sg-2"
+
+    description.securityGroups == ["sg-2", "sg-1"]
+  }
+
+  @Unroll
+  def "security groups include app security group (defaultAppSg=#useFlag)"() {
+    given:
+    TitusDeployDescription description = createTitusDeployDescription()
+    description.labels[PrepareTitusDeploy.USE_APPLICATION_DEFAULT_SG_LABEL] = useFlag.toString()
+
+    when:
+    subject.resolveSecurityGroups(saga, description)
+
+    then:
+    awsLookupUtil.securityGroupIdExists(_, _, "sg-abcd1234") >> true
+    awsLookupUtil.convertSecurityGroupNameToId(_, _, "spindemo") >> "sg-spindemo"
+
+    if (useFlag) {
+      description.securityGroups == ["sg-abcd1234", "sg-spindemo"]
+    } else {
+      description.securityGroups == ["sg-abcd1234"]
+    }
+
+    where:
+    useFlag << [true, false]
   }
 
   private TitusDeployDescription createTitusDeployDescription() {

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/actions/PrepareTitusDeployActionSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/actions/PrepareTitusDeployActionSpec.groovy
@@ -126,6 +126,10 @@ class PrepareTitusDeployActionSpec extends Specification {
     }
   }
 
+  def "uses description only when no source asg is provided"() {
+
+  }
+
   private TitusDeployDescription createTitusDeployDescription() {
     return new TitusDeployDescription(
       application: "spindemo",
@@ -157,7 +161,9 @@ class PrepareTitusDeployActionSpec extends Specification {
         memory: 5_000,
         networkMbps: 128
       ),
-      securityGroups: [],
+      securityGroups: [
+        "sg-abcd1234"
+      ],
       softConstraints: [],
       stack: "staging",
     )


### PR DESCRIPTION
A bit of a refactor to make the Titus deployment code related to security groups a little simpler / consolidated to a single area. Also added a couple tests to validate the rough behavior.