### PR TITLE
fix(kubernetes): Add networking.k8s.io/v1beta1 ingress versions

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
@@ -20,9 +20,11 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.NETWORKING_K8S_IO_V1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1;
 
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.SecurityGroup;
@@ -47,6 +49,9 @@ import lombok.extern.slf4j.Slf4j;
 @Data
 @Slf4j
 public class KubernetesV2SecurityGroup extends ManifestBasedModel implements SecurityGroup {
+  private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
+      ImmutableSet.of(NETWORKING_K8S_IO_V1BETA1, NETWORKING_K8S_IO_V1);
+
   private KubernetesManifest manifest;
   private Keys.InfrastructureCacheKey key;
   private String id;
@@ -91,8 +96,7 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
     if (!manifest.getKind().equals(KubernetesKind.NETWORK_POLICY)) {
       log.warn("Unknown security group kind " + manifest.getKind());
     } else {
-      if (manifest.getApiVersion().equals(NETWORKING_K8S_IO_V1)
-          || (manifest.getApiVersion().equals(NETWORKING_K8S_IO_V1BETA1))) {
+      if (SUPPORTED_API_VERSIONS.contains(manifest.getApiVersion())) {
         V1NetworkPolicy v1beta1NetworkPolicy =
             KubernetesCacheDataConverter.getResource(manifest, V1NetworkPolicy.class);
         inboundRules = inboundRules(v1beta1NetworkPolicy);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.INGRESS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.SERVICE;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.NETWORK_RESOURCE_PRIORITY;
@@ -50,7 +51,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class KubernetesIngressHandler extends KubernetesHandler {
   private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
-      ImmutableSet.of(EXTENSIONS_V1BETA1);
+      ImmutableSet.of(EXTENSIONS_V1BETA1, NETWORKING_K8S_IO_V1BETA1);
 
   @Override
   public int deployPriority() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
@@ -22,12 +22,14 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manife
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.SERVICE;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.NETWORK_RESOURCE_PRIORITY;
 
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCoreCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.KubernetesCacheUtils;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
@@ -47,6 +49,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class KubernetesIngressHandler extends KubernetesHandler {
+  private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
+      ImmutableSet.of(EXTENSIONS_V1BETA1);
+
   @Override
   public int deployPriority() {
     return NETWORK_RESOURCE_PRIORITY.getValue();
@@ -110,13 +115,12 @@ public class KubernetesIngressHandler extends KubernetesHandler {
   }
 
   private static List<String> attachedServices(KubernetesManifest manifest) {
-    if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)) {
-      V1beta1Ingress v1beta1Ingress =
-          KubernetesCacheDataConverter.getResource(manifest, V1beta1Ingress.class);
-      return attachedServices(v1beta1Ingress);
-    } else {
+    if (!SUPPORTED_API_VERSIONS.contains(manifest.getApiVersion())) {
       throw new UnsupportedVersionException(manifest);
     }
+    V1beta1Ingress v1beta1Ingress =
+        KubernetesCacheDataConverter.getResource(manifest, V1beta1Ingress.class);
+    return attachedServices(v1beta1Ingress);
   }
 
   private static List<String> attachedServices(V1beta1Ingress ingress) {


### PR DESCRIPTION
* refactor(kubernetes): Pull api versions to a set 

  A number of different places check the API version of a manifest against a set of supported ones using a log if condition. Replace these with a statically-defined set of supported versions and a check of whether the manifest's API version is in the set.

  This commit doesn't change any of the supported versions.

* fix(kubernetes): Add networking.k8s.io/v1beta1 ingress versions 

  In Kubernetes 1.20, Ingress will stop being served from the extensions/v1beta1 API group and will only be served from the networking.k8s.io/v1beta1 API group (which has been available since 1.14).
