### PR TITLE
fix(titus): shutdown the executor for titus streaming agent

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
@@ -306,6 +306,7 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingA
           getTimeoutMillis(),
           TimeUnit.MILLISECONDS);
       CompletableFuture.completedFuture(handler).join();
+      executor.shutdown();
     }
 
     private Iterator<JobChangeNotification> observeJobs() {


### PR DESCRIPTION
We are leaking an executor (with a single thread in) from the TitusStreamingAgent because it's not shutdown properly
I think it would be better to refactor this code to not create the executor (at least not all the time), but I want to make a minimal change to address the immediate problem first.

There is also some unnamed thread pool that appears to be leaking that I can't track down. Perhaps it's some API that the streaming agent calls, will debug it more after this change goes in
