### PR TITLE
fix(aws): add .get() to optional known to be present

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -165,7 +165,7 @@ class AwsProviderConfig {
       } else {
         // This caching agent runs across all accounts in one iteration (to maintain consistency).
         newlyAddedAgents << new ReservationReportCachingAgent(
-          registry, amazonClientProvider, amazonS3DataProvider, allAccounts, objectMapper, reservationReportPool, ctx
+          registry, amazonClientProvider, amazonS3DataProvider, allAccounts, objectMapper, reservationReportPool.get(), ctx
         )
       }
     }


### PR DESCRIPTION
Fixes "could not find matching constructor" error introduced in https://github.com/spinnaker/clouddriver/pull/4336