### PR TITLE
feat(exceptions): consume SpinnakerRetrofitErrorHandler

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.appengine.config
 
 import com.netflix.spinnaker.clouddriver.appengine.AppengineJobExecutor
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.clouddriver.googlecommon.config.GoogleCommonManagedAccount
 import com.squareup.okhttp.OkHttpClient
 import groovy.json.JsonSlurper
@@ -72,6 +73,7 @@ class AppengineConfigurationProperties {
       RestAdapter restAdapter = new RestAdapter.Builder()
         .setEndpoint(metadataUrl)
         .setClient(new OkClient(new OkHttpClient(retryOnConnectionFailure: true)))
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .build()
 
       return restAdapter.create(MetadataService.class)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/userdata/LocalFileUserDataProvider.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerNetworkException
 import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerServerException
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import org.springframework.beans.factory.annotation.Autowired
-import retrofit.RetrofitError
 
 class LocalFileUserDataProvider implements UserDataProvider {
   private static final INSERTION_MARKER = '\nexport EC2_REGION='

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/edda/EddaApiFactory.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/edda/EddaApiFactory.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.edda
 
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerRetrofitErrorHandler
 import retrofit.RestAdapter
 import retrofit.converter.Converter
 
@@ -33,6 +34,7 @@ class EddaApiFactory {
       return new RestAdapter.Builder()
         .setConverter(eddaConverter)
         .setEndpoint(endpointTemplate.replaceAll(Pattern.quote('{{region}}'), region))
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
         .build()
         .create(EddaApi)
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DisableAsgAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DisableAsgAtomicOperationUnitSpec.groovy
@@ -29,8 +29,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.ops.discovery.AwsEurekaSuppo
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
 import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus
 import com.netflix.spinnaker.clouddriver.data.task.TaskState
-import com.netflix.spinnaker.clouddriver.eureka.model.EurekaApplication
-import com.netflix.spinnaker.clouddriver.eureka.model.EurekaInstance
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerHttpException
 import retrofit.RetrofitError
 import retrofit.client.Response
 import spock.lang.Unroll
@@ -134,9 +133,9 @@ class DisableAsgAtomicOperationUnitSpec extends EnableDisableAtomicOperationUnit
     describeInstanceResult.getReservations() >> [new Reservation().withInstances(instance)]
 
     eureka.updateInstanceStatus('asg1', 'i1', 'OUT_OF_SERVICE') >> {
-      throw new RetrofitError("error", "url",
+      throw new SpinnakerHttpException(new RetrofitError("error", "url",
         new Response("url", 503, "service unavailable", [], null),
-        null, null, null, null)
+        null, null, null, null))
     }
 
     when:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/lifecycle/InstanceTerminationLifecycleWorkerSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.eureka.api.Eureka
 import com.netflix.spinnaker.clouddriver.eureka.deploy.ops.AbstractEurekaSupport.DiscoveryStatus
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerNetworkException
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import retrofit.RetrofitError
 import retrofit.RetrofitError.Kind
@@ -213,7 +214,7 @@ class InstanceTerminationLifecycleWorkerSpec extends Specification {
 
     then:
     1 * eureka.updateInstanceStatus(_, _, _) >> {
-      throw new RetrofitError("cannot connect", "http://discovery", new Response("http://discovery", 400, "reason", [], null), Mock(Converter), String, Kind.NETWORK, Mock(Throwable))
+      throw new SpinnakerNetworkException(new RetrofitError("cannot connect", "http://discovery", new Response("http://discovery", 400, "reason", [], null), Mock(Converter), String, Kind.NETWORK, Mock(Throwable)))
     }
     1 * eureka.updateInstanceStatus(_, _, _)
     0 * eureka.updateInstanceStatus(_, _, _)

--- a/clouddriver-consul/clouddriver-consul.gradle
+++ b/clouddriver-consul/clouddriver-consul.gradle
@@ -1,6 +1,7 @@
 dependencies {
   implementation project(":clouddriver-core")
 
+  implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:retrofit"
   implementation "org.codehaus.groovy:groovy-all"

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/Consul.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/api/v1/Consul.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.consul.api.v1
 
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import com.netflix.spinnaker.clouddriver.consul.config.ConsulProperties
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerRetrofitErrorHandler
 import com.squareup.okhttp.OkHttpClient
 import retrofit.RestAdapter
 import retrofit.client.OkClient
@@ -39,6 +40,7 @@ class Consul<T> {
       .setEndpoint(this.endpoint)
       .setClient(new OkClient(new OkHttpClient()))
       .setLogLevel(RestAdapter.LogLevel.NONE)
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .build()
       .create(type)
   }

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/config/ConsulConfig.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/config/ConsulConfig.groovy
@@ -17,14 +17,9 @@
 package com.netflix.spinnaker.clouddriver.consul.config
 
 import com.netflix.spinnaker.clouddriver.consul.api.v1.ConsulCatalog
-import com.netflix.spinnaker.clouddriver.consul.api.v1.services.CatalogApi
-import com.squareup.okhttp.OkHttpClient
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerServerException
 import groovy.util.logging.Slf4j
-import retrofit.RestAdapter
-import retrofit.RetrofitError
-import retrofit.client.OkClient
 
-import java.lang.invoke.ConstantCallSite
 import java.util.concurrent.TimeUnit
 
 @Slf4j
@@ -57,7 +52,7 @@ class ConsulConfig {
       try {
         def catalog = new ConsulCatalog(this)
         datacenters = catalog.api.datacenters()
-      } catch (RetrofitError e) {
+      } catch (SpinnakerServerException e) {
         log.warn "Unable to connect to Consul running on the local Clouddriver instance.", e
         datacenters = []
       }

--- a/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/provider/ConsulProviderUtils.groovy
+++ b/clouddriver-consul/src/main/groovy/com/netflix/spinnaker/clouddriver/consul/provider/ConsulProviderUtils.groovy
@@ -23,8 +23,8 @@ import com.netflix.spinnaker.clouddriver.consul.config.ConsulConfig
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulHealth
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulNode
 import com.netflix.spinnaker.clouddriver.consul.model.ConsulService
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerServerException
 import groovy.util.logging.Slf4j
-import retrofit.RetrofitError
 
 @Slf4j
 class ConsulProviderUtils {
@@ -40,7 +40,7 @@ class ConsulProviderUtils {
         return new ConsulService(result)
       } ?: []
       running = true
-    } catch (RetrofitError e) {
+    } catch (SpinnakerServerException e) {
       // Instance can't be connected to on hostname:port/v1/agent/checks
       log.debug(e.message)
     }

--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -17,6 +17,7 @@ dependencies {
   implementation "commons-io:commons-io:2.6"
   implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "com.netflix.spinnaker.kork:kork-web"
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/api/v2/auth/DockerBearerTokenService.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.docker.registry.api.v2.auth
 
 import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.DockerUserAgent
 import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.exception.DockerRegistryAuthenticationException
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerRetrofitErrorHandler
 import groovy.util.logging.Slf4j
 import org.apache.commons.io.IOUtils
 import retrofit.RestAdapter
@@ -26,7 +27,6 @@ import retrofit.http.Headers
 import retrofit.http.Path
 import retrofit.http.Query
 
-import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 
 @Slf4j
@@ -188,7 +188,11 @@ class DockerBearerTokenService {
     def tokenService = realmToService.get(realm)
 
     if (tokenService == null) {
-      def builder = new RestAdapter.Builder().setEndpoint(realm).setLogLevel(RestAdapter.LogLevel.NONE).build()
+      def builder = new RestAdapter.Builder()
+        .setEndpoint(realm)
+        .setLogLevel(RestAdapter.LogLevel.NONE)
+        .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
+        .build()
       tokenService = builder.create(TokenService.class)
       realmToService[realm] = tokenService
     }

--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/security/DockerRegistryNamedAccountCredentials.groovy
@@ -20,10 +20,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerOkClientProvider
 import com.netflix.spinnaker.clouddriver.docker.registry.api.v2.client.DockerRegistryClient
 import com.netflix.spinnaker.clouddriver.docker.registry.exception.DockerRegistryConfigException
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerServerException
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import retrofit.RetrofitError
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -375,12 +376,10 @@ class DockerRegistryNamedAccountCredentials implements AccountCredentials<Docker
         .build()
 
       return new DockerRegistryCredentials(client, repositories, trackDigests, skip, sortTagsByDate)
-    } catch (RetrofitError e) {
-      if (e.response?.status == 404) {
-        throw new DockerRegistryConfigException("No repositories specified for ${name}, and the provided endpoint ${address} does not support /_catalog.")
-      } else {
-        throw e
-      }
+    } catch (NotFoundException e) {
+      throw new DockerRegistryConfigException("No repositories specified for ${name}, and the provided endpoint ${address} does not support /_catalog.")
+    } catch (SpinnakerServerException e) {
+      throw e
     }
   }
 

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperation.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperation.java
@@ -23,12 +23,12 @@ import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.DeleteEntityTagsDescription;
 import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerServerException;
 import com.netflix.spinnaker.clouddriver.model.EntityTags;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import retrofit.RetrofitError;
 
 public class DeleteEntityTagsAtomicOperation implements AtomicOperation<Void> {
   private static final String BASE_PHASE = "ENTITY_TAGS";
@@ -54,7 +54,7 @@ public class DeleteEntityTagsAtomicOperation implements AtomicOperation<Void> {
     EntityTags currentTags;
     try {
       currentTags = front50Service.getEntityTags(entityTagsDescription.getId());
-    } catch (RetrofitError e) {
+    } catch (SpinnakerServerException e) {
       getTask()
           .updateStatus(
               BASE_PHASE, format("Did not find %s in Front50", entityTagsDescription.getId()));

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperationSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperationSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.DeleteEntityTagsDescription
 import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerServerException
 import com.netflix.spinnaker.clouddriver.model.EntityTags
 import retrofit.RetrofitError
 import spock.lang.Specification
@@ -49,7 +50,7 @@ class DeleteEntityTagsAtomicOperationSpec extends Specification {
     operation.operate([])
 
     then:
-    1 * front50Service.getEntityTags('abc') >> { throw new RetrofitError("a", null, null, null, null, null, null) }
+    1 * front50Service.getEntityTags('abc') >> { throw new SpinnakerServerException(new RetrofitError("a", null, null, null, null, null, null)) }
     1 * entityTagsProvider.delete('abc')
     0 * _
   }

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApiFactory.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/api/EurekaApiFactory.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.eureka.api
 
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
 import retrofit.RestAdapter
 import retrofit.client.OkClient
@@ -36,6 +37,7 @@ class EurekaApiFactory {
       .setConverter(eurekaConverter)
       .setClient(new OkClient(okHttpClientConfiguration.create()))
       .setEndpoint(endpoint)
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
       .build()
       .create(EurekaApi)
   }

--- a/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/EurekaUtil.groovy
+++ b/clouddriver-eureka/src/main/groovy/com/netflix/spinnaker/clouddriver/eureka/deploy/ops/EurekaUtil.groovy
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.clouddriver.eureka.deploy.ops
 
 import com.netflix.spinnaker.clouddriver.eureka.api.Eureka
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerRetrofitErrorHandler
 import org.apache.http.impl.client.HttpClients
 import retrofit.RestAdapter
 import retrofit.client.ApacheClient
@@ -27,7 +28,12 @@ class EurekaUtil {
 
   static Eureka getWritableEureka(String endpoint, String region) {
     String eurekaEndpoint = endpoint.replaceAll(Pattern.quote('{{region}}'), region)
-    new RestAdapter.Builder().setEndpoint(eurekaEndpoint).setClient(getApacheClient()).build().create(Eureka)
+    new RestAdapter.Builder()
+      .setEndpoint(eurekaEndpoint)
+      .setClient(getApacheClient())
+      .setErrorHandler(SpinnakerRetrofitErrorHandler.getInstance())
+      .build()
+      .create(Eureka)
   }
 
   //Lazy-create apache client on request if there is a discoveryEnabled AmazonCredentials:

--- a/clouddriver-google/clouddriver-google.gradle
+++ b/clouddriver-google/clouddriver-google.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-config"
+  implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.moniker:moniker"
   implementation "com.squareup.retrofit:retrofit"
   implementation "org.springframework.boot:spring-boot-actuator"

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/AbstractEnableDisableAtomicOperation.groovy
@@ -21,6 +21,7 @@ import com.google.api.services.compute.model.*
 import com.netflix.spinnaker.clouddriver.consul.deploy.ops.EnableDisableConsulInstance
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.exceptions.SpinnakerServerException
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.GoogleOperationPoller
 import com.netflix.spinnaker.clouddriver.google.deploy.SafeRetry
@@ -29,7 +30,6 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleClusterProvider
 import com.netflix.spinnaker.clouddriver.google.provider.view.GoogleLoadBalancerProvider
 import org.springframework.beans.factory.annotation.Autowired
-import retrofit.RetrofitError
 
 abstract class AbstractEnableDisableAtomicOperation extends GoogleAtomicOperation<Void> {
   private static final List<Integer> RETRY_ERROR_CODES = [400, 403, 412]
@@ -107,7 +107,7 @@ abstract class AbstractEnableDisableAtomicOperation extends GoogleAtomicOperatio
                                               disable
                                               ? EnableDisableConsulInstance.State.disable
                                               : EnableDisableConsulInstance.State.enable)
-        } catch (RetrofitError e) {
+        } catch (SpinnakerServerException e) {
           // Consul isn't running
         }
       }


### PR DESCRIPTION
Part of https://github.com/spinnaker/spinnaker/issues/5473 (Followup to POC https://github.com/spinnaker/clouddriver/pull/4325)

Registers `SpinnakerRetrofitErrorHandler` with each `RestAdapter` and replaces caught `RetrofitError`s with new exceptions that extend `SpinnakerException`. Each module has its own commit. I made no changes to `clouddriver-cloudfoundry` because they already wrote their own [`CloudFoundyApiException`](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/CloudFoundryApiException.java).

I will add a followup commit to this PR when when we have merged the [Kork PR](https://github.com/spinnaker/kork/pull/538) that exports `SpinnakerRetrofitErrorHandler`, `SpinnakerServerException`, `SpinnakerNetworkException`, and `SpinnakerHttpException` from `kork-exceptions` rather than duplicating them here in Clouddriver.