### PR TITLE
fix(kubernetes): properly set isDisabled on server groups

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2LoadBalancer.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2LoadBalancer.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
@@ -25,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -69,14 +69,13 @@ public class KubernetesV2LoadBalancer extends ManifestBasedModel
 
     Set<LoadBalancerServerGroup> serverGroups =
         serverGroupData.stream()
-            // ignoring load balancers here since they are discarded by ::toLoadBalancerServerGroup
             .map(
                 d ->
                     KubernetesV2ServerGroup.fromCacheData(
                         KubernetesV2ServerGroupCacheData.builder()
                             .serverGroupData(d)
                             .instanceData(serverGroupToInstanceData.get(d.getId()))
-                            .loadBalancerData(new ArrayList<>())
+                            .loadBalancerData(ImmutableList.of(cd))
                             .build()))
             .filter(Objects::nonNull)
             .map(KubernetesV2ServerGroup::toLoadBalancerServerGroup)


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5359

Currently, Deck displays all Kubernetes V2 Load Balancers' associated workloads with the gray `disabled` styling. This is because we are passing an empty list instead of the required load balancer cache data when initializing `KubernetesV2ServerGroup` as part of reading the load balancers and their associated workloads from the cache. [This line](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java#L213) determines whether a workload is considered disabled, which will always return `true` when passed an empty list for `loadBalancersData`.