### PR TITLE
refactor(kubernetes): Fix some unsafe casts in credential creation

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesCachingAgentDispatcher.java
@@ -16,10 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import java.util.Collection;
 
-public interface KubernetesCachingAgentDispatcher {
-  Collection<KubernetesCachingAgent> buildAllCachingAgents(
-      KubernetesNamedAccountCredentials credentials);
+public interface KubernetesCachingAgentDispatcher<C extends KubernetesCredentials> {
+  Collection<KubernetesCachingAgent<C>> buildAllCachingAgents(
+      KubernetesNamedAccountCredentials<C> credentials);
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialFactory.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.security;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.kork.configserver.ConfigFileService;
+import org.apache.commons.lang3.StringUtils;
+
+public interface KubernetesCredentialFactory<C extends KubernetesCredentials> {
+  C build(KubernetesConfigurationProperties.ManagedAccount managedAccount);
+
+  default void validateAccount(KubernetesConfigurationProperties.ManagedAccount managedAccount) {
+    if (StringUtils.isEmpty(managedAccount.getName())) {
+      throw new IllegalArgumentException("Account name for Kubernetes provider missing.");
+    }
+
+    if (!managedAccount.getOmitNamespaces().isEmpty()
+        && !managedAccount.getNamespaces().isEmpty()) {
+      throw new IllegalArgumentException(
+          "At most one of 'namespaces' and 'omitNamespaces' can be specified");
+    }
+
+    if (!managedAccount.getOmitKinds().isEmpty() && !managedAccount.getKinds().isEmpty()) {
+      throw new IllegalArgumentException("At most one of 'kinds' and 'omitKinds' can be specified");
+    }
+  }
+
+  default String getKubeconfigFile(
+      ConfigFileService configFileService,
+      KubernetesConfigurationProperties.ManagedAccount managedAccount) {
+    if (StringUtils.isNotEmpty(managedAccount.getKubeconfigFile())) {
+      return configFileService.getLocalPath(managedAccount.getKubeconfigFile());
+    }
+
+    if (StringUtils.isNotEmpty(managedAccount.getKubeconfigContents())) {
+      return configFileService.getLocalPathForContents(
+          managedAccount.getKubeconfigContents(), managedAccount.getName());
+    }
+
+    return System.getProperty("user.home") + "/.kube/config";
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -18,7 +18,10 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.security;
 
 import java.util.List;
+import java.util.Map;
 
 public interface KubernetesCredentials {
   List<String> getDeclaredNamespaces();
+
+  Map<String, String> getSpinnakerKindMap();
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -18,28 +18,15 @@ package com.netflix.spinnaker.clouddriver.kubernetes.security;
 
 import static lombok.EqualsAndHashCode.Include;
 
-import com.netflix.spectator.api.Registry;
-import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
-import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.AccountResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindRegistry;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
-import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
-import com.netflix.spinnaker.kork.configserver.ConfigFileService;
 import java.util.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -72,7 +59,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials>
   public KubernetesNamedAccountCredentials(
       KubernetesConfigurationProperties.ManagedAccount managedAccount,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
-      CredentialFactory factory) {
+      KubernetesCredentialFactory<C> credentialFactory) {
     this.name = managedAccount.getName();
     this.providerVersion = managedAccount.getProviderVersion();
     this.environment =
@@ -95,18 +82,7 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials>
       this.requiredGroupMembership =
           Collections.unmodifiableList(managedAccount.getRequiredGroupMembership());
     }
-
-    switch (managedAccount.getProviderVersion()) {
-      case v1:
-        this.credentials = (C) factory.buildV1Credentials(managedAccount);
-        break;
-      case v2:
-        this.credentials = (C) factory.buildV2Credentials(managedAccount);
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "Unknown provider type: " + managedAccount.getProviderVersion());
-    }
+    this.credentials = credentialFactory.build(managedAccount);
   }
 
   public List<String> getNamespaces() {
@@ -129,86 +105,5 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials>
                       customResource.getKubernetesKind(), customResource.getSpinnakerKind()));
     }
     return kindMap;
-  }
-
-  @Component
-  @RequiredArgsConstructor
-  public static class CredentialFactory {
-    private final String userAgent;
-    private final Registry spectatorRegistry;
-    private final NamerRegistry namerRegistry;
-    private final AccountCredentialsRepository accountCredentialsRepository;
-    private final KubectlJobExecutor jobExecutor;
-    private final ConfigFileService configFileService;
-    private final AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory;
-    private final KubernetesKindRegistry.Factory kindRegistryFactory;
-
-    KubernetesV1Credentials buildV1Credentials(
-        KubernetesConfigurationProperties.ManagedAccount managedAccount) {
-      validateAccount(managedAccount);
-      return new KubernetesV1Credentials(
-          managedAccount.getName(),
-          getKubeconfigFile(managedAccount),
-          managedAccount.getContext(),
-          managedAccount.getCluster(),
-          managedAccount.getUser(),
-          userAgent,
-          managedAccount.isServiceAccount(),
-          managedAccount.isConfigureImagePullSecrets(),
-          managedAccount.getNamespaces(),
-          managedAccount.getOmitNamespaces(),
-          managedAccount.getDockerRegistries(),
-          spectatorRegistry,
-          accountCredentialsRepository);
-    }
-
-    KubernetesV2Credentials buildV2Credentials(
-        KubernetesConfigurationProperties.ManagedAccount managedAccount) {
-      validateAccount(managedAccount);
-      NamerRegistry.lookup()
-          .withProvider(KubernetesCloudProvider.ID)
-          .withAccount(managedAccount.getName())
-          .setNamer(
-              KubernetesManifest.class,
-              namerRegistry.getNamingStrategy(managedAccount.getNamingStrategy()));
-      return new KubernetesV2Credentials(
-          spectatorRegistry,
-          jobExecutor,
-          managedAccount,
-          resourcePropertyRegistryFactory,
-          kindRegistryFactory.create(),
-          getKubeconfigFile(managedAccount));
-    }
-
-    private void validateAccount(KubernetesConfigurationProperties.ManagedAccount managedAccount) {
-      if (StringUtils.isEmpty(managedAccount.getName())) {
-        throw new IllegalArgumentException("Account name for Kubernetes provider missing.");
-      }
-
-      if (!managedAccount.getOmitNamespaces().isEmpty()
-          && !managedAccount.getNamespaces().isEmpty()) {
-        throw new IllegalArgumentException(
-            "At most one of 'namespaces' and 'omitNamespaces' can be specified");
-      }
-
-      if (!managedAccount.getOmitKinds().isEmpty() && !managedAccount.getKinds().isEmpty()) {
-        throw new IllegalArgumentException(
-            "At most one of 'kinds' and 'omitKinds' can be specified");
-      }
-    }
-
-    private String getKubeconfigFile(
-        KubernetesConfigurationProperties.ManagedAccount managedAccount) {
-      if (StringUtils.isNotEmpty(managedAccount.getKubeconfigFile())) {
-        return configFileService.getLocalPath(managedAccount.getKubeconfigFile());
-      }
-
-      if (StringUtils.isNotEmpty(managedAccount.getKubeconfigContents())) {
-        return configFileService.getLocalPathForContents(
-            managedAccount.getKubeconfigContents(), managedAccount.getName());
-      }
-
-      return System.getProperty("user.home") + "/.kube/config";
-    }
   }
 }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizable.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesCachingAge
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.provider.agent.KubernetesV1CachingAgentDispatcher;
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
@@ -44,7 +45,7 @@ public class KubernetesV1ProviderSynchronizable implements CredentialsInitialize
   private AccountCredentialsRepository accountCredentialsRepository;
   private KubernetesV1CachingAgentDispatcher kubernetesV1CachingAgentDispatcher;
   private KubernetesConfigurationProperties kubernetesConfigurationProperties;
