### PR TITLE
chore(kubernetes): Update API group of NetworkPolicy and PodSecurityPolicy

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -56,7 +56,7 @@ public class KubernetesKind {
   public static final KubernetesKind HORIZONTAL_POD_AUTOSCALER =
       createWithAlias("horizontalpodautoscaler", "hpa", KubernetesApiGroup.AUTOSCALING);
   public static final KubernetesKind INGRESS =
-      createWithAlias("ingress", null, KubernetesApiGroup.EXTENSIONS);
+      createWithAlias("ingress", null, KubernetesApiGroup.NETWORKING_K8S_IO);
   public static final KubernetesKind JOB = createWithAlias("job", null, KubernetesApiGroup.BATCH);
   public static final KubernetesKind MUTATING_WEBHOOK_CONFIGURATION =
       createWithAlias(

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -26,7 +26,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -101,9 +100,9 @@ public class KubernetesKind {
   // kind is not in spinnaker's registry
   public static final KubernetesKind NONE = createWithAlias("none", null, KubernetesApiGroup.NONE);
 
-  @Getter @Nonnull private final String name;
+  @Nonnull private final String name;
   @EqualsAndHashCode.Include @Nonnull private final String lcName;
-  @Getter @Nonnull private final KubernetesApiGroup apiGroup;
+  @Nonnull private final KubernetesApiGroup apiGroup;
   @EqualsAndHashCode.Include @Nullable private final KubernetesApiGroup customApiGroup;
 
   private KubernetesKind(String name, @Nullable KubernetesApiGroup apiGroup) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -64,7 +64,7 @@ public class KubernetesKind {
   public static final KubernetesKind NAMESPACE =
       createWithAlias("namespace", "ns", KubernetesApiGroup.CORE);
   public static final KubernetesKind NETWORK_POLICY =
-      createWithAlias("networkPolicy", "netpol", KubernetesApiGroup.EXTENSIONS);
+      createWithAlias("networkPolicy", "netpol", KubernetesApiGroup.NETWORKING_K8S_IO);
   public static final KubernetesKind PERSISTENT_VOLUME =
       createWithAlias("persistentVolume", "pv", KubernetesApiGroup.CORE);
   public static final KubernetesKind PERSISTENT_VOLUME_CLAIM =
@@ -73,7 +73,7 @@ public class KubernetesKind {
   public static final KubernetesKind POD_PRESET =
       createWithAlias("podPreset", null, KubernetesApiGroup.SETTINGS_K8S_IO);
   public static final KubernetesKind POD_SECURITY_POLICY =
-      createWithAlias("podSecurityPolicy", null, KubernetesApiGroup.EXTENSIONS);
+      createWithAlias("podSecurityPolicy", null, KubernetesApiGroup.POLICY);
   public static final KubernetesKind POD_DISRUPTION_BUDGET =
       createWithAlias("podDisruptionBudget", null, KubernetesApiGroup.POLICY);
   public static final KubernetesKind REPLICA_SET =

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindSpec.groovy
@@ -210,7 +210,6 @@ class KubernetesKindSpec extends Specification {
     def kubernetesKind = KubernetesKind.fromCustomResourceDefinition(crd)
 
     then:
-    kubernetesKind.getName() == kind
-    kubernetesKind.getApiGroup().toString() == group
+    kubernetesKind == kubernetesKind.fromString("TestKind.stable.example.com")
   }
 }


### PR DESCRIPTION
* refactor(kubernetes): Remove getters from KubernetesKind 

  Once a KubernetesKind has been created, external classes should
  (and do) only care about its string representation, not the individual fields. Remove the unused getters from the name and apiGroup fields (and update one test that was relying on them).

* chore(kubernetes): Update API group of NetworkPolicy and PodSecurityPolicy 

  The NetworkPolicy and PodSecurityPolicy kinds have been moved from extensions/v1beta1 to networking.k8s.io/v1 and policy/v1beta1 respectively. Update the API group for these kinds in KubernetesKind.

  Given how the V2 provider queries kinds, this change actually has no functional effect as kinds from built-in API groups are serialized as the kind name alone (wihtout api group) leaving kubectl to resolve the API group. As a result this will neither break users on old versions of Kubernetes nor would failing to make this change have broken users of 1.16 when API stops serving from the old endpoints. That being said, it makes sense to keep these API groups up to date, both for documentation reasons and in the event that in the future we begin using them.
