### PR TITLE
fix(aws): Fixing CLBs listener policies getting dropped on upsert

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/loadbalancer/UpsertAmazonLoadBalancerAtomicOperation.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops.loadbalancer
 
 import com.amazonaws.AmazonServiceException
-import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancing
 import com.amazonaws.services.elasticloadbalancing.model.*
 import com.amazonaws.services.shield.AWSShield
 import com.amazonaws.services.shield.model.CreateProtectionRequest
@@ -37,9 +36,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.config.AwsConfiguration.DeployDefaults
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-
-import static com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerClassicDescription.Listener.ListenerType.HTTP
-import static com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerClassicDescription.Listener.ListenerType.HTTPS
 
 /**
  * An AtomicOperation for creating an Elastic Load Balancer from the description of {@link UpsertAmazonLoadBalancerClassicDescription}.
@@ -200,13 +196,6 @@ class UpsertAmazonLoadBalancerAtomicOperation implements AtomicOperation<UpsertA
         task.updateStatus BASE_PHASE, "Healthcheck configured."
       }
 
-      try {
-        ensureSetLoadBalancerListenerPolicies(description, loadBalancing)
-      } catch(Exception e) {
-        log.error("Failed to apply listener policy names for {}", loadBalancer, e)
-        task.updateStatus BASE_PHASE, "Failed while applying listener policies."
-      }
-
       CrossZoneLoadBalancing crossZoneLoadBalancing = null
       ConnectionDraining connectionDraining = null
       ConnectionSettings connectionSettings = null
@@ -267,31 +256,6 @@ class UpsertAmazonLoadBalancerAtomicOperation implements AtomicOperation<UpsertA
     }
     task.updateStatus BASE_PHASE, "Done deploying load balancers."
     operationResult
-  }
-
-  /**
-   * Ensures policies set in the request are applied to the load balancer
-   */
-  private static void ensureSetLoadBalancerListenerPolicies(
-    UpsertAmazonLoadBalancerClassicDescription loadBalancer, AmazonElasticLoadBalancing loadBalancing) {
-    for (UpsertAmazonLoadBalancerClassicDescription.Listener listener :  loadBalancer.listeners) {
-      final List<String> policyNames = listener.policyNames ?: []
-      if (policyNames.isEmpty() || listener.externalProtocol != HTTP && listener.externalProtocol != HTTPS) {
-        // only applicable to http and https listeners
-        continue
-      }
-
-      final SetLoadBalancerPoliciesOfListenerRequest policyRequest = new SetLoadBalancerPoliciesOfListenerRequest()
-        .withLoadBalancerName(loadBalancer.name)
-        .withLoadBalancerPort(listener.externalPort)
-      try {
-        loadBalancing.setLoadBalancerPoliciesOfListener(
-          policyRequest.withPolicyNames(policyNames)
-        )
-      } catch(Exception e) {
-        log.error("Failed to set listener policies on loadbalancer {}", loadBalancer.name, e)
-      }
-    }
   }
 
   private static String loadBalancerArn(String accountId, String region, String name) {


### PR DESCRIPTION
- updated to now handle listener policies earlier in the operation
- fixed a bug where if a call to drop a listener failed,
the load balancer is left in a dirty state

