### PR TITLE
fix(cf): Parallelize apps/lbs cache building

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -55,7 +54,6 @@ import retrofit.client.Response;
 import retrofit.mime.TypedFile;
 import retrofit.mime.TypedInput;
 
-@RequiredArgsConstructor
 @Slf4j
 public class Applications {
   private final String account;
@@ -64,20 +62,39 @@ public class Applications {
   private final ApplicationService api;
   private final Spaces spaces;
   private final Integer resultsPerPage;
-  private final int maxConnections;
 
-  private final LoadingCache<String, CloudFoundryServerGroup> serverGroupCache =
-      CacheBuilder.newBuilder()
-          .build(
-              new CacheLoader<String, CloudFoundryServerGroup>() {
-                @Override
-                public CloudFoundryServerGroup load(@Nonnull String guid)
-                    throws ResourceNotFoundException {
-                  return safelyCall(() -> api.findById(guid))
-                      .map(Applications.this::map)
-                      .orElseThrow(ResourceNotFoundException::new);
-                }
-              });
+  private final ForkJoinPool forkJoinPool;
+  private final LoadingCache<String, CloudFoundryServerGroup> serverGroupCache;
+
+  public Applications(
+      String account,
+      String appsManagerUri,
+      String metricsUri,
+      ApplicationService api,
+      Spaces spaces,
+      Integer resultsPerPage,
+      int maxConnections) {
+    this.account = account;
+    this.appsManagerUri = appsManagerUri;
+    this.metricsUri = metricsUri;
+    this.api = api;
+    this.spaces = spaces;
+    this.resultsPerPage = resultsPerPage;
+
+    this.forkJoinPool = new ForkJoinPool(maxConnections);
+    this.serverGroupCache =
+        CacheBuilder.newBuilder()
+            .build(
+                new CacheLoader<String, CloudFoundryServerGroup>() {
+                  @Override
+                  public CloudFoundryServerGroup load(@Nonnull String guid)
+                      throws ResourceNotFoundException {
+                    return safelyCall(() -> api.findById(guid))
+                        .map(Applications.this::map)
+                        .orElseThrow(ResourceNotFoundException::new);
+                  }
+                });
+  }
 
   @Nullable
   public CloudFoundryServerGroup findById(String guid) {
@@ -117,7 +134,6 @@ public class Applications {
     // if the update time doesn't match then we need to update the cache
     // if the app is not found in the cache we need to process with `map` and update the cache
     List<Application> appsToBeUpdated;
-    ForkJoinPool forkJoinPool = new ForkJoinPool(maxConnections);
     try {
       appsToBeUpdated =
           forkJoinPool

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -115,7 +115,8 @@ public class Applications {
     // if the update time doesn't match then we need to update the cache
     // if the app is not found in the cache we need to process with `map` and update the cache
     List<Application> appsToBeUpdated =
-        newCloudFoundryAppList.stream()
+        newCloudFoundryAppList
+            .parallelStream()
             .filter(
                 a ->
                     Optional.ofNullable(findById(a.getGuid()))

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
@@ -181,7 +181,8 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
       String user,
       String password,
       boolean skipSslValidation,
-      Integer resultsPerPage) {
+      Integer resultsPerPage,
+      int maxCapiConnectionsForCache) {
     this.apiHost = apiHost;
     this.user = user;
     this.password = password;
@@ -215,7 +216,8 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
             metricsUri,
             createService(ApplicationService.class),
             spaces,
-            resultsPerPage);
+            resultsPerPage,
+            maxCapiConnectionsForCache);
     this.domains = new Domains(createService(DomainService.class), organizations);
     this.serviceInstances =
         new ServiceInstances(
@@ -230,7 +232,8 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
             applications,
             domains,
             spaces,
-            resultsPerPage);
+            resultsPerPage,
+            maxCapiConnectionsForCache);
     this.serviceKeys = new ServiceKeys(createService(ServiceKeyService.class), spaces);
     this.tasks = new Tasks(createService(TaskService.class));
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Routes.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Routes.java
@@ -143,13 +143,10 @@ public class Routes {
   }
 
   public List<CloudFoundryLoadBalancer> all() throws CloudFoundryApiException {
-    List<Resource<Route>> routeResources =
-        collectPageResources("routes", pg -> api.all(pg, resultsPerPage, null));
-    List<CloudFoundryLoadBalancer> loadBalancers = new ArrayList<>(routeResources.size());
-    for (Resource<Route> routeResource : routeResources) {
-      loadBalancers.add(map(routeResource));
-    }
-    return loadBalancers;
+    return collectPageResources("routes", pg -> api.all(pg, resultsPerPage, null))
+        .parallelStream()
+        .map(this::map)
+        .collect(Collectors.toList());
   }
 
   public CloudFoundryLoadBalancer createRoute(RouteId routeId, String spaceId)

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/config/CloudFoundryConfigurationProperties.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/config/CloudFoundryConfigurationProperties.java
@@ -61,5 +61,6 @@ public class CloudFoundryConfigurationProperties implements DisposableBean {
     private String environment;
     private boolean skipSslValidation;
     private Integer resultsPerPage;
+    private Integer maxCapiConnectionsForCache;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgent.java
@@ -95,6 +95,10 @@ public class CloudFoundryLoadBalancerCachingAgent extends AbstractCloudFoundryCa
     onDemandCacheData.forEach(this::processOnDemandCacheData);
     results.put(ON_DEMAND.getNs(), toKeep.values());
 
+    log.debug(
+        "LoadBalancer cache loaded for Cloud Foundry account {}, ({} sec)",
+        accountName,
+        (getInternalClock().millis() - loadDataStart) / 1000);
     return new DefaultCacheResult(results, Collections.singletonMap(ON_DEMAND.getNs(), toEvict));
   }
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
@@ -119,6 +119,10 @@ public class CloudFoundryServerGroupCachingAgent extends AbstractCloudFoundryCac
     onDemandCacheData.forEach(this::processOnDemandCacheData);
     results.put(ON_DEMAND.getNs(), toKeep.values());
 
+    log.debug(
+        "Cache loaded for Cloud Foundry account {}, ({} sec)",
+        accountName,
+        (getInternalClock().millis() - loadDataStart) / 1000);
     return new DefaultCacheResult(results, Collections.singletonMap(ON_DEMAND.getNs(), toEvict));
   }
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
@@ -53,6 +53,8 @@ public class CloudFoundryCredentials implements AccountCredentials<CloudFoundryC
 
   @Nullable private final Integer resultsPerPage;
 
+  private final int maxCapiConnectionsForCache;
+
   private CloudFoundryClient credentials;
 
   public CloudFoundryCredentials(
@@ -64,7 +66,8 @@ public class CloudFoundryCredentials implements AccountCredentials<CloudFoundryC
       String password,
       String environment,
       boolean skipSslValidation,
-      Integer resultsPerPage) {
+      Integer resultsPerPage,
+      Integer maxCapiConnectionsForCache) {
     this.name = name;
     this.appsManagerUri = appsManagerUri;
     this.metricsUri = metricsUri;
@@ -74,6 +77,7 @@ public class CloudFoundryCredentials implements AccountCredentials<CloudFoundryC
     this.environment = Optional.ofNullable(environment).orElse("dev");
     this.skipSslValidation = skipSslValidation;
     this.resultsPerPage = Optional.ofNullable(resultsPerPage).orElse(500);
+    this.maxCapiConnectionsForCache = Optional.ofNullable(maxCapiConnectionsForCache).orElse(16);
   }
 
   public CloudFoundryClient getCredentials() {
@@ -87,7 +91,8 @@ public class CloudFoundryCredentials implements AccountCredentials<CloudFoundryC
               userName,
               password,
               skipSslValidation,
-              resultsPerPage);
+              resultsPerPage,
+              maxCapiConnectionsForCache);
     }
     return credentials;
   }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizer.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizer.java
