### PR TITLE
fix(kubernetes): On refresh, don't replace credentials that have not changed

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
@@ -115,6 +115,10 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
                 // account exists but has changed
                 changedAccounts.add(managedAccount.getName());
                 newAndChangedAccounts.add(managedAccount.getName());
+              } else {
+                // Current credentials may contain memoized namespaces, we should keep if the
+                // definition has not changed
+                return;
               }
 
               accountCredentialsRepository.save(managedAccount.getName(), credentials);


### PR DESCRIPTION
Similar to https://github.com/spinnaker/clouddriver/pull/4297 but limited to not losing the memoized values. It will only address dynamic accounts becoming unreachable.