### PR TITLE
fix(sql): SqlUnknownAgentCleanupAgent should not throw errors on nonexistent tables

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgent.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgent.kt
@@ -91,6 +91,13 @@ class SqlUnknownAgentCleanupAgent(
     }
     log.debug("Checking table '$tableName' for '$dataType' data cleanup")
 
+    val tableExists = jooq.fetch("show tables like '$tableName'").intoResultSet()
+    if (!tableExists.next()) {
+      log.debug("Table '$tableName' not found")
+      state.touchedTables.add(tableName)
+      return
+    }
+
     val rs = jooq.select(*cacheTable.fields)
       .from(table(tableName))
       .fetch()

--- a/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgentTest.kt
+++ b/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgentTest.kt
@@ -29,10 +29,9 @@ import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import de.huxhorn.sulky.ulid.ULID
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import org.jooq.exception.DataAccessException
 import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.table
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.ObjectProvider
 import strikt.api.expect
 import strikt.api.expectThat
@@ -98,8 +97,8 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
         fixture
       }
 
-      test("error is thrown because table does not exist for type for which agent is authoritative") {
-        assertThrows<DataAccessException> {
+      test("error is not thrown when table does not exist for type for which agent is authoritative") {
+        assertDoesNotThrow {
           subject.run()
         }
       }


### PR DESCRIPTION
Related to https://github.com/spinnaker/spinnaker/issues/4803

Kubernetes caching agents can be authoritative for resource types for which there are zero instantiated resources. For example, I can register a CRD to a cluster that I never instantiate, and a caching agent will become authoritative for that type but a SQL table will never be created for it. We should ensure a table exists before scanning it for entries to clean up.