### PR TITLE
fix(travis): Skip 'check' when doing release builds

### DIFF
--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -16,10 +16,10 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   version-*)
     ;; # Ignore Spinnaker product release tags.
   *-rc\.*)
-    $GRADLE -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -x test candidate --stacktrace
+    $GRADLE -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -x test -x check candidate --stacktrace
     ;;
   *)
-    $GRADLE -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -x test final --stacktrace
+    $GRADLE -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -x test -x check final --stacktrace
     ;;
   esac
 else


### PR DESCRIPTION
An attempt at cutting down some of the (unnecessary) gradle tasks that are run during a release.