### PR TITLE
fix (ecs): Unstable deployments for task definitions with more than one container (#5544)

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -144,17 +144,24 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
           continue;
         }
 
-        TaskHealth taskHealth;
-        if (task.getContainers().get(0).getNetworkBindings().size() >= 1) {
-          taskHealth =
-              inferHealthNetworkBindedContainer(
-                  amazonloadBalancing,
-                  task,
-                  containerInstance,
-                  serviceName,
-                  service,
-                  taskDefinition);
-        } else {
+        TaskHealth taskHealth = null;
+        Collection<Container> containers = task.getContainers();
+
+        for (Container container : containers) {
+          if (container.getNetworkBindings().size() >= 1) {
+            taskHealth =
+                inferHealthNetworkBoundContainer(
+                    amazonloadBalancing,
+                    task,
+                    containerInstance,
+                    serviceName,
+                    service,
+                    taskDefinition);
+            break;
+          }
+        }
+
+        if (taskHealth == null) {
           taskHealth =
               inferHealthNetworkInterfacedContainer(
                   amazonloadBalancing, task, serviceName, service, taskDefinition);
@@ -201,7 +208,15 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
         continue;
       }
 
-      NetworkInterface networkInterface = task.getContainers().get(0).getNetworkInterfaces().get(0);
+      Collection<Container> containers = task.getContainers();
+      NetworkInterface networkInterface = null;
+
+      for (Container container : containers) {
+        if (container.getNetworkInterfaces().size() >= 1) {
+          networkInterface = container.getNetworkInterfaces().get(0);
+          break;
+        }
+      }
 
       overallTaskHealth =
           describeTargetHealth(
@@ -248,7 +263,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
     return taskHealth;
   }
 
-  private TaskHealth inferHealthNetworkBindedContainer(
+  private TaskHealth inferHealthNetworkBoundContainer(
       AmazonElasticLoadBalancing amazonloadBalancing,
       Task task,
       ContainerInstance containerInstance,
@@ -372,17 +387,29 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
   }
 
   private boolean isTaskMissingNetworkBindings(Task task) {
-    return task.getContainers().isEmpty()
-        || task.getContainers().get(0).getNetworkBindings() == null
-        || task.getContainers().get(0).getNetworkBindings().isEmpty()
-        || task.getContainers().get(0).getNetworkBindings().get(0) == null;
+    Collection<Container> containers = task.getContainers();
+
+    for (Container container : containers) {
+      if (!(container.getNetworkBindings() == null
+          || container.getNetworkBindings().isEmpty()
+          || container.getNetworkBindings().get(0) == null)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private boolean isTaskMissingNetworkInterfaces(Task task) {
-    return task.getContainers().isEmpty()
-        || task.getContainers().get(0).getNetworkInterfaces() == null
-        || task.getContainers().get(0).getNetworkInterfaces().isEmpty()
-        || task.getContainers().get(0).getNetworkInterfaces().get(0) == null;
+    Collection<Container> containers = task.getContainers();
+
+    for (Container container : containers) {
+      if (!(container.getNetworkInterfaces() == null
+          || container.getNetworkInterfaces().isEmpty()
+          || container.getNetworkInterfaces().get(0) == null)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
@@ -346,6 +346,61 @@ class TaskHealthCachingAgentSpec extends Specification {
     taskHealthList == []
   }
 
+  def 'should get task health for task with some non-networked containers'() {
+    given:
+    ObjectMapper mapper = new ObjectMapper()
+    Map<String, Object> containerMap1 = mapper.convertValue(new Container().withName('noports'), Map.class)
+    Map<String, Object> containerMap2 = mapper.convertValue(new Container().withName('withports').withNetworkBindings(
+      new NetworkBinding().withContainerPort(1338).withHostPort(1338)
+    ), Map.class)
+
+    def taskAttributes = [
+      taskId              : CommonCachingAgent.TASK_ID_1,
+      taskArn             : CommonCachingAgent.TASK_ARN_1,
+      taskDefinitionArn   : CommonCachingAgent.TASK_DEFINITION_ARN_1,
+      startedAt           : new Date().getTime(),
+      containerInstanceArn: CommonCachingAgent.CONTAINER_INSTANCE_ARN_1,
+      group               : 'service:' + CommonCachingAgent.SERVICE_NAME_1,
+      containers          : [containerMap1, containerMap2]
+    ]
+    def taskKey = Keys.getTaskKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_ID_1)
+    def taskCacheData = new DefaultCacheData(taskKey, taskAttributes, Collections.emptyMap())
+    providerCache.getAll(TASKS.toString(), _) >> Collections.singletonList(taskCacheData)
+
+    Map<String, Object> containerDefinitionMap1 = mapper.convertValue(new ContainerDefinition().withName('noports'), Map.class)
+    Map<String, Object> containerDefinitionMap2 = mapper.convertValue(new ContainerDefinition().withName('withports').withPortMappings(
+      new PortMapping().withHostPort(1338)
+    ), Map.class)
+    def taskDefAttributes = [
+      taskDefinitionArn    : CommonCachingAgent.TASK_DEFINITION_ARN_1,
+      containerDefinitions : [ containerDefinitionMap1, containerDefinitionMap2 ]
+    ]
+    def taskDefKey = Keys.getTaskDefinitionKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_DEFINITION_ARN_1)
+    def taskDefCacheData = new DefaultCacheData(taskDefKey, taskDefAttributes, Collections.emptyMap())
+    providerCache.get(TASK_DEFINITIONS.toString(), taskDefKey) >> taskDefCacheData
+    when:
+    def taskHealthList = agent.getItems(ecs, providerCache)
+
+    then:
+    amazonloadBalancing.describeTargetHealth({ DescribeTargetHealthRequest request ->
+      request.targetGroupArn == targetGroupArn
+      request.targets.size() == 1
+      request.targets.get(0).id == CommonCachingAgent.EC2_INSTANCE_ID_1
+      request.targets.get(0).port == 1338
+    }) >> new DescribeTargetHealthResult().withTargetHealthDescriptions(
+      new TargetHealthDescription().withTargetHealth(new TargetHealth().withState(TargetHealthStateEnum.Healthy))
+    )
+
+    taskHealthList.size() == 1
+    TaskHealth taskHealth = taskHealthList.get(0)
+    taskHealth.getState() == 'Up'
+    taskHealth.getType() == 'loadBalancer'
+    taskHealth.getInstanceId() == CommonCachingAgent.TASK_ARN_1
+    taskHealth.getServiceName() == CommonCachingAgent.SERVICE_NAME_1
+    taskHealth.getTaskArn() == CommonCachingAgent.TASK_ARN_1
+    taskHealth.getTaskId() == CommonCachingAgent.TASK_ID_1
+  }
+
   def 'should generate fresh data'() {
     given:
     def taskIds = [CommonCachingAgent.TASK_ID_1, CommonCachingAgent.TASK_ID_2]


### PR DESCRIPTION
The original code will not finish deployment and will eventually time out, in spite of task being successfully deployed by ECS and running (https://github.com/spinnaker/spinnaker/issues/5544)

            "containers": [
                {
                    "networkBindings": [],
                    "networkInterfaces": [],
                },
                {
                    "lastStatus": "RUNNING",
                    "networkBindings": [
                        {
                            "bindIP": "0.0.0.0",
                            "containerPort": 8080,
                            "hostPort": 32773,
                            "protocol": "tcp"
                        }
                }]