### PR TITLE
feat(ecs): require service-linked roles for ECS and autoscaling

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/ResizeServiceAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/ResizeServiceAtomicOperation.java
@@ -82,7 +82,6 @@ public class ResizeServiceAtomicOperation
             .withScalableDimension(ScalableDimension.EcsServiceDesiredCount)
             .withResourceId(
                 String.format("service/%s/%s", ecsClusterName, service.getServiceName()))
-            .withRoleARN(service.getRoleArn())
             .withMinCapacity(description.getCapacity().getMin())
             .withMaxCapacity(description.getCapacity().getMax());
 

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -147,7 +147,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.loadBalancers.get(0).containerPort == 1337
       request.serviceRegistries == []
       request.desiredCount == 3
-      request.role == 'arn:aws:iam::test:test-role'
+      request.role == null
       request.placementConstraints.size() == 1
       request.placementConstraints.get(0).type == 'memberOf'
       request.placementConstraints.get(0).expression == 'attribute:ecs.instance-type =~ t2.*'
@@ -178,7 +178,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       assert request.serviceNamespace == ServiceNamespace.Ecs.toString()
       assert request.scalableDimension == ScalableDimension.EcsServiceDesiredCount.toString()
       assert request.resourceId == "service/test-cluster/${serviceName}-v008"
-      assert request.roleARN == 'arn:aws:iam::test:test-role'
+      assert request.roleARN == null
       assert request.minCapacity == 2
       assert request.maxCapacity == 4
     }
@@ -310,29 +310,6 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
 
     when:
     def request = operation.makeServiceRequest('task-def-arn',
-      'arn:aws:iam::test:test-role',
-      'mygreatapp-stack1-details2-v0011',
-      1)
-
-    then:
-    request.getLoadBalancers() == []
-    request.getRole() == null
-  }
-
-  def 'should create services with multiple load balancers without a role'() {
-    given:
-    def description = Mock(CreateServerGroupDescription)
-
-    description.getApplication() >> 'mygreatapp'
-    description.getStack() >> 'stack1'
-    description.getFreeFormDetails() >> 'details2'
-    description.getTargetGroup() >> null
-
-    def operation = new CreateServerGroupAtomicOperation(description)
-
-    when:
-    def request = operation.makeServiceRequest('task-def-arn',
-      'arn:aws:iam::test:test-role',
       'mygreatapp-stack1-details2-v0011',
       1)
 
@@ -808,7 +785,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.loadBalancers.get(0).containerPort == 1337
       request.serviceRegistries == []
       request.desiredCount == 3
-      request.role == 'arn:aws:iam::test:test-role'
+      request.role == null
       request.placementConstraints.size() == 1
       request.placementConstraints.get(0).type == 'memberOf'
       request.placementConstraints.get(0).expression == 'attribute:ecs.instance-type =~ t2.*'
@@ -839,7 +816,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       assert request.serviceNamespace == ServiceNamespace.Ecs.toString()
       assert request.scalableDimension == ScalableDimension.EcsServiceDesiredCount.toString()
       assert request.resourceId == "service/test-cluster/${serviceName}-v008"
-      assert request.roleARN == 'arn:aws:iam::test:test-role'
+      assert request.roleARN == null
       assert request.minCapacity == 2
       assert request.maxCapacity == 4
     }
@@ -961,7 +938,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       assert request.serviceNamespace == ServiceNamespace.Ecs.toString()
       assert request.scalableDimension == ScalableDimension.EcsServiceDesiredCount.toString()
       assert request.resourceId == "service/test-cluster/${serviceName}-v008"
-      assert request.roleARN == 'arn:aws:iam::test:test-role'
+      assert request.roleARN == null
       assert request.minCapacity == 2
       assert request.maxCapacity == 4
     }
@@ -1052,7 +1029,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.loadBalancers.get(0).containerPort == 80
       request.serviceRegistries == []
       request.desiredCount == 3
-      request.role == 'arn:aws:iam::test:test-role'
+      request.role == null
       request.placementConstraints.size() == 1
       request.placementConstraints.get(0).type == 'memberOf'
       request.placementConstraints.get(0).expression == 'attribute:ecs.instance-type =~ t2.*'
@@ -1083,7 +1060,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       assert request.serviceNamespace == ServiceNamespace.Ecs.toString()
       assert request.scalableDimension == ScalableDimension.EcsServiceDesiredCount.toString()
       assert request.resourceId == "service/test-cluster/${serviceName}-v008"
-      assert request.roleARN == 'arn:aws:iam::test:test-role'
+      assert request.roleARN == null
       assert request.minCapacity == 2
       assert request.maxCapacity == 4
     }
@@ -1209,7 +1186,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       assert request.serviceNamespace == ServiceNamespace.Ecs.toString()
       assert request.scalableDimension == ScalableDimension.EcsServiceDesiredCount.toString()
       assert request.resourceId == "service/test-cluster/${serviceName}-v008"
-      assert request.roleARN == 'arn:aws:iam::test:test-role'
+      assert request.roleARN == null
       assert request.minCapacity == 2
       assert request.maxCapacity == 4
     }


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5465

This change could mean that ECS deployments fail on upgrade to Spinnaker 1.19 due to missing service-linked roles in the AWS account.  This can be fixed by running:
```
aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com
aws iam create-service-linked-role --aws-service-name ecs.application-autoscaling.amazonaws.com
```