### PR TITLE
fix(aws): Protect against huge upsert security group operations

### DIFF
--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
@@ -164,7 +164,7 @@ class SqlTaskRepository(
     withPool(POOL_NAME) {
       jooq.transactional { ctx ->
         val state = selectLatestState(ctx, task.id)
-        addToHistory(ctx, historyId, task.id, state?.state ?: STARTED, phase, status)
+        addToHistory(ctx, historyId, task.id, state?.state ?: STARTED, phase, status.take(MAX_STATUS_LENGTH))
       }
     }
   }
@@ -320,5 +320,6 @@ class SqlTaskRepository(
   companion object {
     private val ulid = ULID()
     private val POOL_NAME = ConnectionPools.TASKS.value
+    private val MAX_STATUS_LENGTH = 10_000
   }
 }


### PR DESCRIPTION
We had an upsert security group operation that changed enough rules in a single security group that the generated status was longer than 65,365 characters, lol.

1. Changed the specific status message to truncate to a count after an arbitrary count of ip rule changes.
2. Added protections in the SQL repository (much below the text column max) that will truncate the status before it hits the database, just in case there are other places where this may happen.