### PR TITLE
fix(core): Create better task exception summaries

### DIFF
--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessorSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessorSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.orchestration
 import com.netflix.spectator.api.Spectator
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTask
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import org.slf4j.MDC
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory
@@ -127,9 +128,53 @@ class DefaultOrchestrationProcessorSpec extends Specification {
     MDC.get(AuthenticatedRequest.Header.USER.header) == null
   }
 
+  void "should extract summary from kork spinnaker exceptions"() {
+    given:
+    Exception rootException = new ExternalLibraryException("INVALID_ARGUMENT: TitusServiceException: Image xyz/abcd:20190822_152019_934d150 does not exist in registry")
+    Exception intermediateException = new CloudProviderException("Let's pretend it was caught elsewhere", rootException)
+    Exception nonSpinnakerException = new RuntimeException("And here's another intermediate but it isn't SpinnakerException", intermediateException)
+    Exception topException = new IntegrationException("Failed to apply action SubmitTitusJob for TitusDeployHandler/sha1", nonSpinnakerException)
+
+    when:
+    def result = processor.extractExceptionSummary(topException)
+
+    then:
+    result == [
+      type: "EXCEPTION",
+      cause: "INVALID_ARGUMENT: TitusServiceException: Image xyz/abcd:20190822_152019_934d150 does not exist in registry",
+      message: "Failed to apply action SubmitTitusJob for TitusDeployHandler/sha1",
+      details: [
+        [
+          message: "INVALID_ARGUMENT: TitusServiceException: Image xyz/abcd:20190822_152019_934d150 does not exist in registry",
+        ],
+        [
+          message: "Let's pretend it was caught elsewhere",
+        ],
+        [
+          message: "And here's another intermediate but it isn't SpinnakerException",
+        ],
+        [
+          message: "Failed to apply action SubmitTitusJob for TitusDeployHandler/sha1"
+        ]
+      ],
+      retryable: false
+    ]
+  }
+
   private void submitAndWait(AtomicOperation atomicOp) {
     processor.process([atomicOp], taskKey)
     processor.executorService.shutdown()
     processor.executorService.awaitTermination(5, TimeUnit.SECONDS)
+  }
+
+  private static class ExternalLibraryException extends RuntimeException {
+    ExternalLibraryException(String var1) {
+      super(var1)
+    }
+  }
+  private static class CloudProviderException extends IntegrationException {
+    CloudProviderException(String message, Throwable cause) {
+      super(message, cause)
+    }
   }
 }


### PR DESCRIPTION
Can move this to kork immediately, but wanted to show a non-generic implementation of (potentially) a more common error summary that can pass between service boundaries.

This should also help make our exceptions a little more obvious to end users when a pipeline fails due to something in clouddriver. Argument could be had for not making the `message` the generic top-most exception message and instead use `cause`; which I'm leaning towards, although this would be a breaking change for existing exception handling. Thoughts?