### PR TITLE
fix(kubernetes): return provider field with kubernetes /search results

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/Keys.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.Kind.KUBERNETES_METRIC;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import java.util.Arrays;
@@ -165,7 +166,7 @@ public class Keys {
 
   @EqualsAndHashCode
   public abstract static class CacheKey {
-    private static final String provider = "kubernetes.v2";
+    @Getter private final String provider = KubernetesCloudProvider.ID;
 
     public abstract String getGroup();
 


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5068

Deck expects each security group returned from `/search` to have a `provider`, `cloudProvider`, or `type` field corresponding to the correct cloud provider in order to render them in the Firewalls tab. [This commit](https://github.com/spinnaker/clouddriver/pull/3826/commits/0331e1f9e03100ad0b72662b724e72fdecd27287) changed the `provider` property of `CacheKey` from "kubernetes" to "kubernetes.v2" (Deck expects it to be "kubernetes"). It also removed `provider`'s getter (this was being generated by `@Data` on `CacheKey` before it was removed) and made it static, so we were no longer deserializing it when returning `/search` results from the cache.