### PR TITLE
chore(mergify): Allow Travis success on release branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,6 +23,20 @@ pull_request_rules:
         strict: smart
       label:
         add: ["auto merged"]
+  # This rule exists because releases 1.19.x and earlier are configured to build using Travis
+  # instead of Github actions. It can be deleted once we are no longer merging to these branches.
+  - name: Automatically merge release branch changes on Travis CI success and release manager review
+    conditions:
+      - base~=^release-
+      - status-success=continuous-integration/travis-ci/pr
+      - "label=ready to merge"
+      - "approved-reviews-by=@release-managers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]
   - name: Automatically merge PRs from maintainers on CI success and review
     conditions:
       - base=master


### PR DESCRIPTION
Mergify is not working on the release branches because it requires the Github actions build to return success, but we only switched to using Github actions after cutting the 1.19 branch.

To remedy this, add another rule that allows merging if Travis CI passes on a branch.  (There's no way to make an OR condition within a rule, so we need to add another rule.) This way, we'll merge if either Github actions or Travis CI reports success.  Once the branches running Travis are no longer maintained (when Spinnaker 1.23 is released) we can delete this rule.