### PR TITLE
fix(saga): Remove import of EventSourceAutoConfiguration on SagaAutoConfiguration

### DIFF
--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/config/SagaAutoConfiguration.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/config/SagaAutoConfiguration.kt
@@ -17,7 +17,6 @@ package com.netflix.spinnaker.clouddriver.saga.config
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.event.SpinnakerEvent
-import com.netflix.spinnaker.clouddriver.event.config.EventSourceAutoConfiguration
 import com.netflix.spinnaker.clouddriver.event.persistence.EventRepository
 import com.netflix.spinnaker.clouddriver.saga.SagaService
 import com.netflix.spinnaker.clouddriver.saga.persistence.DefaultSagaRepository
@@ -30,10 +29,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 
 @Configuration
-@Import(EventSourceAutoConfiguration::class)
 @EnableConfigurationProperties(SagaProperties::class)
 @ComponentScan("com.netflix.spinnaker.clouddriver.saga.controllers")
 open class SagaAutoConfiguration {

--- a/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/SagaSystemTest.kt
+++ b/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/SagaSystemTest.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.clouddriver.saga
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.event.config.EventSourceAutoConfiguration
 import com.netflix.spinnaker.clouddriver.saga.config.SagaAutoConfiguration
 import com.netflix.spinnaker.clouddriver.saga.persistence.SagaRepository
 import dev.minutest.junit.JUnit5Minutests
@@ -36,7 +37,8 @@ class SagaSystemTest : JUnit5Minutests {
     fixture {
       ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(
-          SagaAutoConfiguration::class.java
+          SagaAutoConfiguration::class.java,
+          EventSourceAutoConfiguration::class.java
         ))
     }
 

--- a/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/examples/SpringExampleTest.kt
+++ b/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/examples/SpringExampleTest.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.clouddriver.saga.examples
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.event.config.EventSourceAutoConfiguration
 import com.netflix.spinnaker.clouddriver.saga.Action1
 import com.netflix.spinnaker.clouddriver.saga.Action2
 import com.netflix.spinnaker.clouddriver.saga.Action3
@@ -48,7 +49,8 @@ class SpringExampleTest : JUnit5Minutests {
       fixture {
         ApplicationContextRunner()
           .withConfiguration(AutoConfigurations.of(
-            SagaAutoConfiguration::class.java
+            SagaAutoConfiguration::class.java,
+            EventSourceAutoConfiguration::class.java
           ))
       }
 


### PR DESCRIPTION
Before I muck around with `@Order` I'd like to give this a shot as it seems like the cleanest solution to me.  This should let us specify the bean we want via config (ie, if `sql.enabled` is `true`).