### PR TITLE
fix(sagas): Use a Set instead of List to avoid duplicate Task SagaIds

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DefaultTask.groovy
@@ -104,8 +104,8 @@ public class DefaultTask implements Task {
   }
 
   @Override
-  List<SagaId> getSagaIds() {
-    return sagaIdentifiers.toList()
+  Set<SagaId> getSagaIds() {
+    return sagaIdentifiers.toSet()
   }
 
   @Override

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Task.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Task.java
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.clouddriver.data.task;
 
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nonnull;
 
 /**
@@ -81,9 +82,9 @@ public interface Task {
   /** Returns true if any Sagas have been associated with this Task. */
   boolean hasSagaIds();
 
-  /** A list of Sagas associated with this Task, if any. */
+  /** A set of Sagas associated with this Task, if any. */
   @Nonnull
-  List<SagaId> getSagaIds();
+  Set<SagaId> getSagaIds();
 
   /** Returns true if the Task is retryable (in the case of a failure) */
   default boolean isRetryable() {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTask.groovy
@@ -35,7 +35,7 @@ class JedisTask implements Task {
   final long startTimeMs
   final String ownerId
   final String requestId
-  final List<SagaId> sagaIds
+  final Set<SagaId> sagaIds
 
   @JsonIgnore
   final boolean previousRedis

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
@@ -32,7 +32,7 @@ class SqlTask(
   @JsonIgnore internal val ownerId: String,
   @JsonIgnore internal val requestId: String,
   @JsonIgnore internal val startTimeMs: Long,
-  private val sagaIds: MutableList<SagaId>,
+  private val sagaIds: MutableSet<SagaId>,
   private val repository: SqlTaskRepository
 ) : Task {
 
@@ -105,7 +105,7 @@ class SqlTask(
     log.debug("Added sagaId with name={} and id={} to task={}", sagaId.name, sagaId.id, id)
   }
 
-  override fun getSagaIds(): MutableList<SagaId> {
+  override fun getSagaIds(): MutableSet<SagaId> {
     return sagaIds
   }
 

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepository.kt
@@ -53,7 +53,7 @@ class SqlTaskRepository(
   }
 
   override fun create(phase: String, status: String, clientRequestId: String): Task {
-    var task = SqlTask(ulid.nextULID(), ClouddriverHostname.ID, clientRequestId, clock.millis(), mutableListOf(), this)
+    var task = SqlTask(ulid.nextULID(), ClouddriverHostname.ID, clientRequestId, clock.millis(), mutableSetOf(), this)
     val historyId = ulid.nextULID()
 
     withPool(POOL_NAME) {

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/TaskMapper.kt
@@ -35,7 +35,7 @@ class TaskMapper(
   companion object {
     private val log = LoggerFactory.getLogger(TaskMapper::class.java)
 
-    private val SAGA_IDS_TYPE = object : TypeReference<List<SagaId>>() {}
+    private val SAGA_IDS_TYPE = object : TypeReference<Set<SagaId>>() {}
   }
 
   fun map(rs: ResultSet): Collection<Task> {
@@ -90,9 +90,9 @@ class TaskMapper(
     }
   }
 
-  private fun sagaIds(sagaIdsValue: String?): MutableList<SagaId> {
+  private fun sagaIds(sagaIdsValue: String?): MutableSet<SagaId> {
     if (sagaIdsValue == null) {
-      return mutableListOf()
+      return mutableSetOf()
     }
     return mapper.readValue(sagaIdsValue, SAGA_IDS_TYPE)
   }


### PR DESCRIPTION
So we don't add duplicate SagaIds to tasks (and thereby double the number of atomic operations we retry), use a Set instead of a List.