### PR TITLE
chore(vulnerabilities): resolve CVEs and other security issues

### DIFF
--- a/clouddriver-appengine/clouddriver-appengine.gradle
+++ b/clouddriver-appengine/clouddriver-appengine.gradle
@@ -22,9 +22,9 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:retrofit"
   implementation "commons-io:commons-io"
-  implementation "org.apache.commons:commons-compress:1.14"
+  implementation "org.apache.commons:commons-compress:1.20"
   implementation "org.codehaus.groovy:groovy-all"
-  implementation "org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r"
+  implementation "org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
 

--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -26,8 +26,8 @@ dependencies {
   implementation "org.eclipse.aether:aether-impl:1.1.0"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
-  implementation "org.eclipse.jgit:org.eclipse.jgit:5.4.2.201908231537-r"
-  implementation "org.eclipse.jgit:org.eclipse.jgit.archive:5.4.2.201908231537-r"
+  implementation "org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r"
+  implementation "org.eclipse.jgit:org.eclipse.jgit.archive:5.7.0.202003110725-r"
 
   testImplementation "com.github.tomakehurst:wiremock:latest.release"
   testImplementation "org.assertj:assertj-core"

--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -13,7 +13,7 @@ dependencies {
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.retrofit:retrofit"
-  implementation "org.apache.commons:commons-compress:1.14"
+  implementation "org.apache.commons:commons-compress:1.20"
   implementation "commons-io:commons-io:2.6"
   implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"


### PR DESCRIPTION
remove CVE-2019-12402. Upgrade following libraries:
- commons-compress
- org.eclipse.jgit
- org.eclipse.jgit.archive