### PR TITLE
refactor(kubernetes): Improve error abstraction in kubectl

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobExecutionException.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobExecutionException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jobs;
+
+public class JobExecutionException extends RuntimeException {
+  public JobExecutionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobExecutor.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobExecutor.java
@@ -23,6 +23,15 @@ import com.netflix.spinnaker.clouddriver.jobs.local.ReaderConsumer;
  * <p>The caller can optionally supply a ReaderConsumer, in which case the output from the job will
  * be transformed by the ReaderConsumer before being returned in JobResult.
  *
+ * <p>There are two general types of errors that can occur when executing a job:
+ *
+ * <ul>
+ *   <li>If the JobExecutor fails to start or monitor a job, or if it is unable to read the job's
+ *       output, a {@link JobExecutionException} is thrown.
+ *   <li>If the JobExecutor successfully starts and monitors the job, but the job itself fails, no
+ *       exception is thrown but the returned {@link JobResult} will indicate that the job failed.
+ * </ul>
+ *
  * @see JobRequest
  * @see JobResult
  */
@@ -32,6 +41,7 @@ public interface JobExecutor {
    *
    * @param jobRequest The job request
    * @return The result of the job
+   * @throws JobExecutionException if there is an error starting or monitoring the job
    */
   JobResult<String> runJob(JobRequest jobRequest);
 
@@ -42,6 +52,7 @@ public interface JobExecutor {
    * @param jobRequest The job request
    * @param readerConsumer A function that transforms the job's standard output
    * @return The result of the job
+   * @throws JobExecutionException if there is an error starting or monitoring the job
    */
   <T> JobResult<T> runJob(JobRequest jobRequest, ReaderConsumer<T> readerConsumer);
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/JobRequest.java
@@ -58,4 +58,9 @@ public class JobRequest {
     commandLine.addArguments(arguments, false);
     return commandLine;
   }
+
+  @Override
+  public String toString() {
+    return String.join(" ", tokenizedCommand);
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ReaderConsumer.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/ReaderConsumer.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.jobs.local;
 import java.io.BufferedReader;
 import java.io.IOException;
 import javax.annotation.Nonnull;
+import javax.annotation.WillClose;
 
 /**
  * Transforms a stream into an object of arbitrary type using a supplied BufferReader for the
@@ -26,7 +27,8 @@ import javax.annotation.Nonnull;
  *
  * <p>Implementations are responsible for closing the supplied BufferReader.
  */
+@FunctionalInterface
 public interface ReaderConsumer<T> {
   @Nonnull
-  T consume(BufferedReader r) throws IOException;
+  T consume(@WillClose BufferedReader r) throws IOException;
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -31,7 +31,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.Collection;
 import java.util.Collections;
@@ -77,25 +76,7 @@ public class KubernetesMetricCachingAgent extends KubernetesV2CachingAgent
     List<KubernetesPodMetric> podMetrics =
         getNamespaces()
             .parallelStream()
-            .map(
-                n -> {
-                  try {
-                    return credentials.topPod(n, null);
-                  } catch (KubectlJobExecutor.KubectlException e) {
-                    if (e.getMessage().contains("not available")) {
-                      log.warn(
-                          "{}: Metrics for namespace '"
-                              + n
-                              + "' in account '"
-                              + accountName
-                              + "' have not been recorded yet.",
-                          getAgentType());
-                      return Collections.<KubernetesPodMetric>emptyList();
-                    } else {
-                      throw e;
-                    }
-                  }
-                })
+            .map(n -> credentials.topPod(n, null))
             .flatMap(Collection::stream)
             .filter(Objects::nonNull)
             .collect(Collectors.toList());

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -171,16 +171,10 @@ public abstract class KubernetesV2CachingAgent
     log.info(getAgentType() + ": agent is starting");
     Map<String, Object> details = defaultIntrospectionDetails();
 
-    try {
-      long start = System.currentTimeMillis();
-      Map<KubernetesKind, List<KubernetesManifest>> primaryResourceList = loadPrimaryResourceList();
-      details.put("timeSpentInKubectlMs", System.currentTimeMillis() - start);
-      return buildCacheResult(primaryResourceList);
-    } catch (KubectlJobExecutor.NoResourceTypeException e) {
-      log.warn(
-          getAgentType() + ": resource for this caching agent is not supported for this cluster");
-      return new DefaultCacheResult(new HashMap<>());
-    }
+    long start = System.currentTimeMillis();
+    Map<KubernetesKind, List<KubernetesManifest>> primaryResourceList = loadPrimaryResourceList();
+    details.put("timeSpentInKubectlMs", System.currentTimeMillis() - start);
+    return buildCacheResult(primaryResourceList);
   }
 
   protected CacheResult buildCacheResult(KubernetesManifest resource) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -36,7 +36,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKindProperties.ResourceScope;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor.KubectlException;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,17 +82,7 @@ public abstract class KubernetesV2CachingAgent
   private ImmutableList<KubernetesManifest> loadResources(
       @Nonnull Iterable<KubernetesKind> kubernetesKinds, Optional<String> optionalNamespace) {
     String namespace = optionalNamespace.orElse(null);
-    try {
-      return credentials.list(ImmutableList.copyOf(kubernetesKinds), namespace);
-    } catch (KubectlException e) {
-      log.warn(
-          "{}: Failed to read kind {} from namespace {}: {}",
-          getAgentType(),
-          kubernetesKinds,
-          namespace,
-          e.getMessage());
-      throw e;
-    }
+    return credentials.list(ImmutableList.copyOf(kubernetesKinds), namespace);
   }
 
   @Nonnull

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -36,7 +36,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAcco
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
 import com.netflix.spinnaker.moniker.Namer;
@@ -87,14 +86,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
 
     Long start = System.currentTimeMillis();
     Map<KubernetesKind, List<KubernetesManifest>> primaryResource;
-    try {
-      primaryResource = loadPrimaryResourceList();
-    } catch (KubectlJobExecutor.NoResourceTypeException e) {
-      log.error(
-          getAgentType()
-              + ": resource for this caching agent is not supported for this cluster. This will cause problems, please remove it from caching using the `omitKinds` config parameter.");
-      return new DefaultCacheResult(new HashMap<>());
-    }
+    primaryResource = loadPrimaryResourceList();
 
     details.put("timeSpentInKubectlMs", System.currentTimeMillis() - start);
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -629,6 +629,13 @@ public class KubectlJobExecutor {
     JobResult<String> status = jobExecutor.runJob(new JobRequest(command));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
+      if (status.getError().contains("not available")) {
+        log.warn(
+            String.format(
+                "Error fetching metrics for account %s: %s",
+                credentials.getAccountName(), status.getError()));
+        return ImmutableList.of();
+      }
       throw new KubectlException("Could not read metrics: " + status.getError());
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -54,8 +54,6 @@ public class KubectlJobExecutor {
   private final String executable;
   private final String oAuthExecutable;
 
-  private static final String NO_RESOURCE_TYPE_ERROR = "doesn't have a resource type";
-
   private final Gson gson = new Gson();
 
   @Autowired
@@ -385,8 +383,6 @@ public class KubectlJobExecutor {
     if (status.getResult() != JobResult.Result.SUCCESS) {
       if (status.getError().contains("(NotFound)")) {
         return null;
-      } else if (status.getError().contains(NO_RESOURCE_TYPE_ERROR)) {
-        throw new NoResourceTypeException(status.getError());
       }
 
       throw new KubectlException(
@@ -416,12 +412,8 @@ public class KubectlJobExecutor {
         jobExecutor.runJob(new JobRequest(command), parseManifestList());
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
-      if (status.getError().contains(NO_RESOURCE_TYPE_ERROR)) {
-        throw new NoResourceTypeException(status.getError());
-      } else {
-        throw new KubectlException(
-            "Failed to read events from " + namespace + ": " + status.getError());
-      }
+      throw new KubectlException(
+          "Failed to read events from " + namespace + ": " + status.getError());
     }
 
     if (status.getError().contains("No resources found")) {
@@ -446,12 +438,8 @@ public class KubectlJobExecutor {
         jobExecutor.runJob(new JobRequest(command), parseManifestList());
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
-      if (status.getError().contains(NO_RESOURCE_TYPE_ERROR)) {
-        throw new NoResourceTypeException(status.getError());
-      } else {
-        throw new KubectlException(
-            "Failed to read " + kinds + " from " + namespace + ": " + status.getError());
-      }
+      throw new KubectlException(
+          "Failed to read " + kinds + " from " + namespace + ": " + status.getError());
     }
 
     if (status.getError().contains("No resources found")) {
@@ -757,14 +745,8 @@ public class KubectlJobExecutor {
     };
   }
 
-  public static class NoResourceTypeException extends RuntimeException {
-    protected NoResourceTypeException(String message) {
-      super(message);
-    }
-  }
-
   public static class KubectlException extends RuntimeException {
-    protected KubectlException(String message) {
+    KubectlException(String message) {
       super(message);
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -620,15 +620,10 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     long startTime = clock.monotonicTime();
     try {
       return op.get();
-    } catch (KubectlException e) {
+    } catch (RuntimeException e) {
       tags.put("success", "false");
       tags.put("reason", e.getClass().getSimpleName());
       throw e;
-    } catch (Exception e) {
-      tags.put("success", "false");
-      tags.put("reason", e.getClass().getSimpleName());
-      throw new KubectlException(
-          "Failure running " + action + " on " + kinds + ": " + e.getMessage(), e);
     } finally {
       registry
           .timer(registry.createId("kubernetes.api", tags))

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsTest.java
@@ -297,7 +297,7 @@ final class KubernetesV2CredentialsTest {
                 credentials.list(
                     ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
                     NAMESPACE))
-        .isInstanceOf(KubectlException.class);
+        .isInstanceOf(CustomException.class);
     ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
     assertThat(timers).hasSize(1);
 
@@ -334,7 +334,7 @@ final class KubernetesV2CredentialsTest {
                 credentials.list(
                     ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
                     NAMESPACE))
-        .isInstanceOf(KubectlException.class);
+        .isInstanceOf(CustomException.class);
 
     ImmutableList<Timer> timers = registry.timers().collect(toImmutableList());
     assertThat(timers).hasSize(1);
@@ -360,9 +360,7 @@ final class KubernetesV2CredentialsTest {
                 credentials.list(
                     ImmutableList.of(KubernetesKind.DEPLOYMENT, KubernetesKind.REPLICA_SET),
                     NAMESPACE))
-        .isInstanceOf(KubectlException.class)
-        .hasMessageContaining("Failure running list")
-        .hasCause(cause);
+        .isEqualTo(cause);
   }
 
   // This is an error type that will only ever be thrown by stubs in this test; that way we can


### PR DESCRIPTION
* refactor(kubernetes): Improve error abstraction in kubectl 

  When parsing the output of kubectl as JSON, a few different kinds of errors can happen:
  (1) An IOException if we encounter an error reading from the output stream
  (2) A JSONSyntaxException if the call to gson.fromJson fails
  (3) An IllegalStateException if the JSON format is unexpected (ex: if we get a list back instead of an object and call .beginObject() on it).

  Currently we're propagating all these exceptions as is. Let's continue letting the IOException propagate, as this can be handled by the job executor in the same way it handles any other error reading output.

  Let's wrap the JSONSyntaxException and IllegalStateException in a KubectlException to provide relevant context. This is how we handle a JSONSyntaxException other places in this file when we parse non-streaming responses. (Potentially at some point this could be a specific subclass of KubectlException but for now just being consistent with what happens elsewhere in the file.)

  This means that now the error surface out of the KubectlJobExecutor for a JSON parse exception will be the same regardless of whether this happened in the streaming or non-streaming parser.

* refactor(jobs): Throw exceptions appropriate to the abstraction 

  The JobExecutor class throws RuntimeException in a few places; let's replace this with throwing a JobExecutionException with information about the job that failed.

  Let's also take the opportunity to document the contract about when the JobExecutor throws an exception vs. when it returns a JobResult with a status of FAILED.

* refactor(kubernetes): Remove NoResourceTypeException 

  This exception was added in PR2344, with the goal of in some cases catching exceptions where a type was not recognized by the API
  (for example if a built-in kind is not present on an old Kubernetes cluster). It appears, however, that the change in that PR never actually worked, as all relevant calls to kubectl go through runAndRecordMetrics, which wraps any exception that is not a KubectlException in a KubectlException. So the catch blocks added in that PR will never be triggered as we'll always see a KubectlException at that point.

  Probably what should have been done is to make NoResourceTypeException extend KubectlException (or potentially to have it special-cased in runAndRecordMetrics). In the intervening time since that PR, we've added a check the first time we try to read a kind to make sure that it's readable (mainly for permissions issues, but it would also address this case), so I'm not sure there's much value in actually fixing this. (In any case, the behavior hasn't worked in the two years since it was added and we have not heard reports of people running into unrecognized kinds, except briefly when the readable check noted earlier was broken.)

  This commit then does the following:
  (1) Removes all the catch blocks for NoResourceTypeException that are unreachable
  (2) Removes NoResourceTypeException itself; given that calling code is not distinguishing this particular exception, there's not much benefit to throwing it vs. a generic KubectlException (particularly given that we're relying on string parsing to do so, and that we're only throwing it in some of the methods, not others).
  (3) It makes the constructor of KubectlException package-private instead of protected.

* refactor(kubernetes): Fix a few places where we catch KubectlException 

  In the metrics caching agent, we catch a KubectlException and dig into the message to see if it's because metrics aren't available, then return an empty collection in that case. Let's just have topPod directly handle that so we don't leak the implementation detail of using kubectl (and the specific message); this makes sense for the other two places we call this function as well.

  In KubernetesV2CachingAgent, we catch, log, then re-throw an exception. This is a vestige of when we used to just return an empty list after logging, but that was change to propagate the exception, so there's not really much additional benefit from also logging.

* refactor(kubernetes): Don't wrap kubectl exceptions 

  Let's no longer wrap all exceptions that pass through runAndRecordMetrics in a KubectlException. While it does have the benefit of providing some context at that level of abstraction, it is confusing that we sometimes directly throw that in the KubectlJobExecutor and sometimes create one by wrapping it here.

  I think at some point we may want to create a new KubernetesAPIException here that wraps anything below (either a KubectlException of a client library exception), but for now let's just propagate whatever was thrown below.

  The one thing to be careful about is that this change doesn't break places where we're catching a KubectlException. I've looked through and in all cases the code is catching to deal with some expected
  (but non-successful) kubectl call (ex: a missing resource, logs not there, etc.). All of these remain KubectlExceptions (and in some cases we should potentially even make more specific ones and catch that specific one). What we'll no longer be catching is things like a JobExecutionException where we fail to run the job, etc, which I think actually is better in this case.
