### PR TITLE
chore(kubernetes): Bump fabric8 library to 4.6.0

### DIFF
--- a/clouddriver-kubernetes-v1/clouddriver-kubernetes-v1.gradle
+++ b/clouddriver-kubernetes-v1/clouddriver-kubernetes-v1.gradle
@@ -18,7 +18,7 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-config"
   implementation "com.netflix.spinnaker.moniker:moniker"
-  implementation "io.fabric8:kubernetes-client:4.1.1"
+  implementation "io.fabric8:kubernetes-client:4.3.1"
   implementation "io.kubernetes:client-java:5.0.0"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-kubernetes-v1/clouddriver-kubernetes-v1.gradle
+++ b/clouddriver-kubernetes-v1/clouddriver-kubernetes-v1.gradle
@@ -18,7 +18,7 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-config"
   implementation "com.netflix.spinnaker.moniker:moniker"
-  implementation "io.fabric8:kubernetes-client:4.3.1"
+  implementation "io.fabric8:kubernetes-client:4.6.0"
   implementation "io.kubernetes:client-java:5.0.0"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/autoscaler/UpsertKubernetesAutoscalerAtomicOperation.groovy
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/autoscaler/UpsertKubernetesAutoscalerAtomicOperation.groovy
@@ -29,7 +29,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.exception.Kubernet
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import io.fabric8.kubernetes.api.model.DoneableHorizontalPodAutoscaler
 import io.fabric8.kubernetes.api.model.HorizontalPodAutoscalerBuilder
-import io.fabric8.kubernetes.api.model.MetricSpecBuilder
 
 class UpsertKubernetesAutoscalerAtomicOperation implements AtomicOperation<Void> {
   KubernetesAutoscalerDescription description
@@ -81,8 +80,7 @@ class UpsertKubernetesAutoscalerAtomicOperation implements AtomicOperation<Void>
       description.scalingPolicy = description.scalingPolicy ?: new KubernetesScalingPolicy()
       description.scalingPolicy.cpuUtilization = description.scalingPolicy.cpuUtilization ?: new KubernetesCpuUtilization()
       description.scalingPolicy.cpuUtilization.target = description.scalingPolicy.cpuUtilization.target != null ?
-        description.scalingPolicy.cpuUtilization.target :
-        autoscaler.spec.metrics?.find { metric -> metric.resource.name == "cpu" }?.resource?.targetAverageUtilization
+        description.scalingPolicy.cpuUtilization.target : autoscaler.spec.targetCPUUtilizationPercentage
 
       ((DoneableHorizontalPodAutoscaler) KubernetesApiConverter.toAutoscaler(
         credentials.apiAdaptor.editAutoscaler(namespace, name), description, name, kind, version

--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesAutoscalerStatus.groovy
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesAutoscalerStatus.groovy
@@ -33,7 +33,7 @@ class KubernetesAutoscalerStatus {
     if (autoscaler.status == null) {
       log.warn("Autoscaler on ${autoscaler.metadata.name} has a null status. The replicaset may be missing a CPU request.")
     } else {
-      this.currentCpuUtilization = autoscaler.status.currentMetrics?.find { metric -> metric.resource.name == "cpu" }?.resource?.currentAverageUtilization
+      this.currentCpuUtilization = autoscaler.status.currentCPUUtilizationPercentage
       this.currentReplicas = autoscaler.status.currentReplicas
       this.desiredReplicas = autoscaler.status.desiredReplicas
       this.lastScaleTime = KubernetesModelUtil.translateTime(autoscaler.status.lastScaleTime)


### PR DESCRIPTION
These upgrades get us [compatibility](https://github.com/fabric8io/kubernetes-client#compatibility-matrix) with kubernetes 1.15 without losing compatibility with any older versions.

* chore(kubernetes): Bump fabric8 library to 4.3.1 

  This commit also updates the code in response to a couple of breaking changes in the upgrade. Notably, the cpu utilization target of a replicaset is now a top-level field rather than being nested in a metrics object. Likewise, the current utilization is a top-level field of the status, rather than nested in a metrics object.

* chore(kubernetes): Bump fabric8 library to 4.6.0 