### PR TITLE
fix(kubernetes): Add missing limitrange kind (#4170)

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKind.java
@@ -58,6 +58,8 @@ public class KubernetesKind {
   public static final KubernetesKind INGRESS =
       createWithAlias("ingress", null, KubernetesApiGroup.NETWORKING_K8S_IO);
   public static final KubernetesKind JOB = createWithAlias("job", null, KubernetesApiGroup.BATCH);
+  public static final KubernetesKind LIMIT_RANGE =
+      createWithAlias("limitRange", null, KubernetesApiGroup.NONE);
   public static final KubernetesKind MUTATING_WEBHOOK_CONFIGURATION =
       createWithAlias(
           "mutatingWebhookConfiguration", null, KubernetesApiGroup.ADMISSIONREGISTRATION_K8S_IO);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindProperties.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindProperties.java
@@ -44,6 +44,7 @@ public class KubernetesKindProperties {
         new KubernetesKindProperties(KubernetesKind.HORIZONTAL_POD_AUTOSCALER, true, false),
         new KubernetesKindProperties(KubernetesKind.INGRESS, true, true),
         new KubernetesKindProperties(KubernetesKind.JOB, true, false),
+        new KubernetesKindProperties(KubernetesKind.LIMIT_RANGE, true, false),
         new KubernetesKindProperties(KubernetesKind.MUTATING_WEBHOOK_CONFIGURATION, false, false),
         new KubernetesKindProperties(KubernetesKind.NAMESPACE, false, false),
         new KubernetesKindProperties(KubernetesKind.NETWORK_POLICY, true, true),

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesLimitRangeHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesLimitRangeHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_MODIFIER_PRIORITY;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCoreCachingAgent;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentFactory;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
+import javax.annotation.Nonnull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KubernetesLimitRangeHandler extends KubernetesHandler {
+  @Override
+  public int deployPriority() {
+    return WORKLOAD_MODIFIER_PRIORITY.getValue();
+  }
+
+  @Nonnull
+  @Override
+  public KubernetesKind kind() {
+    return KubernetesKind.LIMIT_RANGE;
+  }
+
+  @Override
+  public boolean versioned() {
+    return false;
+  }
+
+  @Nonnull
+  @Override
+  public SpinnakerKind spinnakerKind() {
+    return SpinnakerKind.UNCLASSIFIED;
+  }
+
+  @Override
+  public Status status(KubernetesManifest manifest) {
+    return new Status();
+  }
+
+  @Override
+  protected KubernetesV2CachingAgentFactory cachingAgentFactory() {
+    return KubernetesCoreCachingAgent::new;
+  }
+}


### PR DESCRIPTION
Manual :cherries: :pick: of #4170 because @spinnakerbot is ghosting me. This applied cleanly so I'm not sure why @spinnakerbot is ignoring me.

Deployments containing a limitrange time out waiting for the manifest to appear, as clouddriver is missing the entry for this kind.

Ideally there would be a better way of auto-detecting kinds like this (particularly ones that don't need any custom logic) but for now just adding another Handler to handle this.