### PR TITLE
fix(kubernetes): surface dockerRegistries to credentials endpoint

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.CustomKubernetesResource;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesCachingPolicy;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubeconfigFileHasher;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentialFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
@@ -398,6 +399,11 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
             customResource ->
                 kindMap.put(customResource.getKubernetesKind(), customResource.getSpinnakerKind()));
     return kindMap;
+  }
+
+  @Override
+  public List<LinkedDockerRegistryConfiguration> getDockerRegistries() {
+    return Collections.emptyList();
   }
 
   public KubernetesManifest get(KubernetesKind kind, String namespace, String name) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.security;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration;
 import java.util.List;
 import java.util.Map;
 
@@ -24,4 +25,6 @@ public interface KubernetesCredentials {
   List<String> getDeclaredNamespaces();
 
   Map<String, String> getSpinnakerKindMap();
+
+  List<LinkedDockerRegistryConfiguration> getDockerRegistries();
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.security;
 import static lombok.EqualsAndHashCode.Include;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties.ManagedAccount;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
@@ -86,5 +87,9 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials>
 
   public Map<String, String> getSpinnakerKindMap() {
     return credentials.getSpinnakerKindMap();
+  }
+
+  public List<LinkedDockerRegistryConfiguration> getDockerRegistries() {
+    return credentials.getDockerRegistries();
   }
 }


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5048

Deck expects Kubernetes V1 accounts to include `dockerRegistries`, so that when it searches for images, it can [filter by the registry configured on that account](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/kubernetes/src/v1/serverGroup/configure/configuration.service.js#L271). I think in one of the account refactors we lost `dockerRegistries` as a `KubernetesNamedAccountCredentials` property so it wasn't being exposed to the `/credentials` endpoint anymore. I handled it the same way we're handling `spinnakerKindMap` (which I think similarly is a property we need exposed as a top level property so it's returned with `/credentials` but is only relevant to one provider version?) but LMK if you see a better way!