### PR TITLE
feat(retry): Resilience4j Spring Boot2 implementation in clouddriver-sql

### DIFF
--- a/clouddriver-sql/clouddriver-sql.gradle
+++ b/clouddriver-sql/clouddriver-sql.gradle
@@ -22,7 +22,6 @@ dependencies {
   implementation project(":clouddriver-event")
 
   implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-sql"
   implementation "com.netflix.spinnaker.kork:kork-telemetry"
   implementation "de.huxhorn.sulky:de.huxhorn.sulky.ulid"

--- a/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
+++ b/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
@@ -38,8 +38,7 @@ public class SqlTaskRepositoryTest extends TaskRepositoryTck {
     properties.setReads(retry);
     properties.setTransactions(retry);
 
-    return new SqlTaskRepository(
-        database.context, new ObjectMapper(), Clock.systemDefaultZone(), properties);
+    return new SqlTaskRepository(database.context, new ObjectMapper(), Clock.systemDefaultZone());
   }
 
   @After

--- a/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventRepositoryTest.kt
+++ b/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventRepositoryTest.kt
@@ -21,16 +21,13 @@ import com.netflix.spinnaker.clouddriver.event.AbstractSpinnakerEvent
 import com.netflix.spinnaker.clouddriver.event.exceptions.AggregateChangeRejectedException
 import com.netflix.spinnaker.clouddriver.event.persistence.EventRepository.ListAggregatesCriteria
 import com.netflix.spinnaker.clouddriver.event.persistence.EventRepository.ListAggregatesResult
-import com.netflix.spinnaker.kork.sql.config.SqlProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import com.netflix.spinnaker.kork.version.ServiceVersion
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.github.resilience4j.retry.RetryRegistry
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.validation.Validator
 import org.testcontainers.shaded.com.fasterxml.jackson.annotation.JsonTypeName
 import strikt.api.expect
 import strikt.api.expectThat
@@ -196,21 +193,16 @@ class SqlEventRepositoryTest : JUnit5Minutests {
 
     val serviceVersion: ServiceVersion = mockk(relaxed = true)
     val applicationEventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
-    val validator: Validator = mockk(relaxed = true)
-    val retryRegistry: RetryRegistry = RetryRegistry.ofDefaults()
 
     val subject = SqlEventRepository(
       jooq = database.context,
-      sqlProperties = SqlProperties(),
       serviceVersion = serviceVersion,
       objectMapper = ObjectMapper().apply {
         findAndRegisterModules()
         registerSubtypes(MyEvent::class.java)
       },
       applicationEventPublisher = applicationEventPublisher,
-      registry = NoopRegistry(),
-      validator = validator,
-      retryRegistry = retryRegistry
+      registry = NoopRegistry()
     )
 
     init {

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -281,6 +281,19 @@ operations.security:
 # Turn on when confirming Fiat authorization checks
 # logging.level.com.netflix.spinnaker.clouddriver.listeners: DEBUG
 
+resilience4j.retry:
+  instances:
+    sqlTransaction:
+      maxRetryAttempts: 5
+      waitDuration: 100ms
+      enableExponentialBackoff: false
+      ignoreExceptions:
+      - com.netflix.spinnaker.clouddriver.event.exceptions.AggregateChangeRejectedException
+    sqlRead:
+      maxRetryAttempts: 5
+      waitDuration: 100ms
+      enableExponentialBackoff: false
+
 ---
 
 spring:


### PR DESCRIPTION
If we go this route, I would like to see the work to back Spectator with a Micrometer registry get resurrected, so we can surface some of these Resilience4j metrics easily (example PR: https://github.com/spinnaker/kork/pull/268)
