### PR TITLE
feat(kubernetes): prepare for upcoming removal of V1 provider

### DIFF
--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
@@ -350,7 +350,7 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
   private void logV1RemovalWarning(String name) {
     LOG.warn(
         String.format(
-            "Account %s is using Spinnaker’s legacy Kubernetes provider (V1), which is scheduled for removal in Spinnaker 1.21. "
+            "Account %s is using Spinnaker's legacy Kubernetes provider (V1), which is scheduled for removal in Spinnaker 1.21. "
                 + "Please migrate to the manifest-based provider (V2). Check out this RFC for more information: "
                 + "https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md.",
             name));

--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/security/KubernetesV1Credentials.java
@@ -112,6 +112,7 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
     this.LOG = LoggerFactory.getLogger(KubernetesV1Credentials.class);
     this.configureImagePullSecrets = configureImagePullSecrets;
     configureDockerRegistries();
+    logV1RemovalWarning(name);
   }
 
   @VisibleForTesting
@@ -344,5 +345,14 @@ public class KubernetesV1Credentials implements KubernetesCredentials {
           spectatorRegistry,
           accountCredentialsRepository);
     }
+  }
+
+  private void logV1RemovalWarning(String name) {
+    LOG.warn(
+        String.format(
+            "Account %s is using Spinnaker’s legacy Kubernetes provider (V1), which is scheduled for removal in Spinnaker 1.21. "
+                + "Please migrate to the manifest-based provider (V2). Check out this RFC for more information: "
+                + "https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md.",
+            name));
   }
 }

--- a/clouddriver-kubernetes-v1/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes-v1/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/provider/KubernetesV1ProviderSynchronizableSpec.groovy
@@ -80,6 +80,7 @@ class KubernetesV1ProviderSynchronizableSpec extends Specification {
     kubernetesConfigurationProperties.setAccounts([
       new KubernetesConfigurationProperties.ManagedAccount(
         name: "test-account",
+        providerVersion: "v1",
         kubeconfigContents: """
 apiVersion: v1
 contexts:

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -29,7 +29,7 @@ public class KubernetesConfigurationProperties {
   @Data
   public static class ManagedAccount {
     private String name;
-    private ProviderVersion providerVersion = ProviderVersion.v1;
+    private ProviderVersion providerVersion = ProviderVersion.v2;
     private String environment;
     private String accountType;
     private String context;


### PR DESCRIPTION
Related to: https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md

- **feat(kubernetes): log v1 warning on KubernetesV1Credentials initialization**

  The goal of this commit is to provide a warning on startup for any Spinnaker operators with Kubernetes V1 accounts. Although we're already providing a [warning](https://github.com/spinnaker/halyard/commit/835dcfdfa5a2ffbed45921488064d4d9367b5d1b) on `hal deploy apply` when one or more V1 accounts are configured, not everyone deploys Spinnaker with Halyard, and perhaps some operators are more likely to tail the Clouddriver logs on startup than they are to pay attention to Halyard validation warnings.

- **feat(kubernetes): default accounts with unspecified providerVersion to V2**

  We are already [defaulting](https://github.com/spinnaker/halyard/commit/835dcfdfa5a2ffbed45921488064d4d9367b5d1b) any Kubernetes accounts with an unspecified `providerVersion` to `V2` when deployed with Halyard; the defaulting behavior in Clouddriver should match this.