### PR TITLE
fix(cf): when scaling cf disabled SG we should use max capacity

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ScaleCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/ScaleCloudFoundryServerGroupAtomicOperation.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.helpers.OperationPoller;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -48,11 +49,18 @@ public class ScaleCloudFoundryServerGroupAtomicOperation implements AtomicOperat
     final CloudFoundryClient client = description.getClient();
 
     ServerGroup.Capacity capacity = description.getCapacity();
+    boolean scaleStoppedInstance =
+        Optional.ofNullable(description.getScaleStoppedServerGroup()).orElse(false);
+    Integer numInstances =
+        Optional.ofNullable(capacity)
+            .map(c -> scaleStoppedInstance ? capacity.getMax() : capacity.getDesired())
+            .orElse(null);
+
     client
         .getApplications()
         .scaleApplication(
             description.getServerGroupId(),
-            capacity == null ? null : capacity.getDesired(),
+            numInstances,
             description.getMemory(),
             description.getDiskQuota());
 


### PR DESCRIPTION
When scaling a disabled server group in cloud foundry we should use the "max" value because a disabled stated in CF would be a stopped state which would result in 0 instances running but we should still adjust the number instances to the target number if the server group is enabled/started.

fix for spinnaker/spinnaker#4786