### PR TITLE
perf(kubernetes): Reduce namespace lookups in a loop

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -47,7 +47,6 @@ public class KubernetesUnregisteredCustomResourceCachingAgent
   public Collection<AgentDataType> getProvidedDataTypes() {
     return Collections.unmodifiableSet(
         primaryKinds().stream()
-            .filter(credentials::isValidKind)
             .map(k -> AUTHORITATIVE.forType(k.toString()))
             .collect(Collectors.toSet()));
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -75,18 +75,19 @@ public abstract class KubernetesV2CachingAgent
   protected abstract List<KubernetesKind> primaryKinds();
 
   protected Map<KubernetesKind, List<KubernetesManifest>> loadPrimaryResourceList() {
+    List<KubernetesKind> primaryKinds = primaryKinds();
     Map<KubernetesKind, List<KubernetesManifest>> result =
         getNamespaces()
             .parallelStream()
             .map(
                 n -> {
                   try {
-                    return credentials.list(primaryKinds(), n);
+                    return credentials.list(primaryKinds, n);
                   } catch (KubectlException e) {
                     log.warn(
                         "{}: Failed to read kind {} from namespace {}: {}",
                         getAgentType(),
-                        primaryKinds(),
+                        primaryKinds,
                         n,
                         e.getMessage());
                     throw e;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -349,6 +349,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
       return Collections.emptyList();
     }
 
+    List<KubernetesKind> primaryKinds = primaryKinds();
     List<String> matchingKeys =
         providerCache.getIdentifiers(ON_DEMAND_TYPE).stream()
             .map(Keys::parseKey)
@@ -359,7 +360,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
             .filter(
                 i ->
                     i.getAccount().equals(getAccountName())
-                        && primaryKinds().contains(i.getKubernetesKind()))
+                        && primaryKinds.contains(i.getKubernetesKind()))
             .map(Keys.InfrastructureCacheKey::toString)
             .collect(Collectors.toList());
 


### PR DESCRIPTION
The call to primaryKinds() on a caching agent can be expensive, as it may (depending on the caching agent) need to look up available CRDs and/or available namespaces. We make this call in a tight loop in a few places; pull the call out of the loop.

Also replace the lambda in liveNamespaceSupplier with an actual private function for readability (and to make later refactoring easier).

Finally, we make a redundant call to credentials::isValidKind in the CRD caching agent; primaryKinds() already filters on this before returning.