### PR TITLE
fix(provider/aws): updated clouddriver to accept aws credentials from external sources.

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsConfig.java
@@ -340,6 +340,8 @@ public class CredentialsConfig {
     }
   }
 
+  private String accessKeyId;
+  private String secretAccessKey;
   private String defaultKeyPairTemplate;
   private List<Region> defaultRegions;
   private List<String> defaultSecurityGroups;
@@ -459,5 +461,21 @@ public class CredentialsConfig {
       String defaultLifecycleHookNotificationTargetARNTemplate) {
     this.defaultLifecycleHookNotificationTargetARNTemplate =
         defaultLifecycleHookNotificationTargetARNTemplate;
+  }
+
+  public String getAccessKeyId() {
+    return accessKeyId;
+  }
+
+  public void setAccessKeyId(String accessKeyId) {
+    this.accessKeyId = accessKeyId;
+  }
+
+  public String getSecretAccessKey() {
+    return secretAccessKey;
+  }
+
+  public void setSecretAccessKey(String secretAccessKey) {
+    this.secretAccessKey = secretAccessKey;
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoader.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoader.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.security.config;
 
+import com.amazonaws.SDKGlobalConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,6 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 public class CredentialsLoader<T extends AmazonCredentials> {
 
@@ -217,6 +219,14 @@ public class CredentialsLoader<T extends AmazonCredentials> {
       return Collections.emptyList();
     }
 
+    if (!StringUtils.isEmpty(config.getAccessKeyId())) {
+      System.setProperty(
+          SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY, config.getAccessKeyId());
+    }
+    if (!StringUtils.isEmpty(config.getSecretAccessKey())) {
+      System.setProperty(
+          SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY, config.getSecretAccessKey());
+    }
     Lazy<List<Region>> defaultRegions = createDefaults(config.getDefaultRegions());
     List<T> initializedAccounts = new ArrayList<>(config.getAccounts().size());
     for (Account account : config.getAccounts()) {


### PR DESCRIPTION
This is a fix for the issue - [#5155](https://github.com/spinnaker/spinnaker/issues/5155)

Updated CredentialConfig class to include the accessKeyId and secretAccessKey when the aws configuration is provided via external sources like Git.

Updated CredentialsLoader class to set the above credentials as system properties.