### PR TITLE
feat(provider/aws): Add roleARN to cloudformation deployments

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeployCloudFormationDescription.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/DeployCloudFormationDescription.java
@@ -29,6 +29,7 @@ public class DeployCloudFormationDescription extends AbstractAmazonCredentialsDe
 
   private String stackName;
   private String templateBody;
+  private String roleARN;
   private Map<String, String> parameters = new HashMap<>();
   private Map<String, String> tags = new HashMap<>();
   private String region;

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeployCloudFormationAtomicOperation.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeployCloudFormationAtomicOperation.java
@@ -57,6 +57,7 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
         amazonClientProvider.getAmazonCloudFormation(
             description.getCredentials(), description.getRegion());
     String template = description.getTemplateBody();
+    String roleARN = description.getRoleARN();
     List<Parameter> parameters =
         description.getParameters().entrySet().stream()
             .map(
@@ -80,6 +81,7 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
           createChangeSet(
               amazonCloudFormation,
               template,
+              roleARN,
               parameters,
               tags,
               description.getCapabilities(),
@@ -89,12 +91,22 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
         log.info("Updating existing stack {}", description);
         stackId =
             updateStack(
-                amazonCloudFormation, template, parameters, tags, description.getCapabilities());
+                amazonCloudFormation,
+                template,
+                roleARN,
+                parameters,
+                tags,
+                description.getCapabilities());
       } else {
         log.info("Creating new stack: {}", description);
         stackId =
             createStack(
-                amazonCloudFormation, template, parameters, tags, description.getCapabilities());
+                amazonCloudFormation,
+                template,
+                roleARN,
+                parameters,
+                tags,
+                description.getCapabilities());
       }
     }
     return Collections.singletonMap("stackId", stackId);
@@ -103,6 +115,7 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
   private String createStack(
       AmazonCloudFormation amazonCloudFormation,
       String template,
+      String roleARN,
       List<Parameter> parameters,
       List<Tag> tags,
       List<String> capabilities) {
@@ -112,6 +125,7 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
         new CreateStackRequest()
             .withStackName(description.getStackName())
             .withParameters(parameters)
+            .withRoleARN(roleARN)
             .withTags(tags)
             .withTemplateBody(template)
             .withCapabilities(capabilities);
@@ -123,6 +137,7 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
   private String updateStack(
       AmazonCloudFormation amazonCloudFormation,
       String template,
+      String roleARN,
       List<Parameter> parameters,
       List<Tag> tags,
       List<String> capabilities) {
@@ -132,6 +147,7 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
         new UpdateStackRequest()
             .withStackName(description.getStackName())
             .withParameters(parameters)
+            .withRoleARN(roleARN)
             .withTags(tags)
             .withTemplateBody(template)
             .withCapabilities(capabilities);
@@ -148,6 +164,7 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
   private String createChangeSet(
       AmazonCloudFormation amazonCloudFormation,
       String template,
+      String roleARN,
       List<Parameter> parameters,
       List<Tag> tags,
       List<String> capabilities,
@@ -159,6 +176,7 @@ public class DeployCloudFormationAtomicOperation implements AtomicOperation<Map>
             .withStackName(description.getStackName())
             .withChangeSetName(description.getChangeSetName())
             .withParameters(parameters)
+            .withRoleARN(roleARN)
             .withTags(tags)
             .withTemplateBody(template)
             .withCapabilities(capabilities)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeployCloudFormationAtomicOperationSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeployCloudFormationAtomicOperationSpec.groovy
@@ -54,6 +54,7 @@ class DeployCloudFormationAtomicOperationSpec extends Specification {
           stackName: "stackTest",
           region: "eu-west-1",
           templateBody: '{"key":"value"}',
+          roleARN: "arn:aws:iam::123456789012:role/test",
           parameters: [ key: "value"],
           tags: [ key: "value" ],
           capabilities: ["cap1", "cap2"],
@@ -73,6 +74,7 @@ class DeployCloudFormationAtomicOperationSpec extends Specification {
     1 * amazonCloudFormation.createStack(_) >> { CreateStackRequest request ->
       assert request.getStackName() == "stackTest"
       assert request.getTemplateBody() == '{"key":"value"}'
+      assert request.getRoleARN() == "arn:aws:iam::123456789012:role/test"
       assert request.getParameters() == [ new Parameter().withParameterKey("key").withParameterValue("value") ]
       assert request.getTags() == [ new Tag().withKey("key").withValue("value") ]
       assert request.getCapabilities() == ["cap1", "cap2"]
@@ -93,6 +95,7 @@ class DeployCloudFormationAtomicOperationSpec extends Specification {
           stackName: "stackTest",
           region: "eu-west-1",
           templateBody: '{"key":"value"}',
+          roleARN: "arn:aws:iam::123456789012:role/test",
           parameters: [ key: "value" ],
           tags: [ key: "value" ],
           capabilities: ["cap1", "cap2"],
@@ -114,6 +117,7 @@ class DeployCloudFormationAtomicOperationSpec extends Specification {
     1 * amazonCloudFormation.updateStack(_) >> { UpdateStackRequest request ->
       assert request.getStackName() == "stackTest"
       assert request.getTemplateBody() == '{"key":"value"}'
+      assert request.getRoleARN() == "arn:aws:iam::123456789012:role/test"
       assert request.getParameters() == [ new Parameter().withParameterKey("key").withParameterValue("value") ]
       assert request.getTags() == [ new Tag().withKey("key").withValue("value") ]
       assert request.getCapabilities() == ["cap1", "cap2"]
@@ -135,6 +139,7 @@ class DeployCloudFormationAtomicOperationSpec extends Specification {
           stackName: "stackTest",
           region: "eu-west-1",
           templateBody: 'key: "value"',
+          roleARN: "arn:aws:iam::123456789012:role/test",
           parameters: [ key: "value" ],
           tags: [ key: "value" ],
           capabilities: ["cap1", "cap2"],
@@ -162,6 +167,7 @@ class DeployCloudFormationAtomicOperationSpec extends Specification {
     1* amazonCloudFormation.createChangeSet(_) >> { CreateChangeSetRequest request ->
       assert request.getStackName() == "stackTest"
       assert request.getTemplateBody() == 'key: "value"'
+      assert request.getRoleARN() == "arn:aws:iam::123456789012:role/test"
       assert request.getParameters() == [ new Parameter().withParameterKey("key").withParameterValue("value") ]
       assert request.getTags() == [ new Tag().withKey("key").withValue("value") ]
       assert request.getCapabilities() == ["cap1", "cap2"]


### PR DESCRIPTION
see https://github.com/spinnaker/spinnaker/issues/5004

Add the ability to specify the roleARN permission in the 'deploy cloudformation' stage.