### PR TITLE
fix(kubernetes): correct spelling in error message

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/provider/view/KubernetesV2JobProvider.java
@@ -102,7 +102,7 @@ public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatu
 
   public void cancelJob(String account, String location, String id) {
     throw new NotImplementedException(
-        "cancelJob is not implemented for the V2 Kubrenetes provider");
+        "cancelJob is not implemented for the V2 Kubernetes provider");
   }
 
   private V1Job getKubernetesJob(String account, String location, String id) {


### PR DESCRIPTION
Noticed this misspelling today, couldn't pass up the opportunity to contribute.