### PR TITLE
fix(saga): Move ConditionalOnMissingBean for EventRepository to eventRepository factory method

### DIFF
--- a/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/config/MemoryEventRepositoryConfig.kt
+++ b/clouddriver-event/src/main/kotlin/com/netflix/spinnaker/clouddriver/event/config/MemoryEventRepositoryConfig.kt
@@ -34,7 +34,6 @@ import javax.validation.constraints.Min
 import kotlin.reflect.KClass
 
 @Configuration
-@ConditionalOnMissingBean(EventRepository::class)
 @EnableConfigurationProperties(MemoryEventRepositoryConfigProperties::class)
 open class MemoryEventRepositoryConfig {
 
@@ -45,6 +44,7 @@ open class MemoryEventRepositoryConfig {
   }
 
   @Bean
+  @ConditionalOnMissingBean(EventRepository::class)
   open fun eventRepository(
     properties: MemoryEventRepositoryConfigProperties,
     applicationEventPublisher: ApplicationEventPublisher,


### PR DESCRIPTION
On February 19th we rolled out a CloudDriver deploy and our EventRepository switched from SQL to in-memory - I can't find any change that would have caused this.  I'd like to give this a shot and see if this resolves the issue.  I'm unable to reproduce the issue locally, even when running with the exact same spring profiles as our production cluster which is odd.