-  private KubernetesNamedAccountCredentials.CredentialFactory credentialFactory;
+  private KubernetesV1Credentials.Factory credentialFactory;
   private KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
   private CatsModule catsModule;
 
@@ -53,7 +54,7 @@ public class KubernetesV1ProviderSynchronizable implements CredentialsInitialize
       AccountCredentialsRepository accountCredentialsRepository,
       KubernetesV1CachingAgentDispatcher kubernetesV1CachingAgentDispatcher,
       KubernetesConfigurationProperties kubernetesConfigurationProperties,
-      KubernetesNamedAccountCredentials.CredentialFactory credentialFactory,
+      KubernetesV1Credentials.Factory credentialFactory,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
       CatsModule catsModule) {
     this.kubernetesV1Provider = kubernetesV1Provider;
@@ -98,14 +99,14 @@ public class KubernetesV1ProviderSynchronizable implements CredentialsInitialize
     List<String> changedAccounts = new ArrayList<>();
     Set<String> newAndChangedAccounts = new HashSet<>();
 
-    deletedAccounts.stream().forEach(accountCredentialsRepository::delete);
+    deletedAccounts.forEach(accountCredentialsRepository::delete);
 
     kubernetesConfigurationProperties.getAccounts().stream()
         .filter(a -> ProviderVersion.v1.equals(a.getProviderVersion()))
         .forEach(
             managedAccount -> {
               KubernetesNamedAccountCredentials credentials =
-                  new KubernetesNamedAccountCredentials(
+                  new KubernetesNamedAccountCredentials<>(
                       managedAccount, kubernetesSpinnakerKindMap, credentialFactory);
 
               AccountCredentials existingCredentials =

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizable.java
@@ -106,8 +106,7 @@ public class KubernetesV1ProviderSynchronizable implements CredentialsInitialize
         .forEach(
             managedAccount -> {
               KubernetesNamedAccountCredentials credentials =
-                  new KubernetesNamedAccountCredentials<>(
-                      managedAccount, kubernetesSpinnakerKindMap, credentialFactory);
+                  new KubernetesNamedAccountCredentials<>(managedAccount, credentialFactory);
 
               AccountCredentials existingCredentials =
                   accountCredentialsRepository.getOne(managedAccount.getName());

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurati
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentDispatcher;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.*;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -43,7 +44,7 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
   private final AccountCredentialsRepository accountCredentialsRepository;
   private final KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher;
   private final KubernetesConfigurationProperties kubernetesConfigurationProperties;
-  private final KubernetesNamedAccountCredentials.CredentialFactory credentialFactory;
+  private final KubernetesV2Credentials.Factory credentialFactory;
   private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
   private final CatsModule catsModule;
 
@@ -52,7 +53,7 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
       AccountCredentialsRepository accountCredentialsRepository,
       KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher,
       KubernetesConfigurationProperties kubernetesConfigurationProperties,
-      KubernetesNamedAccountCredentials.CredentialFactory credentialFactory,
+      KubernetesV2Credentials.Factory credentialFactory,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
       CatsModule catsModule) {
     this.kubernetesV2Provider = kubernetesV2Provider;

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
@@ -107,8 +107,7 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
         .forEach(
             managedAccount -> {
               KubernetesNamedAccountCredentials credentials =
-                  new KubernetesNamedAccountCredentials<>(
-                      managedAccount, kubernetesSpinnakerKindMap, credentialFactory);
+                  new KubernetesNamedAccountCredentials<>(managedAccount, credentialFactory);
 
               AccountCredentials existingCredentials =
                   accountCredentialsRepository.getOne(managedAccount.getName());

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
@@ -75,12 +75,13 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
     Set<String> newAndChangedAccounts = synchronizeAccountCredentials();
 
     // we only want to initialize caching agents for new or updated accounts
-    Set<KubernetesNamedAccountCredentials> allAccounts =
+    Set<KubernetesNamedAccountCredentials<KubernetesV2Credentials>> allAccounts =
         ProviderUtils.buildThreadSafeSetOfAccounts(
                 accountCredentialsRepository,
                 KubernetesNamedAccountCredentials.class,
                 ProviderVersion.v2)
             .stream()
+            .map(c -> (KubernetesNamedAccountCredentials<KubernetesV2Credentials>) c)
             .filter(account -> newAndChangedAccounts.contains(account.getName()))
             .collect(Collectors.toSet());
 
@@ -106,7 +107,7 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
         .forEach(
             managedAccount -> {
               KubernetesNamedAccountCredentials credentials =
-                  new KubernetesNamedAccountCredentials(
+                  new KubernetesNamedAccountCredentials<>(
                       managedAccount, kubernetesSpinnakerKindMap, credentialFactory);
 
               AccountCredentials existingCredentials =
@@ -149,10 +150,11 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
         .collect(Collectors.toList());
   }
 
-  private void synchronizeKubernetesV2Provider(Set<KubernetesNamedAccountCredentials> allAccounts) {
+  private void synchronizeKubernetesV2Provider(
+      Set<KubernetesNamedAccountCredentials<KubernetesV2Credentials>> allAccounts) {
 
     try {
-      for (KubernetesNamedAccountCredentials credentials : allAccounts) {
+      for (KubernetesNamedAccountCredentials<KubernetesV2Credentials> credentials : allAccounts) {
         List<Agent> newlyAddedAgents =
             kubernetesV2CachingAgentDispatcher.buildAllCachingAgents(credentials).stream()
                 .map(c -> (Agent) c)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgentDispatcher.java
@@ -39,7 +39,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class KubernetesV2CachingAgentDispatcher implements KubernetesCachingAgentDispatcher {
+public class KubernetesV2CachingAgentDispatcher
+    implements KubernetesCachingAgentDispatcher<KubernetesV2Credentials> {
   private final ObjectMapper objectMapper;
   private final Registry registry;
 
@@ -50,10 +51,10 @@ public class KubernetesV2CachingAgentDispatcher implements KubernetesCachingAgen
   }
 
   @Override
-  public Collection<KubernetesCachingAgent> buildAllCachingAgents(
-      KubernetesNamedAccountCredentials credentials) {
-    KubernetesV2Credentials v2Credentials = (KubernetesV2Credentials) credentials.getCredentials();
-    List<KubernetesCachingAgent> result = new ArrayList<>();
+  public Collection<KubernetesCachingAgent<KubernetesV2Credentials>> buildAllCachingAgents(
+      KubernetesNamedAccountCredentials<KubernetesV2Credentials> credentials) {
+    KubernetesV2Credentials v2Credentials = credentials.getCredentials();
+    List<KubernetesCachingAgent<KubernetesV2Credentials>> result = new ArrayList<>();
     Long agentInterval =
         Optional.ofNullable(credentials.getCacheIntervalSeconds())
             .map(TimeUnit.SECONDS::toMillis)
@@ -77,7 +78,7 @@ public class KubernetesV2CachingAgentDispatcher implements KubernetesCachingAgen
                                 credentials.getCacheThreads(),
                                 agentInterval))
                     .filter(Objects::nonNull)
-                    .forEach(c -> result.add((KubernetesCachingAgent) c)));
+                    .forEach(result::add));
 
     IntStream.range(0, credentials.getCacheThreads())
         .forEach(

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/config/KubernetesConfiguration.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/config/KubernetesConfiguration.java
@@ -19,17 +19,18 @@ import com.netflix.spinnaker.cats.module.CatsModule;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.health.KubernetesHealthIndicator;
-import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.KubernetesUtil;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.provider.KubernetesV1Provider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.provider.KubernetesV1ProviderSynchronizable;
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.provider.agent.KubernetesV1CachingAgentDispatcher;
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.KubernetesV2Provider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.KubernetesV2ProviderSynchronizable;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentDispatcher;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.GlobalKubernetesKindRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import java.util.Collections;
@@ -88,7 +89,7 @@ public class KubernetesConfiguration {
       AccountCredentialsRepository accountCredentialsRepository,
       KubernetesV2CachingAgentDispatcher kubernetesV2CachingAgentDispatcher,
       KubernetesConfigurationProperties kubernetesConfigurationProperties,
-      KubernetesNamedAccountCredentials.CredentialFactory credentialFactory,
+      KubernetesV2Credentials.Factory credentialFactory,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
       CatsModule catsModule) {
     return new KubernetesV2ProviderSynchronizable(
@@ -107,7 +108,7 @@ public class KubernetesConfiguration {
       AccountCredentialsRepository accountCredentialsRepository,
       KubernetesV1CachingAgentDispatcher kubernetesV1CachingAgentDispatcher,
       KubernetesConfigurationProperties kubernetesConfigurationProperties,
-      KubernetesNamedAccountCredentials.CredentialFactory credentialFactory,
+      KubernetesV1Credentials.Factory credentialFactory,
       KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap,
       CatsModule catsModule) {
     return new KubernetesV1ProviderSynchronizable(

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpi
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion
@@ -34,18 +35,14 @@ import spock.lang.Specification
 import java.nio.file.Files
 
 class KubernetesNamedAccountCredentialsSpec extends Specification {
-
   KubernetesSpinnakerKindMap kindMap = new KubernetesSpinnakerKindMap([])
-  AccountCredentialsRepository accountCredentialsRepository = Mock(AccountCredentialsRepository)
   NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = new ConfigFileService()
   AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
-  KubernetesNamedAccountCredentials.CredentialFactory credentialFactory = new KubernetesNamedAccountCredentials.CredentialFactory(
-    "userAgent",
+  KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),
     namerRegistry,
-    accountCredentialsRepository,
     Mock(KubectlJobExecutor),
     configFileService,
     resourcePropertyRegistryFactory,

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestN
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
-import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import com.netflix.spinnaker.fiat.model.Authorization
 import com.netflix.spinnaker.kork.configserver.ConfigFileService
@@ -35,18 +34,20 @@ import spock.lang.Specification
 import java.nio.file.Files
 
 class KubernetesNamedAccountCredentialsSpec extends Specification {
-  KubernetesSpinnakerKindMap kindMap = new KubernetesSpinnakerKindMap([])
+  KubernetesSpinnakerKindMap kindMap = new KubernetesSpinnakerKindMap(Collections.emptyList())
   NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = new ConfigFileService()
   AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
+  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(Collections.emptyList())
   KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),
     namerRegistry,
     Mock(KubectlJobExecutor),
     configFileService,
     resourcePropertyRegistryFactory,
-    kindRegistryFactory
+    kindRegistryFactory,
+    kubernetesSpinnakerKindMap
   )
 
 
@@ -74,8 +75,8 @@ class KubernetesNamedAccountCredentialsSpec extends Specification {
 
 
     when:
-      def account1 = new KubernetesNamedAccountCredentials(account1Def, kindMap, credentialFactory)
-      def account2 = new KubernetesNamedAccountCredentials(account2Def, kindMap, credentialFactory)
+      def account1 = new KubernetesNamedAccountCredentials(account1Def, credentialFactory)
+      def account2 = new KubernetesNamedAccountCredentials(account2Def, credentialFactory)
 
     then:
       account1.equals(account2)

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationSpec.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.loadba
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.loadbalancer.KubernetesNamedServicePort
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.ObjectMeta
 import io.fabric8.kubernetes.api.model.Service
@@ -68,7 +69,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationSpec extends Specification {
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
     accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
-    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock)
+    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
     namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getCredentials() >> credentials
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/securitygroup/UpsertKubernetesV1SecurityGroupAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/securitygroup/UpsertKubernetesV1SecurityGroupAtomicOperationSpec.groovy
@@ -60,7 +60,7 @@ class UpsertKubernetesV1SecurityGroupAtomicOperationSpec extends Specification {
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
     accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
-    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock)
+    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
     namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getCredentials() >> credentials
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/securitygroup/UpsertKubernetesV1SecurityGroupAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/securitygroup/UpsertKubernetesV1SecurityGroupAtomicOperationSpec.groovy
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.securitygroup.KubernetesIngressTlS
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.securitygroup.KubernetesSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.extensions.Ingress
 import io.fabric8.kubernetes.api.model.extensions.IngressTLS
@@ -60,7 +61,7 @@ class UpsertKubernetesV1SecurityGroupAtomicOperationSpec extends Specification {
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
     accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
-    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
     namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getCredentials() >> credentials
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/CloneKubernetesAtomicOperationSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.server
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.servergroup.KubernetesResourceDescription
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.*
 import spock.lang.Specification
@@ -112,7 +113,7 @@ class CloneKubernetesAtomicOperationSpec extends Specification {
     accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
-    credentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock)
+    credentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
     namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getCredentials() >> credentials
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DeployKubernetesAtomicOperationSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.server
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.exception.KubernetesResourceNotFoundException
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.*
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet
@@ -132,7 +133,7 @@ class DeployKubernetesAtomicOperationSpec extends Specification {
 
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
-    credentials = new KubernetesV1Credentials(apiMock, [NAMESPACE], [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock,)
+    credentials = new KubernetesV1Credentials(apiMock, [NAMESPACE], [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
     namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getCredentials() >> credentials
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
@@ -59,7 +60,7 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       })
     })
 
-    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
     def namedAccountCredentials =Mock(KubernetesNamedAccountCredentials) {
       getName() >> ACCOUNT_NAME
       getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/StandardKubernetesAttributeValidatorSpec.groovy
@@ -59,7 +59,7 @@ class StandardKubernetesAttributeValidatorSpec extends Specification {
       })
     })
 
-    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock)
+    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
     def namedAccountCredentials =Mock(KubernetesNamedAccountCredentials) {
       getName() >> ACCOUNT_NAME
       getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
@@ -68,7 +68,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     spectatorRegistry = new DefaultRegistry()
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
-    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock)
+    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
     namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getName() >> VALID_ACCOUNT
       getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/loadbalancer/UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.loadba
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
@@ -68,7 +69,7 @@ class UpsertKubernetesLoadBalancerAtomicOperationValidatorSpec extends Specifica
     spectatorRegistry = new DefaultRegistry()
     dockerRegistry = Mock(LinkedDockerRegistryConfiguration)
     dockerRegistries = [dockerRegistry]
-    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], [], accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
     namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getName() >> VALID_ACCOUNT
       getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
@@ -91,7 +91,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
       })
     })
 
-    def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock)
+    def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
     def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getName() >> VALID_ACCOUNT
       getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/CloneKubernetesAtomicOperationValidatorSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.server
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
@@ -91,7 +92,7 @@ class CloneKubernetesAtomicOperationValidatorSpec extends Specification {
       })
     })
 
-    def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
     def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getName() >> VALID_ACCOUNT
       getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description.server
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.validators.StandardKubernetesAttributeValidator
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
@@ -97,7 +98,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
       })
     })
 
-    def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
     def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getName() >> VALID_ACCOUNT
       getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/validators/servergroup/DeployKubernetesAtomicOperationValidatorSpec.groovy
@@ -97,7 +97,7 @@ class DeployKubernetesAtomicOperationValidatorSpec extends Specification {
       })
     })
 
-    def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock)
+    def credentials = new KubernetesV1Credentials(apiMock, NAMESPACES, [], DOCKER_REGISTRY_ACCOUNTS, accountCredentialsRepositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
     def namedAccountCredentials = Mock(KubernetesNamedAccountCredentials) {
       getName() >> VALID_ACCOUNT
       getCredentials() >> credentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizableSpec.groovy
@@ -47,7 +47,8 @@ class KubernetesV1ProviderSynchronizableSpec extends Specification {
     "userAgent",
     new NoopRegistry(),
     accountCredentialsRepository,
-    configFileService
+    configFileService,
+    new KubernetesSpinnakerKindMap(Collections.emptyList())
   )
 
   def synchronizeAccounts(KubernetesConfigurationProperties configurationProperties) {
@@ -57,7 +58,7 @@ class KubernetesV1ProviderSynchronizableSpec extends Specification {
       agentDispatcher,
       configurationProperties,
       credentialFactory,
-      new KubernetesSpinnakerKindMap([]),
+      new KubernetesSpinnakerKindMap(Collections.emptyList()),
       catsModule
     )
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizableSpec.groovy
@@ -41,18 +41,13 @@ class KubernetesV1ProviderSynchronizableSpec extends Specification {
   KubernetesV1Provider v1Provider = Mock(KubernetesV1Provider)
   AccountCredentialsRepository accountCredentialsRepository = Mock(AccountCredentialsRepository)
   KubernetesV1CachingAgentDispatcher agentDispatcher = Mock(KubernetesV1CachingAgentDispatcher)
-  NamerRegistry namerRegistry = Mock(NamerRegistry)
   ConfigFileService configFileService = new ConfigFileService()
 
-  KubernetesNamedAccountCredentials.CredentialFactory credentialFactory = new KubernetesNamedAccountCredentials.CredentialFactory(
+  KubernetesV1Credentials.Factory credentialFactory = new KubernetesV1Credentials.Factory(
     "userAgent",
     new NoopRegistry(),
-    namerRegistry,
     accountCredentialsRepository,
-    Mock(KubectlJobExecutor),
-    configFileService,
-    null,
-    null
+    configFileService
   )
 
   def synchronizeAccounts(KubernetesConfigurationProperties configurationProperties) {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgentSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -48,7 +49,7 @@ class KubernetesLoadBalancerCachingAgentSpec extends Specification {
 
     def accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
 
-    kubernetesCredentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock)
+    kubernetesCredentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
 
     def namedCrededentialsMock = Mock(KubernetesNamedAccountCredentials)
     namedCrededentialsMock.getCredentials() >> kubernetesCredentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.KubernetesUtil
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.caching.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import io.fabric8.kubernetes.api.model.ObjectMeta
 import io.fabric8.kubernetes.api.model.PodList
@@ -67,7 +68,7 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
 
     def accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
 
-    kubernetesCredentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock)
+    kubernetesCredentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
 
     def namedCrededentialsMock = Mock(KubernetesNamedAccountCredentials)
     namedCrededentialsMock.getCredentials() >> kubernetesCredentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesV1SecurityGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesV1SecurityGroupCachingAgentSpec.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -48,7 +49,7 @@ class KubernetesV1SecurityGroupCachingAgentSpec extends Specification {
 
     def accountCredentialsRepositoryMock = Mock(AccountCredentialsRepository)
 
-    kubernetesCredentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock)
+    kubernetesCredentials = new KubernetesV1Credentials(apiMock, [], [], [], accountCredentialsRepositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
 
     def namedCrededentialsMock = Mock(KubernetesNamedAccountCredentials)
     namedCrededentialsMock.getCredentials() >> kubernetesCredentials

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1CredentialsSpec.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v1.security
 import com.netflix.spinnaker.clouddriver.docker.registry.security.DockerRegistryNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.api.KubernetesApiAdaptor
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import spock.lang.Specification
 
@@ -61,7 +62,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def result = new KubernetesV1Credentials(adaptorMock, NAMESPACES1, [], REGISTRIES1, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    def result = new KubernetesV1Credentials(adaptorMock, NAMESPACES1, [], REGISTRIES1, repositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
 
     then:
     result.getDeclaredNamespaces() == NAMESPACES1
@@ -78,7 +79,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def result = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES2, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    def result = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES2, repositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
 
     then:
     result.getDeclaredNamespaces() == NAMESPACES2
@@ -95,7 +96,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def result = new KubernetesV1Credentials(adaptorMock, null, NAMESPACES2, REGISTRIES2, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    def result = new KubernetesV1Credentials(adaptorMock, null, NAMESPACES2, REGISTRIES2, repositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
 
     then:
     result.getDeclaredNamespaces() == []
@@ -112,7 +113,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def result = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES1, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
+    def result = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES1, repositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList()))
 
     then:
     result.getDeclaredNamespaces() == NAMESPACES2
@@ -130,7 +131,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def namespaces = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES1, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList())).getDeclaredNamespaces()
+    def namespaces = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES1, repositoryMock, new KubernetesSpinnakerKindMap(Collections.emptyList())).getDeclaredNamespaces()
 
     then:
     namespaces == []

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1CredentialsSpec.groovy
@@ -61,7 +61,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def result = new KubernetesV1Credentials(adaptorMock, NAMESPACES1, [], REGISTRIES1, repositoryMock)
+    def result = new KubernetesV1Credentials(adaptorMock, NAMESPACES1, [], REGISTRIES1, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
 
     then:
     result.getDeclaredNamespaces() == NAMESPACES1
@@ -78,7 +78,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def result = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES2, repositoryMock)
+    def result = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES2, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
 
     then:
     result.getDeclaredNamespaces() == NAMESPACES2
@@ -95,7 +95,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def result = new KubernetesV1Credentials(adaptorMock, null, NAMESPACES2, REGISTRIES2, repositoryMock)
+    def result = new KubernetesV1Credentials(adaptorMock, null, NAMESPACES2, REGISTRIES2, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
 
     then:
     result.getDeclaredNamespaces() == []
@@ -112,7 +112,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def result = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES1, repositoryMock)
+    def result = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES1, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList()))
 
     then:
     result.getDeclaredNamespaces() == NAMESPACES2
@@ -130,7 +130,7 @@ class KubernetesV1CredentialsSpec extends Specification {
     repositoryMock.getOne(ACCOUNT1) >> registryAccountMock
 
     when:
-    def namespaces = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES1, repositoryMock).getDeclaredNamespaces()
+    def namespaces = new KubernetesV1Credentials(adaptorMock, null, [], REGISTRIES1, repositoryMock, new com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap(java.util.Collections.emptyList())).getDeclaredNamespaces()
 
     then:
     namespaces == []

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import com.netflix.spinnaker.kork.configserver.ConfigFileService
+import groovy.transform.CompileStatic
 import spock.lang.Specification
 
 class KubernetesV2ProviderSynchronizableSpec extends Specification {
@@ -45,11 +46,9 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
   AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
 
-  KubernetesNamedAccountCredentials.CredentialFactory credentialFactory = new KubernetesNamedAccountCredentials.CredentialFactory(
-    "userAgent",
+  KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),
     namerRegistry,
-    accountCredentialsRepository,
     Mock(KubectlJobExecutor),
     configFileService,
     resourcePropertyRegistryFactory,

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
@@ -39,12 +39,13 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
 
   CatsModule catsModule = Mock(CatsModule)
   AccountCredentialsRepository accountCredentialsRepository = Mock(AccountCredentialsRepository)
-  NamerRegistry namerRegistry = Mock(NamerRegistry)
+  NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = Mock(ConfigFileService)
   KubernetesV2Provider kubernetesV2Provider = new KubernetesV2Provider()
   KubernetesV2CachingAgentDispatcher agentDispatcher = Mock(KubernetesV2CachingAgentDispatcher)
   AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
+  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(Collections.emptyList())
 
   KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),
@@ -52,7 +53,8 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
     Mock(KubectlJobExecutor),
     configFileService,
     resourcePropertyRegistryFactory,
-    kindRegistryFactory
+    kindRegistryFactory,
+    kubernetesSpinnakerKindMap
   )
 
   def synchronizeAccounts(KubernetesConfigurationProperties configurationProperties) {
@@ -62,7 +64,7 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
       agentDispatcher,
       configurationProperties,
       credentialFactory,
-      new KubernetesSpinnakerKindMap([]),
+      new KubernetesSpinnakerKindMap(Collections.emptyList()),
       catsModule
     )
 
@@ -100,7 +102,6 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
     1 * accountCredentialsRepository.save("test-account", _ as KubernetesNamedAccountCredentials) >> { _, creds ->
       credentials = creds
     }
-    1 * namerRegistry.getNamingStrategy("kubernetesAnnotations") >> Mock(KubernetesManifestNamer)
 
     credentials.getName() == "test-account"
     credentials.getProviderVersion() == ProviderVersion.v2

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -16,16 +16,18 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.security
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.AccountResourcePropertyRegistry
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.ResourcePropertyRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.GlobalKubernetesKindRegistry
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry
+import com.netflix.spinnaker.kork.configserver.ConfigFileService
 import spock.lang.Specification
 
 class KubernetesV2CredentialsSpec extends Specification {
@@ -36,20 +38,27 @@ class KubernetesV2CredentialsSpec extends Specification {
   KubernetesKindRegistry.Factory kindRegistryFactory = new KubernetesKindRegistry.Factory(
     new GlobalKubernetesKindRegistry(KubernetesKindProperties.getGlobalKindProperties())
   )
+  NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
+  ConfigFileService configFileService = new ConfigFileService()
+
+  KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
+    new NoopRegistry(),
+    namerRegistry,
+    kubectlJobExecutor,
+    configFileService,
+    resourcePropertyRegistryFactory,
+    kindRegistryFactory
+  )
 
 
-  private buildCredentials(KubernetesConfigurationProperties.ManagedAccount managedAccount) {
-    return new KubernetesV2Credentials(registry, kubectlJobExecutor, managedAccount, resourcePropertyRegistryFactory, kindRegistryFactory.create(), null)
-  }
 
   void "Built-in Kubernetes kinds are considered valid by default"() {
     when:
-    KubernetesV2Credentials credentials = buildCredentials(
-      new KubernetesConfigurationProperties.ManagedAccount(
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
+        name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: false,
-      )
-    )
+      ))
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -58,13 +67,12 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Built-in Kubernetes kinds are considered valid by default when kinds is empty"() {
     when:
-    KubernetesV2Credentials credentials = buildCredentials(
-      new KubernetesConfigurationProperties.ManagedAccount(
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
+        name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: false,
         kinds: []
-      )
-    )
+      ))
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -73,13 +81,12 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Only explicitly listed kinds are valid when kinds is not empty"() {
     when:
-    KubernetesV2Credentials credentials = buildCredentials(
-      new KubernetesConfigurationProperties.ManagedAccount(
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
+        name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: false,
         kinds: ["deployment"]
-      )
-    )
+      ))
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
@@ -88,13 +95,12 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Explicitly omitted kinds are not valid"() {
     when:
