### PR TITLE
feat(dual SQL DB): Allow task repository to connect to two SQL instances

### DIFF
--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -34,6 +34,7 @@ dependencies {
   implementation "org.springframework.cloud:spring-cloud-context"
   implementation "org.springframework.cloud:spring-cloud-config-server"
   implementation "redis.clients:jedis"
+  implementation "org.jooq:jooq"
 
   testImplementation project(":cats:cats-test")
   testImplementation project(":clouddriver-core-tck")

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepositorySpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/data/task/DualTaskRepositorySpec.groovy
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.clouddriver.data.task
 
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -24,7 +25,7 @@ class DualTaskRepositorySpec extends Specification {
   TaskRepository previous = Mock()
 
   @Subject
-  TaskRepository subject = new DualTaskRepository(primary, previous, 4, 1)
+  TaskRepository subject = new DualTaskRepository(primary, previous, 4, 1, DynamicConfigService.NOOP)
 
   void "always creates tasks from primary"() {
     when:

--- a/clouddriver-sql-mysql/mysql-setup.sql
+++ b/clouddriver-sql-mysql/mysql-setup.sql
@@ -1,0 +1,9 @@
+DROP DATABASE IF EXISTS clouddriver;
+SET tx_isolation = 'READ-COMMITTED';
+
+CREATE DATABASE clouddriver;
+CREATE USER clouddriver_migrate;
+CREATE USER clouddriver_service;
+
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, LOCK TABLES, EXECUTE, SHOW VIEW ON `clouddriver`.* TO 'clouddriver_migrate'@'%';
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, EXECUTE, SHOW VIEW ON `clouddriver`.* TO 'clouddriver_service'@'%';

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.kork.sql.config.SqlProperties
 import com.netflix.spinnaker.kork.telemetry.InstrumentedProxy
 import com.netflix.spinnaker.kork.version.ServiceVersion
 import org.jooq.DSLContext
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -52,7 +53,17 @@ class SqlConfiguration {
     jooq: DSLContext,
     clock: Clock
   ): TaskRepository =
-    SqlTaskRepository(jooq, ObjectMapper(), clock)
+    SqlTaskRepository(jooq, ObjectMapper(), clock, ConnectionPools.TASKS.value)
+
+  @Bean
+  @ConditionalOnProperty("sql.task-repository.enabled", "sql.task-repository.secondary.enabled")
+  fun secondarySqlTaskRepository(
+    jooq: DSLContext,
+    clock: Clock,
+    @Value("\${sql.task-repository.secondary.pool-name}") poolName: String
+
+  ): TaskRepository =
+    SqlTaskRepository(jooq, ObjectMapper(), clock, poolName)
 
   @Bean
   @ConditionalOnProperty("sql.task-repository.enabled")

--- a/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
+++ b/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.sql;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.clouddriver.core.test.TaskRepositoryTck;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
+import com.netflix.spinnaker.config.ConnectionPools;
 import com.netflix.spinnaker.kork.sql.config.RetryProperties;
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties;
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil;
@@ -38,7 +39,11 @@ public class SqlTaskRepositoryTest extends TaskRepositoryTck {
     properties.setReads(retry);
     properties.setTransactions(retry);
 
-    return new SqlTaskRepository(database.context, new ObjectMapper(), Clock.systemDefaultZone());
+    return new SqlTaskRepository(
+        database.context,
+        new ObjectMapper(),
+        Clock.systemDefaultZone(),
+        ConnectionPools.TASKS.getValue());
   }
 
   @After

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
@@ -124,7 +124,7 @@ class OperationsController {
    */
   @PostMapping("/task/{id}:resume")
   StartOperationResult resumeTask(@PathVariable("id") String id) {
-    Task t = taskRepository.get(id);
+    Task t = taskRepository.get(id)
     if (t == null) {
       throw new NotFoundException("Task not found (id: $id)")
     }
@@ -136,7 +136,11 @@ class OperationsController {
       }
     }
 
-    List<AtomicOperation> atomicOperations = operationsService.collectAtomicOperationsFromSagas(t.getSagaIds());
+    List<AtomicOperation> atomicOperations = operationsService.collectAtomicOperationsFromSagas(t.getSagaIds())
+    if (atomicOperations.isEmpty()) {
+      throw new NotFoundException("No saga was found for this task id: $id - can't resume")
+    }
+    
     return start(atomicOperations, t.requestId)
   }
 


### PR DESCRIPTION
Adds functionality to point task repository to two DBs (e.g. for migration).
* Add configurable pool name for secondary repo, and ability to look up repo by name instead of class
* Make sure to dedupe the task results in case prior repo and new repo have the same task (e.g. DNS entries point to the same DB)
* Also, sagas are deliberately not migrated (for now), restarting a task whose saga is not in the primary repo will fail

See This would be configured as follows:
```yaml
sql:
  connectionPools:
    default:
      default: true
      user: clouddriver_service
      jdbcUrl: jdbc:mysql://${sql.secondaryBaseUrl}/clouddriver
    tasks:
      user: clouddriver_service
      jdbcUrl: jdbc:mysql://${sql.secondaryBaseUrl}/clouddriver
    tasksPrevious:
      user: clouddriver_service
      jdbcUrl: jdbc:mysql://${sql.readOnlyBaseUrl}/clouddriver
  migration:
    user: clouddriver_migrate
    jdbcUrl: jdbc:mysql://${sql.secondaryBaseUrl}/clouddriver
  taskRepository:
    secondary:
      enabled: true
      poolName: tasksPrevious

dualTaskRepository:
  enabled: true
  primaryClass: com.netflix.spinnaker.clouddriver.sql.SqlTaskRepository
  primaryName: sqlTaskRepository
  previousClass: com.netflix.spinnaker.clouddriver.sql.SqlTaskRepository
  previousName: secondarySqlTaskRepository
```
