### PR TITLE
fix(cats/sql): ensure cache agent tables exist when using sql backend

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -117,15 +117,15 @@ class SqlCache(
     authoritative: Boolean,
     cleanup: Boolean
   ) {
-    if (
-      type.isEmpty() ||
-      items.isNullOrEmpty() ||
-      items.none { it.id != "_ALL_" }
-    ) {
+    if (type.isEmpty()) {
       return
     }
 
     createTables(type)
+
+    if (items.isNullOrEmpty() || items.none { it.id != "_ALL_" }) {
+      return
+    }
 
     var agent: String? = agentHint
 


### PR DESCRIPTION
Currently agent tables are only created when there are resources to insert
however these tables are queried regardless which results in a large number
of 'Table doesnt exist' errors.  This change creates the table even if
there are no corresponding resources to cache.