### PR TITLE
fix(kubernetes): Dynamic accounts reload when kubeconfig content changed

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -87,7 +87,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   @Include @Getter private final Integer kubectlRequestTimeoutSeconds;
 
-  @Include @Getter private final String kubeconfigFile;
+  @Getter private final String kubeconfigFile;
 
   @Include private final String kubeconfigFileHash;
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.security
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.AccountResourcePropertyRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.kork.configserver.ConfigFileService
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+class KubernetesNamedAccountCredentialsSpec extends Specification {
+
+  KubernetesSpinnakerKindMap kindMap = new KubernetesSpinnakerKindMap()
+  AccountCredentialsRepository accountCredentialsRepository = Mock(AccountCredentialsRepository)
+  NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
+  ConfigFileService configFileService = new ConfigFileService()
+  AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
+  KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
+  KubernetesNamedAccountCredentials.CredentialFactory credentialFactory = new KubernetesNamedAccountCredentials.CredentialFactory(
+    "userAgent",
+    new NoopRegistry(),
+    namerRegistry,
+    accountCredentialsRepository,
+    Mock(KubectlJobExecutor),
+    configFileService,
+    resourcePropertyRegistryFactory,
+    kindRegistryFactory
+  )
+
+
+  void "should equal 2 Kubernetes accounts with same kubeconfig content"() {
+    setup:
+      def file1 = Files.createTempFile("test", "")
+      file1.append("some content")
+      def account1Def = new KubernetesConfigurationProperties.ManagedAccount()
+      account1Def.setName("test")
+      account1Def.setCacheThreads(1)
+      account1Def.setProviderVersion(ProviderVersion.v2)
+      account1Def.getPermissions().add(Authorization.READ, "test@test.com")
+      account1Def.setNamespaces(["ns1", "ns2"])
+      account1Def.setKubeconfigFile(file1.toString())
+
+      def file2 = Files.createTempFile("other", "")
+      file2.append("some content")
+      def account2Def = new KubernetesConfigurationProperties.ManagedAccount()
+      account2Def.setName("test")
+      account2Def.setCacheThreads(1)
+      account2Def.setProviderVersion(ProviderVersion.v2)
+      account2Def.getPermissions().add(Authorization.READ, "test@test.com")
+      account2Def.setNamespaces(["ns1", "ns2"])
+      account2Def.setKubeconfigFile(file2.toString())
+
+
+    when:
+      def account1 = new KubernetesNamedAccountCredentials(account1Def, kindMap, credentialFactory)
+      def account2 = new KubernetesNamedAccountCredentials(account2Def, kindMap, credentialFactory)
+
+    then:
+      account1.equals(account2)
+
+    cleanup:
+      Files.delete(file1)
+      Files.delete(file2)
+  }
+}


### PR DESCRIPTION
This PR fixes dynamic account reloading when configured via `git`. I'm not entirely sure but it seems that when `configserver:` is used on `kubeconfigfile`, a new file is created at each polling. Since the file is different, the account is considered new and reinitialized.

The fix is to remove the test on `kubeconfigfile`. We already test on `kubeconfigFileHash`.

This may potentially be a problem if the operator deletes the old file and decide to add a new account with the exact same parameter since `kubeconfigFileHash` is computed once.

Would appreciate some review from @ethanfrogers and @scottfrederick