### PR TITLE
fix(kubernetes): Application restrictions disabled for V2

### DIFF
--- a/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/KubernetesKindAtomicOperationDescription.groovy
+++ b/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/description/KubernetesKindAtomicOperationDescription.groovy
@@ -27,4 +27,9 @@ import groovy.transform.Canonical
 class KubernetesKindAtomicOperationDescription extends KubernetesAtomicOperationDescription<KubernetesV1Credentials> {
   String kind
   String apiVersion
+
+  @Override
+  boolean requiresApplicationRestriction() {
+    return true;
+  }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesAtomicOperationDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesAtomicOperationDescription.java
@@ -35,4 +35,9 @@ public class KubernetesAtomicOperationDescription<C extends KubernetesCredential
   String account;
 
   KubernetesNamedAccountCredentials<C> credentials;
+
+  @Override
+  public boolean requiresApplicationRestriction() {
+    return false;
+  }
 }


### PR DESCRIPTION
Closes spinnaker/spinnaker#5617.

Kubernetes V2 operations don't expose the applications to which they apply, but don't override the default requiresApplicationRestriction. This causes a log warning on every operation, as the authorizer is expecting to be able to look up the applications relevant to the operation to perform authorization checks.

The choice here would be either to udpate all the operations to expose the relevant accounts (effectively building this feature that was never built for Kubernetes V2) or to toggle the requiresApplicationRestriction flag to indicate to the authorizer to stop trying to find the relevant applications.

After discussion at the Kubernetes SIG, we decided at this point not to implement application authorization (though may revisit if people find use cases for which account-level authorizations aren't sufficient). Based on that discussion, this PR simply flips the flag to false.

All V2 operations inherit from KubernetesAtomicOperationDescription, so flipping it there will fix the issue for all V2 operations. This would also change the behavior for some V1 operations, as KubernetesAtomicOperationDescription also inherits from that class and is the parent of a number of V1 operations.

I don't want to change the behavior for the V1 provider because it looks like some (though not all) of its operations do allow account listing so this might be (at least partially) working in that case. I also don't want to make a change like this to the provider on the verge of its deprecation absent a specific reason/bug in the V1 provider. As a result, I've updated KubernetesAtomicOperationDescription to set the flag to true again, so that all the V1 operations that subclass it retain the value of true.