### PR TITLE
fix(kubernetes): do not throw NPE on NetworkPolicies with null ingres…

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
@@ -115,6 +115,9 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
   }
 
   private static Set<Rule> inboundRules(V1NetworkPolicy policy) {
+    if (policy.getSpec().getIngress() == null) {
+      return Collections.emptySet();
+    }
     return policy.getSpec().getIngress().stream()
         .map(i -> i.getPorts().stream().map(KubernetesV2SecurityGroup::fromPolicyPort))
         .flatMap(s -> s)
@@ -122,6 +125,9 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
   }
 
   private static Set<Rule> outboundRules(V1NetworkPolicy policy) {
+    if (policy.getSpec().getEgress() == null) {
+      return Collections.emptySet();
+    }
     return policy.getSpec().getEgress().stream()
         .map(i -> i.getPorts().stream().map(KubernetesV2SecurityGroup::fromPolicyPort))
         .flatMap(s -> s)


### PR DESCRIPTION
…s and egress

Closes https://github.com/spinnaker/spinnaker/issues/5121

- It is valid for Kubernetes `NetworkPolicy` resource specs to have empty or omitted `ingress` and `egress` fields. In fact, when `ingress` or `egress` is set to `[]`, Kubernetes actually nulls the field out rather than preserving the empty array.
- Clouddriver's Kubernetes V2 caching logic uses the `V1NetworkPolicySpec` model from the Kubernetes Java client library to deserialize `NetworkPolicies`, [which defaults `ingress` and `egress` to `null`](https://github.com/kubernetes-client/java/blob/master/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicySpec.java#L42). It looks like we were expecting the default to be an empty list. Currently, `/securityGroups` requests fail if you've deployed any `NetworkPolicy` with empty `ingress` or `egress` because we'll always throw an NPE when trying to `stream` these fields.