### PR TITLE
Trigger compilation whenever lombok config is updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,12 @@ allprojects {
     apply plugin: 'nebula.kotlin'
     apply plugin: "kotlin-allopen"
 
+    def lombokConf = "$rootProject.projectDir/lombok.config"
+    compileGroovy.inputs.file(lombokConf)
+    compileTestGroovy.inputs.file(lombokConf)
+    compileJava.inputs.file(lombokConf)
+    compileTestJava.inputs.file(lombokConf)
+
     sourceSets.main.java.srcDirs = []
     sourceSets.main.groovy.srcDirs += ["src/main/java"]
 


### PR DESCRIPTION
Hello

This pull request enhances the build script of the project.
Notably, compilation uses the lombokproject which depends on the configuration `lombok.config`.
When there is any update to this configuration file, compilation of source files should be re-triggered in case of incremental builds.

This commit registers `lombok.config` as input to the Gradle tasks that are responsible for compilation.
