### PR TITLE
fix(caching): Config to disable fully qualified caching agents

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlAgentProperties.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlAgentProperties.kt
@@ -20,6 +20,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("sql.agent")
 class SqlAgentProperties {
   var enabledPattern: String = ".*"
+
+  /**
+   * Optionally disable specific agents based on their fully qualified name
+   */
+  var disabledAgents: List<String> = emptyList()
+
   var maxConcurrentAgents: Int = 100
   var agentLockAcquisitionIntervalSeconds: Long = 1
   var poll: SqlPollProperties = SqlPollProperties()

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlAgentSchedulerConfiguration.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlAgentSchedulerConfiguration.kt
@@ -51,6 +51,7 @@ class SqlAgentSchedulerConfiguration {
       nodeStatusProvider = nodeStatusProvider,
       dynamicConfigService = dynamicConfigService,
       enabledAgentPattern = sqlAgentProperties.enabledPattern,
+      disabledAgentsConfig = sqlAgentProperties.disabledAgents,
       tableNamespace = tableNamespace,
       agentLockAcquisitionIntervalSeconds = sqlAgentProperties.agentLockAcquisitionIntervalSeconds
     )


### PR DESCRIPTION
This works in conjunction with the pattern matcher to enable caching agents (which I think is still useful, just not something we should have available to dynamic configuration)
