### PR TITLE
fix(elasticsearch): Upgrading to ElasticSearch 6 for entity tags

### DIFF
--- a/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
+++ b/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
@@ -7,15 +7,16 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.squareup.retrofit:retrofit"
   implementation "org.codehaus.groovy:groovy-all"
-  implementation("org.elasticsearch:elasticsearch:2.4.1") {
+  implementation("org.elasticsearch:elasticsearch:6.8.6") {
     force = true
   }
 
-  implementation("io.searchbox:jest:2.0.3") {
+  implementation("io.searchbox:jest:6.3.1") {
     force = true
   }
   implementation "org.springframework.boot:spring-boot-starter-web"
 
+  testCompile "org.testcontainers:elasticsearch:1.12.5"
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"

--- a/clouddriver-elasticsearch/elasticsearch_index_template.json
+++ b/clouddriver-elasticsearch/elasticsearch_index_template.json
@@ -1,6 +1,8 @@
 {
   "order": 0,
-  "template": "tags_v*",
+  "index_patterns": [
+    "tags_v*"
+  ],
   "settings": {
     "index": {
       "number_of_shards": "6",
@@ -9,7 +11,7 @@
     }
   },
   "mappings": {
-    "_default_": {
+    "_doc": {
       "dynamic": "false",
       "dynamic_templates": [
         {
@@ -24,41 +26,37 @@
           "entityRef_template": {
             "path_match": "entityRef.*",
             "mapping": {
-              "index": "not_analyzed"
+              "index": "keyword"
             }
           }
         }
       ],
       "properties": {
+        "id": {
+          "type": "text"
+        },
         "entityRef": {
           "properties": {
             "accountId": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             },
             "application": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             },
             "entityType": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "text"
             },
             "cloudProvider": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             },
             "entityId": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             },
             "region": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             },
             "account": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             }
           }
         },
@@ -66,20 +64,16 @@
           "type": "nested",
           "properties": {
             "valueType": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             },
             "name": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             },
             "namespace": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             },
             "value": {
-              "index": "not_analyzed",
-              "type": "string"
+              "type": "keyword"
             }
           }
         }

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfigProperties.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/config/ElasticSearchConfigProperties.java
@@ -34,7 +34,6 @@ public class ElasticSearchConfigProperties {
   // The name of the unique mapping type is configurable as mappingTypeName, but is defaulted to
   // "_doc", which is
   // recommended for forward compatibility with Elasticsearch 7.0.
-  private boolean singleMappingType = false;
   private String mappingTypeName = "_doc";
 
   public String getActiveIndex() {
@@ -67,14 +66,6 @@ public class ElasticSearchConfigProperties {
 
   public void setConnectionTimeout(int connectionTimeout) {
     this.connectionTimeout = connectionTimeout;
-  }
-
-  public void setSingleMappingType(boolean singleMappingType) {
-    this.singleMappingType = singleMappingType;
-  }
-
-  public boolean isSingleMappingType() {
-    return singleMappingType;
   }
 
   public void setMappingTypeName(String mappingTypeName) {


### PR DESCRIPTION
This change follows up on the change https://github.com/spinnaker/clouddriver/pull/2913.
    * Remove ES2.x support - now all docs using mapping type `_doc` recommended by ES6 and only one is allowed.
    * Change the queries to use `entityRef.entityType` instead of the document type.
    * Fixup ES template to not use `not_analyzed` but instead use `keyword` (with exception of `entityRef.entityType` which we wildcard query)
    * Adding an `id` field to the document because the built-in `_id` field is no longer wildcard queryable
    * Changing to use a container for the unittests