### PR TITLE
feat(core): add SpinnakerRetrofitErrorHandler

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProvider.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.LaunchConfigurationBuilder
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerHttpException
 import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerNetworkException
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerServerException
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import org.springframework.beans.factory.annotation.Autowired
 import retrofit.RetrofitError
@@ -43,7 +44,7 @@ class LocalFileUserDataProvider implements UserDataProvider {
         return Boolean.valueOf(application.legacyUdf)
       } catch (NotFoundException e) {
         return localFileUserDataProperties.defaultLegacyUdf
-      } catch (SpinnakerNetworkException e) {
+      } catch (SpinnakerServerException e) {
         throw e
       }
     }
@@ -60,10 +61,8 @@ class LocalFileUserDataProvider implements UserDataProvider {
           Thread.sleep(retryBackoff)
         }
       } catch (SpinnakerNetworkException e) {
-        if (e.getKind() == RetrofitError.Kind.NETWORK) {
-          Thread.sleep(retryBackoff)
-        }
-      }
+        Thread.sleep(retryBackoff)
+      } catch (SpinnakerServerException e) {}
     }
     throw new IllegalStateException("Failed to read legacyUdf preference from front50 for $account/$applicationName")
   }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProvider.groovy
@@ -48,6 +48,7 @@ class LocalFileUserDataProvider implements UserDataProvider {
       }
     }
 
