### PR TITLE
fix(aws): Alter AllowLaunchDescription to not overload account

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/AllowLaunchDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/AllowLaunchDescription.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.description
 
 class AllowLaunchDescription extends AbstractAmazonCredentialsDescription {
-  String account
+  String targetAccount
   String amiName
   String region
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
@@ -58,7 +58,7 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
     task.updateStatus BASE_PHASE, "Initializing Allow Launch Operation..."
 
     def sourceCredentials = description.credentials
-    def targetCredentials = accountCredentialsProvider.getCredentials(description.account) as NetflixAmazonCredentials
+    def targetCredentials = accountCredentialsProvider.getCredentials(description.targetAccount) as NetflixAmazonCredentials
     def sourceAmazonEC2 = amazonClientProvider.getAmazonEC2(description.credentials, description.region, true)
     def targetAmazonEC2 = amazonClientProvider.getAmazonEC2(targetCredentials, description.region, true)
 
@@ -94,7 +94,7 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
     if (amiLocation == ResolvedAmiLocation.TARGET) {
       task.updateStatus BASE_PHASE, "AMI found in target account: skipping allow launch"
     } else {
-      task.updateStatus BASE_PHASE, "Allowing launch of $description.amiName from $description.account"
+      task.updateStatus BASE_PHASE, "Allowing launch of $description.amiName from $description.account/$description.region to $description.targetAccount"
 
       OperationPoller.retryWithBackoff({ o ->
         sourceAmazonEC2.modifyImageAttribute(new ModifyImageAttributeRequest().withImageId(resolvedAmi.amiId).withLaunchPermission(
@@ -136,7 +136,7 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
       }
     }
 
-    task.updateStatus BASE_PHASE, "Done allowing launch of $description.amiName from $description.account."
+    task.updateStatus BASE_PHASE, "Done allowing launch of $description.amiName from $description.account/$description.region to $description.targetAccount."
     resolvedAmi
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidator.groovy
@@ -36,10 +36,10 @@ class AllowLaunchDescriptionValidator extends DescriptionValidator<AllowLaunchDe
     if (!description.region) {
       errors.rejectValue("region", "allowLaunchDescription.region.empty")
     }
-    if (!description.account) {
-      errors.rejectValue("account", "allowLaunchDescription.account.empty")
-    } else if (!accountCredentialsProvider.all.collect { it.name }.contains(description.account)) {
-      errors.rejectValue("account", "allowLaunchDescription.account.not.configured")
+    if (!description.targetAccount) {
+      errors.rejectValue("targetAccount", "allowLaunchDescription.targetAccount.empty")
+    } else if (!accountCredentialsProvider.all.collect { it.name }.contains(description.targetAccount)) {
+      errors.rejectValue("targetAccount", "allowLaunchDescription.targetAccount.not.configured")
     }
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperationUnitSpec.groovy
@@ -59,7 +59,7 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def creds = Stub(AccountCredentialsProvider) {
       getCredentials('target') >> target
     }
-    def op = new AllowLaunchAtomicOperation(new AllowLaunchDescription(amiName: 'super-awesome-ami', account: 'target', credentials: source))
+    def op = new AllowLaunchAtomicOperation(new AllowLaunchDescription(amiName: 'super-awesome-ami', targetAccount: 'target', credentials: source))
     op.accountCredentialsProvider = creds
     op.amazonClientProvider = provider
 
@@ -95,7 +95,7 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
       describeImages(_) >> null
     }
     def provider = Mock(AmazonClientProvider)
-    def description = new AllowLaunchDescription(account: "prod", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
+    def description = new AllowLaunchDescription(targetAccount: "prod", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = provider
     op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
@@ -126,7 +126,7 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def targetAmazonEc2 = Mock(AmazonEC2)
     def provider = Mock(AmazonClientProvider)
 
-    def description = new AllowLaunchDescription(account: "prod", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
+    def description = new AllowLaunchDescription(targetAccount: "prod", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = provider
     op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
@@ -161,7 +161,7 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def targetAmazonEc2 = Mock(AmazonEC2)
     def provider = Mock(AmazonClientProvider)
 
-    def description = new AllowLaunchDescription(account: "test", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
+    def description = new AllowLaunchDescription(targetAccount: "test", amiName: "ami-123456", region: "us-west-1", credentials: testCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = provider
     op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
@@ -194,7 +194,7 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def sourceAmazonEc2 = Mock(AmazonEC2)
     def targetAmazonEc2 = Mock(AmazonEC2)
 
-    def description = new AllowLaunchDescription(account: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: sourceCredentials)
+    def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: sourceCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
     op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
@@ -235,7 +235,7 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def ownerAmazonEc2 = Mock(AmazonEC2)
     def targetAmazonEc2 = Mock(AmazonEC2)
 
-    def description = new AllowLaunchDescription(account: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: ownerCredentials)
+    def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: ownerCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
     op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
@@ -272,7 +272,7 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def sourceAmazonEc2 = Mock(AmazonEC2)
     def targetAmazonEc2 = Mock(AmazonEC2)
 
-    def description = new AllowLaunchDescription(account: 'target', amiName: 'ami-123456', region: 'us-west-2', credentials: sourceCredentials)
+    def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-2', credentials: sourceCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
     op.accountCredentialsProvider = Mock(AccountCredentialsProvider)
@@ -314,7 +314,7 @@ class AllowLaunchAtomicOperationUnitSpec extends Specification {
     def ownerAmazonEc2 = Mock(AmazonEC2)
     def targetAmazonEc2 = Mock(AmazonEC2)
 
-    def description = new AllowLaunchDescription(account: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: ownerCredentials)
+    def description = new AllowLaunchDescription(targetAccount: 'target', amiName: 'ami-123456', region: 'us-west-1', credentials: ownerCredentials)
     def op = new AllowLaunchAtomicOperation(description)
     op.amazonClientProvider = Mock(AmazonClientProvider)
     op.accountCredentialsProvider = Mock(AccountCredentialsProvider)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidatorSpec.groovy
@@ -36,7 +36,7 @@ class AllowLaunchDescriptionValidatorSpec extends Specification {
     then:
     1 * errors.rejectValue("amiName", _)
     1 * errors.rejectValue("region", _)
-    1 * errors.rejectValue("account", _)
+    1 * errors.rejectValue("targetAccount", _)
   }
 
   void "unconfigured account is rejected"() {
@@ -44,7 +44,7 @@ class AllowLaunchDescriptionValidatorSpec extends Specification {
     AllowLaunchDescriptionValidator validator = new AllowLaunchDescriptionValidator()
     def credentialsHolder = Mock(AccountCredentialsProvider)
     validator.accountCredentialsProvider = credentialsHolder
-    def description = new AllowLaunchDescription(account: "foo")
+    def description = new AllowLaunchDescription(targetAccount: "foo")
     def errors = Mock(Errors)
 
     when:
@@ -52,6 +52,6 @@ class AllowLaunchDescriptionValidatorSpec extends Specification {
 
     then:
     1 * credentialsHolder.getAll() >> { [TestCredential.named('prod')] }
-    1 * errors.rejectValue("account", _)
+    1 * errors.rejectValue("targetAccount", _)
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AbstractAtomicOperationsCredentialsSupport.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/security/AbstractAtomicOperationsCredentialsSupport.groovy
@@ -39,7 +39,7 @@ abstract class AbstractAtomicOperationsCredentialsSupport implements AtomicOpera
 
   def <T extends AccountCredentials> T getCredentialsObject(String name) {
     if (name == null) {
-      throw new InvalidRequestException("credential name is required")
+      throw new InvalidRequestException("credentials are required")
     }
     T credential
     try {
@@ -49,7 +49,7 @@ abstract class AbstractAtomicOperationsCredentialsSupport implements AtomicOpera
       }
       credential = (T) repoCredential
     } catch (Exception e) {
-      throw new InvalidRequestException("credential not found (name: ${name}, names: ${accountCredentialsProvider.getAll()*.name})", e)
+      throw new InvalidRequestException("credentials not found (name: ${name}, names: ${accountCredentialsProvider.getAll()*.name})", e)
     }
 
     return credential


### PR DESCRIPTION
We asked, "What could possibly go wrong?" with #4017. It turns out `AllowLaunchDescription` overloaded `account`, which broke any deploy from a newly baked image. That's what can go wrong.

This PR fixes that, making the description use a new field and fix-forward whatever Orca sends us.