### PR TITLE
feat(provider/aws): Fix lifecycle hooks racing condition

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -28,6 +28,7 @@ import com.amazonaws.services.autoscaling.model.Tag
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
 import com.amazonaws.services.ec2.model.DescribeSubnetsResult
 import com.amazonaws.services.ec2.model.Subnet
+import com.netflix.spinnaker.clouddriver.aws.model.AmazonAsgLifecycleHook
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
 import com.netflix.spinnaker.clouddriver.aws.model.SubnetData
@@ -95,6 +96,7 @@ class AutoScalingWorker {
   private List<String> availabilityZones
   private List<AmazonBlockDevice> blockDevices
   private Map<String, String> tags
+  private List<AmazonAsgLifecycleHook> lifecycleHooks
 
   private int minInstances
   private int maxInstances
@@ -267,11 +269,23 @@ class AutoScalingWorker {
       throw ex
     }
 
+    if (lifecycleHooks != null && !lifecycleHooks.isEmpty()) {
+      Exception e = retrySupport.retry({ ->
+        task.updateStatus AWS_PHASE, "Creating lifecycle hooks for: $asgName"
+        regionScopedProvider.asgLifecycleHookWorker.attach(task, lifecycleHooks, asgName)
+      }, 10, 1000, false)
+      
+      if (e != null) {
+        task.updateStatus AWS_PHASE, "Unable to attach lifecycle hooks to ASG ($asgName): ${e.message}"
+      }
+    }
+
     if (suspendedProcesses) {
       retrySupport.retry({ ->
         autoScaling.suspendProcesses(new SuspendProcessesRequest(autoScalingGroupName: asgName, scalingProcesses: suspendedProcesses))
       }, 10, 1000, false)
     }
+
     if (enabledMetrics && instanceMonitoring) {
       task.updateStatus AWS_PHASE, "Enabling metrics collection for: $asgName"
       retrySupport.retry({ ->


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5001

Below you can find some Deploy stage logs, which proves that lifecycle hooks are created before scaling out the server group:
```
{ 
   "phase":"AWS_DEPLOY",
   "status":"Beginning Amazon deployment."
},
{ 
   "phase":"AWS_DEPLOY",
   "status":"Beginning ASG deployment."
},
{ 
   "phase":"AWS_DEPLOY",
   "status":"Found ancestor server group, parsing details (name: testaws-stage-v009)"
},
{ 
   "phase":"AWS_DEPLOY",
   "status":"Deploying ASG: testaws-stage-v010"
},
{ 
   "phase":"AWS_DEPLOY",
   "status":" > Deploying to subnetIds: subnet-3d7dd13b,subnet-28b24012,subnet-5bc30543"
},
{ 
   "phase":"AWS_DEPLOY",
   "status":"Creating lifecycle hooks for: testaws-stage-v010"
},
{ 
   "phase":"AWS_DEPLOY",
   "status":"Creating lifecycle hook ({LifecycleHookName: testaws-stage-v010-lifecycle-8b39f839-6c5c-490c-ae3a-58518c1914b5,AutoScalingGroupName: testaws-stage-v010,LifecycleTransition: autoscaling:EC2_INSTANCE_LAUNCHING
},
{ 
   "phase":"AWS_DEPLOY",
   "status":"Creating lifecycle hook ({LifecycleHookName: testaws-stage-v010-lifecycle-08d2b7f7-d8a9-47dd-9157-7d86ee3a81d9,AutoScalingGroupName: testaws-stage-v010,LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
},
{ 
   "phase":"AWS_DEPLOY",
   "status":"Setting size of testaws-stage-v010 in aam-npe/us-east-1 to [min=1, max=1, desired=1]"
},
{ 
   "phase":"DEPLOY",
   "status":"Created the following deployments: [us-east-1:testaws-stage-v010]"
},
{ 
   "phase":"DEPLOY",
   "status":"Server Groups: [us-east-1:testaws-stage-v010] created."
},
{ 
   "phase":"ORCHESTRATION",
   "status":"Orchestration completed."
}
```


Previous logs were something like this (hooks created after scaling out):
```
...
{
"phase": "AWS_DEPLOY",
"status": "Setting size of recommservice-stage-va6-v286 in aam-npe/us-east-1 to [min=1, max=1, desired=1]"
},
{
"phase": "AWS_DEPLOY",
"status": "Creating lifecycle hook ({LifecycleHookName: recommservice-stage-va6-v286-lifecycle-2de43220-adb3-4151-8d81-8f2eb48f1944,AutoScalingGroupName: recommservice-stage-va6-v286,LifecycleTransition: autoscaling:EC2_INSTANCE_LAUNCHING"
},
{
"phase": "AWS_DEPLOY",
"status": "Creating lifecycle hook ({LifecycleHookName: recommservice-stage-va6-v286-lifecycle-ad1c18e1-c573-4914-bb3f-477946bdc067,AutoScalingGroupName: recommservice-stage-va6-v286,LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING"
}
```