### PR TITLE
fix(saga): Handle concurrency issue when same op is sent more than once

### DIFF
--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/exceptions/DuplicateEventAggregateException.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/exceptions/DuplicateEventAggregateException.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.config
+package com.netflix.spinnaker.clouddriver.event.exceptions
 
-import org.springframework.boot.context.properties.ConfigurationProperties
-import java.util.concurrent.TimeUnit
+import com.netflix.spinnaker.kork.exceptions.SystemException
 
-@ConfigurationProperties("sql.agent.task-cleanup")
-class SqlTaskCleanupAgentProperties {
-  var completedTtlMs: Long = TimeUnit.DAYS.toMillis(4)
-  var batchSize: Int = 100
-}
+class DuplicateEventAggregateException(e: Exception) : SystemException(e), EventingException

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventRepository.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventRepository.kt
@@ -93,6 +93,7 @@ class SqlEventRepository(
               // In the event that two requests are made at the same time to create a new aggregate (via two diff
               // clouddriver instances), catch the exception and bubble it up as a duplicate exception so that it
               // may be processed in an idempotent way, rather than causing an error.
+              //
               // This is preferential to going back to the database to load the existing aggregate record, since we
               // already know the aggregate version will not match the originating version expected from this process
               // and would fail just below anyway.

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventRepository.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventRepository.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.event.CompositeSpinnakerEvent
 import com.netflix.spinnaker.clouddriver.event.EventMetadata
 import com.netflix.spinnaker.clouddriver.event.SpinnakerEvent
 import com.netflix.spinnaker.clouddriver.event.exceptions.AggregateChangeRejectedException
+import com.netflix.spinnaker.clouddriver.event.exceptions.DuplicateEventAggregateException
 import com.netflix.spinnaker.clouddriver.event.persistence.EventRepository
 import com.netflix.spinnaker.clouddriver.event.persistence.EventRepository.ListAggregatesCriteria
 import com.netflix.spinnaker.clouddriver.sql.transactional
@@ -37,6 +38,7 @@ import org.jooq.impl.DSL.max
 import org.jooq.impl.DSL.table
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
+import java.sql.SQLIntegrityConstraintViolationException
 import java.util.UUID
 
 class SqlEventRepository(
@@ -82,10 +84,20 @@ class SqlEventRepository(
               field("version") to 0
             )
 
-            ctx.insertInto(AGGREGATES_TABLE)
-              .columns(initialAggregate.keys)
-              .values(initialAggregate.values)
-              .execute()
+            try {
+              ctx.insertInto(AGGREGATES_TABLE)
+                .columns(initialAggregate.keys)
+                .values(initialAggregate.values)
+                .execute()
+            } catch (e: SQLIntegrityConstraintViolationException) {
+              // In the event that two requests are made at the same time to create a new aggregate (via two diff
+              // clouddriver instances), catch the exception and bubble it up as a duplicate exception so that it
+              // may be processed in an idempotent way, rather than causing an error.
+              // This is preferential to going back to the database to load the existing aggregate record, since we
+              // already know the aggregate version will not match the originating version expected from this process
+              // and would fail just below anyway.
+              throw DuplicateEventAggregateException(e)
+            }
 
             Aggregate(aggregateType, aggregateId, 0)
           }()


### PR DESCRIPTION
We experienced an issue with sagas where Orca submitted the same operation into clouddriver at the same time (separated by a few milliseconds). The second request returned a 500 due to the SQL integrity constraint violation, but the work was already being handled successfully by the other clouddriver instance.

What _should_ happen is that the second instance returns a pointer to the original task so that Orca doesn't have to reason about its mistake and just carry on monitoring the operation that's being performed.

Also changed the duration that Kato Tasks are kept around. 1 hour is too short to be able to get notified of an error and to diagnose. 4 days seems a reasonable default so that if an error occurs EOW or on the weekend, there's still sufficient time to get information the following week.