-    KubernetesV2Credentials credentials = buildCredentials(
-      new KubernetesConfigurationProperties.ManagedAccount(
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
+        name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: false,
         omitKinds: ["deployment"]
-      )
-    )
+      ))
 
     then:
     credentials.isValidKind(KubernetesKind.DEPLOYMENT) == false
@@ -103,8 +109,9 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Kinds that are not readable are considered invalid"() {
     given:
-    KubernetesV2Credentials credentials = buildCredentials(
+    KubernetesV2Credentials credentials = credentialFactory.build(
       new KubernetesConfigurationProperties.ManagedAccount(
+        name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: true,
       )
@@ -123,13 +130,12 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Metrics are properly set on the account when not checking permissions"() {
     given:
-    KubernetesV2Credentials credentials = buildCredentials(
-      new KubernetesConfigurationProperties.ManagedAccount(
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
+        name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: false,
         metrics: metrics
-      )
-    )
+      ))
 
     expect:
     credentials.isMetricsEnabled() == metrics
@@ -140,13 +146,12 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Metrics are properly enabled when readable"() {
     given:
-    KubernetesV2Credentials credentials = buildCredentials(
-      new KubernetesConfigurationProperties.ManagedAccount(
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
+        name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: true,
         metrics: true
-      )
-    )
+      ))
     kubectlJobExecutor.topPod(_ as KubernetesV2Credentials, NAMESPACE, _) >> Collections.emptyList()
 
     expect:
