### PR TITLE
fix(kubernetes): Fix deserialization of account property

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesAtomicOperationDescription.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesAtomicOperationDescription.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.description;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.resources.CredentialsNameable;
@@ -29,6 +30,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class KubernetesAtomicOperationDescription
     implements DeployDescription, CredentialsNameable {
+  @JsonProperty("account")
   String account;
+
   KubernetesNamedAccountCredentials credentials;
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesAtomicOperationDescriptionSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesAtomicOperationDescriptionSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.description
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription
+import spock.lang.Specification
+
+class KubernetesAtomicOperationDescriptionSpec extends Specification {
+  def objectMapper = new ObjectMapper()
+    .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+  def "correctly deserializes the account field"() {
+    when:
+    def accountName = "my-k8s-account"
+    def input = [
+      account: accountName
+    ]
+    def output = objectMapper.convertValue(input, KubernetesAtomicOperationDescription.class)
+
+    then:
+    output.getAccount() == accountName
+  }
+}


### PR DESCRIPTION
The change in spinnaker/clouddriver#4017 broke deserialization of the account property. This is due to some confusing inheritence where KubernetesAtomicOperationDescription has a field 'account' that overrides the default method in the CredentialsNameable interface. Adding `@JsonProperty("credentials")` to the interface method broke deserialization.

This can be fixed by adding an explicit @JsonProperty("account") to the field in KubernetesAtomicOperationDescription. As this is subtle, also add a test to validate this (and prevent it from breaking in the future). While it might be better to rename the account field, it's used all over the V1 provider in groovy code, so this change is much safer as it keeps the interface of the class to consumers the same.

The test that is added passes before spinnaker/clouddriver#4017, breaks after that change, and passes again with this change.