### PR TITLE
chore(dependencies): upgrade kork

### DIFF
--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -13,8 +13,7 @@ dependencies {
   implementation "org.codehaus.groovy:groovy-all"
   implementation "org.apache.commons:commons-lang3"
   implementation "com.google.apis:google-api-services-compute"
-  // Move this to spinnaker-dependencies when we can confirm we'll use this feature.
-  implementation "com.google.apis:google-api-services-iam:v1-rev267-1.25.0"
+  implementation "com.google.apis:google-api-services-iam"
   implementation 'com.google.auth:google-auth-library-oauth2-http'
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spectator:spectator-api"

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
@@ -44,8 +44,8 @@ import com.google.api.services.compute.model.NamedPort;
 import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.ServiceAccount;
 import com.google.api.services.compute.model.StatefulPolicy;
-import com.google.api.services.compute.model.StatefulPolicyPreservedDisk;
-import com.google.api.services.compute.model.StatefulPolicyPreservedResources;
+import com.google.api.services.compute.model.StatefulPolicyPreservedState;
+import com.google.api.services.compute.model.StatefulPolicyPreservedStateDiskDevice;
 import com.google.api.services.compute.model.Tags;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -111,11 +111,11 @@ class AbstractGoogleServerGroupCachingAgentTest {
             .setTargetSize(3)
             .setStatefulPolicy(
                 new StatefulPolicy()
-                    .setPreservedResources(
-                        new StatefulPolicyPreservedResources()
+                    .setPreservedState(
+                        new StatefulPolicyPreservedState()
                             .setDisks(
-                                ImmutableList.of(
-                                    new StatefulPolicyPreservedDisk().setDeviceName("myDisk")))))
+                                ImmutableMap.of(
+                                    "myDisk", new StatefulPolicyPreservedStateDiskDevice()))))
             .setAutoHealingPolicies(
                 ImmutableList.of(
                     new InstanceGroupManagerAutoHealingPolicy().setInitialDelaySec(92)));

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 includeCloudProviders=all
 fiatVersion=1.7.2
 enablePublishing=false
-korkVersion=6.14.3
+korkVersion=6.15.0
 spinnakerGradleVersion=7.0.2
 org.gradle.parallel=true


### PR DESCRIPTION
I don't know why we I was using these deprecated (and now deleted)
classes in the tests; we don't use them in the actual stateful disk
code. (The test is just making sure we copy statefulPolicy over, so
doesn't really care what is in it.)