### PR TITLE
fix(titus): Fix SagaContext wiring in DeployHandler cases

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
@@ -23,6 +23,8 @@ import com.netflix.spinnaker.clouddriver.orchestration.SagaContextAware
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
 import org.springframework.beans.factory.annotation.Autowired
 
+import javax.annotation.Nonnull
+
 class DeployAtomicOperation implements AtomicOperation<DeploymentResult>, SagaContextAware {
   private static final String TASK_PHASE = "DEPLOY"
 
@@ -30,7 +32,6 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult>, SagaCo
   DeployHandlerRegistry deploymentHandlerRegistry
 
   private final DeployDescription description
-  SagaContext sagaContext
 
   DeployAtomicOperation(DeployDescription description) {
     this.description = description
@@ -54,10 +55,6 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult>, SagaCo
       throw new DeployHandlerNotFoundException("Could not find handler for ${description.getClass().simpleName}!")
     }
 
-    if (deployHandler instanceof SagaContextAware) {
-      deployHandler.sagaContext = sagaContext
-    }
-
     task.updateStatus TASK_PHASE, "Found handler: ${deployHandler.getClass().simpleName}"
 
     task.updateStatus TASK_PHASE, "Invoking Handler."
@@ -66,5 +63,16 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult>, SagaCo
     task.updateStatus TASK_PHASE, "Server Groups: ${deploymentResult.getDeployments()} created."
 
     return deploymentResult
+  }
+
+  @Override
+  void setSagaContext(@Nonnull SagaContext sagaContext) {
+    // DeployHandlers are singleton objects autowired differently than their one-off AtomicOperations, so we can't
+    // set a SagaContext onto them. Instead, we need to set it onto the description. To pile on, AtomicOperationConverters
+    // throw away the initial converted AtomicOperationDescription, so we can't apply the SagaContext to the description
+    // on behalf of cloud provider integrators... so we have to wire that up for them manually in any AtomicOperation.
+    if (description instanceof SagaContextAware) {
+      ((SagaContextAware) description).sagaContext = sagaContext
+    }
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverter.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverter.groovy
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.orchestration
 
-
 import javax.annotation.Nullable
-
 /**
  * Implementations of this trait will provide an object capable of converting a Map of input parameters to an
  * operation's description object and an {@link AtomicOperation} instance.

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/OperationsService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/OperationsService.java
@@ -174,15 +174,16 @@ public class OperationsService {
                           }
 
                           allowedAccountValidators.forEach(
-                              it -> {
-                                it.validate(username, allowedAccounts, description, errors);
-                              });
+                              it -> it.validate(username, allowedAccounts, description, errors));
 
                           // TODO(rz): Assert `description` is T
                           descriptionAuthorizer.authorize(description, errors);
 
+                          // TODO(rz): This is so bad. We convert the description input twice (once
+                          // above) and then once inside of this convertOperation procedure. This
+                          // means that we do a bunch of serde work twice without needing to.
                           AtomicOperation atomicOperation =
-                              converter.convertOperation(descriptionInput);
+                              converter.convertOperation(processedInput);
                           if (atomicOperation == null) {
                             throw new AtomicOperationNotFoundException(descriptionName);
                           }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/converters/TitusDeployAtomicOperationConverter.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/converters/TitusDeployAtomicOperationConverter.groovy
@@ -28,10 +28,12 @@ import org.springframework.stereotype.Component
 @Component
 class TitusDeployAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
 
+  @Override
   AtomicOperation convertOperation(Map input) {
     new DeployAtomicOperation(convertDescription(input))
   }
 
+  @Override
   TitusDeployDescription convertDescription(Map input) {
     // Backwards-compatibility for when the Titus provider blindly accepted any container
     // attribute value, when in reality this can only be string values. Now that the

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.clouddriver.titus.deploy.description;
 
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription;
+import com.netflix.spinnaker.clouddriver.orchestration.SagaContextAware;
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
 import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable;
 import com.netflix.spinnaker.clouddriver.titus.client.model.DisruptionBudget;
@@ -24,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class TitusDeployDescription extends AbstractTitusCredentialsDescription
-    implements DeployDescription, ApplicationNameable {
+    implements DeployDescription, ApplicationNameable, SagaContextAware {
   private String region;
   private String subnet;
   private List<String> zones = new ArrayList<>();
@@ -56,6 +57,7 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
   private DisruptionBudget disruptionBudget;
   private SubmitJobRequest.Constraints constraints = new SubmitJobRequest.Constraints();
   private ServiceJobProcesses serviceJobProcesses;
+  private SagaContext sagaContext;
 
   /**
    * Will be overridden by any the label {@code PrepareTitusDeploy.USE_APPLICATION_DEFAULT_SG_LABEL}
@@ -77,6 +79,11 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
   @Override
   public Collection<String> getApplications() {
     return Arrays.asList(application);
+  }
+
+  @Override
+  public void setSagaContext(SagaContext sagaContext) {
+    this.sagaContext = sagaContext;
   }
 
   /** For Jackson deserialization. */


### PR DESCRIPTION
It turns out that TitusDeployHandler (and other DeployHandler classes) are singleton components
that get injected into prototype AtomicOperation components, which I didn't realize until now.
The issue with this is that I was setting request-scoped context into a singleton bean, which
could lead to some neat concurrency bugs. This change modifies things for DeployAtomicOperation
specifically to inject the SagaContext into the description (which is actually request-scoped)
rather than passing through to the TitusDeployHandler object.

There's also this neat feature I discovered while working through this where we convert the raw request input into an atomic operation description twice, throwing away the first conversion after we've validated the input. Not sure why we do this, but it seems like something we could make better someday.