### PR TITLE
perf(kubernetes): Defer checking valid kinds until after startup

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
@@ -17,8 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
 
-import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.NONE;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesCachingAgent;
@@ -70,7 +68,6 @@ public class KubernetesV2CachingAgentDispatcher implements KubernetesCachingAgen
                 propertyRegistry.values().stream()
                     .map(KubernetesResourceProperties::getHandler)
                     .filter(Objects::nonNull)
-                    .filter(h -> v2Credentials.isValidKind(h.kind()) || h.kind().equals(NONE))
                     .map(
                         h ->
                             h.buildCachingAgent(

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
@@ -83,7 +83,7 @@ public class KubernetesV2CachingAgentDispatcher implements KubernetesCachingAgen
                     .filter(Objects::nonNull)
                     .forEach(c -> result.add((KubernetesCachingAgent) c)));
 
-    if (v2Credentials.isMetricsComputed()) {
+    if (v2Credentials.isMetricsEnabled()) {
       IntStream.range(0, credentials.getCacheThreads())
           .boxed()
           .forEach(

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -83,7 +83,7 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
             : Collections.emptyList();
 
     List<KubernetesPodMetric.ContainerMetric> metrics = Collections.emptyList();
-    if (kind.equals(KubernetesKind.POD) && credentials.isMetricsComputed()) {
+    if (kind.equals(KubernetesKind.POD) && credentials.isMetricsEnabled()) {
       metrics =
           credentials.topPod(namespace, parsedName.getRight()).stream()
               .map(KubernetesPodMetric::getContainerMetrics)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -108,7 +108,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   @Include @JsonIgnore @Getter private final List<String> oAuthScopes;
 
-  @Include @Getter private boolean metrics;
+  @Include private boolean metrics;
 
   @Include @Getter private final boolean debug;
 
@@ -366,7 +366,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     return result;
   }
 
-  public boolean isMetricsComputed() {
+  public boolean isMetricsEnabled() {
     return metrics && kindValidator.isMetricsReadable();
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -22,6 +22,7 @@ import static lombok.EqualsAndHashCode.Include;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Clock;
 import com.netflix.spectator.api.Registry;
@@ -48,8 +49,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -81,8 +82,6 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   @Include private final Set<KubernetesKind> omitKinds;
 
-  private final Map<KubernetesKind, KubernetesKindStatus> omitKindsComputed;
-
   @Include @Getter private final List<CustomKubernetesResource> customResources;
 
   @Include @Getter private final String kubectlExecutable;
@@ -111,8 +110,6 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   @Include @Getter private boolean metrics;
 
-  @Getter private boolean metricsComputed;
-
   @Include @Getter private final boolean debug;
 
   private String cachedDefaultNamespace;
@@ -120,6 +117,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final Supplier<List<KubernetesKind>> liveCrdSupplier;
   @Getter private final ResourcePropertyRegistry resourcePropertyRegistry;
   @Getter private final KubernetesKindRegistry kindRegistry;
+  private final KindValidator kindValidator;
 
   public KubernetesV2Credentials(
       Registry registry,
@@ -157,13 +155,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         managedAccount.getOmitKinds().stream()
             .map(KubernetesKind::fromString)
             .collect(ImmutableSet.toImmutableSet());
-
-    this.omitKindsComputed =
-        managedAccount.getOmitKinds().stream()
-            .map(KubernetesKind::fromString)
-            .collect(
-                Collectors.toMap(
-                    k -> k, k -> KubernetesKindStatus.EXPLICITLY_OMITTED_BY_CONFIGURATION));
+    this.kindValidator = new KindValidator(this.kinds, this.omitKinds);
 
     this.customResources = managedAccount.getCustomResources();
 
@@ -183,7 +175,6 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.oAuthScopes = managedAccount.getOAuthScopes();
 
     this.metrics = managedAccount.isMetrics();
-    this.metricsComputed = managedAccount.isMetrics();
 
     this.debug = managedAccount.isDebug();
 
@@ -302,15 +293,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   @Nonnull
   public KubernetesKindStatus getKindStatus(@Nonnull KubernetesKind kind) {
-    if (kind.equals(KubernetesKind.NONE)) {
-      return KubernetesKindStatus.KIND_NONE;
-    } else if (!this.kinds.isEmpty()) {
-      return !kinds.contains(kind)
-          ? KubernetesKindStatus.MISSING_FROM_ALLOWED_KINDS
-          : KubernetesKindStatus.VALID;
-    } else {
-      return this.omitKindsComputed.getOrDefault(kind, KubernetesKindStatus.VALID);
-    }
+    return kindValidator.getKindStatus(kind);
   }
 
   public String getDefaultNamespace() {
@@ -360,10 +343,6 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     // ensure this is called at least once before the credentials object is created to ensure all
     // crds are registered
     this.liveCrdSupplier.get();
-
-    if (checkPermissionsOnStartup) {
-      determineOmitKinds();
-    }
   }
 
   public List<KubernetesKind> getCrds() {
@@ -387,93 +366,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     return result;
   }
 
-  private void determineOmitKinds() {
-    List<String> namespaces = getDeclaredNamespaces();
-
-    if (namespaces.isEmpty()) {
-      log.warn(
-          "There are no namespaces configured (or loadable) -- please check that the list of 'omitNamespaces' for account '"
-              + accountName
-              + "' doesn't prevent access from all namespaces in this cluster, or that the cluster is reachable.");
-      return;
-    }
-
-    // we are making the assumption that the roles granted to spinnaker for this account in all
-    // namespaces are identical.
-    // otherwise, checking all namespaces for all kinds is too expensive in large clusters (imagine
-    // a cluster with 100s of namespaces).
-    String checkNamespace = namespaces.get(0);
-    List<KubernetesKind> allKinds =
-        kindRegistry.getRegisteredKinds().stream()
-            .map(KubernetesKindProperties::getKubernetesKind)
-            .collect(Collectors.toList());
-
-    log.info(
-        "Checking permissions on configured kinds for account {}... {}", accountName, allKinds);
-    long startTime = System.nanoTime();
-
-    // compute list of kinds we explicitly know the server doesn't support
-    try {
-      Set<KubernetesKind> availableResources = jobExecutor.apiResources(this);
-      Map<KubernetesKind, KubernetesKindStatus> unavailableKinds =
-          allKinds.stream()
-              .filter(Objects::nonNull)
-              .filter(k -> !k.equals(KubernetesKind.NONE))
-              .filter(k -> !availableResources.contains(k))
-              .collect(Collectors.toConcurrentMap(k -> k, k -> KubernetesKindStatus.READ_ERROR));
-
-      omitKindsComputed.putAll(unavailableKinds);
-    } catch (Exception e) {
-      log.warn("Failed to evaluate kinds available on server. {}.", e.getMessage());
-    }
-
-    Map<KubernetesKind, KubernetesKindStatus> unreadableKinds =
-        allKinds
-            .parallelStream()
-            .filter(Objects::nonNull)
-            .filter(k -> !k.equals(KubernetesKind.NONE))
-            .filter(k -> !omitKindsComputed.containsKey(k))
-            .filter(k -> !canReadKind(k, checkNamespace))
-            .collect(
-                Collectors.toConcurrentMap(
-                    Function.identity(), k -> KubernetesKindStatus.READ_ERROR));
-    long endTime = System.nanoTime();
-    long duration = (endTime - startTime) / 1000000;
-    log.info("determineOmitKinds for account {} took {} ms", accountName, duration);
-    omitKindsComputed.putAll(unreadableKinds);
-
-    if (metricsComputed) {
-      try {
-        log.info("Checking if pod metrics are readable for account {}...", accountName);
-        topPod(checkNamespace, null);
-      } catch (Exception e) {
-        log.warn(
-            "Could not read pod metrics in account '{}' for reason: {}",
-            accountName,
-            e.getMessage());
-        log.debug("Reading logs for account '{}' failed with exception: ", accountName, e);
-        metricsComputed = false;
-      }
-    }
-  }
-
-  private boolean canReadKind(KubernetesKind kind, String checkNamespace) {
-    log.info("Checking if {} is readable in account '{}'...", kind, accountName);
-    boolean allowed;
-    if (kindRegistry.getRegisteredKind(kind).isNamespaced()) {
-      allowed = jobExecutor.authCanINamespaced(this, checkNamespace, kind.getName(), "list");
-    } else {
-      allowed = jobExecutor.authCanI(this, kind.getName(), "list");
-    }
-
-    if (!allowed) {
-      log.info(
-          "Kind {} will not be cached in account '{}' because it cannot be listed.",
-          kind,
-          accountName);
-    }
-
-    return allowed;
+  public boolean isMetricsComputed() {
+    return metrics && kindValidator.isMetricsReadable();
   }
 
   public KubernetesManifest get(KubernetesKind kind, String namespace, String name) {
@@ -677,6 +571,132 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       } else {
         return result;
       }
+    }
+  }
+
+  /**
+   * Handles validating whether kubernetes kinds should be cached by the current account, and
+   * whether metrics are enabled for the account.
+   */
+  private class KindValidator {
+    private final Supplier<String> checkNamespace = Suppliers.memoize(this::computeCheckNamespace);
+    private final Map<KubernetesKind, Boolean> readableKinds = new ConcurrentHashMap<>();
+    private final Supplier<Boolean> metricsReadable = Suppliers.memoize(this::checkMetricsReadable);
+
+    private final Set<KubernetesKind> kinds;
+    private final Set<KubernetesKind> omitKinds;
+
+    KindValidator(Set<KubernetesKind> kinds, Set<KubernetesKind> omitKinds) {
+      this.kinds = kinds;
+      this.omitKinds = omitKinds;
+    }
+
+    private String getCheckNamespace() {
+      return checkNamespace.get();
+    }
+
+    private String computeCheckNamespace() {
+      List<String> namespaces = getDeclaredNamespaces();
+
+      if (namespaces.isEmpty()) {
+        log.warn(
+            "There are no namespaces configured (or loadable) -- please check that the list of 'omitNamespaces' for account '"
+                + accountName
+                + "' doesn't prevent access from all namespaces in this cluster, or that the cluster is reachable.");
+        return null;
+      }
+
+      // we are making the assumption that the roles granted to spinnaker for this account in all
+      // namespaces are identical.
+      // otherwise, checking all namespaces for all kinds is too expensive in large clusters
+      // (imagine
+      // a cluster with 100s of namespaces).
+      return namespaces.get(0);
+    }
+
+    private boolean skipPermissionChecks() {
+      // checkPermissionsOnStartup exists from when permission checks were done at startup (and took
+      // a long time); this flag was added to skip the checks and assume all kinds were readable.
+      // Now that permissions are checked on-the-fly, this flag is probably not necessary, but for
+      // now we'll continue to support the prior behavior, which is to short-circuit and assume all
+      // kinds are readable before checking.
+      return !checkPermissionsOnStartup;
+    }
+
+    private boolean canReadKind(KubernetesKind kind) {
+      if (skipPermissionChecks()) {
+        return true;
+      }
+      log.info("Checking if {} is readable in account '{}'...", kind, accountName);
+      boolean allowed;
+      if (kindRegistry.getRegisteredKind(kind).isNamespaced()) {
+        allowed =
+            jobExecutor.authCanINamespaced(
+                KubernetesV2Credentials.this, getCheckNamespace(), kind.getName(), "list");
+      } else {
+        allowed = jobExecutor.authCanI(KubernetesV2Credentials.this, kind.getName(), "list");
+      }
+
+      if (!allowed) {
+        log.info(
+            "Kind {} will not be cached in account '{}' because it cannot be listed.",
+            kind,
+            accountName);
+      }
+
+      return allowed;
+    }
+
+    private boolean checkMetricsReadable() {
+      if (skipPermissionChecks()) {
+        return true;
+      }
+      try {
+        log.info("Checking if pod metrics are readable for account {}...", accountName);
+        topPod(getCheckNamespace(), null);
+        return true;
+      } catch (Exception e) {
+        log.warn(
+            "Could not read pod metrics in account '{}' for reason: {}",
+            accountName,
+            e.getMessage());
+        log.debug("Reading logs for account '{}' failed with exception: ", accountName, e);
+        return false;
+      }
+    }
+
+    /**
+     * Returns the status of a given kubernetes kind with respect to the current account. Checks of
+     * whether a kind is readable are cached for the lifetime of the process (and are only performed
+     * when a kind is otherwise considered valid for the account).
+     */
+    @Nonnull
+    KubernetesKindStatus getKindStatus(@Nonnull KubernetesKind kind) {
+      if (kind.equals(KubernetesKind.NONE)) {
+        return KubernetesKindStatus.KIND_NONE;
+      }
+
+      if (!kinds.isEmpty()) {
+        return kinds.contains(kind)
+            ? KubernetesKindStatus.VALID
+            : KubernetesKindStatus.MISSING_FROM_ALLOWED_KINDS;
+      }
+
+      if (omitKinds.contains(kind)) {
+        return KubernetesKindStatus.EXPLICITLY_OMITTED_BY_CONFIGURATION;
+      }
+
+      return readableKinds.computeIfAbsent(kind, this::canReadKind)
+          ? KubernetesKindStatus.VALID
+          : KubernetesKindStatus.READ_ERROR;
+    }
+
+    /**
+     * Returns whether metrics are readable for the current kubernetes account. This check is cached
+     * for the lifetime of the process, and subsequent calls return the cached value.
+     */
+    boolean isMetricsReadable() {
+      return metricsReadable.get();
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.validator;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials.KubernetesKindStatus;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.ArrayList;
@@ -125,10 +126,9 @@ public class KubernetesValidationUtil {
 
   private boolean validateKind(KubernetesKind kind, KubernetesV2Credentials credentials) {
     if (!credentials.isValidKind(kind)) {
-      KubernetesV2Credentials.InvalidKindReason invalidReason =
-          credentials.getInvalidKindReason(kind);
-      if (invalidReason != null) {
-        reject(invalidReason.getErrorMessage(kind), kind.toString());
+      KubernetesKindStatus kindStatus = credentials.getKindStatus(kind);
+      if (kindStatus != KubernetesKindStatus.VALID) {
+        reject(kindStatus.getErrorMessage(kind), kind.toString());
       } else {
         reject("notValidKind", kind.toString());
       }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
@@ -116,7 +116,7 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
     accountCredentials.isServiceAccount() == false
     accountCredentials.isOnlySpinnakerManaged() == false
     accountCredentials.isDebug() == false
-    accountCredentials.isMetrics() == true
+    accountCredentials.isMetricsEnabled() == true
     accountCredentials.isLiveManifestCalls() == false
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -131,7 +131,7 @@ class KubernetesV2CredentialsSpec extends Specification {
     )
 
     expect:
-    credentials.isMetricsComputed() == metrics
+    credentials.isMetricsEnabled() == metrics
 
     where:
     metrics << [true, false]
@@ -149,7 +149,7 @@ class KubernetesV2CredentialsSpec extends Specification {
     kubectlJobExecutor.topPod(_ as KubernetesV2Credentials, NAMESPACE, _) >> Collections.emptyList()
 
     expect:
-    credentials.isMetricsComputed() == true
+    credentials.isMetricsEnabled() == true
   }
 
   void "Metrics are properly disabled when not readable"() {
@@ -166,6 +166,6 @@ class KubernetesV2CredentialsSpec extends Specification {
     }
 
     expect:
-    credentials.isMetricsComputed() == false
+    credentials.isMetricsEnabled() == false
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -49,7 +49,6 @@ class KubernetesV2CredentialsSpec extends Specification {
         checkPermissionsOnStartup: false,
       )
     )
-    credentials.initialize()
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -65,7 +64,6 @@ class KubernetesV2CredentialsSpec extends Specification {
         kinds: []
       )
     )
-    credentials.initialize()
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -81,7 +79,6 @@ class KubernetesV2CredentialsSpec extends Specification {
         kinds: ["deployment"]
       )
     )
-    credentials.initialize()
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -97,67 +94,78 @@ class KubernetesV2CredentialsSpec extends Specification {
         omitKinds: ["deployment"]
       )
     )
-    credentials.initialize()
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == false
     credentials.isValidKind(KubernetesKind.REPLICA_SET) == true
   }
 
-  void "Kinds that are not available on the server are considered invalid"() {
-    when:
-    KubernetesV2Credentials credentials = buildCredentials(
-      new KubernetesConfigurationProperties.ManagedAccount(
-        namespaces: [NAMESPACE],
-        checkPermissionsOnStartup: true,
-      )
-    )
-    credentials.initialize()
-
-    then:
-
-    kubectlJobExecutor.apiResources(_) >> {
-      return [
-        KubernetesKind.from("Deployment", KubernetesApiGroup.APPS)
-      ]
-    }
-
-    kubectlJobExecutor.authCanINamespaced(_, _, "deployment", _) >> {
-      return true
-    }
-
-    credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
-    credentials.isValidKind(KubernetesKind.REPLICA_SET) == false
-  }
-
   void "Kinds that are not readable are considered invalid"() {
-    when:
+    given:
     KubernetesV2Credentials credentials = buildCredentials(
       new KubernetesConfigurationProperties.ManagedAccount(
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: true,
       )
     )
-    credentials.initialize()
-
-    then:
-
-    kubectlJobExecutor.apiResources(_) >> {
-      return [
-        KubernetesKind.from("Deployment", KubernetesApiGroup.APPS),
-        KubernetesKind.from("ReplicaSet", KubernetesApiGroup.APPS)
-      ]
-    }
-
     kubectlJobExecutor.authCanINamespaced(_, _, "deployment", _) >> {
       return false
     }
-
     kubectlJobExecutor.authCanINamespaced(_, _, "replicaSet", _) >> {
       return true
     }
 
+    expect:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == false
     credentials.isValidKind(KubernetesKind.REPLICA_SET) == true
+  }
+
+  void "Metrics are properly set on the account when not checking permissions"() {
+    given:
+    KubernetesV2Credentials credentials = buildCredentials(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        namespaces: [NAMESPACE],
+        checkPermissionsOnStartup: false,
+        metrics: metrics
+      )
+    )
+
+    expect:
+    credentials.isMetricsComputed() == metrics
+
+    where:
+    metrics << [true, false]
+  }
+
+  void "Metrics are properly enabled when readable"() {
+    given:
+    KubernetesV2Credentials credentials = buildCredentials(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        namespaces: [NAMESPACE],
+        checkPermissionsOnStartup: true,
+        metrics: true
+      )
+    )
+    kubectlJobExecutor.topPod(_ as KubernetesV2Credentials, NAMESPACE, _) >> Collections.emptyList()
+
+    expect:
+    credentials.isMetricsComputed() == true
+  }
+
+  void "Metrics are properly disabled when not readable"() {
+    given:
+    KubernetesV2Credentials credentials = buildCredentials(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        namespaces: [NAMESPACE],
+        checkPermissionsOnStartup: true,
+        metrics: true
+      )
+    )
+    kubectlJobExecutor.topPod(_ as KubernetesV2Credentials, NAMESPACE, _) >> {
+      throw new KubectlJobExecutor.KubectlException("Error", new Exception())
+    }
+
+    expect:
+    credentials.isMetricsComputed() == false
   }
 }


### PR DESCRIPTION
* refactor(kubernetes): Rename InvalidKindReason and avoid nulls 

  Instead of having an enum InvalidKindReason, and returning null when a kind is valid, jsut call it KindStatus and use an enum value VALID to represent a valid kind. This avoids the need to use null as a sentinel value.

* refactor(kubernetes): Change lists to immutable sets 

  We store a list of kinds and kinds to omit on each account; these lists are never modified after they are created, and we only ever do set-like operations on them (contains, size).

  In order to make lookups more efficient, and prevent bugs (and make the following refactor easier), change the lists to immutable sets.

* perf(kubernetes): Defer checking valid kinds until after startup 

  Instead of blocking the startup of clouddriver while we check whether we can read every kind in every account, defer these checks until first use.

  Encapsulate this logic in an inner class called KindValidator; this class handles keeping track of what kinds are valid for an account as well as whether metrics are readable for the account. It will only ever attempt to read a kind once (the first time it is asked), and short-circuits just like the earlier logic based on the contents of kinds and omitKinds.

* refactor(kubernetes): Rename isMetricsComputed 

  The fact that whether metrics is enabled or not is computed by reading metrics is an implementation details; make it easier for consumers by renaming this function isMetricsEnabled.

  Also, remove the getter for metrics, which should never be read by consumers of the class, which should always use isMetricsEnabled.

* perf(kubernetes): Don't check valid kinds in agent scheduling 

  We currently check whether kinds are valid while scheduling caching agents which blocks agents starting. Caching agents themselves should
  (and currently do) check whether kinds are valid before actually querying them; remove the check that occurs before scheduling agents.

  This means that at worst we'll schedule a no-op agent that immediately returns for an invalid kind (though given that kinds are generally grouped in agents that handle many kinds, this likely won't happen much in practice).

  While the earlier commit in this PR deferred checking readable kinds, the fact that we're checking all readable kinds during agent scheduling means we're still effectively blocking startup on checking readable kinds. Removing this allow startup to proceed before we've checked all readable kinds.
