### PR TITLE
chore(java11): Compile with Java 11 (but targeting Java 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1.1.2
         with:
           path: ~/.gradle
@@ -27,4 +32,4 @@ jobs:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-        run: ./gradlew -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace
+        run: ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # Install Java 8 for cross-compilation support. Setting it up before
+    # Java 11 means it comes later in $PATH (because of how setup-java works)
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - uses: actions/cache@v1.1.2
       with:
         path: ~/.gradle
@@ -19,4 +24,4 @@ jobs:
     - name: Build
       env:
         GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-      run: ./gradlew build javadoc
+      run: ./gradlew -PenableCrossCompilerPlugin=true build javadoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1.1.2
         with:
           path: ~/.gradle
@@ -37,7 +42,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
       - name: Release build
         if: steps.release_info.outputs.IS_CANDIDATE == 'false'
         env:
@@ -45,7 +50,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,5 +1,11 @@
-FROM openjdk:8
+FROM ubuntu:bionic
+RUN apt-get update && apt-get install -y \
+    openjdk-8-jdk \
+    openjdk-11-jdk \
+ && rm -rf /var/lib/apt/lists/*
 MAINTAINER sig-platform@spinnaker.io
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
-ENV GRADLE_OPTS -Xmx2048m
-CMD ./gradlew clouddriver-web:installDist -x test
+ENV GRADLE_OPTS -Xmx4g
+CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true clouddriver-web:installDist -x test

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/ReconcileClassicLinkSecurityGroupsAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/agent/ReconcileClassicLinkSecurityGroupsAgentSpec.groovy
@@ -32,6 +32,7 @@ import spock.lang.Specification
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
 /**
  * ReconcileClassicLinkSecurityGroupsAgentSpec.
@@ -53,8 +54,12 @@ class ReconcileClassicLinkSecurityGroupsAgentSpec extends Specification {
 
   def agent = buildAgent(test)
 
+  // We convert this to a Date in "should filter instances that havent been up
+  // long enough", but Date objects can't store nanosecond precision, meaning
+  // our before/after calculations are off by nanoseconds. Just truncate this
+  // down to something a Date can handle.
   @Shared
-  Instant currentTime = Instant.now()
+  Instant currentTime = Instant.now().truncatedTo(ChronoUnit.MILLIS)
 
   private ReconcileClassicLinkSecurityGroupsAgent buildAgent(NetflixAmazonCredentials account) {
     return new ReconcileClassicLinkSecurityGroupsAgent(

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupManagerController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupManagerController.java
@@ -38,13 +38,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/applications/{application}/serverGroupManagers")
 public class ServerGroupManagerController {
-  final List<ServerGroupManagerProvider> serverGroupManagerProviders;
+  final List<ServerGroupManagerProvider<ServerGroupManager>> serverGroupManagerProviders;
 
   final RequestQueue requestQueue;
 
   @Autowired
   public ServerGroupManagerController(
-      List<ServerGroupManagerProvider> serverGroupManagerProviders, RequestQueue requestQueue) {
+      List<ServerGroupManagerProvider<ServerGroupManager>> serverGroupManagerProviders,
+      RequestQueue requestQueue) {
     this.serverGroupManagerProviders = serverGroupManagerProviders;
     this.requestQueue = requestQueue;
   }
@@ -66,7 +67,6 @@ public class ServerGroupManagerController {
             })
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
-        .map(i -> (ServerGroupManager) i)
         .collect(Collectors.toSet());
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 includeCloudProviders=all
 fiatVersion=1.18.0
 enablePublishing=false
-spinnakerGradleVersion=7.0.2
+spinnakerGradleVersion=7.9.0
 korkVersion=7.31.1
 org.gradle.parallel=true


### PR DESCRIPTION
Additional differences:

1. The `Dockerfile.compile` is using Ubuntu instead of Alpine. Gradle downloads a `protoc` from Maven that is built against glibc. Alpine uses musl libc, so the downloaded `protoc` won't run. We need a glibc-based distro.

    For consistency, I may backport this change to the other five services I've already updated. I can't decide :/

2. Add `--no-daemon` to the `Dockerfile.compile` for consistency and because otherwise setting `-Xmx` in `GRADLE_OPTS` doesn't do anything useful.

3. `ServerGroupManagerController.java` had to be changed a little because of some tweaks to the type inference in Java 11. I honestly don't understand why the old code wouldn't compile, but this new code is better anyway.

4. `ReconcileClassicLinkSecurityGroupsAgentSpec` had to be changed because `Instant.now()` under Java 11 returns nanosecond precision. This test converts back and forth to `Date` objects, which can't store that level of precision.