### PR TITLE
fix(cloudFoundry): fix cloudFoundry job provider

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/job/CloudFoundryJobProvider.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/job/CloudFoundryJobProvider.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.Map;
 import lombok.Getter;
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -51,7 +50,7 @@ public class CloudFoundryJobProvider implements JobProvider<CloudFoundryJobStatu
   @Override
   public Map<String, Object> getFileContents(
       String account, String location, String id, String fileName) {
-    throw new NotImplementedException("");
+    return null;
   }
 
   @Override


### PR DESCRIPTION
if cloud foundry is enabled, this job provider breaks run job for all
other cloud providers because of the exception thrown in
getFileContents. other cloud providers simply return null if this method
isn't implemented. this whole area could probably use a refactored.
currently, every job provider is queried regardless of whether or not
the account is for that cloud provider.