### PR TITLE
fix(ALB): Don't try to fetch LB when ALB is requested

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
@@ -63,7 +63,7 @@ class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAg
     if (!data.containsKey("loadBalancerName")) {
       return null
     }
-    if (data.containsKey("loadBalancerType") && data.loadBalancerType.equals("application")) {
+    if ("application".equals(data.loadBalancerType)) {
       return null
     }
     if (!data.containsKey("account")) {
@@ -250,4 +250,3 @@ class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAg
     ])
   }
 }
-

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
@@ -63,6 +63,9 @@ class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAg
     if (!data.containsKey("loadBalancerName")) {
       return null
     }
+    if (data.containsKey("loadBalancerType") && data.loadBalancerType.equals("application")) {
+      return null
+    }
     if (!data.containsKey("account")) {
       return null
     }


### PR DESCRIPTION
We see an issue where whenever you create an ALB we will actually fail in edda because we try to get the updated details of the ALB
from both the ALB and the non-ALB list.
Don't try to fetch an ALB from regular LBs (this is symmetric to what ALB caching agent does)
