### PR TITLE
chore(build): Increase parallelism of circle builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ workflows:
 jobs:
   build:
     machine: true
+    parallelism: 16
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Apparently changing the parallelism via the UI doesn't work.