### PR TITLE
feat(titusJobSearch): Support searching with titus jobIds

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -137,6 +137,7 @@ class CatsSearchProvider implements SearchProvider, Runnable {
     } catch (Exception e) {
       log.error("Unable to refresh cached identifiers (instances)", e)
     }
+    //Populate jobId cache only when titus is enabled
     if (titusEnabled) {
       try {
         log.info("Refreshing Cached Identifiers (jobIds)")
@@ -145,6 +146,7 @@ class CatsSearchProvider implements SearchProvider, Runnable {
           provider.supportsSearch('serverGroups', Collections.emptyMap())
         }.collect { provider ->
           def cache = providerRegistry.getProviderCache(provider.getProviderName())
+          //Populate job cache based of the ids that are mapped to titus server groups
           def ids = cache.filterIdentifiers("serverGroups", "titus*")
           ids.collect {
             def job = cache.get("serverGroups", it)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -86,9 +86,6 @@ class CatsSearchProvider implements SearchProvider, Runnable {
       mappings.putAll(provider.urlMappingTemplates.collectEntries {
         [(it.key): tmpl.createTemplate(it.value)]
       })
-      mappings.putAll(provider.urlMappingTemplates.collectEntries {
-        [(it.key): tmpl.createTemplate(it.value)]
-      })
       return mappings
     }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
@@ -32,7 +32,8 @@ class Keys implements KeyParser {
     CLUSTERS,
     APPLICATIONS,
     HEALTH,
-    ON_DEMAND
+    ON_DEMAND,
+    JOB_IDS
 
     public final String ns
 


### PR DESCRIPTION
- Adding support to search based on titus jobIds.
- The `jobCache` here is populated only when `titus` is enabled 
- The `cache` has a mapping for the `jobId:serverGroupKey`
- `types=jobIds` to be used for this search
