### PR TITLE
fix(kubernetes): Fix all agents caching cluster-scoped resources

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ReaderConsumer.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ReaderConsumer.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.jobs.local;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import javax.annotation.Nonnull;
 
 /**
  * Transforms a stream into an object of arbitrary type using a supplied BufferReader for the
@@ -26,5 +27,6 @@ import java.io.IOException;
  * <p>Implementations are responsible for closing the supplied BufferReader.
  */
 public interface ReaderConsumer<T> {
+  @Nonnull
   T consume(BufferedReader r) throws IOException;
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentIntervalAware;
 import com.netflix.spinnaker.cats.agent.CacheResult;
@@ -31,6 +32,8 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesCachingPoli
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.RegistryUtils;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindProperties.ResourceScope;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor.KubectlException;
@@ -40,8 +43,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -74,27 +80,57 @@ public abstract class KubernetesV2CachingAgent
 
   protected abstract List<KubernetesKind> primaryKinds();
 
+  private ImmutableList<KubernetesManifest> loadResources(
+      @Nonnull Iterable<KubernetesKind> kubernetesKinds, Optional<String> optionalNamespace) {
+    String namespace = optionalNamespace.orElse(null);
+    try {
+      return credentials.list(ImmutableList.copyOf(kubernetesKinds), namespace);
+    } catch (KubectlException e) {
+      log.warn(
+          "{}: Failed to read kind {} from namespace {}: {}",
+          getAgentType(),
+          kubernetesKinds,
+          namespace,
+          e.getMessage());
+      throw e;
+    }
+  }
+
+  @Nonnull
+  private ImmutableList<KubernetesManifest> loadNamespaceScopedResources(
+      @Nonnull Iterable<KubernetesKind> kubernetesKinds) {
+    return getNamespaces()
+        .parallelStream()
+        .map(n -> loadResources(kubernetesKinds, Optional.of(n)))
+        .flatMap(Collection::stream)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  @Nonnull
+  private ImmutableList<KubernetesManifest> loadClusterScopedResources(
+      @Nonnull Iterable<KubernetesKind> kubernetesKinds) {
+    return loadResources(kubernetesKinds, Optional.empty());
+  }
+
+  private ImmutableSetMultimap<ResourceScope, KubernetesKind> primaryKindsByScope() {
+    return primaryKinds().stream()
+        .collect(
+            ImmutableSetMultimap.toImmutableSetMultimap(
+                k -> credentials.getKindRegistry().getKindProperties(k).getResourceScope(),
+                Function.identity()));
+  }
+
   protected Map<KubernetesKind, List<KubernetesManifest>> loadPrimaryResourceList() {
-    List<KubernetesKind> primaryKinds = primaryKinds();
+    ImmutableSetMultimap<ResourceScope, KubernetesKind> kindsByScope = primaryKindsByScope();
+
     Map<KubernetesKind, List<KubernetesManifest>> result =
-        getNamespaces()
-            .parallelStream()
-            .map(
-                n -> {
-                  try {
-                    return credentials.list(primaryKinds, n);
-                  } catch (KubectlException e) {
-                    log.warn(
-                        "{}: Failed to read kind {} from namespace {}: {}",
-                        getAgentType(),
-                        primaryKinds,
-                        n,
-                        e.getMessage());
-                    throw e;
-                  }
-                })
-            .filter(Objects::nonNull)
-            .flatMap(Collection::stream)
+        Stream.concat(
+                loadClusterScopedResources(
+                    kindsByScope.get(KubernetesKindProperties.ResourceScope.CLUSTER))
+                    .stream(),
+                loadNamespaceScopedResources(
+                    kindsByScope.get(KubernetesKindProperties.ResourceScope.NAMESPACE))
+                    .stream())
             .collect(Collectors.groupingBy(KubernetesManifest::getKind));
 
     for (KubernetesCachingPolicy policy : credentials.getCachingPolicies()) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -109,7 +109,11 @@ public abstract class KubernetesV2CachingAgent
   @Nonnull
   private ImmutableList<KubernetesManifest> loadClusterScopedResources(
       @Nonnull Iterable<KubernetesKind> kubernetesKinds) {
-    return loadResources(kubernetesKinds, Optional.empty());
+    if (handleClusterScopedResources()) {
+      return loadResources(kubernetesKinds, Optional.empty());
+    } else {
+      return ImmutableList.of();
+    }
   }
 
   private ImmutableSetMultimap<ResourceScope, KubernetesKind> primaryKindsByScope() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindProperties.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindProperties.java
@@ -99,4 +99,13 @@ public class KubernetesKindProperties {
   public boolean hasClusterRelationship() {
     return this.hasClusterRelationship;
   }
+
+  public ResourceScope getResourceScope() {
+    return isNamespaced ? ResourceScope.NAMESPACE : ResourceScope.CLUSTER;
+  }
+
+  public enum ResourceScope {
+    CLUSTER,
+    NAMESPACE;
+  }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -405,7 +405,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         "get", kind, namespace, () -> jobExecutor.get(this, kind, namespace, name));
   }
 
-  public List<KubernetesManifest> list(KubernetesKind kind, String namespace) {
+  @Nonnull
+  public ImmutableList<KubernetesManifest> list(KubernetesKind kind, String namespace) {
     return runAndRecordMetrics(
         "list",
         kind,
@@ -415,7 +416,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
                 this, Collections.singletonList(kind), namespace, new KubernetesSelectorList()));
   }
 
-  public List<KubernetesManifest> list(
+  @Nonnull
+  public ImmutableList<KubernetesManifest> list(
       KubernetesKind kind, String namespace, KubernetesSelectorList selectors) {
     return runAndRecordMetrics(
         "list",
@@ -424,9 +426,10 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         () -> jobExecutor.list(this, Collections.singletonList(kind), namespace, selectors));
   }
 
-  public List<KubernetesManifest> list(List<KubernetesKind> kinds, String namespace) {
+  @Nonnull
+  public ImmutableList<KubernetesManifest> list(List<KubernetesKind> kinds, String namespace) {
     if (kinds.isEmpty()) {
-      return new ArrayList<>();
+      return ImmutableList.of();
     } else {
       return runAndRecordMetrics(
           "list",
@@ -436,7 +439,9 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     }
   }
 
-  public List<KubernetesManifest> eventsFor(KubernetesKind kind, String namespace, String name) {
+  @Nonnull
+  public ImmutableList<KubernetesManifest> eventsFor(
+      KubernetesKind kind, String namespace, String name) {
     return runAndRecordMetrics(
         "list",
         KubernetesKind.EVENT,

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.security
 
+import com.google.common.collect.ImmutableList
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
@@ -117,11 +118,11 @@ class KubernetesV2CredentialsSpec extends Specification {
         namespaces: [NAMESPACE],
         checkPermissionsOnStartup: true,
       ))
-    kubectlJobExecutor.list(_ as KubernetesV2Credentials, [KubernetesKind.DEPLOYMENT], NAMESPACE, _ as KubernetesSelectorList) >> {
+    kubectlJobExecutor.list(_ as KubernetesV2Credentials, ImmutableList.of(KubernetesKind.DEPLOYMENT), NAMESPACE, _ as KubernetesSelectorList) >> {
       throw new KubectlJobExecutor.KubectlException("Error", new Exception())
     }
-    kubectlJobExecutor.list(_ as KubernetesV2Credentials, [KubernetesKind.REPLICA_SET], NAMESPACE, _ as KubernetesSelectorList) >> {
-      return Collections.emptyList()
+    kubectlJobExecutor.list(_ as KubernetesV2Credentials, ImmutableList.of(KubernetesKind.REPLICA_SET), NAMESPACE, _ as KubernetesSelectorList) >> {
+      return ImmutableList.of()
     }
 
     expect:

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -494,16 +494,6 @@ final class KubernetesCoreCachingAgentTest {
     LoadDataResult loadDataResult = processLoadData(cachingAgents, ImmutableMap.of());
 
     assertThat(loadDataResult.getResults()).containsKey(DEPLOYMENT_KIND);
-    assertThat(loadDataResult.getResults().get(DEPLOYMENT_KIND))
-        .extracting(data -> data.getAttributes().get("name"))
-        .containsExactly(DEPLOYMENT_NAME);
-
-    assertThat(loadDataResult.getResults()).containsKey(STORAGE_CLASS_KIND);
-    assertThat(loadDataResult.getResults().get(STORAGE_CLASS_KIND))
-        .extracting(data -> data.getAttributes().get("name"))
-        .containsExactly(STORAGE_CLASS_NAME);
-
-    assertThat(loadDataResult.getResults()).containsKey(DEPLOYMENT_KIND);
     Collection<CacheData> deployments = loadDataResult.getResults().get(DEPLOYMENT_KIND);
     assertThat(deployments).extracting(CacheData::getId).containsExactly(deploymentKey);
     assertThat(deployments)

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -501,7 +501,7 @@ final class KubernetesCoreCachingAgentTest {
     assertThat(loadDataResult.getResults()).containsKey(STORAGE_CLASS_KIND);
     assertThat(loadDataResult.getResults().get(STORAGE_CLASS_KIND))
         .extracting(data -> data.getAttributes().get("name"))
-        .contains(STORAGE_CLASS_NAME);
+        .containsExactly(STORAGE_CLASS_NAME);
 
     assertThat(loadDataResult.getResults()).containsKey(DEPLOYMENT_KIND);
     Collection<CacheData> deployments = loadDataResult.getResults().get(DEPLOYMENT_KIND);
@@ -515,7 +515,7 @@ final class KubernetesCoreCachingAgentTest {
     assertThat(storageClasses).extracting(CacheData::getId).contains(storageClassKey);
     assertThat(storageClasses)
         .extracting(storageClass -> storageClass.getAttributes().get("name"))
-        .contains(STORAGE_CLASS_NAME);
+        .containsExactly(STORAGE_CLASS_NAME);
   }
 
   /**


### PR DESCRIPTION
* refactor(kubernetes): Minor refactor of core caching agent test 

  Pull some common logic out of ProcessOnDemandResult so that it can be reused when we need to process the results of a loadData request in an upcoming commit.

* test(kubernetes): Add tests to loadData in core caching agent 

  There are no tests of loadData() in the KubernetesCoreCachingAgent; add a simple test that validates a namespaced and cluster-scoped kind can be succesfully cached (ie, is returned from loadData and is persisted to the cache).

* refactor(kubernetes): Immutable collections and nonnull annotations 

  Make a few collections returned by the kubernetes caching agent immutable, and add some nonnull annotations that simplify the work of calling code.

* refactor(kubernetes): Split caching of resources by scope 

  This commit splits the work to cache kubernetes objects into two functions: the first caches namespace-scoped objects for all namespaces relevant for the caching agent, and the second caches all cluster-scoped resources.

  This means that we'll no longer try to read the cluster-scoped resources once per namespace and will read them once per caching agent.

* fix(kubernetes): Fix all agents caching cluster-scoped resources 

  Currently all caching agents are caching cluster-scoped resources; this should be delegated to a single agent so that we don't duplicate work.
