### PR TITLE
refactor(kubernetes): remove unnecessary casts to credentials classes

### DIFF
--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/KubernetesKindAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/KubernetesKindAtomicOperationDescription.groovy
@@ -17,13 +17,14 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.description
 
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 
 // Pair of credentials name and associated kubernetes client
 @AutoClone
 @Canonical
-class KubernetesKindAtomicOperationDescription extends KubernetesAtomicOperationDescription {
+class KubernetesKindAtomicOperationDescription extends KubernetesAtomicOperationDescription<KubernetesV1Credentials> {
   String kind
   String apiVersion
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/artifact/KubernetesCleanupArtifactsDescription.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/artifact/KubernetesCleanupArtifactsDescription.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.artifact;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.AllArgsConstructor;
@@ -30,6 +31,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class KubernetesCleanupArtifactsDescription extends KubernetesAtomicOperationDescription {
+public class KubernetesCleanupArtifactsDescription
+    extends KubernetesAtomicOperationDescription<KubernetesV2Credentials> {
   Set<KubernetesManifest> manifests = new HashSet<>();
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/job/KubernetesRunJobOperationDescription.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/job/KubernetesRunJobOperationDescription.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.job;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import lombok.Data;
@@ -25,7 +26,8 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class KubernetesRunJobOperationDescription extends KubernetesAtomicOperationDescription {
+public class KubernetesRunJobOperationDescription
+    extends KubernetesAtomicOperationDescription<KubernetesV2Credentials> {
   String application;
   String namespace = "";
   KubernetesManifest manifest;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesDeployManifestDescription.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.List;
@@ -26,7 +27,8 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class KubernetesDeployManifestDescription extends KubernetesAtomicOperationDescription {
+public class KubernetesDeployManifestDescription
+    extends KubernetesAtomicOperationDescription<KubernetesV2Credentials> {
   @Deprecated private KubernetesManifest manifest;
   private List<KubernetesManifest> manifests;
   private Moniker moniker;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesMultiManifestOperationDescription.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesMultiManifestOperationDescription.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,7 +33,7 @@ import org.apache.commons.lang3.tuple.Pair;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class KubernetesMultiManifestOperationDescription
-    extends KubernetesAtomicOperationDescription {
+    extends KubernetesAtomicOperationDescription<KubernetesV2Credentials> {
   private String manifestName;
   private String location;
   private List<String> kinds = new ArrayList<>();

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesPatchManifestDescription.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesPatchManifestDescription.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPatchOptions;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import lombok.Data;
@@ -28,7 +29,8 @@ import org.apache.commons.lang3.tuple.Pair;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class KubernetesPatchManifestDescription extends KubernetesAtomicOperationDescription {
+public class KubernetesPatchManifestDescription
+    extends KubernetesAtomicOperationDescription<KubernetesV2Credentials> {
   private String manifestName;
   private String location;
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/servergroup/KubernetesServerGroupOperationDescription.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/servergroup/KubernetesServerGroupOperationDescription.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomic
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.tuple.Pair;
@@ -29,7 +30,7 @@ import org.apache.commons.lang3.tuple.Pair;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class KubernetesServerGroupOperationDescription
-    extends KubernetesAtomicOperationDescription {
+    extends KubernetesAtomicOperationDescription<KubernetesV2Credentials> {
   private String serverGroupName;
   private String region; // :(
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -51,7 +51,7 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
   public KubernetesCleanupArtifactsOperation(
       KubernetesCleanupArtifactsDescription description, ArtifactProvider artifactProvider) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
     this.accountName = description.getCredentials().getName();
     this.artifactProvider = artifactProvider;
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -51,7 +51,7 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
   protected AbstractKubernetesEnableDisableManifestOperation(
       KubernetesEnableDisableManifestDescription description) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
   }
 
   private static Task getTask() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
@@ -37,7 +37,7 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
 
   public KubernetesDeleteManifestOperation(KubernetesDeleteManifestDescription description) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
   }
 
   private static Task getTask() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -55,7 +55,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
   public KubernetesDeployManifestOperation(
       KubernetesDeployManifestDescription description, ArtifactProvider provider) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
     this.provider = provider;
     this.accountName = description.getCredentials().getName();
     this.namer =

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
@@ -49,7 +49,7 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
 
   public KubernetesPatchManifestOperation(KubernetesPatchManifestDescription description) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
   }
 
   private static Task getTask() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPauseRolloutManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPauseRolloutManifestOperation.java
@@ -36,7 +36,7 @@ public class KubernetesPauseRolloutManifestOperation implements AtomicOperation<
   public KubernetesPauseRolloutManifestOperation(
       KubernetesPauseRolloutManifestDescription description) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
   }
 
   private static Task getTask() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesResumeRolloutManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesResumeRolloutManifestOperation.java
@@ -36,7 +36,7 @@ public class KubernetesResumeRolloutManifestOperation implements AtomicOperation
   public KubernetesResumeRolloutManifestOperation(
       KubernetesResumeRolloutManifestDescription description) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
   }
 
   private static Task getTask() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesScaleManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesScaleManifestOperation.java
@@ -35,7 +35,7 @@ public class KubernetesScaleManifestOperation implements AtomicOperation<Void> {
 
   public KubernetesScaleManifestOperation(KubernetesScaleManifestDescription description) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
   }
 
   private static Task getTask() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesUndoRolloutManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesUndoRolloutManifestOperation.java
@@ -36,7 +36,7 @@ public class KubernetesUndoRolloutManifestOperation implements AtomicOperation<V
   public KubernetesUndoRolloutManifestOperation(
       KubernetesUndoRolloutManifestDescription description) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
   }
 
   private static Task getTask() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/servergroup/KubernetesResizeServerGroupOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/servergroup/KubernetesResizeServerGroupOperation.java
@@ -35,7 +35,7 @@ public class KubernetesResizeServerGroupOperation implements AtomicOperation<Voi
 
   public KubernetesResizeServerGroupOperation(KubernetesResizeServerGroupDescription description) {
     this.description = description;
-    this.credentials = (KubernetesV2Credentials) description.getCredentials().getCredentials();
+    this.credentials = description.getCredentials().getCredentials();
   }
 
   private static Task getTask() {


### PR DESCRIPTION
- Per the wisdom of @ezimanyi, [this PR](https://github.com/spinnaker/clouddriver/pull/4100) parameterized `KubernetesAtomicOperationDescription` so we would not have to cast the credentials object to either V1 or V2. This PR explicitly parameterizes the other extensions of `KubernetesAtomicOperationDescription` and removes casting wherever possible.
- P.S. This was so much more straightforward now that all the V1-only and V2-only code is in separate modules! :house_with_garden: :nail_care: :bento: 