### PR TITLE
refactor(kubernetes): Clean up metrics code

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetric.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetric.java
@@ -16,26 +16,51 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.ArrayList;
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.Map;
+import java.util.Optional;
+import javax.annotation.ParametersAreNullableByDefault;
 import lombok.*;
 
-@Getter
-@Builder
+@NonnullByDefault
+@Value
 public class KubernetesPodMetric {
   private final String podName;
   private final String namespace;
-  @Builder.Default private final List<ContainerMetric> containerMetrics = new ArrayList<>();
+  private final ImmutableList<ContainerMetric> containerMetrics;
 
-  @Data
   @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
+  @ParametersAreNullableByDefault
+  public KubernetesPodMetric(
+      String podName, String namespace, Iterable<ContainerMetric> containerMetrics) {
+    this.podName = Strings.nullToEmpty(podName);
+    this.namespace = Strings.nullToEmpty(namespace);
+    this.containerMetrics =
+        Optional.ofNullable(containerMetrics)
+            .map(ImmutableList::copyOf)
+            .orElseGet(ImmutableList::of);
+  }
+
   @JsonIgnoreProperties(ignoreUnknown = true)
+  @Value
   public static class ContainerMetric {
-    private String containerName;
-    private Map<String, String> metrics;
+    private final String containerName;
+    private final ImmutableMap<String, String> metrics;
+
+    @JsonCreator
+    @ParametersAreNullableByDefault
+    public ContainerMetric(
+        @JsonProperty("containerName") String containerName,
+        @JsonProperty("metrics") Map<String, String> metrics) {
+      this.containerName = Strings.nullToEmpty(containerName);
+      this.metrics =
+          Optional.ofNullable(metrics).map(ImmutableMap::copyOf).orElseGet(ImmutableMap::of);
+    }
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -615,14 +615,9 @@ public class KubectlJobExecutor {
       throw new KubectlException("Could not read metrics: " + status.getError());
     }
 
-    ImmutableList<MetricParser.MetricLine> lines = MetricParser.parseMetrics(status.getOutput());
-    return lines.stream()
-        .collect(
-            ImmutableSetMultimap.toImmutableSetMultimap(
-                MetricParser.MetricLine::getPod, MetricParser.MetricLine::toContainerMetric))
-        .asMap()
-        .entrySet()
-        .stream()
+    ImmutableSetMultimap<String, KubernetesPodMetric.ContainerMetric> metrics =
+        MetricParser.parseMetrics(status.getOutput());
+    return metrics.asMap().entrySet().stream()
         .map(
             podMetrics ->
                 KubernetesPodMetric.builder()

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -49,21 +49,22 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class KubectlJobExecutor {
-  @Value("${kubernetes.kubectl.executable:kubectl}")
-  String executable;
-
-  @Value("${kubernetes.o-auth.executable:oauth2l}")
-  String oAuthExecutable;
+  private final JobExecutor jobExecutor;
+  private final String executable;
+  private final String oAuthExecutable;
 
   private static final String NO_RESOURCE_TYPE_ERROR = "doesn't have a resource type";
-
-  private final JobExecutor jobExecutor;
 
   private final Gson gson = new Gson();
 
   @Autowired
-  KubectlJobExecutor(JobExecutor jobExecutor) {
+  KubectlJobExecutor(
+      JobExecutor jobExecutor,
+      @Value("${kubernetes.kubectl.executable:kubectl}") String executable,
+      @Value("${kubernetes.o-auth.executable:oauth2l}") String oAuthExecutable) {
     this.jobExecutor = jobExecutor;
+    this.executable = executable;
+    this.oAuthExecutable = oAuthExecutable;
   }
 
   private String configCurrentContext(KubernetesV2Credentials credentials) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonReader;
@@ -28,7 +29,6 @@ import com.netflix.spinnaker.clouddriver.jobs.local.ReaderConsumer;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.JsonPatch;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPatchOptions;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric.ContainerMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
@@ -599,7 +599,7 @@ public class KubectlJobExecutor {
     return status.getOutput();
   }
 
-  public Collection<KubernetesPodMetric> topPod(
+  public ImmutableList<KubernetesPodMetric> topPod(
       KubernetesV2Credentials credentials, String namespace, String pod) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
     command.add("top");
@@ -615,63 +615,22 @@ public class KubectlJobExecutor {
       throw new KubectlException("Could not read metrics: " + status.getError());
     }
 
-    Map<String, KubernetesPodMetric> result = new HashMap<>();
-
-    String output = status.getOutput().trim();
-    if (StringUtils.isEmpty(output)) {
-      log.warn("No output from `kubectl top` command, no metrics to report.");
-      return new ArrayList<>();
-    }
-
-    String[] lines = output.split("\n");
-    if (lines.length <= 1) {
-      return new ArrayList<>();
-    }
-
-    // POD NAME CPU(cores) MEMORY(bytes) ...
-    String[] header = lines[0].trim().split("\\s+");
-
-    if (header.length <= 2) {
-      log.warn(
-          "Unexpected metric format -- no metrics to report based on table header {}.",
-          Arrays.asList(header));
-      return new ArrayList<>();
-    }
-
-    // CPU(cores) MEMORY(bytes)
-    String[] metricKeys = Arrays.copyOfRange(header, 2, header.length);
-    for (int i = 1; i < lines.length; i++) {
-      String[] entry = lines[i].trim().split("\\s+");
-      if (entry.length != header.length) {
-        log.warn("Entry {} does not match column width of {}, skipping", entry, header);
-      }
-
-      String podName = entry[0];
-      String containerName = entry[1];
-
-      Map<String, String> metrics = new HashMap<>();
-      for (int j = 0; j < metricKeys.length; j++) {
-        metrics.put(metricKeys[j], entry[j + 2]);
-      }
-
-      ContainerMetric containerMetric =
-          ContainerMetric.builder().containerName(containerName).metrics(metrics).build();
-
-      KubernetesPodMetric podMetric =
-          result.getOrDefault(
-              podName,
-              KubernetesPodMetric.builder()
-                  .podName(podName)
-                  .namespace(namespace)
-                  .containerMetrics(new ArrayList<>())
-                  .build());
-
-      podMetric.getContainerMetrics().add(containerMetric);
-
-      result.put(podName, podMetric);
-    }
-
-    return result.values();
+    ImmutableList<MetricParser.MetricLine> lines = MetricParser.parseMetrics(status.getOutput());
+    return lines.stream()
+        .collect(
+            ImmutableSetMultimap.toImmutableSetMultimap(
+                MetricParser.MetricLine::getPod, MetricParser.MetricLine::toContainerMetric))
+        .asMap()
+        .entrySet()
+        .stream()
+        .map(
+            podMetrics ->
+                KubernetesPodMetric.builder()
+                    .podName(podMetrics.getKey())
+                    .namespace(namespace)
+                    .containerMetrics(podMetrics.getValue())
+                    .build())
+        .collect(ImmutableList.toImmutableList());
   }
 
   public Void patch(

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/MetricParser.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/MetricParser.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric.ContainerMetric;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@NonnullByDefault
+final class MetricParser {
+  private static final Splitter lineSplitter = Splitter.on('\n').trimResults().omitEmptyStrings();
+
+  /**
+   * Given the output of a kubectl top command, parses the metrics returning a MetricLine for each
+   * line successfully parsed.
+   *
+   * <p>If the output is empty or is in an unrecognized format, returns an empty list.
+   *
+   * @param kubectlOutput the output from kubectl top
+   * @return The parsed metrics
+   */
+  static ImmutableList<MetricLine> parseMetrics(String kubectlOutput) {
+    Iterator<String> lines = lineSplitter.split(kubectlOutput.trim()).iterator();
+    if (!lines.hasNext()) {
+      return ImmutableList.of();
+    }
+
+    Optional<MetricParser.LineParser> optionalParser =
+        MetricParser.LineParser.withHeader(lines.next());
+    if (!optionalParser.isPresent()) {
+      return ImmutableList.of();
+    }
+    MetricParser.LineParser parser = optionalParser.get();
+    return Streams.stream(lines)
+        .map(parser::readLine)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(toImmutableList());
+  }
+
+  @Slf4j
+  private static final class LineParser {
+    private static final Splitter columnSplitter =
+        Splitter.on(Pattern.compile("\\s+")).trimResults();
+    private final ImmutableList<String> headers;
+
+    private LineParser(Iterable<String> header) throws IllegalArgumentException {
+      ImmutableList<String> headers = ImmutableList.copyOf(header);
+      if (headers.size() <= 2) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Unexpected metric format -- no metrics to report based on table header %s.",
+                headers));
+      }
+      this.headers = headers;
+    }
+
+    /**
+     * Returns a metric parser that parses metrics from an ASCII table with the input string as the
+     * header. If the header is not in the expected format, logs a warning and returns an empty
+     * optional.
+     *
+     * @param header header of the ASCII table
+     * @return A optional containing a metric parser if the header was in the expected format; an
+     *     empty optional otherwise
+     */
+    static Optional<LineParser> withHeader(String header) {
+      try {
+        return Optional.of(new LineParser(columnSplitter.split(header)));
+      } catch (IllegalArgumentException e) {
+        log.warn(e.getMessage());
+        return Optional.empty();
+      }
+    }
+
+    private Optional<MetricLine> readLine(String line) {
+      List<String> entry = columnSplitter.splitToList(line);
+      if (entry.size() != headers.size()) {
+        log.warn("Entry {} does not match column width of {}, skipping", entry, headers);
+        return Optional.empty();
+      }
+      String podName = entry.get(0);
+      String containerName = entry.get(1);
+      ImmutableMap.Builder<String, String> metrics = ImmutableMap.builder();
+      for (int j = 2; j < headers.size(); j++) {
+        metrics.put(headers.get(j), entry.get(j));
+      }
+      return Optional.of(new MetricLine(podName, containerName, metrics.build()));
+    }
+  }
+
+  static final class MetricLine {
+    @Getter private final String pod;
+    private final String container;
+    private final ImmutableMap<String, String> metrics;
+
+    private MetricLine(String pod, String container, Map<String, String> metrics) {
+      this.pod = pod;
+      this.container = container;
+      this.metrics = ImmutableMap.copyOf(metrics);
+    }
+
+    ContainerMetric toContainerMetric() {
+      return new ContainerMetric(container, metrics);
+    }
+  }
+}

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -169,12 +169,10 @@ metadata:
   }
 
   def containerMetric(String containerName) {
-    return KubernetesPodMetric.ContainerMetric.builder()
-      .containerName(containerName)
-      .metrics([
+    return new KubernetesPodMetric.ContainerMetric(containerName, [
         "CPU(cores)": "10m",
         "MEMORY(bytes)": "2Mi"
-      ]).build()
+    ])
   }
 
   def filterRelationships(Collection<String> keys, List<Pair<KubernetesKind, String>> existingResources) {

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -168,7 +168,7 @@ class KubernetesV2CredentialsSpec extends Specification {
         checkPermissionsOnStartup: true,
         metrics: true
       ))
-    kubectlJobExecutor.topPod(_ as KubernetesV2Credentials, NAMESPACE, _) >> Collections.emptyList()
+    kubectlJobExecutor.topPod(_ as KubernetesV2Credentials, NAMESPACE, _) >> ImmutableList.of()
 
     expect:
     credentials.isMetricsEnabled() == true

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetricTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesPodMetricTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric.ContainerMetric;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesPodMetricTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void deserializeContainerMetric() throws IOException {
+    String json =
+        Resources.toString(
+            KubernetesPodMetricTest.class.getResource("pod-metric.json"), StandardCharsets.UTF_8);
+
+    KubernetesPodMetric.ContainerMetric containerMetric =
+        objectMapper.readValue(json, KubernetesPodMetric.ContainerMetric.class);
+    assertThat(containerMetric.getContainerName()).isEqualTo("istio-proxy");
+    assertThat(containerMetric.getMetrics())
+        .containsOnly(entry("MEMORY(bytes)", "27Mi"), entry("CPU(cores)", "3m"));
+  }
+
+  @Test
+  public void deserializeContainerMetricWithUnknownField() throws IOException {
+    String json =
+        Resources.toString(
+            KubernetesPodMetricTest.class.getResource("pod-metric-extra-property.json"),
+            StandardCharsets.UTF_8);
+
+    KubernetesPodMetric.ContainerMetric containerMetric =
+        objectMapper.readValue(json, KubernetesPodMetric.ContainerMetric.class);
+    assertThat(containerMetric.getContainerName()).isEqualTo("istio-proxy");
+    assertThat(containerMetric.getMetrics())
+        .containsOnly(entry("MEMORY(bytes)", "27Mi"), entry("CPU(cores)", "3m"));
+  }
+
+  @Test
+  public void serializeContainerMetric() throws IOException {
+    String expectedResult =
+        Resources.toString(
+            KubernetesPodMetricTest.class.getResource("pod-metric.json"), StandardCharsets.UTF_8);
+
+    KubernetesPodMetric.ContainerMetric metric =
+        new ContainerMetric(
+            "istio-proxy",
+            ImmutableMap.of(
+                "MEMORY(bytes)", "27Mi",
+                "CPU(cores)", "3m"));
+    String result = objectMapper.writeValueAsString(metric);
+
+    // Compare the parsed trees of the two results, which is agnostic to key order
+    AssertionsForClassTypes.assertThat(objectMapper.readTree(result))
+        .isEqualTo(objectMapper.readTree(expectedResult));
+  }
+}

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.io.Resources;
+import com.netflix.spinnaker.clouddriver.jobs.JobExecutor;
+import com.netflix.spinnaker.clouddriver.jobs.JobRequest;
+import com.netflix.spinnaker.clouddriver.jobs.JobResult;
+import com.netflix.spinnaker.clouddriver.jobs.JobResult.Result;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric.ContainerMetric;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesJobExecutorTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private static final String NAMESPACE = "test-namespace";
+
+  @Test
+  void topPodEmptyOutput() {
+    JobExecutor jobExecutor = mock(JobExecutor.class);
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder().result(Result.SUCCESS).output("").error("").build());
+
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(jobExecutor, "kubectl", "oauth2l");
+    Collection<KubernetesPodMetric> podMetrics =
+        kubectlJobExecutor.topPod(mockKubernetesV2Credentials(), "test", "");
+    assertThat(podMetrics).isEmpty();
+  }
+
+  @Test
+  void topPodMultipleContainers() throws Exception {
+    JobExecutor jobExecutor = mock(JobExecutor.class);
+    when(jobExecutor.runJob(any(JobRequest.class)))
+        .thenReturn(
+            JobResult.<String>builder()
+                .result(Result.SUCCESS)
+                .output(
+                    Resources.toString(
+                        KubectlJobExecutor.class.getResource("top-pod.txt"),
+                        StandardCharsets.UTF_8))
+                .error("")
+                .build());
+
+    KubectlJobExecutor kubectlJobExecutor =
+        new KubectlJobExecutor(jobExecutor, "kubectl", "oauth2l");
+    Collection<KubernetesPodMetric> podMetrics =
+        kubectlJobExecutor.topPod(mockKubernetesV2Credentials(), NAMESPACE, "");
+    assertThat(podMetrics).hasSize(2);
+
+    ImmutableSetMultimap<String, ContainerMetric> expectedMetrics =
+        ImmutableSetMultimap.<String, ContainerMetric>builder()
+            .putAll(
+                "spinnaker-io-nginx-v000-42gnq",
+                ImmutableList.of(
+                    new ContainerMetric(
+                        "spinnaker-github-io",
+                        ImmutableMap.of("CPU(cores)", "0m", "MEMORY(bytes)", "2Mi")),
+                    new ContainerMetric(
+                        "istio-proxy",
+                        ImmutableMap.of("CPU(cores)", "3m", "MEMORY(bytes)", "28Mi")),
+                    new ContainerMetric(
+                        "istio-init", ImmutableMap.of("CPU(cores)", "0m", "MEMORY(bytes)", "0Mi"))))
+            .putAll(
+                "spinnaker-io-nginx-v001-jvkgb",
+                ImmutableList.of(
+                    new ContainerMetric(
+                        "spinnaker-github-io",
+                        ImmutableMap.of("CPU(cores)", "0m", "MEMORY(bytes)", "2Mi")),
+                    new ContainerMetric(
+                        "istio-proxy",
+                        ImmutableMap.of("CPU(cores)", "32m", "MEMORY(bytes)", "30Mi")),
+                    new ContainerMetric(
+                        "istio-init", ImmutableMap.of("CPU(cores)", "0m", "MEMORY(bytes)", "0Mi"))))
+            .build();
+
+    for (String pod : expectedMetrics.keys()) {
+      Optional<KubernetesPodMetric> podMetric =
+          podMetrics.stream()
+              .filter(metric -> metric.getPodName().equals(pod))
+              .filter(metric -> metric.getNamespace().equals(NAMESPACE))
+              .findAny();
+      assertThat(podMetric.isPresent()).isTrue();
+      assertThat(podMetric.get().getContainerMetrics())
+          .containsExactlyInAnyOrderElementsOf(expectedMetrics.get(pod));
+    }
+  }
+
+  /** Returns a mock KubernetesV2Credentials object */
+  private static KubernetesV2Credentials mockKubernetesV2Credentials() {
+    KubernetesV2Credentials v2Credentials = mock(KubernetesV2Credentials.class);
+    when(v2Credentials.getKubectlExecutable()).thenReturn("");
+    return v2Credentials;
+  }
+}

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/pod-metric-extra-property.json
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/pod-metric-extra-property.json
@@ -1,0 +1,8 @@
+{
+  "containerName" : "istio-proxy",
+  "something": "what-am-i",
+  "metrics" : {
+    "MEMORY(bytes)" : "27Mi",
+    "CPU(cores)" : "3m"
+  }
+}

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/pod-metric.json
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/pod-metric.json
@@ -1,0 +1,7 @@
+{
+  "containerName" : "istio-proxy",
+  "metrics" : {
+    "MEMORY(bytes)" : "27Mi",
+    "CPU(cores)" : "3m"
+  }
+}

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/top-pod.txt
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/top-pod.txt
@@ -1,0 +1,7 @@
+POD                             NAME                  CPU(cores)   MEMORY(bytes)
+spinnaker-io-nginx-v000-42gnq   spinnaker-github-io   0m           2Mi
+spinnaker-io-nginx-v000-42gnq   istio-proxy           3m           28Mi
+spinnaker-io-nginx-v000-42gnq   istio-init            0m           0Mi
+spinnaker-io-nginx-v001-jvkgb   spinnaker-github-io   0m           2Mi
+spinnaker-io-nginx-v001-jvkgb   istio-proxy           32m          30Mi
+spinnaker-io-nginx-v001-jvkgb   istio-init            0m           0Mi


### PR DESCRIPTION
* test(kubernetes): Add some tests to metric fetching logic

  Before making a few changes to the call to get pod metrics, add some tests around this to ensure the changes don't break existing functionality.

* refactor(kubernetes): Clean up metrics code

  This started out just trying to remove the noisy log statement
  "No output from `kubectl top` command, no metrics to report", which is logged with severity warn any time we cache an empty namespace. There's no need to log this as it's a perfectly normal situation; we asked for pod metrics and there were none.

  But then I noticed some things that could be cleaned up a bit 😄. So this PR does the following:
  * Extracts the logic to parse the output of kubectl top out of the already large job executor class and into a helper class
  * Replaces use of .split() which compiles a regex every call and requires us to deal in arrays with Guava Splitters
  * Cleans up KubernetesPodMetric, making things immutable and also removing an excessive buidler from ContainerMetric which has only two fields of different types.