### PR TITLE
refactor(core): Push halyard defaults into base config defaults

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -1,12 +1,13 @@
 server:
-  port: 7002
+  port: ${services.clouddriver.port:7002}
+  address: ${services.clouddriver.host:localhost}
   ssl:
     enabled: false
   compression:
     enabled: true
 
 redis:
-  connection: redis://localhost:6379
+  connection: ${services.redis.baseUrl:redis://localhost:6379}
   scheduler: default
   parallelism: -1
 

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/OperationsController.groovy
@@ -53,7 +53,7 @@ class OperationsController {
     OperationsService operationsService,
     OrchestrationProcessor orchestrationProcessor,
     TaskRepository taskRepository,
-    @Value('${admin.tasks.shutdown-wait-seconds:-1}') long shutdownWaitSeconds) {
+    @Value('${admin.tasks.shutdown-wait-seconds:600}') long shutdownWaitSeconds) {
     this.operationsService = operationsService
     this.orchestrationProcessor = orchestrationProcessor
     this.taskRepository = taskRepository

--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,0 +1,6 @@
+This directory contains skeleton clouddriver configs to which Halyard concatenates
+its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated. To
+set a default config value, either set the value in `clouddriver-web/config/clouddriver.yml`
+or set a default in the code reading the config property.

--- a/halconfig/clouddriver-bootstrap.yml
+++ b/halconfig/clouddriver-bootstrap.yml
@@ -6,7 +6,3 @@ server:
 
 redis:
   connection: ${services.redisBootstrap.baseUrl:redis://localhost:6379}
-
-caching:
-  redis:
-    hashingEnabled: true

--- a/halconfig/clouddriver-caching.yml
+++ b/halconfig/clouddriver-caching.yml
@@ -3,8 +3,3 @@
 server:
   port: ${services.clouddriverCaching.port:7002}
   address: ${services.clouddriverCaching.host:localhost}
-
-caching:
-  redis:
-    hashingEnabled: true
-  writeEnabled: true

--- a/halconfig/clouddriver-ro-deck.yml
+++ b/halconfig/clouddriver-ro-deck.yml
@@ -5,6 +5,4 @@ server:
   address: ${services.clouddriverRoDeck.host:localhost}
 
 caching:
-  redis:
-    hashingEnabled: false
   writeEnabled: false

--- a/halconfig/clouddriver-ro.yml
+++ b/halconfig/clouddriver-ro.yml
@@ -5,6 +5,4 @@ server:
   address: ${services.clouddriverRo.host:localhost}
 
 caching:
-  redis:
-    hashingEnabled: false
   writeEnabled: false

--- a/halconfig/clouddriver-rw.yml
+++ b/halconfig/clouddriver-rw.yml
@@ -5,6 +5,4 @@ server:
   address: ${services.clouddriverRw.host:localhost}
 
 caching:
-  redis:
-    hashingEnabled: false
   writeEnabled: false

--- a/halconfig/clouddriver.yml
+++ b/halconfig/clouddriver.yml
@@ -8,7 +8,3 @@ server:
 
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}
-
-caching:
-  redis:
-    hashingEnabled: true

--- a/halconfig/clouddriver.yml
+++ b/halconfig/clouddriver.yml
@@ -1,7 +1,5 @@
 # halconfig
 
-admin.tasks.shutdownWaitSeconds: 600 # 10 minutes
-
 server:
   port: ${services.clouddriver.port:7002}
   address: ${services.clouddriver.host:localhost}

--- a/halconfig/clouddriver.yml
+++ b/halconfig/clouddriver.yml
@@ -1,8 +1,1 @@
 # halconfig
-
-server:
-  port: ${services.clouddriver.port:7002}
-  address: ${services.clouddriver.host:localhost}
-
-redis:
-  connection: ${services.redis.baseUrl:redis://localhost:6379}


### PR DESCRIPTION
Halyard had a pattern of generating its own base default config for each service, and then concatenating it to the generated config for the service.  This pattern is problematic for a few reasons:
* It just uses string concatenation to merge the base config with its generated config, which can (and has) led to errors when there are [duplicate values](https://github.com/spinnaker/halyard/pull/1314).
* Halyard needs to figure out how to get the version of the base hal config that corresponds to the version of clouddriver it's deploying, which led to a fairly complex system of uploading the contents of the `halconfig` directory to a GCS bucket each time to build an image, and having halyard pull down the corresponding files each time it does a deploy.
* We end up with diverging defaults, with Halyard users and non-Halyard users ending up with different defaults, and confusion among contributors about where to put new settings.

Needless to say, [kleat](https://github.com/spinnaker/governance/blob/master/rfc/halyard-lite.md) will not be following that pattern and will instead rely on a more typical pattern of defaulting config values.

This PR pushes things from the hal-specific defaults down to the web defaults.

* fix(redis): Clean up cache hashing config 

  The config setting caching.redis.hashingEnabled controls whether we try to short-circuit sending data to redis by comparing a hash of the data client-side with a hash of the data server-side.

  This setting is on by default, (see DEFAULT_HASHING_ENABLED in RedisCacheOptions.java) so there's no need to explicitly set it in config files.

  Also remove the setting turning it off in the HA clouddriver instances; this has no effect for -ro and -ro-deck as those instances never write to the cache anyway. This will be a change for the -rw instance, but in general this should improve performance. (At least there's no reason a priori to have the default different between different clouddriver instances.)

* refactor(core): Remove explicit setting of shutdownWaitSeconds 

  This parameter controls how long clouddriver will wait for in-flight tasks before shutting down. It is defaulted to 600 for all users deploying with halyard (which is most users). Rather than put this setting directly in the halyard-generated config, set the default in code.

  This will change the default for users that don't use Halyard
  (primarily Netflix). I'm happy to pick a different default if that is more reasonable, but given this is what all Halyard users have had for years it seems like the smallest change.

* refactor(core): Push defaulting of port and host to base config 

  Halyard has been using the settings in spinnaker.yml to default the port and host for clouddriver for all Halyard users by adding a block to the user's config.

  Push this logic to the base clouddriver config; the defaults are the same for anyone that does not have a services.* block in their config overriding the values, but for users who do (all Halyard users) this now respects those overrides.

* refactor(core): Add README to halconfig directory 

  Let's note that the configs in this directory are deprecated and should not be updated. (I didn't add the comment to the files themselves as they get interpolated, including comments, into the users' config files.)
