### PR TITLE
fix(docker): Fix sorting array of non-comparable types

### DIFF
--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -3,9 +3,13 @@ dependencies {
   implementation project(":clouddriver-security")
   implementation project(":cats:cats-core")
 
+  compileOnly "org.projectlombok:lombok"
+  testCompile "org.projectlombok:lombok"
+
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.codehaus.groovy:groovy-all"
+  implementation "com.google.guava:guava"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:retrofit"
@@ -16,6 +20,11 @@ dependencies {
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
+  testImplementation "org.junit.platform:junit-platform-runner"
+  testImplementation "org.mockito:mockito-core"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
@@ -329,15 +329,12 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
     return this.credentials?.client?.basicAuth ?: ""
   }
 
+  @CompileStatic
   @JsonIgnore
   List<String> getTags(String repository) {
     def tags = credentials.client.getTags(repository).tags
     if (sortTagsByDate) {
-      tags = tags.parallelStream().map({
-        tag -> [date: getCreationDate(repository, tag), tag: tag]
-      }).toArray().sort {
-        it.date
-      }.reverse().tag
+      tags = KeyBasedSorter.sort(tags, { String t -> getCreationDate(repository, t)}, Comparator.reverseOrder())
     }
     tags
   }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/KeyBasedSorter.java
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/KeyBasedSorter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.security;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This class implements a Schwartzian transform to sort the elements of an array on a sort key
+ * while guaranteeing that the sort key will only be computed once per element, and is thus suitable
+ * for cases where computation of the sort key is expensive.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
+public final class KeyBasedSorter {
+  /**
+   * Sorts a collection and returns the result as an array without modifying the input collection.
+   * The sort is performed by first extracting a sort key using the supplied extractor, then
+   * comparing the sort keys using the supplied comparator.
+   *
+   * <p>The algorithm is guaranteed to only apply the extractor once per method, and is thus
+   * suitable for cases where this computation is expensive. It may execute the extractor in
+   * parallel.
+   *
+   * @param input The collection to sort
+   * @param extractor A function to extract a sort key from each element of the input collection
+   * @param comparator A comparator that defines an ordering on the sort keys
+   * @param <T> The class of objects in the collection to be sorted
+   * @param <U> The class of the sort key extracted from objects in the collection
+   * @return A list containing the sorted elements of the collection
+   */
+  public static <T, U> List<T> sort(
+      Collection<T> input, Function<T, U> extractor, Comparator<U> comparator) {
+    return input
+        .parallelStream()
+        .map(t -> new ElementWithComparisonField<>(t, extractor.apply(t)))
+        .sorted(Comparator.comparing(ElementWithComparisonField::getComparisonField, comparator))
+        .map(ElementWithComparisonField::getElement)
+        .collect(Collectors.toList());
+  }
+
+  @AllArgsConstructor
+  @Getter
+  private static class ElementWithComparisonField<P, Q> {
+    private P element;
+    private Q comparisonField;
+  }
+}

--- a/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentialsTest.java
+++ b/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentialsTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerOkClientProvider;
+import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryTags;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import retrofit.client.OkClient;
+import retrofit.client.Request;
+import retrofit.client.Response;
+import retrofit.mime.TypedString;
+
+@RunWith(JUnitPlatform.class)
+final class DockerRegistryNamedAccountCredentialsTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final String ACCOUNT_NAME = "test-account";
+  private static final String REPO_NAME = "myrepo";
+  private static Instant LATEST_DATE = Instant.ofEpochSecond(1500000000L);
+
+  @Test
+  void getTags() throws IOException {
+    ImmutableList<String> tags = ImmutableList.of("latest", "other", "something");
+    OkClient okClient = mockDockerOkClient(tags, ImmutableMap.of());
+    DockerRegistryNamedAccountCredentials credentials =
+        new DockerRegistryNamedAccountCredentials.Builder()
+            .accountName(ACCOUNT_NAME)
+            .address("https://gcr.io")
+            .dockerOkClientProvider(new MockDockerOkClientProvider(okClient))
+            .build();
+    assertThat(credentials.getTags(REPO_NAME)).containsExactlyInAnyOrderElementsOf(tags);
+  }
+
+  @Test
+  void getTagsInOrder() throws IOException {
+    ImmutableList<String> tags = ImmutableList.of("older", "nodate", "oldest", "latest");
+    ImmutableMap<String, Instant> creationDates =
+        ImmutableMap.of(
+            "latest",
+            LATEST_DATE,
+            "older",
+            LATEST_DATE.minus(Duration.ofSeconds(1)),
+            "oldest",
+            LATEST_DATE.minus(Duration.ofDays(1)));
+
+    OkClient okClient = mockDockerOkClient(tags, creationDates);
+    DockerRegistryNamedAccountCredentials credentials =
+        new DockerRegistryNamedAccountCredentials.Builder()
+            .accountName(ACCOUNT_NAME)
+            .address("https://gcr.io")
+            .sortTagsByDate(true)
+            .dockerOkClientProvider(new MockDockerOkClientProvider(okClient))
+            .build();
+    assertThat(credentials.getTags(REPO_NAME))
+        .containsExactly("latest", "older", "oldest", "nodate");
+  }
+
+  /**
+   * Generates a mock OkClient that simulates responses from a docker registry with the supplied
+   * tags and supplied creation dates for each tag. Tags that are not present in the map of creation
+   * dates will return null as their creation date.
+   */
+  private static OkClient mockDockerOkClient(
+      Iterable<String> tags, Map<String, Instant> creationDates) throws IOException {
+    OkClient okClient = mock(OkClient.class);
+    doReturn(
+            new Response(
+                "https://gcr.io/v2/myrepo/tags/list",
+                200,
+                "",
+                Collections.emptyList(),
+                new TypedString(objectMapper.writeValueAsString(getTagsResponse(tags)))))
+        .when(okClient)
+        .execute(argThat(r -> r.getUrl().equals("https://gcr.io/v2/myrepo/tags/list")));
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                Request request = (Request) args[0];
+                String tag = getTag(request.getUrl());
+                Instant optionalDate = creationDates.get(tag);
+                return new Response(
+                    "https://gcr.io/v2/myrepo/manifests/latest",
+                    200,
+                    "",
+                    Collections.emptyList(),
+                    new TypedString(
+                        objectMapper.writeValueAsString(
+                            DockerManifestResponse.withCreationDate(optionalDate))));
+              }
+
+              private String getTag(String url) {
+                Matcher matcher =
+                    Pattern.compile("https://gcr.io/v2/myrepo/manifests/(.*)").matcher(url);
+                if (matcher.matches()) {
+                  return matcher.group(1);
+                }
+                throw new IllegalArgumentException();
+              }
+            })
+        .when(okClient)
+        .execute(argThat(r -> r.getUrl().matches("https://gcr.io/v2/myrepo/manifests/.*")));
+
+    return okClient;
+  }
+
+  private static DockerRegistryTags getTagsResponse(Iterable<String> tags) {
+    DockerRegistryTags tagsResponse = new DockerRegistryTags();
+    tagsResponse.setName(REPO_NAME);
+    tagsResponse.setTags(ImmutableList.copyOf(tags));
+    return tagsResponse;
+  }
+
+  /**
+   * Helper class for generating the response from a call to the /manifests docker endpoint. At this
+   * point, the only field we look at is the created timestamp, so we only send this part of the
+   * response.
+   */
+  @Getter
+  @RequiredArgsConstructor
+  private static class DockerManifestResponse {
+    private final ImmutableList<HistoryEntry> history;
+
+    static DockerManifestResponse withCreationDate(Instant instant) throws IOException {
+      return new DockerManifestResponse(ImmutableList.of(HistoryEntry.withCreationDate(instant)));
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private static class HistoryEntry {
+      private final String v1Compatibility;
+      private static DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
+
+      static HistoryEntry withCreationDate(Instant instant) throws IOException {
+        Map<String, Object> entries = new HashMap<>();
+        entries.put("created", formatter.format(instant));
+        return new HistoryEntry(objectMapper.writeValueAsString(entries));
+      }
+    }
+  }
+
+  @RequiredArgsConstructor
+  private static class MockDockerOkClientProvider implements DockerOkClientProvider {
+    private final OkClient mockClient;
+
+    @Override
+    public OkClient provide(String address, long timeoutMs, boolean insecure) {
+      return mockClient;
+    }
+  }
+}

