### PR TITLE
chore(mergify): release-* branches require release manager approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,7 @@
 pull_request_rules:
   - name: Automatically merge on CI success and review
     conditions:
+      - base=master
       - status-success=build
       - "label=ready to merge"
       - "approved-reviews-by=@oss-approvers"
@@ -10,8 +11,21 @@ pull_request_rules:
         strict: smart
       label:
         add: ["auto merged"]
+  - name: Automatically merge release branch changes on CI success and release manager review
+    conditions:
+      - base~=^release-
+      - status-success=build
+      - "label=ready to merge"
+      - "approved-reviews-by=@release-managers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]
   - name: Automatically merge PRs from maintainers on CI success and review
     conditions:
+      - base=master
       - status-success=build
       - "label=ready to merge"
       - "author=@oss-approvers"
@@ -23,6 +37,7 @@ pull_request_rules:
         add: ["auto merged"]
   - name: Automatically merge kork autobump PRs on CI success
     conditions:
+      - base=master
       - status-success=build
       - "label~=autobump-*"
       - "author:spinnakerbot"


### PR DESCRIPTION
The mergify config currently doesn't distinguish between merging to master and merging to a release branch.  It currently never merges to release branches because mergify doesn't have permission to merge to these branches (due to branch protection rules).

I don't want to give mergify that permission without updating the config file here, as then it would merge to release branches after any approval, whereas we only want to merge to release branches if a PR is approved by a release manager.

This updates the mergify config to scope the existing rules to only apply to the master branch, and adds a new rule to merge to release branches upon approval by a release manager.