### PR TITLE
feat(sql): Conditionally allow MySQL Connector to be excluded from the build

### DIFF
--- a/clouddriver-sql-mysql/clouddriver-sql-mysql.gradle
+++ b/clouddriver-sql-mysql/clouddriver-sql-mysql.gradle
@@ -2,5 +2,5 @@ dependencies {
   implementation project(":cats:cats-sql")
   implementation project(":clouddriver-sql")
 
-  implementation "mysql:mysql-connector-java:8.0.12"
+  runtimeOnly "mysql:mysql-connector-java:8.0.12"
 }

--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -23,8 +23,11 @@ dependencies {
   implementation project(":clouddriver-artifacts")
   implementation project(":clouddriver-core")
   implementation project(":clouddriver-security")
-  implementation project(":clouddriver-sql-mysql")
+  implementation project(":clouddriver-sql")
 
+  if (!rootProject.hasProperty("excludeSqlDrivers")) {
+    runtimeOnly(project(":clouddriver-sql-mysql"))
+  }
 
   compileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"


### PR DESCRIPTION
This change allows a custom build of Spinnaker to exclude the `mysql-connector-java` driver from the generated distribution with a build command like:

`./gradlew clouddriver-web:installDist -x test -PexcludeSqlDrivers`

The driver is included in the build by default, so the build results are not changed for existing open-source and custom builds. 

The Gradle dependency types were changed from `implementation` to `runtimeOnly` to reflect the fact that `mysql-connector-java` is not needed for compilation. 