### PR TITLE
chore(release): Use the alpine containers instead of openjdk

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,10 +1,10 @@
-FROM openjdk:8-jdk-alpine
+FROM alpine:3.10
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/clouddriver-web/build/install/clouddriver /opt/clouddriver
 
 ENV KUBECTL_VERSION v1.16.0
 
-RUN apk --no-cache add --update bash wget unzip 'python2>2.7.9' && \
+RUN apk --no-cache add --update bash wget unzip openjdk8 'python2>2.7.9' && \
   wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && \
   unzip -qq google-cloud-sdk.zip -d /opt && \
   rm google-cloud-sdk.zip && \


### PR DESCRIPTION
The container we had been using hasn't been updated in months. See
spinnaker/spinnaker#5204.