### PR TITLE
perf(kubernetes): improve pendingOnDemandRequests lookups when a scoped manifest is provided

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineLoadBalancerCachingAgent.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineLoadBalancerCachingAgent.groovy
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.provider.view.MutableCacheData
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
 import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
@@ -82,7 +83,7 @@ class AppengineLoadBalancerCachingAgent extends AbstractAppengineCachingAgent im
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == AppengineCloudProvider.ID
   }
 
@@ -210,7 +211,7 @@ class AppengineLoadBalancerCachingAgent extends AbstractAppengineCachingAgent im
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(ON_DEMAND.ns)
     keys = keys.findResults {
       def parse = Keys.parse(it)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineServerGroupCachingAgent.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/provider/agent/AppengineServerGroupCachingAgent.groovy
@@ -42,6 +42,8 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.provider.view.MutableCacheData
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 import static com.netflix.spinnaker.clouddriver.appengine.cache.Keys.Namespace.*
@@ -89,7 +91,7 @@ class AppengineServerGroupCachingAgent extends AbstractAppengineCachingAgent imp
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == AppengineCloudProvider.ID
   }
 
@@ -406,7 +408,7 @@ class AppengineServerGroupCachingAgent extends AbstractAppengineCachingAgent imp
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(ON_DEMAND.ns)
     keys = keys.findResults {
       def parse = Keys.parse(it)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AbstractAmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AbstractAmazonLoadBalancerCachingAgent.groovy
@@ -37,6 +37,8 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
@@ -121,14 +123,14 @@ abstract class AbstractAmazonLoadBalancerCachingAgent implements CachingAgent, O
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == amazonCloudProvider.id
   }
 
   abstract CacheResult loadDataInternal(ProviderCache providerCache)
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return []
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
@@ -43,6 +43,8 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 import com.netflix.spinnaker.clouddriver.core.provider.agent.HealthProvidingCachingAgent
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
@@ -382,7 +384,7 @@ class AmazonApplicationLoadBalancerCachingAgent extends AbstractAmazonLoadBalanc
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     Collection<String> keys = providerCache.filterIdentifiers(
       ON_DEMAND.ns,
       Keys.getLoadBalancerKey("*", "*", "*", "*", "*")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgent.java
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent;
 import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -79,7 +80,8 @@ public class AmazonCloudFormationCachingAgent
   }
 
   @Override
-  public boolean handles(OnDemandType type, String cloudProvider) {
+  public boolean handles(
+      OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     return OnDemandType.CloudFormation.equals(type) && cloudProvider.equals(AmazonCloudProvider.ID);
   }
 
@@ -113,7 +115,8 @@ public class AmazonCloudFormationCachingAgent
   }
 
   @Override
-  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  public Collection<Map> pendingOnDemandRequests(
+      ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return Collections.emptyList();
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonSecurityGroupCachingAgent.groovy
@@ -38,6 +38,8 @@ import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.ON_DEMAND
 import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.SECURITY_GROUPS
@@ -125,7 +127,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == AmazonCloudProvider.ID
   }
 
@@ -164,7 +166,7 @@ class AmazonSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Ac
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return []
   }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -55,6 +55,8 @@ import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.*
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
 import com.netflix.spinnaker.cats.agent.CacheResult
@@ -169,7 +171,7 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == amazonCloudProvider.id
   }
 