@@ -155,13 +160,12 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Metrics are properly disabled when not readable"() {
     given:
-    KubernetesV2Credentials credentials = buildCredentials(
-      new KubernetesConfigurationProperties.ManagedAccount(
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
+        name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: true,
         metrics: true
-      )
-    )
+      ))
     kubectlJobExecutor.topPod(_ as KubernetesV2Credentials, NAMESPACE, _) >> {
       throw new KubectlJobExecutor.KubectlException("Error", new Exception())
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -20,6 +20,7 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.AccountResourcePropertyRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.GlobalKubernetesKindRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindProperties
@@ -40,6 +41,7 @@ class KubernetesV2CredentialsSpec extends Specification {
   )
   NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = new ConfigFileService()
+  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(Collections.emptyList())
 
   KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),
@@ -47,7 +49,8 @@ class KubernetesV2CredentialsSpec extends Specification {
     kubectlJobExecutor,
     configFileService,
     resourcePropertyRegistryFactory,
-    kindRegistryFactory
+    kindRegistryFactory,
+    kubernetesSpinnakerKindMap
   )
 
 
@@ -109,13 +112,11 @@ class KubernetesV2CredentialsSpec extends Specification {
 
   void "Kinds that are not readable are considered invalid"() {
     given:
-    KubernetesV2Credentials credentials = credentialFactory.build(
-      new KubernetesConfigurationProperties.ManagedAccount(
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
         name: "k8s",
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: true,
-      )
-    )
+      ))
     kubectlJobExecutor.list(_ as KubernetesV2Credentials, [KubernetesKind.DEPLOYMENT], NAMESPACE, _ as KubernetesSelectorList) >> {
       throw new KubectlJobExecutor.KubectlException("Error", new Exception())
     }


