### PR TITLE
chore(kork): use Guava's ThreadFactoryBuilder instead of NamedThreadFactory

### DIFF
--- a/cats/cats-core/cats-core.gradle
+++ b/cats/cats-core/cats-core.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "org.slf4j:slf4j-api"
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "org.codehaus.groovy:groovy-all"
+  implementation "com.google.guava:guava"
 
   compileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"

--- a/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultAgentScheduler.java
+++ b/cats/cats-core/src/main/java/com/netflix/spinnaker/cats/agent/DefaultAgentScheduler.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.cats.agent;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.cats.module.CatsModuleAware;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -54,7 +54,9 @@ public class DefaultAgentScheduler extends CatsModuleAware implements AgentSched
     this(
         Executors.newScheduledThreadPool(
             Runtime.getRuntime().availableProcessors(),
-            new NamedThreadFactory(DefaultAgentScheduler.class.getSimpleName())),
+            new ThreadFactoryBuilder()
+                .setNameFormat(DefaultAgentScheduler.class.getSimpleName() + "-%d")
+                .build()),
         interval,
         unit);
   }

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredAgentScheduler.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.cats.redis.cluster;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.cats.agent.Agent;
 import com.netflix.spinnaker.cats.agent.AgentExecution;
 import com.netflix.spinnaker.cats.agent.AgentLock;
@@ -28,7 +29,6 @@ import com.netflix.spinnaker.cats.cluster.NodeStatusProvider;
 import com.netflix.spinnaker.cats.module.CatsModuleAware;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -74,9 +74,13 @@ public class ClusteredAgentScheduler extends CatsModuleAware
         intervalProvider,
         nodeStatusProvider,
         Executors.newSingleThreadScheduledExecutor(
-            new NamedThreadFactory(ClusteredAgentScheduler.class.getSimpleName())),
+            new ThreadFactoryBuilder()
+                .setNameFormat(ClusteredAgentScheduler.class.getSimpleName() + "-%d")
+                .build()),
         Executors.newCachedThreadPool(
-            new NamedThreadFactory(AgentExecutionAction.class.getSimpleName())),
+            new ThreadFactoryBuilder()
+                .setNameFormat(AgentExecutionAction.class.getSimpleName() + "-%d")
+                .build()),
         enabledAgentPattern,
         agentLockAcquisitionIntervalSeconds,
         dynamicConfigService);

--- a/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentScheduler.java
+++ b/cats/cats-redis/src/main/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentScheduler.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.cats.redis.cluster;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.cats.agent.Agent;
 import com.netflix.spinnaker.cats.agent.AgentExecution;
 import com.netflix.spinnaker.cats.agent.AgentScheduler;
@@ -26,7 +27,6 @@ import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation;
 import com.netflix.spinnaker.cats.cluster.AgentIntervalProvider;
 import com.netflix.spinnaker.cats.cluster.NodeStatusProvider;
 import com.netflix.spinnaker.cats.module.CatsModuleAware;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -111,9 +111,14 @@ public class ClusteredSortAgentScheduler extends CatsModuleAware
     storeScripts();
 
     this.agentWorkPool =
-        Executors.newCachedThreadPool(new NamedThreadFactory(AgentWorker.class.getSimpleName()));
+        Executors.newCachedThreadPool(
+            new ThreadFactoryBuilder()
+                .setNameFormat(AgentWorker.class.getSimpleName() + "-%d")
+                .build());
     Executors.newSingleThreadScheduledExecutor(
-            new NamedThreadFactory(ClusteredSortAgentScheduler.class.getSimpleName()))
+            new ThreadFactoryBuilder()
+                .setNameFormat(ClusteredSortAgentScheduler.class.getSimpleName() + "-%d")
+                .build())
         .scheduleAtFixedRate(this, 0, 1, TimeUnit.SECONDS);
   }
 

