### PR TITLE
fix(model): fix reference to renamed property and remove overridden .any on AmazonInstance

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/RebootInstancesAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/RebootInstancesAtomicOperationConverter.groovy
@@ -47,7 +47,7 @@ class RebootInstancesAtomicOperationConverter extends AbstractAtomicOperationsCr
     try {
       def serverGroups = converted.instanceIds.findResults {
         def instance = amazonInstanceProvider.getInstance(converted.credentials.name, converted.region, it)
-        return instance?.any()?.get("serverGroup")
+        return instance?.extraAttributes()?.get("serverGroup")
       } as Set<String>
       converted.serverGroups = serverGroups
     } catch (Exception e) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/TerminateInstancesAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/TerminateInstancesAtomicOperationConverter.groovy
@@ -46,7 +46,7 @@ class TerminateInstancesAtomicOperationConverter extends AbstractAtomicOperation
     try {
       def serverGroups = converted.instanceIds.findResults {
         def instance = amazonInstanceProvider.getInstance(converted.credentials.name, converted.region, it)
-        return instance?.any()?.get("serverGroup")
+        return instance?.extraAttributes?.get("serverGroup")
       } as Set<String>
       converted.serverGroups = serverGroups
     } catch (Exception e) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstance.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstance.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.model
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.model.HealthState
 import com.netflix.spinnaker.clouddriver.model.Instance
@@ -32,16 +33,26 @@ class AmazonInstance implements Instance, Serializable {
   final String providerType = AmazonCloudProvider.ID
   final String cloudProvider = AmazonCloudProvider.ID
 
-  private Map<String, Object> dynamicProperties = new HashMap<String, Object>()
+  @JsonIgnore
+  private Map<String, Object> extraAttributes = new LinkedHashMap<String, Object>()
 
   @JsonAnyGetter
-  public Map<String,Object> any() {
-    return dynamicProperties;
+  Map<String,Object> getExtraAttributes() {
+    return extraAttributes
   }
 
+  /**
+   * Setter for non explicitly defined values.
+   *
+   * Used for both Jackson mapping {@code @JsonAnySetter} as well
+   * as Groovy's implicit Map constructor (this is the reason the
+   * method is named {@code set(String name, Object value)}
+   * @param name The property name
+   * @param value The property value
+   */
   @JsonAnySetter
-  public void set(String name, Object value) {
-    dynamicProperties.put(name, value);
+  void set(String name, Object value) {
+    extraAttributes.put(name, value)
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
@@ -200,7 +200,7 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
             ]
         )
       } : [],
-      detachedInstances: serverGroup.any().detachedInstances,
+      detachedInstances: serverGroup.extraAttributes().detachedInstances,
       cloudProvider: AmazonCloudProvider.ID
     )
   }


### PR DESCRIPTION
previous commit renamed .any to .extraAttributes to avoid name collision with GroovyDefaultObject methods but
missed a spot on AmazonLoadBalancerProvider and missed an occurrence of .any on AmazonInstance