### PR TITLE
fix(kubernetes): throw more helpful errors for invalid services

### DIFF
--- a/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationTest.java
+++ b/clouddriver-kubernetes-v2/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/KubernetesDeployManifestOperationTest.java
@@ -140,8 +140,7 @@ final class KubernetesDeployManifestOperationTest {
         baseDeployDescription("deploy/replicaset.yml")
             .setServices(ImmutableList.of("service my-service-no-selector"))
             .setEnableTraffic(true);
-    // todo: throw more helpful error
-    assertThatThrownBy(() -> deploy(description)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> deploy(description)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -150,17 +149,7 @@ final class KubernetesDeployManifestOperationTest {
         baseDeployDescription("deploy/replicaset-overlapping-selector.yml")
             .setServices(ImmutableList.of("service my-service"))
             .setEnableTraffic(true);
-    // todo: this should not succeed because a subsequent disable operation would make the
-    // ReplicaSet invalid
-    OperationResult result = deploy(description);
-
-    KubernetesManifest manifest = Iterables.getOnlyElement(result.getManifests());
-    assertThat(manifest.getSpecTemplateLabels()).isNotEmpty();
-    assertThat(manifest.getSpecTemplateLabels().get())
-        .contains(entry("selector-key", "selector-value"));
-
-    KubernetesManifestTraffic traffic = KubernetesManifestAnnotater.getTraffic(manifest);
-    assertThat(traffic.getLoadBalancers()).containsExactly("service my-service");
+    assertThatThrownBy(() -> deploy(description)).isInstanceOf(IllegalArgumentException.class);
   }
 
   private static KubernetesDeployManifestDescription baseDeployDescription(String manifest) {

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deploy/replicaset-overlapping-selector.yml
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deploy/replicaset-overlapping-selector.yml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: replicaSet
+metadata:
+  name: my-name
+  namespace: my-namespace
+spec:
+  selector:
+    matchLabels:
+      selector-key: selector-value
+  template:
+    metadata:
+      labels:
+        selector-key: selector-value

--- a/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deploy/service-no-selector.yml
+++ b/clouddriver-kubernetes-v2/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/deploy/service-no-selector.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: service
+metadata:
+  name: my-service
+  namespace: my-namespace


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5582

- chore(kubernetes): add tests demonstrating problems with service selector validation

  When getting started with Spinnaker-managed rollout strategies, a poorly validated failure mode is one in which the Service you are attaching to your workload has either 1) no label selectors, or 2) label selectors that overlap with the workload's label selectors. In case 1, the pipeline will fail with a confusing NPE. In case 2, the pipeline will succeed, but any subsequent "disable" operations will fail because removing those labels will leave the ReplicaSet in an invalid state (because its selector will not match its template labels). This commit adds tests to document this behavior, which will be fixed in the next commit.

- fix(kubernetes): throw more helpful errors for invalid services

  Adds more helpful error messages for the two cases described above, and updates tests accordingly.

