### PR TITLE
fix(core): Only log relevant details of description

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizer.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.clouddriver.deploy;
 
 import static java.lang.String.format;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
@@ -134,16 +133,10 @@ public class DescriptionAuthorizer<T> {
                   "descriptionClass", description.getClass().getSimpleName()))
           .increment();
 
-      String rawJson = null;
-      try {
-        rawJson = objectMapper.writeValueAsString(description);
-      } catch (JsonProcessingException ignored) {
-      }
-
       log.warn(
-          "No application(s) specified for operation with account restriction (type: {}, rawJson: {})",
+          "No application(s) specified for operation with account restriction (type: {}, account: {})",
           description.getClass().getSimpleName(),
-          rawJson);
+          account);
     }
 
     registry


### PR DESCRIPTION
Closes spinnaker/spinnaker#5585.

When we encounter a description that should have application restrictions but doesn't, we log a warning including the full description JSON. In some cases (ex: Kubernetes) this description may contain sensitive information that ideally wouldn't be logged.

Ideally really sensitive values would come from artifacts so they aren't in the pipeline JSON at all, but let's nonetheless cut back on how much we are logging here to reduce the chance of sensitive information ending up in the logs.

In particular, it's not clear how much the full description would help in debugging, as generally what is important is the class of the description (to check whether it implements ApplicationNameable or ResourcesNameable) and and the account, both of which will still be logged after this change.