@@ -456,7 +458,7 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.filterIdentifiers(ON_DEMAND.ns, Keys.getServerGroupKey("*", "*", account.name, region))
     return fetchPendingOnDemandRequests(providerCache, keys)
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonCloudFormationCachingAgentSpec.groovy
@@ -206,7 +206,7 @@ class AmazonCloudFormationCachingAgentSpec extends Specification {
   @Unroll
   void "OnDemand request should be handled for type '#onDemandType' and provider '#provider': '#expected'"() {
     when:
-    def result = agent.handles(onDemandType, provider)
+    def result = agent.handles(onDemandType, provider, Collections.emptyMap())
 
     then:
     result == expected

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/cache/AzureCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/cache/AzureCachingAgent.groovy
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.clouddriver.azure.resources.common.cache.provider.A
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
 
+import javax.annotation.Nonnull
+
 abstract class AzureCachingAgent implements CachingAgent, OnDemandAgent, AccountAware {
 
   protected static ON_DEMAND_UPDATED = "OnDemandUpdated"
@@ -84,7 +86,7 @@ abstract class AzureCachingAgent implements CachingAgent, OnDemandAgent, Account
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == getOnDemandType() && cloudProvider == azureCloudProvider.id
   }
 
@@ -92,7 +94,7 @@ abstract class AzureCachingAgent implements CachingAgent, OnDemandAgent, Account
   abstract OnDemandAgent.OnDemandResult handle(ProviderCache providerCache, Map<String, ? extends Object> data)
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return []
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/cache/AzureAppGatewayCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/cache/AzureAppGatewayCachingAgent.groovy
@@ -40,6 +40,8 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import groovy.transform.WithWriteLock
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 
 @Slf4j
@@ -84,7 +86,7 @@ class AzureAppGatewayCachingAgent extends AzureCachingAgent {
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == azureCloudProvider.id
   }
 
@@ -138,7 +140,7 @@ class AzureAppGatewayCachingAgent extends AzureCachingAgent {
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return []
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/cache/AzureLoadBalancerCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/cache/AzureLoadBalancerCachingAgent.groovy
@@ -39,6 +39,8 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import groovy.transform.WithWriteLock
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 
 @Slf4j
@@ -97,7 +99,7 @@ class AzureLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, Acco
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == azureCloudProvider.id
   }
 
@@ -153,7 +155,7 @@ class AzureLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, Acco
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return []
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/cache/AzureSecurityGroupCachingAgent.groovy
@@ -39,6 +39,8 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandMetricsSupport
 import groovy.transform.WithWriteLock
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 
 @Slf4j
@@ -97,7 +99,7 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == azureCloudProvider.id
   }
 
@@ -153,7 +155,7 @@ class AzureSecurityGroupCachingAgent implements CachingAgent, OnDemandAgent, Acc
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return []
   }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -33,6 +33,8 @@ import com.netflix.spinnaker.clouddriver.azure.common.cache.MutableCacheData
 import com.netflix.spinnaker.clouddriver.azure.resources.common.cache.Keys
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancer
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.clouddriver.azure.resources.common.cache.Keys.Namespace.*
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
@@ -166,7 +168,7 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(AZURE_ON_DEMAND.ns)
     keys = keys.findAll {
       def key = Keys.parse(azureCloudProvider, it)

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgent.java
@@ -44,6 +44,7 @@ import io.vavr.collection.HashMap;
 import java.time.Clock;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -265,7 +266,8 @@ public class CloudFoundryCachingAgent implements CachingAgent, OnDemandAgent, Ac
   }
 
   @Override
-  public boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  public boolean handles(
+      OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     return type.equals(OnDemandAgent.OnDemandType.ServerGroup)
         && cloudProvider.equals(CloudFoundryProvider.PROVIDER_ID);
   }
@@ -309,7 +311,8 @@ public class CloudFoundryCachingAgent implements CachingAgent, OnDemandAgent, Ac
   }
 
   @Override
-  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  public Collection<Map> pendingOnDemandRequests(
+      ProviderCache providerCache, @Nonnull Map<String, String> data) {
     Collection<String> keys =
         providerCache.filterIdentifiers(
             ON_DEMAND.getNs(), Keys.getServerGroupKey(account, "*", "*"));

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgentTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryCachingAgentTest.java
@@ -226,7 +226,8 @@ class CloudFoundryCachingAgentTest {
                     "processedTime", processedTime)
                 .toJavaMap());
 
