### PR TITLE
fix(kubernetes): do not throw NPE on NetworkPolicies with ingresses w…

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
@@ -32,9 +32,13 @@ import com.netflix.spinnaker.clouddriver.model.SecurityGroup;
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupSummary;
 import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule;
 import io.kubernetes.client.models.V1NetworkPolicy;
+import io.kubernetes.client.models.V1NetworkPolicyEgressRule;
+import io.kubernetes.client.models.V1NetworkPolicyIngressRule;
 import io.kubernetes.client.models.V1NetworkPolicyPort;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -119,8 +123,10 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
       return Collections.emptySet();
     }
     return policy.getSpec().getIngress().stream()
-        .map(i -> i.getPorts().stream().map(KubernetesV2SecurityGroup::fromPolicyPort))
-        .flatMap(s -> s)
+        .map(V1NetworkPolicyIngressRule::getPorts)
+        .filter(Objects::nonNull)
+        .flatMap(Collection::stream)
+        .map(KubernetesV2SecurityGroup::fromPolicyPort)
         .collect(Collectors.toSet());
   }
 
@@ -129,8 +135,10 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
       return Collections.emptySet();
     }
     return policy.getSpec().getEgress().stream()
-        .map(i -> i.getPorts().stream().map(KubernetesV2SecurityGroup::fromPolicyPort))
-        .flatMap(s -> s)
+        .map(V1NetworkPolicyEgressRule::getPorts)
+        .filter(Objects::nonNull)
+        .flatMap(Collection::stream)
+        .map(KubernetesV2SecurityGroup::fromPolicyPort)
         .collect(Collectors.toSet());
   }
 


### PR DESCRIPTION
…ith null ports

Similar to #4172, the code is assuming that a NetworkPolicy that has an ingress
will return an empty list of ports, but instead it defaults to null for this[1]
and so crashes.

[1] https://github.com/kubernetes-client/java/blob/master/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicyIngressRule.java#L45
