### PR TITLE
feat(kubernetes): Replace deploy strategy acts as upsert

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeploy.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeploy.java
@@ -52,7 +52,7 @@ public interface CanDeploy {
         deployedManifest = credentials.deploy(manifest);
         break;
       case REPLACE:
-        deployedManifest = credentials.replace(manifest);
+        deployedManifest = credentials.createOrReplace(manifest);
         break;
       case APPLY:
         deployedManifest = credentials.deploy(manifest);

--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeployTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDeployTest.java
@@ -61,9 +61,9 @@ final class CanDeployTest {
   void replaceMutations() {
     KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
     KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
-    when(credentials.replace(manifest)).thenReturn(manifest);
+    when(credentials.createOrReplace(manifest)).thenReturn(manifest);
     handler.deploy(credentials, manifest, DeployStrategy.REPLACE);
-    verify(credentials).replace(manifest);
+    verify(credentials).createOrReplace(manifest);
     verifyNoMoreInteractions(credentials);
   }
 
@@ -71,7 +71,7 @@ final class CanDeployTest {
   void replaceReturnValue() {
     KubernetesV2Credentials credentials = mock(KubernetesV2Credentials.class);
     KubernetesManifest manifest = ManifestFetcher.getManifest("candeploy/deployment.yml");
-    when(credentials.replace(manifest)).thenReturn(manifest);
+    when(credentials.createOrReplace(manifest)).thenReturn(manifest);
     OperationResult result = handler.deploy(credentials, manifest, DeployStrategy.REPLACE);
     assertThat(result.getManifests()).containsExactlyInAnyOrder(manifest);
   }


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5148

Currently if using the strategy.spinnaker.io/replace annotation, the manifest will be applied with kubectl replace. This will fail the first time the pipeline is run as the object won't exist and kubectl replace fails if there is no existing resource to replace. (There is an open issue in kubernetes to make replace act as an upsert, but as of now it just as workarounds to try the replace and then create if it fails.)

As this is a common issue, Spinnaker should be able to make this easier. This commit updates the behavior on doing a replace to fall back to creating the resource if the replace call fails due to the resource not existing.