### PR TITLE
fix(docker/test): Switch to java.util.Base64

### DIFF
--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenServiceSpec.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenServiceSpec.groovy
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
-import sun.misc.BASE64Decoder
+import java.util.Base64
 
 class DockerBearerTokenServiceSpec extends Specification {
   private static final REALM1 = "https://auth.docker.io"


### PR DESCRIPTION
sun.misc.BASE64Decoder was removed in JDK 9 in favor of java.util.Base64.
JDK 8+ contains java.util.Base64, as such this remains backward compatible
with JDK 8.