-    Collection<Map> result = cloudFoundryCachingAgent.pendingOnDemandRequests(mockProviderCache);
+    Collection<Map> result =
+        cloudFoundryCachingAgent.pendingOnDemandRequests(mockProviderCache, Collections.emptyMap());
 
     assertThat(result).isEqualTo(expectedResult);
     verify(mockProviderCache)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/NoopOnDemandCacheUpdater.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/NoopOnDemandCacheUpdater.groovy
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.clouddriver.cache
 
 import org.springframework.stereotype.Component
 
+import javax.annotation.Nonnull
+
 /**
  * A default, no-op implementation of an {@link OnDemandCacheUpdater}
  */
@@ -25,7 +27,7 @@ import org.springframework.stereotype.Component
 class NoopOnDemandCacheUpdater implements OnDemandCacheUpdater {
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     false
   }
 
@@ -37,7 +39,7 @@ class NoopOnDemandCacheUpdater implements OnDemandCacheUpdater {
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  Collection<Map> pendingOnDemandRequests(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     return []
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandAgent.java
@@ -22,8 +22,10 @@ import com.netflix.spinnaker.moniker.Moniker;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +57,7 @@ public interface OnDemandAgent {
     }
   }
 
-  boolean handles(OnDemandType type, String cloudProvider);
+  boolean handles(OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data);
 
   static class OnDemandResult {
     String sourceAgentType;
@@ -101,10 +103,12 @@ public interface OnDemandAgent {
 
   OnDemandResult handle(ProviderCache providerCache, Map<String, ?> data);
 
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache);
+  Collection<Map> pendingOnDemandRequests(
+      ProviderCache providerCache, @Nonnull Map<String, String> data);
 
   default Map pendingOnDemandRequest(ProviderCache providerCache, String id) {
-    Collection<Map> pendingOnDemandRequests = pendingOnDemandRequests(providerCache);
+    Collection<Map> pendingOnDemandRequests =
+        pendingOnDemandRequests(providerCache, Collections.emptyMap());
     return pendingOnDemandRequests.stream()
         .filter(m -> id.equals(m.get("id")))
         .findFirst()

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandCacheUpdater.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/OnDemandCacheUpdater.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.clouddriver.cache
 
+import javax.annotation.Nonnull
+
 /**
  * An on-demand cache updater. Allows some non-scheduled trigger to initiate a cache refresh for a given type. An on-demand cache request will fan-out to all available updaters.
  *
@@ -32,9 +34,10 @@ interface OnDemandCacheUpdater {
    * Indicates if the updater is able to handle this on-demand request given the type and cloudProvider
    * @param type
    * @param cloudProvider
+   * @param data
    * @return
    */
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider)
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data)
 
   /**
    * Handles the update request
@@ -44,7 +47,7 @@ interface OnDemandCacheUpdater {
    */
   OnDemandCacheResult handle(OnDemandAgent.OnDemandType type, String cloudProvider, Map<String, ? extends Object> data)
 
-  Collection<Map> pendingOnDemandRequests(OnDemandAgent.OnDemandType type, String cloudProvider)
+  Collection<Map> pendingOnDemandRequests(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data)
 
   Map pendingOnDemandRequest(OnDemandAgent.OnDemandType type, String cloudProvider, String id)
 

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosLoadBalancerCachingAgent.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosLoadBalancerCachingAgent.groovy
@@ -39,6 +39,8 @@ import mesosphere.dcos.client.DCOS
 import mesosphere.marathon.client.model.v2.App
 import mesosphere.marathon.client.model.v2.GetAppNamespaceResponse
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 
 @Slf4j
@@ -178,7 +180,7 @@ class DcosLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, DcosC
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(Keys.Namespace.ON_DEMAND.ns)
     keys = keys.findResults {
       def parse = Keys.parse(it)
@@ -203,7 +205,7 @@ class DcosLoadBalancerCachingAgent implements CachingAgent, OnDemandAgent, DcosC
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     OnDemandAgent.OnDemandType.LoadBalancer == type && cloudProvider == dcosCloudProvider.id
   }
 

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosServerGroupCachingAgent.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/provider/agent/DcosServerGroupCachingAgent.groovy
@@ -41,6 +41,8 @@ import mesosphere.dcos.client.DCOS
 import mesosphere.marathon.client.model.v2.App
 import mesosphere.marathon.client.model.v2.GetAppNamespaceResponse
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 
@@ -158,7 +160,7 @@ class DcosServerGroupCachingAgent implements CachingAgent, OnDemandAgent, DcosCl
   }
 
   @Override
