### PR TITLE
fix(kubernetes/v1): Fix NPE in autoscaler caching

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/api/KubernetesApiConverter.groovy
@@ -820,7 +820,7 @@ class KubernetesApiConverter {
     description.capacity = new Capacity(min: autoscaler.spec.minReplicas,
                                         max: autoscaler.spec.maxReplicas,
                                         desired: description.targetSize)
-    def cpuUtilization = new KubernetesCpuUtilization(target: autoscaler.spec.metrics?.find { metric -> metric.resource.name == "cpu" }?.resource?.targetAverageUtilization)
+    def cpuUtilization = new KubernetesCpuUtilization(target: autoscaler.spec.metrics?.find { metric -> metric?.resource?.name == "cpu" }?.resource?.targetAverageUtilization)
     description.scalingPolicy = new KubernetesScalingPolicy(cpuUtilization: cpuUtilization)
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/autoscaler/UpsertKubernetesAutoscalerAtomicOperation.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/autoscaler/UpsertKubernetesAutoscalerAtomicOperation.groovy
@@ -82,7 +82,7 @@ class UpsertKubernetesAutoscalerAtomicOperation implements AtomicOperation<Void>
       description.scalingPolicy.cpuUtilization = description.scalingPolicy.cpuUtilization ?: new KubernetesCpuUtilization()
       description.scalingPolicy.cpuUtilization.target = description.scalingPolicy.cpuUtilization.target != null ?
         description.scalingPolicy.cpuUtilization.target :
-        autoscaler.spec.metrics?.find { metric -> metric.resource.name == "cpu" }?.resource?.targetAverageUtilization
+        autoscaler.spec.metrics?.find { metric -> metric?.resource?.name == "cpu" }?.resource?.targetAverageUtilization
 
       ((DoneableHorizontalPodAutoscaler) KubernetesApiConverter.toAutoscaler(
         credentials.apiAdaptor.editAutoscaler(namespace, name), description, name, kind, version

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesAutoscalerStatus.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/KubernetesAutoscalerStatus.groovy
@@ -33,7 +33,7 @@ class KubernetesAutoscalerStatus {
     if (autoscaler.status == null) {
       log.warn("Autoscaler on ${autoscaler.metadata.name} has a null status. The replicaset may be missing a CPU request.")
     } else {
-      this.currentCpuUtilization = autoscaler.status.currentMetrics?.find { metric -> metric.resource.name == "cpu" }?.resource?.currentAverageUtilization
+      this.currentCpuUtilization = autoscaler.status.currentMetrics?.find { metric -> metric?.resource?.name == "cpu" }?.resource?.currentAverageUtilization
       this.currentReplicas = autoscaler.status.currentReplicas
       this.desiredReplicas = autoscaler.status.desiredReplicas
       this.lastScaleTime = KubernetesModelUtil.translateTime(autoscaler.status.lastScaleTime)


### PR DESCRIPTION
We are throwing an NPE if the resource field on a metric is null.

This PR is directly against the 1.16 branch as this has already been fixed by bumping the fabric8 library and changing how we look up metrics on master in #4060