### PR TITLE
fix(plugins): add an option for strict plugin loading

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 fiatVersion=1.14.0
 includeCloudProviders=all
 enablePublishing=false
-korkVersion=7.25.1
+korkVersion=7.25.13
 spinnakerGradleVersion=7.0.2
 org.gradle.parallel=true


### PR DESCRIPTION
This PR is part of a series of PRs for allowing relaxed plugin loading by adding a config option to turn strict plugin loading on or off. See https://docs.google.com/document/d/1yFDrpkCCV7Vp0wN0gDc9GTbTOBoIzNo-tGj1-vVjq04/edit?usp=sharing for more info