### PR TITLE
fix(sql): Mark task as dirty on retry() invocation

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
@@ -87,7 +87,7 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
     def tasksId = registry.createId('tasks')
 
     // Get the task (either an existing one, or a new one). If the task already exists, `shouldExecute` will be false
-    // if the task is in a non-failed state, or is not retryable.
+    // if the task is in a failed state and the failure is not retryable.
     def result = getTask(clientRequestId)
     def task = result.task
     if (!result.shouldExecute) {
@@ -228,7 +228,7 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
       if (!existingTask.isRetryable()) {
         return new GetTaskResult(existingTask, false)
       }
-      existingTask.updateStatus(TASK_PHASE, "Re-initializing Orchestration Task")
+      existingTask.updateStatus(TASK_PHASE, "Re-initializing Orchestration Task (failure is retryable)")
       existingTask.retry()
       return new GetTaskResult(existingTask, true)
     }

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTask.kt
@@ -114,6 +114,7 @@ class SqlTask(
   }
 
   override fun retry() {
+    this.dirty.set(true)
     repository.updateState(this, TaskState.STARTED)
   }
 


### PR DESCRIPTION
I'm not totally sure this will fix the issue we're seeing where the `Re-initializing` message sometimes gets added multiple times, but this is a bug anyhow.