### PR TITLE
fix(kubernetes): Move generation checks to be object-specific

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -287,6 +287,9 @@ public class KubernetesManifest extends HashMap<String, Object> {
     return get("status");
   }
 
+  // Consumers should convert to a strongly-typed object and implement type-specific logic instead
+  // of calling this function.
+  @Deprecated
   @JsonIgnore
   public int getObservedGeneration() {
     Object statusObj = getStatus();
@@ -307,6 +310,9 @@ public class KubernetesManifest extends HashMap<String, Object> {
     return ((Number) observedGenObj).intValue();
   }
 
+  // Consumers should convert to a strongly-typed object and implement type-specific logic instead
+  // of calling this function.
+  @Deprecated
   @JsonIgnore
   public int getGeneration() {
     Object generationObj = getMetadata().get("generation");
@@ -327,6 +333,9 @@ public class KubernetesManifest extends HashMap<String, Object> {
     return String.join(" ", kind.toString(), name);
   }
 
+  // Consumers should convert to a strongly-typed object and implement type-specific logic instead
+  // of calling this function.
+  @Deprecated
   @JsonIgnore
   public boolean isNewerThanObservedGeneration() {
     int generation = getGeneration();

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
@@ -46,19 +46,13 @@ public interface Manifest {
   @NonnullByDefault
   @ToString
   class Status {
-    private @Nullable Condition stable = Condition.withState(true);
+    private Condition stable = Condition.withState(true);
     private Condition paused = Condition.withState(false);
     private Condition available = Condition.withState(true);
-    private @Nullable Condition failed = Condition.withState(false);
+    private Condition failed = Condition.withState(false);
 
     public static Status defaultStatus() {
       return new Status();
-    }
-
-    public Status unknown() {
-      stable = null;
-      failed = null;
-      return this;
     }
 
     public Status failed(@Nullable String message) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
@@ -55,6 +55,12 @@ public interface Manifest {
       return new Status();
     }
 
+    public static Status noneReported() {
+      return defaultStatus()
+          .unstable("No status reported yet")
+          .unavailable("No availability reported");
+    }
+
     public Status failed(@Nullable String message) {
       failed = new Condition(true, message);
       return this;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCronJobHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesCronJobHandler.java
@@ -87,9 +87,7 @@ public class KubernetesCronJobHandler extends KubernetesHandler
   private Status status(V2alpha1CronJob job) {
     V2alpha1CronJobStatus status = job.getStatus();
     if (status == null) {
-      return Status.defaultStatus()
-          .unstable("No status reported yet")
-          .unavailable("No availability reported");
+      return Status.noneReported();
     }
 
     return Status.defaultStatus();

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
@@ -88,7 +88,7 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
   @Override
   public Status status(KubernetesManifest manifest) {
     if (manifest.isNewerThanObservedGeneration()) {
-      return Status.defaultStatus().unknown();
+      return Status.defaultStatus().unstable(UnstableReason.OLD_GENERATION.getMessage());
     }
     V1beta2DaemonSet v1beta2DaemonSet =
         KubernetesCacheDataConverter.getResource(manifest, V1beta2DaemonSet.class);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandler.java
@@ -105,9 +105,7 @@ public class KubernetesDaemonSetHandler extends KubernetesHandler
   private Status status(V1beta2DaemonSet daemonSet) {
     V1beta2DaemonSetStatus status = daemonSet.getStatus();
     if (status == null) {
-      return Status.defaultStatus()
-          .unstable("No status reported yet")
-          .unavailable("No availability reported");
+      return Status.noneReported();
     }
 
     if (!generationMatches(daemonSet, status)) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -109,9 +109,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
   private Status status(V1Deployment deployment) {
     V1DeploymentStatus status = deployment.getStatus();
     if (status == null) {
-      return Status.defaultStatus()
-          .unstable("No status reported yet")
-          .unavailable("No availability reported");
+      return Status.noneReported();
     }
 
     if (!generationMatches(deployment, status)) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -38,6 +38,7 @@ import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentCondition;
 import io.kubernetes.client.openapi.models.V1DeploymentStatus;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -95,9 +96,6 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
     if (!SUPPORTED_API_VERSIONS.contains(manifest.getApiVersion())) {
       throw new UnsupportedVersionException(manifest);
     }
-    if (manifest.isNewerThanObservedGeneration()) {
-      return Status.defaultStatus().unstable(UnstableReason.OLD_GENERATION.getMessage());
-    }
     V1Deployment appsV1Deployment =
         KubernetesCacheDataConverter.getResource(manifest, V1Deployment.class);
     return status(appsV1Deployment);
@@ -114,6 +112,10 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
       return Status.defaultStatus()
           .unstable("No status reported yet")
           .unavailable("No availability reported");
+    }
+
+    if (!generationMatches(deployment, status)) {
+      return Status.defaultStatus().unstable(UnstableReason.OLD_GENERATION.getMessage());
     }
 
     List<V1DeploymentCondition> conditions =
@@ -153,6 +155,14 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
         .filter(c -> c.getReason().equalsIgnoreCase("progressdeadlineexceeded"))
         .map(c -> "Deployment exceeded its progress deadline")
         .findAny();
+  }
+
+  private boolean generationMatches(V1Deployment deployment, V1DeploymentStatus status) {
+    Optional<Long> metadataGeneration =
+        Optional.ofNullable(deployment.getMetadata()).map(V1ObjectMeta::getGeneration);
+    Optional<Long> statusGeneration = Optional.ofNullable(status.getObservedGeneration());
+
+    return statusGeneration.isPresent() && statusGeneration.equals(metadataGeneration);
   }
 
   // Unboxes an Integer, returning 0 if the input is null

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandler.java
@@ -96,7 +96,7 @@ public class KubernetesDeploymentHandler extends KubernetesHandler
       throw new UnsupportedVersionException(manifest);
     }
     if (manifest.isNewerThanObservedGeneration()) {
-      return Status.defaultStatus().unknown();
+      return Status.defaultStatus().unstable(UnstableReason.OLD_GENERATION.getMessage());
     }
     V1Deployment appsV1Deployment =
         KubernetesCacheDataConverter.getResource(manifest, V1Deployment.class);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
@@ -89,9 +89,7 @@ public class KubernetesJobHandler extends KubernetesHandler implements ServerGro
   private Status status(V1Job job) {
     V1JobStatus status = job.getStatus();
     if (status == null) {
-      return Status.defaultStatus()
-          .unstable("No status reported yet")
-          .unavailable("No availability reported");
+      return Status.noneReported();
     }
 
     int completions = 1;

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
@@ -73,9 +73,7 @@ public class KubernetesPodHandler extends KubernetesHandler {
     V1PodStatus status = pod.getStatus();
 
     if (status == null) {
-      return Status.defaultStatus()
-          .unstable("No status reported yet")
-          .unavailable("No availability reported");
+      return Status.noneReported();
     }
 
     PodPhase phase = PodPhase.fromString(status.getPhase());

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandler.java
@@ -33,6 +33,8 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Getter;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -76,29 +78,40 @@ public class KubernetesPodHandler extends KubernetesHandler {
           .unavailable("No availability reported");
     }
 
-    // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
-    String phase = status.getPhase();
-
-    // This code appears to be broken, as Kubernetes always reports pod status in initial caps
-    // and we're comparing to lower-case strings. We'll thus never enter any of the else-if cases.
-    // TODO(ezimanyi): Fix this when cleaning up status reporting code
-    if (phase == null) {
-      return Status.defaultStatus()
-          .unstable("No phase reported yet")
-          .unavailable("No availability reported");
-    } else if (phase.equals("pending")) {
-      return Status.defaultStatus()
-          .unstable("Pod is 'pending'")
-          .unavailable("Pod has not been scheduled yet");
-    } else if (phase.equals("unknown")) {
-      return Status.defaultStatus()
-          .unstable("Pod has 'unknown' phase")
-          .unavailable("No availability reported");
-    } else if (phase.equals("failed")) {
-      return Status.defaultStatus().failed("Pod has 'failed'").unavailable("Pod is not running");
+    PodPhase phase = PodPhase.fromString(status.getPhase());
+    if (phase.isUnstable()) {
+      return Status.defaultStatus().unstable(phase.getMessage()).unavailable(phase.getMessage());
     }
 
     return Status.defaultStatus();
+  }
+
+  private enum PodPhase {
+    // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+    Pending(true, "Pod is pending"),
+    Running(false, ""),
+    Succeeded(false, ""),
+    Failed(true, "Pod has failed"),
+    Unknown(true, "Pod phase is unknown");
+
+    @Getter private String message;
+    @Getter private boolean unstable;
+
+    PodPhase(boolean unstable, String message) {
+      this.message = message;
+      this.unstable = unstable;
+    }
+
+    static PodPhase fromString(@Nullable String phase) {
+      if (phase == null) {
+        return Unknown;
+      }
+      try {
+        return valueOf(phase);
+      } catch (IllegalArgumentException e) {
+        return Unknown;
+      }
+    }
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesReplicaSetHandler.java
@@ -107,9 +107,7 @@ public class KubernetesReplicaSetHandler extends KubernetesHandler
   private Status status(V1ReplicaSet replicaSet) {
     V1ReplicaSetStatus status = replicaSet.getStatus();
     if (status == null) {
-      return Status.defaultStatus()
-          .unstable("No status reported yet")
-          .unavailable("No availability reported");
+      return Status.noneReported();
     }
 
     Optional<UnstableReason> unstableReason = checkReplicaCounts(replicaSet, status);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1beta2RollingUpdateStatefulSetStrategy;
 import io.kubernetes.client.openapi.models.V1beta2StatefulSet;
 import io.kubernetes.client.openapi.models.V1beta2StatefulSetStatus;
@@ -38,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -96,9 +98,6 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    if (manifest.isNewerThanObservedGeneration()) {
-      return Status.defaultStatus().unstable(UnstableReason.OLD_GENERATION.getMessage());
-    }
     V1beta2StatefulSet v1beta2StatefulSet =
         KubernetesCacheDataConverter.getResource(manifest, V1beta2StatefulSet.class);
     return status(v1beta2StatefulSet);
@@ -128,6 +127,10 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
       return Status.defaultStatus()
           .unstable("No status reported yet")
           .unavailable("No availability reported");
+    }
+
+    if (!generationMatches(statefulSet, status)) {
+      return Status.defaultStatus().unstable(UnstableReason.OLD_GENERATION.getMessage());
     }
 
     int desiredReplicas = defaultToZero(statefulSet.getSpec().getReplicas());
@@ -168,6 +171,15 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
     }
 
     return Status.defaultStatus();
+  }
+
+  private boolean generationMatches(
+      V1beta2StatefulSet statefulSet, V1beta2StatefulSetStatus status) {
+    Optional<Long> metadataGeneration =
+        Optional.ofNullable(statefulSet.getMetadata()).map(V1ObjectMeta::getGeneration);
+    Optional<Long> statusGeneration = Optional.ofNullable(status.getObservedGeneration());
+
+    return statusGeneration.isPresent() && statusGeneration.equals(metadataGeneration);
   }
 
   // Unboxes an Integer, returning 0 if the input is null

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -97,7 +97,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
   @Override
   public Status status(KubernetesManifest manifest) {
     if (manifest.isNewerThanObservedGeneration()) {
-      return Status.defaultStatus().unknown();
+      return Status.defaultStatus().unstable(UnstableReason.OLD_GENERATION.getMessage());
     }
     V1beta2StatefulSet v1beta2StatefulSet =
         KubernetesCacheDataConverter.getResource(manifest, V1beta2StatefulSet.class);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -124,9 +124,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
 
     V1beta2StatefulSetStatus status = statefulSet.getStatus();
     if (status == null) {
-      return Status.defaultStatus()
-          .unstable("No status reported yet")
-          .unavailable("No availability reported");
+      return Status.noneReported();
     }
 
     if (!generationMatches(statefulSet, status)) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/UnstableReason.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/UnstableReason.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 enum UnstableReason {
   AVAILABLE_REPLICAS("Waiting for all replicas to be available"),
   FULLY_LABELED_REPLICAS("Waiting for all replicas to be fully-labeled"),
+  OLD_GENERATION("Waiting for status generation to match updated object generation"),
   OLD_REPLICAS("Waiting for old replicas to finish termination"),
   READY_REPLICAS("Waiting for all replicas to be ready"),
   UPDATED_REPLICAS("Waiting for all replicas to be updated");

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandlerTest.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
@@ -32,9 +31,14 @@ final class KubernetesDaemonSetHandlerTest {
   @Test
   void noStatus() {
     KubernetesManifest daemonSet = ManifestFetcher.getManifest("daemonset/base.yml");
-    // Documenting the existing behavior before refactoring
-    assertThatExceptionOfType(NullPointerException.class)
-        .isThrownBy(() -> handler.status(daemonSet));
+    Status status = handler.status(daemonSet);
+
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage()).isEqualTo("No status reported yet");
+    assertThat(status.getAvailable().isState()).isFalse();
+    assertThat(status.getAvailable().getMessage()).isEqualTo("No availability reported");
+    assertThat(status.getPaused().isState()).isFalse();
+    assertThat(status.getFailed().isState()).isFalse();
   }
 
   @Test

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDaemonSetHandlerTest.java
@@ -99,10 +99,12 @@ final class KubernetesDaemonSetHandlerTest {
         ManifestFetcher.getManifest("daemonset/base.yml", "daemonset/old-generation.yml");
     Status status = handler.status(daemonSet);
 
-    assertThat(status.getStable()).isNull();
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage())
+        .isEqualTo("Waiting for status generation to match updated object generation");
     assertThat(status.getAvailable().isState()).isTrue();
     assertThat(status.getPaused().isState()).isFalse();
-    assertThat(status.getFailed()).isNull();
+    assertThat(status.getFailed().isState()).isFalse();
   }
 
   @Test

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandlerTest.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
@@ -29,10 +28,14 @@ final class KubernetesDeploymentHandlerTest {
   @Test
   void noStatus() {
     KubernetesManifest deployment = ManifestFetcher.getManifest("deployment/base.yml");
+    Status status = handler.status(deployment);
 
-    // Documenting the existing behavior before refactoring
-    assertThatExceptionOfType(NullPointerException.class)
-        .isThrownBy(() -> handler.status(deployment));
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage()).isEqualTo("No status reported yet");
+    assertThat(status.getAvailable().isState()).isFalse();
+    assertThat(status.getAvailable().getMessage()).isEqualTo("No availability reported");
+    assertThat(status.getPaused().isState()).isFalse();
+    assertThat(status.getFailed().isState()).isFalse();
   }
 
   @Test

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesDeploymentHandlerTest.java
@@ -80,10 +80,12 @@ final class KubernetesDeploymentHandlerTest {
             "deployment/base.yml", "deployment/stable-with-old-generation.yml");
     Status status = handler.status(deployment);
 
-    assertThat(status.getStable()).isNull();
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage())
+        .isEqualTo("Waiting for status generation to match updated object generation");
     assertThat(status.getAvailable().isState()).isTrue();
     assertThat(status.getPaused().isState()).isFalse();
-    assertThat(status.getFailed()).isNull();
+    assertThat(status.getFailed().isState()).isFalse();
   }
 
   @Test

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesPodHandlerTest.java
@@ -44,9 +44,9 @@ final class KubernetesPodHandlerTest {
     Status status = handler.status(pod);
 
     assertThat(status.getStable().isState()).isFalse();
-    assertThat(status.getStable().getMessage()).isEqualTo("No phase reported yet");
+    assertThat(status.getStable().getMessage()).isEqualTo("Pod phase is unknown");
     assertThat(status.getAvailable().isState()).isFalse();
-    assertThat(status.getAvailable().getMessage()).isEqualTo("No availability reported");
+    assertThat(status.getAvailable().getMessage()).isEqualTo("Pod phase is unknown");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }
@@ -56,9 +56,10 @@ final class KubernetesPodHandlerTest {
     KubernetesManifest pod = ManifestFetcher.getManifest("pod/base.yml", "pod/pending-phase.yml");
     Status status = handler.status(pod);
 
-    // TODO(ezimanyi): Should be unstable; see comment in KubernetesPodHandler.status
-    assertThat(status.getStable().isState()).isTrue();
-    assertThat(status.getAvailable().isState()).isTrue();
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage()).isEqualTo("Pod is pending");
+    assertThat(status.getAvailable().isState()).isFalse();
+    assertThat(status.getAvailable().getMessage()).isEqualTo("Pod is pending");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }
@@ -90,9 +91,10 @@ final class KubernetesPodHandlerTest {
     KubernetesManifest pod = ManifestFetcher.getManifest("pod/base.yml", "pod/failed-phase.yml");
     Status status = handler.status(pod);
 
-    // TODO(ezimanyi): Should be unstable; see comment in KubernetesPodHandler.status
-    assertThat(status.getStable().isState()).isTrue();
-    assertThat(status.getAvailable().isState()).isTrue();
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage()).isEqualTo("Pod has failed");
+    assertThat(status.getAvailable().isState()).isFalse();
+    assertThat(status.getAvailable().getMessage()).isEqualTo("Pod has failed");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }
@@ -102,9 +104,10 @@ final class KubernetesPodHandlerTest {
     KubernetesManifest pod = ManifestFetcher.getManifest("pod/base.yml", "pod/unknown-phase.yml");
     Status status = handler.status(pod);
 
-    // TODO(ezimanyi): Should be unstable; see comment in KubernetesPodHandler.status
-    assertThat(status.getStable().isState()).isTrue();
-    assertThat(status.getAvailable().isState()).isTrue();
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage()).isEqualTo("Pod phase is unknown");
+    assertThat(status.getAvailable().isState()).isFalse();
+    assertThat(status.getAvailable().getMessage()).isEqualTo("Pod phase is unknown");
     assertThat(status.getPaused().isState()).isFalse();
     assertThat(status.getFailed().isState()).isFalse();
   }

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerTest.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
@@ -32,9 +31,14 @@ final class KubernetesStatefulSetHandlerTest {
   @Test
   void noStatus() {
     KubernetesManifest statefulSet = ManifestFetcher.getManifest("statefulset/base.yml");
-    // Documenting the existing behavior before refactoring
-    assertThatExceptionOfType(NullPointerException.class)
-        .isThrownBy(() -> handler.status(statefulSet));
+    Status status = handler.status(statefulSet);
+
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage()).isEqualTo("No status reported yet");
+    assertThat(status.getAvailable().isState()).isFalse();
+    assertThat(status.getAvailable().getMessage()).isEqualTo("No availability reported");
+    assertThat(status.getPaused().isState()).isFalse();
+    assertThat(status.getFailed().isState()).isFalse();
   }
 
   @Test

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandlerTest.java
@@ -43,10 +43,12 @@ final class KubernetesStatefulSetHandlerTest {
         ManifestFetcher.getManifest("statefulset/base.yml", "statefulset/old-generation.yml");
     Status status = handler.status(statefulSet);
 
-    assertThat(status.getStable()).isNull();
+    assertThat(status.getStable().isState()).isFalse();
+    assertThat(status.getStable().getMessage())
+        .isEqualTo("Waiting for status generation to match updated object generation");
     assertThat(status.getAvailable().isState()).isTrue();
     assertThat(status.getPaused().isState()).isFalse();
-    assertThat(status.getFailed()).isNull();
+    assertThat(status.getFailed().isState()).isFalse();
   }
 
   @Test

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/statefulset/partitioned-rollout-complete.yml
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/statefulset/partitioned-rollout-complete.yml
@@ -3,7 +3,7 @@ status:
   collisionCount: 0
   currentReplicas: 2
   currentRevision: web-b46f789c4
-  observedGeneration: 3
+  observedGeneration: 2
   readyReplicas: 4
   replicas: 4
   updateRevision: web-c5f4bdc97


### PR DESCRIPTION
* test(kubernetes): Fix observed generation in stateful set test 

  One of the stateful set tests incorrectly had the observed generation newer than the metadata one; fix this.

* fix(kubernetes): Replace null status with false 

  When the observed generation in the status does not match the object's generation, we set the stable and failed conditions to null. This should not be treated any differently than if the status generation did match but the object had not fully rolled out---it just means we need to wait a bit longer to see the new status.

  The recent changes to orca have explicitly made it so that from orca's perspective there is no different beteween stable/failed being null and stable/failed being false. Make things more clear (and null-safe) by removing the ability to null these conditions.

* fix(kubernetes): Move generation checks to be object-specific 

  We have a generic function in KubernetesManifest to determine whether the status generation is correct. It has a lot of type-safety and null-safety issues as it's operating on an untyped map.

  As each status handler already converts the manifest to a strongly-typed representation of its handled object, let's move the status checks to happen on that object.

  This in particular fixes some null-pointer issues that were documented in the tests.

* fix(kubernetes): Fix pod phase status reporting 

  This was the last remaining TODO I had noted when adding tests to all of the handlers.

* refactor(kubernetes): Pull unknown status to factory method 

  We frequently create an unknown status with the same text; pull it up to a factory method so we don't keep repeating the same text.