### PR TITLE
fix(elasticsearch): URL encode the ID

### DIFF
--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProvider.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProvider.java
@@ -40,6 +40,7 @@ import io.searchbox.indices.CreateIndex;
 import io.searchbox.indices.DeleteIndex;
 import io.searchbox.params.Parameters;
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.lucene.search.join.ScoreMode;
@@ -189,7 +190,7 @@ public class ElasticSearchEntityTagsProvider implements EntityTagsProvider {
                   objectMapper.convertValue(prepareForWrite(objectMapper, entityTags), Map.class))
               .index(activeElasticSearchIndex)
               .type(mappingTypeName)
-              .id(entityTags.getId())
+              .id(URLEncoder.encode(entityTags.getId(), "UTF-8"))
               .build();
 
       JestResult jestResult = jestClient.execute(action);

--- a/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProviderSpec.groovy
+++ b/clouddriver-elasticsearch/src/test/groovy/com/netflix/spinnaker/clouddriver/elasticsearch/model/ElasticSearchEntityTagsProviderSpec.groovy
@@ -319,6 +319,7 @@ class ElasticSearchEntityTagsProviderSpec extends Specification {
   def "should delete all entity tags in namespace"() {
     given:
     def allEntityTags = [
+      buildEntityTags("titus:servergroup:clouddriver-main-^1.0.0-v150:myaccount:us-west-1", ["a": "1"], "my_namespace"),
       buildEntityTags("aws:servergroup:clouddriver-main-v001:myaccount:us-west-1", ["a": "1"], "my_namespace"),
       buildEntityTags("aws:servergroup:clouddriver-main-v002:myaccount:us-west-1", ["b": "2"], "my_namespace"),
       buildEntityTags("aws:servergroup:clouddriver-main-v003:myaccount:us-west-1", ["c": "3"]),


### PR DESCRIPTION
In cases where the tag ID has illegal url character we need to encode.
Not sure why it worked in Jest2 and not in Jest6 - will figure this out separately.
