### PR TITLE
fix(titus): Fixing titus instance id search

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
@@ -166,7 +166,8 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingA
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
-    return null;
+
+    throw new RuntimeException("Not supported for " + this.getClass().getSimpleName());
   }
 
   @Override

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
@@ -64,7 +64,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TitusStreamingUpdateAgent implements CustomScheduledAgent {
+public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingAgent {
 
   private static final TypeReference<Map<String, Object>> ANY_MAP =
       new TypeReference<Map<String, Object>>() {};
@@ -157,6 +157,16 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent {
   @Override
   public String getProviderName() {
     return TitusCachingProvider.PROVIDER_NAME;
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return TYPES;
+  }
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
- It turns out titus instances where not getting cached in the `instances` in memory cache , this was due to the fact that `TitusStreamingUpdateAgent` was not implementing `getProvidedDataTypes` method 
Refer here for more context : https://github.com/spinnaker/clouddriver/blob/master/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/SearchableProvider.java#L91

