### PR TITLE
fix(kubernetes): Fix matching of artifacts in deploy/patch stages (#4078)

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -27,6 +27,9 @@ dependencies {
   implementation "com.github.ben-manes.caffeine:guava"
 
   testImplementation "cglib:cglib-nodep"
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/ArtifactKey.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/ArtifactKey.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import com.google.common.collect.ImmutableSet;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.Collection;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * When determining whether the deploy and patch manifest stages bound all required artifacts, the
+ * artifacts in the list of required artifacts have an artifact account set while those in the list
+ * we're trying to bind don't.
+ *
+ * <p>As the .equals function of Artifact includes the account in its comparison, this means that we
+ * don't recognize the replaced artifacts as the ones we expected to replace and fail the stage.
+ *
+ * <p>As a temporary fix until we can refactor the artifact passing code to consistently include (or
+ * not) account, or decide that account should always be excluded from Artifact.equals(), create a
+ * class to hold the fields of Artifact that these two stages should use when deciding whether
+ * artifacts are equal.
+ */
+@EqualsAndHashCode
+@ToString
+class ArtifactKey {
+  private final String type;
+  private final String name;
+  private final String version;
+  private final String location;
+  private final String reference;
+
+  private ArtifactKey(Artifact artifact) {
+    this.type = artifact.getType();
+    this.name = artifact.getName();
+    this.version = artifact.getVersion();
+    this.location = artifact.getLocation();
+    this.reference = artifact.getReference();
+  }
+
+  @Nonnull
+  static ArtifactKey fromArtifact(@Nonnull Artifact artifact) {
+    return new ArtifactKey(artifact);
+  }
+
+  @Nonnull
+  static ImmutableSet<ArtifactKey> fromArtifacts(@Nullable Collection<Artifact> artifacts) {
+    if (artifacts == null) {
+      return ImmutableSet.of();
+    }
+    return artifacts.stream()
+        .filter(Objects::nonNull)
+        .map(ArtifactKey::fromArtifact)
+        .collect(toImmutableSet());
+  }
+}

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest;
 
+import com.google.common.collect.Sets;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
@@ -135,8 +136,10 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
       boundArtifacts.addAll(replaceResult.getBoundArtifacts());
     }
 
-    Set<Artifact> unboundArtifacts = new HashSet<>(requiredArtifacts);
-    unboundArtifacts.removeAll(boundArtifacts);
+    Set<ArtifactKey> unboundArtifacts =
+        Sets.difference(
+            ArtifactKey.fromArtifacts(description.getRequiredArtifacts()),
+            ArtifactKey.fromArtifacts(boundArtifacts));
 
     getTask().updateStatus(OP_NAME, "Checking if all requested artifacts were bound...");
     if (!unboundArtifacts.isEmpty()) {

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
@@ -34,7 +34,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Cred
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -119,9 +118,10 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
             manifest, allArtifacts, objToPatch.getNamespace(), description.getAccount());
 
     if (description.getRequiredArtifacts() != null) {
-      Set<Artifact> unboundArtifacts =
+      Set<ArtifactKey> unboundArtifacts =
           Sets.difference(
-              new HashSet<>(description.getRequiredArtifacts()), replaceResult.getBoundArtifacts());
+              ArtifactKey.fromArtifacts(description.getRequiredArtifacts()),
+              ArtifactKey.fromArtifacts(replaceResult.getBoundArtifacts()));
       if (!unboundArtifacts.isEmpty()) {
         throw new IllegalArgumentException(
             String.format(

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/ArtifactKeyTest.java
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/ArtifactKeyTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact.ArtifactBuilder;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class ArtifactKeyTest {
+  private static String TYPE = "docker/image";
+  private static String NAME = "gcr.io/test/test-image";
+  private static String VERSION = "latest";
+  private static String REFERENCE = "gcr.io/test/test-image:latest";
+  private static String ACCOUNT = "docker-registry";
+
+  private static ArtifactBuilder defaultArtifactBuilder() {
+    return Artifact.builder().type(TYPE).name(NAME).version(VERSION).reference(REFERENCE);
+  }
+
+  @Test
+  public void equalsTest() {
+    Artifact artifact1 = defaultArtifactBuilder().build();
+    Artifact artifact2 = defaultArtifactBuilder().build();
+    assertThat(ArtifactKey.fromArtifact(artifact1)).isEqualTo(ArtifactKey.fromArtifact(artifact2));
+  }
+
+  @Test
+  public void equalsWithDifferentAccountsTest() {
+    Artifact artifact1 = defaultArtifactBuilder().artifactAccount(ACCOUNT).build();
+    Artifact artifact2 = defaultArtifactBuilder().build();
+    assertThat(ArtifactKey.fromArtifact(artifact1)).isEqualTo(ArtifactKey.fromArtifact(artifact2));
+  }
+
+  @Test
+  public void differentTypeTest() {
+    Artifact artifact1 = defaultArtifactBuilder().type("gcs/file").build();
+    Artifact artifact2 = defaultArtifactBuilder().build();
+    assertThat(ArtifactKey.fromArtifact(artifact1))
+        .isNotEqualTo(ArtifactKey.fromArtifact(artifact2));
+  }
+
+  @Test
+  public void differentNameTest() {
+    Artifact artifact1 = defaultArtifactBuilder().name("aaa").build();
+    Artifact artifact2 = defaultArtifactBuilder().build();
+    assertThat(ArtifactKey.fromArtifact(artifact1))
+        .isNotEqualTo(ArtifactKey.fromArtifact(artifact2));
+  }
+
+  @Test
+  public void differentVersionTest() {
+    Artifact artifact1 = defaultArtifactBuilder().version("oldest").build();
+    Artifact artifact2 = defaultArtifactBuilder().build();
+    assertThat(ArtifactKey.fromArtifact(artifact1))
+        .isNotEqualTo(ArtifactKey.fromArtifact(artifact2));
+  }
+
+  @Test
+  public void differentLocationTest() {
+    Artifact artifact1 = defaultArtifactBuilder().location("test").build();
+    Artifact artifact2 = defaultArtifactBuilder().build();
+    assertThat(ArtifactKey.fromArtifact(artifact1))
+        .isNotEqualTo(ArtifactKey.fromArtifact(artifact2));
+  }
+
+  @Test
+  public void differentReferenceTest() {
+    Artifact artifact1 = defaultArtifactBuilder().reference("zzz").build();
+    Artifact artifact2 = defaultArtifactBuilder().build();
+    assertThat(ArtifactKey.fromArtifact(artifact1))
+        .isNotEqualTo(ArtifactKey.fromArtifact(artifact2));
+  }
+
+  @Test
+  public void nullSafetyTest() {
+    Artifact artifact1 = defaultArtifactBuilder().build();
+    Artifact artifact2 = Artifact.builder().build();
+    assertThat(ArtifactKey.fromArtifact(artifact1))
+        .isNotEqualTo(ArtifactKey.fromArtifact(artifact2));
+  }
+
+  @Test
+  public void fromArtifactsTest() {
+    Collection<Artifact> artifacts =
+        ImmutableList.of(
+            defaultArtifactBuilder().build(),
+            defaultArtifactBuilder().build(), // duplicate of above entry
+            defaultArtifactBuilder().version("oldest").build(),
+            Artifact.builder().build());
+    ImmutableSet<ArtifactKey> keys = ArtifactKey.fromArtifacts(artifacts);
+    assertThat(keys.size()).isEqualTo(3);
+    assertThat(keys)
+        .containsOnly(
+            ArtifactKey.fromArtifact(defaultArtifactBuilder().build()),
+            ArtifactKey.fromArtifact(defaultArtifactBuilder().version("oldest").build()),
+            ArtifactKey.fromArtifact(Artifact.builder().build()));
+  }
+
+  @Test
+  public void fromArtifactsNullSafety() {
+    ImmutableSet<ArtifactKey> keys = ArtifactKey.fromArtifacts(null);
+    assertThat(keys.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void toStringTest() {
+    ArtifactKey key = ArtifactKey.fromArtifact(defaultArtifactBuilder().build());
+    assertThat(key.toString()).contains(TYPE, NAME, REFERENCE);
+  }
+}


### PR DESCRIPTION
Manual cherry pick of #4078; had to manually update the `.gradle` files due to split of `clouddriver-kubernetes` into v1 and v2 code.

* fix(kubernetes): Fix matching of artifacts in deploy/patch stages

When determining whether the deploy and patch manifest stages bound
all required artifacts, the artifacts in the list of required artifacts
have an artifact account set while those in the list we're trying to
bind don't.

As the .equals function of Artifact includes the account in its
comparison, this means that we don't recognize the replaced artifacts
as the ones we expected to replace and fail the stage.

Trying to fix this more generally is riskier than I'd like to cherry
pick, so as a temporary fix, define a class ArtifactKey that contains
the fields we'd like to use when comparing artifacts and use that
class for the comparison.

* style(kubernetes): Add javadoc explaining ArtifactKey