### PR TITLE
feat(kubernetes): do not set replicas to 1 when removed

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -33,11 +33,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
-import io.kubernetes.client.models.V1Deployment;
-import io.kubernetes.client.models.V1DeploymentCondition;
-import io.kubernetes.client.models.V1DeploymentStatus;
-import javax.annotation.Nonnull;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.model.Manifest.Status;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -64,6 +62,24 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
         Replacer.secretEnv(),
         Replacer.configMapKeyValue(),
         Replacer.secretKeyValue());
+  }
+
+  @Override
+  public OperationResult deploy(KubernetesV2Credentials credentials, KubernetesManifest manifest) {
+    Double replicas = manifest.getReplicas();
+
+    KubernetesManifest prevManifest =
+        credentials.getLastApplied(manifest.getKind(), manifest.getNamespace(), manifest.getName());
+    if (prevManifest != null) {
+      Double prevReplicas = prevManifest.getReplicas();
+
+      if (replicas == null && prevReplicas != null && prevReplicas > 0) {
+        prevManifest.setReplicas(null);
+        credentials.setLastApplied(prevManifest);
+      }
+    }
+
+    return super.deploy(credentials, manifest);
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -576,6 +576,22 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         () -> jobExecutor.patch(this, kind, namespace, name, options, patches));
   }
 
+  public KubernetesManifest getLastApplied(KubernetesKind kind, String namespace, String name) {
+    return runAndRecordMetrics(
+        "view-last-applied",
+        kind,
+        namespace,
+        () -> jobExecutor.getLastApplied(this, kind, namespace, name));
+  }
+
+  public void setLastApplied(KubernetesManifest manifest) {
+    runAndRecordMetrics(
+        "set-last-applied",
+        manifest.getKind(),
+        manifest.getNamespace(),
+        () -> jobExecutor.setLastApplied(this, manifest));
+  }
+
   private <T> T runAndRecordMetrics(
       String action, KubernetesKind kind, String namespace, Supplier<T> op) {
     return runAndRecordMetrics(action, Collections.singletonList(kind), namespace, op);


### PR DESCRIPTION
WIP

When adding a horizontal pod autoscaler, it is typical to remove the
replicas: N from the Deployment specification. Unfortunately, that will
set the pod count to 1 on the subsequent deployment. This PR is an early
attempt at preventing that by explicitly patching the
last-applied-configuration in kubernetes.

For more details about this issue (and the original proposed workaround in kubernetes that I'm drawing this from, please look at: https://github.com/kubernetes/kubernetes/issues/25238#issuecomment-406415297

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
