### PR TITLE
fix(artifacts): Replace implicit use of all-args Artifact constructor

### DIFF
--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -37,6 +37,7 @@ import com.netflix.spinnaker.clouddriver.ecs.services.EcsCloudMetricService
 import com.netflix.spinnaker.clouddriver.ecs.services.SecurityGroupSelector
 import com.netflix.spinnaker.clouddriver.ecs.services.SubnetSelector
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 
 import static com.netflix.spinnaker.clouddriver.ecs.deploy.ops.CreateServerGroupAtomicOperation.DOCKER_LABEL_KEY_SERVERGROUP
 
@@ -517,12 +518,12 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
 
   def 'should generate a RegisterTaskDefinitionRequest object from artifact'() {
     given:
-    def resolvedArtifact = [
-      name: "taskdef.json",
-      reference: "fake.github.com/repos/org/repo/taskdef.json",
-      artifactAccount: "my-github-acct",
-      type: "github/file"
-    ]
+    def resolvedArtifact = Artifact.builder()
+      .name("taskdef.json")
+      .reference("fake.github.com/repos/org/repo/taskdef.json")
+      .artifactAccount("my-github-acct")
+      .type("github/file")
+      .build()
     def containerDef1 =
       new ContainerDefinition()
         .withName("web")
@@ -592,12 +593,12 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
 
   def 'should set spinnaker role on FARGATE RegisterTaskDefinitionRequest if none in artifact'() {
     given:
-    def resolvedArtifact = [
-      name: "taskdef.json",
-      reference: "fake.github.com/repos/org/repo/taskdef.json",
-      artifactAccount: "my-github-acct",
-      type: "github/file"
-    ]
+    def resolvedArtifact = Artifact.builder()
+      .name("taskdef.json")
+      .reference("fake.github.com/repos/org/repo/taskdef.json")
+      .artifactAccount("my-github-acct")
+      .type("github/file")
+      .build()
     def containerDef =
       new ContainerDefinition()
         .withName("web")
@@ -642,12 +643,12 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
 
   def 'should fail if network mode in artifact does not match description'() {
     given:
-    def resolvedArtifact = [
-      name: "taskdef.json",
-      reference: "fake.github.com/repos/org/repo/taskdef.json",
-      artifactAccount: "my-github-acct",
-      type: "github/file"
-    ]
+    def resolvedArtifact = Artifact.builder()
+      .name("taskdef.json")
+      .reference("fake.github.com/repos/org/repo/taskdef.json")
+      .artifactAccount("my-github-acct")
+      .type("github/file")
+      .build()
     def registerTaskDefRequest =
       new RegisterTaskDefinitionRequest()
         .withContainerDefinitions([new ContainerDefinition()])


### PR DESCRIPTION
A few tests are implicitly using the all-arg Artifact constructor, which is being made private. These tests were relying on groovy's automatic return value casting to cast a mock return value from a map to an artifact. The automatic casing was relying on the all-args constructor, which has been removed.  The fix is to construct the artifact directly using the builder.