### PR TITLE
fix(kubernetes): do not throw NPE when no initContainers

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
@@ -119,7 +119,8 @@ public class KubernetesV2InstanceProvider
   @Nonnull
   private List<ContainerLog> getPodLogs(
       @Nonnull KubernetesV2Credentials credentials, @Nonnull V1Pod pod) {
-    List<V1Container> initContainers = pod.getSpec().getInitContainers();
+    List<V1Container> initContainers =
+        Optional.ofNullable(pod.getSpec().getInitContainers()).orElse(Collections.emptyList());
     List<V1Container> containers = pod.getSpec().getContainers();
 
     return Stream.concat(initContainers.stream(), containers.stream())


### PR DESCRIPTION
Fixes potential NPE introduced by https://github.com/spinnaker/clouddriver/pull/4235

- `spec.initContainers` defaults to null, not an empty list. Do not throw NPE when no `initContainers` are configured.
- Once https://github.com/spinnaker/clouddriver/pull/4250 is merged, we will get IDE warnings for these nullable properties :smile: 

cc @sgarlick987 