### PR TITLE
fix(aws/loadbalancing): don't mark an instance out of service until draining completes.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/InstanceTargetGroupState.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/InstanceTargetGroupState.groovy
@@ -40,14 +40,18 @@ class InstanceTargetGroupState {
   private HealthState deriveHealthState() {
     //ELBv2 has concrete states: unused -> initial -> healthy    -> draining
     //                                            \-> unhealthy -/
-    if (state == 'healthy') {
+
+    // a draining instance is still serving active connections, and will
+    //  transition to unused once those complete - we will consider it
+    //  UP until it completes draining
+    if (state == 'healthy' || state == 'draining') {
       return HealthState.Up
     }
 
     if (state == 'initial') {
       return HealthState.Starting
     }
-    if (state == 'unused' || state == 'draining') {
+    if (state == 'unused') {
       return HealthState.OutOfService
     }
     return HealthState.Down


### PR DESCRIPTION
An instance in a draining state still has open connections, wait until draining
completes before marking the instance out of service.

This is consistent with CLB behaviour where an instance remains InService during
its draining period, and we still consider it to be UP as a result.