### PR TITLE
fix(appengine): Propagate gcloud failures from job executor to task.

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/AppengineJobExecutor.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/AppengineJobExecutor.groovy
@@ -33,10 +33,10 @@ class AppengineJobExecutor {
 
   void runCommand(List<String> command) {
     JobResult<String> jobStatus = jobExecutor.runJob(new JobRequest(command))
-    if (jobStatus.getResult() == JobResult.Result.FAILURE && jobStatus.getOutput()) {
+    if (jobStatus.getResult() == JobResult.Result.FAILURE) {
       String stdOut = jobStatus.getOutput()
       String stdErr = jobStatus.getError()
-      throw new IllegalArgumentException("$stdOut + $stdErr")
+      throw new IllegalArgumentException("stdout: $stdOut, stderr: $stdErr")
     }
   }
 }


### PR DESCRIPTION
Without this change, executions that fail while emitting only stderr output, but not stdout output, would be considered successes and the stderr output would be squashed.