### PR TITLE
fix(artifacts): Close OkHttpClient on failures

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/BaseHttpArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/config/BaseHttpArtifactCredentials.java
@@ -77,6 +77,7 @@ public abstract class BaseHttpArtifactCredentials<T extends ArtifactAccount> {
 
     Response downloadResponse = okHttpClient.newCall(request).execute();
     if (!downloadResponse.isSuccessful()) {
+      downloadResponse.body().close();
       throw new IOException(
           String.format("Received %d status code from %s", downloadResponse.code(), url.host()));
     }


### PR DESCRIPTION
The OkHttpClient warns about connection leak when an artifact download is
unsuccessful, since the connection is not closed in that case.

Reading the body closes the connection, and thus it doesn't trigger in the
successful cases.