### PR TITLE
fix(titus): Update filters for observeJob

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusStreamingUpdateAgent.java
@@ -353,6 +353,7 @@ public class TitusStreamingUpdateAgent implements CustomScheduledAgent, CachingA
           ObserveJobsQuery.newBuilder()
               .putFilteringCriteria("jobType", "SERVICE")
               .putFilteringCriteria("attributes", "source:spinnaker")
+              .putFilteringCriteria("attributes", "spinnakerAccount:" + account.getName())
               .build());
     }
 


### PR DESCRIPTION
- Add `spinnakerAccount` to filters , This should help fix duplicate cache entries when same titus accounts are mapped to different aws accounts 