-  boolean handles(final OnDemandAgent.OnDemandType type, final String cloudProvider) {
+  boolean handles(final OnDemandAgent.OnDemandType type, final String cloudProvider, @Nonnull Map<String, String> data) {
     return OnDemandAgent.OnDemandType.ServerGroup == type && cloudProvider == dcosCloudProvider.id
   }
 
@@ -235,7 +237,7 @@ class DcosServerGroupCachingAgent implements CachingAgent, OnDemandAgent, DcosCl
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(final ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(final ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(Keys.Namespace.ON_DEMAND.ns)
     keys = keys.findResults {
       def parse = Keys.parse(it)

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsOnDemandAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/AbstractEcsOnDemandAgent.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 abstract class AbstractEcsOnDemandAgent<T> extends AbstractEcsCachingAgent<T>
     implements OnDemandAgent {
@@ -58,7 +59,8 @@ abstract class AbstractEcsOnDemandAgent<T> extends AbstractEcsCachingAgent<T>
   }
 
   @Override
-  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  public Collection<Map> pendingOnDemandRequests(
+      ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return new LinkedList<>();
   }
 
@@ -68,7 +70,8 @@ abstract class AbstractEcsOnDemandAgent<T> extends AbstractEcsCachingAgent<T>
   }
 
   @Override
-  public boolean handles(OnDemandType type, String cloudProvider) {
+  public boolean handles(
+      OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     return type.equals(OnDemandType.ServerGroup) && cloudProvider.equals(EcsCloudProvider.ID);
   }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskCachingAgent.java
@@ -46,6 +46,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,7 +106,8 @@ public class TaskCachingAgent extends AbstractEcsOnDemandAgent<Task> {
   }
 
   @Override
-  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  public Collection<Map> pendingOnDemandRequests(
+      ProviderCache providerCache, @Nonnull Map<String, String> data) {
     Collection<CacheData> allOnDemand = providerCache.getAll(ON_DEMAND.toString());
     List<Map> returnResults = new LinkedList<>();
     for (CacheData onDemand : allOnDemand) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleLoadBalancerCachingAgent.groovy
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import groovy.transform.Canonical
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
 import java.util.concurrent.TimeUnit
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
@@ -73,7 +74,7 @@ abstract class AbstractGoogleLoadBalancerCachingAgent extends AbstractGoogleCach
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.LoadBalancer && cloudProvider == GoogleCloudProvider.ID
   }
 
@@ -152,7 +153,7 @@ abstract class AbstractGoogleLoadBalancerCachingAgent extends AbstractGoogleCach
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keyOwnedByThisAgent = { Map<String, String> parsedKey ->
       parsedKey && parsedKey.account == accountName && parsedKey.region == region
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalLoadBalancerCachingAgent.groovy
@@ -35,6 +35,8 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.clouddriver.google.batch.GoogleBatchRequest
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 @Slf4j
 class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachingAgent {
 
@@ -61,7 +63,7 @@ class GoogleInternalLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerC
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     // Just let GoogleNetworkLoadBalancerCachingAgent return the pending regional on demand requests.
     []
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleRegionalServerGroupCachingAgent.groovy
@@ -48,6 +48,7 @@ import com.netflix.spinnaker.moniker.Moniker
 import groovy.transform.Canonical
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
 import java.util.concurrent.TimeUnit
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
@@ -171,7 +172,7 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.ServerGroup && cloudProvider == GoogleCloudProvider.ID
   }
 
@@ -233,7 +234,7 @@ class GoogleRegionalServerGroupCachingAgent extends AbstractGoogleCachingAgent i
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keyOwnedByThisAgent = { Map<String, String> parsedKey ->
       parsedKey && parsedKey.account == accountName && parsedKey.region == region && !parsedKey.zone
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSecurityGroupCachingAgent.groovy
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import groovy.transform.Canonical
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
 import java.util.concurrent.TimeUnit
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
@@ -69,7 +70,7 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == GoogleCloudProvider.ID
   }
 
@@ -146,7 +147,7 @@ class GoogleSecurityGroupCachingAgent extends AbstractGoogleCachingAgent impleme
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keyOwnedByThisAgent = { Map<String, String> parsedKey ->
       parsedKey && parsedKey.account == accountName && parsedKey.region == "global"
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleSslLoadBalancerCachingAgent.groovy
@@ -37,6 +37,8 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.clouddriver.google.batch.GoogleBatchRequest
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 @Slf4j
 class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachingAgent {
 
@@ -62,7 +64,7 @@ class GoogleSslLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     // Just let GoogleHttpLoadBalancerCachingAgent return the pending global on demand requests.
     []
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleTcpLoadBalancerCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleTcpLoadBalancerCachingAgent.groovy
@@ -37,6 +37,8 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.clouddriver.google.batch.GoogleBatchRequest
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 @Slf4j
 class GoogleTcpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachingAgent {
 
@@ -62,7 +64,7 @@ class GoogleTcpLoadBalancerCachingAgent extends AbstractGoogleLoadBalancerCachin
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     // Just let GoogleHttpLoadBalancerCachingAgent return the pending global on demand requests.
     []
   }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleZonalServerGroupCachingAgent.groovy
@@ -52,6 +52,7 @@ import com.netflix.spinnaker.moniker.Moniker
 import groovy.transform.Canonical
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
 import java.util.concurrent.TimeUnit
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
@@ -199,7 +200,7 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
   }
 
   @Override
-  boolean handles(OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandType.ServerGroup && cloudProvider == GoogleCloudProvider.ID
   }
 
@@ -271,7 +272,7 @@ class GoogleZonalServerGroupCachingAgent extends AbstractGoogleCachingAgent impl
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keyOwnedByThisAgent = { Map<String, String> parsedKey ->
       parsedKey && parsedKey.account == accountName && parsedKey.region == region && parsedKey.zone
     }

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesControllersCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesControllersCachingAgent.groovy
@@ -41,6 +41,8 @@ import io.kubernetes.client.models.V1PodList
 import io.kubernetes.client.models.V1beta1DaemonSet
 import io.kubernetes.client.models.V1beta1StatefulSet
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 
@@ -82,7 +84,7 @@ class KubernetesControllersCachingAgent extends KubernetesV1CachingAgent impleme
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     OnDemandAgent.OnDemandType.ServerGroup == type && cloudProvider == KubernetesCloudProvider.ID
   }
 
@@ -169,7 +171,7 @@ class KubernetesControllersCachingAgent extends KubernetesV1CachingAgent impleme
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(Keys.Namespace.ON_DEMAND.ns)
     keys = keys.findResults {
       def parse = Keys.parse(it)

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgent.groovy
@@ -35,6 +35,8 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Cred
 import groovy.util.logging.Slf4j
 import io.fabric8.kubernetes.api.model.Service
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 
@@ -134,7 +136,7 @@ class KubernetesLoadBalancerCachingAgent extends KubernetesV1CachingAgent implem
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(Keys.Namespace.ON_DEMAND.ns)
     keys = keys.findResults {
       def parse = Keys.parse(it)
@@ -159,7 +161,7 @@ class KubernetesLoadBalancerCachingAgent extends KubernetesV1CachingAgent implem
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     OnDemandAgent.OnDemandType.LoadBalancer == type && cloudProvider == KubernetesCloudProvider.ID
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesSecurityGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesSecurityGroupCachingAgent.groovy
@@ -35,6 +35,8 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Cred
 import groovy.util.logging.Slf4j
 import io.fabric8.kubernetes.api.model.extensions.Ingress
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 
@@ -135,7 +137,7 @@ class KubernetesSecurityGroupCachingAgent extends KubernetesV1CachingAgent imple
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(Keys.Namespace.ON_DEMAND.ns)
     keys = keys.findResults {
       def parse = Keys.parse(it)
@@ -160,7 +162,7 @@ class KubernetesSecurityGroupCachingAgent extends KubernetesV1CachingAgent imple
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     ON_DEMAND_TYPE == type && cloudProvider == KubernetesCloudProvider.ID
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgent.groovy
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgent.groovy
@@ -42,6 +42,8 @@ import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.ReplicationController
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
 
@@ -160,7 +162,7 @@ class KubernetesServerGroupCachingAgent extends KubernetesV1CachingAgent impleme
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     def keys = providerCache.getIdentifiers(Keys.Namespace.ON_DEMAND.ns)
     keys = keys.findResults {
       def parse = Keys.parse(it)
@@ -190,7 +192,7 @@ class KubernetesServerGroupCachingAgent extends KubernetesV1CachingAgent impleme
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     OnDemandAgent.OnDemandType.ServerGroup == type && cloudProvider == KubernetesCloudProvider.ID
   }
 

--- a/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -44,6 +44,7 @@ import com.netflix.spinnaker.moniker.Namer;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -350,12 +351,14 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
   }
 
   @Override
-  public boolean handles(OnDemandType type, String cloudProvider) {
+  public boolean handles(
+      OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     return type == Manifest && cloudProvider.equals(KubernetesCloudProvider.getID());
   }
 
   @Override
-  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  public Collection<Map> pendingOnDemandRequests(
+      ProviderCache providerCache, @Nonnull Map<String, String> data) {
     if (!handleReadRequests()) {
       return Collections.emptyList();
     }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesLoadBalancerCachingAgentSpec.groovy
@@ -61,7 +61,7 @@ class KubernetesLoadBalancerCachingAgentSpec extends Specification {
   @Unroll
   void "correctly reports #type/#provider is handled by the load balancer caching agent (#result)"() {
     expect:
-    cachingAgent.handles(type, provider) == result
+    cachingAgent.handles(type, provider, Collections.emptyMap()) == result
 
     where:
     type                                     | provider                   || result

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesServerGroupCachingAgentSpec.groovy
@@ -133,7 +133,7 @@ class KubernetesServerGroupCachingAgentSpec extends Specification {
   @Unroll
   void "correctly reports #type/#provider is handled by the server group caching agent (#result)"() {
     expect:
-    cachingAgent.handles(type, provider) == result
+    cachingAgent.handles(type, provider, Collections.emptyMap()) == result
 
     where:
     type                                     | provider                   || result

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesV1SecurityGroupCachingAgentSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/agent/KubernetesV1SecurityGroupCachingAgentSpec.groovy
@@ -60,7 +60,7 @@ class KubernetesV1SecurityGroupCachingAgentSpec extends Specification {
   @Unroll
   void "correctly reports #type/#provider is handled by the security group caching agent (#result)"() {
     expect:
-    cachingAgent.handles(type, provider) == result
+    cachingAgent.handles(type, provider, Collections.emptyMap()) == result
 
     where:
     type                                     | provider                   || result

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/provider/agent/OracleSecurityGroupCachingAgent.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/provider/agent/OracleSecurityGroupCachingAgent.groovy
@@ -27,6 +27,8 @@ import com.oracle.bmc.core.requests.ListSecurityListsRequest
 import com.oracle.bmc.core.requests.ListVcnsRequest
 import groovy.util.logging.Slf4j
 
+import javax.annotation.Nonnull
+
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.clouddriver.oracle.cache.Keys.Namespace.SECURITY_GROUPS
 
@@ -67,12 +69,12 @@ class OracleSecurityGroupCachingAgent extends AbstractOracleCachingAgent impleme
   }
 
   @Override
-  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  Collection<Map> pendingOnDemandRequests(ProviderCache providerCache, @Nonnull Map<String, String> data) {
     return []
   }
 
   @Override
-  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider) {
+  boolean handles(OnDemandAgent.OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     type == OnDemandAgent.OnDemandType.SecurityGroup && cloudProvider == OracleCloudProvider.ID
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
@@ -62,6 +62,7 @@ import com.netflix.titus.grpc.protogen.ScalingPolicyStatus;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import javax.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,7 +179,8 @@ public class TitusV2ClusterCachingAgent
   }
 
   @Override
-  public boolean handles(OnDemandType type, String cloudProvider) {
+  public boolean handles(
+      OnDemandType type, String cloudProvider, @Nonnull Map<String, String> data) {
     return type == OnDemandType.ServerGroup && cloudProvider.equals(TitusCloudProvider.ID);
   }
 
@@ -521,7 +523,8 @@ public class TitusV2ClusterCachingAgent
   }
 
   @Override
-  public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
+  public Collection<Map> pendingOnDemandRequests(
+      ProviderCache providerCache, @Nonnull Map<String, String> data) {
     Set<String> keys =
         providerCache.getIdentifiers("onDemand").stream()
             .filter(

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
@@ -40,7 +40,7 @@ class CacheController {
     OnDemandAgent.OnDemandType onDemandType = getOnDemandType(type);
 
     def onDemandCacheResult = onDemandCacheUpdaters.find {
-      it.handles(onDemandType, cloudProvider)
+      it.handles(onDemandType, cloudProvider, Collections.emptyMap())
     }?.handle(onDemandType, cloudProvider, data)
 
     def cacheStatus = onDemandCacheResult?.status
@@ -65,16 +65,16 @@ class CacheController {
   @RequestMapping(method = RequestMethod.GET, value = "/{cloudProvider}/{type}")
   Collection<Map> pendingOnDemands(@PathVariable String cloudProvider,
                                    @PathVariable String type,
-                                   @RequestParam(value = "id", required = false) String id) {
+                                   @RequestParam(required = false) Map<String, String> data) {
     OnDemandAgent.OnDemandType onDemandType = getOnDemandType(type)
     onDemandCacheUpdaters.findAll {
-      it.handles(onDemandType, cloudProvider)
+      it.handles(onDemandType, cloudProvider, data)
     }?.collect {
-      if (id) {
-        def pendingOnDemandRequest = it.pendingOnDemandRequest(onDemandType, cloudProvider, id)
+      if (data.id) {
+        def pendingOnDemandRequest = it.pendingOnDemandRequest(onDemandType, cloudProvider, data.id)
         return pendingOnDemandRequest ? [ pendingOnDemandRequest ] : []
       }
-      return it.pendingOnDemandRequests(onDemandType, cloudProvider)
+      return it.pendingOnDemandRequests(onDemandType, cloudProvider, data)
     }.flatten()
   }
 


### PR DESCRIPTION
changes are split into two commits. it's probably easier to review them separately.

- f2d6fbe
this introduces a new parameter called `data` (`Map<String, String>`) to `handle()` and `pendingOnDemandRequests()` methods in `OnDemandCacheUpdater` and `OnDemandAgent` interfaces. this is done primary to allow `CacheController` endpoint to accept parameters other than `id` and pass them to agents. primary motivation here was to use these new arguments in `KubernetesV2OnDemandCachingAgent`.

- d7b5fad
this updates `KubernetesV2OnDemandCachingAgent#pendingOnDemandRequests` to
make use of the newly introduced parameter mentioned above. in order to preserve the current functionality, method uses presence of scoped manifest fields in data parameter (account and name) to determine whether or not to derive `matchingKeys` without any cache lookups. when a scoped manifest is provided, we use `InfrastructureCacheKey.createKey` to derive the key we need to look up in the cache.

with these changes, @fkyc and i have seen substantial increase in # of concurrent k8s deploys (100 -> 700) we can do without pegging redis CPU utilization at 100% as it eliminates the need to do a scan and then multi-get.

note that this is against `1.15.x` which doesn't have some of the other perf improvements made since then. if these changes look reasonable, we will be submitting another patch against master.