### PR TITLE
fix(aws): Handle SG upsert with description object already present in console

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupIngressConverter.groovy
@@ -175,6 +175,18 @@ class SecurityGroupIngressConverter {
     }
   }
 
+  /**
+   *
+   * @param newList from description
+   * @param existingRules
+   * @return Map of rules that needs to be added , removed and updated
+   * Computes the delta between the existing rules and new rule
+   * Any rule present in description and not in the existing rule gets added to addition list.
+   * Any rule not present in description but present in existing rule get added to the remove list.
+   * Any rule with a change in description only gets added to the update list based on the following,
+   * - If a new rule has description value add it to update list to make it consistent.
+   * - If new rule has no description value set, ignore.
+   */
   static UserIdGroupPairsDelta computeUserIdGroupPairsDelta(List<IpPermission> newList, List<IpPermission> existingRules) {
     List<IpPermission> tobeAdded = new ArrayList<>()
     List<IpPermission> tobeRemoved = new ArrayList<>()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperation.groovy
@@ -102,16 +102,17 @@ class UpsertSecurityGroupAtomicOperation implements AtomicOperation<Void> {
     }
 
     SecurityGroupIngressConverter.IpRuleDelta ipRuleDelta = SecurityGroupIngressConverter.computeIpRuleDelta(ipPermissionsFromDescription.converted, existingIpPermissions)
-
     List<IpPermission> ipPermissionsToAdd = ipRuleDelta.toAdd
-    List<IpPermission> userIdGroupPermissions = SecurityGroupIngressConverter.userIdGroupPairsDiff(ipPermissionsFromDescription.converted,existingIpPermissions)
-    ipPermissionsToAdd = ipPermissionsToAdd + userIdGroupPermissions
+
+    SecurityGroupIngressConverter.UserIdGroupPairsDelta userIdGroupPairsDelta = SecurityGroupIngressConverter.computeUserIdGroupPairsDelta(ipPermissionsFromDescription.converted,existingIpPermissions)
+
+    ipPermissionsToAdd = ipPermissionsToAdd + userIdGroupPairsDelta.toAdd
 
     List<IpPermission> ipPermissionsToRemove = ipRuleDelta.toRemove
-    List<IpPermission> userIdGroupPermissionsToRemove = SecurityGroupIngressConverter.userIdGroupPairsDiff(existingIpPermissions,ipPermissionsFromDescription.converted)
-    ipPermissionsToRemove = ipPermissionsToRemove + userIdGroupPermissionsToRemove
 
-    List<IpPermission> tobeUpdated = ipRuleDelta.toUpdate
+    ipPermissionsToRemove = ipPermissionsToRemove + userIdGroupPairsDelta.toRemove
+
+    List<IpPermission> tobeUpdated = ipRuleDelta.toUpdate + userIdGroupPairsDelta.toUpdate
 
     //Update rules that are already present on the security group
     if(tobeUpdated) {


### PR DESCRIPTION
_Issue_ : 

Some SG's ingress rules were added manually via console with description , this makes the groovy list diff to produce rules that differ only in description , resulting in failures while calling `authorizeSecurityGroupIngress` due to duplicate rule violation.

_Fix:_

Use the same diff approach used for `IPRange` rules #4300