### PR TITLE
fix(gce): Revert support for target shape on regional migs

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BasicGoogleDeployDescription.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/description/BasicGoogleDeployDescription.groovy
@@ -53,7 +53,7 @@ class BasicGoogleDeployDescription extends BaseGoogleInstanceDescription impleme
   GoogleAutoHealingPolicy autoHealingPolicy
   Boolean overwriteAncestorAutoHealingPolicy = false
   /**
-   * Optional explicit specification of zones and target shape for an RMIG.
+   * Optional explicit specification of zones for an RMIG.
    */
   GoogleDistributionPolicy distributionPolicy
   // Capacity is optional. If it is specified, capacity.desired takes precedence over targetSize.

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleDistributionPolicy.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleDistributionPolicy.java
@@ -21,11 +21,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/** Distribution policy for selecting zones and target shape in a regional MIG. */
+/** Distribution policy for selecting zones in a regional MIG. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class GoogleDistributionPolicy {
   List<String> zones;
-  String targetShape;
 }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
@@ -647,11 +647,9 @@ abstract class AbstractGoogleServerGroupCachingAgent
 
     if (serverGroup.getRegional()) {
       serverGroup.setRegion(Utils.getLocalName(manager.getRegion()));
-      DistributionPolicy distributionPolicy = manager.getDistributionPolicy();
-      ImmutableList<String> zones = getZones(distributionPolicy);
+      ImmutableList<String> zones = getZones(manager.getDistributionPolicy());
       serverGroup.setZones(ImmutableSet.copyOf(zones));
-      serverGroup.setDistributionPolicy(
-          new GoogleDistributionPolicy(zones, getTargetShape(distributionPolicy)));
+      serverGroup.setDistributionPolicy(new GoogleDistributionPolicy(zones));
     } else {
       String zone = Utils.getLocalName(manager.getZone());
       serverGroup.setZone(zone);
@@ -667,14 +665,6 @@ abstract class AbstractGoogleServerGroupCachingAgent
     return distributionPolicy.getZones().stream()
         .map(z -> Utils.getLocalName(z.getZone()))
         .collect(toImmutableList());
-  }
-
-  @Nullable
-  private static String getTargetShape(@Nullable DistributionPolicy distributionPolicy) {
-    if (distributionPolicy == null) {
-      return null;
-    }
-    return distributionPolicy.getTargetShape();
   }
 
   @Nullable

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
@@ -201,8 +201,7 @@ class AbstractGoogleServerGroupCachingAgentTest {
                             new DistributionPolicyZoneConfiguration()
                                 .setZone("http://compute/zones/fakezone2"),
                             new DistributionPolicyZoneConfiguration()
-                                .setZone("http://compute/zones/fakezone3")))
-                    .setTargetShape("ANY"));
+                                .setZone("http://compute/zones/fakezone3"))));
 
     Compute compute =
         new StubComputeFactory().setInstanceGroupManagers(instanceGroupManager).create();
@@ -217,7 +216,6 @@ class AbstractGoogleServerGroupCachingAgentTest {
     assertThat(serverGroup.getZone()).isNull();
     assertThat(serverGroup.getZones())
         .containsExactlyInAnyOrder("fakezone1", "fakezone2", "fakezone3");
-    assertThat(serverGroup.getDistributionPolicy().getTargetShape()).isEqualTo("ANY");
   }
 
   @Test


### PR DESCRIPTION
The integration tests are failing with errors like:
```
2020-03-25 19:58:17.280  INFO 21942 --- [ionProcessor-11] c.n.s.c.data.task.jedis.JedisTask        : [ORCHESTRATION] Orchestration failed: CopyLastGoogleServerGroupAtomicOperation | GoogleJsonResponseException: [400 Bad Request
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Invalid value for field 'resource.distributionPolicy': ''. Distribution policy cannot be empty.",
    "reason" : "invalid"
  } ],
  "message" : "Invalid value for field 'resource.distributionPolicy': ''. Distribution policy cannot be empty."
}]
```
It seems like maybe we're passing along an empty field to the Google API when it should either be absent or non-empty?  Either way, reverting this so the tests pass in time to investigate.


This reverts commit 9407597200604aa5168dee8101b431f7a1e033f3.