### PR TITLE
fix(kotlin): spring config classes shouldn't use constructors

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlAgentProperties.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlAgentProperties.kt
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.config
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("sql.agent")
-data class SqlAgentProperties(
-  var enabledPattern: String = ".*",
-  var maxConcurrentAgents: Int = 100,
-  var agentLockAcquisitionIntervalSeconds: Long = 1,
+class SqlAgentProperties {
+  var enabledPattern: String = ".*"
+  var maxConcurrentAgents: Int = 100
+  var agentLockAcquisitionIntervalSeconds: Long = 1
   var poll: SqlPollProperties = SqlPollProperties()
-)
+}
 
-data class SqlPollProperties(
-  var intervalSeconds: Long = 30,
-  var errorIntervalSeconds: Long = 30,
+class SqlPollProperties {
+  var intervalSeconds: Long = 30
+  var errorIntervalSeconds: Long = 30
   var timeoutSeconds: Long = 300
-)
+}

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlTaskCleanupAgentProperties.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlTaskCleanupAgentProperties.kt
@@ -19,7 +19,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import java.util.concurrent.TimeUnit
 
 @ConfigurationProperties("sql.agent.task-cleanup")
-class SqlTaskCleanupAgentProperties(
-  var completedTtlMs: Long = TimeUnit.MINUTES.toMillis(60),
+class SqlTaskCleanupAgentProperties {
+  var completedTtlMs: Long = TimeUnit.MINUTES.toMillis(60)
   var batchSize: Int = 100
-)
+}


### PR DESCRIPTION
- This fixes an issue preventing users of open source releases of clouddriver from using the sql backed caching agent scheduler.