### PR TITLE
fix(ecs): Add null check for empty serviceDiscoveryAssociation

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServerGroupDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServerGroupDescriptionValidator.java
@@ -103,6 +103,15 @@ public class EcsCreateServerGroupDescriptionValidator extends CommonValidator {
       rejectValue(errors, "ecsClusterName", "not.nullable");
     }
 
+    if (createServerGroupDescription.getServiceDiscoveryAssociations() != null) {
+      for (CreateServerGroupDescription.ServiceDiscoveryAssociation association :
+          createServerGroupDescription.getServiceDiscoveryAssociations()) {
+        if (association.getRegistry() == null) {
+          rejectValue(errors, "serviceDiscoveryAssociations", "item.invalid");
+        }
+      }
+    }
+
     boolean hasTargetGroup = StringUtils.isNotBlank(createServerGroupDescription.getTargetGroup());
 
     if (!createServerGroupDescription.isUseTaskDefinitionArtifact()) {


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5444.

### Testing

Empty `serviceDiscoveryAssociations` items are now validated and msg'd:

![service-disc-assoc-validation](https://user-images.githubusercontent.com/34254888/74989082-5320b700-53f4-11ea-8517-7cce7ae36c9f.PNG)
