### PR TITLE
refactor(kubernetes): Clean up KubernetesManifestStrategy

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestStrategy.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestStrategy.java
@@ -17,19 +17,119 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
-import lombok.AllArgsConstructor;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Ints;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class KubernetesManifestStrategy {
-  Boolean versioned;
-  Boolean recreate;
-  Boolean replace;
-  Integer maxVersionHistory;
-  Boolean useSourceCapacity;
+@Value
+@Slf4j
+@NonnullByDefault
+public final class KubernetesManifestStrategy {
+  private static final String STRATEGY_ANNOTATION_PREFIX =
+      "strategy." + KubernetesManifestAnnotater.SPINNAKER_ANNOTATION;
+  private static final String VERSIONED = STRATEGY_ANNOTATION_PREFIX + "/versioned";
+  static final String MAX_VERSION_HISTORY = STRATEGY_ANNOTATION_PREFIX + "/max-version-history";
+  private static final String USE_SOURCE_CAPACITY =
+      STRATEGY_ANNOTATION_PREFIX + "/use-source-capacity";
+
+  private final DeployStrategy deployStrategy;
+  private final Versioned versioned;
+  private final OptionalInt maxVersionHistory;
+  private final boolean useSourceCapacity;
+
+  @Builder
+  @ParametersAreNullableByDefault
+  private KubernetesManifestStrategy(
+      DeployStrategy deployStrategy,
+      Versioned versioned,
+      Integer maxVersionHistory,
+      boolean useSourceCapacity) {
+    this.deployStrategy = Optional.ofNullable(deployStrategy).orElse(DeployStrategy.APPLY);
+    this.versioned = Optional.ofNullable(versioned).orElse(Versioned.DEFAULT);
+    this.maxVersionHistory =
+        maxVersionHistory == null ? OptionalInt.empty() : OptionalInt.of(maxVersionHistory);
+    this.useSourceCapacity = useSourceCapacity;
+  }
+
+  static KubernetesManifestStrategy fromAnnotations(Map<String, String> annotations) {
+    return KubernetesManifestStrategy.builder()
+        .versioned(Versioned.fromAnnotations(annotations))
+        .deployStrategy(DeployStrategy.fromAnnotations(annotations))
+        .useSourceCapacity(Boolean.parseBoolean(annotations.get(USE_SOURCE_CAPACITY)))
+        .maxVersionHistory(Ints.tryParse(annotations.getOrDefault(MAX_VERSION_HISTORY, "")))
+        .build();
+  }
+
+  ImmutableMap<String, String> toAnnotations() {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    builder.putAll(deployStrategy.toAnnotations());
+    builder.putAll(versioned.toAnnotations());
+    if (maxVersionHistory.isPresent()) {
+      builder.put(MAX_VERSION_HISTORY, Integer.toString(maxVersionHistory.getAsInt()));
+    }
+    if (useSourceCapacity) {
+      builder.put(USE_SOURCE_CAPACITY, Boolean.TRUE.toString());
+    }
+    return builder.build();
+  }
+
+  public enum Versioned {
+    TRUE(ImmutableMap.of(VERSIONED, Boolean.TRUE.toString())),
+    FALSE(ImmutableMap.of(VERSIONED, Boolean.FALSE.toString())),
+    DEFAULT(ImmutableMap.of());
+
+    private final ImmutableMap<String, String> annotations;
+
+    Versioned(ImmutableMap<String, String> annotations) {
+      this.annotations = annotations;
+    }
+
+    static Versioned fromAnnotations(Map<String, String> annotations) {
+      if (annotations.containsKey(VERSIONED)) {
+        return Boolean.parseBoolean(annotations.get(VERSIONED)) ? TRUE : FALSE;
+      }
+      return DEFAULT;
+    }
+
+    ImmutableMap<String, String> toAnnotations() {
+      return annotations;
+    }
+  }
+
+  public enum DeployStrategy {
+    APPLY(null),
+    RECREATE(STRATEGY_ANNOTATION_PREFIX + "/recreate"),
+    REPLACE(STRATEGY_ANNOTATION_PREFIX + "/replace");
+
+    @Nullable private final String annotation;
+
+    DeployStrategy(@Nullable String annotation) {
+      this.annotation = annotation;
+    }
+
+    static DeployStrategy fromAnnotations(Map<String, String> annotations) {
+      if (Boolean.parseBoolean(annotations.get(RECREATE.annotation))) {
+        return RECREATE;
+      }
+      if (Boolean.parseBoolean(annotations.get(REPLACE.annotation))) {
+        return REPLACE;
+      }
+      return APPLY;
+    }
+
+    ImmutableMap<String, String> toAnnotations() {
+      if (annotation == null) {
+        return ImmutableMap.of();
+      }
+      return ImmutableMap.of(annotation, Boolean.TRUE.toString());
+    }
+  }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -97,11 +98,12 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
 
   private List<Artifact> artifactsToDelete(KubernetesManifest manifest) {
     KubernetesManifestStrategy strategy = KubernetesManifestAnnotater.getStrategy(manifest);
-    if (strategy.getMaxVersionHistory() == null) {
+    OptionalInt optionalMaxVersionHistory = strategy.getMaxVersionHistory();
+    if (!optionalMaxVersionHistory.isPresent()) {
       return new ArrayList<>();
     }
 
-    int maxVersionHistory = strategy.getMaxVersionHistory();
+    int maxVersionHistory = optionalMaxVersionHistory.getAsInt();
     Optional<Artifact> optional = KubernetesManifestAnnotater.getArtifact(manifest);
     if (!optional.isPresent()) {
       return new ArrayList<>();

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeploy.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeploy.java
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy.DeployStrategy;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
@@ -28,9 +30,8 @@ public interface CanDeploy {
   default OperationResult deploy(
       KubernetesV2Credentials credentials,
       KubernetesManifest manifest,
-      boolean recreate,
-      boolean replace) {
-    if (recreate) {
+      KubernetesManifestStrategy.DeployStrategy deployStrategy) {
+    if (deployStrategy == DeployStrategy.RECREATE) {
       try {
         credentials.delete(
             manifest.getKind(),
@@ -42,7 +43,7 @@ public interface CanDeploy {
       }
     }
 
-    if (replace) {
+    if (deployStrategy == DeployStrategy.REPLACE) {
       credentials.replace(manifest);
     } else {
       credentials.deploy(manifest);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.ArtifactReplacer
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.KubernetesArtifactConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.*;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy.Versioned;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.CanLoadBalance;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.CanScale;
@@ -159,13 +160,11 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     for (KubernetesManifest manifest : deployManifests) {
       KubernetesResourceProperties properties = findResourceProperties(manifest);
       KubernetesManifestStrategy strategy = KubernetesManifestAnnotater.getStrategy(manifest);
-      boolean versioned = isVersioned(properties, strategy);
-      boolean useSourceCapacity = isUseSourceCapacity(strategy);
-      boolean recreate = isRecreate(strategy);
-      boolean replace = isReplace(strategy);
 
       KubernetesArtifactConverter converter =
-          versioned ? properties.getVersionedConverter() : properties.getUnversionedConverter();
+          isVersioned(properties, strategy)
+              ? properties.getVersionedConverter()
+              : properties.getUnversionedConverter();
       KubernetesHandler deployer = properties.getHandler();
 
       Moniker moniker = cloneMoniker(description.getMoniker());
@@ -192,7 +191,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
                   + " with artifact, relationships & moniker...");
       KubernetesManifestAnnotater.annotateManifest(manifest, artifact);
 
-      if (useSourceCapacity && deployer instanceof CanScale) {
+      if (strategy.isUseSourceCapacity() && deployer instanceof CanScale) {
         Double replicas = KubernetesSourceCapacity.getSourceCapacity(manifest, credentials);
         if (replicas != null) {
           manifest.setReplicas(replicas);
@@ -225,7 +224,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
               OP_NAME,
               "Submitting manifest " + manifest.getFullResourceName() + " to kubernetes master...");
       log.debug("Manifest in {} to be deployed: {}", accountName, manifest);
-      result.merge(deployer.deploy(credentials, manifest, recreate, replace));
+      result.merge(deployer.deploy(credentials, manifest, strategy.getDeployStrategy()));
 
       result.getCreatedArtifacts().add(artifact);
     }
@@ -285,8 +284,8 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
 
   private boolean isVersioned(
       KubernetesResourceProperties properties, KubernetesManifestStrategy strategy) {
-    if (strategy.getVersioned() != null) {
-      return strategy.getVersioned();
+    if (strategy.getVersioned() != Versioned.DEFAULT) {
+      return strategy.getVersioned() == Versioned.TRUE;
     }
 
     if (description.getVersioned() != null) {
@@ -294,22 +293,6 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     }
 
     return properties.isVersioned();
-  }
-
-  private boolean isRecreate(KubernetesManifestStrategy strategy) {
-    return strategy.getRecreate() != null ? strategy.getRecreate() : false;
-  }
-
-  private boolean isReplace(KubernetesManifestStrategy strategy) {
-    return strategy.getReplace() != null ? strategy.getReplace() : false;
-  }
-
-  private boolean isUseSourceCapacity(KubernetesManifestStrategy strategy) {
-    if (strategy.getUseSourceCapacity() != null) {
-      return strategy.getUseSourceCapacity();
-    }
-
-    return false;
   }
 
   // todo(lwander): move to kork

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestStrategyTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestStrategyTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy.DeployStrategy;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy.Versioned;
+import java.util.Map;
+import java.util.OptionalInt;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesManifestStrategyTest {
+  @Test
+  void deployStrategyDefaultsToApply() {
+    KubernetesManifestStrategy.DeployStrategy strategy =
+        KubernetesManifestStrategy.DeployStrategy.fromAnnotations(ImmutableMap.of());
+    assertThat(strategy).isEqualTo(DeployStrategy.APPLY);
+  }
+
+  @Test
+  void otherStrategiesFalse() {
+    KubernetesManifestStrategy.DeployStrategy strategy =
+        KubernetesManifestStrategy.DeployStrategy.fromAnnotations(
+            ImmutableMap.of(
+                "strategy.spinnaker.io/recreate", "false",
+                "strategy.spinnaker.io/replace", "false"));
+    assertThat(strategy).isEqualTo(DeployStrategy.APPLY);
+  }
+
+  @Test
+  void recreateStrategy() {
+    KubernetesManifestStrategy.DeployStrategy strategy =
+        KubernetesManifestStrategy.DeployStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/recreate", "true"));
+    assertThat(strategy).isEqualTo(DeployStrategy.RECREATE);
+  }
+
+  @Test
+  void replaceStrategy() {
+    KubernetesManifestStrategy.DeployStrategy strategy =
+        KubernetesManifestStrategy.DeployStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/replace", "true"));
+    assertThat(strategy).isEqualTo(DeployStrategy.REPLACE);
+  }
+
+  @Test
+  void nonBooleanValue() {
+    KubernetesManifestStrategy.DeployStrategy strategy =
+        KubernetesManifestStrategy.DeployStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/replace", "zzzz"));
+    assertThat(strategy).isEqualTo(DeployStrategy.APPLY);
+  }
+
+  @Test
+  void recreatePreferredOverReplace() {
+    KubernetesManifestStrategy.DeployStrategy strategy =
+        KubernetesManifestStrategy.DeployStrategy.fromAnnotations(
+            ImmutableMap.of(
+                "strategy.spinnaker.io/replace", "true",
+                "strategy.spinnaker.io/recreate", "true"));
+    assertThat(strategy).isEqualTo(DeployStrategy.RECREATE);
+  }
+
+  @Test
+  void applyToAnnotations() {
+    Map<String, String> annotations = DeployStrategy.APPLY.toAnnotations();
+    assertThat(annotations).isEmpty();
+  }
+
+  @Test
+  void recreateToAnnotations() {
+    Map<String, String> annotations = DeployStrategy.RECREATE.toAnnotations();
+    assertThat(annotations).containsOnly(entry("strategy.spinnaker.io/recreate", "true"));
+  }
+
+  @Test
+  void replaceToAnnotations() {
+    Map<String, String> annotations = DeployStrategy.REPLACE.toAnnotations();
+    assertThat(annotations).containsOnly(entry("strategy.spinnaker.io/replace", "true"));
+  }
+
+  @Test
+  void versionedDefaultsToDefault() {
+    KubernetesManifestStrategy.Versioned versioned =
+        KubernetesManifestStrategy.Versioned.fromAnnotations(ImmutableMap.of());
+    assertThat(versioned).isEqualTo(Versioned.DEFAULT);
+  }
+
+  @Test
+  void versionedTrue() {
+    KubernetesManifestStrategy.Versioned versioned =
+        KubernetesManifestStrategy.Versioned.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/versioned", "true"));
+    assertThat(versioned).isEqualTo(Versioned.TRUE);
+  }
+
+  @Test
+  void versionedFalse() {
+    KubernetesManifestStrategy.Versioned versioned =
+        KubernetesManifestStrategy.Versioned.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/versioned", "false"));
+    assertThat(versioned).isEqualTo(Versioned.FALSE);
+  }
+
+  @Test
+  void versionedNonsense() {
+    KubernetesManifestStrategy.Versioned versioned =
+        KubernetesManifestStrategy.Versioned.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/versioned", "zzz"));
+    assertThat(versioned).isEqualTo(Versioned.FALSE);
+  }
+
+  @Test
+  void versionedDefaultToAnnotations() {
+    Map<String, String> annotations = Versioned.DEFAULT.toAnnotations();
+    assertThat(annotations).isEmpty();
+  }
+
+  @Test
+  void versionedTrueToAnnotations() {
+    Map<String, String> annotations = Versioned.TRUE.toAnnotations();
+    assertThat(annotations).containsOnly(entry("strategy.spinnaker.io/versioned", "true"));
+  }
+
+  @Test
+  void versionedFalseToAnnotations() {
+    Map<String, String> annotations = Versioned.FALSE.toAnnotations();
+    assertThat(annotations).containsOnly(entry("strategy.spinnaker.io/versioned", "false"));
+  }
+
+  @Test
+  void fromEmptyAnnotations() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(ImmutableMap.of());
+    assertThat(strategy.getDeployStrategy()).isEqualTo(DeployStrategy.APPLY);
+    assertThat(strategy.getVersioned()).isEqualTo(Versioned.DEFAULT);
+    assertThat(strategy.getMaxVersionHistory()).isEqualTo(OptionalInt.empty());
+    assertThat(strategy.isUseSourceCapacity()).isFalse();
+  }
+
+  @Test
+  void fromDeployStrategyAnnotation() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/replace", "true"));
+    assertThat(strategy.getDeployStrategy()).isEqualTo(DeployStrategy.REPLACE);
+  }
+
+  @Test
+  void fromVersionedAnnotation() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/versioned", "true"));
+    assertThat(strategy.getVersioned()).isEqualTo(Versioned.TRUE);
+  }
+
+  @Test
+  void fromMaxVersionHistoryAnnotation() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/max-version-history", "10"));
+    assertThat(strategy.getMaxVersionHistory()).isEqualTo(OptionalInt.of(10));
+  }
+
+  @Test
+  void fromNonIntegerMaxVersionHistoryAnnotation() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/max-version-history", "zz"));
+    assertThat(strategy.getMaxVersionHistory()).isEqualTo(OptionalInt.empty());
+  }
+
+  @Test
+  void fromUseSourceCapacityAnnotation() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/use-source-capacity", "true"));
+    assertThat(strategy.isUseSourceCapacity()).isTrue();
+  }
+
+  @Test
+  void fromUseSourceCapacityAnnotationFalse() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/use-source-capacity", "false"));
+    assertThat(strategy.isUseSourceCapacity()).isFalse();
+  }
+
+  @Test
+  void fromUseSourceCapacityAnnotationNonsense() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(
+            ImmutableMap.of("strategy.spinnaker.io/use-source-capacity", "zzz"));
+    assertThat(strategy.isUseSourceCapacity()).isFalse();
+  }
+
+  @Test
+  void allAnnotationsPresent() {
+    KubernetesManifestStrategy strategy =
+        KubernetesManifestStrategy.fromAnnotations(
+            ImmutableMap.of(
+                "strategy.spinnaker.io/replace", "true",
+                "strategy.spinnaker.io/versioned", "true",
+                "strategy.spinnaker.io/max-version-history", "20",
+                "strategy.spinnaker.io/use-source-capacity", "true",
+                "strategy.spinnaker.io/random-annotation", "abc"));
+
+    assertThat(strategy.getDeployStrategy()).isEqualTo(DeployStrategy.REPLACE);
+    assertThat(strategy.getVersioned()).isEqualTo(Versioned.TRUE);
+    assertThat(strategy.getMaxVersionHistory()).isEqualTo(OptionalInt.of(20));
+    assertThat(strategy.isUseSourceCapacity()).isTrue();
+  }
+
+  @Test
+  void builderDefaults() {
+    KubernetesManifestStrategy strategy = KubernetesManifestStrategy.builder().build();
+    assertThat(strategy.getDeployStrategy()).isEqualTo(DeployStrategy.APPLY);
+    assertThat(strategy.getVersioned()).isEqualTo(Versioned.DEFAULT);
+    assertThat(strategy.getMaxVersionHistory()).isEqualTo(OptionalInt.empty());
+    assertThat(strategy.isUseSourceCapacity()).isFalse();
+  }
+
+  @Test
+  void emptyAnnotations() {
+    Map<String, String> annotations = KubernetesManifestStrategy.builder().build().toAnnotations();
+    assertThat(annotations).isEmpty();
+  }
+
+  @Test
+  void deployStrategyRecreateToAnnotations() {
+    Map<String, String> annotations =
+        KubernetesManifestStrategy.builder()
+            .deployStrategy(DeployStrategy.RECREATE)
+            .build()
+            .toAnnotations();
+    assertThat(annotations).containsOnly(entry("strategy.spinnaker.io/recreate", "true"));
+  }
+
+  @Test
+  void deployStrategyReplaceToAnnotations() {
+    Map<String, String> annotations =
+        KubernetesManifestStrategy.builder()
+            .deployStrategy(DeployStrategy.REPLACE)
+            .build()
+            .toAnnotations();
+    assertThat(annotations).containsOnly(entry("strategy.spinnaker.io/replace", "true"));
+  }
+
+  @Test
+  void versionedToAnnotations() {
+    Map<String, String> annotations =
+        KubernetesManifestStrategy.builder().versioned(Versioned.FALSE).build().toAnnotations();
+    assertThat(annotations).containsOnly(entry("strategy.spinnaker.io/versioned", "false"));
+  }
+
+  @Test
+  void maxVersionHistoryToAnnotations() {
+    Map<String, String> annotations =
+        KubernetesManifestStrategy.builder().maxVersionHistory(10).build().toAnnotations();
+    assertThat(annotations).containsOnly(entry("strategy.spinnaker.io/max-version-history", "10"));
+  }
+
+  @Test
+  void useSourceCapacityToAnnotations() {
+    Map<String, String> annotations =
+        KubernetesManifestStrategy.builder().useSourceCapacity(true).build().toAnnotations();
+    assertThat(annotations)
+        .containsOnly(entry("strategy.spinnaker.io/use-source-capacity", "true"));
+  }
+
+  @Test
+  void toAnnotationsMultipleAnnotations() {
+    Map<String, String> annotations =
+        KubernetesManifestStrategy.builder()
+            .deployStrategy(DeployStrategy.RECREATE)
+            .versioned(Versioned.TRUE)
+            .maxVersionHistory(30)
+            .useSourceCapacity(true)
+            .build()
+            .toAnnotations();
+    assertThat(annotations)
+        .containsOnly(
+            entry("strategy.spinnaker.io/recreate", "true"),
+            entry("strategy.spinnaker.io/versioned", "true"),
+            entry("strategy.spinnaker.io/max-version-history", "30"),
+            entry("strategy.spinnaker.io/use-source-capacity", "true"));
+  }
+}


### PR DESCRIPTION
We have a class KubernetesManifestStrategy to represent how to deploy a manifest, but it doesn't encapsulate itself well and pushes a lot of logic into callers.

Make the following changes:
* Move the logic for creating this KubernetesManifestStrategy object from annotations into the KubernetesManifestStrategy class; this allows us to move the strings representing the annotations into this class as well, increasing encapsulation.
* Improve the type safety of the member variables so that callers don't need to perform redundant null-unsafe checks. In particular:
  * Add a DeployStrategy enum to replace (no pun intended) the replace and recreate Booleans; these are mutually exclusive as setting both to true will 'kubectl delete' then 'kubectl replace' the manifest which always fails as there's nothing to replace.
  * Change versioned to an enum; we do care if it's set or not because if it's unset we use the value on the deploy operation. I guess this could have just stayed a Boolean, but it seemed clearer to make this an enum with three values (TRUE, FALSE, DEFAULT) though I could be convinced otherwise, I was on the fence here.
  * Make maxVersionHistory an OptionalInt instead of an Integer to get some null-safety in callers
  * Make useSourceCapacity a boolean instead of a Boolean as we always consider null the same as false.
* Make all the member variables private and final, exposing only getters of these new, more convenient return types. This simplifies a lot of the logic in callers.

A few notes:
* The new logic to read annotations avoids the complex logic that was in getAnnotations in KubernetesManifestAnnotater, which used an ObjectMapper instead of parseBoolean or parseInt. ObjectMapper is actually *more* strict here for booleans and would only return true if the value was exactly (case-sensitive) "true"; there is a slight change here that now we'll accept any casing of "true" (ex: "trUe", "TRUE") but I think that's sensible and probably what people would expect anyway.
* A couple of the annotation strings are shared between classes in the same package so I made them package-private instead of private.

Overall this ended up making KubernetesManifestStrategy larger than I might have intended at the beginning but I think this helps a lot with encapsulation, in that consumers need much less of an understanding of its internal workings.