### PR TITLE
feat(config): Add ro and rw profiles

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -342,3 +342,24 @@ spring:
 #  port: 22
 #  proxyRegion: us-west-1
 #  proxyCluster: my-credentials-cluster
+
+---
+# This profile is used in HA deployments for a clouddriver that handles read-only requests from
+# other services
+spring:
+  profiles: ro
+
+redis:
+  connection: ${services.redis-ro.baseUrl:redis://localhost:6379}
+
+caching:
+  writeEnabled: false
+
+---
+# This profile is used in HA deployments for a clouddriver that handles mutating requests from
+# other services, but does not run caching agents
+spring:
+  profiles: rw
+
+caching:
+  writeEnabled: false

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -1,6 +1,5 @@
 server:
-  port: ${services.clouddriver.port:7002}
-  address: ${services.clouddriver.host:localhost}
+  port: 7002
   ssl:
     enabled: false
   compression:

--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -350,7 +350,7 @@ spring:
   profiles: ro
 
 redis:
-  connection: ${services.redis-ro.baseUrl:redis://localhost:6379}
+  connection: ${services.redisRo.baseUrl}
 
 caching:
   writeEnabled: false

--- a/halconfig/clouddriver.yml
+++ b/halconfig/clouddriver.yml
@@ -1,1 +1,5 @@
 # halconfig
+
+server:
+  port: ${services.clouddriver.port:7002}
+  address: ${services.clouddriver.host:localhost}


### PR DESCRIPTION
* refactor(core): Move some things back to halyard config

  In a recent PR I moved the server.port and server.address settings into the base config to reduce what's in the Halyard config.

  After further reflection, we don't want these to be overridable easily in kleat anyway as I don't think there's a common use case for this.  (And in any case, it's easier to override this by just overriding these in the clouddriver-local.yml than to need to go through the services.* settings in spinnaker.yml.)

  So let's avoid bringing these settings along for the ride, and just leave them in the halconfig where they will still help halyard users. This restores this block of clouddriver.yml to what it was before the recent change.

* feat(config): Add ro and rw profiles

  In order to make it easier to configure HA deployments, add profiles to support the following:
  * A read-only deployment that does not run caching agents, and can connect to a read-only backing store.
  * A read-write deployment that does not run caching agents, but connects to a writeable backing store so that it can serve mutating requests from other microservices.