### PR TITLE
feat(config): move Halyard defaults to Clouddriver

### DIFF
--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/config/AppengineConfigurationProperties.groovy
@@ -34,7 +34,7 @@ class AppengineConfigurationProperties {
     static final String metadataUrl = "http://metadata.google.internal/computeMetadata/v1"
 
     String serviceAccountEmail
-    String localRepositoryDirectory
+    String localRepositoryDirectory = "/var/tmp/clouddriver"
     String gitHttpsUsername
     String gitHttpsPassword
     String githubOAuthAccessToken

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -64,7 +64,7 @@ aws:
   #  proxyWorkstation: foo
   #  protocol: HTTP
   defaults:
-    iamRole: FooRole
+    iamRole: BaseIAMRole
     unknownInstanceTypeBlockDevice:
       deviceName: /dev/sdb
       size: 40


### PR DESCRIPTION
As @ezimanyi described in [this PR](https://github.com/spinnaker/clouddriver/pull/4368), we would like to push reasonable microservice-specific defaults (currently set by Halyard) to each microservice's config or code instead of specifying them in [Kleat](https://github.com/spinnaker/governance/blob/master/rfc/halyard-lite.md).

* feat(appengine): default Appengine `localRepositoryDirectory` to [Halyard default](https://github.com/spinnaker/halyard/blob/master/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineAddAccountCommand.java#L51).

* feat(aws): replace AWS default `iamRole` with [Halyard default](https://github.com/spinnaker/halyard/blob/master/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsProvider.java#L58).