### PR TITLE
fix(kubernetes): Fix stability for stateful/daemon set

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -132,14 +133,14 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
       return result;
     }
 
-    Integer desiredReplicas = statefulSet.getSpec().getReplicas();
-    Integer existing = status.getReplicas();
-    if (existing == null || (desiredReplicas != null && desiredReplicas > existing)) {
+    int desiredReplicas = defaultToZero(statefulSet.getSpec().getReplicas());
+    int existing = defaultToZero(status.getReplicas());
+    if (desiredReplicas > existing) {
       return result.unstable("Waiting for at least the desired replica count to be met");
     }
 
-    existing = status.getReadyReplicas();
-    if (existing == null || (desiredReplicas != null && desiredReplicas > existing)) {
+    existing = defaultToZero(status.getReadyReplicas());
+    if (desiredReplicas > existing) {
       return result.unstable("Waiting for all updated replicas to be ready");
     }
 
@@ -159,8 +160,8 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
       return result;
     }
 
-    existing = status.getCurrentReplicas();
-    if (existing == null || (desiredReplicas != null && desiredReplicas > existing)) {
+    existing = defaultToZero(status.getCurrentReplicas());
+    if (desiredReplicas > existing) {
       return result.unstable("Waiting for all updated replicas to be scheduled");
     }
 
@@ -169,6 +170,11 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
     }
 
     return result;
+  }
+
+  // Unboxes an Integer, returning 0 if the input is null
+  private int defaultToZero(@Nullable Integer input) {
+    return input == null ? 0 : input;
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
@@ -10,39 +10,36 @@ import spock.lang.Specification
 
 
 class KubernetesStatefulSetHandlerSpec extends Specification {
-  def objectMapper = new ObjectMapper()
   def handler = new KubernetesStatefulSetHandler()
   def gsonObj = new Gson()
 
   def IMAGE = "gcr.io/project/image"
-  def ACCOUNT = "my-account"
   def CLUSTER_SIZE = 5
   def VERSION = "version"
   def NAMESPACE = "my-namespace"
   def NAME = "my-name"
-  def KIND = KubernetesKind.STATEFUL_SET
 
   String statefulSetManifestWithPartition(Integer partition = CLUSTER_SIZE) {
     def sourceJson = KubernetesStatefulSetHandler.class.getResource("statefulsetpartitionbase.json").getText("utf-8")
     def templateEngine = new SimpleTemplateEngine()
     def binding = [
       "partition": partition,
-      "name": getNAME(),
-      "namespace": getNAMESPACE(),
-      "replicas": getCLUSTER_SIZE(),
-      "image": getIMAGE(),
+      "name": NAME,
+      "namespace": NAMESPACE,
+      "replicas": CLUSTER_SIZE,
+      "image": IMAGE,
     ]
     def template = templateEngine.createTemplate(sourceJson).make(binding)
     return template.toString()
   }
 
-  String statefulSetManifest() {
+  String statefulSetManifest(int replicas = CLUSTER_SIZE) {
     def sourceJson = KubernetesStatefulSetHandler.class.getResource("statefulsetbase.json").getText("utf-8")
     def templateEngine = new SimpleTemplateEngine()
     def binding = [
       "name": getNAME(),
       "namespace": getNAMESPACE(),
-      "replicas": getCLUSTER_SIZE(),
+      "replicas": replicas,
       "image": getIMAGE(),
     ]
     def template = templateEngine.createTemplate(sourceJson).make(binding)
@@ -332,4 +329,52 @@ class KubernetesStatefulSetHandlerSpec extends Specification {
     status.stable.message == "Partitioned roll out complete"
   }
 
+  def "[status] unstable with no replicas when desired replicas > 0"() {
+    when:
+    // When there are no replicas, availableReplicas, currentReplicas, readyReplicas,
+    // and updatedReplicas may be absent from the status.
+    def statusJSONString = """
+{
+  "status": {
+    "observedGeneration": 1,
+    "replicas": 0,
+    "currentRevision": "$NAME-$VERSION",
+    "updateRevision": "$NAME-$VERSION"
+  }
+}
+""".toString()
+    def baseJson = gsonObj.fromJson(statefulSetManifest(1), Object)
+    def statusJson = gsonObj.fromJson(statusJSONString, Object)
+    def manifestJson = baseJson << statusJson
+    def manifest = stringToManifest(manifestJson)
+    def status = handler.status(manifest)
+
+    then:
+    !status.stable.state
+  }
+
+  def "[status] stable with no replicas when desired replicas = 0"() {
+    when:
+    // When there are no replicas, availableReplicas, currentReplicas, readyReplicas,
+    // and updatedReplicas may be absent from the status.
+    def statusJSONString = """
+{
+  "status": {
+    "observedGeneration": 1,
+    "replicas": 0,
+    "currentRevision": "$NAME-$VERSION",
+    "updateRevision": "$NAME-$VERSION"
+  }
+}
+""".toString()
+    def baseJson = gsonObj.fromJson(statefulSetManifest(0), Object)
+    def statusJson = gsonObj.fromJson(statusJSONString, Object)
+    def manifestJson = baseJson << statusJson
+    def manifest = stringToManifest(manifestJson)
+    def status = handler.status(manifest)
+
+    then:
+    //TODO(ezimanyi): This is incorrect! Should be stable in this case.
+    !status.stable.state
+  }
 }

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerSpec.groovy
@@ -374,7 +374,6 @@ class KubernetesStatefulSetHandlerSpec extends Specification {
     def status = handler.status(manifest)
 
     then:
-    //TODO(ezimanyi): This is incorrect! Should be stable in this case.
-    !status.stable.state
+    status.stable.state
   }
 }

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandlerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesDaemonSetHandlerTest {
+  private static final Gson gson = new Gson();
+
+  private static KubernetesManifest baseDaemonSet() throws IOException {
+    String text =
+        Resources.toString(
+            KubernetesDaemonSetHandler.class.getResource("daemonsetbase.json"),
+            StandardCharsets.UTF_8);
+    return gson.fromJson(text, KubernetesManifest.class);
+  }
+
+  private static KubernetesManifest daemonSet(Map<String, Object> status) throws IOException {
+    KubernetesManifest daemonSet = baseDaemonSet();
+    daemonSet.put("status", status);
+    // The logic in KubernetesManifest expects that numeric values are deserialized as Doubles, and
+    // fails when these are Integers.  To avoid having code in this test that works around the issue
+    // (such as by inserting 1.0 as the observedGeneration) just serialize then deserialize the
+    // updated manifest so the test is getting a manifest that is produced exactly as would happen
+    // in real use cases when clouddriver fetches the manifest from kubernetes.
+    return gson.fromJson(gson.toJson(daemonSet), KubernetesManifest.class);
+  }
+
+  @Test
+  public void unstableWhenUnavailable() throws IOException {
+    KubernetesDaemonSetHandler daemonSetHandler = new KubernetesDaemonSetHandler();
+    KubernetesManifest manifest =
+        daemonSet(
+            ImmutableMap.<String, Object>builder()
+                .put("currentNumberScheduled", 1)
+                .put("desiredNumberScheduled", 1)
+                .put("numberMisscheduled", 0)
+                .put("numberReady", 0)
+                .put("numberUnavailable", 1)
+                .put("observedGeneration", 1)
+                .put("updatedNumberScheduled", 1)
+                .build());
+    Status status = daemonSetHandler.status(manifest);
+
+    assertThat(status.getStable().isState()).isFalse();
+  }
+
+  @Test
+  public void stableWhenAllAvailable() throws IOException {
+    KubernetesDaemonSetHandler daemonSetHandler = new KubernetesDaemonSetHandler();
+    KubernetesManifest manifest =
+        daemonSet(
+            ImmutableMap.<String, Object>builder()
+                .put("currentNumberScheduled", 1)
+                .put("desiredNumberScheduled", 1)
+                .put("numberAvailable", 1)
+                .put("numberMisscheduled", 0)
+                .put("numberReady", 1)
+                .put("observedGeneration", 1)
+                .put("updatedNumberScheduled", 1)
+                .build());
+    Status status = daemonSetHandler.status(manifest);
+
+    assertThat(status.getStable().isState()).isTrue();
+  }
+
+  @Test
+  public void stableWhenNoneDesired() throws IOException {
+    KubernetesDaemonSetHandler daemonSetHandler = new KubernetesDaemonSetHandler();
+    KubernetesManifest manifest =
+        daemonSet(
+            ImmutableMap.<String, Object>builder()
+                .put("currentNumberScheduled", 0)
+                .put("desiredNumberScheduled", 0)
+                .put("numberMisscheduled", 0)
+                .put("numberReady", 0)
+                .put("observedGeneration", 1)
+                .build());
+    Status status = daemonSetHandler.status(manifest);
+
+    // TODO(ezimanyi): This is incorrect! Should be stable in this case.
+    assertThat(status.getStable().isState()).isFalse();
+  }
+}

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandlerTest.java
@@ -105,7 +105,6 @@ final class KubernetesDaemonSetHandlerTest {
                 .build());
     Status status = daemonSetHandler.status(manifest);
 
-    // TODO(ezimanyi): This is incorrect! Should be stable in this case.
-    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().isState()).isTrue();
   }
 }

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/daemonsetbase.json
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/daemonsetbase.json
@@ -1,0 +1,65 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "DaemonSet",
+  "metadata": {
+    "creationTimestamp": "2020-01-09T01:01:54Z",
+    "generation": 1,
+    "labels": {
+      "name": "clouddriver"
+    },
+    "name": "clouddriver",
+    "namespace": "unittest",
+    "resourceVersion": "174765289",
+    "selfLink": "/apis/extensions/v1beta1/namespaces/unittest/daemonsets/clouddriver",
+    "uid": "790e9d00-22a2-4f17-87d0-22e79040260b"
+  },
+  "spec": {
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "name": "clouddriver"
+      }
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "name": "clouddriver"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "gcr.io/spinnaker-marketplace/clouddriver",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "clouddriver",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    },
+    "templateGeneration": 1,
+    "updateStrategy": {
+      "rollingUpdate": {
+        "maxUnavailable": 1
+      },
+      "type": "RollingUpdate"
+    }
+  },
+  "status": {
+    "currentNumberScheduled": 1,
+    "desiredNumberScheduled": 1,
+    "numberMisscheduled": 0,
+    "numberReady": 0,
+    "numberUnavailable": 1,
+    "observedGeneration": 1,
+    "updatedNumberScheduled": 1
+  }
+}


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5283.

* test(kubernetes): Add tests to stateful/daemon set stability 

  The next commit will fix bugs in the stateful set and daemon set stability conditions. Add tests to cover the cases that will be fixed; in the case of the daemon set handler, there were no existing tests so this commit adds some basic tests in addition to tests of the bug that will be fixed.

  This commit also does some minor cleanup on the stateful set tests, removing some unused variables and referring to member variables by their name instead of via their groovy-generated accessors.

* fix(kubernetes): Fix stability for stateful/daemon set 

  When scaling a stateful set down to zero replicas, we never consider the stateful set stable. This is because the status field for a stateful set with no replicas omits some fields
  (instead of setting them to 0) and our logic does not properly handle the null case. Fix this and add some tests to validate the fix.

  A similar bug exists with daemon sets; for daemon sets, you don't explicitly set replicas but if you configure the daemon set such that it runs on 0 nodes (for example by including a node selector that doesn't match anything), Spinnaker will never consider the daemon set stable.
