### PR TITLE
fix(aws): fix `AmazonInstance#getZone`

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstance.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstance.groovy
@@ -85,7 +85,7 @@ class AmazonInstance implements Instance, Serializable {
 
   @Override
   String getZone() {
-    any().get("placement")?.availabilityZone
+    getExtraAttributes().get("placement")?.availabilityZone
   }
 
   @Override


### PR DESCRIPTION
`any()` was renamed to `getExtraAttributes()` in #4375, but this call site was missed. This was causing failures in the E2E tests.