### PR TITLE
refactor(kubernetes): Look up CRD details on-demand

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -208,7 +208,7 @@ public class KubernetesCacheDataConverter {
               + ":"
               + manifest.getFullResourceName());
     } else {
-      if (kindRegistry.getRegisteredKind(kind).hasClusterRelationship()) {
+      if (kindRegistry.getKindProperties(kind).hasClusterRelationship()) {
         addLogicalRelationships(kubernetesCacheData, key, account, moniker);
       }
     }
@@ -324,7 +324,7 @@ public class KubernetesCacheDataConverter {
     }
 
     if (StringUtils.isEmpty(manifest.getNamespace())
-        && kindRegistry.getRegisteredKind(manifest.getKind()).isNamespaced()) {
+        && kindRegistry.getKindProperties(manifest.getKind()).isNamespaced()) {
       log.warn("{}: manifest namespace may not be null, {}", contextMessage.get(), manifest);
     }
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -54,7 +54,7 @@ public class KubernetesUnregisteredCustomResourceCachingAgent
 
   @Override
   protected List<KubernetesKind> primaryKinds() {
-    return credentials.getCrds().stream()
+    return credentials.getCrds().keySet().stream()
         .filter(credentials::isValidKind)
         .collect(Collectors.toList());
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -302,7 +302,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     }
 
     if (StringUtils.isNotEmpty(namespace)
-        && !credentials.getKindRegistry().getRegisteredKind(kind).isNamespaced()) {
+        && !credentials.getKindRegistry().getKindProperties(kind).isNamespaced()) {
       log.warn(
           "{}: Kind {} is not namespace but namespace {} was provided, ignoring",
           getAgentType(),

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -72,7 +72,7 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
     }
 
     KubernetesKind kind = parsedName.getLeft();
-    if (!getKindRegistry(account).getRegisteredKind(kind).isNamespaced()
+    if (!getKindRegistry(account).getKindProperties(kind).isNamespaced()
         && StringUtils.isNotEmpty(location)) {
       log.warn(
           "Kind {} is not namespaced, but namespace {} was provided (ignoring)", kind, location);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
@@ -24,8 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesUnversionedArtifactConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesVersionedArtifactConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindProperties;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.CustomKubernetesHandlerFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import lombok.Getter;
@@ -48,7 +46,7 @@ public class KubernetesResourceProperties {
   }
 
   public static KubernetesResourceProperties fromCustomResource(
-      CustomKubernetesResource customResource, KubernetesKindRegistry kindRegistry) {
+      CustomKubernetesResource customResource) {
     String deployPriority = customResource.getDeployPriority();
     int deployPriorityValue;
     if (StringUtils.isEmpty(deployPriority)) {
@@ -62,20 +60,9 @@ public class KubernetesResourceProperties {
       }
     }
 
-    KubernetesKind kubernetesKind = KubernetesKind.fromString(customResource.getKubernetesKind());
-    kindRegistry.getOrRegisterKind(
-        kubernetesKind,
-        () -> {
-          log.info(
-              "Dynamically registering {}, (namespaced: {})",
-              kubernetesKind.toString(),
-              customResource.isNamespaced());
-          return KubernetesKindProperties.create(kubernetesKind, customResource.isNamespaced());
-        });
-
     KubernetesHandler handler =
         CustomKubernetesHandlerFactory.create(
-            kubernetesKind,
+            KubernetesKind.fromString(customResource.getKubernetesKind()),
             SpinnakerKind.fromString(customResource.getSpinnakerKind()),
             customResource.isVersioned(),
             deployPriorityValue);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/GlobalKubernetesKindRegistry.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/GlobalKubernetesKindRegistry.java
@@ -48,7 +48,7 @@ public class GlobalKubernetesKindRegistry {
    * that were registered for the kind; otherwise, returns an empty {@link Optional}.
    */
   @Nonnull
-  public Optional<KubernetesKindProperties> getRegisteredKind(@Nonnull KubernetesKind kind) {
+  public Optional<KubernetesKindProperties> getKindProperties(@Nonnull KubernetesKind kind) {
     return Optional.ofNullable(nameMap.get(kind));
   }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -19,15 +19,18 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.kubernetes.client.models.V1beta1CustomResourceDefinition;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ParametersAreNonnullByDefault
 public class KubernetesKind {
   private static final Map<KubernetesKind, KubernetesKind> aliasMap = new ConcurrentHashMap<>();
 
@@ -103,7 +106,7 @@ public class KubernetesKind {
   @Getter @Nonnull private final KubernetesApiGroup apiGroup;
   @EqualsAndHashCode.Include @Nullable private final KubernetesApiGroup customApiGroup;
 
-  private KubernetesKind(@Nonnull String name, @Nullable KubernetesApiGroup apiGroup) {
+  private KubernetesKind(String name, @Nullable KubernetesApiGroup apiGroup) {
     this.name = name;
     this.lcName = name.toLowerCase();
     this.apiGroup = apiGroup == null ? KubernetesApiGroup.NONE : apiGroup;
@@ -115,7 +118,7 @@ public class KubernetesKind {
   }
 
   private static KubernetesKind createWithAlias(
-      @Nonnull String name, @Nullable String alias, @Nullable KubernetesApiGroup apiGroup) {
+      String name, @Nullable String alias, @Nullable KubernetesApiGroup apiGroup) {
     KubernetesKind kind = new KubernetesKind(name, apiGroup);
     aliasMap.put(kind, kind);
     if (alias != null) {
@@ -124,6 +127,7 @@ public class KubernetesKind {
     return kind;
   }
 
+  @Nonnull
   public static KubernetesKind from(@Nullable String name, @Nullable KubernetesApiGroup apiGroup) {
     if (name == null || name.isEmpty()) {
       return KubernetesKind.NONE;
@@ -133,8 +137,15 @@ public class KubernetesKind {
   }
 
   @Nonnull
+  public static KubernetesKind fromCustomResourceDefinition(V1beta1CustomResourceDefinition crd) {
+    return from(
+        crd.getSpec().getNames().getKind(),
+        KubernetesApiGroup.fromString(crd.getSpec().getGroup()));
+  }
+
+  @Nonnull
   @JsonCreator
-  public static KubernetesKind fromString(@Nonnull String qualifiedKind) {
+  public static KubernetesKind fromString(String qualifiedKind) {
     KubernetesApiGroup apiGroup;
     String kindName;
     String[] parts = StringUtils.split(qualifiedKind, ".", 2);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindProperties.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindProperties.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import com.google.common.collect.ImmutableList;
+import io.kubernetes.client.models.V1beta1CustomResourceDefinition;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -76,6 +77,7 @@ public class KubernetesKindProperties {
     this.hasClusterRelationship = hasClusterRelationship;
   }
 
+  @Nonnull
   public static KubernetesKindProperties withDefaultProperties(KubernetesKind kubernetesKind) {
     return new KubernetesKindProperties(kubernetesKind, true, false);
   }
@@ -84,6 +86,14 @@ public class KubernetesKindProperties {
   public static KubernetesKindProperties create(
       KubernetesKind kubernetesKind, boolean isNamespaced) {
     return new KubernetesKindProperties(kubernetesKind, isNamespaced, false);
+  }
+
+  @Nonnull
+  public static KubernetesKindProperties fromCustomResourceDefinition(
+      V1beta1CustomResourceDefinition crd) {
+    return create(
+        KubernetesKind.fromCustomResourceDefinition(crd),
+        crd.getSpec().getScope().equalsIgnoreCase("namespaced"));
   }
 
   public boolean hasClusterRelationship() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -110,7 +110,7 @@ public class KubernetesKindRegistry {
     @Nonnull
     public KubernetesKindRegistry create() {
       return new KubernetesKindRegistry(
-          globalKindRegistry, k -> Optional.empty(), Collections.emptyList());
+          globalKindRegistry, k -> Optional.empty(), ImmutableList.of());
     }
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
@@ -69,8 +69,8 @@ public class KubernetesKindRegistry {
    * KubernetesKindProperties} with default properties.
    */
   @Nonnull
-  public KubernetesKindProperties getRegisteredKind(KubernetesKind kind) {
-    Optional<KubernetesKindProperties> globalResult = globalKindRegistry.getRegisteredKind(kind);
+  public KubernetesKindProperties getKindProperties(KubernetesKind kind) {
+    Optional<KubernetesKindProperties> globalResult = globalKindRegistry.getKindProperties(kind);
     if (globalResult.isPresent()) {
       return globalResult.get();
     }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
@@ -61,7 +61,7 @@ public class KubernetesKindRegistry {
   }
 
   /**
-   * Searches the the registry for a {@link KubernetesKindProperties} with the supplied {@link
+   * Searches the registry for a {@link KubernetesKindProperties} with the supplied {@link
    * KubernetesKind}. If the kind has been registered, returns the {@link KubernetesKindProperties}
    * that were registered for the kind. If the kind is not registered, tries to look up the
    * properties using the registry's CRD lookup function. If the lookup returns properties,

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindRegistry.java
@@ -48,8 +48,7 @@ public class KubernetesKindRegistry {
   }
 
   /** Registers a given {@link KubernetesKindProperties} into the registry */
-  // TODO(ezimanyi): Remove the one usage outside this class and make the method private
-  public KubernetesKindProperties registerKind(KubernetesKindProperties kindProperties) {
+  private KubernetesKindProperties registerKind(KubernetesKindProperties kindProperties) {
     return kindMap.computeIfAbsent(
         kindProperties.getKubernetesKind(),
         k -> {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -100,7 +100,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     validateManifestsForRolloutStrategies(inputManifests);
 
     for (KubernetesManifest manifest : inputManifests) {
-      if (credentials.getKindRegistry().getRegisteredKind(manifest.getKind()).isNamespaced()) {
+      if (credentials.getKindRegistry().getKindProperties(manifest.getKind()).isNamespaced()) {
         if (!StringUtils.isEmpty(description.getNamespaceOverride())) {
           manifest.setNamespace(description.getNamespaceOverride());
         } else if (StringUtils.isEmpty(manifest.getNamespace())) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -145,6 +145,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.jobExecutor = jobExecutor;
     this.kindRegistry =
         kindRegistryFactory.create(
+            // TODO(ezimanyi): Replace this no-op with an actual CRD lookup
+            k -> Optional.empty(),
             managedAccount.getCustomResources().stream()
                 .map(
                     cr ->
@@ -226,15 +228,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
                                   manifest, V1beta1CustomResourceDefinition.class);
                           KubernetesKindProperties kindProperties =
                               KubernetesKindProperties.fromCustomResourceDefinition(crd);
-                          return kindRegistry.getOrRegisterKind(
-                              kindProperties.getKubernetesKind(),
-                              () -> {
-                                log.info(
-                                    "Dynamically registering {}, (namespaced: {})",
-                                    kindProperties.getKubernetesKind().toString(),
-                                    kindProperties.isNamespaced());
-                                return kindProperties;
-                              });
+                          return kindRegistry.registerKind(kindProperties);
                         })
                     .map(KubernetesKindProperties::getKubernetesKind)
                     .collect(Collectors.toList());

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -653,7 +653,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
       }
       log.info("Checking if {} is readable in account '{}'...", kind, accountName);
       try {
-        if (kindRegistry.getRegisteredKind(kind).isNamespaced()) {
+        if (kindRegistry.getKindProperties(kind).isNamespaced()) {
           list(kind, checkNamespace.get());
         } else {
           list(kind, null);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -299,10 +299,15 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     try {
       KubernetesManifest result =
           get(KubernetesKind.CUSTOM_RESOURCE_DEFINITION, null, kubernetesKind.toString());
+      if (result == null) {
+        return Optional.empty();
+      }
       V1beta1CustomResourceDefinition rd =
           KubernetesCacheDataConverter.getResource(result, V1beta1CustomResourceDefinition.class);
       return Optional.of(KubernetesKindProperties.fromCustomResourceDefinition(rd));
     } catch (KubectlException e) {
+      log.info(
+          "Failure looking up CRD {} for account {}", kubernetesKind.toString(), accountName, e);
       return Optional.empty();
     }
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -150,16 +150,6 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     this.kinds =
         managedAccount.getKinds().stream()
             .map(KubernetesKind::fromString)
-            .map(
-                k ->
-                    kindRegistry.getOrRegisterKind(
-                        k,
-                        () -> {
-                          log.info(
-                              "Dynamically registering {}, (namespaced: {})", k.toString(), true);
-                          return KubernetesKindProperties.create(k, true);
-                        }))
-            .map(KubernetesKindProperties::getKubernetesKind)
             .collect(toImmutableSet());
     // omitKinds is a simple placeholder that we can use to compare one instance to another
     // when refreshing credentials.

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalKubernetesKindRegistrySpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalKubernetesKindRegistrySpec.groovy
@@ -60,7 +60,7 @@ class GlobalKubernetesKindRegistrySpec extends Specification {
     ])
 
     when:
-    def properties = kindRegistry.getRegisteredKind(KubernetesKind.from("customKind", CUSTOM_API_GROUP))
+    def properties = kindRegistry.getKindProperties(KubernetesKind.from("customKind", CUSTOM_API_GROUP))
 
     then:
     properties.get() == CUSTOM_KIND
@@ -74,7 +74,7 @@ class GlobalKubernetesKindRegistrySpec extends Specification {
     ])
 
     when:
-    def properties = kindRegistry.getRegisteredKind(KubernetesKind.from("otherKind", CUSTOM_API_GROUP))
+    def properties = kindRegistry.getKindProperties(KubernetesKind.from("otherKind", CUSTOM_API_GROUP))
 
     then:
     !properties.isPresent()

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesAccountResolverSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesAccountResolverSpec.groovy
@@ -128,7 +128,7 @@ class KubernetesAccountResolverSpec extends Specification {
         getKindRegistry() >> v2KindRegistry
       }
     }
-    0 * kindRegistryFactory.create()
+    0 * kindRegistryFactory.create(*_)
     registry == v2KindRegistry
 
     when:
@@ -138,7 +138,7 @@ class KubernetesAccountResolverSpec extends Specification {
     1 * credentialsRepository.getOne(ACCOUNT_NAME) >> Mock(KubernetesNamedAccountCredentials) {
       getCredentials() >> Mock(KubernetesCredentials)
     }
-    1 * kindRegistryFactory.create() >> v2KindRegistry
+    1 * kindRegistryFactory.create(*_) >> v2KindRegistry
     registry == v2KindRegistry
 
     when:
@@ -148,7 +148,7 @@ class KubernetesAccountResolverSpec extends Specification {
     1 * credentialsRepository.getOne(ACCOUNT_NAME) >> Mock(AccountCredentials) {
       getCredentials() >> Mock(KubernetesCredentials)
     }
-    1 * kindRegistryFactory.create() >> v2KindRegistry
+    1 * kindRegistryFactory.create(*_) >> v2KindRegistry
     registry == v2KindRegistry
 
 
@@ -157,7 +157,7 @@ class KubernetesAccountResolverSpec extends Specification {
 
     then:
     1 * credentialsRepository.getOne(ACCOUNT_NAME) >> null
-    1 * kindRegistryFactory.create() >> v2KindRegistry
+    1 * kindRegistryFactory.create(*_) >> v2KindRegistry
     registry == v2KindRegistry
   }
 }

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKindRegistrySpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKindRegistrySpec.groovy
@@ -91,7 +91,7 @@ class KubernetesKindRegistrySpec extends Specification {
     given:
     Function<KubernetesKind, KubernetesKindProperties> supplier = Mock(Function)
     KubernetesKindProperties customProperties = KubernetesKindProperties.create(CUSTOM_KIND, false)
-    @Subject KubernetesKindRegistry kindRegistry = factory.create(supplier, Collections.emptyList())
+    @Subject KubernetesKindRegistry kindRegistry = factory.create(supplier, ImmutableList.of())
     KubernetesKindProperties result
 
     when:

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKindRegistrySpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKindRegistrySpec.groovy
@@ -31,8 +31,20 @@ class KubernetesKindRegistrySpec extends Specification {
   final GlobalKubernetesKindRegistry globalRegistry = Mock(GlobalKubernetesKindRegistry)
   final KubernetesKindRegistry.Factory factory = new KubernetesKindRegistry.Factory(globalRegistry)
 
-  @Unroll
-  void "getRegisteredKind returns kinds that have been registered, and falls back to the global registry otherwise"() {
+  void "getRegisteredKind returns kinds that have been registered"() {
+    given:
+    @Subject KubernetesKindRegistry kindRegistry = factory.create(ImmutableList.of(CUSTOM_KIND_PROPERTIES))
+    KubernetesKindProperties result
+
+    when:
+    result = kindRegistry.getRegisteredKind(CUSTOM_KIND)
+
+    then:
+    0 * kindRegistry.getRegisteredKind(CUSTOM_KIND)
+    result == CUSTOM_KIND_PROPERTIES
+  }
+
+  void "getRegisteredKind falls back to the global registry for kinds that are not registered"() {
     given:
     @Subject KubernetesKindRegistry kindRegistry = factory.create()
     KubernetesKindProperties result
@@ -44,24 +56,14 @@ class KubernetesKindRegistrySpec extends Specification {
     then:
     1 * globalRegistry.getRegisteredKind(CUSTOM_KIND) >> Optional.of(globalResult)
     result == globalResult
-
-    when:
-    kindRegistry.registerKind(CUSTOM_KIND_PROPERTIES)
-    result = kindRegistry.getRegisteredKind(CUSTOM_KIND)
-
-    then:
-    0 * kindRegistry.getRegisteredKind(CUSTOM_KIND)
-    result == CUSTOM_KIND_PROPERTIES
   }
 
-  @Unroll
   void "getGlobalKinds returns all global kinds that are registered"() {
     given:
-    @Subject KubernetesKindRegistry kindRegistry = factory.create()
+    @Subject KubernetesKindRegistry kindRegistry = factory.create(ImmutableList.of(CUSTOM_KIND_PROPERTIES))
     Collection<KubernetesKindProperties> kinds
 
     when:
-    kindRegistry.registerKind(CUSTOM_KIND_PROPERTIES)
     kinds = kindRegistry.getGlobalKinds()
 
     then:

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKindRegistrySpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesKindRegistrySpec.groovy
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.*
 import spock.lang.Specification
 import spock.lang.Subject
-import spock.lang.Unroll
 
 import java.util.function.Function
 
@@ -40,10 +39,10 @@ class KubernetesKindRegistrySpec extends Specification {
     KubernetesKindProperties result
 
     when:
-    result = kindRegistry.getRegisteredKind(CUSTOM_KIND)
+    result = kindRegistry.getKindProperties(CUSTOM_KIND)
 
     then:
-    _ * globalRegistry.getRegisteredKind(_ as KubernetesKind) >> Optional.empty()
+    _ * globalRegistry.getKindProperties(_ as KubernetesKind) >> Optional.empty()
     result == CUSTOM_KIND_PROPERTIES
   }
 
@@ -54,10 +53,10 @@ class KubernetesKindRegistrySpec extends Specification {
     KubernetesKindProperties globalResult = KubernetesKindProperties.create(CUSTOM_KIND, false)
 
     when:
-    result = kindRegistry.getRegisteredKind(CUSTOM_KIND)
+    result = kindRegistry.getKindProperties(CUSTOM_KIND)
 
     then:
-    _ * globalRegistry.getRegisteredKind(CUSTOM_KIND) >> Optional.of(globalResult)
+    _ * globalRegistry.getKindProperties(CUSTOM_KIND) >> Optional.of(globalResult)
     result == globalResult
   }
 
@@ -81,10 +80,10 @@ class KubernetesKindRegistrySpec extends Specification {
     KubernetesKindProperties result
 
     when:
-    result = kindRegistry.getRegisteredKind(CUSTOM_KIND)
+    result = kindRegistry.getKindProperties(CUSTOM_KIND)
 
     then:
-    _ * globalRegistry.getRegisteredKind(CUSTOM_KIND) >> Optional.empty()
+    _ * globalRegistry.getKindProperties(CUSTOM_KIND) >> Optional.empty()
     result == KubernetesKindProperties.withDefaultProperties(CUSTOM_KIND)
   }
 
@@ -96,26 +95,26 @@ class KubernetesKindRegistrySpec extends Specification {
     KubernetesKindProperties result
 
     when:
-    result = kindRegistry.getRegisteredKind(CUSTOM_KIND)
+    result = kindRegistry.getKindProperties(CUSTOM_KIND)
 
     then:
-    _ * globalRegistry.getRegisteredKind(CUSTOM_KIND) >> Optional.empty()
+    _ * globalRegistry.getKindProperties(CUSTOM_KIND) >> Optional.empty()
     1 * supplier.apply(CUSTOM_KIND) >> Optional.empty()
     result == KubernetesKindProperties.withDefaultProperties(CUSTOM_KIND)
 
     when:
-    result = kindRegistry.getRegisteredKind(CUSTOM_KIND)
+    result = kindRegistry.getKindProperties(CUSTOM_KIND)
 
     then:
-    _ * globalRegistry.getRegisteredKind(CUSTOM_KIND) >> Optional.empty()
+    _ * globalRegistry.getKindProperties(CUSTOM_KIND) >> Optional.empty()
     1 * supplier.apply(CUSTOM_KIND) >> Optional.of(customProperties)
     result == customProperties
 
     when:
-    result = kindRegistry.getRegisteredKind(CUSTOM_KIND)
+    result = kindRegistry.getKindProperties(CUSTOM_KIND)
 
     then:
-    _ * globalRegistry.getRegisteredKind(CUSTOM_KIND) >> Optional.empty()
+    _ * globalRegistry.getKindProperties(CUSTOM_KIND) >> Optional.empty()
     0 * supplier.apply(CUSTOM_KIND) >> Optional.of(customProperties)
     result == customProperties
   }

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindSpec.groovy
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.kubernetes.v2.description
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
+import io.kubernetes.client.models.V1beta1CustomResourceDefinition
+import io.kubernetes.client.models.V1beta1CustomResourceDefinitionBuilder
+import io.kubernetes.client.models.V1beta1CustomResourceDefinitionNames
+import io.kubernetes.client.models.V1beta1CustomResourceDefinitionNamesBuilder
+import io.kubernetes.client.models.V1beta1CustomResourceDefinitionSpec
+import io.kubernetes.client.models.V1beta1CustomResourceDefinitionSpecBuilder
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -186,5 +192,25 @@ class KubernetesKindSpec extends Specification {
     KubernetesKind.REPLICA_SET | "replicaSet"
     KubernetesKind.SERVICE     | "service"
     CUSTOM_RESOURCE_KIND       | "deployment.stable.example.com"
+  }
+
+  void "creates a kind from a custom resource definition spec"() {
+    when:
+    def kind = "TestKind"
+    def group = "stable.example.com"
+    V1beta1CustomResourceDefinition crd =
+      new V1beta1CustomResourceDefinitionBuilder()
+        .withSpec(
+          new V1beta1CustomResourceDefinitionSpecBuilder()
+            .withNames(
+              new V1beta1CustomResourceDefinitionNamesBuilder().withKind(kind).build())
+            .withGroup(group)
+            .build())
+        .build()
+    def kubernetesKind = KubernetesKind.fromCustomResourceDefinition(crd)
+
+    then:
+    kubernetesKind.getName() == kind
+    kubernetesKind.getApiGroup().toString() == group
   }
 }


### PR DESCRIPTION
* refactor(kubernetes): Remove useless call to register kind 

  On account creation, we iterate over all kinds in the account and call registerKind. Since we only have the name of the kind and no other information, we just assume the kind is namespaced and pass true.

  Since the kind registry will return a set of default properties
  (including isNamespaced set to true) for something not in the registry, skip the needless call to register these kinds with default properties.

* refactor(kubernetes): Pass custom resources to registry constructor 

  Each account has a set of custom resources that are statically defined in the account config. We register each of these into the KubernetesKindRegistry, but currently do so in a somewhat opaque way, by depending on a side-effect of the KubernetesResourceProperties.fromCustomResource function we use when creating a different property on the account.

  Remove the side effect from the fromCustomResource function and instead pass the list of custom resources to the constructor for KubernetesKindRegistry, allowing it to register resources there.

* refactor(kubernetes): Use ObjectMapper to parse CRD 

  The current logic for reading CRD details is full of unsafe casts and is hard to read. Define a class that has the fields we expect on a CRD and use ObjectMapper to convert the manifest back from the cluster into a typed object.

* refactor(kubernetes): Allow KubernetesKindRegistry to look up CRDs 

  To avoid needing to pre-register all CRDs into the kind registry, the registry should be able to look up kind information in the cluster if it comes across a kind that it does not have any information about.

  When creating a KubernetesKindRegistry, the caller can provide a Function<KubernetesKind, Optional<KubernetesKindProperties>>; when looking up a kind that is not in the registry, the registry will call that function to try to resolve the kind properties. If the function returns a result, the properties are recorded in the registry
  (so subsequent lookups of the same kind don't call the function again). If the function returns an empty Optional, we return a set of default properties as before.

  This commit does not actually use the new functionality; this will come in a later commit.

* refactor(kubernetes): Look up CRD details on-demand 

  Create a new function getCrdProperties that on-demand looks up the properties of a CRD and pass this to the constructor for the kind registry. This removes the need to pre-register kinds that are fround when listing CRDs as the registry will look up any kinds it needs, and also removes the last remaining side-effect of calling liveCrdSupplier.

  The only call to getCrds is from the unregistered CRD caching agent. Given that this happens once per caching cycle (along with a lot of other lookups) there's no real benefit to memoizing the result with a timed expiration. Remove the memoization and just have getCrds do a live lookup.

* refactor(kubernetes): Rename getRegisteredKind to getKindProperties 

  The term registered is confusing, and also somewhat redundant given that the method is on a kind regsitry. (It's also not entirely correct as the function can also live lookup properties and register them.)

  Let's rename the function getKindProperties to be more in line with what it does.
