### PR TITLE
refactor(*): Remove credentialAccount from all AWS-derived cloud providers

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/AbstractAmazonCredentialsDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/AbstractAmazonCredentialsDescription.groovy
@@ -17,16 +17,10 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.security.resources.CredentialsNameable
 
 abstract class AbstractAmazonCredentialsDescription implements CredentialsNameable {
   @JsonIgnore
   NetflixAmazonCredentials credentials
-
-  @JsonProperty("credentials")
-  String getCredentialAccount() {
-    this.credentials?.name
-  }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -324,7 +324,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
       deploymentResult.deployments.add(
           new DeploymentResult.Deployment(
               cloudProvider: "aws",
-              account: description.getCredentialAccount(),
+              account: description.getAccount(),
               location: region,
               serverGroupName: asgName,
               capacity: capacity

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerAtomicOperation.groovy
@@ -146,7 +146,7 @@ class UpsertAmazonLoadBalancerAtomicOperation implements AtomicOperation<UpsertA
             IngressLoadBalancerBuilder.IngressLoadBalancerGroupResult ingressLoadBalancerResult = ingressLoadBalancerBuilder.ingressApplicationLoadBalancerGroup(
               application,
               region,
-              description.credentialAccount,
+              description.account,
               description.credentials,
               description.vpcId,
               ports,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerV2AtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerV2AtomicOperation.groovy
@@ -164,7 +164,7 @@ class UpsertAmazonLoadBalancerV2AtomicOperation implements AtomicOperation<Upser
         IngressLoadBalancerBuilder.IngressLoadBalancerGroupResult ingressLoadBalancerResult = ingressLoadBalancerBuilder.ingressApplicationLoadBalancerGroup(
           application,
           region,
-          description.credentialAccount,
+          description.account,
           description.credentials,
           description.vpcId,
           ports,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
@@ -68,7 +68,7 @@ class SecurityGroupIngressConverter {
       permission
     }
     description.securityGroupIngress.each { ingress ->
-      final accountName = ingress.accountName ?: description.credentialAccount
+      final accountName = ingress.accountName ?: description.account
       final accountId = ingress.accountId ?: securityGroupLookup.getAccountIdForName(accountName)
       final vpcId = ingress.vpcId ?: description.vpcId
       def newUserIdGroupPair = null
@@ -96,7 +96,7 @@ class SecurityGroupIngressConverter {
     }
     new ConvertedIngress(ipPermissions, new MissingSecurityGroups(
       all: missing,
-      selfReferencing: missing.findAll { it.name == description.name && it.accountName == description.credentialAccount }
+      selfReferencing: missing.findAll { it.name == description.name && it.accountName == description.account }
     ))
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -112,7 +112,7 @@ class SecurityGroupLookupFactory {
     }
 
     SecurityGroupUpdater createSecurityGroup(UpsertSecurityGroupDescription description) {
-      final credentials = getCredentialsForName(description.credentialAccount)
+      final credentials = getCredentialsForName(description.account)
       final request = new CreateSecurityGroupRequest(description.name, description.description)
       if (description.vpcId) {
         request.withVpcId(description.vpcId)
@@ -152,7 +152,7 @@ class SecurityGroupLookupFactory {
       }
 
       if (!skipEdda) {
-        getEddaSecurityGroups(amazonEC2, description.credentialAccount, region).add(newSecurityGroup)
+        getEddaSecurityGroups(amazonEC2, description.account, region).add(newSecurityGroup)
       }
       new SecurityGroupUpdater(newSecurityGroup, amazonEC2)
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/CredentialsAccountNormalizationPreProcessor.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/preprocessors/CredentialsAccountNormalizationPreProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.clouddriver.aws.deploy.preprocessors;
+
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationDescriptionPreProcessor;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/** Normalizes the use of `account` vs `credentials`, ensuring that both are always set. */
+@Slf4j
+@Component
+public class CredentialsAccountNormalizationPreProcessor
+    implements AtomicOperationDescriptionPreProcessor {
+  @Override
+  public boolean supports(Class descriptionClass) {
+    return true;
+  }
+
+  @Override
+  public Map process(Map description) {
+    final String account = (String) description.get("account");
+    final String credentials = (String) description.get("credentials");
+
+    if (account != null && credentials != null && !account.equals(credentials)) {
+      log.warn(
+          "Passed 'account' ({}) and 'credentials' ({}), but values are not equal",
+          account,
+          credentials);
+    }
+
+    if (credentials == null && account != null) {
+      description.put("credentials", account);
+    }
+    if (account == null && credentials != null) {
+      description.put("account", credentials);
+    }
+
+    return description;
+  }
+}

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/AbstractEcsAtomicOperation.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.deploy.ops;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScaling;
 import com.amazonaws.services.ecs.AmazonECS;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
@@ -53,7 +52,6 @@ public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescriptio
   }
 
   AmazonECS getAmazonEcsClient() {
-    AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
     String region = getRegion();
     NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
@@ -61,7 +59,6 @@ public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescriptio
   }
 
   AWSApplicationAutoScaling getAmazonApplicationAutoScalingClient() {
-    AWSCredentialsProvider credentialsProvider = getCredentials().getCredentialsProvider();
     String region = getRegion();
     NetflixAmazonCredentials credentialAccount = description.getCredentials();
 
@@ -73,8 +70,7 @@ public abstract class AbstractEcsAtomicOperation<T extends AbstractECSDescriptio
   }
 
   AmazonCredentials getCredentials() {
-    return (AmazonCredentials)
-        accountCredentialsProvider.getCredentials(description.getCredentialAccount());
+    return (AmazonCredentials) accountCredentialsProvider.getCredentials(description.getAccount());
   }
 
   void updateTaskStatus(String status) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DisableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/DisableServiceAtomicOperation.java
@@ -45,7 +45,7 @@ public class DisableServiceAtomicOperation
     AWSApplicationAutoScaling autoScalingClient = getAmazonApplicationAutoScalingClient();
 
     String service = description.getServerGroupName();
-    String account = description.getCredentialAccount();
+    String account = description.getAccount();
     String cluster = getCluster(service, account);
 
     updateTaskStatus(

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/EnableServiceAtomicOperation.java
@@ -43,7 +43,7 @@ public class EnableServiceAtomicOperation
     AWSApplicationAutoScaling autoScalingClient = getAmazonApplicationAutoScalingClient();
 
     String service = description.getServerGroupName();
-    String account = description.getCredentialAccount();
+    String account = description.getAccount();
     String cluster = getCluster(service, account);
 
     UpdateServiceRequest request =

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstancesAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/TerminateInstancesAtomicOperation.java
@@ -37,7 +37,7 @@ public class TerminateInstancesAtomicOperation
       updateTaskStatus("Terminating instance: " + taskId);
       String clusterArn =
           containerInformationService.getClusterArn(
-              description.getCredentialAccount(), description.getRegion(), taskId);
+              description.getAccount(), description.getRegion(), taskId);
       StopTaskRequest request = new StopTaskRequest().withTask(taskId).withCluster(clusterArn);
       ecs.stopTask(request);
     }

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
@@ -113,7 +113,7 @@ abstract class AbstractEurekaSupport {
         if (index % eurekaSupportConfigurationProperties.attemptShortCircuitEveryNInstances == 0) {
           try {
             def hasUpInstances = doesCachedClusterContainDiscoveryStatus(
-              clusterProviders, description.credentialAccount, description.region, description.asgName, "UP"
+              clusterProviders, description.account, description.region, description.asgName, "UP"
             )
             if (hasUpInstances.present && !hasUpInstances.get()) {
               // there are no UP instances, we can return early
@@ -121,7 +121,7 @@ abstract class AbstractEurekaSupport {
               break
             }
           } catch (Exception e) {
-            def account = description.credentialAccount
+            def account = description.account
             def region = description.region
             def asgName = description.asgName
             AbstractEurekaSupport.log.error("[$phaseName] - Unable to verify cached discovery status (account: ${account}, region: ${region}, asgName: ${asgName}", e)

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/AbstractLambdaAtomicOperation.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/AbstractLambdaAtomicOperation.java
@@ -61,8 +61,7 @@ public abstract class AbstractLambdaAtomicOperation<T extends AbstractLambdaFunc
   }
 
   protected AmazonCredentials getCredentials() {
-    return (AmazonCredentials)
-        accountCredentialsProvider.getCredentials(description.getCredentialAccount());
+    return (AmazonCredentials) accountCredentialsProvider.getCredentials(description.getAccount());
   }
 
   void updateTaskStatus(String status) {

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/CredentialsNameable.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/CredentialsNameable.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.security.resources;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 
 /**
@@ -25,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 public interface CredentialsNameable extends AccountNameable {
   AccountCredentials getCredentials();
 
+  @JsonProperty("credentials")
   @Override
   default String getAccount() {
     return getCredentials().getName();


### PR DESCRIPTION
What could possibly go wrong with this? Really. What could possibly go wrong with this? I know we have duplication for `credentials` vs `account`, this is standardizing on `credentials`, since like... I don't even know why `credentialAccount` ever existed to begin with.

It looks to me like most of the code for descriptions expects `credentials`, whereas `account` isn't really referenced directly anyhow? (Looking at `AtomicOperationConverter`s for the AWS-derived cloud providers).