### PR TITLE
fix(kubernetes): add support 'apps/v1' for deployments/replicaset

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
@@ -33,6 +33,7 @@ public class KubernetesApiVersion {
       new KubernetesApiVersion("network.k8s.io/v1");
   public static final KubernetesApiVersion NETWORKING_K8S_IO_V1BETA1 =
       new KubernetesApiVersion("network.k8s.io/v1beta1");
+  public static final KubernetesApiVersion APPS_V1 = new KubernetesApiVersion("apps/v1");
   public static final KubernetesApiVersion APPS_V1BETA1 = new KubernetesApiVersion("apps/v1beta1");
   public static final KubernetesApiVersion APPS_V1BETA2 = new KubernetesApiVersion("apps/v1beta2");
   public static final KubernetesApiVersion BATCH_V1 = new KubernetesApiVersion("batch/v1");

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA2;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
@@ -31,9 +32,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
-import io.kubernetes.client.models.V1beta2Deployment;
-import io.kubernetes.client.models.V1beta2DeploymentCondition;
-import io.kubernetes.client.models.V1beta2DeploymentStatus;
+import io.kubernetes.client.models.*;
 import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
@@ -85,13 +84,14 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
   public Status status(KubernetesManifest manifest) {
     if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)
         || manifest.getApiVersion().equals(APPS_V1BETA1)
-        || manifest.getApiVersion().equals(APPS_V1BETA2)) {
+        || manifest.getApiVersion().equals(APPS_V1BETA2)
+        || manifest.getApiVersion().equals(APPS_V1)) {
       if (manifest.isNewerThanObservedGeneration()) {
         return (new Status()).unknown();
       }
-      V1beta2Deployment appsV1beta2Deployment =
-          KubernetesCacheDataConverter.getResource(manifest, V1beta2Deployment.class);
-      return status(appsV1beta2Deployment);
+      V1Deployment appsV1Deployment =
+          KubernetesCacheDataConverter.getResource(manifest, V1Deployment.class);
+      return status(appsV1Deployment);
     } else {
       throw new UnsupportedVersionException(manifest);
     }
@@ -102,21 +102,21 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
     return KubernetesCoreCachingAgent::new;
   }
 
-  private Status status(V1beta2Deployment deployment) {
+  private Status status(V1Deployment deployment) {
     Status result = new Status();
-    V1beta2DeploymentStatus status = deployment.getStatus();
+    V1DeploymentStatus status = deployment.getStatus();
     if (status == null) {
       result.unstable("No status reported yet").unavailable("No availability reported");
       return result;
     }
 
-    V1beta2DeploymentCondition paused =
+    V1DeploymentCondition paused =
         status.getConditions().stream()
             .filter(c -> c.getReason().equalsIgnoreCase("deploymentpaused"))
             .findAny()
             .orElse(null);
 
-    V1beta2DeploymentCondition available =
+    V1DeploymentCondition available =
         status.getConditions().stream()
             .filter(c -> c.getType().equalsIgnoreCase("available"))
             .findAny()
@@ -130,7 +130,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
       result.unstable(available.getMessage()).unavailable(available.getMessage());
     }
 
-    V1beta2DeploymentCondition condition =
+    V1DeploymentCondition condition =
         status.getConditions().stream()
             .filter(c -> c.getType().equalsIgnoreCase("progressing"))
             .findAny()

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -32,7 +32,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
-import io.kubernetes.client.models.*;
+import io.kubernetes.client.models.V1Deployment;
+import io.kubernetes.client.models.V1DeploymentCondition;
+import io.kubernetes.client.models.V1DeploymentStatus;
 import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -35,7 +35,10 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestSelector;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
-import io.kubernetes.client.models.*;
+import io.kubernetes.client.models.V1ReplicaSet;
+import io.kubernetes.client.models.V1beta1ReplicaSet;
+import io.kubernetes.client.models.V1beta2ReplicaSet;
+import io.kubernetes.client.models.V1ReplicaSetStatus;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -36,9 +36,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import io.kubernetes.client.models.V1ReplicaSet;
+import io.kubernetes.client.models.V1ReplicaSetStatus;
 import io.kubernetes.client.models.V1beta1ReplicaSet;
 import io.kubernetes.client.models.V1beta2ReplicaSet;
-import io.kubernetes.client.models.V1ReplicaSetStatus;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA2;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
@@ -34,9 +35,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestSelector;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
-import io.kubernetes.client.models.V1beta1ReplicaSet;
-import io.kubernetes.client.models.V1beta2ReplicaSet;
-import io.kubernetes.client.models.V1beta2ReplicaSetStatus;
+import io.kubernetes.client.models.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -90,18 +89,19 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
   @Override
   public Status status(KubernetesManifest manifest) {
     if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)
-        || manifest.getApiVersion().equals(APPS_V1BETA2)) {
-      V1beta2ReplicaSet v1beta2ReplicaSet =
-          KubernetesCacheDataConverter.getResource(manifest, V1beta2ReplicaSet.class);
-      return status(v1beta2ReplicaSet);
+        || manifest.getApiVersion().equals(APPS_V1BETA2)
+        || manifest.getApiVersion().equals(APPS_V1)) {
+      V1ReplicaSet v1ReplicaSet =
+          KubernetesCacheDataConverter.getResource(manifest, V1ReplicaSet.class);
+      return status(v1ReplicaSet);
     } else {
       throw new UnsupportedVersionException(manifest);
     }
   }
 
-  private Status status(V1beta2ReplicaSet replicaSet) {
+  private Status status(V1ReplicaSet replicaSet) {
     Status result = new Status();
-    V1beta2ReplicaSetStatus status = replicaSet.getStatus();
+    V1ReplicaSetStatus status = replicaSet.getStatus();
     if (status == null) {
       result.unstable("No status reported yet").unavailable("No availability reported");
       return result;
@@ -150,6 +150,10 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
       V1beta2ReplicaSet v1beta2ReplicaSet =
           KubernetesCacheDataConverter.getResource(manifest, V1beta2ReplicaSet.class);
       return getPodTemplateLabels(v1beta2ReplicaSet);
+    } else if (manifest.getApiVersion().equals(APPS_V1)) {
+      V1ReplicaSet v1ReplicaSet =
+          KubernetesCacheDataConverter.getResource(manifest, V1ReplicaSet.class);
+      return getPodTemplateLabels(v1ReplicaSet);
     } else {
       throw new UnsupportedVersionException(manifest);
     }
@@ -160,6 +164,10 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
   }
 
   private static Map<String, String> getPodTemplateLabels(V1beta2ReplicaSet replicaSet) {
+    return replicaSet.getSpec().getTemplate().getMetadata().getLabels();
+  }
+
+  private static Map<String, String> getPodTemplateLabels(V1ReplicaSet replicaSet) {
     return replicaSet.getSpec().getTemplate().getMetadata().getLabels();
   }
 


### PR DESCRIPTION
This PR implements support kubernetes 'apps/v1' ApiVersions for deployments/replicaset, deployed to Kubernetes clusters >1.16.0 and solves issue [#4946](https://github.com/spinnaker/spinnaker/issues/4946)