### PR TITLE
fix(runJob): fix output on multi container

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -124,10 +124,12 @@ public class KubectlJobExecutor {
     return status.getOutput();
   }
 
-  public String jobLogs(KubernetesV2Credentials credentials, String namespace, String jobName) {
+  public String jobLogs(
+      KubernetesV2Credentials credentials, String namespace, String jobName, String containerName) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
     command.add("logs");
     command.add("job/" + jobName);
+    command.add("-c=" + containerName);
 
     JobResult<String> status = jobExecutor.runJob(new JobRequest(command));
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
@@ -83,14 +83,15 @@ public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatu
   }
 
   public Map<String, Object> getFileContents(
-      String account, String location, String id, String filename) {
+      String account, String location, String id, String containerName) {
     KubernetesV2Credentials credentials =
         (KubernetesV2Credentials)
             accountCredentialsProvider.getCredentials(account).getCredentials();
     Map<String, Object> props = null;
     try {
       V1Job job = getKubernetesJob(account, location, id);
-      String logContents = credentials.jobLogs(location, job.getMetadata().getName());
+      String logContents =
+          credentials.jobLogs(location, job.getMetadata().getName(), containerName);
       props = PropertyParser.extractPropertiesFromLog(logContents);
     } catch (Exception e) {
       log.error("Couldn't parse properties for account {} at {}", account, location);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -452,9 +452,12 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         () -> jobExecutor.logs(this, namespace, podName, containerName));
   }
 
-  public String jobLogs(String namespace, String jobName) {
+  public String jobLogs(String namespace, String jobName, String containerName) {
     return runAndRecordMetrics(
-        "logs", KubernetesKind.JOB, namespace, () -> jobExecutor.jobLogs(this, namespace, jobName));
+        "logs",
+        KubernetesKind.JOB,
+        namespace,
+        () -> jobExecutor.jobLogs(this, namespace, jobName, containerName));
   }
 
   public void scale(KubernetesKind kind, String namespace, String name, int replicas) {


### PR DESCRIPTION
fixes a bug where you couldn't fetch output on jobs with multiple
containers. this was because we weren't specifying the exact container
name to fetch. update the method to take the container name.