### PR TITLE
fix(titus): allow setting jobGroupDetails and jobGroupStack for Titus…

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
@@ -570,17 +570,19 @@ public class JobDescription {
     Capacity.Builder jobCapacity = Capacity.newBuilder();
     jobCapacity.setMin(instancesMin).setMax(instancesMax).setDesired(instancesDesired);
 
-    if (type.equals("service")) {
-      JobGroupInfo.Builder jobGroupInfoBuilder = JobGroupInfo.newBuilder();
-      if (jobGroupStack != null) {
-        jobGroupInfoBuilder.setStack(jobGroupStack);
-      }
-      if (jobGroupDetail != null) {
-        jobGroupInfoBuilder.setDetail(jobGroupDetail);
-      }
+    JobGroupInfo.Builder jobGroupInfoBuilder = JobGroupInfo.newBuilder();
+    if (jobGroupStack != null) {
+      jobGroupInfoBuilder.setStack(jobGroupStack);
+    }
+    if (jobGroupDetail != null) {
+      jobGroupInfoBuilder.setDetail(jobGroupDetail);
+    }
+    if (jobGroupSequence != null) {
       jobGroupInfoBuilder.setSequence(jobGroupSequence);
-      jobDescriptorBuilder.setJobGroupInfo(jobGroupInfoBuilder);
+    }
+    jobDescriptorBuilder.setJobGroupInfo(jobGroupInfoBuilder);
 
+    if (type.equals("service")) {
       if (inService == null) {
         inService = true;
       }


### PR DESCRIPTION
At one point in 2018 we disabled setting the job group detail and stack for batch jobs under the incorrect assumption that it was increasing the time for deploying Titus instances. 

This PR restores the ability to set job group details, stack and sequence number which is available in the Titus API. 