### PR TITLE
fix(ecs): provide port mappings if legacy target group setting is set

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -210,7 +210,7 @@ public class CreateServerGroupAtomicOperation
 
     Set<PortMapping> portMappings = new HashSet<>();
 
-    if (StringUtils.isEmpty(description.getTargetGroup())
+    if (!StringUtils.isEmpty(description.getTargetGroup())
         && description.getContainerPort() != null) {
       PortMapping portMapping =
           new PortMapping()

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -472,10 +472,10 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     description.getApplication() >> 'v1'
     description.getStack() >> 'kcats'
     description.getFreeFormDetails() >> 'liated'
-    description.ecsClusterName = 'test-cluster'
-    description.iamRole = 'None (No IAM role)'
+    description.getEcsClusterName() >> 'test-cluster'
+    description.getIamRole() >> 'None (No IAM role)'
     description.getContainerPort() >> 1337
-    description.targetGroup = 'target-group-arn'
+    description.getTargetGroup() >> 'target-group-arn'
     description.getPortProtocol() >> 'tcp'
     description.getComputeUnits() >> 9001
     description.getReservedMemory() >> 9001
@@ -542,8 +542,8 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     description.getApplication() >> 'v1'
     description.getStack() >> 'ecs'
     description.getFreeFormDetails() >> 'test'
-    description.ecsClusterName = 'test-cluster'
-    description.iamRole = 'None (No IAM role)'
+    description.getEcsClusterName() >> 'test-cluster'
+    description.getIamRole() >> 'None (No IAM role)'
     description.getResolvedTaskDefinitionArtifact() >> resolvedArtifact
     description.getContainerToImageMap() >> [
       web: "docker-image-url/one",
@@ -610,8 +610,8 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     description.getApplication() >> 'v1'
     description.getStack() >> 'ecs'
     description.getFreeFormDetails() >> 'test'
-    description.ecsClusterName = 'test-cluster'
-    description.iamRole = 'None (No IAM role)'
+    description.getEcsClusterName() >> 'test-cluster'
+    description.getIamRole() >> 'None (No IAM role)'
     description.getLaunchType() >> 'FARGATE'
     description.getResolvedTaskDefinitionArtifact() >> resolvedArtifact
     description.getContainerToImageMap() >> [
@@ -657,7 +657,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     description.getApplication() >> 'v1'
     description.getStack() >> 'ecs'
     description.getFreeFormDetails() >> 'test'
-    description.ecsClusterName = 'test-cluster'
+    description.getEcsClusterName() >> 'test-cluster'
     description.getLaunchType() >> 'FARGATE'
     description.getNetworkMode() >> 'awsvpc'
     description.getResolvedTaskDefinitionArtifact() >> resolvedArtifact
@@ -708,6 +708,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
   def 'should use same port for host and container in host mode'() {
     given:
     def description = Mock(CreateServerGroupDescription)
+    description.getTargetGroup() >> 'target-group-arn'
     description.getContainerPort() >> 10000
     description.getNetworkMode() >> 'host'
     def operation = new CreateServerGroupAtomicOperation(description)


### PR DESCRIPTION
A bug in the unit tests caused the check for the legacy target group setting to be flipped

When the server group has the legacy settings:
```
      "containerPort": 80,
      "targetGroup": "spinnaker-ecs-ec2-demo-tg",
```
Then the deployment will currently fail with the error message:
```
The container v002 did not have a container port 80 defined. (Service: AmazonECS; Status Code: 400; Error Code: InvalidParameterException; Request ID: 93dc346b-02e8-4ded-a651-b452e44736c6)
```

cc @pkandasamy91 