### PR TITLE
refactor(kubernetes): Clean up runAndRecordMetrics

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -627,7 +627,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     } catch (Exception e) {
       tags.put("success", "false");
       tags.put("reason", e.getClass().getSimpleName());
-      throw new KubectlJobExecutor.KubectlException(
+      throw new KubectlException(
           "Failure running " + action + " on " + kinds + ": " + e.getMessage(), e);
     } finally {
       registry

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -609,46 +609,32 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   private <T> T runAndRecordMetrics(
       String action, List<KubernetesKind> kinds, String namespace, Supplier<T> op) {
-    T result = null;
-    Throwable failure = null;
-    KubectlException apiException = null;
+    Map<String, String> tags = new HashMap<>();
+    tags.put("action", action);
+    if (kinds.size() == 1) {
+      tags.put("kind", kinds.get(0).toString());
+    } else {
+      tags.put(
+          "kinds", kinds.stream().map(KubernetesKind::toString).collect(Collectors.joining(",")));
+    }
+    tags.put("account", accountName);
+    tags.put("namespace", StringUtils.isEmpty(namespace) ? "none" : namespace);
+    tags.put("success", "true");
     long startTime = clock.monotonicTime();
     try {
-      result = op.get();
+      return op.get();
     } catch (KubectlException e) {
-      apiException = e;
+      // TODO(ezimanyi): We should be setting success to false here; this does not feel like success
+      throw e;
     } catch (Exception e) {
-      failure = e;
+      tags.put("success", "false");
+      tags.put("reason", e.getClass().getSimpleName() + ": " + e.getMessage());
+      throw new KubectlJobExecutor.KubectlException(
+          "Failure running " + action + " on " + kinds + ": " + e.getMessage(), e);
     } finally {
-      Map<String, String> tags = new HashMap<>();
-      tags.put("action", action);
-      if (kinds.size() == 1) {
-        tags.put("kind", kinds.get(0).toString());
-      } else {
-        tags.put(
-            "kinds", kinds.stream().map(KubernetesKind::toString).collect(Collectors.joining(",")));
-      }
-      tags.put("account", accountName);
-      tags.put("namespace", StringUtils.isEmpty(namespace) ? "none" : namespace);
-      if (failure == null) {
-        tags.put("success", "true");
-      } else {
-        tags.put("success", "false");
-        tags.put("reason", failure.getClass().getSimpleName() + ": " + failure.getMessage());
-      }
-
       registry
           .timer(registry.createId("kubernetes.api", tags))
           .record(clock.monotonicTime() - startTime, TimeUnit.NANOSECONDS);
-
-      if (failure != null) {
-        throw new KubectlJobExecutor.KubectlException(
-            "Failure running " + action + " on " + kinds + ": " + failure.getMessage(), failure);
-      } else if (apiException != null) {
-        throw apiException;
-      } else {
-        return result;
-      }
     }
   }
 

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsTest.java
@@ -101,7 +101,7 @@ final class KubernetesV2CredentialsTest {
         .containsExactlyInAnyOrder(
             Tag.of("account", ACCOUNT_NAME),
             Tag.of("action", "deploy"),
-            Tag.of("kind", KubernetesKind.DEPLOYMENT.toString()),
+            Tag.of("kinds", KubernetesKind.DEPLOYMENT.toString()),
             Tag.of("namespace", NAMESPACE),
             Tag.of("success", "true"));
   }
@@ -228,10 +228,8 @@ final class KubernetesV2CredentialsTest {
             Tag.of("action", "list"),
             Tag.of("kinds", "deployment,replicaSet"),
             Tag.of("namespace", NAMESPACE),
-            // It's potentially a bug that we record success as true here, though it *might* be
-            // deliberate as generally a KubectlException is thrown when we do get a response back
-            // from kubectl but fail parsing the result.
-            Tag.of("success", "true"));
+            Tag.of("success", "false"),
+            Tag.of("reason", "KubectlException"));
   }
 
   @Test
