### PR TITLE
fix(aws): illegal access of private field of AmazonInstance and AmazonServerGroup

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/RebootInstancesAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/RebootInstancesAtomicOperationConverter.groovy
@@ -47,7 +47,7 @@ class RebootInstancesAtomicOperationConverter extends AbstractAtomicOperationsCr
     try {
       def serverGroups = converted.instanceIds.findResults {
         def instance = amazonInstanceProvider.getInstance(converted.credentials.name, converted.region, it)
-        return instance?.extraAttributes?.serverGroup
+        return instance?.getExtraAttributes()?.serverGroup
       } as Set<String>
       converted.serverGroups = serverGroups
     } catch (Exception e) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/TerminateInstancesAtomicOperationConverter.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/converters/TerminateInstancesAtomicOperationConverter.groovy
@@ -46,7 +46,7 @@ class TerminateInstancesAtomicOperationConverter extends AbstractAtomicOperation
     try {
       def serverGroups = converted.instanceIds.findResults {
         def instance = amazonInstanceProvider.getInstance(converted.credentials.name, converted.region, it)
-        return instance?.extraAttributes?.get("serverGroup")
+        return instance?.getExtraAttributes()?.get("serverGroup")
       } as Set<String>
       converted.serverGroups = serverGroups
     } catch (Exception e) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonLoadBalancerProvider.groovy
@@ -200,7 +200,7 @@ class AmazonLoadBalancerProvider implements LoadBalancerProvider<AmazonLoadBalan
             ]
         )
       } : [],
-      detachedInstances: serverGroup.extraAttributes?.detachedInstances,
+      detachedInstances: serverGroup.getExtraAttributes()?.detachedInstances,
       cloudProvider: AmazonCloudProvider.ID
     )
   }


### PR DESCRIPTION
This PR fixes the issue - https://github.com/spinnaker/spinnaker/issues/5632 

Previous related commits, in spinnaker:master:
*  https://github.com/spinnaker/clouddriver/pull/4375
* https://github.com/spinnaker/clouddriver/pull/4385