### PR TITLE
fix(unittests): Added dependency required to run spock tests along wi…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ allprojects {
       annotationProcessor "org.projectlombok:lombok"
       testAnnotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
       testAnnotationProcessor "org.projectlombok:lombok"
+      testRuntimeOnly "org.junit.vintage:junit-vintage-engine" // Required for Spock tests to execute along with Junit5 tests.
     }
 
     test {


### PR DESCRIPTION
I recently modified the test configuration to run  `kotlin/Junit5'  tests and due to that change Spock tests stopped executing. To fix this, adding vintage engine required to run spock/junit4 style tests.

Fixes: https://github.com/spinnaker/spinnaker/issues/5299