### PR TITLE
refactor(kubernetes): Remove extraneous null checks

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -175,7 +175,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials>
           spectatorRegistry,
           jobExecutor,
           managedAccount,
-          resourcePropertyRegistryFactory.create(),
+          resourcePropertyRegistryFactory,
           kindRegistryFactory.create(),
           getKubeconfigFile(managedAccount));
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentDispatcher;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.*;
@@ -156,19 +155,6 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
       for (KubernetesNamedAccountCredentials credentials : allAccounts) {
         KubernetesV2Credentials v2Credentials =
             (KubernetesV2Credentials) credentials.getCredentials();
-        v2Credentials
-            .getCustomResources()
-            .forEach(
-                cr -> {
-                  try {
-                    KubernetesResourceProperties properties =
-                        KubernetesResourceProperties.fromCustomResource(
-                            cr, v2Credentials.getKindRegistry());
-                    v2Credentials.getResourcePropertyRegistry().register(properties);
-                  } catch (Exception e) {
-                    log.warn("Error encountered registering {}: ", cr, e);
-                  }
-                });
         v2Credentials.initialize();
         List<Agent> newlyAddedAgents =
             kubernetesV2CachingAgentDispatcher.buildAllCachingAgents(credentials).stream()

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2SearchProvider.java
@@ -142,12 +142,6 @@ public class KubernetesV2SearchProvider implements SearchProvider {
           resourcePropertyResolver
               .getResourcePropertyRegistry(infraKey.getAccount())
               .get(infraKey.getKubernetesKind());
-      if (properties == null) {
-        log.warn(
-            "No hydrator for type {}, this is possibly a developer error",
-            infraKey.getKubernetesKind());
-        return null;
-      }
 
       result = properties.getHandler().hydrateSearchResult(infraKey, cacheUtils);
     } else if (parsedKey instanceof Keys.LogicalKey) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
@@ -82,9 +82,6 @@ public abstract class KubernetesV2AbstractManifestProvider
     KubernetesKind kind = manifest.getKind();
 
     KubernetesResourceProperties properties = getRegistry(account).get(kind);
-    if (properties == null) {
-      return null;
-    }
 
     Function<KubernetesManifest, String> lastEventTimestamp =
         (m) -> (String) m.getOrDefault("lastTimestamp", m.getOrDefault("firstTimestamp", "n/a"));

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -97,9 +97,6 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
       String account, String location, String kind, String app, String cluster, Sort sort) {
     KubernetesResourceProperties properties =
         getRegistry(account).get(KubernetesKind.fromString(kind));
-    if (properties == null) {
-      return null;
-    }
 
     KubernetesHandler handler = properties.getHandler();
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/AccountResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/AccountResourcePropertyRegistry.java
@@ -17,24 +17,32 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.springframework.stereotype.Component;
 
+@ParametersAreNonnullByDefault
 public class AccountResourcePropertyRegistry implements ResourcePropertyRegistry {
   private final GlobalResourcePropertyRegistry globalResourcePropertyRegistry;
-
-  private final ConcurrentHashMap<KubernetesKind, KubernetesResourceProperties> propertyMap =
-      new ConcurrentHashMap<>();
+  private final ImmutableMap<KubernetesKind, KubernetesResourceProperties> propertyMap;
 
   private AccountResourcePropertyRegistry(
-      GlobalResourcePropertyRegistry globalResourcePropertyRegistry) {
+      GlobalResourcePropertyRegistry globalResourcePropertyRegistry,
+      Collection<KubernetesResourceProperties> resourceProperties) {
     this.globalResourcePropertyRegistry = globalResourcePropertyRegistry;
+    this.propertyMap =
+        resourceProperties.stream()
+            .collect(toImmutableMap(p -> p.getHandler().kind(), Function.identity()));
   }
 
+  @Override
   @Nonnull
   public KubernetesResourceProperties get(KubernetesKind kind) {
     KubernetesResourceProperties accountResult = propertyMap.get(kind);
@@ -45,10 +53,8 @@ public class AccountResourcePropertyRegistry implements ResourcePropertyRegistry
     return globalResourcePropertyRegistry.get(kind);
   }
 
-  public void register(KubernetesResourceProperties properties) {
-    propertyMap.put(properties.getHandler().kind(), properties);
-  }
-
+  @Override
+  @Nonnull
   public Collection<KubernetesResourceProperties> values() {
     Collection<KubernetesResourceProperties> result =
         new ArrayList<>(globalResourcePropertyRegistry.values());
@@ -65,8 +71,10 @@ public class AccountResourcePropertyRegistry implements ResourcePropertyRegistry
       this.globalResourcePropertyRegistry = globalResourcePropertyRegistry;
     }
 
-    public AccountResourcePropertyRegistry create() {
-      return new AccountResourcePropertyRegistry(globalResourcePropertyRegistry);
+    public AccountResourcePropertyRegistry create(
+        Collection<KubernetesResourceProperties> resourceProperties) {
+      return new AccountResourcePropertyRegistry(
+          globalResourcePropertyRegistry, resourceProperties);
     }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/AccountResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/AccountResourcePropertyRegistry.java
@@ -19,9 +19,10 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -55,12 +56,11 @@ public class AccountResourcePropertyRegistry implements ResourcePropertyRegistry
 
   @Override
   @Nonnull
-  public Collection<KubernetesResourceProperties> values() {
-    Collection<KubernetesResourceProperties> result =
-        new ArrayList<>(globalResourcePropertyRegistry.values());
-    result.addAll(propertyMap.values());
-
-    return result;
+  public ImmutableCollection<KubernetesResourceProperties> values() {
+    return new ImmutableList.Builder<KubernetesResourceProperties>()
+        .addAll(globalResourcePropertyRegistry.values())
+        .addAll(propertyMap.values())
+        .build();
   }
 
   @Component

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistry.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesUnregisteredCustomResourceHandler;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -32,15 +33,20 @@ import org.springframework.stereotype.Component;
 @ParametersAreNonnullByDefault
 public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry {
   private final ImmutableMap<KubernetesKind, KubernetesResourceProperties> globalProperties;
+  private final KubernetesResourceProperties defaultProperties;
 
   @Autowired
-  public GlobalResourcePropertyRegistry(List<KubernetesHandler> handlers) {
+  public GlobalResourcePropertyRegistry(
+      List<KubernetesHandler> handlers,
+      KubernetesUnregisteredCustomResourceHandler defaultHandler) {
     this.globalProperties =
         handlers.stream()
             .collect(
                 toImmutableMap(
                     KubernetesHandler::kind,
                     h -> new KubernetesResourceProperties(h, h.versioned())));
+    this.defaultProperties =
+        new KubernetesResourceProperties(defaultHandler, defaultHandler.versioned());
   }
 
   @Override
@@ -51,7 +57,7 @@ public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry 
       return globalResult;
     }
 
-    return globalProperties.get(KubernetesKind.NONE);
+    return defaultProperties;
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistry.java
@@ -34,11 +34,7 @@ public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry 
   private final ImmutableMap<KubernetesKind, KubernetesResourceProperties> globalProperties;
 
   @Autowired
-  public GlobalResourcePropertyRegistry(
-      List<KubernetesHandler> handlers, KubernetesSpinnakerKindMap kindMap) {
-    for (KubernetesHandler handler : handlers) {
-      kindMap.addRelationship(handler.spinnakerKind(), handler.kind());
-    }
+  public GlobalResourcePropertyRegistry(List<KubernetesHandler> handlers) {
     this.globalProperties =
         handlers.stream()
             .collect(

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistry.java
@@ -18,10 +18,10 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
-import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -60,7 +60,7 @@ public class GlobalResourcePropertyRegistry implements ResourcePropertyRegistry 
 
   @Override
   @Nonnull
-  public Collection<KubernetesResourceProperties> values() {
+  public ImmutableCollection<KubernetesResourceProperties> values() {
     return globalProperties.values();
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
@@ -17,15 +17,13 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -62,26 +60,22 @@ public class KubernetesSpinnakerKindMap {
     }
   }
 
-  private final ImmutableMap<SpinnakerKind, ImmutableSet<KubernetesKind>> spinnakerToKubernetes;
   private final ImmutableMap<KubernetesKind, SpinnakerKind> kubernetesToSpinnaker;
+  private final ImmutableSetMultimap<SpinnakerKind, KubernetesKind> spinnakerToKubernetes;
 
   public KubernetesSpinnakerKindMap(List<KubernetesHandler> handlers) {
-    ImmutableMap.Builder<KubernetesKind, SpinnakerKind> spinnakerToKubernetesBuilder =
+    ImmutableMap.Builder<KubernetesKind, SpinnakerKind> kubernetesToSpinnakerBuilder =
         new ImmutableMap.Builder<>();
-    Map<SpinnakerKind, ImmutableSet.Builder<KubernetesKind>> kubernetesToSpinnakerBuilder =
-        new HashMap<>();
+    ImmutableSetMultimap.Builder<SpinnakerKind, KubernetesKind> spinnakerToKubernetesBuilder =
+        new ImmutableSetMultimap.Builder<>();
     for (KubernetesHandler handler : handlers) {
       SpinnakerKind spinnakerKind = handler.spinnakerKind();
       KubernetesKind kubernetesKind = handler.kind();
-      kubernetesToSpinnakerBuilder
-          .computeIfAbsent(spinnakerKind, k -> new ImmutableSet.Builder<>())
-          .add(kubernetesKind);
-      spinnakerToKubernetesBuilder.put(kubernetesKind, spinnakerKind);
+      kubernetesToSpinnakerBuilder.put(kubernetesKind, spinnakerKind);
+      spinnakerToKubernetesBuilder.put(spinnakerKind, kubernetesKind);
     }
-    this.kubernetesToSpinnaker = spinnakerToKubernetesBuilder.build();
-    this.spinnakerToKubernetes =
-        kubernetesToSpinnakerBuilder.entrySet().stream()
-            .collect(toImmutableMap(Map.Entry::getKey, e -> e.getValue().build()));
+    this.kubernetesToSpinnaker = kubernetesToSpinnakerBuilder.build();
+    this.spinnakerToKubernetes = spinnakerToKubernetesBuilder.build();
   }
 
   public SpinnakerKind translateKubernetesKind(KubernetesKind kubernetesKind) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMap.java
@@ -19,9 +19,11 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -61,7 +63,13 @@ public class KubernetesSpinnakerKindMap {
   private final Map<SpinnakerKind, Set<KubernetesKind>> spinnakerToKubernetes = new HashMap<>();
   private final Map<KubernetesKind, SpinnakerKind> kubernetesToSpinnaker = new HashMap<>();
 
-  void addRelationship(SpinnakerKind spinnakerKind, KubernetesKind kubernetesKind) {
+  public KubernetesSpinnakerKindMap(List<KubernetesHandler> handlers) {
+    for (KubernetesHandler handler : handlers) {
+      addRelationship(handler.spinnakerKind(), handler.kind());
+    }
+  }
+
+  private void addRelationship(SpinnakerKind spinnakerKind, KubernetesKind kubernetesKind) {
     Set<KubernetesKind> kinds = spinnakerToKubernetes.get(spinnakerKind);
     if (kinds == null) {
       kinds = new HashSet<>();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/RegistryUtils.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/RegistryUtils.java
@@ -34,9 +34,6 @@ public class RegistryUtils {
     }
 
     KubernetesResourceProperties properties = propertyRegistry.get(kind);
-    if (properties == null) {
-      return Optional.empty();
-    }
 
     KubernetesHandler handler = properties.getHandler();
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/ResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/ResourcePropertyRegistry.java
@@ -23,6 +23,4 @@ public interface ResourcePropertyRegistry {
   KubernetesResourceProperties get(KubernetesKind kind);
 
   Collection<KubernetesResourceProperties> values();
-
-  void register(KubernetesResourceProperties properties);
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/ResourcePropertyRegistry.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/ResourcePropertyRegistry.java
@@ -16,11 +16,16 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
+import com.google.common.collect.ImmutableCollection;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
-import java.util.Collection;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public interface ResourcePropertyRegistry {
+  @Nonnull
   KubernetesResourceProperties get(KubernetesKind kind);
 
-  Collection<KubernetesResourceProperties> values();
+  @Nonnull
+  ImmutableCollection<KubernetesResourceProperties> values();
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -80,10 +80,6 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
           String kind = type.substring("kubernetes/".length());
           KubernetesResourceProperties properties =
               credentials.getResourcePropertyRegistry().get(KubernetesKind.fromString(kind));
-          if (properties == null) {
-            log.warn("No properties for artifact {}, ignoring", a);
-            return;
-          }
 
           getTask().updateStatus(OP_NAME, "Deleting artifact '" + a + '"');
           KubernetesHandler handler = properties.getHandler();

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanLoadBalance.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanLoadBalance.java
@@ -34,12 +34,6 @@ public interface CanLoadBalance {
   static CanLoadBalance lookupProperties(
       ResourcePropertyRegistry registry, Pair<KubernetesKind, String> name) {
     KubernetesResourceProperties loadBalancerProperties = registry.get(name.getLeft());
-    if (loadBalancerProperties == null) {
-      throw new IllegalArgumentException(
-          "No properties are registered for "
-              + name
-              + ", are you sure it's a valid load balancer type?");
-    }
 
     KubernetesHandler loadBalancerHandler = loadBalancerProperties.getHandler();
     if (loadBalancerHandler == null) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CustomKubernetesHandlerFactory.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CustomKubernetesHandlerFactory.java
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.model.Manifest;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 public class CustomKubernetesHandlerFactory {
@@ -68,6 +69,7 @@ public class CustomKubernetesHandlerFactory {
       return deployPriority;
     }
 
+    @Nonnull
     @Override
     public KubernetesKind kind() {
       return kubernetesKind;
@@ -78,6 +80,7 @@ public class CustomKubernetesHandlerFactory {
       return versioned;
     }
 
+    @Nonnull
     @Override
     public SpinnakerKind spinnakerKind() {
       return spinnakerKind;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/HasPods.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/HasPods.java
@@ -29,12 +29,6 @@ public interface HasPods {
 
   static HasPods lookupProperties(ResourcePropertyRegistry registry, KubernetesKind kind) {
     KubernetesResourceProperties hasPodsProperties = registry.get(kind);
-    if (hasPodsProperties == null) {
-      throw new IllegalArgumentException(
-          "No properties are registered for "
-              + kind
-              + ", are you sure it's a valid pod manager type?");
-    }
     KubernetesHandler hasPodsHandler = hasPodsProperties.getHandler();
     if (hasPodsHandler == null) {
       throw new IllegalArgumentException(

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesAPIServiceHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesAPIServiceHandler.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,6 +34,7 @@ public class KubernetesAPIServiceHandler extends KubernetesHandler {
     return API_SERVICE_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.API_SERVICE;
@@ -43,6 +45,7 @@ public class KubernetesAPIServiceHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleBindingHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleBindingHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesClusterRoleBindingHandler extends KubernetesHandler {
     return ROLE_BINDING_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CLUSTER_ROLE_BINDING;
@@ -44,6 +46,7 @@ public class KubernetesClusterRoleBindingHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesClusterRoleHandler extends KubernetesHandler {
     return ROLE_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CLUSTER_ROLE;
@@ -44,6 +46,7 @@ public class KubernetesClusterRoleHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesConfigMapHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesConfigMapHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesConfigMapHandler extends KubernetesHandler {
     return MOUNTABLE_DATA_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CONFIG_MAP;
@@ -44,6 +46,7 @@ public class KubernetesConfigMapHandler extends KubernetesHandler {
     return true;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.CONFIGS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesControllerRevisionHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesControllerRevisionHandler.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -32,6 +33,7 @@ public class KubernetesControllerRevisionHandler extends KubernetesHandler {
     throw new IllegalStateException("Controller revisions cannot be deployed.");
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CONTROLLER_REVISION;
@@ -42,6 +44,7 @@ public class KubernetesControllerRevisionHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCronJobHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCronJobHandler.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import io.kubernetes.client.models.V2alpha1CronJob;
 import io.kubernetes.client.models.V2alpha1CronJobStatus;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -50,6 +51,7 @@ public class KubernetesCronJobHandler extends KubernetesHandler
     return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CRON_JOB;
@@ -60,6 +62,7 @@ public class KubernetesCronJobHandler extends KubernetesHandler
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.SERVER_GROUPS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCustomResourceDefinitionHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCustomResourceDefinitionHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesCustomResourceDefinitionHandler extends KubernetesHandler
     return RESOURCE_DEFINITION_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.CUSTOM_RESOURCE_DEFINITION;
@@ -44,6 +46,7 @@ public class KubernetesCustomResourceDefinitionHandler extends KubernetesHandler
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import io.kubernetes.client.models.V1beta2DaemonSet;
 import io.kubernetes.client.models.V1beta2DaemonSetStatus;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -53,6 +54,7 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
     return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.DAEMON_SET;
@@ -63,6 +65,7 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.SERVER_GROUPS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import io.kubernetes.client.models.V1beta2Deployment;
 import io.kubernetes.client.models.V1beta2DeploymentCondition;
 import io.kubernetes.client.models.V1beta2DeploymentStatus;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -59,6 +60,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
     return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.DEPLOYMENT;
@@ -69,6 +71,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.SERVER_GROUP_MANAGERS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
@@ -46,6 +47,7 @@ public class KubernetesEventHandler extends KubernetesHandler {
     throw new IllegalStateException("Events cannot be deployed.");
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return EVENT;
@@ -56,6 +58,7 @@ public class KubernetesEventHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHandler.java
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.clouddriver.model.Manifest.Warning;
 import com.netflix.spinnaker.clouddriver.model.ManifestProvider;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.*;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,10 +48,12 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
 
   public abstract int deployPriority();
 
+  @Nonnull
   public abstract KubernetesKind kind();
 
   public abstract boolean versioned();
 
+  @Nonnull
   public abstract SpinnakerKind spinnakerKind();
 
   public abstract Status status(KubernetesManifest manifest);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHorizontalPodAutoscalerHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHorizontalPodAutoscalerHandler.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -40,6 +41,7 @@ public class KubernetesHorizontalPodAutoscalerHandler extends KubernetesHandler 
     return WORKLOAD_ATTACHMENT_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.HORIZONTAL_POD_AUTOSCALER;
@@ -50,6 +52,7 @@ public class KubernetesHorizontalPodAutoscalerHandler extends KubernetesHandler 
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -51,6 +52,7 @@ public class KubernetesIngressHandler extends KubernetesHandler {
     return NETWORK_RESOURCE_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.INGRESS;
@@ -61,6 +63,7 @@ public class KubernetesIngressHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.LOAD_BALANCERS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
@@ -34,6 +34,7 @@ import io.kubernetes.client.models.V1JobStatus;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -54,6 +55,7 @@ public class KubernetesJobHandler extends KubernetesHandler implements ServerGro
     return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.JOB;
@@ -64,6 +66,7 @@ public class KubernetesJobHandler extends KubernetesHandler implements ServerGro
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.SERVER_GROUPS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesMutatingWebhookConfigurationHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesMutatingWebhookConfigurationHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,6 +32,7 @@ public class KubernetesMutatingWebhookConfigurationHandler extends KubernetesHan
     return DeployPriority.ADMISSION_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.MUTATING_WEBHOOK_CONFIGURATION;
@@ -41,6 +43,7 @@ public class KubernetesMutatingWebhookConfigurationHandler extends KubernetesHan
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNamespaceHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNamespaceHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesNamespaceHandler extends KubernetesHandler {
     return NAMESPACE_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.NAMESPACE;
@@ -44,6 +46,7 @@ public class KubernetesNamespaceHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNetworkPolicyHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNetworkPolicyHandler.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -37,6 +38,7 @@ public class KubernetesNetworkPolicyHandler extends KubernetesHandler {
     return NETWORK_RESOURCE_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.NETWORK_POLICY;
@@ -47,6 +49,7 @@ public class KubernetesNetworkPolicyHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.SECURITY_GROUPS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeClaimHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeClaimHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesPersistentVolumeClaimHandler extends KubernetesHandler {
     return MOUNTABLE_DATA_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.PERSISTENT_VOLUME_CLAIM;
@@ -44,6 +46,7 @@ public class KubernetesPersistentVolumeClaimHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.CONFIGS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesPersistentVolumeHandler extends KubernetesHandler {
     return MOUNTABLE_DATA_BACKING_RESOURCE_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.PERSISTENT_VOLUME;
@@ -44,6 +46,7 @@ public class KubernetesPersistentVolumeHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.CONFIGS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodDisruptionBudgetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodDisruptionBudgetHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesPodDisruptionBudgetHandler extends KubernetesHandler {
     return PDB_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.POD_DISRUPTION_BUDGET;
@@ -44,6 +46,7 @@ public class KubernetesPodDisruptionBudgetHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.models.V1PodStatus;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -51,6 +52,7 @@ public class KubernetesPodHandler extends KubernetesHandler {
     return WORKLOAD_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.POD;
@@ -61,6 +63,7 @@ public class KubernetesPodHandler extends KubernetesHandler {
     return true;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.INSTANCES;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodPresetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodPresetHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,6 +32,7 @@ public class KubernetesPodPresetHandler extends KubernetesHandler {
     return DeployPriority.WORKLOAD_MODIFIER_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.POD_PRESET;
@@ -41,6 +43,7 @@ public class KubernetesPodPresetHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodSecurityPolicyHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodSecurityPolicyHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,6 +32,7 @@ public class KubernetesPodSecurityPolicyHandler extends KubernetesHandler {
     return DeployPriority.WORKLOAD_MODIFIER_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.POD_SECURITY_POLICY;
@@ -41,6 +43,7 @@ public class KubernetesPodSecurityPolicyHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -61,6 +62,7 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
     return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.REPLICA_SET;
@@ -71,6 +73,7 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
     return true;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.SERVER_GROUPS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleBindingHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleBindingHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesRoleBindingHandler extends KubernetesHandler {
     return ROLE_BINDING_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.ROLE_BINDING;
@@ -44,6 +46,7 @@ public class KubernetesRoleBindingHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesRoleHandler extends KubernetesHandler {
     return ROLE_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.ROLE;
@@ -44,6 +46,7 @@ public class KubernetesRoleHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesSecretHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesSecretHandler.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -36,6 +37,7 @@ public class KubernetesSecretHandler extends KubernetesHandler {
     return MOUNTABLE_DATA_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.SECRET;
@@ -51,6 +53,7 @@ public class KubernetesSecretHandler extends KubernetesHandler {
     return true;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.CONFIGS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceAccountHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceAccountHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesServiceAccountHandler extends KubernetesHandler {
     return SERVICE_ACCOUNT_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.SERVICE_ACCOUNT;
@@ -44,6 +46,7 @@ public class KubernetesServiceAccountHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandler.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -51,6 +52,7 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
     return NETWORK_RESOURCE_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.SERVICE;
@@ -61,6 +63,7 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.LOAD_BALANCERS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -67,6 +68,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
     return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return STATEFUL_SET;
@@ -77,6 +79,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.SERVER_GROUPS;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStorageClassHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStorageClassHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class KubernetesStorageClassHandler extends KubernetesHandler {
     return STORAGE_CLASS_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.STORAGE_CLASS;
@@ -44,6 +46,7 @@ public class KubernetesStorageClassHandler extends KubernetesHandler {
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesUnregisteredCustomResourceHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesUnregisteredCustomResourceHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -35,6 +36,7 @@ public class KubernetesUnregisteredCustomResourceHandler extends KubernetesHandl
     return LOWEST_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.NONE;
@@ -45,9 +47,10 @@ public class KubernetesUnregisteredCustomResourceHandler extends KubernetesHandl
     return false;
   }
 
+  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
-    return null;
+    return SpinnakerKind.UNCLASSIFIED;
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesValidatingWebhookConfigurationHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesValidatingWebhookConfigurationHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,6 +32,7 @@ public class KubernetesValidatingWebhookConfigurationHandler extends KubernetesH
     return DeployPriority.ADMISSION_PRIORITY.getValue();
   }
 
+  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.VALIDATING_WEBHOOK_CONFIGURATION;
@@ -41,6 +43,7 @@ public class KubernetesValidatingWebhookConfigurationHandler extends KubernetesH
     return false;
   }
 
+  @Nonnull
   @Override
   public KubernetesSpinnakerKindMap.SpinnakerKind spinnakerKind() {
     return KubernetesSpinnakerKindMap.SpinnakerKind.UNCLASSIFIED;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -37,6 +37,7 @@ import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.moniker.Namer;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -108,12 +109,6 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
       }
 
       KubernetesResourceProperties properties = findResourceProperties(manifest);
-      if (properties == null) {
-        throw new IllegalArgumentException(
-            "Unsupported Kubernetes object kind '"
-                + manifest.getKind().toString()
-                + "', unable to continue.");
-      }
       KubernetesHandler deployer = properties.getHandler();
       if (deployer == null) {
         throw new IllegalArgumentException(
@@ -336,6 +331,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
         .build();
   }
 
+  @Nonnull
   private KubernetesResourceProperties findResourceProperties(KubernetesManifest manifest) {
     KubernetesKind kind = manifest.getKind();
     getTask().updateStatus(OP_NAME, "Finding deployer for " + kind + "...");

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
@@ -137,10 +137,6 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
   private KubernetesHandler findPatchHandler(KubernetesCoordinates objToPatch) {
     KubernetesResourceProperties properties =
         credentials.getResourcePropertyRegistry().get(objToPatch.getKind());
-    if (properties == null) {
-      throw new IllegalArgumentException(
-          "Unsupported Kubernetes object kind '" + objToPatch.getKind() + "', unable to continue");
-    }
     KubernetesHandler patchHandler = properties.getHandler();
     if (patchHandler == null) {
       throw new IllegalArgumentException(

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentia
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.JsonPatch;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPatchOptions;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.ResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
@@ -362,6 +363,17 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   }
 
   public void initialize() {
+    this.getCustomResources()
+        .forEach(
+            cr -> {
+              try {
+                KubernetesResourceProperties properties =
+                    KubernetesResourceProperties.fromCustomResource(cr, kindRegistry);
+                resourcePropertyRegistry.register(properties);
+              } catch (Exception e) {
+                log.warn("Error encountered registering {}: ", cr, e);
+              }
+            });
     // ensure this is called at least once before the credentials object is created to ensure all
     // crds are registered
     this.liveCrdSupplier.get();

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -35,7 +35,7 @@ import java.nio.file.Files
 
 class KubernetesNamedAccountCredentialsSpec extends Specification {
 
-  KubernetesSpinnakerKindMap kindMap = new KubernetesSpinnakerKindMap()
+  KubernetesSpinnakerKindMap kindMap = new KubernetesSpinnakerKindMap([])
   AccountCredentialsRepository accountCredentialsRepository = Mock(AccountCredentialsRepository)
   NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = new ConfigFileService()

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizableSpec.groovy
@@ -62,7 +62,7 @@ class KubernetesV1ProviderSynchronizableSpec extends Specification {
       agentDispatcher,
       configurationProperties,
       credentialFactory,
-      new KubernetesSpinnakerKindMap(),
+      new KubernetesSpinnakerKindMap([]),
       catsModule
     )
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
@@ -63,7 +63,7 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
       agentDispatcher,
       configurationProperties,
       credentialFactory,
-      new KubernetesSpinnakerKindMap(),
+      new KubernetesSpinnakerKindMap([]),
       catsModule
     )
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/AccountResourcePropertyRegistrySpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/AccountResourcePropertyRegistrySpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description
 
+import com.google.common.collect.ImmutableList
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesReplicaSetHandler
@@ -26,7 +27,7 @@ class AccountResourcePropertyRegistrySpec extends Specification {
     given:
     def replicaSetProperties = new KubernetesResourceProperties(new KubernetesReplicaSetHandler(), true)
     def globalResourcePropertyRegistry = Mock(GlobalResourcePropertyRegistry) {
-      values() >> []
+      values() >> ImmutableList.of()
       get(_ as KubernetesKind) >> KubernetesKind.NONE
     }
     def factory = new AccountResourcePropertyRegistry.Factory(globalResourcePropertyRegistry)
@@ -50,7 +51,7 @@ class AccountResourcePropertyRegistrySpec extends Specification {
     given:
     def properties = new KubernetesResourceProperties(Mock(KubernetesHandler), true)
     def globalResourcePropertyRegistry = Mock(GlobalResourcePropertyRegistry) {
-      values() >> [properties]
+      values() >> ImmutableList.of(properties)
       get(KubernetesKind.DEPLOYMENT) >> properties
     }
     def factory = new AccountResourcePropertyRegistry.Factory(globalResourcePropertyRegistry)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/AccountResourcePropertyRegistrySpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/AccountResourcePropertyRegistrySpec.groovy
@@ -32,14 +32,14 @@ class AccountResourcePropertyRegistrySpec extends Specification {
     def factory = new AccountResourcePropertyRegistry.Factory(globalResourcePropertyRegistry)
 
     when:
-    AccountResourcePropertyRegistry registry = factory.create()
+    AccountResourcePropertyRegistry registry = factory.create([])
 
     then:
     registry instanceof AccountResourcePropertyRegistry
     registry.values().isEmpty()
 
     when:
-    registry.register(replicaSetProperties)
+    registry = factory.create([replicaSetProperties])
 
     then:
     registry.values().size() == 1
@@ -56,7 +56,7 @@ class AccountResourcePropertyRegistrySpec extends Specification {
     def factory = new AccountResourcePropertyRegistry.Factory(globalResourcePropertyRegistry)
 
     when:
-    AccountResourcePropertyRegistry registry = factory.create()
+    AccountResourcePropertyRegistry registry = factory.create([])
 
     then:
     registry instanceof AccountResourcePropertyRegistry

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistrySpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistrySpec.groovy
@@ -23,19 +23,20 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesUnre
 import spock.lang.Specification
 
 class GlobalResourcePropertyRegistrySpec extends Specification {
+  KubernetesUnregisteredCustomResourceHandler defaultHandler = new KubernetesUnregisteredCustomResourceHandler()
   void "creates an empty resource map"() {
     given:
     def replicaSetHandler = new KubernetesReplicaSetHandler()
 
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(Collections.emptyList())
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(Collections.emptyList(), defaultHandler)
 
     then:
     registry instanceof GlobalResourcePropertyRegistry
     registry.values().isEmpty()
 
     when:
-    registry = new GlobalResourcePropertyRegistry([replicaSetHandler])
+    registry = new GlobalResourcePropertyRegistry([replicaSetHandler], defaultHandler)
 
     then:
     registry.values().size() == 1
@@ -43,17 +44,14 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
     registry.get(KubernetesKind.REPLICA_SET).isVersioned() == replicaSetHandler.versioned()
   }
 
-  void "defaults to the handler for NONE if no handler is specified"() {
-    given:
-    def unregisteredHandler = new KubernetesUnregisteredCustomResourceHandler()
-
+  void "defaults to the default handler if no handler is specified"() {
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([unregisteredHandler])
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([], defaultHandler)
 
     then:
-    registry.values().size() == 1
-    registry.get(KubernetesKind.REPLICA_SET).getHandler() == unregisteredHandler
-    registry.get(KubernetesKind.REPLICA_SET).isVersioned() == unregisteredHandler.versioned()
+    registry.values().isEmpty()
+    registry.get(KubernetesKind.REPLICA_SET).getHandler() == defaultHandler
+    registry.get(KubernetesKind.REPLICA_SET).isVersioned() == defaultHandler.versioned()
   }
 
   void "registers handlers passed to the constructor"() {
@@ -62,7 +60,7 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
     def replicaSetHandler = new KubernetesReplicaSetHandler()
 
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([unregisteredHandler, replicaSetHandler])
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([unregisteredHandler, replicaSetHandler], defaultHandler)
 
     then:
     registry.values().size() == 2

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistrySpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistrySpec.groovy
@@ -26,7 +26,6 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
   void "creates an empty resource map"() {
     given:
     def replicaSetHandler = new KubernetesReplicaSetHandler()
-    def replicaSetProperties = new KubernetesResourceProperties(replicaSetHandler, replicaSetHandler.versioned())
 
     when:
     GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(Collections.emptyList(), new KubernetesSpinnakerKindMap())
@@ -36,25 +35,25 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
     registry.values().isEmpty()
 
     when:
-    registry.register(replicaSetProperties)
+    registry = new GlobalResourcePropertyRegistry([replicaSetHandler], new KubernetesSpinnakerKindMap())
 
     then:
     registry.values().size() == 1
-    registry.get(KubernetesKind.REPLICA_SET) == replicaSetProperties
+    registry.get(KubernetesKind.REPLICA_SET).getHandler() == replicaSetHandler
+    registry.get(KubernetesKind.REPLICA_SET).isVersioned() == replicaSetHandler.versioned()
   }
 
   void "defaults to the handler for NONE if no handler is specified"() {
     given:
     def unregisteredHandler = new KubernetesUnregisteredCustomResourceHandler()
-    def unregisteredProperties = new KubernetesResourceProperties(unregisteredHandler, unregisteredHandler.versioned())
 
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(Collections.emptyList(), new KubernetesSpinnakerKindMap())
-    registry.register(unregisteredProperties)
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([unregisteredHandler], new KubernetesSpinnakerKindMap())
 
     then:
     registry.values().size() == 1
-    registry.get(KubernetesKind.REPLICA_SET) == unregisteredProperties
+    registry.get(KubernetesKind.REPLICA_SET).getHandler() == unregisteredHandler
+    registry.get(KubernetesKind.REPLICA_SET).isVersioned() == unregisteredHandler.versioned()
   }
 
   void "properly updates the kindMap"() {
@@ -67,8 +66,7 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
     def kindMap = new KubernetesSpinnakerKindMap()
 
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(Collections.emptyList(), kindMap)
-    registry.register(properties)
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([mockHandler], kindMap)
 
     then:
     kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES) == [KubernetesKind.REPLICA_SET] as Set

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistrySpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistrySpec.groovy
@@ -28,14 +28,14 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
     def replicaSetHandler = new KubernetesReplicaSetHandler()
 
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(Collections.emptyList(), new KubernetesSpinnakerKindMap())
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(Collections.emptyList())
 
     then:
     registry instanceof GlobalResourcePropertyRegistry
     registry.values().isEmpty()
 
     when:
-    registry = new GlobalResourcePropertyRegistry([replicaSetHandler], new KubernetesSpinnakerKindMap())
+    registry = new GlobalResourcePropertyRegistry([replicaSetHandler])
 
     then:
     registry.values().size() == 1
@@ -48,29 +48,12 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
     def unregisteredHandler = new KubernetesUnregisteredCustomResourceHandler()
 
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([unregisteredHandler], new KubernetesSpinnakerKindMap())
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([unregisteredHandler])
 
     then:
     registry.values().size() == 1
     registry.get(KubernetesKind.REPLICA_SET).getHandler() == unregisteredHandler
     registry.get(KubernetesKind.REPLICA_SET).isVersioned() == unregisteredHandler.versioned()
-  }
-
-  void "properly updates the kindMap"() {
-    given:
-    def mockHandler = Mock(KubernetesHandler) {
-      spinnakerKind() >> KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
-      kind() >> KubernetesKind.REPLICA_SET
-    }
-    def properties = new KubernetesResourceProperties(mockHandler, true)
-    def kindMap = new KubernetesSpinnakerKindMap()
-
-    when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([mockHandler], kindMap)
-
-    then:
-    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES) == [KubernetesKind.REPLICA_SET] as Set
-    kindMap.translateKubernetesKind(KubernetesKind.REPLICA_SET) == KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
   }
 
   void "registers handlers passed to the constructor"() {
@@ -79,7 +62,7 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
     def replicaSetHandler = new KubernetesReplicaSetHandler()
 
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([unregisteredHandler, replicaSetHandler], new KubernetesSpinnakerKindMap())
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry([unregisteredHandler, replicaSetHandler])
 
     then:
     registry.values().size() == 2

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMapSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMapSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description
+
+import com.google.common.collect.ImmutableSet
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler
+import spock.lang.Specification
+
+class KubernetesSpinnakerKindMapSpec extends Specification {
+  void "the kind map is properly initialized"() {
+    given:
+    def mockHandler = Mock(KubernetesHandler) {
+      spinnakerKind() >> KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
+      kind() >> KubernetesKind.REPLICA_SET
+    }
+
+    when:
+    def kindMap = new KubernetesSpinnakerKindMap([mockHandler])
+
+    then:
+    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES) == [KubernetesKind.REPLICA_SET] as Set
+    kindMap.translateKubernetesKind(KubernetesKind.REPLICA_SET) == KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
+  }
+
+  void "the kind map properly groups kinds"() {
+    when:
+    def kindMap = new KubernetesSpinnakerKindMap([
+      Mock(KubernetesHandler) {
+        spinnakerKind() >> KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
+        kind() >> KubernetesKind.REPLICA_SET
+      },
+      Mock(KubernetesHandler) {
+        spinnakerKind() >> KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
+        kind() >> KubernetesKind.DEPLOYMENT
+      },
+      Mock(KubernetesHandler) {
+        spinnakerKind() >> KubernetesSpinnakerKindMap.SpinnakerKind.LOAD_BALANCERS
+        kind() >> KubernetesKind.SERVICE
+      }
+    ])
+
+    then:
+    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES) == [KubernetesKind.REPLICA_SET, KubernetesKind.DEPLOYMENT] as Set
+    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.LOAD_BALANCERS) == [KubernetesKind.SERVICE] as Set
+    kindMap.translateKubernetesKind(KubernetesKind.REPLICA_SET) == KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
+    kindMap.translateKubernetesKind(KubernetesKind.DEPLOYMENT) == KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
+    kindMap.translateKubernetesKind(KubernetesKind.SERVICE) == KubernetesSpinnakerKindMap.SpinnakerKind.LOAD_BALANCERS
+  }
+}

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMapSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesSpinnakerKindMapSpec.groovy
@@ -33,7 +33,7 @@ class KubernetesSpinnakerKindMapSpec extends Specification {
     def kindMap = new KubernetesSpinnakerKindMap([mockHandler])
 
     then:
-    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES) == [KubernetesKind.REPLICA_SET] as Set
+    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES) == ImmutableSet.of(KubernetesKind.REPLICA_SET)
     kindMap.translateKubernetesKind(KubernetesKind.REPLICA_SET) == KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
   }
 
@@ -55,8 +55,8 @@ class KubernetesSpinnakerKindMapSpec extends Specification {
     ])
 
     then:
-    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES) == [KubernetesKind.REPLICA_SET, KubernetesKind.DEPLOYMENT] as Set
-    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.LOAD_BALANCERS) == [KubernetesKind.SERVICE] as Set
+    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES) == ImmutableSet.of(KubernetesKind.REPLICA_SET, KubernetesKind.DEPLOYMENT)
+    kindMap.translateSpinnakerKind(KubernetesSpinnakerKindMap.SpinnakerKind.LOAD_BALANCERS) == ImmutableSet.of(KubernetesKind.SERVICE)
     kindMap.translateKubernetesKind(KubernetesKind.REPLICA_SET) == KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
     kindMap.translateKubernetesKind(KubernetesKind.DEPLOYMENT) == KubernetesSpinnakerKindMap.SpinnakerKind.INSTANCES
     kindMap.translateKubernetesKind(KubernetesKind.SERVICE) == KubernetesSpinnakerKindMap.SpinnakerKind.LOAD_BALANCERS

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.security
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.AccountResourcePropertyRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.ResourcePropertyRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.GlobalKubernetesKindRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup
@@ -31,14 +32,14 @@ class KubernetesV2CredentialsSpec extends Specification {
   Registry registry = Stub(Registry)
   KubectlJobExecutor kubectlJobExecutor = Stub(KubectlJobExecutor)
   String NAMESPACE = "my-namespace"
-  ResourcePropertyRegistry resourcePropertyRegistry = Mock(ResourcePropertyRegistry)
+  AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = new KubernetesKindRegistry.Factory(
     new GlobalKubernetesKindRegistry(KubernetesKindProperties.getGlobalKindProperties())
   )
 
 
   private buildCredentials(KubernetesConfigurationProperties.ManagedAccount managedAccount) {
-    return new KubernetesV2Credentials(registry, kubectlJobExecutor, managedAccount, resourcePropertyRegistry, kindRegistryFactory.create(), null)
+    return new KubernetesV2Credentials(registry, kubectlJobExecutor, managedAccount, resourcePropertyRegistryFactory, kindRegistryFactory.create(), null)
   }
 
   void "Built-in Kubernetes kinds are considered valid by default"() {


### PR DESCRIPTION
* refactor(kubernetes): Initialize property registry in credentials class 

  The property registry is owned by the credentials class; rather than have the agent scheduler call into the class to initialize it, just have the class handle this in its initialize method.

* refactor(kubernetes): Make AccountResourcePropertyRegistry immutable 

  AccountResourcePropertyRegistry support a register method, but it is only used a single time to initialize the registry with the account's KubernetesResourceProperties.

  Instead, require the KubernetesResourceProperties in the constructor, and remove the register method.

* refactor(kubernetes): Make GlobalResourcePropertyRegistry immutable 

  GlobalResourcePropertyRegistry has a register method that is only ever called from the constructor. Remove this method and instead build an immutable map in the constructor.

* refactor(kubernetes): Update return values from registries to be immutable 

  Now that both AccountResourcePropertyRegistry and GlobalResourcePropertyRegistry are immutable, update the public methods on these classes, and the interface to return immutable collections where approriate. Also add NonNull annotations where appropriate.

* refactor(kubernetes): Add Nonnull annotation to handler kinds 

  In an upcoming commit, we're going to be storing the KubernetesKind and SpinnakerKind associated with handlers in an ImmutableMap, which won't allow null values.

  As we already have null objects for each of these (KubernetesKind.NONE and SpinnakerKind.UNCLASSIFIED) there's no need to ever have these methods return null.  Add annotations to the interface and implementations, and update the one implementation returning null to instead return SpinnakerKind.UNCLASSIFIED.

* refactor(kubernetes): Let KubernetesSpinnakerKindMap initialize itself 

  It's a bit strange that GlobalResourcePropertyRegistry is responsible for initializing KubernetesSpinnakerKindMap. (It takes the singleton kind map in the constructor, mutates it, then forgets about it.) This is a vestige of the way the code worked before the kind registries were created.

  Instead, let KubernetesSpinnakerKindMap handle its own initialization; its constructor should expect the same list of KubernetesHandlers and should register the kinds found on each of them.

  This also means that we can make the register method private as it's only called from the constructor. If you were to guess that the next commit would remove the register method entirely and make the class immutable, you would probably be correct...

* refactor(kubernetes): Make KubernetesSpinnakerKindMap immutable 

  Now that KubernetesSpinnakerKindMap handles its own initialization, the constructor has all the information needed to completely construct the maps. Create immutable maps in the constructor and remove the register method.

* refactor(kubernetes): Enforce that defaultProperties are not null 

  We've added the NonNull annotation to GlobalResourcePropertyRegistry.get because we fall back to the properties for KubernetesKind.NONE for a kind that's not in the registry. While it is statically true that there will be properties for the NONE kind (because KubernetesUnregisteredCustomResourceHandler handles the NONE kind) it's a bit confusing to see how this defaulting happens and is liable to break if one day we remove the NONE kind from that handler.

  Instead, let's be more explicit and expect to receive the unregistered custom resource handler bean in the constructor of the global registry, and set that as the default to return. Then if we somehow don't have this default value, autowiring will fail at startup (instead of causing null-pointer exceptions later).

  This makes it much more clear that get() always returns a non-null value, even though it always did.

* refactor(kubernetes): Remove extraneous null checks 

  Now that we have statically guaranteed that the return value of KubernetesKindRegistry.get is non-null, we can remove multiple extraneous non-null checks from the code.