### PR TITLE
chore(core): standardize on javax nonnull and nullable annotations

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/LoadFront50App.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/LoadFront50App.java
@@ -42,7 +42,6 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -106,9 +105,9 @@ public class LoadFront50App implements SagaAction<LoadFront50App.LoadFront50AppC
     return command;
   }
 
-  @NotNull
+  @Nonnull
   @Override
-  public Result apply(@NotNull LoadFront50AppCommand command, @NotNull Saga saga) {
+  public Result apply(@Nonnull LoadFront50AppCommand command, @Nonnull Saga saga) {
     try {
       Map response = front50Service.getApplication(command.getAppName());
       try {
@@ -154,7 +153,7 @@ public class LoadFront50App implements SagaAction<LoadFront50App.LoadFront50AppC
       this.metadata = metadata;
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public List<SpinnakerEvent> getComposedEvents() {
       return Collections.singletonList(nextCommand);

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/SnapshotAtomicOperationInput.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/SnapshotAtomicOperationInput.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 /**
@@ -41,9 +40,9 @@ import org.springframework.stereotype.Component;
 public class SnapshotAtomicOperationInput
     implements SagaAction<SnapshotAtomicOperationInput.SnapshotAtomicOperationInputCommand> {
 
-  @NotNull
+  @Nonnull
   @Override
-  public Result apply(@NotNull SnapshotAtomicOperationInputCommand command, @NotNull Saga saga) {
+  public Result apply(@Nonnull SnapshotAtomicOperationInputCommand command, @Nonnull Saga saga) {
     // We happily don't need to do anything here. This action just snapshots our input data.
     return new Result(command.nextCommand, Collections.emptyList());
   }
@@ -64,7 +63,7 @@ public class SnapshotAtomicOperationInput
     @NonFinal private EventMetadata metadata;
 
     @Override
-    public void setMetadata(@NotNull EventMetadata eventMetadata) {
+    public void setMetadata(@Nonnull EventMetadata eventMetadata) {
       this.metadata = eventMetadata;
     }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/StatefullyUpdateBootImageAtomicOperation.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/StatefullyUpdateBootImageAtomicOperation.java
@@ -50,8 +50,8 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 
 @Slf4j
 public class StatefullyUpdateBootImageAtomicOperation extends GoogleAtomicOperation<Void> {
@@ -160,7 +160,7 @@ public class StatefullyUpdateBootImageAtomicOperation extends GoogleAtomicOperat
     }
   }
 
-  @NotNull
+  @Nonnull
   private Image getImage(Task task, GoogleNamedAccountCredentials credentials) throws IOException {
 
     task.updateStatus(BASE_PHASE, "Looking up image " + description.getBootImage());

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/AttachTitusServiceLoadBalancers.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/AttachTitusServiceLoadBalancers.java
@@ -33,7 +33,6 @@ import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -52,9 +51,9 @@ public class AttachTitusServiceLoadBalancers extends AbstractTitusDeployAction
     this.titusClientProvider = titusClientProvider1;
   }
 
-  @NotNull
+  @Nonnull
   @Override
-  public Result apply(@NotNull AttachTitusServiceLoadBalancersCommand command, @NotNull Saga saga) {
+  public Result apply(@Nonnull AttachTitusServiceLoadBalancersCommand command, @Nonnull Saga saga) {
     final TitusDeployDescription description = command.description;
 
     prepareDeployDescription(description);

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/CopyTitusServiceScalingPolicies.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/CopyTitusServiceScalingPolicies.java
@@ -45,7 +45,6 @@ import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -63,9 +62,9 @@ public class CopyTitusServiceScalingPolicies extends AbstractTitusDeployAction
     super(accountCredentialsRepository, titusClientProvider);
   }
 
-  @NotNull
+  @Nonnull
   @Override
-  public Result apply(@NotNull CopyTitusServiceScalingPoliciesCommand command, @NotNull Saga saga) {
+  public Result apply(@Nonnull CopyTitusServiceScalingPoliciesCommand command, @Nonnull Saga saga) {
     final TitusDeployDescription description = command.description;
 
     prepareDeployDescription(description);

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/PrepareTitusDeploy.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/PrepareTitusDeploy.java
@@ -63,7 +63,6 @@ import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -117,9 +116,9 @@ public class PrepareTitusDeploy extends AbstractTitusDeployAction
     return input;
   }
 
-  @NotNull
+  @Nonnull
   @Override
-  public Result apply(@NotNull PrepareTitusDeployCommand command, @NotNull Saga saga) {
+  public Result apply(@Nonnull PrepareTitusDeployCommand command, @Nonnull Saga saga) {
     final TitusDeployDescription description = command.description;
 
     prepareDeployDescription(description);

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/SubmitTitusJob.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/SubmitTitusJob.java
@@ -45,7 +45,6 @@ import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,9 +72,9 @@ public class SubmitTitusJob extends AbstractTitusDeployAction
    * references inside of the lambda. This should really be refactored so that pattern isn't
    * necessary. It's really gross as-is.
    */
-  @NotNull
+  @Nonnull
   @Override
-  public Result apply(@NotNull SubmitTitusJobCommand command, @NotNull Saga saga) {
+  public Result apply(@Nonnull SubmitTitusJobCommand command, @Nonnull Saga saga) {
     final TitusDeployDescription description = command.description;
 
     prepareDeployDescription(description);

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployCompletionHandler.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployCompletionHandler.java
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.clouddriver.titus.TitusUtils;
 import com.netflix.spinnaker.clouddriver.titus.deploy.actions.SubmitTitusJob;
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.TitusDeployDescription;
 import com.netflix.spinnaker.clouddriver.titus.deploy.events.TitusJobSubmitted;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -39,7 +39,7 @@ public class TitusDeployCompletionHandler implements SagaCompletionHandler<Titus
 
   @Nullable
   @Override
-  public TitusDeploymentResult handle(@NotNull Saga completedSaga) {
+  public TitusDeploymentResult handle(@Nonnull Saga completedSaga) {
     final TitusDeployDescription description =
         completedSaga.getEvent(SubmitTitusJob.SubmitTitusJobCommand.class).getDescription();
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusExceptionHandler.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusExceptionHandler.java
@@ -19,15 +19,15 @@ package com.netflix.spinnaker.clouddriver.titus.deploy.handlers;
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaExceptionHandler;
 import com.netflix.spinnaker.clouddriver.titus.TitusException;
 import io.grpc.StatusRuntimeException;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TitusExceptionHandler implements SagaExceptionHandler {
 
-  @NotNull
+  @Nonnull
   @Override
-  public Exception handle(@NotNull Exception exception) {
+  public Exception handle(@Nonnull Exception exception) {
     if (exception instanceof StatusRuntimeException) {
       StatusRuntimeException statusRuntimeException = (StatusRuntimeException) exception;
       return new TitusException(statusRuntimeException, isRetryable(statusRuntimeException));


### PR DESCRIPTION
While working with @sgarlick987 on https://github.com/spinnaker/clouddriver/pull/4235, he pointed out that there is a mix of `javax` and `jetbrains` `Nonnull` and `Nullable` annotations in Clouddriver, so it's unclear which is preferred. This change removes all `jetbrains.annotations` in favor of `javax`.