### PR TITLE
fix(dockerfile): use deterministic version for kubectl

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -2,6 +2,8 @@ FROM openjdk:8-jdk-alpine
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/clouddriver-web/build/install/clouddriver /opt/clouddriver
 
+ENV KUBECTL_VERSION v1.16.0
+
 RUN apk --no-cache add --update bash wget unzip 'python2>2.7.9' && \
   wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && \
   unzip -qq google-cloud-sdk.zip -d /opt && \
@@ -9,8 +11,7 @@ RUN apk --no-cache add --update bash wget unzip 'python2>2.7.9' && \
   CLOUDSDK_PYTHON="python2.7" /opt/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false --additional-components app-engine-java && \
   rm -rf ~/.config/gcloud
 
-RUN wget https://storage.googleapis.com/kubernetes-release/release/stable.txt && wget https://storage.googleapis.com/kubernetes-release/release/$(cat stable.txt)/bin/linux/amd64/kubectl && \
-  rm stable.txt && \
+RUN wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
   chmod +x kubectl && \
   mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
reading from `stable.txt` causes builds to be non-deterministic which could lead to problems in the future. we should be explicit about the version of `kubectl` that we ship. `v1.16.0` was the latest version as of this PR.