### PR TITLE
fix(clouddriver-kubernetes-v1): Update json-patch to v1.12

### DIFF
--- a/clouddriver-kubernetes-v1/clouddriver-kubernetes-v1.gradle
+++ b/clouddriver-kubernetes-v1/clouddriver-kubernetes-v1.gradle
@@ -11,7 +11,7 @@ dependencies {
 
   implementation "org.codehaus.groovy:groovy-all"
 
-  implementation "com.github.fge:json-patch:1.9"
+  implementation "com.github.java-json-tools:json-patch:1.12"
   implementation "com.google.guava:guava"
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spectator:spectator-api"


### PR DESCRIPTION
This also changes the organization from fge to java-json-tools, as the former is retired. Avoids v1.9's references to Guava and Jackson Databind versions with known CVEs. Addresses spinnaker/spinnaker#5525