### PR TITLE
chore(gha): don't run the GHA build when pushing to a fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   branch-build:
+    # Only run this on repositories in the 'spinnaker' org, not on forks.
+    if: startsWith(github.repository, 'spinnaker/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
These builds will always fail because the secrets don't exist there, but
even if they did exist, we wouldn't want to publish a release from a fork.

Sending this to make sure it looks okay before I put it in 16 other
repositories.