### PR TITLE
chore(kork): use ThreadFactoryBuilder instead of NamedThreadFactory

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cluster/SqlClusteredAgentScheduler.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cluster/SqlClusteredAgentScheduler.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.cats.sql.cluster
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentExecution
 import com.netflix.spinnaker.cats.agent.AgentLock
@@ -28,7 +29,6 @@ import com.netflix.spinnaker.cats.module.CatsModuleAware
 import com.netflix.spinnaker.config.ConnectionPools
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.sql.routing.withPool
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory
 import org.jooq.DSLContext
 import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.table
@@ -61,10 +61,10 @@ class SqlClusteredAgentScheduler(
   agentLockAcquisitionIntervalSeconds: Long? = null,
   private val tableNamespace: String? = null,
   private val agentExecutionPool: ExecutorService = Executors.newCachedThreadPool(
-    NamedThreadFactory(AgentExecutionAction::class.java.simpleName)
+    ThreadFactoryBuilder().setNameFormat(AgentExecutionAction::class.java.simpleName + "-%d").build()
   ),
   lockPollingScheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
-    NamedThreadFactory(SqlClusteredAgentScheduler::class.java.simpleName)
+    ThreadFactoryBuilder().setNameFormat(SqlClusteredAgentScheduler::class.java.simpleName + "-%d").build()
   )
 ) : CatsModuleAware(), AgentScheduler<AgentLock>, Runnable {
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.provider.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentProvider
@@ -45,7 +46,6 @@ import com.netflix.spinnaker.clouddriver.aws.provider.agent.InstanceCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.LaunchConfigCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.ReservationReportCachingAgent
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
@@ -95,7 +95,11 @@ class AwsProviderConfig {
 
   @Bean
   ExecutorService reservationReportPool(ReservationReportConfigurationProperties reservationReportConfigurationProperties) {
-    return Executors.newFixedThreadPool(reservationReportConfigurationProperties.threadPoolSize, new NamedThreadFactory(ReservationReport.class.getSimpleName()))
+    return Executors.newFixedThreadPool(
+        reservationReportConfigurationProperties.threadPoolSize,
+        new ThreadFactoryBuilder()
+          .setNameFormat(ReservationReport.class.getSimpleName() + "-%d")
+          .build());
   }
 
   private void synchronizeAwsProvider(AwsProvider awsProvider,

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/cache/CatsSearchProvider.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.cache
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.provider.ProviderRegistry
 import com.netflix.spinnaker.clouddriver.search.SearchProvider
 import com.netflix.spinnaker.clouddriver.search.SearchResultSet
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory
 import groovy.text.SimpleTemplateEngine
 import groovy.text.Template
 import org.slf4j.Logger
@@ -88,7 +88,12 @@ class CatsSearchProvider implements SearchProvider, Runnable {
     }
 
     if (catsInMemorySearchProperties.enabled) {
-      scheduledExecutorService = Executors.newScheduledThreadPool(1, new NamedThreadFactory(CatsSearchProvider.class.getSimpleName()))
+      scheduledExecutorService =
+        Executors.newScheduledThreadPool(
+          1,
+          new ThreadFactoryBuilder()
+            .setNameFormat(CatsSearchProvider.class.getSimpleName() + "-%d")
+            .build());
     }
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.orchestration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
@@ -25,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.metrics.TimedCallable
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEventHandler
 import com.netflix.spinnaker.kork.exceptions.ExceptionSummary
-import com.netflix.spinnaker.kork.threads.NamedThreadFactory
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.Canonical
 import groovy.util.logging.Slf4j
@@ -48,7 +48,7 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
   protected ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
     60L, TimeUnit.SECONDS,
     new SynchronousQueue<Runnable>(),
-    new NamedThreadFactory(DefaultOrchestrationProcessor.class.getSimpleName())) {
+    new ThreadFactoryBuilder().setNameFormat(DefaultOrchestrationProcessor.class.getSimpleName() + "-%d").build()) {
     @Override
     protected void afterExecute(Runnable r, Throwable t) {
       resetMDC()


### PR DESCRIPTION
The prior commit missed a few places where we use NamedThreadFactory; fix these.