### PR TITLE
fix(saga): Unwrap exception coming from a saga action

### DIFF
--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/SagaService.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/SagaService.kt
@@ -116,8 +116,8 @@ class SagaService(
             .counter(actionInvocationsId.withTags("result", "failure", "action", action.javaClass.simpleName))
             .increment()
 
-          throw SagaIntegrationException(
-            "Failed to apply action ${action.javaClass.simpleName} for ${saga.name}/${saga.id}", e)
+          log.error("Failed to apply action ${action.javaClass.simpleName} for ${saga.name}/${saga.id}")
+          throw e
         }
 
         saga.setSequence(stepCommand.getMetadata().sequence)


### PR DESCRIPTION
Having a wrapped exception was making `ExceptionSummary` expose a less useful exception to end users. It would _probably_ be a good idea longer-term to add some smarts around automatically unwrapping, but... nah.