--- a/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/KeyBasedSorterTest.java
+++ b/clouddriver-docker/src/test/java/com/netflix/spinnaker/clouddriver/docker/registry/security/KeyBasedSorterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.docker.registry.security;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KeyBasedSorterTest {
+  @Test
+  void naturalOrderSort() {
+    ImmutableList<IntegerWrapper> listToSort = IntegerWrapper.from(2, 0, 7, -100, 27, -38, -2, -3);
+    assertThat(KeyBasedSorter.sort(listToSort, IntegerWrapper::getValue, Comparator.naturalOrder()))
+        .containsExactlyElementsOf(IntegerWrapper.from(-100, -38, -3, -2, 0, 2, 7, 27));
+  }
+
+  @Test
+  void reverseOrderSort() {
+    ImmutableList<IntegerWrapper> listToSort = IntegerWrapper.from(2, 0, 7, -100, 27, -38, -2, -3);
+    assertThat(KeyBasedSorter.sort(listToSort, IntegerWrapper::getValue, Comparator.reverseOrder()))
+        .containsExactlyElementsOf(IntegerWrapper.from(27, 7, 2, 0, -2, -3, -38, -100));
+  }
+
+  @Test
+  void callsKeyFunctionOnce() {
+    ImmutableList<IntegerWrapper> listToSort = IntegerWrapper.from(2, 0, 7, -100, 27, -38, -2, -3);
+
+    // Check that no exceptions are thrown by trying to look up the sort key more than once for
+    // a given element.
+    KeyBasedSorter.sort(listToSort, IntegerWrapper::getSortKey, Comparator.naturalOrder());
+  }
+
+  /**
+   * Test class that wraps a simple integer used to test sorting. The integer can either be accessed
+   * by getInteger or by getSortKey, with the difference being that getSortKey will throw an
+   * IllegalStageException when called more than once on the same instance, which is useful for
+   * validating that we only extract the sort key once per element per sort.
+   */
+  @EqualsAndHashCode
+  @ToString
+  @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+  private static class IntegerWrapper {
+    @EqualsAndHashCode.Exclude private AtomicBoolean sortKeyCalled = new AtomicBoolean(false);
+
+    @Getter private final int value;
+
+    static ImmutableList<IntegerWrapper> from(int... values) {
+      return IntStream.of(values).mapToObj(IntegerWrapper::new).collect(toImmutableList());
+    }
+
+    int getSortKey() {
+      if (sortKeyCalled.getAndSet(true)) {
+        throw new IllegalStateException("Sort key can only be called once!");
+      }
+      return value;
+    }
+  }
+}


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5002.  The second commit is what actually fixes the bug, but I wanted to clean up some of the unsafe groovy and add tests, so this PR is a bit bigger than just that commit.

* test(docker): Add tests on docker registry tag fetching 

  There are currently no tests that the fetching of docker registry tags and the sorting of these tags by creation date works properly; add some tests before touching that code.

* fix(docker): Fix sorting array of non-comparable types 

  getCreationDate returns an Instant; when the call fails, we're returning a default value as a Date. This means we can end up with an array with a mix of Instant and Date objects, which don't together obey the general Comparable contract.

  Fix this by returning an Instant from the catch block; also pull the error handling logic into a CompileStatic function so we get some additional type safety.

* refactor(docker): Pull key-based sorter into its own class 

  When sorting docker tags by creation date, we are effectively doing a Schwartzian transform to map each item to a key, sort by that key, then re-map back to the original item. Rather than have this ad-hoc in Groovy, make a simple Java class that handles this algorithm and that can be tested. This also allows us to mark the method that contained this logic as CompileStatic, as we've removed the non-safe operations into Java (and made them safe).

  Right now, leaving the class alongside the single place it is used, but if we need this in other places we can move it to a more general location.
