### PR TITLE
refactor(kubernetes): Simplify status handlers

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
@@ -17,12 +17,16 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.model;
 
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.Value;
 
 public interface Manifest {
   Moniker getMoniker();
@@ -37,55 +41,68 @@ public interface Manifest {
 
   List<Warning> getWarnings();
 
-  @Data
+  @Getter
+  @EqualsAndHashCode
+  @NonnullByDefault
+  @ToString
   class Status {
-    Condition stable = Condition.builder().state(true).build();
-    Condition paused = Condition.builder().state(false).build();
-    Condition available = Condition.builder().state(true).build();
-    Condition failed = Condition.builder().state(false).build();
+    private @Nullable Condition stable = Condition.withState(true);
+    private Condition paused = Condition.withState(false);
+    private Condition available = Condition.withState(true);
+    private @Nullable Condition failed = Condition.withState(false);
+
+    public static Status defaultStatus() {
+      return new Status();
+    }
 
     public Status unknown() {
       stable = null;
       failed = null;
-
       return this;
     }
 
-    public Status failed(String message) {
-      failed.setMessage(message);
-      failed.setState(true);
-
+    public Status failed(@Nullable String message) {
+      failed = new Condition(true, message);
       return this;
     }
 
-    public Status unstable(String message) {
-      stable.setMessage(message);
-      stable.setState(false);
-
+    public Status stable(@Nullable String message) {
+      stable = new Condition(true, message);
       return this;
     }
 
-    public Status paused(String message) {
-      paused.setMessage(message);
-      paused.setState(true);
-
+    public Status unstable(@Nullable String message) {
+      stable = new Condition(false, message);
       return this;
     }
 
-    public Status unavailable(String message) {
-      available.setMessage(message);
-      available.setState(false);
-
+    public Status paused(@Nullable String message) {
+      paused = new Condition(true, message);
       return this;
     }
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
+    public Status unavailable(@Nullable String message) {
+      available = new Condition(false, message);
+      return this;
+    }
+
+    @NonnullByDefault
+    @Value
     public static class Condition {
-      boolean state;
-      String message;
+      private static final Condition TRUE = new Condition(true, null);
+      private static final Condition FALSE = new Condition(false, null);
+
+      private final boolean state;
+      @Nullable private final String message;
+
+      public static Condition withState(boolean state) {
+        return state ? TRUE : FALSE;
+      }
+
+      public Condition(boolean state, @Nullable String message) {
+        this.state = state;
+        this.message = message;
+      }
     }
   }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
@@ -88,18 +88,18 @@ public interface Manifest {
 
     @NonnullByDefault
     @Value
-    public static class Condition {
+    public static final class Condition {
       private static final Condition TRUE = new Condition(true, null);
       private static final Condition FALSE = new Condition(false, null);
 
       private final boolean state;
       @Nullable private final String message;
 
-      public static Condition withState(boolean state) {
+      private static Condition withState(boolean state) {
         return state ? TRUE : FALSE;
       }
 
-      public Condition(boolean state, @Nullable String message) {
+      private Condition(boolean state, @Nullable String message) {
         this.state = state;
         this.message = message;
       }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CustomKubernetesHandlerFactory.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CustomKubernetesHandlerFactory.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.dat
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
@@ -88,7 +89,7 @@ public class CustomKubernetesHandlerFactory {
 
     @Override
     public Manifest.Status status(KubernetesManifest manifest) {
-      return new Manifest.Status();
+      return Status.defaultStatus();
     }
 
     @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesAPIServiceHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesAPIServiceHandler.java
@@ -53,7 +53,7 @@ public class KubernetesAPIServiceHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleBindingHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleBindingHandler.java
@@ -54,7 +54,7 @@ public class KubernetesClusterRoleBindingHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesClusterRoleHandler.java
@@ -54,7 +54,7 @@ public class KubernetesClusterRoleHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesConfigMapHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesConfigMapHandler.java
@@ -54,7 +54,7 @@ public class KubernetesConfigMapHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesControllerRevisionHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesControllerRevisionHandler.java
@@ -52,7 +52,7 @@ public class KubernetesControllerRevisionHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCronJobHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCronJobHandler.java
@@ -85,13 +85,13 @@ public class KubernetesCronJobHandler extends KubernetesHandler
   }
 
   private Status status(V2alpha1CronJob job) {
-    Status result = new Status();
     V2alpha1CronJobStatus status = job.getStatus();
     if (status == null) {
-      result.unstable("No status reported yet").unavailable("No availability reported");
-      return result;
+      return Status.defaultStatus()
+          .unstable("No status reported yet")
+          .unavailable("No availability reported");
     }
 
-    return result;
+    return Status.defaultStatus();
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCustomResourceDefinitionHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCustomResourceDefinitionHandler.java
@@ -54,7 +54,7 @@ public class KubernetesCustomResourceDefinitionHandler extends KubernetesHandler
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
@@ -88,7 +88,7 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
   @Override
   public Status status(KubernetesManifest manifest) {
     if (manifest.isNewerThanObservedGeneration()) {
-      return (new Status()).unknown();
+      return Status.defaultStatus().unknown();
     }
     V1beta2DaemonSet v1beta2DaemonSet =
         KubernetesCacheDataConverter.getResource(manifest, V1beta2DaemonSet.class);
@@ -104,46 +104,45 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
   }
 
   private Status status(V1beta2DaemonSet daemonSet) {
-    Status result = new Status();
-
     V1beta2DaemonSetStatus status = daemonSet.getStatus();
     if (status == null) {
-      result.unstable("No status reported yet").unavailable("No availability reported");
-      return result;
+      return Status.defaultStatus()
+          .unstable("No status reported yet")
+          .unavailable("No availability reported");
     }
 
     if (!daemonSet.getSpec().getUpdateStrategy().getType().equalsIgnoreCase("rollingupdate")) {
-      return result;
+      return Status.defaultStatus();
     }
 
     Long observedGeneration = status.getObservedGeneration();
     if (observedGeneration != null
         && !observedGeneration.equals(daemonSet.getMetadata().getGeneration())) {
-      return result.unstable("Waiting for daemonset spec update to be observed");
+      return Status.defaultStatus().unstable("Waiting for daemonset spec update to be observed");
     }
 
     int desiredReplicas = defaultToZero(status.getDesiredNumberScheduled());
     int existing = defaultToZero(status.getCurrentNumberScheduled());
     if (desiredReplicas > existing) {
-      return result.unstable("Waiting for all replicas to be scheduled");
+      return Status.defaultStatus().unstable("Waiting for all replicas to be scheduled");
     }
 
     existing = defaultToZero(status.getUpdatedNumberScheduled());
     if (desiredReplicas > existing) {
-      return result.unstable("Waiting for all updated replicas to be scheduled");
+      return Status.defaultStatus().unstable("Waiting for all updated replicas to be scheduled");
     }
 
     existing = defaultToZero(status.getNumberAvailable());
     if (desiredReplicas > existing) {
-      return result.unstable("Waiting for all replicas to be available");
+      return Status.defaultStatus().unstable("Waiting for all replicas to be available");
     }
 
     existing = defaultToZero(status.getNumberReady());
     if (desiredReplicas > existing) {
-      return result.unstable("Waiting for all replicas to be ready");
+      return Status.defaultStatus().unstable("Waiting for all replicas to be ready");
     }
 
-    return result;
+    return Status.defaultStatus();
   }
 
   // Unboxes an Integer, returning 0 if the input is null

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -34,13 +34,19 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentCondition;
 import io.kubernetes.client.openapi.models.V1DeploymentStatus;
-import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import lombok.Getter;
 import org.springframework.stereotype.Component;
 
 @Component
+@NonnullByDefault
 public class KubernetesDeploymentHandler extends KubernetesHandler
     implements CanResize,
         CanScale,
@@ -53,7 +59,6 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
   private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
       ImmutableSet.of(EXTENSIONS_V1BETA1, APPS_V1BETA1, APPS_V1BETA2, APPS_V1);
 
-  @Nonnull
   @Override
   protected ImmutableList<Replacer> artifactReplacers() {
     return ImmutableList.of(
@@ -71,7 +76,6 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
     return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
-  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.DEPLOYMENT;
@@ -82,7 +86,6 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
     return false;
   }
 
-  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.SERVER_GROUP_MANAGERS;
@@ -107,68 +110,97 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
   }
 
   private Status status(V1Deployment deployment) {
-    Status result = Status.defaultStatus();
     V1DeploymentStatus status = deployment.getStatus();
     if (status == null) {
-      result.unstable("No status reported yet").unavailable("No availability reported");
-      return result;
+      return Status.defaultStatus()
+          .unstable("No status reported yet")
+          .unavailable("No availability reported");
     }
 
-    V1DeploymentCondition paused =
-        status.getConditions().stream()
-            .filter(c -> c.getReason().equalsIgnoreCase("deploymentpaused"))
-            .findAny()
-            .orElse(null);
+    List<V1DeploymentCondition> conditions =
+        Optional.ofNullable(status.getConditions()).orElse(ImmutableList.of());
 
-    V1DeploymentCondition available =
-        status.getConditions().stream()
-            .filter(c -> c.getType().equalsIgnoreCase("available"))
-            .findAny()
-            .orElse(null);
-
-    if (paused != null) {
-      result.paused(paused.getMessage());
+    Status result = Status.defaultStatus();
+    getPausedReason(conditions).ifPresent(reason -> result.paused(reason));
+    getUnavailableReason(conditions)
+        .ifPresent(reason -> result.unstable(reason).unavailable(reason));
+    Optional<String> failedReason = getFailedReason(conditions);
+    // TODO(ezimanyi): Unclear that we should return early here; worth properly setting stable below
+    if (failedReason.isPresent()) {
+      return result.failed(failedReason.get());
     }
-
-    if (available != null && available.getStatus().equalsIgnoreCase("false")) {
-      result.unstable(available.getMessage()).unavailable(available.getMessage());
-    }
-
-    V1DeploymentCondition condition =
-        status.getConditions().stream()
-            .filter(c -> c.getType().equalsIgnoreCase("progressing"))
-            .findAny()
-            .orElse(null);
-    if (condition != null && condition.getReason().equalsIgnoreCase("progressdeadlineexceeded")) {
-      return result.failed("Deployment exceeded its progress deadline");
-    }
-
-    Integer desiredReplicas = deployment.getSpec().getReplicas();
-    Integer statusReplicas = status.getReplicas();
-    if ((desiredReplicas == null || desiredReplicas == 0)
-        && (statusReplicas == null || statusReplicas == 0)) {
-      return result;
-    }
-
-    Integer updatedReplicas = status.getUpdatedReplicas();
-    if (updatedReplicas == null || (desiredReplicas != null && desiredReplicas > updatedReplicas)) {
-      return result.unstable("Waiting for all replicas to be updated");
-    }
-
-    if (statusReplicas != null && statusReplicas > updatedReplicas) {
-      return result.unstable("Waiting for old replicas to finish termination");
-    }
-
-    Integer availableReplicas = status.getAvailableReplicas();
-    if (availableReplicas == null || availableReplicas < updatedReplicas) {
-      return result.unstable("Waiting for all replicas to be available");
-    }
-
-    Integer readyReplicas = status.getReadyReplicas();
-    if (readyReplicas == null || (desiredReplicas != null && desiredReplicas > readyReplicas)) {
-      return result.unstable("Waiting for all replicas to be ready");
-    }
-
+    checkReplicaCounts(deployment, status)
+        .ifPresent(reason -> result.unstable(reason.getMessage()));
     return result;
+  }
+
+  private static Optional<String> getUnavailableReason(
+      Collection<V1DeploymentCondition> conditions) {
+    return conditions.stream()
+        .filter(c -> c.getType().equalsIgnoreCase("available"))
+        .filter(c -> c.getStatus().equalsIgnoreCase("false"))
+        .map(V1DeploymentCondition::getMessage)
+        .findAny();
+  }
+
+  private static Optional<String> getPausedReason(Collection<V1DeploymentCondition> conditions) {
+    return conditions.stream()
+        .filter(c -> c.getReason() != null)
+        .filter(c -> c.getReason().equalsIgnoreCase("deploymentpaused"))
+        .map(V1DeploymentCondition::getMessage)
+        .findAny();
+  }
+
+  private static Optional<String> getFailedReason(Collection<V1DeploymentCondition> conditions) {
+    return conditions.stream()
+        .filter(c -> c.getType().equalsIgnoreCase("progressing"))
+        .filter(c -> c.getReason() != null)
+        .filter(c -> c.getReason().equalsIgnoreCase("progressdeadlineexceeded"))
+        .map(c -> "Deployment exceeded its progress deadline")
+        .findAny();
+  }
+
+  // Unboxes an Integer, returning 0 if the input is null
+  private static int defaultToZero(@Nullable Integer input) {
+    return input == null ? 0 : input;
+  }
+
+  private static Optional<UnstableReason> checkReplicaCounts(
+      V1Deployment deployment, V1DeploymentStatus status) {
+    int desiredReplicas = defaultToZero(deployment.getSpec().getReplicas());
+    int updatedReplicas = defaultToZero(status.getUpdatedReplicas());
+    if (updatedReplicas < desiredReplicas) {
+      return Optional.of(UnstableReason.UPDATED_REPLICAS);
+    }
+
+    int statusReplicas = defaultToZero(status.getReplicas());
+    if (statusReplicas > updatedReplicas) {
+      return Optional.of(UnstableReason.OLD_REPLICAS);
+    }
+
+    int availableReplicas = defaultToZero(status.getAvailableReplicas());
+    if (availableReplicas < desiredReplicas) {
+      return Optional.of(UnstableReason.AVAILABLE_REPLICAS);
+    }
+
+    int readyReplicas = defaultToZero(status.getReadyReplicas());
+    if (readyReplicas < desiredReplicas) {
+      return Optional.of(UnstableReason.READY_REPLICAS);
+    }
+
+    return Optional.empty();
+  }
+
+  private enum UnstableReason {
+    UPDATED_REPLICAS("Waiting for all replicas to be updated"),
+    OLD_REPLICAS("Waiting for old replicas to finish termination"),
+    AVAILABLE_REPLICAS("Waiting for all replicas to be available"),
+    READY_REPLICAS("Waiting for all replicas to be ready");
+
+    @Getter private final String message;
+
+    UnstableReason(String message) {
+      this.message = message;
+    }
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -120,14 +120,10 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
         Optional.ofNullable(status.getConditions()).orElse(ImmutableList.of());
 
     Status result = Status.defaultStatus();
-    getPausedReason(conditions).ifPresent(reason -> result.paused(reason));
+    getPausedReason(conditions).ifPresent(result::paused);
     getUnavailableReason(conditions)
         .ifPresent(reason -> result.unstable(reason).unavailable(reason));
-    Optional<String> failedReason = getFailedReason(conditions);
-    // TODO(ezimanyi): Unclear that we should return early here; worth properly setting stable below
-    if (failedReason.isPresent()) {
-      return result.failed(failedReason.get());
-    }
+    getFailedReason(conditions).ifPresent(result::failed);
     checkReplicaCounts(deployment, status)
         .ifPresent(reason -> result.unstable(reason.getMessage()));
     return result;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -94,7 +94,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
       throw new UnsupportedVersionException(manifest);
     }
     if (manifest.isNewerThanObservedGeneration()) {
-      return (new Status()).unknown();
+      return Status.defaultStatus().unknown();
     }
     V1Deployment appsV1Deployment =
         KubernetesCacheDataConverter.getResource(manifest, V1Deployment.class);
@@ -107,7 +107,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
   }
 
   private Status status(V1Deployment deployment) {
-    Status result = new Status();
+    Status result = Status.defaultStatus();
     V1DeploymentStatus status = deployment.getStatus();
     if (status == null) {
       result.unstable("No status reported yet").unavailable("No availability reported");

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -42,7 +42,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import lombok.Getter;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -189,18 +188,5 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
     }
 
     return Optional.empty();
-  }
-
-  private enum UnstableReason {
-    UPDATED_REPLICAS("Waiting for all replicas to be updated"),
-    OLD_REPLICAS("Waiting for old replicas to finish termination"),
-    AVAILABLE_REPLICAS("Waiting for all replicas to be available"),
-    READY_REPLICAS("Waiting for all replicas to be ready");
-
-    @Getter private final String message;
-
-    UnstableReason(String message) {
-      this.message = message;
-    }
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
 import io.kubernetes.client.openapi.models.V1Event;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import java.util.ArrayList;
@@ -66,7 +67,7 @@ public class KubernetesEventHandler extends KubernetesHandler {
 
   @Override
   public Manifest.Status status(KubernetesManifest manifest) {
-    return new Manifest.Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHorizontalPodAutoscalerHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesHorizontalPodAutoscalerHandler.java
@@ -62,7 +62,7 @@ public class KubernetesHorizontalPodAutoscalerHandler extends KubernetesHandler 
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesIngressHandler.java
@@ -80,7 +80,7 @@ public class KubernetesIngressHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
@@ -87,11 +87,11 @@ public class KubernetesJobHandler extends KubernetesHandler implements ServerGro
   }
 
   private Status status(V1Job job) {
-    Status result = new Status();
     V1JobStatus status = job.getStatus();
     if (status == null) {
-      result.unstable("No status reported yet").unavailable("No availability reported");
-      return result;
+      return Status.defaultStatus()
+          .unstable("No status reported yet")
+          .unavailable("No availability reported");
     }
 
     int completions = 1;
@@ -109,13 +109,13 @@ public class KubernetesJobHandler extends KubernetesHandler implements ServerGro
       conditions = conditions != null ? conditions : Collections.emptyList();
       Optional<V1JobCondition> condition = conditions.stream().filter(this::jobFailed).findAny();
       if (condition.isPresent()) {
-        return result.failed(condition.get().getMessage());
+        return Status.defaultStatus().failed(condition.get().getMessage());
       } else {
-        return result.unstable("Waiting for jobs to finish");
+        return Status.defaultStatus().unstable("Waiting for jobs to finish");
       }
     }
 
-    return result;
+    return Status.defaultStatus();
   }
 
   private boolean jobFailed(V1JobCondition condition) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesLimitRangeHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesLimitRangeHandler.java
@@ -53,7 +53,7 @@ public class KubernetesLimitRangeHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesMutatingWebhookConfigurationHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesMutatingWebhookConfigurationHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
 import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
@@ -51,7 +52,7 @@ public class KubernetesMutatingWebhookConfigurationHandler extends KubernetesHan
 
   @Override
   public Manifest.Status status(KubernetesManifest manifest) {
-    return new Manifest.Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNamespaceHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNamespaceHandler.java
@@ -54,7 +54,7 @@ public class KubernetesNamespaceHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNetworkPolicyHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesNetworkPolicyHandler.java
@@ -56,7 +56,7 @@ public class KubernetesNetworkPolicyHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeClaimHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeClaimHandler.java
@@ -54,7 +54,7 @@ public class KubernetesPersistentVolumeClaimHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPersistentVolumeHandler.java
@@ -54,7 +54,7 @@ public class KubernetesPersistentVolumeHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodDisruptionBudgetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodDisruptionBudgetHandler.java
@@ -54,7 +54,7 @@ public class KubernetesPodDisruptionBudgetHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
@@ -67,13 +67,13 @@ public class KubernetesPodHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    Status result = new Status();
     V1Pod pod = KubernetesCacheDataConverter.getResource(manifest, V1Pod.class);
     V1PodStatus status = pod.getStatus();
 
     if (status == null) {
-      result.unstable("No status reported yet").unavailable("No availability reported");
-      return result;
+      return Status.defaultStatus()
+          .unstable("No status reported yet")
+          .unavailable("No availability reported");
     }
 
     // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
@@ -83,16 +83,22 @@ public class KubernetesPodHandler extends KubernetesHandler {
     // and we're comparing to lower-case strings. We'll thus never enter any of the else-if cases.
     // TODO(ezimanyi): Fix this when cleaning up status reporting code
     if (phase == null) {
-      result.unstable("No phase reported yet").unavailable("No availability reported");
+      return Status.defaultStatus()
+          .unstable("No phase reported yet")
+          .unavailable("No availability reported");
     } else if (phase.equals("pending")) {
-      result.unstable("Pod is 'pending'").unavailable("Pod has not been scheduled yet");
+      return Status.defaultStatus()
+          .unstable("Pod is 'pending'")
+          .unavailable("Pod has not been scheduled yet");
     } else if (phase.equals("unknown")) {
-      result.unstable("Pod has 'unknown' phase").unavailable("No availability reported");
+      return Status.defaultStatus()
+          .unstable("Pod has 'unknown' phase")
+          .unavailable("No availability reported");
     } else if (phase.equals("failed")) {
-      result.failed("Pod has 'failed'").unavailable("Pod is not running");
+      return Status.defaultStatus().failed("Pod has 'failed'").unavailable("Pod is not running");
     }
 
-    return result;
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodPresetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodPresetHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
 import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
@@ -51,7 +52,7 @@ public class KubernetesPodPresetHandler extends KubernetesHandler {
 
   @Override
   public Manifest.Status status(KubernetesManifest manifest) {
-    return new Manifest.Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodSecurityPolicyHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodSecurityPolicyHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
 import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
@@ -51,7 +52,7 @@ public class KubernetesPodSecurityPolicyHandler extends KubernetesHandler {
 
   @Override
   public Manifest.Status status(KubernetesManifest manifest) {
-    return new Manifest.Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -104,7 +104,7 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
   }
 
   private Status status(V1ReplicaSet replicaSet) {
-    Status result = new Status();
+    Status result = Status.defaultStatus();
     V1ReplicaSetStatus status = replicaSet.getStatus();
     if (status == null) {
       result.unstable("No status reported yet").unavailable("No availability reported");

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -124,20 +124,16 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
           .unavailable("Not all replicas have become labeled yet");
     }
 
+    if (desired > ready) {
+      return Status.defaultStatus()
+          .unstable("Waiting for all replicas to be ready")
+          .unavailable("Not all replicas have become ready yet");
+    }
+
     if (desired > available) {
       return Status.defaultStatus()
           .unstable("Waiting for all replicas to be available")
           .unavailable("Not all replicas have become available yet");
-    }
-
-    // Unclear that we can ever go into this if statement this state (at least in a meaningful way,
-    // setting aside a bug or inconsistency in kubernetes); availableReplicas is defined as replicas
-    // that have been ready for > minReadySeconds which means ready >= available.  If we reach this
-    // point, we also know that available >= desired, which by the transitive property of >= implies
-    // ready >= desired and the if condition will always be false.
-    // TODO(ezimanyi): Consider removing this condition, or moving it above the available check
-    if (desired > ready) {
-      return Status.defaultStatus().unstable("Waiting for all replicas to be ready");
     }
 
     if (!generationMatches(replicaSet, status)) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -36,7 +36,10 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestSelector;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ReplicaSet;
+import io.kubernetes.client.openapi.models.V1ReplicaSetSpec;
 import io.kubernetes.client.openapi.models.V1ReplicaSetStatus;
 import io.kubernetes.client.openapi.models.V1beta1ReplicaSet;
 import io.kubernetes.client.openapi.models.V1beta2ReplicaSet;
@@ -44,16 +47,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
+@NonnullByDefault
 public class KubernetesReplicaSetHandler extends KubernetesHandler
     implements CanResize, CanScale, HasPods, ServerGroupHandler {
   private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
       ImmutableSet.of(EXTENSIONS_V1BETA1, APPS_V1BETA2, APPS_V1);
 
-  @Nonnull
   @Override
   protected ImmutableList<Replacer> artifactReplacers() {
     return ImmutableList.of(
@@ -71,7 +74,6 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
     return WORKLOAD_CONTROLLER_PRIORITY.getValue();
   }
 
-  @Nonnull
   @Override
   public KubernetesKind kind() {
     return KubernetesKind.REPLICA_SET;
@@ -82,7 +84,6 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
     return true;
   }
 
-  @Nonnull
   @Override
   public SpinnakerKind spinnakerKind() {
     return SpinnakerKind.SERVER_GROUPS;
@@ -104,36 +105,27 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
   }
 
   private Status status(V1ReplicaSet replicaSet) {
-    Status result = Status.defaultStatus();
     V1ReplicaSetStatus status = replicaSet.getStatus();
     if (status == null) {
-      result.unstable("No status reported yet").unavailable("No availability reported");
-      return result;
+      return Status.defaultStatus()
+          .unstable("No status reported yet")
+          .unavailable("No availability reported");
     }
 
-    Long observedGeneration = status.getObservedGeneration();
-    if (observedGeneration != null
-        && !observedGeneration.equals(replicaSet.getMetadata().getGeneration())) {
-      result.unstable("Waiting for replicaset spec update to be observed");
-    }
-
-    int desired = replicaSet.getSpec().getReplicas();
-    int fullyLabeled = Optional.ofNullable(status.getFullyLabeledReplicas()).orElse(0);
-    int available = Optional.ofNullable(status.getAvailableReplicas()).orElse(0);
-    int ready = Optional.ofNullable(status.getReadyReplicas()).orElse(0);
-
-    if (desired == 0 && fullyLabeled == 0 && available == 0 && ready == 0) {
-      return result;
-    }
+    int desired =
+        Optional.ofNullable(replicaSet.getSpec()).map(V1ReplicaSetSpec::getReplicas).orElse(0);
+    int fullyLabeled = defaultToZero(status.getFullyLabeledReplicas());
+    int available = defaultToZero(status.getAvailableReplicas());
+    int ready = defaultToZero(status.getReadyReplicas());
 
     if (desired > fullyLabeled) {
-      return result
+      return Status.defaultStatus()
           .unstable("Waiting for all replicas to be fully-labeled")
           .unavailable("Not all replicas have become labeled yet");
     }
 
     if (desired > available) {
-      return result
+      return Status.defaultStatus()
           .unstable("Waiting for all replicas to be available")
           .unavailable("Not all replicas have become available yet");
     }
@@ -145,10 +137,27 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
     // ready >= desired and the if condition will always be false.
     // TODO(ezimanyi): Consider removing this condition, or moving it above the available check
     if (desired > ready) {
-      return result.unstable("Waiting for all replicas to be ready");
+      return Status.defaultStatus().unstable("Waiting for all replicas to be ready");
     }
 
-    return result;
+    if (!generationMatches(replicaSet, status)) {
+      return Status.defaultStatus().unstable("Waiting for replicaset spec update to be observed");
+    }
+
+    return Status.defaultStatus();
+  }
+
+  // Unboxes an Integer, returning 0 if the input is null
+  private static int defaultToZero(@Nullable Integer input) {
+    return input == null ? 0 : input;
+  }
+
+  private boolean generationMatches(V1ReplicaSet replicaSet, V1ReplicaSetStatus status) {
+    Optional<Long> metadataGeneration =
+        Optional.ofNullable(replicaSet.getMetadata()).map(V1ObjectMeta::getGeneration);
+    Optional<Long> statusGeneration = Optional.ofNullable(status.getObservedGeneration());
+
+    return statusGeneration.isPresent() && statusGeneration.equals(metadataGeneration);
   }
 
   public static Map<String, String> getPodTemplateLabels(KubernetesManifest manifest) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleBindingHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleBindingHandler.java
@@ -54,7 +54,7 @@ public class KubernetesRoleBindingHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesRoleHandler.java
@@ -54,7 +54,7 @@ public class KubernetesRoleHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesSecretHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesSecretHandler.java
@@ -61,7 +61,7 @@ public class KubernetesSecretHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceAccountHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceAccountHandler.java
@@ -54,7 +54,7 @@ public class KubernetesServiceAccountHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesServiceHandler.java
@@ -70,7 +70,7 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -171,7 +171,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
   }
 
   // Unboxes an Integer, returning 0 if the input is null
-  private int defaultToZero(@Nullable Integer input) {
+  private static int defaultToZero(@Nullable Integer input) {
     return input == null ? 0 : input;
   }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -154,8 +154,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
       if (replicas != null && partition != null && (updated < (replicas - partition))) {
         return result.unstable("Waiting for partitioned roll out to finish");
       }
-      result.setStable(new Status.Condition(true, "Partitioned roll out complete"));
-      return result;
+      return result.stable("Partitioned roll out complete");
     }
 
     existing = defaultToZero(status.getCurrentReplicas());

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -97,7 +97,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
   @Override
   public Status status(KubernetesManifest manifest) {
     if (manifest.isNewerThanObservedGeneration()) {
-      return (new Status()).unknown();
+      return Status.defaultStatus().unknown();
     }
     V1beta2StatefulSet v1beta2StatefulSet =
         KubernetesCacheDataConverter.getResource(manifest, V1beta2StatefulSet.class);
@@ -119,27 +119,27 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
   }
 
   private Status status(V1beta2StatefulSet statefulSet) {
-    Status result = new Status();
-
     if (statefulSet.getSpec().getUpdateStrategy().getType().equalsIgnoreCase("ondelete")) {
-      return result;
+      return Status.defaultStatus();
     }
 
     V1beta2StatefulSetStatus status = statefulSet.getStatus();
     if (status == null) {
-      result.unstable("No status reported yet").unavailable("No availability reported");
-      return result;
+      return Status.defaultStatus()
+          .unstable("No status reported yet")
+          .unavailable("No availability reported");
     }
 
     int desiredReplicas = defaultToZero(statefulSet.getSpec().getReplicas());
     int existing = defaultToZero(status.getReplicas());
     if (desiredReplicas > existing) {
-      return result.unstable("Waiting for at least the desired replica count to be met");
+      return Status.defaultStatus()
+          .unstable("Waiting for at least the desired replica count to be met");
     }
 
     existing = defaultToZero(status.getReadyReplicas());
     if (desiredReplicas > existing) {
-      return result.unstable("Waiting for all updated replicas to be ready");
+      return Status.defaultStatus().unstable("Waiting for all updated replicas to be ready");
     }
 
     String updateType = statefulSet.getSpec().getUpdateStrategy().getType();
@@ -152,21 +152,22 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
       Integer partition = rollingUpdate.getPartition();
       Integer replicas = status.getReplicas();
       if (replicas != null && partition != null && (updated < (replicas - partition))) {
-        return result.unstable("Waiting for partitioned roll out to finish");
+        return Status.defaultStatus().unstable("Waiting for partitioned roll out to finish");
       }
-      return result.stable("Partitioned roll out complete");
+      return Status.defaultStatus().stable("Partitioned roll out complete");
     }
 
     existing = defaultToZero(status.getCurrentReplicas());
     if (desiredReplicas > existing) {
-      return result.unstable("Waiting for all updated replicas to be scheduled");
+      return Status.defaultStatus().unstable("Waiting for all updated replicas to be scheduled");
     }
 
     if (!status.getCurrentRevision().equals(status.getUpdateRevision())) {
-      return result.unstable("Waiting for the updated revision to match the current revision");
+      return Status.defaultStatus()
+          .unstable("Waiting for the updated revision to match the current revision");
     }
 
-    return result;
+    return Status.defaultStatus();
   }
 
   // Unboxes an Integer, returning 0 if the input is null

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStorageClassHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStorageClassHandler.java
@@ -54,7 +54,7 @@ public class KubernetesStorageClassHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesUnregisteredCustomResourceHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesUnregisteredCustomResourceHandler.java
@@ -55,7 +55,7 @@ public class KubernetesUnregisteredCustomResourceHandler extends KubernetesHandl
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    return new Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesValidatingWebhookConfigurationHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesValidatingWebhookConfigurationHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
 import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
 
@@ -51,7 +52,7 @@ public class KubernetesValidatingWebhookConfigurationHandler extends KubernetesH
 
   @Override
   public Manifest.Status status(KubernetesManifest manifest) {
-    return new Manifest.Status();
+    return Status.defaultStatus();
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/UnstableReason.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/UnstableReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2020 Google, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/UnstableReason.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/UnstableReason.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import lombok.Getter;
+
+enum UnstableReason {
+  AVAILABLE_REPLICAS("Waiting for all replicas to be available"),
+  FULLY_LABELED_REPLICAS("Waiting for all replicas to be fully-labeled"),
+  OLD_REPLICAS("Waiting for old replicas to finish termination"),
+  READY_REPLICAS("Waiting for all replicas to be ready"),
+  UPDATED_REPLICAS("Waiting for all replicas to be updated");
+
+  @Getter private final String message;
+
+  UnstableReason(String message) {
+    this.message = message;
+  }
+}

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandlerTest.java
@@ -103,6 +103,25 @@ final class KubernetesDeploymentHandlerTest {
   }
 
   @Test
+  void progressDeadlineExceededUnavailable() {
+    KubernetesManifest deployment =
+        ManifestFetcher.getManifest(
+            "deployment/base.yml", "deployment/progress-deadline-exceeded-unavailable.yml");
+    Status status = handler.status(deployment);
+
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage())
+        .isEqualTo("Deployment does not have minimum availability.");
+    assertThat(status.getAvailable().isState()).isFalse();
+    assertThat(status.getAvailable().getMessage())
+        .isEqualTo("Deployment does not have minimum availability.");
+    assertThat(status.getPaused().isState()).isFalse();
+    assertThat(status.getFailed().isState()).isTrue();
+    assertThat(status.getFailed().getMessage())
+        .isEqualTo("Deployment exceeded its progress deadline");
+  }
+
+  @Test
   void progressDeadlineExceeded() {
     KubernetesManifest deployment =
         ManifestFetcher.getManifest(

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandlerTest.java
@@ -111,7 +111,7 @@ final class KubernetesDeploymentHandlerTest {
 
     assertThat(status.getStable().isState()).isFalse();
     assertThat(status.getStable().getMessage())
-        .isEqualTo("Deployment does not have minimum availability.");
+        .isEqualTo("Waiting for all replicas to be available");
     assertThat(status.getAvailable().isState()).isFalse();
     assertThat(status.getAvailable().getMessage())
         .isEqualTo("Deployment does not have minimum availability.");
@@ -128,7 +128,9 @@ final class KubernetesDeploymentHandlerTest {
             "deployment/base.yml", "deployment/progress-deadline-exceeded.yml");
     Status status = handler.status(deployment);
 
-    assertThat(status.getStable().isState()).isTrue();
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage())
+        .isEqualTo("Waiting for all replicas to be available");
     assertThat(status.getAvailable().isState()).isTrue();
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isTrue();

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandlerTest.java
@@ -103,11 +103,10 @@ final class KubernetesReplicaSetHandlerTest {
     Status status = handler.status(replicaSet);
 
     assertThat(status.getStable().isState()).isFalse();
-    assertThat(status.getStable().getMessage())
-        .isEqualTo("Waiting for all replicas to be available");
+    assertThat(status.getStable().getMessage()).isEqualTo("Waiting for all replicas to be ready");
     assertThat(status.getAvailable().isState()).isFalse();
     assertThat(status.getAvailable().getMessage())
-        .isEqualTo("Not all replicas have become available yet");
+        .isEqualTo("Not all replicas have become ready yet");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandlerTest.java
@@ -75,7 +75,7 @@ final class KubernetesReplicaSetHandlerTest {
         .isEqualTo("Waiting for all replicas to be fully-labeled");
     assertThat(status.getAvailable().isState()).isFalse();
     assertThat(status.getAvailable().getMessage())
-        .isEqualTo("Not all replicas have become labeled yet");
+        .isEqualTo("Waiting for all replicas to be fully-labeled");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }
@@ -91,7 +91,7 @@ final class KubernetesReplicaSetHandlerTest {
         .isEqualTo("Waiting for all replicas to be available");
     assertThat(status.getAvailable().isState()).isFalse();
     assertThat(status.getAvailable().getMessage())
-        .isEqualTo("Not all replicas have become available yet");
+        .isEqualTo("Waiting for all replicas to be available");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }
@@ -106,7 +106,7 @@ final class KubernetesReplicaSetHandlerTest {
     assertThat(status.getStable().getMessage()).isEqualTo("Waiting for all replicas to be ready");
     assertThat(status.getAvailable().isState()).isFalse();
     assertThat(status.getAvailable().getMessage())
-        .isEqualTo("Not all replicas have become ready yet");
+        .isEqualTo("Waiting for all replicas to be ready");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }
@@ -122,7 +122,7 @@ final class KubernetesReplicaSetHandlerTest {
         .isEqualTo("Waiting for all replicas to be fully-labeled");
     assertThat(status.getAvailable().isState()).isFalse();
     assertThat(status.getAvailable().getMessage())
-        .isEqualTo("Not all replicas have become labeled yet");
+        .isEqualTo("Waiting for all replicas to be fully-labeled");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/deployment/progress-deadline-exceeded-unavailable.yml
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/deployment/progress-deadline-exceeded-unavailable.yml
@@ -1,0 +1,21 @@
+# Condition reports progress deadline exceeded and deployment is not available
+status:
+  availableReplicas: 98
+  conditions:
+    - lastTransitionTime: "2020-01-31T16:02:23Z"
+      lastUpdateTime: "2020-01-31T16:02:23Z"
+      message: Deployment does not have minimum availability.
+      reason: MinimumReplicasUnavailable
+      status: "False"
+      type: Available
+    - lastTransitionTime: "2020-01-31T17:27:49Z"
+      lastUpdateTime: "2020-01-31T17:27:49Z"
+      message: ReplicaSet "nginx-deployment-5754944d6c" has timed out progressing.
+      reason: ProgressDeadlineExceeded
+      status: "False"
+      type: Progressing
+  observedGeneration: 3
+  readyReplicas: 98
+  replicas: 100
+  unavailableReplicas: 2
+  updatedReplicas: 100


### PR DESCRIPTION
* test(kubernetes): Add test for progress deadline exceeded 

  The test for progress deadline exceeded only considers the case where the deployment reports it is available; also add a case where the deadline is exceeded and the deployment reports it is not available.

* refactor(kubernetes): Improve Status and Condition classes 

  There are way too many ways to create and mutate these classes, as both have fully public fields as well as setters; in the case of Status there are also custom setters, and in the case of Condition there is additionally a builder.

  Clean this up as follows:
  * Update the custom setters (ex: failed, unstable, etc.) in Status to create a new condition and assign it to the appropriate value instead of mutating the existing condition. (This fixes a null-safety issue as some of these fields can be null, if unknown() has been called.)
  * This now allows us to make Condition immutable, as we never change an existing condition. Make it immutable by removing the setters and marking the fields final. Replace builders with a constructor (which is reasonable given that we have only two fields with different types). As it's common to create a condition with a null message (because it shows up in defaults for Status) make a convenience factory method withState that returns a Condition with null message.  (Because the class is immutable we can just return a pre-created static Condition in this case.)
  * Add a defaultStatus() factory method to Status; it's the same as the constructor new Status() but I think makes the intent much more clear when reading the Handlers; that is, start with some default status and mutate it if the desired status differs from the default.  I didn't make the no-arg constructor private because I didn't want to needlessly break people who used it in their own custom handlers, but ideally they'd migrate to defaultStatus() for clarity.
  * Add a stable() mutator to replace the one case where we explicitly called setStable()
  * Add nullity annotations.  Many things are nullable; the new annotations just document that existing behavior.

* refactor(kubernetes): Simplify status reporting in handlers 

  The logic to report workload status is fairly complex to follow; one of the reasons it's complex is that in general we create an empty Status object (which defaults some fields) at the beginning of the status function and mutate it throughout the functions, sometimes returning immediately after the mutation but sometimes not.

  In order to understand what we're returning at any given point, we need to read the entire function up to that point to see if any of the prior conditions wrote to the result variable.

  Where possible, simplify this by just creating a new Status inline at the point of return (and change from using new Status() to the factory method Status.defaultStatus()). This is possible in any cases where there are no mutations of result earlier in the function that don't immediately return. By doing this analysis now once, we make it easier for future readers of the function to see what is returned in each case.

  This commit only touches the handlers where it was trivial to make this change (ie, we never mutate the result without immediately returning it).

* refactor(kubernetes): Simplify Deployment and ReplicaSet handlers 

  Now that there is a robust test suite on the Deployment and ReplicaSet handlers, refactor these to make the control flow more clear when determining status. This commit only makes changes that do not affect results (as seen by the lack of changes to the tests in this commit).

* fix(kubernetes): Fix ready condition check for replicaset 

  We currently check the available replicas count before we check the ready replica count; this isn't correct as there will always be more ready replicas than available replicas. (The definition of an available replica is one that has been ready for at least minReadySeconds.) Switch the order of the check so that we generate the correct message in each case.

* fix(kubernetes): Simplify status messages 

  When a replicaset is unstable and unavailable we use slightly different wording in the unstable and unavailable message even though the cause is the same. This isn't complicates both the code and the user's parsing of messages (as they need to parse both to realize they are the same error).

  Simplify this; the tests show exactly where the text of errors has changed and shows that the actual stable/unstable status does not change.

  Also, push the Deployment's UnstableReason up to the top level so we can re-use it for replica sets.

* fix(kubernetes): Don't return early after setting failed flag 

  When a deployment reports that it is failed we exit early instead of checking the remaining condition. This means that we don't always properly set the other flags of the status in this case; update the logic to set the other flags.

  The logic in orca to decide how to handle the status of a manifest checks both the stable and the failed flags (so we won't risk breaking it by sometimes setting a deployment to unstable when it is also failed, which we already do in some cases anyway if the condition reports unavailable).
