### PR TITLE
fix(ecs): only add service role to create request if there is one lb

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -520,7 +520,7 @@ public class CreateServerGroupAtomicOperation
     // N/A for non-load-balanced services
     // Services using awsvpc mode must not specify a role in order to use the
     // ECS service-linked role
-    if (!AWSVPC_NETWORK_MODE.equals(description.getNetworkMode()) && !loadBalancers.isEmpty()) {
+    if (!AWSVPC_NETWORK_MODE.equals(description.getNetworkMode()) && loadBalancers.size() == 1) {
       request.withRole(ecsServiceRole);
     }
 

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperationSpec.groovy
@@ -319,6 +319,28 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
     request.getRole() == null
   }
 
+  def 'should create services with multiple load balancers without a role'() {
+    given:
+    def description = Mock(CreateServerGroupDescription)
+
+    description.getApplication() >> 'mygreatapp'
+    description.getStack() >> 'stack1'
+    description.getFreeFormDetails() >> 'details2'
+    description.getTargetGroup() >> null
+
+    def operation = new CreateServerGroupAtomicOperation(description)
+
+    when:
+    def request = operation.makeServiceRequest('task-def-arn',
+      'arn:aws:iam::test:test-role',
+      'mygreatapp-stack1-details2-v0011',
+      1)
+
+    then:
+    request.getLoadBalancers() == []
+    request.getRole() == null
+  }
+
   def 'should create default Docker labels'() {
     given:
     def description = Mock(CreateServerGroupDescription)
@@ -908,7 +930,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.loadBalancers.get(1).containerPort == 80
       request.serviceRegistries == []
       request.desiredCount == 3
-      request.role == 'arn:aws:iam::test:test-role'
+      request.role == null
       request.placementConstraints.size() == 1
       request.placementConstraints.get(0).type == 'memberOf'
       request.placementConstraints.get(0).expression == 'attribute:ecs.instance-type =~ t2.*'
@@ -1156,7 +1178,7 @@ class CreateServerGroupAtomicOperationSpec extends CommonAtomicOperation {
       request.loadBalancers.get(1).containerPort == 80
       request.serviceRegistries == []
       request.desiredCount == 3
-      request.role == 'arn:aws:iam::test:test-role'
+      request.role == null
       request.placementConstraints.size() == 1
       request.placementConstraints.get(0).type == 'memberOf'
       request.placementConstraints.get(0).expression == 'attribute:ecs.instance-type =~ t2.*'


### PR DESCRIPTION
Spinnaker infers the role to pass to ECS when creating services with load balancers. Previously, if you had a load balancer, it would pass the inferred role (SpinnakerManaged) vs using the Service Linked Role (which is required by ECS to interact with multiple load balancers using bridge mode). 

Testing Performed:
- Manually reproduce the error.
- After deploying the change, I was successfully able to deploy a service with multiple target groups associated to it using EC2 with Bridge network mode.

Fixes: https://github.com/spinnaker/spinnaker/issues/5412