### PR TITLE
feat(aws): upgrade awscli

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -21,7 +21,7 @@ RUN wget https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/lin
   ln -sf /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
 
 RUN apk -v --update add py-pip && \
-  pip install --upgrade awscli==1.16.208 s3cmd==2.0.1 python-magic && \
+  pip install --upgrade awscli==1.16.258 s3cmd==2.0.1 python-magic && \
   apk -v --purge del py-pip && \
   rm /var/cache/apk/*
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y curl gnupg && \
       google-cloud-sdk-app-engine-java \
       kubectl \
       python-pip && \
-    pip install awscli==1.16.208 --upgrade && \
+    pip install awscli==1.16.258 --upgrade && \
     rm -rf ~/.config/gcloud
 
 RUN curl -o  /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && \


### PR DESCRIPTION
Bump awscli to a more recent version (https://github.com/aws/aws-cli/releases/tag/1.16.258 release on October 11th)

This allows using the recently added `aws eks get-token` command (added in 1.16.232) for kubernetes auth instead of `aws-iam-authenticator` command. 

see https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
