### PR TITLE
fix(titus/entitytags): remove schema version from key returned by TitusClusterProvider

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/Keys.groovy
@@ -188,4 +188,19 @@ class Keys implements KeyParser {
   static String getInstanceHealthKey(String id, String healthProvider) {
     "${TitusCloudProvider.ID}:${Namespace.HEALTH}:${id}:${healthProvider}"
   }
+
+  static String removeSchemaVersion(String key) {
+    def parts = key.split(':')
+
+    if ((parts.length < 2) || (parts[0] != TitusCloudProvider.ID)) {
+      return key
+    }
+
+    if ((parts[2] != CachingSchema.V2.toString()) && (parts[2] != CachingSchema.V1.toString())) {
+      return key
+    }
+
+    parts[2] = null
+    return parts.findAll({ it != null }).join(':')
+  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/providers/TitusClusterProvider.groovy
@@ -219,7 +219,11 @@ class TitusClusterProvider implements ClusterProvider<TitusCluster>, ServerGroup
     account = Optional.ofNullable(account).orElse("*")
     region = Optional.ofNullable(region).orElse("*")
 
-    return cacheView.filterIdentifiers(SERVER_GROUPS.ns, Keys.getServerGroupKey("*", "*", account, region))
+    Collection<String> ids = cacheView.filterIdentifiers(SERVER_GROUPS.ns, Keys.getServerGroupKey("*", "*", account, region))
+
+    return ids.collect({ id ->
+      Keys.removeSchemaVersion(id)
+    }).toList()
   }
 
   @Override


### PR DESCRIPTION
EntityTag reconciliation process gets all server groups from the provider and matches them against the existing entity tags.
Titus returns keys in the form
```
titus:servergroups:v2:<application>:...
```
while the tags are stored in the form
```
titus:servergroups:<application>:...
```

This change removes the schema key (`v1` or `v2`) from the key IDs that are returned. This API (`getServerGroupIdentifiers`) is only used by the tag reconciler