@@ -313,7 +311,7 @@ final class KubernetesV2CredentialsTest {
             Tag.of("kinds", "deployment,replicaSet"),
             Tag.of("namespace", NAMESPACE),
             Tag.of("success", "false"),
-            Tag.of("reason", "CustomException: Kubernetes error"));
+            Tag.of("reason", "CustomException"));
   }
 
   @Test

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsTest.java
@@ -353,12 +353,14 @@ final class KubernetesV2CredentialsTest {
     Exception cause = new CustomException("Kubernetes error");
     when(jobExecutor.list(eq(credentials), any(), any(), any())).thenThrow(cause);
 
-    // Assert that a The source exception is the cause is passed through without modification
+    // Assert that the source exception is wrapped in a KubectlException with details about the call
+    // that failed
     assertThatThrownBy(
             () ->
                 credentials.list(
                     ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
                     NAMESPACE))
+        .isInstanceOf(KubectlException.class)
         .hasMessageContaining("Failure running list")
         .hasCause(cause);
   }

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.v2.security;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonSyntaxException;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Tag;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties.ManagedAccount;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.AccountResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.GlobalResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.names.KubernetesManifestNamer;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesUnregisteredCustomResourceHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor.KubectlException;
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
+import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
+import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
+import com.netflix.spinnaker.kork.configserver.ConfigFileService;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesV2CredentialsTest {
+  private static final String ACCOUNT_NAME = "my-account";
+  private static final String DEPLOYMENT_NAME = "my-deployment";
+  private static final String NAMESPACE = "my-namespace";
+
+  private KubernetesV2Credentials getCredentials(
+      Registry registry, KubectlJobExecutor jobExecutor) {
+    KubernetesV2Credentials.Factory factory =
+        new KubernetesV2Credentials.Factory(
+            registry,
+            new NamerRegistry(ImmutableList.of(new KubernetesManifestNamer())),
+            jobExecutor,
+            new ConfigFileService(new CloudConfigResourceService()),
+            new AccountResourcePropertyRegistry.Factory(
+                new GlobalResourcePropertyRegistry(
+                    ImmutableList.of(), new KubernetesUnregisteredCustomResourceHandler())),
+            new KubernetesKindRegistry.Factory(
+                new GlobalKubernetesKindRegistry(ImmutableList.of())),
+            new KubernetesSpinnakerKindMap(ImmutableList.of()));
+    ManagedAccount managedAccount = new ManagedAccount();
+    managedAccount.setName("my-account");
+    managedAccount.setProviderVersion(ProviderVersion.v2);
+    return factory.build(managedAccount);
+  }
+
+  private KubernetesManifest getManifest() {
+    KubernetesManifest manifest = new KubernetesManifest();
+    manifest.put("metadata", new HashMap<>());
+    manifest.setName(DEPLOYMENT_NAME);
+    manifest.setNamespace(NAMESPACE);
+    manifest.setKind(KubernetesKind.DEPLOYMENT);
+    return manifest;
+  }
+
+  @Test
+  void metricTagsForSuccessfulDeploy() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+    credentials.deploy(getManifest());
+
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+    assertThat(timer.id().tags())
+        .containsExactlyInAnyOrder(
+            Tag.of("account", ACCOUNT_NAME),
+            Tag.of("action", "deploy"),
+            Tag.of("kind", KubernetesKind.DEPLOYMENT.toString()),
+            Tag.of("namespace", NAMESPACE),
+            Tag.of("success", "true"));
+  }
+
+  @Test
+  void metricTagsForSuccessfulList() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+    credentials.list(
+        ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET), NAMESPACE);
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+
+    assertThat(timer.id().tags())
+        .containsExactlyInAnyOrder(
+            Tag.of("account", ACCOUNT_NAME),
+            Tag.of("action", "list"),
+            Tag.of("kinds", "deployment,replicaSet"),
+            Tag.of("namespace", NAMESPACE),
+            Tag.of("success", "true"));
+  }
+
+  @Test
+  void metricTagsForSuccessfulListNoNamespace() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+    credentials.list(ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET), null);
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+
+    assertThat(timer.id().tags()).contains(Tag.of("namespace", "none"));
+  }
+
+  @Test
+  void metricTagsForSuccessfulListEmptyNamespace() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+    credentials.list(ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET), "");
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+
+    assertThat(timer.id().tags()).contains(Tag.of("namespace", "none"));
+  }
+
+  @Test
+  void returnValueForSuccessfulList() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+
+    KubernetesManifest manifest = getManifest();
+    when(jobExecutor.list(eq(credentials), any(), any(), any()))
+        .thenReturn(ImmutableList.of(manifest));
+    ImmutableList<KubernetesManifest> result =
+        credentials.list(
+            ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET), NAMESPACE);
+    assertThat(result).containsExactly(manifest);
+  }
+
+  @Test
+  void timeRecordedForSuccessfulList() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+
+    ManualClock clock = new ManualClock();
+    Registry registry = new DefaultRegistry(clock);
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+
+    clock.setMonotonicTime(1000);
+    when(jobExecutor.list(eq(credentials), any(), any(), any()))
+        .then(
+            call -> {
+              clock.setMonotonicTime(1500);
+              return ImmutableList.of();
+            });
+    credentials.list(
+        ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET), NAMESPACE);
+
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+    assertThat(timer.totalTime()).isEqualTo(500);
+  }
+
+  @Test
+  void metricTagsForListThrowingKubectlException() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+
+    when(jobExecutor.list(eq(credentials), any(), any(), any()))
+        .thenThrow(
+            new KubectlException(
+                "Failed to parse kubectl output: failure", new JsonSyntaxException("failure")));
+
+    assertThatThrownBy(
+            () ->
+                credentials.list(
+                    ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
+                    NAMESPACE))
+        .isInstanceOf(KubectlException.class);
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+
+    assertThat(timer.id().tags())
+        .containsExactlyInAnyOrder(
+            Tag.of("account", ACCOUNT_NAME),
+            Tag.of("action", "list"),
+            Tag.of("kinds", "deployment,replicaSet"),
+            Tag.of("namespace", NAMESPACE),
+            // It's potentially a bug that we record success as true here, though it *might* be
+            // deliberate as generally a KubectlException is thrown when we do get a response back
+            // from kubectl but fail parsing the result.
+            Tag.of("success", "true"));
+  }
+
+  @Test
+  void propagatedExceptionForListThrowingKubectlException() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+
+    KubectlException exception =
+        new KubectlException(
+            "Failed to parse kubectl output: failure", new JsonSyntaxException("failure"));
+    when(jobExecutor.list(eq(credentials), any(), any(), any())).thenThrow(exception);
+
+    // Assert that a KubectlException is passed through without modification
+    assertThatThrownBy(
+            () ->
+                credentials.list(
+                    ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
+                    NAMESPACE))
+        .isEqualTo(exception);
+  }
+
+  @Test
+  void timeRecordedForListThrowingKubectlException() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+
+    ManualClock clock = new ManualClock();
+    Registry registry = new DefaultRegistry(clock);
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+
+    clock.setMonotonicTime(1000);
+    when(jobExecutor.list(eq(credentials), any(), any(), any()))
+        .then(
+            call -> {
+              clock.setMonotonicTime(1500);
+              throw new KubectlException(
+                  "Failed to parse kubectl output: failure", new JsonSyntaxException("failure"));
+            });
+    assertThatThrownBy(
+            () ->
+                credentials.list(
+                    ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
+                    NAMESPACE))
+        .isInstanceOf(KubectlException.class);
+
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+    assertThat(timer.totalTime()).isEqualTo(500);
+  }
+
+  @Test
+  void metricTagsForListThrowingOtherException() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+
+    when(jobExecutor.list(eq(credentials), any(), any(), any()))
+        .thenThrow(new CustomException("Kubernetes error"));
+
+    assertThatThrownBy(
+            () ->
+                credentials.list(
+                    ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
+                    NAMESPACE))
+        .isInstanceOf(KubectlException.class);
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+
+    assertThat(timer.id().tags())
+        .containsExactlyInAnyOrder(
+            Tag.of("account", ACCOUNT_NAME),
+            Tag.of("action", "list"),
+            Tag.of("kinds", "deployment,replicaSet"),
+            Tag.of("namespace", NAMESPACE),
+            Tag.of("success", "false"),
+            Tag.of("reason", "CustomException: Kubernetes error"));
+  }
+
+  @Test
+  void timeRecordedForListThrowingOtherException() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+
+    ManualClock clock = new ManualClock();
+    Registry registry = new DefaultRegistry(clock);
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+
+    clock.setMonotonicTime(1000);
+    when(jobExecutor.list(eq(credentials), any(), any(), any()))
+        .then(
+            call -> {
+              clock.setMonotonicTime(1500);
+              throw new CustomException("Kubernetes errror");
+            });
+    assertThatThrownBy(
+            () ->
+                credentials.list(
+                    ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
+                    NAMESPACE))
+        .isInstanceOf(KubectlException.class);
+
+    ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
+    assertThat(timers).hasSize(1);
+
+    Timer timer = timers.get(0);
+    assertThat(timer.id().name()).isEqualTo("kubernetes.api");
+    assertThat(timer.totalTime()).isEqualTo(500);
+  }
+
+  @Test
+  void propagatedExceptionForListThrowingOtherException() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class);
+    Registry registry = new DefaultRegistry();
+    KubernetesV2Credentials credentials = getCredentials(registry, jobExecutor);
+
+    Exception cause = new CustomException("Kubernetes error");
+    when(jobExecutor.list(eq(credentials), any(), any(), any())).thenThrow(cause);
+
+    // Assert that a The source exception is the cause is passed through without modification
+    assertThatThrownBy(
+            () ->
+                credentials.list(
+                    ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
+                    NAMESPACE))
+        .hasMessageContaining("Failure running list")
+        .hasCause(cause);
+  }
+
+  // This is an error type that will only ever be thrown by stubs in this test; that way we can
+  // assert that it is thrown and be sure that we aren't accidentally passing due to an unrelated
+  // exception.
+  private static class CustomException extends RuntimeException {
+    CustomException(String message) {
+      super(message);
+    }
+  }
+}


