### PR TITLE
fix(AWS/securityGroup): Handle description in IPRules and Update tagg…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
@@ -107,21 +107,18 @@ class SecurityGroupIngressConverter {
         it.groupName = null
         it.peeringStatus = null
         it.vpcPeeringConnectionId = null
-        it.description = null // not passed in via the UI
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)
           .withIpProtocol(ipPermission.ipProtocol)
           .withUserIdGroupPairs(it)
       } + ipPermission.ipv4Ranges.collect {
-        it.description = null // not passed in via the UI
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)
           .withIpProtocol(ipPermission.ipProtocol)
           .withIpv4Ranges(it)
       } + ipPermission.ipv6Ranges.collect {
-        it.description = null // not passed in via the UI
         new IpPermission()
           .withFromPort(ipPermission.fromPort)
           .withToPort(ipPermission.toPort)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupFactory.groovy
@@ -20,12 +20,16 @@ import com.amazonaws.services.ec2.AmazonEC2
 import com.amazonaws.services.ec2.model.AuthorizeSecurityGroupIngressRequest
 import com.amazonaws.services.ec2.model.CreateSecurityGroupRequest
 import com.amazonaws.services.ec2.model.CreateTagsRequest
+import com.amazonaws.services.ec2.model.DeleteTagsRequest
 import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest
+import com.amazonaws.services.ec2.model.DescribeTagsRequest
 import com.amazonaws.services.ec2.model.Filter
 import com.amazonaws.services.ec2.model.IpPermission
 import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest
 import com.amazonaws.services.ec2.model.SecurityGroup
 import com.amazonaws.services.ec2.model.Tag
+import com.amazonaws.services.ec2.model.DescribeTagsResult
+import com.amazonaws.services.ec2.model.TagDescription
 import com.google.common.collect.ImmutableSet
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -234,6 +238,7 @@ class SecurityGroupLookupFactory {
   static class SecurityGroupUpdater {
     final SecurityGroup securityGroup
     private final AmazonEC2 amazonEC2
+    private final Logger log = LoggerFactory.getLogger(getClass())
 
     SecurityGroup getSecurityGroup() {
       securityGroup
@@ -258,6 +263,45 @@ class SecurityGroupLookupFactory {
         ipPermissions: ipPermissionsToRemove
       ))
       securityGroup.ipPermissions.removeAll(ipPermissionsToRemove)
+    }
+
+    void updateTags(UpsertSecurityGroupDescription description) {
+      String groupId = securityGroup.groupId
+      try {
+
+        //fetch -> delete -> create new tags to ensure they are consistent
+        DescribeTagsRequest describeTagsRequest = new DescribeTagsRequest().withFilters(
+          new Filter("resource-id", [groupId])
+        )
+        DescribeTagsResult tagsResult = amazonEC2.describeTags(describeTagsRequest)
+        List<TagDescription> tags1 = tagsResult.getTags()
+        Collection<Tag> oldTags = new HashSet()
+        tags1.each {
+          it -> oldTags.add(new Tag(it.key, it.value))
+        }
+
+        DeleteTagsRequest deleteTagsRequest = new DeleteTagsRequest()
+          .withResources(groupId)
+          .withTags(oldTags)
+        amazonEC2.deleteTags(deleteTagsRequest)
+
+        CreateTagsRequest createTagRequest = new CreateTagsRequest()
+        Collection<Tag> tags = new HashSet()
+        tags.add(new Tag("Name", description.name))
+        description.tags.each {
+          entry -> tags.add(new Tag(entry.key, entry.value))
+        }
+        createTagRequest.withResources(groupId).withTags(tags)
+        amazonEC2.createTags(createTagRequest)
+
+      } catch (Exception e) {
+        log.error(
+          "Unable to update tags for security group (groupName: {}, groupId: {})",
+          description.name,
+          groupId,
+          e
+        )
+      }
     }
 
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperation.groovy
@@ -115,6 +115,8 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
 
       try {
         securityGroupUpdater.addIngress(ipPermissionsToAdd)
+        //Update tags to ensure they are consistent with rule changes
+        securityGroupUpdater.updateTags(description)
         task.updateStatus BASE_PHASE, status
       } catch (AmazonServiceException e) {
         task.updateStatus BASE_PHASE, "Error adding ingress to '${description.name}' - ${e.errorMessage}"
@@ -131,6 +133,8 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
 
       try {
         securityGroupUpdater.removeIngress(ipPermissionsToRemove)
+        //Update tags to ensure they are consistent with rule changes
+        securityGroupUpdater.updateTags(description)
         task.updateStatus BASE_PHASE, status
       } catch (AmazonServiceException e) {
         task.updateStatus BASE_PHASE, "Error removing ingress from ${description.name}: ${e.errorMessage}"

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
@@ -101,7 +101,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
-    0 * _
+    1 * createdSecurityGroup.updateTags(description)
   }
 
   void "non-existent security group that is found on create should be updated"() {
@@ -144,7 +144,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
-    0 * _
+    1 * existingSecurityGroup.updateTags(description)
   }
 
   void "existing security group should be unchanged"() {
@@ -181,7 +181,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
-    0 * _
+    1 * existingSecurityGroup.updateTags(description)
   }
 
   void "existing security group should be updated with ingress by id"() {
@@ -206,7 +206,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
-    0 * _
+    1 * existingSecurityGroup.updateTags(description)
   }
 
   void "existing security group should be updated with ingress from another account"() {
@@ -233,7 +233,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         new UserIdGroupPair(userId: "accountId2", groupId: "id-bar")
       ])
     ])
-    0 * _
+    1 * existingSecurityGroup.updateTags(description)
   }
 
   void "existing permissions should not be re-created when a security group is modified"() {
@@ -283,7 +283,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         new UserIdGroupPair(userId: "accountId1", groupId: "grp")
       ])
     ])
-    0 * _
+    2 * existingSecurityGroup.updateTags(description)
   }
 
   void "should only append security group ingress"() {
@@ -326,7 +326,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         new UserIdGroupPair(userId: "accountId1", groupId: "id-bar")
       ])
     ])
-    0 * _
+    1 * existingSecurityGroup.updateTags(description)
   }
 
   void "should fail for missing ingress security group in vpc"() {
@@ -391,7 +391,6 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
     then:
     1 * securityGroupLookup.getSecurityGroupByName("test", "foo", null) >> Optional.of(existingSecurityGroup)
     1 * existingSecurityGroup.getSecurityGroup() >> new SecurityGroup(groupName: "foo", groupId: "123", ipPermissions: [])
-    0 * _
 
     then:
     1 * existingSecurityGroup.addIngress([
@@ -399,6 +398,7 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
         new UserIdGroupPair(userId: "accountId1", groupName: "bar")
       ])
     ])
+    1 * existingSecurityGroup.updateTags(description)
 
   }
 


### PR DESCRIPTION
- Update the diff logic to include description in IP Rules , this was failing to find the correct diff when the rules had description object
- Update tags even while processing Rule changes to make sure we are consistent with tags