### PR TITLE
refactor(docker): Remove unused getTags() function

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
@@ -327,24 +327,6 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
     return this.credentials?.client?.basicAuth ?: ""
   }
 
-  @JsonIgnore
-  List<String> getTags(String repository) {
-    def tags = credentials.client.getTags(repository).tags
-    if (sortTagsByDate) {
-      tags = tags.parallelStream().map({
-        tag -> try {
-          [date: credentials.client.getCreationDate(repository, tag), tag: tag]
-        } catch (Exception e) {
-          log.warn("Unable to fetch tag creation date, reason: {} (tag: {}, repository: {})", e.message, tag, repository)
-          return [date: new Date(0), tag: tag]
-        }
-      }).toArray().sort {
-        it.date
-      }.reverse().tag
-    }
-    tags
-  }
-
   String getV2Endpoint() {
     return "$address/v2"
   }


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5002 though that issue no longer actually manifests since 1.15 due to the fact this code has been unused since then.

The function getTags() in DockerRegistryNamedAccountCredentials has a bug. Depending on whether we return from the try or the catch block, we'll get either an Instant or a Date, which we then put into a single array and try to sort. In some cases this can lead to an error 'Comparison method violates its general contract' when we try to sort this heterogenous array.

While fixing this, I realized that this function is completely unused since #3809, so just removing the function instead of fixing it.