### PR TITLE
refactor(kubernetes): Clean up some account resolving code

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesAccountResolver.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesAccountResolver.java
@@ -21,13 +21,12 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.ResourcePrope
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.Optional;
-import javax.annotation.Nonnull;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
+@NonnullByDefault
 class KubernetesAccountResolver {
   private final AccountCredentialsRepository credentialsRepository;
   private final ResourcePropertyRegistry globalResourcePropertyRegistry;
@@ -48,7 +47,6 @@ class KubernetesAccountResolver {
         .map(c -> (KubernetesV2Credentials) c);
   }
 
-  @Nonnull
   ResourcePropertyRegistry getResourcePropertyRegistry(String account) {
     return getCredentials(account)
         .map(KubernetesV2Credentials::getResourcePropertyRegistry)

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesAccountResolver.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesAccountResolver.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.ResourcePropertyRegistry;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesKindRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
@@ -32,15 +31,12 @@ import org.springframework.stereotype.Component;
 class KubernetesAccountResolver {
   private final AccountCredentialsRepository credentialsRepository;
   private final ResourcePropertyRegistry globalResourcePropertyRegistry;
-  private final KubernetesKindRegistry.Factory kindRegistryFactory;
 
   KubernetesAccountResolver(
       AccountCredentialsRepository credentialsRepository,
-      ResourcePropertyRegistry globalResourcePropertyRegistry,
-      KubernetesKindRegistry.Factory kindRegistryFactory) {
+      ResourcePropertyRegistry globalResourcePropertyRegistry) {
     this.credentialsRepository = credentialsRepository;
     this.globalResourcePropertyRegistry = globalResourcePropertyRegistry;
-    this.kindRegistryFactory = kindRegistryFactory;
   }
 
   Optional<KubernetesV2Credentials> getCredentials(String account) {
@@ -57,12 +53,5 @@ class KubernetesAccountResolver {
     return getCredentials(account)
         .map(KubernetesV2Credentials::getResourcePropertyRegistry)
         .orElse(globalResourcePropertyRegistry);
-  }
-
-  @Nonnull
-  KubernetesKindRegistry getKindRegistry(String account) {
-    return getCredentials(account)
-        .map(KubernetesV2Credentials::getKindRegistry)
-        .orElseGet(kindRegistryFactory::create);
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
@@ -35,13 +35,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class KubernetesV2AbstractManifestProvider
     implements ManifestProvider<KubernetesV2Manifest> {
-  protected final KubernetesAccountResolver resourcePropertyResolver;
 
-  public KubernetesV2AbstractManifestProvider(KubernetesAccountResolver resourcePropertyResolver) {
-    this.resourcePropertyResolver = resourcePropertyResolver;
-  }
-
-  protected KubernetesV2Manifest buildManifest(
+  protected static KubernetesV2Manifest buildManifest(
       KubernetesV2Credentials credentials,
       KubernetesManifest manifest,
       List<KubernetesManifest> events,

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
@@ -26,11 +26,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.ManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesKindRegistry;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -39,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class KubernetesV2AbstractManifestProvider
     implements ManifestProvider<KubernetesV2Manifest> {
-  private final KubernetesAccountResolver resourcePropertyResolver;
+  protected final KubernetesAccountResolver resourcePropertyResolver;
 
   public KubernetesV2AbstractManifestProvider(KubernetesAccountResolver resourcePropertyResolver) {
     this.resourcePropertyResolver = resourcePropertyResolver;
@@ -50,26 +48,9 @@ public abstract class KubernetesV2AbstractManifestProvider
     return resourcePropertyResolver.getResourcePropertyRegistry(account);
   }
 
-  protected Optional<KubernetesV2Credentials> getCredentials(String account) {
-    return resourcePropertyResolver.getCredentials(account);
-  }
-
   @Nonnull
   protected KubernetesKindRegistry getKindRegistry(String account) {
     return resourcePropertyResolver.getKindRegistry(account);
-  }
-
-  protected boolean isAccountRelevant(String account) {
-    return getCredentials(account).isPresent();
-  }
-
-  protected boolean makesLiveCalls(String account) {
-    return getCredentials(account)
-        .map(KubernetesV2Credentials::isLiveManifestCalls)
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    "Account " + account + " is not a Kubernetess v2 account"));
   }
 
   protected KubernetesV2Manifest buildManifest(

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2AbstractManifestProvider.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestAnnotater;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.ManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesKindRegistry;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.Comparator;
 import java.util.List;
@@ -46,11 +45,6 @@ public abstract class KubernetesV2AbstractManifestProvider
   @Nonnull
   protected final ResourcePropertyRegistry getRegistry(String account) {
     return resourcePropertyResolver.getResourcePropertyRegistry(account);
-  }
-
-  @Nonnull
-  protected KubernetesKindRegistry getKindRegistry(String account) {
-    return resourcePropertyResolver.getKindRegistry(account);
   }
 
   protected KubernetesV2Manifest buildManifest(

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -34,16 +34,17 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManifestProvider {
+  private final KubernetesAccountResolver accountResolver;
+
   @Autowired
-  public KubernetesV2LiveManifestProvider(KubernetesAccountResolver resourcePropertyResolver) {
-    super(resourcePropertyResolver);
+  public KubernetesV2LiveManifestProvider(KubernetesAccountResolver accountResolver) {
+    this.accountResolver = accountResolver;
   }
 
   @Override
   public KubernetesV2Manifest getManifest(
       String account, String location, String name, boolean includeEvents) {
-    Optional<KubernetesV2Credentials> optionalCredentials =
-        resourcePropertyResolver.getCredentials(account);
+    Optional<KubernetesV2Credentials> optionalCredentials = accountResolver.getCredentials(account);
     if (!optionalCredentials.isPresent()) {
       return null;
     }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -90,7 +90,7 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
               .collect(Collectors.toList());
     }
 
-    return buildManifest(account, manifest, events, metrics);
+    return buildManifest(credentials, manifest, events, metrics);
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.Kubern
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.ManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,7 +34,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManifestProvider {
+public class KubernetesV2LiveManifestProvider implements ManifestProvider<KubernetesV2Manifest> {
   private final KubernetesAccountResolver accountResolver;
 
   @Autowired
@@ -91,7 +92,7 @@ public class KubernetesV2LiveManifestProvider extends KubernetesV2AbstractManife
               .collect(Collectors.toList());
     }
 
-    return buildManifest(credentials, manifest, events, metrics);
+    return KubernetesV2ManifestBuilder.buildManifest(credentials, manifest, events, metrics);
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestBuilder.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestBuilder.java
@@ -22,21 +22,18 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesRes
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestAnnotater;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.ManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
-public abstract class KubernetesV2AbstractManifestProvider
-    implements ManifestProvider<KubernetesV2Manifest> {
-
-  protected static KubernetesV2Manifest buildManifest(
+@NonnullByDefault
+final class KubernetesV2ManifestBuilder {
+  static KubernetesV2Manifest buildManifest(
       KubernetesV2Credentials credentials,
       KubernetesManifest manifest,
       List<KubernetesManifest> events,

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -75,7 +75,7 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
     }
 
     KubernetesKind kind = parsedName.getLeft();
-    if (!getKindRegistry(account).getKindProperties(kind).isNamespaced()
+    if (!credentials.getKindRegistry().getKindProperties(kind).isNamespaced()
         && StringUtils.isNotEmpty(location)) {
       log.warn(
           "Kind {} is not namespaced, but namespace {} was provided (ignoring)", kind, location);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesRes
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,11 +56,14 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
   @Override
   public KubernetesV2Manifest getManifest(
       String account, String location, String name, boolean includeEvents) {
-    if (!isAccountRelevant(account)) {
+    Optional<KubernetesV2Credentials> optionalCredentials =
+        resourcePropertyResolver.getCredentials(account);
+    if (!optionalCredentials.isPresent()) {
       return null;
     }
+    KubernetesV2Credentials credentials = optionalCredentials.get();
 
-    if (makesLiveCalls(account)) {
+    if (credentials.isLiveManifestCalls()) {
       return null;
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -45,19 +45,19 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestProvider {
   private final KubernetesCacheUtils cacheUtils;
+  private final KubernetesAccountResolver accountResolver;
 
   @Autowired
   public KubernetesV2ManifestProvider(
-      KubernetesAccountResolver resourcePropertyResolver, KubernetesCacheUtils cacheUtils) {
-    super(resourcePropertyResolver);
+      KubernetesAccountResolver accountResolver, KubernetesCacheUtils cacheUtils) {
     this.cacheUtils = cacheUtils;
+    this.accountResolver = accountResolver;
   }
 
   @Override
   public KubernetesV2Manifest getManifest(
       String account, String location, String name, boolean includeEvents) {
-    Optional<KubernetesV2Credentials> optionalCredentials =
-        resourcePropertyResolver.getCredentials(account);
+    Optional<KubernetesV2Credentials> optionalCredentials = accountResolver.getCredentials(account);
     if (!optionalCredentials.isPresent()) {
       return null;
     }
@@ -98,8 +98,7 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
   @Override
   public List<KubernetesV2Manifest> getClusterAndSortAscending(
       String account, String location, String kind, String app, String cluster, Sort sort) {
-    Optional<KubernetesV2Credentials> optionalCredentials =
-        resourcePropertyResolver.getCredentials(account);
+    Optional<KubernetesV2Credentials> optionalCredentials = accountResolver.getCredentials(account);
     if (!optionalCredentials.isPresent()) {
       return null;
     }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPod
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.ManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.ArrayList;
@@ -43,7 +44,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestProvider {
+public class KubernetesV2ManifestProvider implements ManifestProvider<KubernetesV2Manifest> {
   private final KubernetesCacheUtils cacheUtils;
   private final KubernetesAccountResolver accountResolver;
 
@@ -152,6 +153,6 @@ public class KubernetesV2ManifestProvider extends KubernetesV2AbstractManifestPr
             .map(KubernetesCacheDataConverter::getMetrics)
             .orElse(Collections.emptyList());
 
-    return buildManifest(credentials, manifest, events, metrics);
+    return KubernetesV2ManifestBuilder.buildManifest(credentials, manifest, events, metrics);
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -88,7 +88,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private final Clock clock;
   private final KubectlJobExecutor jobExecutor;
 
-  @Include private final String accountName;
+  @Include @Getter private final String accountName;
 
   @Include @Getter private final ImmutableList<String> namespaces;
 


### PR DESCRIPTION
This is primarily to make the code simpler, but may help a bit with performance as it will stop us from continually looking up an account from the registry inside of loops; instead we'll get the account outside of the loop and use it as needed inside the loop.

I promise there is actually a bug fix at the end of these refactor PRs, these are just cleaning things up before I apply the fix (and will make the fix easier).

* refactor(kubernetes): Remove isAccountRelevant and makesLiveCalls 

  Both implementations of KubernetesV2AbstractManifestProvider separately call isAccountRelevant and makesLiveCalls to determine if an account exists. This duplicates work and also adds an unnecessary layer of indirection; instead juts have them get the optional account and ask the account (if present) directly what they need to know.

  This commit makes resourcePropertyResolver protected in the parent class so that subclasses can use it, but a later commit will just push it directly down to the subclasses.

* refactor(kubernetes): Remove getKindRegistry 

  Just as with the prior commit, we don't need the account resolver anymore by the time we're calling this as we already have valid credentials; just call credentials.getKindRegistry() to get the kind regsitry.

* refactor(kubernetes): Pass credentials instead of account name 

  In a number of the functions in the KubernetesManifestProvider (and LiveManifestProvider) we pass around an account name even when we already have the credentials; to avoid having the function we call need to resolve the credentials again, just pass the credentials.

  To account (no pun intended) for cases where we need the name of the account (generally for logging), add a Getter to get the account name from the credentials.

  This allows us to remove getRegistry from the base manifest provider as it is no longer used.

* refactor(kubernetes): Add NonnullByDefault to account resolver 

  Also remove an unused Slf4j annotation

* refactor(kubernetes): Push account resolver to implementing classes 

  The KubernetesAccountResolver is never actually used in the abstract base class; move it to the implementations. Also rename it in the instances from resourcePropertyResolver to accountResolver as that is a better name.

  Finally, mark buildManifest as static as it does not depend on any instance properties.

* refactor(kubernetes): Eliminate abstract base class 

  At this point, all the KubernetesV2AbstractManifestProvider is doing is supplying a single static method. Rather than using inheritance to share it between the two implementations, we'll use composition.

  * Change the two concrete manifest providers to directly implement ManifestProvider<KubernetesV2Manifest>
  * Rename KubernetesV2AbstractManifestProvider to KubernetesV2ManifestBuilder as it helps build a manifest
  * Call the static method in KubernetesV2ManifestBuilder from the manifest providers

  The abstract class being eliminatd is not one that should be used by people extending Spinnaker; the only reason there is a base class at all was to sit on top of live- and non-live- manifest providers.

  There may be a better place for the single method in KubernetesV2ManifestBuilder but for now I'll leave it there and will leave finding a better place to a future refactor.
