### PR TITLE
fix(kubernetes): Fix mis-spelled API group

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model;
 
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.EXTENSIONS_V1BETA1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.NETWORKING_K8S_IO_V1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1;
 
@@ -50,7 +51,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class KubernetesV2SecurityGroup extends ManifestBasedModel implements SecurityGroup {
   private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
-      ImmutableSet.of(NETWORKING_K8S_IO_V1BETA1, NETWORKING_K8S_IO_V1);
+      ImmutableSet.of(EXTENSIONS_V1BETA1, NETWORKING_K8S_IO_V1BETA1, NETWORKING_K8S_IO_V1);
 
   private KubernetesManifest manifest;
   private Keys.InfrastructureCacheKey key;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesApiVersion.java
@@ -30,9 +30,9 @@ public class KubernetesApiVersion {
   public static final KubernetesApiVersion EXTENSIONS_V1BETA1 =
       new KubernetesApiVersion("extensions/v1beta1");
   public static final KubernetesApiVersion NETWORKING_K8S_IO_V1 =
-      new KubernetesApiVersion("network.k8s.io/v1");
+      new KubernetesApiVersion("networking.k8s.io/v1");
   public static final KubernetesApiVersion NETWORKING_K8S_IO_V1BETA1 =
-      new KubernetesApiVersion("network.k8s.io/v1beta1");
+      new KubernetesApiVersion("networking.k8s.io/v1beta1");
   public static final KubernetesApiVersion APPS_V1 = new KubernetesApiVersion("apps/v1");
   public static final KubernetesApiVersion APPS_V1BETA1 = new KubernetesApiVersion("apps/v1beta1");
   public static final KubernetesApiVersion APPS_V1BETA2 = new KubernetesApiVersion("apps/v1beta2");

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesApiVersionSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesApiVersionSpec.groovy
@@ -31,12 +31,12 @@ class KubernetesApiVersionSpec extends Specification {
     apiVersion.equals(expectedApiGroup)
 
     where:
-    name                     | expectedApiGroup
-    null                     | KubernetesApiVersion.NONE
-    ""                       | KubernetesApiVersion.NONE
-    "v1"                     | KubernetesApiVersion.V1
-    "network.k8s.io/v1beta1" | KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1
-    "neTwoRk.k8s.io/v1beTA1" | KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1
+    name                        | expectedApiGroup
+    null                        | KubernetesApiVersion.NONE
+    ""                          | KubernetesApiVersion.NONE
+    "v1"                        | KubernetesApiVersion.V1
+    "networking.k8s.io/v1beta1" | KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1
+    "neTwoRkiNG.k8s.io/v1beTA1" | KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1
   }
 
   @Unroll


### PR DESCRIPTION
The networking.k8s.io API group is mis-spelled as network.k8s.io; fix this. This bug is preventing security groups from being cached by clouddriver.

We also should accept extensions/v1beta1 as the API group, which can still be returned from clusters running Kubernetes < 1.16.