### PR TITLE
fix(kubernetes): Null check in health endpoint to avoid NPE

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicator.java
@@ -45,7 +45,9 @@ public class KubernetesHealthIndicator implements HealthIndicator {
     Map<String, String> warnings = warningMessages.get();
 
     Health.Builder resultBuilder = new Health.Builder().up();
-    warnings.forEach(resultBuilder::withDetail);
+    if (warnings != null) {
+      warnings.forEach(resultBuilder::withDetail);
+    }
 
     return resultBuilder.build();
   }


### PR DESCRIPTION
Adding a null check for Kubernetes provider health check.

There's a case during startup when the `warningMessages` map has not been initialized and health endpoint is called, leading to a `NullPointerException`.
Since `warningMessages` is an AtomicReference being changed every 5 minutes, it makes sense to put the null check where the map is being retrieved.