### PR TITLE
fix(kubernetes): Add Json annotations

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -17,6 +17,8 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
@@ -131,6 +133,7 @@ public class KubernetesKind {
   }
 
   @Nonnull
+  @JsonCreator
   public static KubernetesKind fromString(@Nonnull String qualifiedKind) {
     KubernetesApiGroup apiGroup;
     String kindName;
@@ -146,6 +149,7 @@ public class KubernetesKind {
   }
 
   @Override
+  @JsonValue
   public String toString() {
     if (apiGroup.isNativeGroup()) {
       return name;


### PR DESCRIPTION
These annotations were dropped in converting KubernetesKind; this means that we're serializing a KubernetesKind as a full object rather than just as a string. This slightly changes the result of calls to /serverGroups and /loadBalancers as now the 'kind' field is an object not a string. This could cause issues with consumers that expect a specific format; our integration tests expect to see just a string there which is how I found this.