### PR TITLE
fix(eureka): make non-404 error codes non fatal on disable ops

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/AbstractEnableDisableInstanceDiscoveryAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/AbstractEnableDisableInstanceDiscoveryAtomicOperation.groovy
@@ -70,7 +70,7 @@ abstract class AbstractEnableDisableInstanceDiscoveryAtomicOperation implements 
 
       def status = isEnable() ? AbstractEurekaSupport.DiscoveryStatus.Enable : AbstractEurekaSupport.DiscoveryStatus.Disable
       discoverySupport.updateDiscoveryStatusForInstances(
-          description, task, phaseName, status, instancesInAsg*.instanceId
+          description, task, phaseName, status, instancesInAsg*.instanceId, true
       )
     }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableDisableAtomicOperationUnitSpecSupport.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/EnableDisableAtomicOperationUnitSpecSupport.groovy
@@ -94,6 +94,8 @@ abstract class EnableDisableAtomicOperationUnitSpecSupport extends Specification
     }
     op.discoverySupport.regionScopedProviderFactory = regionScopedProviderFactory
     op.discoverySupport.eurekaSupportConfigurationProperties = new EurekaSupportConfigurationProperties()
+    op.discoverySupport.eurekaSupportConfigurationProperties.retryIntervalMillis = 0
+    op.discoverySupport.eurekaSupportConfigurationProperties.throttleMillis = 0
     op.regionScopedProviderFactory = regionScopedProviderFactory
   }
 }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/EnableDisableInstancesInDiscoveryAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/discovery/EnableDisableInstancesInDiscoveryAtomicOperationUnitSpec.groovy
@@ -65,7 +65,7 @@ class EnableDisableInstancesInDiscoveryAtomicOperationUnitSpec extends Specifica
 
     then:
     1 * operation.discoverySupport.updateDiscoveryStatusForInstances(
-      _, _, _, expectedDiscoveryStatus, description.instanceIds
+      _, _, _, expectedDiscoveryStatus, description.instanceIds, true
     )
 
     where:

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Status.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/Status.groovy
@@ -21,7 +21,7 @@ package com.netflix.spinnaker.clouddriver.data.task
  * may be used for more complex requirements, like querying a database or centralized task system in a multi-threaded/
  * multi-service environment.
  *
- * A psuedo-composite key of a Status is its phase and status strings.
+ * A pseudo-composite key of a Status is its phase and status strings.
  *
  *
  */
@@ -43,7 +43,7 @@ public interface Status {
   Boolean isCompleted()
 
   /**
-   * Informs whether the task has failed or not. A "failed" state is always indicitive of a "completed" state.
+   * Informs whether the task has failed or not. A "failed" state is always indicative of a "completed" state.
    */
   Boolean isFailed()
 

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
@@ -146,8 +146,12 @@ abstract class AbstractEurekaSupport {
           }
         }
       } catch (RetrofitError retrofitError) {
-        if (retrofitError.response?.status == 404 && discoveryStatus == DiscoveryStatus.Disable) {
-          task.updateStatus phaseName, "Could not find ${instanceId} in application $applicationName in discovery, skipping disable operation."
+        if (discoveryStatus == DiscoveryStatus.Disable) {
+          String errorMessage = (retrofitError.response?.status == 404)
+            ? "Could not find ${instanceId} in application $applicationName in discovery, skipping disable operation."
+            : "Failed updating status of ${instanceId} in application $applicationName in discovery, skipping disable operation."
+
+          task.updateStatus phaseName, errorMessage
         } else {
           errors[instanceId] = retrofitError
         }

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/AbstractEurekaSupport.groovy
@@ -150,12 +150,15 @@ abstract class AbstractEurekaSupport {
         }
       } catch (RetrofitError retrofitError) {
         if (discoveryStatus == DiscoveryStatus.Disable) {
-          String errorMessage = (retrofitError.response?.status == 404)
-            ? "Could not find ${instanceId} in application $applicationName in discovery, skipping disable operation."
-            : "Failed updating status of ${instanceId} in application $applicationName in discovery, skipping disable operation."
+          def alwaysSkippable = retrofitError.response?.status == 404
+          def willSkip = alwaysSkippable || !strict
+          def skippingOrNot = willSkip ? "skipping" : "not skipping"
+
+          String errorMessage = "Failed updating status of ${instanceId} in application $applicationName in discovery" +
+            " and strict=$strict, $skippingOrNot disable operation."
 
           // in strict mode, only 404 errors on disable are ignored
-          if (strict && retrofitError.response?.status != 404) {
+          if (!willSkip) {
             errors[instanceId] = retrofitError
           }
 


### PR DESCRIPTION
There already are a lot of special cases in this class, but marking the task as failed can have pretty bad consequences like failing entire deploy stages and pipelines, triggering rollbacks, etc. If the stars are really poorly aligned and we do get 10 failures (timeouts, 404s, 503s...) I think the kato task should still be considered a success, allowing orca to proceed to the next steps (most likely waiting for down instances) which have a chance of succeeding.