### PR TITLE
 feat(kubernetes): Apply manifests with generateName using create

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -105,6 +106,15 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   public String getName() {
     return (String) getMetadata().get("name");
+  }
+
+  @JsonIgnore
+  public boolean hasGenerateName() {
+    if (!Strings.isNullOrEmpty(this.getName())) {
+      // If a name is present, it will be used instead of a generateName
+      return false;
+    }
+    return !Strings.isNullOrEmpty((String) getMetadata().get("generateName"));
   }
 
   @JsonIgnore

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeploy.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeploy.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy.DeployStrategy;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
@@ -31,24 +30,26 @@ public interface CanDeploy {
       KubernetesV2Credentials credentials,
       KubernetesManifest manifest,
       KubernetesManifestStrategy.DeployStrategy deployStrategy) {
-    if (deployStrategy == DeployStrategy.RECREATE) {
-      try {
-        credentials.delete(
-            manifest.getKind(),
-            manifest.getNamespace(),
-            manifest.getName(),
-            new KubernetesSelectorList(),
-            new V1DeleteOptions());
-      } catch (KubectlJobExecutor.KubectlException ignored) {
-      }
-    }
 
-    if (deployStrategy == DeployStrategy.REPLACE) {
-      credentials.replace(manifest);
-    } else {
-      credentials.deploy(manifest);
+    switch (deployStrategy) {
+      case RECREATE:
+        try {
+          credentials.delete(
+              manifest.getKind(),
+              manifest.getNamespace(),
+              manifest.getName(),
+              new KubernetesSelectorList(),
+              new V1DeleteOptions());
+        } catch (KubectlJobExecutor.KubectlException ignored) {
+        }
+        credentials.deploy(manifest);
+        break;
+      case REPLACE:
+        credentials.replace(manifest);
+        break;
+      case APPLY:
+        credentials.deploy(manifest);
     }
-
     return new OperationResult().addManifest(manifest);
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeploy.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeploy.java
@@ -30,6 +30,12 @@ public interface CanDeploy {
       KubernetesV2Credentials credentials,
       KubernetesManifest manifest,
       KubernetesManifestStrategy.DeployStrategy deployStrategy) {
+    // If the manifest has a generateName, we must apply with kubectl create as all other operations
+    // require looking up a manifest by name, which will fail.
+    if (manifest.hasGenerateName()) {
+      KubernetesManifest result = credentials.create(manifest);
+      return new OperationResult().addManifest(result);
+    }
 
     switch (deployStrategy) {
       case RECREATE:

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -528,6 +528,14 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         () -> jobExecutor.replace(this, manifest));
   }
 
+  public KubernetesManifest create(KubernetesManifest manifest) {
+    return runAndRecordMetrics(
+        "create",
+        manifest.getKind(),
+        manifest.getNamespace(),
+        () -> jobExecutor.create(this, manifest));
+  }
+
   public List<Integer> historyRollout(KubernetesKind kind, String namespace, String name) {
     return runAndRecordMetrics(
         "historyRollout",

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeployTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeployTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy.DeployStrategy;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
+import io.kubernetes.client.openapi.models.V1DeleteOptions;
+import org.junit.jupiter.api.Test;
+
+final class CanDeployTest {
+  private final CanDeploy handler = new CanDeploy() {};
+
+  @Test
+  void applyMutations() {
+    KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
+    KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
+    handler.deploy(credentials, manifest, DeployStrategy.APPLY);
+    verify(credentials).deploy(manifest);
+    verifyNoMoreInteractions(credentials);
+  }
+
+  @Test
+  void applyReturnValue() {
+    KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
+    KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
+    OperationResult result = handler.deploy(credentials, manifest, DeployStrategy.APPLY);
+    assertThat(result.getManifests()).containsExactlyInAnyOrder(manifest);
+  }
+
+  @Test
+  void replaceMutations() {
+    KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
+    KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
+    handler.deploy(credentials, manifest, DeployStrategy.REPLACE);
+    verify(credentials).replace(manifest);
+    verifyNoMoreInteractions(credentials);
+  }
+
+  @Test
+  void replaceReturnValue() {
+    KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
+    KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
+    OperationResult result = handler.deploy(credentials, manifest, DeployStrategy.REPLACE);
+    assertThat(result.getManifests()).containsExactlyInAnyOrder(manifest);
+  }
+
+  @Test
+  void recreateMutations() {
+    KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
+    KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
+    handler.deploy(credentials, manifest, DeployStrategy.RECREATE);
+    verify(credentials).deploy(manifest);
+    verify(credentials)
+        .delete(
+            eq(manifest.getKind()),
+            eq(manifest.getNamespace()),
+            eq(manifest.getName()),
+            any(KubernetesSelectorList.class),
+            any(V1DeleteOptions.class));
+    verifyNoMoreInteractions(credentials);
+  }
+
+  @Test
+  void recreateReturnValue() {
+    KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
+    KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
+    OperationResult result = handler.deploy(credentials, manifest, DeployStrategy.RECREATE);
+    assertThat(result.getManifests()).containsExactlyInAnyOrder(manifest);
+  }
+
+  @Test
+  void createMutation() {
+    KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
+    KubernetesManifest manifest =
+        ManifestFetcher.getManifest("candeploy/deployment-generate-name.yml");
+    handler.deploy(credentials, manifest, DeployStrategy.APPLY);
+    // TODO(ezimanyi): This is a bug, as a manifest with a generateName must be created with a
+    // create operation
+    verify(credentials).deploy(manifest);
+    verifyNoMoreInteractions(credentials);
+  }
+
+  @Test
+  void createReturnValue() {
+    KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
+    KubernetesManifest manifest =
+        ManifestFetcher.getManifest("candeploy/deployment-generate-name.yml");
+    OperationResult result = handler.deploy(credentials, manifest, DeployStrategy.APPLY);
+    // TODO(ezimanyi): This is a bug, as we should return the result of the create call, which will
+    // include the generated name
+    assertThat(result.getManifests()).containsExactlyInAnyOrder(manifest);
+  }
+}

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeployTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeployTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2020 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestStrategy.DeployStrategy;
@@ -97,10 +98,11 @@ final class CanDeployTest {
     KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
     KubernetesManifest manifest =
         ManifestFetcher.getManifest("candeploy/deployment-generate-name.yml");
+    KubernetesManifest createResult =
+        ManifestFetcher.getManifest("candeploy/deployment-generate-name-result.yml");
+    when(credentials.create(manifest)).thenReturn(createResult);
     handler.deploy(credentials, manifest, DeployStrategy.APPLY);
-    // TODO(ezimanyi): This is a bug, as a manifest with a generateName must be created with a
-    // create operation
-    verify(credentials).deploy(manifest);
+    verify(credentials).create(manifest);
     verifyNoMoreInteractions(credentials);
   }
 
@@ -109,9 +111,10 @@ final class CanDeployTest {
     KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
     KubernetesManifest manifest =
         ManifestFetcher.getManifest("candeploy/deployment-generate-name.yml");
+    KubernetesManifest createResult =
+        ManifestFetcher.getManifest("candeploy/deployment-generate-name-result.yml");
+    when(credentials.create(manifest)).thenReturn(createResult);
     OperationResult result = handler.deploy(credentials, manifest, DeployStrategy.APPLY);
-    // TODO(ezimanyi): This is a bug, as we should return the result of the create call, which will
-    // include the generated name
-    assertThat(result.getManifests()).containsExactlyInAnyOrder(manifest);
+    assertThat(result.getManifests()).containsExactlyInAnyOrder(createResult);
   }
 }

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/candeploy/deployment-generate-name-result.yml
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/candeploy/deployment-generate-name-result.yml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: nginx-cknv6
   generateName: nginx-
 spec:
   replicas: 5

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/candeploy/deployment-generate-name.yml
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/candeploy/deployment-generate-name.yml
@@ -1,0 +1,16 @@
+# Base deployment spec
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generateName: nginx
+spec:
+  replicas: 5
+  template:
+    spec:
+      containers:
+      - image: nginx:1.7.9
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/candeploy/deployment.yml
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/candeploy/deployment.yml
@@ -1,0 +1,16 @@
+# Base deployment spec
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 5
+  template:
+    spec:
+      containers:
+      - image: nginx:1.7.9
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP


### PR DESCRIPTION
* feat(kubernetes): Add support for kubectl create

  Some manifest need to be applied with kubectl create; one example is manifests that specify a generateName instead of a name. In this case, we can't apply or replace, as both of these operations require looking up the existing manifest which is impossible when the name changes each time.

  This commit adds support to KubernetesV2Credentials to create a manifest using kubectl create operation.

* test(kubernetes): Add tests to CanDeploy

  Before lightly refactoring and adding some new functionality to the CanDeploy interface, add some tests to validate the existing behavior.

* refactor(kubernetes): Use switch in CanDeploy

  The logic in CanDeploy is a bit too complicated; let's make it cleaner by using a switch over the enum of possible deploy strategies.

* feat(kubernetes): Apply manifests with generateName using create

  Manifests that have a generateName instead of a name need to be created using a create operation, as other operations require looking up the existing manifest to reconcile changes, but this is not possible if we don't have the manifest's name.

  This change updates CanDeploy to check if the manifest has a generateName (and no name, as this would take priority), and to always use 'kubectl create' if that is the case.