+    // TODO(rz) standardize retry logic
     final int maxRetry = 5
     final int retryBackoff = 500
     final Set<Integer> retryStatus = [429, 500]

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/RetrofitConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/RetrofitConfig.groovy
@@ -56,7 +56,7 @@ class RetrofitConfig {
       .setConverter(new JacksonConverter())
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(Front50Service))
-      .setErrorHandler(new SpinnakerRetrofitErrorHandler())
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .build()
       .create(Front50Service)
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/RetrofitConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/RetrofitConfig.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.config
 
 import com.netflix.spinnaker.clouddriver.core.Front50ConfigurationProperties
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
@@ -55,6 +56,7 @@ class RetrofitConfig {
       .setConverter(new JacksonConverter())
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(Front50Service))
+      .setErrorHandler(new SpinnakerRetrofitErrorHandler())
       .build()
       .create(Front50Service)
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerHttpException.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerHttpException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.exceptions;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import lombok.Getter;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+// todo(mneterval): move to kork-exceptions
+
+/**
+ * An exception that exposes the {@link Response} of a given HTTP {@link RetrofitError} and a detail
+ * message that extracts useful information from the {@link Response}.
+ */
+@Getter
+@NonnullByDefault
+public final class SpinnakerHttpException extends SpinnakerNetworkException {
+  private final Response response;
+
+  public SpinnakerHttpException(RetrofitError e) {
+    super(e);
+    this.response = e.getResponse();
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format(
+        "Status: %s, URL: %s, Message: %s",
+        response.getStatus(), response.getUrl(), getRawMessage());
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerHttpException.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerHttpException.java
@@ -29,7 +29,7 @@ import retrofit.client.Response;
  */
 @Getter
 @NonnullByDefault
-public final class SpinnakerHttpException extends SpinnakerNetworkException {
+public final class SpinnakerHttpException extends SpinnakerServerException {
   private final Response response;
 
   public SpinnakerHttpException(RetrofitError e) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerNetworkException.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerNetworkException.java
@@ -16,50 +16,15 @@
 
 package com.netflix.spinnaker.clouddriver.exceptions;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
-import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
-import java.util.Optional;
-import lombok.Getter;
 import retrofit.RetrofitError;
 
 // todo(mneterval): move to kork-exceptions
 
-/** An exception that exposes the message and kind of a {@link RetrofitError}. */
-@Getter
+/** Wraps an exception of kind {@link RetrofitError.Kind} NETWORK. */
 @NonnullByDefault
-public class SpinnakerNetworkException extends SpinnakerException {
-  private final String rawMessage;
-  private final RetrofitError.Kind kind;
-
-  /**
-   * Parses the message and kind from the {@link RetrofitErrorResponseBody} of a {@link
-   * RetrofitError}.
-   *
-   * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
-   */
+public final class SpinnakerNetworkException extends SpinnakerServerException {
   public SpinnakerNetworkException(RetrofitError e) {
-    super(e.getCause());
-    RetrofitErrorResponseBody body =
-        (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
-    this.rawMessage =
-        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse("");
-    this.kind = e.getKind();
-  }
-
-  @Override
-  public String getMessage() {
-    return rawMessage;
-  }
-
-  @Getter
-  private static final class RetrofitErrorResponseBody {
-    private final String message;
-
-    @JsonCreator
-    RetrofitErrorResponseBody(@JsonProperty("message") String message) {
-      this.message = message;
-    }
+    super(e);
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerNetworkException.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerNetworkException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.exceptions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.util.Optional;
+import lombok.Getter;
+import retrofit.RetrofitError;
+
+// todo(mneterval): move to kork-exceptions
+
+/** An exception that exposes the message and kind of a {@link RetrofitError}. */
+@Getter
+@NonnullByDefault
+public class SpinnakerNetworkException extends SpinnakerException {
+  private final String rawMessage;
+  private final RetrofitError.Kind kind;
+
+  /**
+   * Parses the message and kind from the {@link RetrofitErrorResponseBody} of a {@link
+   * RetrofitError}.
+   *
+   * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
+   */
+  public SpinnakerNetworkException(RetrofitError e) {
+    super(e.getCause());
+    RetrofitErrorResponseBody body =
+        (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
+    this.rawMessage =
+        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse("");
+    this.kind = e.getKind();
+  }
+
+  @Override
+  public String getMessage() {
+    return rawMessage;
+  }
+
+  @Getter
+  private static final class RetrofitErrorResponseBody {
+    private final String message;
+
+    @JsonCreator
+    RetrofitErrorResponseBody(@JsonProperty("message") String message) {
+      this.message = message;
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerRetrofitErrorHandler.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerRetrofitErrorHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.exceptions;
+
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import org.springframework.http.HttpStatus;
+import retrofit.ErrorHandler;
+import retrofit.RetrofitError;
+import retrofit.RetrofitError.Kind;
+
+// todo(mneterval): move to kork-exceptions
+
+/**
+ * An error handler to be registered with a {@link retrofit.RestAdapter}. Allows clients to catch
+ * more specific {@link NotFoundException}, {@link SpinnakerHttpException}, or {@link
+ * SpinnakerNetworkException} depending on the properties of the {@link RetrofitError}.
+ */
+@NonnullByDefault
+public final class SpinnakerRetrofitErrorHandler implements ErrorHandler {
+  /**
+   * Returns a more specific {@link Throwable} depending on properties of the caught {@link
+   * RetrofitError}.
+   *
+   * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
+   * @return A more informative {@link Throwable}
+   */
+  @Override
+  public Throwable handleError(RetrofitError e) {
+    if (e.getKind() == Kind.HTTP) {
+      if (e.getResponse().getStatus() == HttpStatus.NOT_FOUND.value()) {
+        return new NotFoundException(e);
+      }
+      return new SpinnakerHttpException(e);
+    }
+    return new SpinnakerNetworkException(e);
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerRetrofitErrorHandler.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerRetrofitErrorHandler.java
@@ -32,6 +32,17 @@ import retrofit.RetrofitError.Kind;
  */
 @NonnullByDefault
 public final class SpinnakerRetrofitErrorHandler implements ErrorHandler {
+  private SpinnakerRetrofitErrorHandler() {}
+
+  /**
+   * Returns an instance of a {@link SpinnakerRetrofitErrorHandler}.
+   *
+   * @return An instance of {@link SpinnakerRetrofitErrorHandler}
+   */
+  public static SpinnakerRetrofitErrorHandler getInstance() {
+    return new SpinnakerRetrofitErrorHandler();
+  }
+
   /**
    * Returns a more specific {@link Throwable} depending on properties of the caught {@link
    * RetrofitError}.

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerRetrofitErrorHandler.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerRetrofitErrorHandler.java
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import org.springframework.http.HttpStatus;
 import retrofit.ErrorHandler;
 import retrofit.RetrofitError;
-import retrofit.RetrofitError.Kind;
 
 // todo(mneterval): move to kork-exceptions
 
@@ -52,12 +51,16 @@ public final class SpinnakerRetrofitErrorHandler implements ErrorHandler {
    */
   @Override
   public Throwable handleError(RetrofitError e) {
-    if (e.getKind() == Kind.HTTP) {
-      if (e.getResponse().getStatus() == HttpStatus.NOT_FOUND.value()) {
-        return new NotFoundException(e);
-      }
-      return new SpinnakerHttpException(e);
+    switch (e.getKind()) {
+      case HTTP:
+        if (e.getResponse().getStatus() == HttpStatus.NOT_FOUND.value()) {
+          return new NotFoundException(e);
+        }
+        return new SpinnakerHttpException(e);
+      case NETWORK:
+        return new SpinnakerNetworkException(e);
+      default:
+        return new SpinnakerServerException(e);
     }
-    return new SpinnakerNetworkException(e);
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerServerException.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerServerException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.exceptions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException;
+import java.util.Optional;
+import lombok.Getter;
+import retrofit.RetrofitError;
+
+// todo(mneterval): move to kork-exceptions
+
+/** An exception that exposes the message of a {@link RetrofitError}. */
+@Getter
+@NonnullByDefault
+public class SpinnakerServerException extends SpinnakerException {
+  private final String rawMessage;
+
+  /**
+   * Parses the message from the {@link RetrofitErrorResponseBody} of a {@link RetrofitError}.
+   *
+   * @param e The {@link RetrofitError} thrown by an invocation of the {@link retrofit.RestAdapter}
+   */
+  public SpinnakerServerException(RetrofitError e) {
+    super(e.getCause());
+    RetrofitErrorResponseBody body =
+        (RetrofitErrorResponseBody) e.getBodyAs(RetrofitErrorResponseBody.class);
+    this.rawMessage =
+        Optional.ofNullable(body).map(RetrofitErrorResponseBody::getMessage).orElse("");
+  }
+
+  @Override
+  public String getMessage() {
+    return rawMessage;
+  }
+
+  @Getter
+  private static final class RetrofitErrorResponseBody {
+    private final String message;
+
+    @JsonCreator
+    RetrofitErrorResponseBody(@JsonProperty("message") String message) {
+      this.message = message;
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerServerException.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/exceptions/SpinnakerServerException.java
@@ -27,7 +27,6 @@ import retrofit.RetrofitError;
 // todo(mneterval): move to kork-exceptions
 
 /** An exception that exposes the message of a {@link RetrofitError}. */
-@Getter
 @NonnullByDefault
 public class SpinnakerServerException extends SpinnakerException {
   private final String rawMessage;
@@ -47,6 +46,10 @@ public class SpinnakerServerException extends SpinnakerException {
 
   @Override
   public String getMessage() {
+    return rawMessage;
+  }
+
+  final String getRawMessage() {
     return rawMessage;
   }
 


### PR DESCRIPTION
Users are frequently frustrated by generic `RetrofitErrors` surfaced in pipeline execution details in the UI. A `RetrofitError`'s message is not surfaced when the error was thrown in a microservice more than one network call from the Orca task in which it originated. For example:

- An Orca task that calls out to Rosco, in which Rosco throws an exception, successfully surfaces the exception's message because Orca's `RetrofitExceptionHandler` [parses the RetrofitException.Response's `body.message`](https://github.com/spinnaker/orca/blob/master/orca-retrofit/src/main/groovy/com/netflix/spinnaker/orca/retrofit/exceptions/RetrofitExceptionHandler.groovy#L50).
- However, if the same Orca task calls out to Rosco, which calls out to Clouddriver, and Clouddriver throws an exception, we can no longer parse the message since we now have a `RetrofitError` body within the body of another `RetrofitError` (at `body.body.message`).

This PR is a proof-of-concept solution to this problem. By registering an error handler with each `Retrofit.RestAdapter` that re-throws `RetrofitErrors` as some subclass of `SpinnakerException` with a useful detail message, Orca is able to surface the useful detail message to end users. As an added benefit, we can centralize logic that is duplicated in many `catch (RetrofitError e)` blocks:

- Checking if a `RetrofitError` is an HTTP error in order to safely read its status.
- Checking if a `RetrofitError` is an HTTP error with a status of 404.

If this seems reasonable, I'm happy to move forward by:

1. Moving `SpinnakerRetrofitErrorHandler`, `SpinnakerNetworkException`, and `SpinnakerHttpException` to Kork.
2. Registering `SpinnakerRetrofitErrorHandler` with each `Retrofit.RestAdapter`.
3. Replacing each `RetrofitError` catch-block with a `SpinnakerNetworkException` catch-block, preceded by more specific `SpinnakerHttpException` and/or `NotFoundException` catch-blocks where appropriate.
(I would complete 2 and 3 for Clouddriver before moving on to the other microservices)
