### PR TITLE
refactor(artifacts): Use builder to create artifacts

### DIFF
--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentialsTest.java
@@ -128,8 +128,7 @@ class IvyArtifactCredentialsTest {
     Path cache = tempDir.resolve("cache");
     Files.createDirectories(cache);
 
-    Artifact artifact = new Artifact();
-    artifact.setReference("com.test:app:1.0");
+    Artifact artifact = Artifact.builder().reference("com.test:app:1.0").build();
 
     assertThat(new IvyArtifactCredentials(account, () -> cache).download(artifact))
         .hasSameContentAs(new ByteArrayInputStream("contents".getBytes(Charsets.UTF_8)));

--- a/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentialsTest.java
+++ b/clouddriver-artifacts/src/test/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentialsTest.java
@@ -176,8 +176,7 @@ class MavenArtifactCredentialsTest {
     MavenArtifactAccount account = new MavenArtifactAccount();
     account.setRepositoryUrl(server.baseUrl());
 
-    Artifact artifact = new Artifact();
-    artifact.setReference("com.test:app:" + version);
+    Artifact artifact = Artifact.builder().reference("com.test:app:" + version).build();
 
     assertThat(new MavenArtifactCredentials(account, new OkHttpClient()).download(artifact))
         .hasSameContentAs(

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtilSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtilSpec.groovy
@@ -242,7 +242,7 @@ package com.netflix.spinnaker.clouddriver.google.deploy
     credentials.compute >> compute
     credentials.project >> PROJECT_NAME
     def executor = GroovyMock(GoogleExecutorTraits)
-    def artifact = new Artifact()
+    def artifact = Artifact.builder().build()
     GroovySpy(GCEUtil, global: true)
 
     when:

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
@@ -88,8 +88,8 @@ class KubernetesVersionedArtifactConverterSpec extends Specification {
     def version1 = "v001"
     def version2 = "v002"
 
-    def artifact1 = new Artifact(version: version1, metadata: [lastAppliedConfiguration: manifest1])
-    def artifact2 = new Artifact(version: version2, metadata: [lastAppliedConfiguration: manifest2])
+    def artifact1 = Artifact.builder().version(version1).metadata([lastAppliedConfiguration: manifest1]).build()
+    def artifact2 = Artifact.builder().version(version2).metadata([lastAppliedConfiguration: manifest2]).build()
     def artifacts = [artifact1, artifact2]
 
     def artifactProvider = Mock(KubernetesV2ArtifactProvider)

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationSpec.groovy
@@ -101,7 +101,7 @@ spec:
         isVersioned() >> true
         getVersionedConverter() >> Mock(KubernetesVersionedArtifactConverter) {
           getDeployedName(_) >> "$NAME-$VERSION"
-          toArtifact(_, _, _) >> new Artifact()
+          toArtifact(_, _, _) >> Artifact.builder().build()
         }
       }
       get(KubernetesKind.SERVICE) >> Mock(KubernetesResourceProperties) {


### PR DESCRIPTION
The all-arg and no-arg constructors for Artifact were deprecated in spinnaker/kork#429. Replace their usages with a builder.