### PR TITLE
fix(aws): Only consider accounts for the AWS cloud provider

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupAlarmsAgent.groovy
@@ -23,6 +23,7 @@ import com.amazonaws.services.cloudwatch.model.MetricAlarm
 import com.amazonaws.services.cloudwatch.model.StateValue
 import com.amazonaws.services.gamelift.model.DescribeScalingPoliciesRequest
 import com.netflix.spinnaker.cats.agent.RunnableAgent
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsCleanupProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
@@ -119,7 +120,7 @@ class CleanupAlarmsAgent implements RunnableAgent, CustomScheduledAgent {
   }
 
   private Set<NetflixAmazonCredentials> getAccounts() {
-    ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials)
+    ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
   }
 
   private static Set<String> getAttachedAlarms(AmazonAutoScaling autoScaling) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CleanupDetachedInstancesAgent.groovy
@@ -21,6 +21,7 @@ import com.amazonaws.services.ec2.model.Filter
 import com.amazonaws.services.ec2.model.Instance
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest
 import com.netflix.spinnaker.cats.agent.RunnableAgent
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
@@ -107,7 +108,7 @@ class CleanupDetachedInstancesAgent implements RunnableAgent, CustomScheduledAge
   }
 
   private Set<NetflixAmazonCredentials> getAccounts() {
-    ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials)
+    ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
   }
 
   /**

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsInfrastructureProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsInfrastructureProviderConfig.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.provider.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonElasticIpCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonInstanceTypeCachingAgent
@@ -68,7 +69,7 @@ class AwsInfrastructureProviderConfig {
                                                            Registry registry,
                                                            EddaTimeoutConfig eddaTimeoutConfig) {
     def scheduledAccounts = ProviderUtils.getScheduledAccounts(awsInfrastructureProvider)
-    def allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials)
+    def allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
 
     Set<String> regions = new HashSet<>();
     allAccounts.each { NetflixAmazonCredentials credentials ->

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -110,7 +110,7 @@ class AwsProviderConfig {
                                       EddaTimeoutConfig eddaTimeoutConfig,
                                       DynamicConfigService dynamicConfigService) {
     def scheduledAccounts = ProviderUtils.getScheduledAccounts(awsProvider)
-    Set<NetflixAmazonCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials)
+    Set<NetflixAmazonCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
 
     List<Agent> newlyAddedAgents = []
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.awsobjectmapper.AmazonObjectMapperConfigurer
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties
 import com.netflix.spinnaker.clouddriver.aws.agent.CleanupAlarmsAgent
 import com.netflix.spinnaker.clouddriver.aws.agent.CleanupDetachedInstancesAgent
@@ -219,7 +220,7 @@ class AwsConfiguration {
                                                     AccountCredentialsRepository accountCredentialsRepository,
                                                     DeployDefaults deployDefaults) {
     def scheduledAccounts = ProviderUtils.getScheduledAccounts(awsCleanupProvider)
-    Set<NetflixAmazonCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials)
+    Set<NetflixAmazonCredentials> allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, NetflixAmazonCredentials, AmazonCloudProvider.ID)
 
     List<Agent> newlyAddedAgents = []
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/config/EcsProviderConfig.java
@@ -82,85 +82,83 @@ public class EcsProviderConfig {
     Set<String> scheduledAccounts = ProviderUtils.getScheduledAccounts(ecsProvider);
     Set<NetflixAmazonCredentials> allAccounts =
         ProviderUtils.buildThreadSafeSetOfAccounts(
-            accountCredentialsRepository, NetflixAmazonCredentials.class);
+            accountCredentialsRepository, NetflixAmazonCredentials.class, EcsCloudProvider.ID);
     List<Agent> newAgents = new LinkedList<>();
 
     for (NetflixAmazonCredentials credentials : allAccounts) {
-      if (credentials.getCloudProvider().equals(EcsCloudProvider.ID)) {
-        newAgents.add(
-            new IamRoleCachingAgent(
-                credentials,
-                amazonClientProvider,
-                awsCredentialsProvider,
-                iamPolicyReader)); // IAM is region-agnostic, so one caching agent per account is
-        // enough
+      newAgents.add(
+          new IamRoleCachingAgent(
+              credentials,
+              amazonClientProvider,
+              awsCredentialsProvider,
+              iamPolicyReader)); // IAM is region-agnostic, so one caching agent per account is
+      // enough
 
-        for (AWSRegion region : credentials.getRegions()) {
-          if (!scheduledAccounts.contains(credentials.getName())) {
-            newAgents.add(
-                new EcsClusterCachingAgent(
-                    credentials, region.getName(), amazonClientProvider, awsCredentialsProvider));
-            newAgents.add(
-                new ServiceCachingAgent(
-                    credentials,
-                    region.getName(),
-                    amazonClientProvider,
-                    awsCredentialsProvider,
-                    registry));
-            newAgents.add(
-                new TaskCachingAgent(
-                    credentials,
-                    region.getName(),
-                    amazonClientProvider,
-                    awsCredentialsProvider,
-                    registry));
-            newAgents.add(
-                new ContainerInstanceCachingAgent(
-                    credentials,
-                    region.getName(),
-                    amazonClientProvider,
-                    awsCredentialsProvider,
-                    registry));
-            newAgents.add(
-                new TaskDefinitionCachingAgent(
-                    credentials,
-                    region.getName(),
-                    amazonClientProvider,
-                    awsCredentialsProvider,
-                    registry,
-                    objectMapper));
-            newAgents.add(
-                new TaskHealthCachingAgent(
-                    credentials,
-                    region.getName(),
-                    amazonClientProvider,
-                    awsCredentialsProvider,
-                    objectMapper));
-            newAgents.add(
-                new EcsCloudMetricAlarmCachingAgent(
-                    credentials, region.getName(), amazonClientProvider, awsCredentialsProvider));
-            newAgents.add(
-                new ScalableTargetsCachingAgent(
-                    credentials,
-                    region.getName(),
-                    amazonClientProvider,
-                    awsCredentialsProvider,
-                    objectMapper));
-            newAgents.add(
-                new SecretCachingAgent(
-                    credentials,
-                    region.getName(),
-                    amazonClientProvider,
-                    awsCredentialsProvider,
-                    objectMapper));
-            newAgents.add(
-                new ServiceDiscoveryCachingAgent(
-                    credentials,
-                    region.getName(),
-                    amazonClientProvider,
-                    awsCredentialsProvider,
-                    objectMapper));
-          }
+      for (AWSRegion region : credentials.getRegions()) {
+        if (!scheduledAccounts.contains(credentials.getName())) {
+          newAgents.add(
+              new EcsClusterCachingAgent(
+                  credentials, region.getName(), amazonClientProvider, awsCredentialsProvider));
+          newAgents.add(
+              new ServiceCachingAgent(
+                  credentials,
+                  region.getName(),
+                  amazonClientProvider,
+                  awsCredentialsProvider,
+                  registry));
+          newAgents.add(
+              new TaskCachingAgent(
+                  credentials,
+                  region.getName(),
+                  amazonClientProvider,
+                  awsCredentialsProvider,
+                  registry));
+          newAgents.add(
+              new ContainerInstanceCachingAgent(
+                  credentials,
+                  region.getName(),
+                  amazonClientProvider,
+                  awsCredentialsProvider,
+                  registry));
+          newAgents.add(
+              new TaskDefinitionCachingAgent(
+                  credentials,
+                  region.getName(),
+                  amazonClientProvider,
+                  awsCredentialsProvider,
+                  registry,
+                  objectMapper));
+          newAgents.add(
+              new TaskHealthCachingAgent(
+                  credentials,
+                  region.getName(),
+                  amazonClientProvider,
+                  awsCredentialsProvider,
+                  objectMapper));
+          newAgents.add(
+              new EcsCloudMetricAlarmCachingAgent(
+                  credentials, region.getName(), amazonClientProvider, awsCredentialsProvider));
+          newAgents.add(
+              new ScalableTargetsCachingAgent(
+                  credentials,
+                  region.getName(),
+                  amazonClientProvider,
+                  awsCredentialsProvider,
+                  objectMapper));
+          newAgents.add(
+              new SecretCachingAgent(
+                  credentials,
+                  region.getName(),
+                  amazonClientProvider,
+                  awsCredentialsProvider,
+                  objectMapper));
+          newAgents.add(
+              new ServiceDiscoveryCachingAgent(
+                  credentials,
+                  region.getName(),
+                  amazonClientProvider,
+                  awsCredentialsProvider,
+                  objectMapper));
         }
       }
     }

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtils.groovy
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtils.groovy
@@ -55,8 +55,28 @@ public class ProviderUtils {
    * credentialsType, and (if specified) of provdierVersion version.
    */
   public static <T extends AccountCredentials> Set<T> buildThreadSafeSetOfAccounts(AccountCredentialsRepository accountCredentialsRepository, Class<T> credentialsType, ProviderVersion version) {
+    buildThreadSafeSetOfAccounts(accountCredentialsRepository, credentialsType, null, version)
+  }
+
+  /**
+   * Build a thread-safe set containing each account in the accountCredentialsRepository that is of type
+   * credentialsType, and (if specified) for a cloud provider.
+   */
+  public static <T extends AccountCredentials> Set<T> buildThreadSafeSetOfAccounts(AccountCredentialsRepository accountCredentialsRepository, Class<T> credentialsType, String cloudProvider) {
+    buildThreadSafeSetOfAccounts(accountCredentialsRepository, credentialsType, cloudProvider, null)
+  }
+
+  /**
+   * Build a thread-safe set containing each account in the accountCredentialsRepository that is of type
+   * credentialsType, (if specified) cloud provider, and (if specified) of providerVersion version.
+   */
+  public static <T extends AccountCredentials> Set<T> buildThreadSafeSetOfAccounts(AccountCredentialsRepository accountCredentialsRepository, Class<T> credentialsType, String cloudProvider, ProviderVersion version) {
     def allAccounts = Collections.newSetFromMap(new ConcurrentHashMap<T, Boolean>())
     allAccounts.addAll(accountCredentialsRepository.all.findResults { credentialsType.isInstance(it) ? credentialsType.cast(it) : null })
+
+    if (cloudProvider != null) {
+      allAccounts = allAccounts.findAll { acc -> acc.cloudProvider == cloudProvider }
+    }
 
     if (version != null) {
       allAccounts = allAccounts.findAll { acc -> acc.providerVersion == version }

--- a/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
+++ b/clouddriver-security/src/test/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtilsSpec.groovy
@@ -103,6 +103,24 @@ class ProviderUtilsSpec extends Specification {
       credentialsType         | accountNameSet
       TestAccountCredentials2 | ["google-account-1", "google-account-2", "google-account-3"] as Set
       TestAccountCredentials1 | ["aws-account-1", "aws-account-2", "aws-account-3"] as Set
+      AccountCredentials      | ["google-account-1", "google-account-2", "google-account-3", "aws-account-1", "aws-account-2", "aws-account-3"] as Set
+  }
+
+  @Unroll
+  void "should collect accounts matching specified credentials type and cloud provider"() {
+    when:
+    def accountSet = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository, credentialsType, cloudProvider)
+
+    then:
+    accountSet.collect { it.name } as Set == accountNameSet
+
+    where:
+    credentialsType         | cloudProvider | accountNameSet
+    TestAccountCredentials2 | "testCloudProvider" | ["google-account-1", "google-account-2", "google-account-3"] as Set
+    TestAccountCredentials2 | "otherCloudProvider" | [] as Set
+    TestAccountCredentials1 | "testCloudProvider" | ["aws-account-1", "aws-account-2", "aws-account-3"] as Set
+    TestAccountCredentials1 | "otherCloudProvider" | [] as Set
+    AccountCredentials      | "testCloudProvider" | ["google-account-1", "google-account-2", "google-account-3", "aws-account-1", "aws-account-2", "aws-account-3"] as Set
   }
 
   void "should reschedule specified agents"() {


### PR DESCRIPTION
Filter out ECS accounts that also use the NetflixAmazonCredentials class

Fixes spinnaker/spinnaker#4688