### PR TITLE
refactor(cats-core): Remove Cache.StoreType

### DIFF
--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/Cache.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/Cache.java
@@ -23,11 +23,6 @@ import java.util.Map;
 
 /** Cache provides view access to data keyed by type and identifier. */
 public interface Cache {
-  enum StoreType {
-    REDIS,
-    IN_MEMORY,
-    SQL
-  }
 
   /**
    * Gets a single item from the cache by type and id
@@ -122,9 +117,17 @@ public interface Cache {
    */
   Collection<CacheData> getAll(String type, String... identifiers);
 
+  /** Returns whether or not the three {@code getAllByApplication} methods are supported */
+  default boolean supportsGetAllByApplication() {
+    return false;
+  }
+
   /**
    * Retrieves all items for the specified type associated with the provided application. Requires a
    * storeType with secondary indexes and support in the type's caching agent.
+   *
+   * <p>Clients should check {@link #supportsGetAllByApplication()} to check if this method is
+   * supported before calling it.
    *
    * @param type the type for which to retrieve items
    * @param application the application name
@@ -137,6 +140,9 @@ public interface Cache {
   /**
    * Retrieves all items for the specified type associated with the provided application. Requires a
    * storeType with secondary indexes and support in the type's caching agent.
+   *
+   * <p>Clients should check {@link #supportsGetAllByApplication()} to check if this method is
+   * supported before calling it.
    *
    * @param type the type for which to retrieve items
    * @param application the application name
@@ -152,6 +158,9 @@ public interface Cache {
    * Retrieves all items for the specified type associated with the provided application. Requires a
    * storeType with secondary indexes and support in the type's caching agent.
    *
+   * <p>Clients should check {@link #supportsGetAllByApplication()} to check if this method is
+   * supported before calling it.
+   *
    * @param types collection of types for which to retrieve items
    * @param application the application name
    * @param cacheFilters cacheFilters to govern which relationships to fetch, as type to filter
@@ -160,14 +169,5 @@ public interface Cache {
   default Map<String, Collection<CacheData>> getAllByApplication(
       Collection<String> types, String application, Map<String, CacheFilter> cacheFilters) {
     throw new UnsupportedCacheMethodException("Method only implemented for StoreType.SQL");
-  }
-
-  /**
-   * Get backing store type for Cache implementation
-   *
-   * @return the backing StoreType
-   */
-  default StoreType storeType() {
-    return StoreType.REDIS;
   }
 }

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/CompositeCache.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/cache/CompositeCache.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.cats.cache;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /** A cache that provides a unified view of multiples, merging items from each cache together. */
 public class CompositeCache implements Cache {
@@ -28,8 +27,9 @@ public class CompositeCache implements Cache {
     this.caches = caches;
   }
 
-  public Set<StoreType> getStoreTypes() {
-    return caches.stream().map(c -> ((Cache) c).storeType()).collect(Collectors.toSet());
+  @Override
+  public boolean supportsGetAllByApplication() {
+    return caches.stream().allMatch(Cache::supportsGetAllByApplication);
   }
 
   @Override

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/mem/InMemoryCache.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/mem/InMemoryCache.java
@@ -40,11 +40,6 @@ public class InMemoryCache implements WriteableCache {
       new ConcurrentHashMap<>();
 
   @Override
-  public StoreType storeType() {
-    return StoreType.IN_MEMORY;
-  }
-
-  @Override
   public void merge(String type, CacheData cacheData) {
     merge(getOrCreate(type, cacheData.getId()), cacheData);
   }

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
@@ -1,8 +1,6 @@
 package com.netflix.spinnaker.cats.sql
 
 import com.netflix.spinnaker.cats.agent.CacheResult
-import com.netflix.spinnaker.cats.cache.Cache.StoreType
-import com.netflix.spinnaker.cats.cache.Cache.StoreType.SQL
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.CacheFilter
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
@@ -29,8 +27,6 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
       throw IllegalStateException("SqlProviderCache must be wired with a SqlCache backingStore")
     }
   }
-
-  override fun storeType(): StoreType = SQL
 
   /**
    * Filters the supplied list of identifiers to only those that exist in the cache.
@@ -80,6 +76,10 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
   ): MutableCollection<CacheData> {
     validateTypes(type)
     return backingStore.getAll(type, identifiers, cacheFilter)
+  }
+
+  override fun supportsGetAllByApplication(): Boolean {
+    return true
   }
 
   override fun getAllByApplication(type: String, application: String): Map<String, MutableCollection<CacheData>> {

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -1,8 +1,6 @@
 package com.netflix.spinnaker.cats.sql.cache
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.cats.cache.Cache.StoreType
-import com.netflix.spinnaker.cats.cache.Cache.StoreType.SQL
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.CacheFilter
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
@@ -75,8 +73,6 @@ class SqlCache(
   init {
     log.info("Configured for $name")
   }
-
-  override fun storeType(): StoreType = SQL
 
   /**
    * Only evicts cache records but not relationship rows
@@ -265,6 +261,10 @@ class SqlCache(
     val ids = mutableListOf<String>()
     identifiers.forEach { ids.add(it!!) }
     return getAll(type, ids)
+  }
+
+  override fun supportsGetAllByApplication(): Boolean {
+    return true
   }
 
   override fun getAllByApplication(

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -21,7 +21,6 @@ import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.CacheFilter
-import com.netflix.spinnaker.cats.cache.CompositeCache
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.data.Keys
@@ -34,7 +33,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
-import static com.netflix.spinnaker.cats.cache.Cache.StoreType.SQL
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 
 @Component
@@ -259,12 +257,7 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
 
     Collection<AmazonCluster> clusters
 
-    // TODO: remove special casing for sql vs. redis; possibly via dropping redis support in the future
-    if ((includeDetails && sqlEnabled) &&
-      ((cacheView instanceof CompositeCache &&
-        (cacheView as CompositeCache).getStoreTypes().every { (it == SQL) }) ||
-        (cacheView.storeType() == SQL))
-    ) {
+    if (includeDetails && cacheView.supportsGetAllByApplication()) {
       clusters = allClustersByApplication(applicationName)
     } else {
       clusters = translateClusters(resolveRelationshipData(application, CLUSTERS.ns), includeDetails)


### PR DESCRIPTION
We don't need to leak this information to clients. They don't care what
the storage type is; they care whether or not getAllByApplication works,
so just let them ask that.