### PR DESCRIPTION
The motivation here is to fix a number of unsafe casts in the creation of credentials, and to clean up that code a bit.  I ran into this while working on my next performance change (in an upcoming PR) to fix a few endpoints that hang when a cluster is unreachable (now that startup is fixed in that case). 

* refactor(kubernetes): Split CredentialFactory to V1 and V2 

  A lot of the unecessary casts that we do when creating credentials stem from the fact that we have a single CredentialFactory with different methods for creating V1 and V2 credentials.

  Instead, make a generic interface KubernetesCredentialFactory that pulls out the common logic to default methods.  (These default methods should probably both eventually live somewhere else, but I think having them on the interface is a resonable solution for now.)

  Then give both the V1 and V2 credentials an inner factory class that implements that interface and allows us to create credentials in a type-safe way. It also logically makes more sense, as the factory for credentials lives with the credentials it's creating.

* refactor(kubernetes): Add some generic bounds to the account code 

  Add some parametrized types to eliminate a bunch of unsafe casts.

* refactor(kubernetes): Push getSpinnakerKindMap to V1/V2 

  The getSpinnakerKindMap function on the base KubernetesNamedAccountCredentials class is needed to support sending the kind map to the UI. It forks using an if block depending on which implementation we're using, which means we should push the logic down to the actual implementations.

  One solution would have been to keep the kind map at the top level and just implement an "add custom resources" in the V2 provider class (that is a no-op in V1). I didn't do that because:
  (1) It's strange that there's logic in this class anyway, which is just supposed to hold some metadata and delegate down to the actual credentials.
  (2) Ultimately, it probably makes sense for the V2 provider to implement its own account-specific KubernetesSpinnakerKindMap instead of building this map on the fly. Pushing this down to the V1/V2 implementations allows us to do this later.