--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -17,7 +17,6 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-config"
-  implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "com.netflix.spinnaker.moniker:moniker"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.squareup.okhttp:okhttp"

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
@@ -27,8 +27,8 @@ import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.clouddriver.artifacts.ArtifactUtils;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -117,7 +117,10 @@ public class GcsStorageService {
     Objects objects;
     ExecutorService executor =
         Executors.newFixedThreadPool(
-            8, new NamedThreadFactory(GcsStorageService.class.getSimpleName()));
+            8,
+            new ThreadFactoryBuilder()
+                .setNameFormat(GcsStorageService.class.getSimpleName() + "-%d")
+                .build());
 
     do {
       objects = listMethod.execute();

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerProvider.java
@@ -16,12 +16,12 @@
 package com.netflix.spinnaker.clouddriver.aws.lifecycle;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSupport;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -76,8 +76,10 @@ public class InstanceTerminationLifecycleWorkerProvider {
     ExecutorService executorService =
         Executors.newFixedThreadPool(
             credentials.getRegions().size(),
-            new NamedThreadFactory(
-                InstanceTerminationLifecycleWorkerProvider.class.getSimpleName()));
+            new ThreadFactoryBuilder()
+                .setNameFormat(
+                    InstanceTerminationLifecycleWorkerProvider.class.getSimpleName() + "-%d")
+                .build());
 
     credentials
         .getRegions()

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepository.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepository.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.clouddriver.data.task;
 
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -41,7 +41,10 @@ public class DualTaskRepository implements TaskRepository {
         primary,
         previous,
         Executors.newFixedThreadPool(
-            threadPoolSize, new NamedThreadFactory(DualTaskRepository.class.getSimpleName())),
+            threadPoolSize,
+            new ThreadFactoryBuilder()
+                .setNameFormat(DualTaskRepository.class.getSimpleName() + "-%d")
+                .build()),
         asyncTimeoutSeconds);
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/refresh/CloudConfigRefreshScheduler.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/refresh/CloudConfigRefreshScheduler.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.refresh;
 
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,9 @@ public class CloudConfigRefreshScheduler implements Runnable {
     this.contextRefresher = contextRefresher;
 
     Executors.newSingleThreadScheduledExecutor(
-            new NamedThreadFactory(CloudConfigRefreshScheduler.class.getSimpleName()))
+            new ThreadFactoryBuilder()
+                .setNameFormat(CloudConfigRefreshScheduler.class.getSimpleName() + "-%d")
+                .build())
         .scheduleAtFixedRate(this, interval, interval, TimeUnit.SECONDS);
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueue.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/requestqueue/pooled/PooledRequestQueue.java
@@ -16,11 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.requestqueue.pooled;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.util.Collection;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -93,7 +93,9 @@ public class PooledRequestQueue implements RequestQueue {
             0,
             TimeUnit.MILLISECONDS,
             submittedRequests,
-            new NamedThreadFactory(PooledRequestQueue.class.getSimpleName()));
+            new ThreadFactoryBuilder()
+                .setNameFormat(PooledRequestQueue.class.getSimpleName() + "-%d")
+                .build());
     registry.gauge(
         "pooledRequestQueue.corePoolSize", executorService, ThreadPoolExecutor::getCorePoolSize);
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/search/executor/SearchExecutor.java
@@ -16,11 +16,11 @@
 
 package com.netflix.spinnaker.clouddriver.search.executor;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.search.SearchProvider;
 import com.netflix.spinnaker.clouddriver.search.SearchQueryCommand;
 import com.netflix.spinnaker.clouddriver.search.SearchResultSet;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +41,9 @@ public class SearchExecutor {
     this.executor =
         Executors.newFixedThreadPool(
             configProperties.getThreadPoolSize(),
-            new NamedThreadFactory(SearchExecutor.class.getSimpleName()));
+            new ThreadFactoryBuilder()
+                .setNameFormat(SearchExecutor.class.getSimpleName() + "-%d")
+                .build());
   }
 
   public List<SearchResultSet> searchAllProviders(

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -21,7 +21,6 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-config"
-  implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "com.netflix.spinnaker.moniker:moniker"
   implementation "com.squareup.retrofit:retrofit"
   implementation "org.springframework.boot:spring-boot-actuator"

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/ComputeConfiguration.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/ComputeConfiguration.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.google.compute;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.Executors;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -34,6 +34,8 @@ public class ComputeConfiguration {
   public ListeningExecutorService batchRequestExecutor() {
     return MoreExecutors.listeningDecorator(
         Executors.newCachedThreadPool(
-            new NamedThreadFactory(ComputeConfiguration.class.getSimpleName())));
+            new ThreadFactoryBuilder()
+                .setNameFormat(ComputeConfiguration.class.getSimpleName() + "-%d")
+                .build()));
   }
 }

--- a/clouddriver-kubernetes-v1/clouddriver-kubernetes-v1.gradle
+++ b/clouddriver-kubernetes-v1/clouddriver-kubernetes-v1.gradle
@@ -17,7 +17,6 @@ dependencies {
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-config"
-  implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "com.netflix.spinnaker.moniker:moniker"
   implementation "io.fabric8:kubernetes-client:4.6.0"
   implementation "io.kubernetes:client-java:7.0.0"

--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizable.java
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizable.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v1.provider;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.cats.module.CatsModule;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesCachingAgent;
@@ -29,7 +30,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.CredentialsInitializerSynchronizable;
 import com.netflix.spinnaker.clouddriver.security.ProviderUtils;
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -63,7 +63,9 @@ public class KubernetesV1ProviderSynchronizable implements CredentialsInitialize
 
     ScheduledExecutorService poller =
         Executors.newSingleThreadScheduledExecutor(
-            new NamedThreadFactory(KubernetesV1ProviderSynchronizable.class.getSimpleName()));
+            new ThreadFactoryBuilder()
+                .setNameFormat(KubernetesV1ProviderSynchronizable.class.getSimpleName() + "-%d")
+                .build());
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.cats.agent.Agent;
 import com.netflix.spinnaker.cats.module.CatsModule;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
@@ -25,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAcco
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentDispatcher;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.*;
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -62,7 +62,9 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
 
     ScheduledExecutorService poller =
         Executors.newSingleThreadScheduledExecutor(
-            new NamedThreadFactory(KubernetesV2ProviderSynchronizable.class.getSimpleName()));
+            new ThreadFactoryBuilder()
+                .setNameFormat(KubernetesV2ProviderSynchronizable.class.getSimpleName() + "-%d")
+                .build());
   }
 
   @Override


### PR DESCRIPTION
[`ThreadFactoryBuilder`](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/util/concurrent/ThreadFactoryBuilder.html) supports named threads, but also has additional options that we may want to use in the future. I think guiding people towards that is preferred...