### PR TITLE
chore(vulnerabilities): resolve CVEs and other security issues

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.sun.jersey:jersey-client:1.9.1"
   implementation "commons-io:commons-io"
-  implementation "org.apache.commons:commons-compress:1.14"
+  implementation "org.apache.commons:commons-compress:1.20"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.apache.ivy:ivy:2.4.0"
   implementation "org.apache.maven:maven-aether-provider:3.3.9"

--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -13,7 +13,7 @@ dependencies {
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:retrofit"
-  implementation "org.apache.commons:commons-compress:1.14"
+  implementation "org.apache.commons:commons-compress:1.20"
   implementation "commons-io:commons-io:2.6"
   implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"


### PR DESCRIPTION
- remove CVE-2019-12402, bump commons-compress dependency