### PR TITLE
fix(cf): Improved caching agent robustness

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -424,7 +424,7 @@ public class Applications {
                       })
                   .collect(toSet());
 
-          log.debug(
+          log.trace(
               "Successfully retrieved "
                   + instances.size()
                   + " instances for application '"

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -169,6 +169,13 @@ public class Applications {
 
     for (CloudFoundryServerGroup serverGroup : serverGroupCache.asMap().values()) {
       Names names = Names.parseName(serverGroup.getName());
+      if (names.getCluster() == null) {
+        log.debug(
+            "Skipping app '{}' from foundation '{}' because the name isn't following the frigga naming schema.",
+            serverGroup.getName(),
+            this.account);
+        continue;
+      }
       serverGroupsByClusters
           .computeIfAbsent(names.getCluster(), clusterName -> new HashSet<>())
           .add(serverGroup);

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryApiException.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryApiException.java
@@ -36,14 +36,15 @@ public class CloudFoundryApiException extends RuntimeException {
     super(
         Optional.ofNullable(errorCause)
             .map(e -> getMessage(e.getErrors().toArray(new String[0])))
-            .orElse(getRetrofitErrorMessage(retrofitError)));
+            .orElse(getRetrofitErrorMessage(retrofitError)),
+        retrofitError);
     if (errorCause != null) {
       this.errorCode = errorCause.getCode();
     }
   }
 
   public CloudFoundryApiException(RetrofitError retrofitError) {
-    super(getRetrofitErrorMessage(retrofitError));
+    super(getRetrofitErrorMessage(retrofitError), retrofitError);
   }
 
   public CloudFoundryApiException(Throwable t, String... errors) {

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
@@ -41,6 +41,7 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -181,6 +182,7 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
     this.password = password;
 
     this.okHttpClient = createHttpClient(skipSslValidation);
+    this.okHttpClient.setReadTimeout(20, TimeUnit.SECONDS);
 
     okHttpClient.interceptors().add(this::createRetryInterceptor);
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
@@ -114,7 +114,7 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
                 .intervalFunction(IntervalFunction.ofExponentialBackoff(Duration.ofSeconds(10), 3))
                 .retryExceptions(RetryableApiException.class)
                 .build());
-    logger.debug("cf request: " + chain.request().urlString());
+    logger.trace("cf request: " + chain.request().urlString());
     AtomicReference<Response> lastResponse = new AtomicReference<>();
     try {
       return retry.executeCallable(

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/HttpCloudFoundryClient.java
@@ -41,7 +41,6 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -77,8 +76,9 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
   private Logger logger = LoggerFactory.getLogger(HttpCloudFoundryClient.class);
 
   private AuthenticationService uaaService;
-  private AtomicLong tokenExpirationNs = new AtomicLong(System.nanoTime());
-  private volatile Token token;
+  private long tokenExpiration = System.currentTimeMillis();
+  private Token token;
+  private final Object tokenLock = new Object();
 
   private JacksonConverter jacksonConverter;
 
@@ -93,13 +93,7 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
   private Logs logs;
 
   private final RequestInterceptor oauthInterceptor =
-      new RequestInterceptor() {
-        @Override
-        public void intercept(RequestFacade request) {
-          refreshTokenIfNecessary();
-          request.addHeader("Authorization", "bearer " + token.getAccessToken());
-        }
-      };
+      request -> request.addHeader("Authorization", "bearer " + getToken(false).getAccessToken());
 
   private static class RetryableApiException extends RuntimeException {
     RetryableApiException(String message) {
@@ -135,13 +129,12 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
                 Buffer buffer = source.buffer();
                 String body = buffer.clone().readString(Charset.forName("UTF-8"));
                 if (!body.contains("Bad credentials")) {
-                  refreshToken();
                   response =
                       chain.proceed(
                           chain
                               .request()
                               .newBuilder()
-                              .header("Authorization", "bearer " + token.getAccessToken())
+                              .header("Authorization", "bearer " + getToken(true).getAccessToken())
                               .build());
                   lastResponse.set(response);
                 }
@@ -284,23 +277,19 @@ public class HttpCloudFoundryClient implements CloudFoundryClient {
     return client;
   }
 
-  private void refreshTokenIfNecessary() {
-    long currentExpiration = tokenExpirationNs.get();
-    long now = System.nanoTime();
-    long comp = Math.min(currentExpiration, now);
-    if (tokenExpirationNs.compareAndSet(comp, now)) {
-      this.refreshToken();
+  private Token getToken(boolean forceRefresh) {
+    synchronized (tokenLock) {
+      if (forceRefresh || (token == null || System.currentTimeMillis() >= tokenExpiration)) {
+        try {
+          token = uaaService.passwordToken("password", user, password, "cf", "");
+        } catch (Exception e) {
+          log.warn("Failed to obtain a token", e);
+          throw e;
+        }
+        tokenExpiration = System.currentTimeMillis() + ((token.getExpiresIn() - 120) * 1000);
+      }
+      return token;
     }
-  }
-
-  private void refreshToken() {
-    try {
-      token = uaaService.passwordToken("password", user, password, "cf", "");
-    } catch (Exception e) {
-      log.warn("Failed to obtain a token", e);
-      throw e;
-    }
-    tokenExpirationNs.addAndGet(Duration.ofSeconds(token.getExpiresIn()).toNanos());
   }
 
   private <S> S createService(Class<S> serviceClass) {

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryLoadBalancerCachingAgent.java
@@ -77,7 +77,7 @@ public class CloudFoundryLoadBalancerCachingAgent extends AbstractCloudFoundryCa
         cacheData -> {
           long cacheTime = (long) cacheData.getAttributes().get("cacheTime");
           if (cacheTime < loadDataStart
-              && (int) cacheData.getAttributes().get("processedCount") > 0) {
+              && (int) cacheData.getAttributes().computeIfAbsent("processedCount", s -> 0) > 0) {
             toEvict.add(cacheData.getId());
           } else {
             toKeep.put(cacheData.getId(), cacheData);

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
@@ -92,7 +92,7 @@ public class CloudFoundryServerGroupCachingAgent extends AbstractCloudFoundryCac
         cacheData -> {
           long cacheTime = (long) cacheData.getAttributes().get("cacheTime");
           if (cacheTime < loadDataStart
-              && (int) cacheData.getAttributes().get("processedCount") > 0) {
+              && (int) cacheData.getAttributes().computeIfAbsent("processedCount", s -> 0) > 0) {
             toEvict.add(cacheData.getId());
           } else {
             toKeep.put(cacheData.getId(), cacheData);

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
@@ -150,13 +150,6 @@ public class CloudFoundryServerGroupCachingAgent extends AbstractCloudFoundryCac
     if (serverGroupName == null) {
       return null;
     }
-    CloudFoundryServerGroup serverGroup =
-        this.getClient()
-            .getApplications()
-            .findServerGroupByNameAndSpaceId(serverGroupName, space.getId());
-    if (serverGroup == null) {
-      return null;
-    }
 
     log.info("On Demand cache refresh triggered, waiting for Server group loadData to be called");
     CloudFoundryServerGroup cloudFoundryServerGroup =

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentials.java
@@ -76,7 +76,7 @@ public class CloudFoundryCredentials implements AccountCredentials<CloudFoundryC
     this.password = password;
     this.environment = Optional.ofNullable(environment).orElse("dev");
     this.skipSslValidation = skipSslValidation;
-    this.resultsPerPage = Optional.ofNullable(resultsPerPage).orElse(500);
+    this.resultsPerPage = Optional.ofNullable(resultsPerPage).orElse(100);
     this.maxCapiConnectionsForCache = Optional.ofNullable(maxCapiConnectionsForCache).orElse(16);
   }
 

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizerTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/security/CloudFoundryCredentialsSynchronizerTest.java
@@ -149,7 +149,7 @@ class CloudFoundryCredentialsSynchronizerTest {
 
   private CloudFoundryCredentials createCredentials(String name) {
     return new CloudFoundryCredentials(
-        name, null, null, "api." + name, "user-" + name, "pwd-" + name, null, false, 500, 16);
+        name, null, null, "api." + name, "user-" + name, "pwd-" + name, null, false, null, 16);
   }
 
   private void loadProviderFromRepository() {


### PR DESCRIPTION
* fix(cf): Skip caching CF apps having frigga incompatible names

* fix(cf): Stop swallowing exception causes.
  Makes for deeper and informative stack traces.

* fix(cf): Race condition causing NPE getting token in the HTTP Client.
  Was happening at startup when both the LoadBalancer and Application caching agents were first ran and shared the same client.

* fix(cf): NPE after on-demand cache refresh run
  An on-demand cache refresh creates an ON_DEMAND cache entry that never been processed so the `processedCount` was null instead of 0 and the scheduled cache agent wasn't expecting that.

* fix(cf): Adjusted log verbosity level

* fix(cf): Re-enabling cache eviction of a serverGroup on-demand
  When not found, a serverGroup wouldn't be evicted from the cache upon an on-demand request.

* fix(cf): Sensible defaults for cache data retrieval