### PR TITLE
feat(kubernetes): add initContainer logs to kubernetes v2 provider container logs

### DIFF
--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/ContainerLog.java
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/model/ContainerLog.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.model;
+package com.netflix.spinnaker.clouddriver.kubernetes.v1.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -23,6 +23,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 @NoArgsConstructor
+@Deprecated
+/**
+ * @deprecated only used in kubernetes v1 provider. use @ContainerLog in the clouddriver-kubernetes
+ *     project instead.
+ */
 public class ContainerLog {
   private String name;
   private String output;

--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/view/KubernetesV1InstanceProvider.groovy
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/view/KubernetesV1InstanceProvider.groovy
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAcco
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.caching.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.model.KubernetesV1Instance
 import com.netflix.spinnaker.clouddriver.kubernetes.v1.security.KubernetesV1Credentials
-import com.netflix.spinnaker.clouddriver.model.ContainerLog
+import com.netflix.spinnaker.clouddriver.kubernetes.v1.model.ContainerLog
 import com.netflix.spinnaker.clouddriver.model.InstanceProvider
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProviderTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProviderTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2020 Discovery, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.model.ContainerLog;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Instance;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesAccountResolver;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import io.kubernetes.client.JSON;
+import io.kubernetes.client.models.V1Container;
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1Pod;
+import io.kubernetes.client.models.V1PodSpec;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesV2InstanceProviderTest {
+
+  private KubernetesV2InstanceProvider provider;
+  private KubernetesV2Credentials credentials;
+  private KubernetesAccountResolver accountResolver;
+  private KubernetesCacheUtils cacheUtils;
+
+  private static final JSON json = new JSON();
+  private static final KubernetesKind KIND = KubernetesKind.POD;
+  private static final String ACCOUNT = "account";
+  private static final String NAMESPACE = "namespace";
+  private static final String POD_NAME = "mypod";
+  private static final String POD_FULL_NAME = KIND + " " + POD_NAME;
+  private static final String CONTAINER = "container";
+  private static final String INIT_CONTAINER = "initContainer";
+  private static final String LOG_OUTPUT = "logs";
+  private static final String CACHE_KEY =
+      Keys.InfrastructureCacheKey.createKey(KIND, ACCOUNT, NAMESPACE, POD_NAME);
+
+  @BeforeEach
+  public void setup() {
+    accountResolver = mock(KubernetesAccountResolver.class);
+    cacheUtils = mock(KubernetesCacheUtils.class);
+    credentials = mock(KubernetesV2Credentials.class);
+    provider = new KubernetesV2InstanceProvider(cacheUtils, accountResolver);
+    when(accountResolver.getCredentials(ACCOUNT)).thenReturn(Optional.of(credentials));
+  }
+
+  @Test
+  void getCloudProvider() {
+    assertThat(provider.getCloudProvider()).isEqualTo(KubernetesCloudProvider.ID);
+  }
+
+  @Test
+  void getInstanceSuccess() {
+    final CacheData cacheData = mock(CacheData.class);
+    final Map<String, Object> attributes = new HashMap<>();
+    final KubernetesManifest manifest = getKubernetesManifest();
+    attributes.put("manifest", manifest);
+    when(cacheData.getAttributes()).thenReturn(attributes);
+    when(cacheUtils.getSingleEntry(KIND.toString(), CACHE_KEY)).thenReturn(Optional.of(cacheData));
+    when(cacheData.getId()).thenReturn(CACHE_KEY);
+
+    final KubernetesV2Instance instance = provider.getInstance(ACCOUNT, NAMESPACE, POD_FULL_NAME);
+
+    assertThat(instance.getManifest()).isEqualTo(manifest);
+  }
+
+  @Test
+  void getInstanceBadPodNameShouldReturnNull() {
+    final KubernetesV2Instance instance = provider.getInstance(ACCOUNT, NAMESPACE, "badname");
+
+    assertThat(instance).isNull();
+  }
+
+  @Test
+  void getInstancePodNotFoundShouldReturnNull() {
+    when(cacheUtils.getSingleEntry(KIND.toString(), CACHE_KEY)).thenReturn(Optional.empty());
+
+    final KubernetesV2Instance instance = provider.getInstance(ACCOUNT, NAMESPACE, POD_FULL_NAME);
+
+    assertThat(instance).isNull();
+  }
+
+  @Test
+  void getConsoleOutputSuccess() {
+    final KubernetesManifest manifest = getKubernetesManifest();
+    when(credentials.get(KubernetesKind.POD, NAMESPACE, POD_NAME)).thenReturn(manifest);
+    when(credentials.logs(anyString(), anyString(), anyString())).thenReturn(LOG_OUTPUT);
+
+    final List<ContainerLog> logs = provider.getConsoleOutput(ACCOUNT, NAMESPACE, POD_FULL_NAME);
+
+    assertThat(logs).isNotEmpty();
+    assertThat(logs).hasSize(2);
+    assertThat(logs.get(0).getName()).isEqualTo(INIT_CONTAINER);
+    assertThat(logs.get(0).getOutput()).isEqualTo(LOG_OUTPUT);
+    assertThat(logs.get(1).getName()).isEqualTo(CONTAINER);
+    assertThat(logs.get(1).getOutput()).isEqualTo(LOG_OUTPUT);
+  }
+
+  @Test
+  void getConsoleOutputKubectlException() {
+    final KubernetesManifest manifest = getKubernetesManifest();
+    when(credentials.get(KubernetesKind.POD, NAMESPACE, POD_NAME)).thenReturn(manifest);
+    when(credentials.logs(anyString(), anyString(), anyString()))
+        .thenThrow(new KubectlJobExecutor.KubectlException(LOG_OUTPUT, null));
+
+    final List<ContainerLog> logs = provider.getConsoleOutput(ACCOUNT, NAMESPACE, POD_FULL_NAME);
+
+    assertThat(logs).isNotEmpty();
+    assertThat(logs).hasSize(2);
+    assertThat(logs.get(0).getName()).isEqualTo(INIT_CONTAINER);
+    assertThat(logs.get(0).getOutput()).isEqualTo(LOG_OUTPUT);
+    assertThat(logs.get(1).getName()).isEqualTo(CONTAINER);
+    assertThat(logs.get(1).getOutput()).isEqualTo(LOG_OUTPUT);
+  }
+
+  private KubernetesManifest getKubernetesManifest() {
+    final V1Pod pod = new V1Pod();
+    final V1PodSpec podSpec = new V1PodSpec();
+    final V1ObjectMeta metadata = new V1ObjectMeta();
+    final V1Container container = new V1Container();
+    final V1Container initContainer = new V1Container();
+
+    metadata.setName(POD_NAME);
+    metadata.setNamespace(NAMESPACE);
+    container.setName(CONTAINER);
+    initContainer.setName(INIT_CONTAINER);
+    pod.setMetadata(metadata);
+    pod.setSpec(podSpec);
+    podSpec.setContainers(Lists.newArrayList(container));
+    podSpec.setInitContainers(Lists.newArrayList(initContainer));
+
+    return json.deserialize(json.serialize(pod), KubernetesManifest.class);
+  }
+
+  @Test
+  void getConsoleOutputAccountNotFoundShouldReturnNull() {
+    when(accountResolver.getCredentials(ACCOUNT)).thenReturn(Optional.empty());
+
+    final List<ContainerLog> logs = provider.getConsoleOutput(ACCOUNT, NAMESPACE, POD_FULL_NAME);
+
+    assertThat(logs).isNull();
+  }
+
+  @Test
+  void getConsoleOutputBadPodNameShouldReturnNull() {
+    final List<ContainerLog> logs = provider.getConsoleOutput(ACCOUNT, NAMESPACE, "badname");
+
+    assertThat(logs).isNull();
+  }
+
+  @Test
+  void getConsoleOutputPodNotFoundShouldReturnErrorContainerLog() {
+    when(credentials.get(KubernetesKind.POD, NAMESPACE, POD_NAME)).thenReturn(null);
+
+    final List<ContainerLog> logs = provider.getConsoleOutput(ACCOUNT, NAMESPACE, POD_FULL_NAME);
+
+    assertThat(logs).isNotEmpty();
+    assertThat(logs).hasSize(1);
+    assertThat(logs.get(0).getName()).isEqualTo("Error");
+    assertThat(logs.get(0).getOutput())
+        .isEqualTo("Failed to retrieve pod data; pod may have been deleted.");
+  }
+}

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/ContainerLog.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/ContainerLog.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Discovery, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ContainerLog {
+  private final String name;
+  private final String output;
+}


### PR DESCRIPTION
@maggieneterval @ethanfrogers I've gone ahead and made the changes @maggieneterval  and I discussed yesterday. Let me know what you think.

This is the first step that partially implements https://github.com/spinnaker/spinnaker/issues/4869 by adding initContainer logs to the existing logs being returned. We add all the initContainer logs before the current container logs so they'll show up in deck with initContainers to the left of the existing ones (screenshot in issue). Differentiating the different types of containers in the gui will come in a later PR for clouddriver and deck.

This also handles the refactoring mentioned by @maggieneterval on the issue. I ended up leaving the current ContainerLogs where it was in core and deprecating since the v1 provider was using it, and I opted to not many any code changes to v1. The new ContainerLogs lives in the shared kubernetes project and is immutable and used in the v2 provider now. Let me know what you think, and I can change how I handled it if needed.

Lastly this adds tests KubernetesV2InstanceProviderTest that cover the new and existing code in KubernetesV2InstanceProvider.