### PR TITLE
fix(repository): Enforce serialization order for JedisTask

### DIFF
--- a/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskTest.java
+++ b/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskTest.java
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus;
 import com.netflix.spinnaker.clouddriver.data.task.TaskState;
 import java.nio.charset.StandardCharsets;
 import org.assertj.core.api.AssertionsForClassTypes;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -62,8 +61,6 @@ final class JedisTaskTest {
         .isEqualTo(objectMapper.readTree(expectedResult));
   }
 
-  // Ignore this test as the order is currently not deterministic
-  @Disabled
   @Test
   void statusComputedFirst() throws Exception {
     RedisTaskRepository taskRepository = mock(RedisTaskRepository.class);

--- a/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskTest.java
+++ b/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskTest.java
@@ -61,6 +61,7 @@ final class JedisTaskTest {
         .isEqualTo(objectMapper.readTree(expectedResult));
   }
 
+  // See the large comment on the top of JedisTask for this test's rationale
   @Test
   void statusComputedFirst() throws Exception {
     RedisTaskRepository taskRepository = mock(RedisTaskRepository.class);

--- a/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskTest.java
+++ b/clouddriver-core/src/test/java/com/netflix/spinnaker/clouddriver/data/task/jedis/JedisTaskTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.data.task.jedis;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import com.netflix.spinnaker.clouddriver.data.task.DefaultTaskStatus;
+import com.netflix.spinnaker.clouddriver.data.task.TaskState;
+import java.nio.charset.StandardCharsets;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+final class JedisTaskTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final String PHASE = "DEPLOY";
+
+  @Test
+  void serializationTest() throws Exception {
+    RedisTaskRepository taskRepository = mock(RedisTaskRepository.class);
+    JedisTask task = new JedisTask("123", 100, taskRepository, "owner", ImmutableList.of(), false);
+
+    DefaultTaskStatus oldStatus =
+        DefaultTaskStatus.create(PHASE, "Starting deploy", TaskState.STARTED);
+    DefaultTaskStatus status =
+        DefaultTaskStatus.create(PHASE, "Finished deploy", TaskState.COMPLETED);
+    Object results =
+        ImmutableMap.of("instances", ImmutableList.of("my-instance-v000", "my-instance-v001"));
+
+    when(taskRepository.getHistory(eq(task))).thenReturn(ImmutableList.of(oldStatus, status));
+    when(taskRepository.getResultObjects(eq(task))).thenReturn(ImmutableList.of(results));
+    when(taskRepository.currentState(eq(task))).thenReturn(status);
+
+    String result = objectMapper.writeValueAsString(task);
+    String expectedResult =
+        Resources.toString(JedisTaskTest.class.getResource("task.json"), StandardCharsets.UTF_8);
+
+    // Compare the parsed trees of the two results, which is agnostic to key order
+    AssertionsForClassTypes.assertThat(objectMapper.readTree(result))
+        .isEqualTo(objectMapper.readTree(expectedResult));
+  }
+
+  // Ignore this test as the order is currently not deterministic
+  @Disabled
+  @Test
+  void statusComputedFirst() throws Exception {
+    RedisTaskRepository taskRepository = mock(RedisTaskRepository.class);
+    JedisTask task = new JedisTask("123", 100, taskRepository, "owner", ImmutableList.of(), false);
+
+    objectMapper.writeValueAsString(task);
+
+    InOrder inOrder = Mockito.inOrder(taskRepository);
+    inOrder.verify(taskRepository).currentState(eq(task));
+    inOrder.verify(taskRepository).getHistory(eq(task));
+    inOrder.verify(taskRepository).getResultObjects(eq(task));
+  }
+}

--- a/clouddriver-core/src/test/resources/com/netflix/spinnaker/clouddriver/data/task/jedis/task.json
+++ b/clouddriver-core/src/test/resources/com/netflix/spinnaker/clouddriver/data/task/jedis/task.json
@@ -1,0 +1,34 @@
+{
+  "history" : [
+    {
+      "complete" : false,
+      "completed" : false,
+      "failed" : false,
+      "phase" : "DEPLOY",
+      "retryable" : false,
+      "status" : "Starting deploy"
+    }
+  ],
+  "id" : "123",
+  "ownerId" : "owner",
+  "requestId" : null,
+  "resultObjects" : [
+    {
+      "instances" : [
+        "my-instance-v000",
+        "my-instance-v001"
+      ]
+    }
+  ],
+  "retryable" : false,
+  "sagaIds" : [],
+  "startTimeMs" : 100,
+  "status" : {
+    "complete" : true,
+    "completed" : true,
+    "failed" : false,
+    "phase" : "DEPLOY",
+    "retryable" : false,
+    "status" : "Finished deploy"
+  }
+}


### PR DESCRIPTION
* test(repository): Add tests to JedisTask 

  Before making a minor change to JedisTask, add some tests of the serialization logic.

* fix(repository): Enforce serialization order for JedisTask 

  There have been a number of end-to-end test failures recently due to race conditions where orca fetches a task status from clouddriver and receives a status of complete, but incomplete task results.

  The fields of the task are computed on-demand by querying the repository. This means that the serialized task may not be internally consistent; each field will reflect the state of the task in the repository at the time that field's accessor was called during serialization.

  This is in general a difficult problem to solve with redis, which does not support atomic reads of multiple keys, but has been solved in the SQL repository by fetching all data in a single query. As a workaround, we'll instruct Jackson to serialize the status first. The reason is that consumers tend to use the status field to check if a task is complete, and expect the other fields to be filled out if it is. If there is an inconsistency between the status and other fields, we'd rather return a stale value in the status field than in other fields.

  In general, returning an older status (ie, still running) and newer other fields will just cause clients to poll again until they see the updated status. Returning a newer status (ie, completed or failed) but stale values in other fields will in general cause clients to use these stale values, leading to bugs.
