### PR TITLE
fix(provider/kubernetes): validate spec.template is a map before cast

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -225,6 +225,10 @@ public class KubernetesManifest extends HashMap<String, Object> {
       return Optional.empty();
     }
 
+    if (!(spec.get("template") instanceof Map)) {
+      return Optional.empty();
+    }
+
     Map<String, Object> template = (Map<String, Object>) spec.get("template");
     if (!template.containsKey("metadata")) {
       return Optional.empty();
@@ -252,6 +256,10 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
     Map<String, Object> spec = (Map<String, Object>) get("spec");
     if (!spec.containsKey("template")) {
+      return Optional.empty();
+    }
+
+    if (!(spec.get("template") instanceof Map)) {
       return Optional.empty();
     }
 

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -165,7 +165,7 @@ class KubernetesManifestSpec extends Specification {
 
   void "correctly handles a crd with custom cases"() {
     when:
-    def sourceJson = KubernetesManifest.class.getResource("crd-manifest.json").getText("utf-8")
+    def sourceJson = KubernetesManifest.class.getResource("crd-manifest-spec.json").getText("utf-8")
     def testPayload =  gsonObj.fromJson(sourceJson, Object)
     KubernetesManifest manifest = objectToManifest(testPayload)
 

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesManifestSpec.groovy
@@ -36,6 +36,9 @@ class KubernetesManifestSpec extends Specification {
   def API_VERSION = KubernetesApiVersion.EXTENSIONS_V1BETA1
   def KEY = "hi"
   def VALUE = "there"
+  def CRD_NAME = "default-custom1"
+  def CRD_KIND = "Custom1"
+  def CRD_API_VERSION = "test.example/v1alpha1"
 
   String basicManifestSource() {
     def sourceJson = KubernetesManifest.class.getResource("manifest.json").getText("utf-8")
@@ -158,5 +161,18 @@ class KubernetesManifestSpec extends Specification {
 
     then:
     manifest.getApiVersion() == KubernetesApiVersion.NETWORKING_K8S_IO_V1
+  }
+
+  void "correctly handles a crd with custom cases"() {
+    when:
+    def sourceJson = KubernetesManifest.class.getResource("crd-manifest.json").getText("utf-8")
+    def testPayload =  gsonObj.fromJson(sourceJson, Object)
+    KubernetesManifest manifest = objectToManifest(testPayload)
+
+    then:
+    manifest.getName() == CRD_NAME
+    manifest.getKindName() == CRD_KIND
+    manifest.getApiVersion().toString() == CRD_API_VERSION
+    manifest.getSpecTemplateAnnotations() == Optional.empty()
   }
 }

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/crd-manifest-spec.json
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/crd-manifest-spec.json
@@ -8,5 +8,9 @@
     "name": "default-custom1"
   },
   "spec": {
+    "template": "template1",
+    "params": {
+      "value": "1"
+    }
   }
 }

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/crd-manifest.json
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/crd-manifest.json
@@ -8,5 +8,6 @@
     "name": "default-custom1"
   },
   "spec": {
+    "template": "template1"
   }
 }


### PR DESCRIPTION
Currently a CRDs from Istio kind expect a string as value of spec.template instead of a map, this cause an error in clouddriver at the moment to cast from object to map to get the annotations inside spec.template.

Issue: https://github.com/spinnaker/spinnaker/issues/4664

Example manifest: https://github.com/signalfx/signalfx-istio-adapter/blob/master/resources/metric-instances.yaml

Reference: https://istio.io/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1/#Instance