### PR TITLE
fix(kubernetes): Fix missing API versions

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
@@ -33,6 +33,7 @@ public class KubernetesApiVersion {
       new KubernetesApiVersion("network.k8s.io/v1");
   public static final KubernetesApiVersion NETWORKING_K8S_IO_V1BETA1 =
       new KubernetesApiVersion("network.k8s.io/v1beta1");
+  public static final KubernetesApiVersion APPS_V1 = new KubernetesApiVersion("apps/v1");
   public static final KubernetesApiVersion APPS_V1BETA1 = new KubernetesApiVersion("apps/v1beta1");
   public static final KubernetesApiVersion APPS_V1BETA2 = new KubernetesApiVersion("apps/v1beta2");
   public static final KubernetesApiVersion BATCH_V1 = new KubernetesApiVersion("batch/v1");

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA2;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
@@ -78,7 +79,8 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
   public Status status(KubernetesManifest manifest) {
     if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)
         || manifest.getApiVersion().equals(APPS_V1BETA1)
-        || manifest.getApiVersion().equals(APPS_V1BETA2)) {
+        || manifest.getApiVersion().equals(APPS_V1BETA2)
+        || manifest.getApiVersion().equals(APPS_V1)) {
       if (manifest.isNewerThanObservedGeneration()) {
         return (new Status()).unknown();
       }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.INGRESS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.SERVICE;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.NETWORK_RESOURCE_PRIORITY;
@@ -107,7 +108,8 @@ public class KubernetesIngressHandler extends KubernetesHandler {
   }
 
   private static List<String> attachedServices(KubernetesManifest manifest) {
-    if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)) {
+    if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)
+        || manifest.getApiVersion().equals(NETWORKING_K8S_IO_V1BETA1)) {
       V1beta1Ingress v1beta1Ingress =
           KubernetesCacheDataConverter.getResource(manifest, V1beta1Ingress.class);
       return attachedServices(v1beta1Ingress);

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.APPS_V1BETA2;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
@@ -33,6 +34,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestSelector;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
+import io.kubernetes.client.models.V1ReplicaSet;
 import io.kubernetes.client.models.V1beta1ReplicaSet;
 import io.kubernetes.client.models.V1beta2ReplicaSet;
 import io.kubernetes.client.models.V1beta2ReplicaSetStatus;
@@ -84,7 +86,8 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
   @Override
   public Status status(KubernetesManifest manifest) {
     if (manifest.getApiVersion().equals(EXTENSIONS_V1BETA1)
-        || manifest.getApiVersion().equals(APPS_V1BETA2)) {
+        || manifest.getApiVersion().equals(APPS_V1BETA2)
+        || manifest.getApiVersion().equals(APPS_V1)) {
       V1beta2ReplicaSet v1beta2ReplicaSet =
           KubernetesCacheDataConverter.getResource(manifest, V1beta2ReplicaSet.class);
       return status(v1beta2ReplicaSet);
@@ -144,6 +147,10 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
       V1beta2ReplicaSet v1beta2ReplicaSet =
           KubernetesCacheDataConverter.getResource(manifest, V1beta2ReplicaSet.class);
       return getPodTemplateLabels(v1beta2ReplicaSet);
+    } else if (manifest.getApiVersion().equals(APPS_V1)) {
+      V1ReplicaSet v1ReplicaSet =
+          KubernetesCacheDataConverter.getResource(manifest, V1ReplicaSet.class);
+      return getPodTemplateLabels(v1ReplicaSet);
     } else {
       throw new UnsupportedVersionException(manifest);
     }
@@ -154,6 +161,10 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
   }
 
   private static Map<String, String> getPodTemplateLabels(V1beta2ReplicaSet replicaSet) {
+    return replicaSet.getSpec().getTemplate().getMetadata().getLabels();
+  }
+
+  private static Map<String, String> getPodTemplateLabels(V1ReplicaSet replicaSet) {
     return replicaSet.getSpec().getTemplate().getMetadata().getLabels();
   }
 


### PR DESCRIPTION
This change cherry-picks the safe parts of #4055 and #4056 into the 1.16 branch. In particular, it pulls just the additive changes that admit new API versions: we now accept v1 Deployments and ReplicaSets, as well as networking.k8s.io/v1beta1 Ingresses.

This change does *not* update the code to start deserializing all existing objects as these new types, as that does have the potential to break existing functionality. It also does not cherry-pick the minor refactoring to pull the supported versions into sets and avoid the long chain of or conditions.

The interest of cherry-picking this is that these new API versions have been supported since Kubernetes 1.9 so even users who have not fully upgraded may still run into errors using them (and the erorrs are not necessarily easy to debug, leading to timeouts on waiting for manifests to stabilize). This will also unblock users who have upgraded to Kubernetes 1.16 (and also help us hear sooner if there are other issues).
