### PR TITLE
fix(titus/instance): Temporarily expose agentId to access IPv6

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Task.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Task.java
@@ -40,6 +40,7 @@ public class Task {
     startedAt = getTimestampFromStatus(grpcTask, TaskStatus.TaskState.StartInitiated);
     finishedAt = getTimestampFromStatus(grpcTask, TaskStatus.TaskState.Finished);
     containerIp = grpcTask.getTaskContextOrDefault("task.containerIp", null);
+    //  The agentId will be used temporarily by deck to lookup IPv6 until Titus API is updated.
     agentId = grpcTask.getTaskContextOrDefault("agent.instanceId", null);
     logLocation = new HashMap<>();
     logLocation.put("ui", grpcTask.getLogLocation().getUi().getUrl());

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Task.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Task.java
@@ -40,6 +40,7 @@ public class Task {
     startedAt = getTimestampFromStatus(grpcTask, TaskStatus.TaskState.StartInitiated);
     finishedAt = getTimestampFromStatus(grpcTask, TaskStatus.TaskState.Finished);
     containerIp = grpcTask.getTaskContextOrDefault("task.containerIp", null);
+    agentId = grpcTask.getTaskContextOrDefault("agent.instanceId", null);
     logLocation = new HashMap<>();
     logLocation.put("ui", grpcTask.getLogLocation().getUi().getUrl());
     logLocation.put("liveStream", grpcTask.getLogLocation().getLiveStream().getUrl());
@@ -78,6 +79,7 @@ public class Task {
   private String logs;
   private String snapshots;
   private String containerIp;
+  private String agentId;
 
   private Map<String, Object> logLocation;
 
@@ -211,6 +213,14 @@ public class Task {
 
   public String getContainerIp() {
     return containerIp;
+  }
+
+  public String getAgentId() {
+    return agentId;
+  }
+
+  public void setAgentId(String agentId) {
+    this.agentId = agentId;
   }
 
   public void setContainerIp(String containerIp) {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -48,6 +48,7 @@ class TitusInstance implements Instance {
   final String providerType = TitusCloudProvider.ID
   final String cloudProvider = TitusCloudProvider.ID
   String privateIpAddress
+  String agentId
 
   TitusInstance() {}
 
@@ -84,6 +85,8 @@ class TitusInstance implements Instance {
 
     // expose containerIp as privateIpAddress to remain consistent with aws
     privateIpAddress = task.containerIp ?: task.data?.ipAddresses?.nfvpc
+
+    agentId = task.agentId
   }
 
   @Override
@@ -93,6 +96,10 @@ class TitusInstance implements Instance {
 
   String getContainerIp() {
     placement.getContainerIp()
+  }
+
+  String getAgentId() {
+    agentId
   }
 
   String getHostIp() {

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
@@ -42,7 +42,8 @@ class TitusInstanceSpec extends Specification {
     submittedAt: launchDate,
     region: 'us-east-1',
     host: 'ec2-1-2-3-4.compute-1.amazonaws.com',
-    data: [ipAddresses: [nfvpc: '4.5.6.7'], NetworkConfiguration: [EniIPAddress: '1.2.3.4']]
+    data: [ipAddresses: [nfvpc: '4.5.6.7'], NetworkConfiguration: [EniIPAddress: '1.2.3.4']],
+    agentId: 'i-abc123'
   )
 
   void 'valid titus instance is created from a titus task'() {
@@ -72,6 +73,7 @@ class TitusInstanceSpec extends Specification {
     titusInstance.submittedAt == task.submittedAt.time
     titusInstance.finishedAt == null
     titusInstance.privateIpAddress == task.data.ipAddresses.nfvpc
+    titusInstance.agentId == task.agentId
   }
 
   void 'can handle null ports'() {


### PR DESCRIPTION
The Titus API does not expose IPv6 addresses yet. In the meantime, accessing the task's `agent.instanceId` enables a secondary lookup of the network interfaces so we can obtain the IPv6 address(es). 

This workaround is necessary for some other work around IPv6 support. In the future, the Titus API will be updated and we can directly replace the `agentId` with `ipv6Addresses` from Titus. 