### PR TITLE
feat(kubernetes): permit multiple ReplicaSets to be deployed with a s…

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -98,8 +98,6 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
 
     Set<Artifact> boundArtifacts = new HashSet<>();
 
-    validateManifestsForRolloutStrategies(inputManifests);
-
     for (KubernetesManifest manifest : inputManifests) {
       if (credentials.getKindRegistry().getKindProperties(manifest.getKind()).isNamespaced()) {
         if (!StringUtils.isEmpty(description.getNamespaceOverride())) {
@@ -249,15 +247,6 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
 
   private void applyTraffic(KubernetesManifestTraffic traffic, KubernetesManifest target) {
     traffic.getLoadBalancers().forEach(l -> attachLoadBalancer(l, target));
-  }
-
-  private void validateManifestsForRolloutStrategies(List<KubernetesManifest> manifests) {
-    long numReplicaSets =
-        manifests.stream().filter(m -> m.getKind().equals(KubernetesKind.REPLICA_SET)).count();
-    if (description.getStrategy() != null && numReplicaSets != 1) {
-      throw new RuntimeException(
-          "Spinnaker can manage traffic for one ReplicaSet only. Please deploy one ReplicaSet manifest or disable rollout strategies.");
-    }
   }
 
   private void attachLoadBalancer(String loadBalancerName, KubernetesManifest target) {


### PR DESCRIPTION
…ingle rollout strategy config

Closes https://github.com/spinnaker/spinnaker/issues/5025

Corresponding PRs:
Deck: https://github.com/spinnaker/deck/pull/7574
Orca: https://github.com/spinnaker/orca/pull/3264

- Previously, we restricted users to deploying a single ReplicaSet when configuring Spinnaker-managed rollout strategies. This removes that restriction so that users generating a multi-manifest with tools like Kustomize can configure multiple ReplicaSets to be deployed with the same rollout strategy.
- The cost of removing this restriction is potential confusion in the case where a user did not intend to apply the rollout strategy to multiple workloads, but I think this is acceptable and we can consider further warning messages if we receive feedback that this is confusing.
- This change does _not_ allow you to configure multiple rollout strategies and associate each with a workload. Each Deploy (Manifest) stage has _one_ associated rollout strategy config that will be associated with _each_ ReplicaSet it deploys.

![dca05054-1db8-493c-8fa6-67c7749a0899](https://user-images.githubusercontent.com/15936279/67718192-9d91aa00-f9a5-11e9-96e1-b1755307d9f0.gif)