### PR TITLE
Escape label names when attaching/detaching a replicaset from a service

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/JsonPatch.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/JsonPatch.java
@@ -36,4 +36,17 @@ public class JsonPatch {
     add,
     remove
   }
+
+  /**
+   * Returns an escaped JSON path node for use in a JSON pointer as defined in RFC6901
+   *
+   * <p>~ is replaced by ~0 / is replaced by ~1
+   *
+   * @param node a node to be used as part of a JSON pointer
+   * @return the node with escaped characters
+   * @see <a href="https://tools.ietf.org/html/rfc6901#section-3">RFC6901, section 3</a>
+   */
+  public static String escapeNode(String node) {
+    return node.replace("~", "~0").replace("/", "~1");
+  }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandler.java
@@ -206,7 +206,7 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
             kv ->
                 JsonPatch.builder()
                     .op(labels.containsKey(kv.getKey()) ? Op.replace : Op.add)
-                    .path(String.join("/", pathPrefix, kv.getKey()))
+                    .path(String.join("/", pathPrefix, JsonPatch.escapeNode(kv.getKey())))
                     .value(kv.getValue())
                     .build())
         .collect(Collectors.toList());
@@ -219,7 +219,12 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
 
     return getSelector(loadBalancer).keySet().stream()
         .filter(labels::containsKey)
-        .map(k -> JsonPatch.builder().op(remove).path(String.join("/", pathPrefix, k)).build())
+        .map(
+            k ->
+                JsonPatch.builder()
+                    .op(remove)
+                    .path(String.join("/", pathPrefix, JsonPatch.escapeNode(k)))
+                    .build())
         .collect(Collectors.toList());
   }
 }

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandlerSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandlerSpec.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 Air France-KLM Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.JsonPatch.Op;
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+import spock.lang.Specification
+
+class KubernetesServiceHandlerSpec extends Specification {
+  def objectMapper = new ObjectMapper()
+  def yaml = new Yaml(new SafeConstructor())
+  def handler = new KubernetesServiceHandler()
+
+  def BASIC_SERVICE = """
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    load-balancer-test-app: 'true'
+"""
+
+  def SERVICE_WITH_SLASH = """
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    load-balancer/test-app: 'true'
+status:
+  loadBalancer: {}
+"""
+
+  def SERVICE_WITH_NAME_LABEL = """
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app.kubernetes.io/name: test-app
+status:
+  loadBalancer: {}
+"""
+
+  def BASIC_REPLICASET = """
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: app-replicaset
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: app-instance
+      app.kubernetes.io/name: test-app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: app-instance
+        app.kubernetes.io/name: test-app
+"""
+
+  KubernetesManifest stringToManifest(String input) {
+    return objectMapper.convertValue(yaml.load(input), KubernetesManifest)
+  }
+
+  void "check that loadbalancer label is added"() {
+    when:
+    def service = stringToManifest(BASIC_SERVICE)
+    def target = stringToManifest(BASIC_REPLICASET)
+
+    def result = handler.attachPatch(service, target)
+
+    then:
+    result[0].op == Op.add && result[0].path == "/spec/template/metadata/labels/load-balancer-test-app"
+  }
+
+  void "check that loadbalancer label with slash is escaped"() {
+    when:
+    def service = stringToManifest(SERVICE_WITH_SLASH)
+    def target = stringToManifest(BASIC_REPLICASET)
+
+    def result = handler.attachPatch(service, target)
+
+    then:
+    result[0].op == Op.add && result[0].path == "/spec/template/metadata/labels/load-balancer~1test-app"
+  }
+
+  void "check that loadbalancer label with slash is escaped when removing"() {
+    when:
+    def service = stringToManifest(SERVICE_WITH_NAME_LABEL)
+    def target = stringToManifest(BASIC_REPLICASET)
+
+    def result = handler.detachPatch(service, target)
+
+    then:
+    result[0].op == Op.remove && result[0].path == "/spec/template/metadata/labels/app.kubernetes.io~1name"
+  }
+
+}


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4893.

Implements escaping of '~' and '/' characters when used in labels as defined in RFC 6901.
https://tools.ietf.org/html/rfc6901#section-3

Allows for the use of labels such as "app.kubernetes.io/name" and "app.kubernetes.io/instance" in the service selector.