### PR TITLE
fix(kubernetes): Allow deploying a CRD and object in same manifest

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.validator;
 
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
@@ -124,9 +125,15 @@ public class KubernetesValidationUtil {
     return true;
   }
 
+  // When validating a kind, we'll allow kinds that are either valid or unknown. This is to support
+  // the case where a user is deploying a multi-manifest (perhaps from a Helm chart) that contains
+  // a CRD and an object using that CRD.
+  private static ImmutableSet<KubernetesKindStatus> validKindStatuses =
+      ImmutableSet.of(KubernetesKindStatus.VALID, KubernetesKindStatus.UNKNOWN);
+
   private boolean validateKind(KubernetesKind kind, KubernetesV2Credentials credentials) {
     KubernetesKindStatus kindStatus = credentials.getKindStatus(kind);
-    if (kindStatus != KubernetesKindStatus.VALID) {
+    if (!validKindStatuses.contains(kindStatus)) {
       reject(kindStatus.getErrorMessage(kind), kind.toString());
       return false;
     }

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -21,7 +21,9 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.AccountResourcePropertyRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesApiGroupSpec
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
@@ -108,6 +110,19 @@ class KubernetesV2CredentialsSpec extends Specification {
     then:
     credentials.getKindStatus(KubernetesKind.DEPLOYMENT) == KubernetesKindStatus.EXPLICITLY_OMITTED_BY_CONFIGURATION
     credentials.getKindStatus(KubernetesKind.REPLICA_SET) == KubernetesKindStatus.VALID
+  }
+
+  void "CRDs that are not installed return unknown"() {
+    given:
+    KubernetesApiGroup customGroup = KubernetesApiGroup.fromString("deployment.stable.example.com")
+    KubernetesV2Credentials credentials = credentialFactory.build(new KubernetesConfigurationProperties.ManagedAccount(
+      name: "k8s",
+      namespaces: [NAMESPACE],
+      checkPermissionsOnStartup: true,
+    ))
+
+    expect:
+    credentials.getKindStatus(KubernetesKind.from("my-kind", customGroup)) == KubernetesKindStatus.UNKNOWN
   }
 
   void "Kinds that are not readable are considered invalid"() {

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials.KubernetesKindStatus
 import com.netflix.spinnaker.kork.configserver.ConfigFileService
 import spock.lang.Specification
 
@@ -63,8 +64,8 @@ class KubernetesV2CredentialsSpec extends Specification {
       ))
 
     then:
-    credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
-    credentials.isValidKind(KubernetesKind.REPLICA_SET) == true
+    credentials.getKindStatus(KubernetesKind.DEPLOYMENT) == KubernetesKindStatus.VALID
+    credentials.getKindStatus(KubernetesKind.REPLICA_SET) == KubernetesKindStatus.VALID
   }
 
   void "Built-in Kubernetes kinds are considered valid by default when kinds is empty"() {
@@ -77,8 +78,8 @@ class KubernetesV2CredentialsSpec extends Specification {
       ))
 
     then:
-    credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
-    credentials.isValidKind(KubernetesKind.REPLICA_SET) == true
+    credentials.getKindStatus(KubernetesKind.DEPLOYMENT) == KubernetesKindStatus.VALID
+    credentials.getKindStatus(KubernetesKind.REPLICA_SET) == KubernetesKindStatus.VALID
   }
 
   void "Only explicitly listed kinds are valid when kinds is not empty"() {
@@ -91,8 +92,8 @@ class KubernetesV2CredentialsSpec extends Specification {
       ))
 
     then:
-    credentials.isValidKind(KubernetesKind.DEPLOYMENT) == true
-    credentials.isValidKind(KubernetesKind.REPLICA_SET) == false
+    credentials.getKindStatus(KubernetesKind.DEPLOYMENT) == KubernetesKindStatus.VALID
+    credentials.getKindStatus(KubernetesKind.REPLICA_SET) == KubernetesKindStatus.MISSING_FROM_ALLOWED_KINDS
   }
 
   void "Explicitly omitted kinds are not valid"() {
@@ -105,8 +106,8 @@ class KubernetesV2CredentialsSpec extends Specification {
       ))
 
     then:
-    credentials.isValidKind(KubernetesKind.DEPLOYMENT) == false
-    credentials.isValidKind(KubernetesKind.REPLICA_SET) == true
+    credentials.getKindStatus(KubernetesKind.DEPLOYMENT) == KubernetesKindStatus.EXPLICITLY_OMITTED_BY_CONFIGURATION
+    credentials.getKindStatus(KubernetesKind.REPLICA_SET) == KubernetesKindStatus.VALID
   }
 
   void "Kinds that are not readable are considered invalid"() {
@@ -124,8 +125,8 @@ class KubernetesV2CredentialsSpec extends Specification {
     }
 
     expect:
-    credentials.isValidKind(KubernetesKind.DEPLOYMENT) == false
-    credentials.isValidKind(KubernetesKind.REPLICA_SET) == true
+    credentials.getKindStatus(KubernetesKind.DEPLOYMENT) == KubernetesKindStatus.READ_ERROR
+    credentials.getKindStatus(KubernetesKind.REPLICA_SET) == KubernetesKindStatus.VALID
   }
 
   void "Metrics are properly set on the account when not checking permissions"() {


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4645.

* test(kubernetes): Fix some tests on kind status 

  The prior PR made isValidKind private, leaving only getKindStatus exposed. Change the tests to exercise the public method rather than the private one.

* fix(kubernetes): Allow deploying a CRD and object in same manifest 

  Currently a multi-manifest that deploys a CRD and an object referencing that CRD will fail, because we validate that all objects are of a kind that exists in the cluster, but the CRD won't exist until the manifest is deployed.

  Let's fix this by adding a kind status UNKNOWN, which means that Spinnaker does not know about this kind (and can't find it in the cluster's CRDs) and allow deploying manifests whose kind has this status.