@@ -87,7 +87,8 @@ public class CloudFoundryCredentialsSynchronizer implements CredentialsInitializ
                   managedAccount.getPassword(),
                   managedAccount.getEnvironment(),
                   managedAccount.isSkipSslValidation(),
-                  managedAccount.getResultsPerPage());
+                  managedAccount.getResultsPerPage(),
+                  managedAccount.getMaxCapiConnectionsForCache());
 
           AccountCredentials existingCredentials =
               accountCredentialsRepository.getOne(credentials.getName());

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/ApplicationsTest.java
@@ -47,7 +47,7 @@ class ApplicationsTest {
   private Spaces spaces = mock(Spaces.class);
   private Applications apps =
       new Applications(
-          "pws", "some-apps-man-uri", "some-metrics-uri", applicationService, spaces, 500);
+          "pws", "some-apps-man-uri", "some-metrics-uri", applicationService, spaces, 500, 16);
   private String spaceId = "space-guid";
   private CloudFoundrySpace cloudFoundrySpace =
       CloudFoundrySpace.builder()
@@ -67,7 +67,8 @@ class ApplicationsTest {
             "baduser",
             "badpassword",
             false,
-            500);
+            500,
+            16);
 
     assertThatThrownBy(() -> client.getApplications().all())
         .isInstanceOf(CloudFoundryApiException.class);

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClientTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClientTest.java
@@ -68,7 +68,7 @@ class HttpCloudFoundryClientTest {
 
     HttpCloudFoundryClient cloudFoundryClient =
         new HttpCloudFoundryClient(
-            "account", "appsManUri", "metricsUri", "host", "user", "password", false, 500);
+            "account", "appsManUri", "metricsUri", "host", "user", "password", false, 500, 16);
     Response response = cloudFoundryClient.createRetryInterceptor(chain);
 
     try {
@@ -97,7 +97,7 @@ class HttpCloudFoundryClientTest {
 
     HttpCloudFoundryClient cloudFoundryClient =
         new HttpCloudFoundryClient(
-            "account", "appsManUri", "metricsUri", "host", "user", "password", false, 500);
+            "account", "appsManUri", "metricsUri", "host", "user", "password", false, 500, 16);
     Response response = cloudFoundryClient.createRetryInterceptor(chain);
 
     try {
@@ -126,7 +126,7 @@ class HttpCloudFoundryClientTest {
 
     HttpCloudFoundryClient cloudFoundryClient =
         new HttpCloudFoundryClient(
-            "account", "appsManUri", "metricsUri", "host", "user", "password", false, 500);
+            "account", "appsManUri", "metricsUri", "host", "user", "password", false, 500, 16);
     Response response = cloudFoundryClient.createRetryInterceptor(chain);
 
     try {

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/RoutesTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/RoutesTest.java
@@ -57,7 +57,7 @@ class RoutesTest {
     when(routeService.all(any(), any(), any())).thenReturn(Page.singleton(route, "abc123"));
     when(routeService.routeMappings(any(), any())).thenReturn(new Page<>());
 
-    Routes routes = new Routes("pws", routeService, null, domains, spaces, 500);
+    Routes routes = new Routes("pws", routeService, null, domains, spaces, 500, 16);
     RouteId routeId = routes.toRouteId("demo1-prod.apps.calabasas.cf-app.com/path");
     assertThat(routeId).isNotNull();
     assertThat(routeId.getHost()).isEqualTo("demo1-prod");
@@ -67,7 +67,7 @@ class RoutesTest {
 
   @Test
   void toRouteIdReturnsNullForInvalidRoute() {
-    Routes routes = new Routes(null, null, null, null, null, 500);
+    Routes routes = new Routes(null, null, null, null, null, 500, 16);
     assertNull(routes.toRouteId("demo1-pro cf-app.com/path"));
   }
 
@@ -127,7 +127,7 @@ class RoutesTest {
     when(routeService.all(any(), any(), any())).thenReturn(routePage);
     when(routeService.routeMappings(any(), any())).thenReturn(routeMappingPage);
 
-    Routes routes = new Routes("pws", routeService, null, domains, spaces, 500);
+    Routes routes = new Routes("pws", routeService, null, domains, spaces, 500, 16);
 
     CloudFoundryLoadBalancer loadBalancer =
         routes.find(new RouteId().setHost("somehost").setDomainGuid("domain-guid"), "space-guid");

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractLoadBalancersAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/AbstractLoadBalancersAtomicOperationConverterTest.java
@@ -85,7 +85,7 @@ class AbstractLoadBalancersAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("test", "", "", "", "", "", "", false, 500) {
+      new CloudFoundryCredentials("test", "", "", "", "", "", "", false, 500, 16) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/CreateCloudFoundryServiceKeyAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/CreateCloudFoundryServiceKeyAtomicOperationConverterTest.java
@@ -52,7 +52,7 @@ class CreateCloudFoundryServiceKeyAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("my-account", "", "", "", "", "", "", false, 500) {
+      new CloudFoundryCredentials("my-account", "", "", "", "", "", "", false, 500, 16) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceKeyAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeleteCloudFoundryServiceKeyAtomicOperationConverterTest.java
@@ -57,7 +57,7 @@ class DeleteCloudFoundryServiceKeyAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("my-account", "", "", "", "", "", "", false, 500) {
+      new CloudFoundryCredentials("my-account", "", "", "", "", "", "", false, 500, 16) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -69,7 +69,7 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                       .build()));
     }
 
-    return new CloudFoundryCredentials(name, "", "", "", "", "", "", false, 500) {
+    return new CloudFoundryCredentials(name, "", "", "", "", "", "", false, 500, 16) {
       public CloudFoundryClient getClient() {
         return cloudFoundryClient;
       }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServiceAtomicOperationConverterTest.java
@@ -71,7 +71,7 @@ class DeployCloudFoundryServiceAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("test", "", "", "", "", "", "", false, 500) {
+      new CloudFoundryCredentials("test", "", "", "", "", "", "", false, 500, 16) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/ScaleCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -60,7 +60,7 @@ class ScaleCloudFoundryServerGroupAtomicOperationConverterTest {
   }
 
   private final CloudFoundryCredentials cloudFoundryCredentials =
-      new CloudFoundryCredentials("test", "", "", "", "", "", "", false, 500) {
+      new CloudFoundryCredentials("test", "", "", "", "", "", "", false, 500, 16) {
         public CloudFoundryClient getClient() {
           return cloudFoundryClient;
         }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizerTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizerTest.java
@@ -149,7 +149,7 @@ class CloudFoundryCredentialsSynchronizerTest {
 
   private CloudFoundryCredentials createCredentials(String name) {
     return new CloudFoundryCredentials(
-        name, null, null, "api." + name, "user-" + name, "pwd-" + name, null, false, 500);
+        name, null, null, "api." + name, "user-" + name, "pwd-" + name, null, false, 500, 16);
   }
 
   private void loadProviderFromRepository() {


### PR DESCRIPTION
Creating a cache entry for one CF app requires 5 distinct HTTP calls to the CF API which adds up quickly when there's thousands of apps to process. The change takes advantage of Java's parallelStream and OKHttp's thread safety/connection pool management.
A better solution will be to use the CF-java client which is fully reactive and will allow to better configure the parameters of what's being done in parallel; but that's a non trivial refactor compared to the current change.