### PR TITLE
refactor(artifacts): Make artifact classes final and package-private

### DIFF
--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:retrofit"
   implementation "commons-io:commons-io"
+  implementation "org.apache.commons:commons-compress:1.14"
   implementation "org.codehaus.groovy:groovy-all"
   implementation "org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r"
   implementation "org.springframework.boot:spring-boot-actuator"

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gcsClient/AppengineGcsRepositoryClient.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/gcsClient/AppengineGcsRepositoryClient.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.appengine.gcsClient
 import com.netflix.spinnaker.clouddriver.appengine.AppengineJobExecutor
 import com.netflix.spinnaker.clouddriver.appengine.artifacts.GcsStorageService
 import com.netflix.spinnaker.clouddriver.appengine.model.AppengineRepositoryClient
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactUtils
+import com.netflix.spinnaker.clouddriver.appengine.artifacts.ArtifactUtils
 import groovy.transform.CompileStatic
 import groovy.transform.TupleConstructor
 import groovy.util.logging.Slf4j

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/ArtifactUtils.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/ArtifactUtils.java
@@ -15,7 +15,7 @@
  *
  */
 
-package com.netflix.spinnaker.clouddriver.artifacts;
+package com.netflix.spinnaker.clouddriver.appengine.artifacts;
 
 import java.io.*;
 import java.util.Stack;

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
@@ -28,7 +28,6 @@ import com.google.api.services.storage.model.StorageObject;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -18,8 +18,6 @@ dependencies {
   implementation "com.oracle.oci.sdk:oci-java-sdk-core"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.sun.jersey:jersey-client:1.9.1"
-  implementation "commons-io:commons-io"
-  implementation "org.apache.commons:commons-compress:1.14"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.apache.ivy:ivy:2.4.0"
   implementation "org.apache.maven:maven-aether-provider:3.3.9"

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -1,6 +1,5 @@
-test {
-  useJUnitPlatform()
-}
+tasks.compileGroovy.enabled = false
+sourceSets.main.java.srcDirs = ['src/main/java']
 
 dependencies {
   implementation project(":clouddriver-core")

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactCredentialsRepository.java
@@ -40,7 +40,7 @@ public class ArtifactCredentialsRepository {
                 .collect(Collectors.toList()));
   }
 
-  public ArtifactCredentials getCredentials(String accountName) {
+  private ArtifactCredentials getCredentials(String accountName) {
     return getAllCredentials().stream()
         .filter(e -> e.getName().equals(accountName))
         .findFirst()

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactUtils.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ArtifactUtils.java
@@ -24,8 +24,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 
 public class ArtifactUtils {
-  public static final String GCE_IMAGE_TYPE = "gce/image";
-
   public static void untarStreamToPath(InputStream inputStream, String basePath)
       throws IOException {
     class DirectoryTimestamp {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactAccount.java
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.BasicAuth;
 import lombok.Data;
 
 @Data
-public class BitbucketArtifactAccount implements ArtifactAccount, BasicAuth {
+final class BitbucketArtifactAccount implements ArtifactAccount, BasicAuth {
   private String name;
   private String username;
   private String password;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(BitbucketArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class BitbucketArtifactConfiguration {
+class BitbucketArtifactConfiguration {
   private final BitbucketArtifactProviderProperties bitbucketArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactCredentials.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class BitbucketArtifactCredentials
+final class BitbucketArtifactCredentials
     extends SimpleHttpArtifactCredentials<BitbucketArtifactAccount> implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("bitbucket/file");

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/bitbucket/BitbucketArtifactProviderProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.bitbucket")
-public class BitbucketArtifactProviderProperties
+final class BitbucketArtifactProviderProperties
     implements ArtifactProvider<BitbucketArtifactAccount> {
   private boolean enabled;
   private List<BitbucketArtifactAccount> accounts = new ArrayList<>();

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactAccount.java
@@ -21,6 +21,6 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import lombok.Data;
 
 @Data
-public class CustomArtifactAccount implements ArtifactAccount {
+final class CustomArtifactAccount implements ArtifactAccount {
   private String name = "custom-artifact";
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 @Slf4j
-public class CustomArtifactConfiguration {
+class CustomArtifactConfiguration {
   @Bean
   List<? extends CustomArtifactCredentials> customArtifactCredentials() {
     CustomArtifactAccount account = new CustomArtifactAccount();

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/custom/CustomArtifactCredentials.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class CustomArtifactCredentials implements ArtifactCredentials {
+final class CustomArtifactCredentials implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("custom/object");
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactAccount.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.artifacts.docker;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 
-public class DockerArtifactAccount implements ArtifactAccount {
+final class DockerArtifactAccount implements ArtifactAccount {
   @Override
   public String getName() {
     return "docker-registry";

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty("kubernetes.enabled")
 @RequiredArgsConstructor
 @Slf4j
-public class DockerArtifactConfiguration {
+class DockerArtifactConfiguration {
   @Bean
   List<? extends DockerArtifactCredentials> dockerArtifactCredentials() {
     return Collections.singletonList(new DockerArtifactCredentials(new DockerArtifactAccount()));

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/docker/DockerArtifactCredentials.java
@@ -27,13 +27,13 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Data
-public class DockerArtifactCredentials implements ArtifactCredentials {
+final class DockerArtifactCredentials implements ArtifactCredentials {
   public static final String TYPE = "docker/image";
 
   private final String name;
   private final List<String> types = Collections.singletonList(TYPE);
 
-  public DockerArtifactCredentials(DockerArtifactAccount account) {
+  DockerArtifactCredentials(DockerArtifactAccount account) {
     this.name = account.getName();
   }
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactAccount.java
@@ -21,6 +21,6 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import lombok.Data;
 
 @Data
-public class EmbeddedArtifactAccount implements ArtifactAccount {
+final class EmbeddedArtifactAccount implements ArtifactAccount {
   private String name = "embedded-artifact";
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 @Slf4j
-public class EmbeddedArtifactConfiguration {
+class EmbeddedArtifactConfiguration {
   @Bean
   List<? extends EmbeddedArtifactCredentials> embeddedArtifactCredentials() {
     EmbeddedArtifactAccount account = new EmbeddedArtifactAccount();

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/embedded/EmbeddedArtifactCredentials.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
 
 @Slf4j
-public class EmbeddedArtifactCredentials implements ArtifactCredentials {
+final class EmbeddedArtifactCredentials implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("embedded/base64");
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 @Slf4j
-public class Front50ArtifactConfiguration {
+class Front50ArtifactConfiguration {
   @Bean
   List<? extends Front50ArtifactCredentials> front50ArtifactCredentials(
       ObjectMapper objectMapper, Front50Service front50Service) {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/front50/Front50ArtifactCredentials.java
@@ -35,8 +35,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-public class Front50ArtifactCredentials implements ArtifactCredentials {
-  public static final String ACCOUNT_NAME = "front50ArtifactCredentials";
+final class Front50ArtifactCredentials implements ArtifactCredentials {
+  private static final String ACCOUNT_NAME = "front50ArtifactCredentials";
   private static final String URL_PREFIX = "spinnaker://";
 
   @Getter private final String name = ACCOUNT_NAME;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactAccount.java
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import lombok.Data;
 
 @Data
-public class GcsArtifactAccount implements ArtifactAccount {
+final class GcsArtifactAccount implements ArtifactAccount {
   private String name;
   private String jsonPath;
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(GcsArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class GcsArtifactConfiguration {
+class GcsArtifactConfiguration {
   private final GcsArtifactProviderProperties gcsArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactCredentials.java
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-public class GcsArtifactCredentials implements ArtifactCredentials {
+final class GcsArtifactCredentials implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("gcs/object");
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gcs/GcsArtifactProviderProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.gcs")
-public class GcsArtifactProviderProperties implements ArtifactProvider<GcsArtifactAccount> {
+final class GcsArtifactProviderProperties implements ArtifactProvider<GcsArtifactAccount> {
   private boolean enabled;
   private List<GcsArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactAccount.java
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import lombok.Data;
 
 @Data
-public class GitRepoArtifactAccount implements ArtifactAccount {
+final class GitRepoArtifactAccount implements ArtifactAccount {
 
   private String name;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(GitRepoArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class GitRepoArtifactConfiguration {
+class GitRepoArtifactConfiguration {
   private final GitRepoArtifactProviderProperties gitRepoArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
@@ -51,7 +51,7 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.util.FS;
 
 @Slf4j
-public class GitRepoArtifactCredentials implements ArtifactCredentials {
+final class GitRepoArtifactCredentials implements ArtifactCredentials {
   @Getter private final List<String> types = Collections.singletonList("git/repo");
 
   @Getter private final String name;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactProviderProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.git-repo")
-public class GitRepoArtifactProviderProperties implements ArtifactProvider<GitRepoArtifactAccount> {
+final class GitRepoArtifactProviderProperties implements ArtifactProvider<GitRepoArtifactAccount> {
   private boolean enabled;
   private List<GitRepoArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactAccount.java
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.TokenAuth;
 import lombok.Data;
 
 @Data
-public class GitHubArtifactAccount implements ArtifactAccount, BasicAuth, TokenAuth {
+final class GitHubArtifactAccount implements ArtifactAccount, BasicAuth, TokenAuth {
   private String name;
   /*
    One of the following are required for auth:

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(GitHubArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class GitHubArtifactConfiguration {
+class GitHubArtifactConfiguration {
   private final GitHubArtifactProviderProperties gitHubArtifactProviderProperties;
   private final ObjectMapper objectMapper;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactCredentials.java
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-public class GitHubArtifactCredentials extends SimpleHttpArtifactCredentials<GitHubArtifactAccount>
+final class GitHubArtifactCredentials extends SimpleHttpArtifactCredentials<GitHubArtifactAccount>
     implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("github/file");

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/github/GitHubArtifactProviderProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.github")
-public class GitHubArtifactProviderProperties implements ArtifactProvider<GitHubArtifactAccount> {
+final class GitHubArtifactProviderProperties implements ArtifactProvider<GitHubArtifactAccount> {
   private boolean enabled;
   private List<GitHubArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactAccount.java
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.TokenAuth;
 import lombok.Data;
 
 @Data
-public class GitlabArtifactAccount implements ArtifactAccount, TokenAuth {
+final class GitlabArtifactAccount implements ArtifactAccount, TokenAuth {
   private String name;
   private String token;
   private String tokenFile;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(GitlabArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class GitlabArtifactConfiguration {
+class GitlabArtifactConfiguration {
   private final GitlabArtifactProviderProperties gitlabArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactCredentials.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-public class GitlabArtifactCredentials extends SimpleHttpArtifactCredentials<GitlabArtifactAccount>
+final class GitlabArtifactCredentials extends SimpleHttpArtifactCredentials<GitlabArtifactAccount>
     implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("gitlab/file");

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitlab/GitlabArtifactProviderProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.gitlab")
-public class GitlabArtifactProviderProperties implements ArtifactProvider<GitlabArtifactAccount> {
+final class GitlabArtifactProviderProperties implements ArtifactProvider<GitlabArtifactAccount> {
   private boolean enabled;
   private List<GitlabArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactAccount.java
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.BasicAuth;
 import lombok.Data;
 
 @Data
-public class HelmArtifactAccount implements ArtifactAccount, BasicAuth {
+final class HelmArtifactAccount implements ArtifactAccount, BasicAuth {
   private String name;
   /*
    One of the following are required for auth:

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(HelmArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class HelmArtifactConfiguration {
+class HelmArtifactConfiguration {
   private final HelmArtifactProviderProperties helmArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactCredentials.java
@@ -33,7 +33,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class HelmArtifactCredentials extends BaseHttpArtifactCredentials<HelmArtifactAccount>
+final class HelmArtifactCredentials extends BaseHttpArtifactCredentials<HelmArtifactAccount>
     implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("helm/chart");

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/helm/HelmArtifactProviderProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.helm")
-public class HelmArtifactProviderProperties implements ArtifactProvider<HelmArtifactAccount> {
+final class HelmArtifactProviderProperties implements ArtifactProvider<HelmArtifactAccount> {
   private boolean enabled;
   private List<HelmArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactAccount.java
@@ -24,7 +24,7 @@ import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
-public class HttpArtifactAccount implements ArtifactAccount, BasicAuth {
+final class HttpArtifactAccount implements ArtifactAccount, BasicAuth {
   private String name;
   /*
    One of the following are required for auth:

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(HttpArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class HttpArtifactConfiguration {
+class HttpArtifactConfiguration {
   private final HttpArtifactProviderProperties httpArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactCredentials.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class HttpArtifactCredentials extends SimpleHttpArtifactCredentials<HttpArtifactAccount>
+final class HttpArtifactCredentials extends SimpleHttpArtifactCredentials<HttpArtifactAccount>
     implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("http/file");

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/http/HttpArtifactProviderProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.http")
-public class HttpArtifactProviderProperties implements ArtifactProvider<HttpArtifactAccount> {
+final class HttpArtifactProviderProperties implements ArtifactProvider<HttpArtifactAccount> {
   private boolean enabled;
   private List<HttpArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/DiskFreeingInputStream.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/DiskFreeingInputStream.java
@@ -24,7 +24,7 @@ import java.nio.file.Path;
 import java.util.Comparator;
 
 /** An {@link java.io.InputStream} that frees local disk resources when closed. */
-public class DiskFreeingInputStream extends InputStream {
+final class DiskFreeingInputStream extends InputStream {
   private final InputStream delegate;
   private final Path deleteOnClose;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactAccount.java
@@ -24,7 +24,7 @@ import java.util.List;
 import lombok.Data;
 
 @Data
-public class IvyArtifactAccount implements ArtifactAccount {
+final class IvyArtifactAccount implements ArtifactAccount {
   private String name;
   private IvySettings settings;
   private List<String> resolveConfigurations = singletonList("master");

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(IvyArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class IvyArtifactConfiguration {
+class IvyArtifactConfiguration {
   private final IvyArtifactProviderProperties ivyArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactCredentials.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Slf4j
-public class IvyArtifactCredentials implements ArtifactCredentials {
+final class IvyArtifactCredentials implements ArtifactCredentials {
   @Getter private final List<String> types = Collections.singletonList("ivy/file");
   private final IvyArtifactAccount account;
   private final Supplier<Path> cacheBuilder;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/IvyArtifactProviderProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.ivy")
-public class IvyArtifactProviderProperties {
+final class IvyArtifactProviderProperties {
   private boolean enabled;
   private List<IvyArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/BintrayResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/BintrayResolver.java
@@ -23,7 +23,7 @@ import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class BintrayResolver extends Resolver<org.apache.ivy.plugins.resolver.BintrayResolver> {
+final class BintrayResolver extends Resolver<org.apache.ivy.plugins.resolver.BintrayResolver> {
   /** Bintray username of a repository owner. */
   @JacksonXmlProperty(isAttribute = true)
   @Nullable

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/ChainResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/ChainResolver.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class ChainResolver extends Resolver<org.apache.ivy.plugins.resolver.ChainResolver> {
+final class ChainResolver extends Resolver<org.apache.ivy.plugins.resolver.ChainResolver> {
   @JsonIgnore private final Resolvers resolvers = new Resolvers();
   /** If the first found should be returned. */
   @JacksonXmlProperty(isAttribute = true)

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Credentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Credentials.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 import lombok.Data;
 
 @Data
-public class Credentials {
+final class Credentials {
   @JacksonXmlProperty(isAttribute = true)
   private String host;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IBiblioResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IBiblioResolver.java
@@ -23,7 +23,7 @@ import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class IBiblioResolver extends Resolver<org.apache.ivy.plugins.resolver.IBiblioResolver> {
+final class IBiblioResolver extends Resolver<org.apache.ivy.plugins.resolver.IBiblioResolver> {
   /** The root of the artifact repository. */
   @JacksonXmlProperty(isAttribute = true)
   @Nullable

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IvySettings.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/IvySettings.java
@@ -31,7 +31,7 @@ import org.apache.ivy.util.url.CredentialsStore;
 
 @JacksonXmlRootElement(localName = "ivysettings")
 @Data
-public class IvySettings {
+public final class IvySettings {
   private Resolvers resolvers = new Resolvers();
   private Settings settings = new Settings();
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Pattern.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Pattern.java
@@ -19,6 +19,6 @@ package com.netflix.spinnaker.clouddriver.artifacts.ivy.settings;
 import lombok.Data;
 
 @Data
-public class Pattern {
+final class Pattern {
   private String pattern;
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Resolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Resolver.java
@@ -21,7 +21,7 @@ import lombok.Data;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 
 @Data
-public abstract class Resolver<M extends DependencyResolver> {
+abstract class Resolver<M extends DependencyResolver> {
   /** The name which identifies the resolver. */
   @JacksonXmlProperty(isAttribute = true)
   private String name;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Resolvers.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Resolvers.java
@@ -24,7 +24,7 @@ import lombok.Data;
 import org.apache.ivy.plugins.resolver.DependencyResolver;
 
 @Data
-public class Resolvers {
+final class Resolvers {
   @JacksonXmlElementWrapper(useWrapping = false)
   @Nullable
   private List<BintrayResolver> bintray;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Settings.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/Settings.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 import lombok.Data;
 
 @Data
-public class Settings {
+final class Settings {
   @Nullable
   @JacksonXmlProperty(isAttribute = true)
   private String defaultResolver;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/SshResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/SshResolver.java
@@ -25,7 +25,7 @@ import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class SshResolver extends Resolver<org.apache.ivy.plugins.resolver.SshResolver> {
+final class SshResolver extends Resolver<org.apache.ivy.plugins.resolver.SshResolver> {
   /** The username to provide as a credential. */
   @JacksonXmlProperty(isAttribute = true)
   private String user;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/UrlResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/UrlResolver.java
@@ -26,7 +26,7 @@ import org.apache.ivy.plugins.resolver.URLResolver;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class UrlResolver extends Resolver<URLResolver> {
+final class UrlResolver extends Resolver<URLResolver> {
   @JacksonXmlProperty(isAttribute = true)
   @Nullable
   private Boolean m2compatible;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactAccount.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 @Data
 @RequiredArgsConstructor
-public class JenkinsArtifactAccount implements ArtifactAccount, BasicAuth {
+final class JenkinsArtifactAccount implements ArtifactAccount, BasicAuth {
   private final String name;
   private final String username;
   private final String password;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(JenkinsProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class JenkinsArtifactConfiguration {
+class JenkinsArtifactConfiguration {
   private final JenkinsProperties jenkinsProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsArtifactCredentials.java
@@ -27,9 +27,9 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class JenkinsArtifactCredentials
-    extends SimpleHttpArtifactCredentials<JenkinsArtifactAccount> implements ArtifactCredentials {
-  public static final String TYPE = "jenkins/file";
+final class JenkinsArtifactCredentials extends SimpleHttpArtifactCredentials<JenkinsArtifactAccount>
+    implements ArtifactCredentials {
+  private static final String TYPE = "jenkins/file";
 
   @Getter private final String name;
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/jenkins/JenkinsProperties.java
@@ -23,12 +23,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("jenkins")
-public class JenkinsProperties {
+final class JenkinsProperties {
   private boolean enabled;
   private List<Master> masters = new ArrayList<>();
 
   @Data
-  public static class Master {
+  static final class Master {
     private String name;
     private String address;
     private String username;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactAccount.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.artifacts.kubernetes;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 
-public class KubernetesArtifactAccount implements ArtifactAccount {
+final class KubernetesArtifactAccount implements ArtifactAccount {
   @Override
   public String getName() {
     return "kubernetes";

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty("kubernetes.enabled")
 @RequiredArgsConstructor
 @Slf4j
-public class KubernetesArtifactConfiguration {
+class KubernetesArtifactConfiguration {
   @Bean
   List<? extends KubernetesArtifactCredentials> kubernetesArtifactAccounts() {
     return Collections.singletonList(

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactCredentials.java
@@ -18,7 +18,6 @@
 package com.netflix.spinnaker.clouddriver.artifacts.kubernetes;
 
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
-import com.netflix.spinnaker.clouddriver.artifacts.docker.DockerArtifactCredentials;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -29,17 +28,17 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Data
-public class KubernetesArtifactCredentials implements ArtifactCredentials {
+final class KubernetesArtifactCredentials implements ArtifactCredentials {
   private final String name;
   private final List<String> types;
 
-  public KubernetesArtifactCredentials(KubernetesArtifactAccount account) {
+  KubernetesArtifactCredentials(KubernetesArtifactAccount account) {
     this.name = account.getName();
     this.types =
         Arrays.stream(KubernetesArtifactType.values())
+            .filter(t -> t != KubernetesArtifactType.DockerImage)
             .map(KubernetesArtifactType::getType)
             .collect(Collectors.toList());
-    types.remove(DockerArtifactCredentials.TYPE);
   }
 
   public InputStream download(Artifact artifact) {

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactType.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/kubernetes/KubernetesArtifactType.java
@@ -17,10 +17,8 @@
 
 package com.netflix.spinnaker.clouddriver.artifacts.kubernetes;
 
-import com.netflix.spinnaker.clouddriver.artifacts.docker.DockerArtifactCredentials;
-
 public enum KubernetesArtifactType {
-  DockerImage(DockerArtifactCredentials.TYPE),
+  DockerImage("docker/image"),
   ConfigMap("kubernetes/configMap"),
   Deployment("kubernetes/deployment"),
   ReplicaSet("kubernetes/replicaSet"),

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactAccount.java
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import lombok.Data;
 
 @Data
-public class MavenArtifactAccount implements ArtifactAccount {
+final class MavenArtifactAccount implements ArtifactAccount {
   private String name;
   private String repositoryUrl;
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(MavenArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class MavenArtifactConfiguration {
+class MavenArtifactConfiguration {
   private final MavenArtifactProviderProperties mavenArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactCredentials.java
@@ -48,7 +48,7 @@ import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionConstraint;
 import org.eclipse.aether.version.VersionScheme;
 
-public class MavenArtifactCredentials implements ArtifactCredentials {
+public final class MavenArtifactCredentials implements ArtifactCredentials {
   private static final String RELEASE = "RELEASE";
   private static final String SNAPSHOT = "SNAPSHOT";
   private static final String LATEST = "LATEST";

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/maven/MavenArtifactProviderProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.maven")
-public class MavenArtifactProviderProperties {
+final class MavenArtifactProviderProperties {
   private boolean enabled;
   private List<MavenArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactAccount.java
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import lombok.Data;
 
 @Data
-public class OracleArtifactAccount implements ArtifactAccount {
+final class OracleArtifactAccount implements ArtifactAccount {
   private String name;
 
   private String namespace;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(OracleArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class OracleArtifactConfiguration {
+class OracleArtifactConfiguration {
   private final OracleArtifactProviderProperties oracleArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactCredentials.java
@@ -23,7 +23,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class OracleArtifactCredentials implements ArtifactCredentials {
+final class OracleArtifactCredentials implements ArtifactCredentials {
   private static final String ARTIFACT_REFERENCE_PREFIX = "oci://";
 
   private static final String ARTIFACT_URI =

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/oracle/OracleArtifactProviderProperties.java
@@ -17,7 +17,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.oracle")
-public class OracleArtifactProviderProperties implements ArtifactProvider<OracleArtifactAccount> {
+final class OracleArtifactProviderProperties implements ArtifactProvider<OracleArtifactAccount> {
   private boolean enabled;
   private List<OracleArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactAccount.java
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactAccount;
 import lombok.Data;
 
 @Data
-public class S3ArtifactAccount implements ArtifactAccount {
+final class S3ArtifactAccount implements ArtifactAccount {
   private String name;
   private String apiEndpoint;
   private String apiRegion;

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactConfiguration.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(S3ArtifactProviderProperties.class)
 @RequiredArgsConstructor
 @Slf4j
-public class S3ArtifactConfiguration {
+class S3ArtifactConfiguration {
   private final S3ArtifactProviderProperties s3ArtifactProviderProperties;
 
   @Bean

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactCredentials.java
@@ -32,7 +32,7 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-public class S3ArtifactCredentials implements ArtifactCredentials {
+final class S3ArtifactCredentials implements ArtifactCredentials {
   @Getter private final String name;
   @Getter private final List<String> types = Collections.singletonList("s3/object");
 

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactProviderProperties.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/s3/S3ArtifactProviderProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("artifacts.s3")
-public class S3ArtifactProviderProperties implements ArtifactProvider<S3ArtifactAccount> {
+final class S3ArtifactProviderProperties implements ArtifactProvider<S3ArtifactAccount> {
   private boolean enabled;
   private List<S3ArtifactAccount> accounts = new ArrayList<>();
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -29,7 +29,6 @@ import com.google.api.services.compute.Compute
 import com.google.api.services.compute.model.*
 import com.netflix.spinnaker.cats.cache.Cache
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactUtils
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.google.GoogleExecutorTraits
 import com.netflix.spinnaker.clouddriver.google.batch.GoogleBatchRequest
@@ -58,6 +57,7 @@ import static com.netflix.spinnaker.clouddriver.google.cache.Keys.Namespace.HTTP
 
 @Slf4j
 class GCEUtil {
+  public static final String GCE_IMAGE_TYPE = "gce/image";
   private static final String DISK_TYPE_PERSISTENT = "PERSISTENT"
   private static final String DISK_TYPE_SCRATCH = "SCRATCH"
   private static final String GCE_API_PREFIX = "https://compute.googleapis.com/compute/v1/projects/"
@@ -130,8 +130,8 @@ class GCEUtil {
                                     String phase,
                                     SafeRetry safeRetry,
                                     GoogleExecutorTraits executor) {
-    if (artifact.getType() != ArtifactUtils.GCE_IMAGE_TYPE) {
-      throw new GoogleOperationException("Artifact to deploy to GCE must be of type ${ArtifactUtils.GCE_IMAGE_TYPE}")
+    if (artifact.getType() != GCE_IMAGE_TYPE) {
+      throw new GoogleOperationException("Artifact to deploy to GCE must be of type ${GCE_IMAGE_TYPE}")
     }
 
     def reference = artifact.getReference()

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
-import com.netflix.spinnaker.clouddriver.artifacts.ArtifactUtils
+import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BaseGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoHealingPolicy
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
@@ -255,7 +255,7 @@ class StandardGceAttributeValidator {
       // If there's no artifact at all, return early rather than try to validate the null artifact
       return false
     }
-    if (imageArtifact.getType() != ArtifactUtils.GCE_IMAGE_TYPE) {
+    if (imageArtifact.getType() != GCEUtil.GCE_IMAGE_TYPE) {
       errors.rejectValue("imageArtifact.type", "${context}.imageArtifact.type.invalid")
     }
   }


### PR DESCRIPTION
* refactor(artifacts): Compile clouddriver-artifacts with Java compiler 

  This package is already entirely in java, so no additional changes are needed other than setting the flag to compile it with the java compiler.

  We can also remove the useJUnitPlatform() setting as it has now been added to the base clouddriver build file so does not need to be specified in individual modules.

* refactor(artifacts): Make artifact classes final and package-private 

  In general, the interface of the artifacts module is to allow clients to pass in an artifact and get back an InputStream of the resolved artifact's contents. All of the accounts, configuration, and credentials are just implementation details of how this module does that and should be made package-private (and final as they were not designed for inheritance).

  The interfaces of course remain public, but clients should not need to know which particular implementation of an artifact account is handling their request.  In general, this is the case, though there is one place that breaks this encapsulation, where the cloud foundry deploy depends on details of the Maven artifact resolver. For that reason (to keep this refactor smaller) I'm just leaving that resolver public but ideally we'd find a better way of supporting what that consumer needs rather than make the entire resolver public.

* refactor(artifacts): Remove GCE reference from ArtifactUtils 

  There is a GCE-specific string contstant in ArtifactUtils; move it to a more appropriate location in the GCE module. (This in particular should not live in the core artifacts module as we don't even have a gce/image artifact handler at all.)

* refactor(artifacts): Move ArtifactUtils to appengine 

  The ArtifactUtils class is only used for appengine-specific operations of un-taring an archive. Rather than have it live in the core module, move it to the appengine module near its only use case.