### PR DESCRIPTION
* test(kubernetes): Add tests to metric recording on kubectl calls

  The runAndRecordMetrics funcgtion in KubernetesV2Credentials is very complex and has no tests. Before simplifying it, add some tests to document and validate the current behavior.

  This commit also updates the constructor of KubernetesManifest to set the metadata to an empty map. In real code, we always create a KubernetesManifest by deserializing, so the metadata is set to a map of whatever was on the incoming manifest. But it's often useful in tests to be able to create a manifest and set a few fields on it; before this change, this wasn't possible because metadata was always null. There were functions to set various keys on the metadata, but these would all fail due to the null metadata.

* refactor(kubernetes): Clean up runAndRecordMetrics

  The control flow in runAndRecordMetric is really confusing, in particular in that we re-throw and return from a finally block. Clean this up so that it uses better style.

* fix(kubernetes): Fix some issues with kubectl metrics

  Cleaning up the code in the last commit surfaced a few issues that this commit cleans up.

  (1) We should add a failure tag if a KubectlException is thrown
  (2) Metric tags are intended to be short descriptors, so we shouldn't add the text of an error message. Remove that message from the cause tag and just include the class of the exception.
  (3) There's no reason to separately tag 'kind' and 'kinds' depending if there are more than 1 or not; just always add 'kinds' with the full list of kinds. Also sort it for consistency in the metric tags.

  There's probably a bit we can do to futher clean up the exception handling
  (deciding when to wrap the exception, etc.) and deduplicate the two catch blocks but leaving that s is for now.