### PR TITLE
fix(thread): make sure to provide NamedThreadFactory to all executors

### DIFF
--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
@@ -27,6 +27,7 @@ import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import com.netflix.spinnaker.clouddriver.artifacts.ArtifactUtils;
 import java.io.File;
 import java.io.FileInputStream;
@@ -114,7 +115,9 @@ public class GcsStorageService {
     Storage.Objects.List listMethod = storage_.objects().list(bucketName);
     listMethod.setPrefix(pathPrefix);
     Objects objects;
-    ExecutorService executor = Executors.newFixedThreadPool(8);
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            8, new NamedThreadFactory(GcsStorageService.class.getSimpleName()));
 
     do {
       objects = listMethod.execute();

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.clouddriver.aws.lifecycle;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
@@ -72,7 +73,11 @@ public class InstanceTerminationLifecycleWorkerProvider {
     NetflixAmazonCredentials credentials =
         (NetflixAmazonCredentials)
             accountCredentialsProvider.getCredentials(properties.getAccountName());
-    ExecutorService executorService = Executors.newFixedThreadPool(credentials.getRegions().size());
+    ExecutorService executorService =
+        Executors.newFixedThreadPool(
+            credentials.getRegions().size(),
+            new NamedThreadFactory(
+                InstanceTerminationLifecycleWorkerProvider.class.getSimpleName()));
 
     credentials
         .getRegions()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentProvider
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonApplicationLoadBalancerCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCertificateCachingAgent
@@ -32,6 +33,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.EddaTimeoutConfig
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.model.ReservationReport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils
 import com.netflix.spinnaker.clouddriver.aws.edda.EddaApiFactory
@@ -93,7 +95,7 @@ class AwsProviderConfig {
 
   @Bean
   ExecutorService reservationReportPool(ReservationReportConfigurationProperties reservationReportConfigurationProperties) {
-    return Executors.newFixedThreadPool(reservationReportConfigurationProperties.threadPoolSize)
+    return Executors.newFixedThreadPool(reservationReportConfigurationProperties.threadPoolSize, new NamedThreadFactory(ReservationReport.class.getSimpleName()))
   }
 
   private void synchronizeAwsProvider(AwsProvider awsProvider,

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.cache
 
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.provider.ProviderRegistry
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory
 import com.netflix.spinnaker.clouddriver.search.SearchProvider
 import com.netflix.spinnaker.clouddriver.search.SearchResultSet
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
@@ -87,7 +88,7 @@ class CatsSearchProvider implements SearchProvider, Runnable {
     }
 
     if (catsInMemorySearchProperties.enabled) {
-      scheduledExecutorService = Executors.newScheduledThreadPool(1)
+      scheduledExecutorService = Executors.newScheduledThreadPool(1, new NamedThreadFactory(CatsSearchProvider.class.getSimpleName()))
     }
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepository.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepository.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.clouddriver.data.task;
 
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +37,12 @@ public class DualTaskRepository implements TaskRepository {
       TaskRepository previous,
       int threadPoolSize,
       long asyncTimeoutSeconds) {
-    this(primary, previous, Executors.newFixedThreadPool(threadPoolSize), asyncTimeoutSeconds);
+    this(
+        primary,
+        previous,
+        Executors.newFixedThreadPool(
+            threadPoolSize, new NamedThreadFactory(DualTaskRepository.class.getSimpleName())),
+        asyncTimeoutSeconds);
   }
 
   public DualTaskRepository(

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.orchestration
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.metrics.TimedCallable
@@ -45,7 +46,8 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
 
   protected ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
     60L, TimeUnit.SECONDS,
-    new SynchronousQueue<Runnable>()) {
+    new SynchronousQueue<Runnable>(),
+    new NamedThreadFactory(DefaultOrchestrationProcessor.class.getSimpleName())) {
     @Override
     protected void afterExecute(Runnable r, Throwable t) {
       resetMDC()

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueue.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueue.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
 
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import java.util.Collection;
@@ -87,7 +88,12 @@ public class PooledRequestQueue implements RequestQueue {
     final int actualThreads = requestPoolSize + 1;
     this.executorService =
         new ThreadPoolExecutor(
-            actualThreads, actualThreads, 0, TimeUnit.MILLISECONDS, submittedRequests);
+            actualThreads,
+            actualThreads,
+            0,
+            TimeUnit.MILLISECONDS,
+            submittedRequests,
+            new NamedThreadFactory(PooledRequestQueue.class.getSimpleName()));
     registry.gauge(
         "pooledRequestQueue.corePoolSize", executorService, ThreadPoolExecutor::getCorePoolSize);
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutor.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.search.executor;
 
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import com.netflix.spinnaker.clouddriver.search.SearchProvider;
 import com.netflix.spinnaker.clouddriver.search.SearchQueryCommand;
 import com.netflix.spinnaker.clouddriver.search.SearchResultSet;
@@ -37,7 +38,10 @@ public class SearchExecutor {
 
   SearchExecutor(SearchExecutorConfigProperties configProperties) {
     this.timeout = configProperties.getTimeout();
-    this.executor = Executors.newFixedThreadPool(configProperties.getThreadPoolSize());
+    this.executor =
+        Executors.newFixedThreadPool(
+            configProperties.getThreadPoolSize(),
+            new NamedThreadFactory(SearchExecutor.class.getSimpleName()));
   }
 
   public List<SearchResultSet> searchAllProviders(

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/ComputeConfiguration.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/ComputeConfiguration.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.compute;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import java.util.concurrent.Executors;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -31,6 +32,8 @@ public class ComputeConfiguration {
   @Bean
   @Qualifier(BATCH_REQUEST_EXECUTOR)
   public ListeningExecutorService batchRequestExecutor() {
-    return MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+    return MoreExecutors.listeningDecorator(
+        Executors.newCachedThreadPool(
+            new NamedThreadFactory(ComputeConfiguration.class.getSimpleName())));
   }
 }

--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/AbstractEnableDisableKubernetesAtomicOperation.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v1.deploy.ops.servergroup
 
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.helpers.EnableDisablePercentageCategorizer
@@ -141,7 +142,7 @@ abstract class AbstractEnableDisableKubernetesAtomicOperation implements AtomicO
 
     task.updateStatus basePhase, "Resetting service labels for each pod..."
 
-    def pool = Executors.newWorkStealingPool((int) (pods.size() / 2) + 1)
+    def pool = Executors.newWorkStealingPool((int) (pods.size() / 2) + 1, new NamedThreadFactory(AbstractEnableDisableKubernetesAtomicOperation.class.getSimpleName()))
 
     if (desiredPercentage != null) {
       task.updateStatus basePhase, "Operating on $desiredPercentage% of pods"

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
@@ -38,6 +38,7 @@ import com.netflix.spinnaker.cats.agent.*;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.cats.provider.ProviderRegistry;
+import com.netflix.spinnaker.cats.thread.NamedThreadFactory;
 import com.netflix.spinnaker.clouddriver.aws.data.ArnUtils;
 import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent;
 import com.netflix.spinnaker.clouddriver.model.HealthState;
@@ -216,7 +217,9 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingA
 
       StreamingCacheState state = new StreamingCacheState();
 
-      ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+      ScheduledExecutorService executor =
+          Executors.newScheduledThreadPool(
+              1, new NamedThreadFactory(TitusStreamingUpdateAgent.class.getSimpleName()));
       final Future handler =
           executor.submit(
               () -> {


### PR DESCRIPTION
It's a good practice to name all the threads/executors so that it's easy to see what threads are running away (if any).
Add NamedThreadFactory to all places we create a new executor
