### PR TITLE
refactor(kubernetes): A few assorted code cleanup commits

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
@@ -22,6 +22,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.jayway.jsonpath.Configuration;
@@ -40,7 +41,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 
 @ParametersAreNonnullByDefault
 @Slf4j
@@ -66,7 +66,7 @@ public class ArtifactReplacer {
         .filter(
             a -> {
               String type = a.getType();
-              if (StringUtils.isEmpty(type)) {
+              if (Strings.isNullOrEmpty(type)) {
                 log.warn("Artifact {} without a type, ignoring", a);
                 return false;
               }
@@ -77,8 +77,8 @@ public class ArtifactReplacer {
 
               boolean locationMatches;
               String location = a.getLocation();
-              if (StringUtils.isEmpty(location)) {
-                locationMatches = StringUtils.isEmpty(namespace);
+              if (Strings.isNullOrEmpty(location)) {
+                locationMatches = Strings.isNullOrEmpty(namespace);
               } else {
                 locationMatches = location.equals(namespace);
               }
@@ -88,7 +88,7 @@ public class ArtifactReplacer {
               // If the artifact fails to provide an account, we'll assume this was unintentional
               // and match anyways
               accountMatches =
-                  StringUtils.isEmpty(artifactAccount) || artifactAccount.equals(account);
+                  Strings.isNullOrEmpty(artifactAccount) || artifactAccount.equals(account);
 
               return accountMatches && locationMatches;
             })

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/ArtifactReplacer.java
@@ -34,7 +34,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -155,7 +154,7 @@ public class ArtifactReplacer {
                     input.getFullResourceName(),
                     r,
                     e);
-                return Collections.<Artifact>emptyList();
+                return ImmutableList.<Artifact>of();
               }
             })
         .flatMap(Collection::stream)

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/Replacer.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/Replacer.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
 import com.jayway.jsonpath.DocumentContext;
@@ -37,7 +38,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 
 @Builder(access = AccessLevel.PRIVATE)
 @ParametersAreNonnullByDefault
@@ -104,7 +104,7 @@ public class Replacer {
   }
 
   private boolean replaceIfPossible(DocumentContext obj, @Nullable Artifact artifact) {
-    if (artifact == null || StringUtils.isEmpty(artifact.getType())) {
+    if (artifact == null || Strings.isNullOrEmpty(artifact.getType())) {
       throw new IllegalArgumentException("Artifact and artifact type must be set.");
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/CustomKubernetesCachingAgentFactory.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/CustomKubernetesCachingAgentFactory.java
@@ -20,15 +20,13 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 
 public class CustomKubernetesCachingAgentFactory {
   public static KubernetesV2OnDemandCachingAgent create(
@@ -65,14 +63,13 @@ public class CustomKubernetesCachingAgentFactory {
     }
 
     @Override
-    protected List<KubernetesKind> primaryKinds() {
-      return Collections.singletonList(this.kind);
+    protected ImmutableList<KubernetesKind> primaryKinds() {
+      return ImmutableList.of(this.kind);
     }
 
     @Override
-    public final Collection<AgentDataType> getProvidedDataTypes() {
-      return Collections.unmodifiableSet(
-          new HashSet<>(Collections.singletonList(AUTHORITATIVE.forType(this.kind.toString()))));
+    public final ImmutableSet<AgentDataType> getProvidedDataTypes() {
+      return ImmutableSet.of(AUTHORITATIVE.forType(this.kind.toString()));
     }
 
     @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.CacheKey;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.ClusterCacheKey;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesCachingProperties;
@@ -49,7 +51,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 public class KubernetesCacheDataConverter {
@@ -268,8 +269,8 @@ public class KubernetesCacheDataConverter {
     kubernetesCacheData.addRelationship(infrastructureKey, applicationKey);
 
     String cluster = moniker.getCluster();
-    if (StringUtils.isNotEmpty(cluster)) {
-      Keys.CacheKey clusterKey = new Keys.ClusterCacheKey(account, application, cluster);
+    if (!Strings.isNullOrEmpty(cluster)) {
+      CacheKey clusterKey = new ClusterCacheKey(account, application, cluster);
       kubernetesCacheData.addRelationship(infrastructureKey, clusterKey);
       kubernetesCacheData.addRelationship(applicationKey, clusterKey);
     }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -23,6 +23,7 @@ import static java.lang.Math.toIntExact;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.DefaultCacheData;
@@ -165,7 +166,7 @@ public class KubernetesCacheDataConverter {
       return;
     }
 
-    if (onlySpinnakerManaged && StringUtils.isEmpty(cachingProperties.getApplication())) {
+    if (onlySpinnakerManaged && Strings.isNullOrEmpty(cachingProperties.getApplication())) {
       return;
     }
 
@@ -202,7 +203,7 @@ public class KubernetesCacheDataConverter {
     kubernetesCacheData.addItem(key, attributes);
 
     String application = moniker.getApp();
-    if (StringUtils.isEmpty(application)) {
+    if (Strings.isNullOrEmpty(application)) {
       log.debug(
           "Encountered not-spinnaker-owned resource "
               + namespace
@@ -320,11 +321,11 @@ public class KubernetesCacheDataConverter {
       log.warn("{}: manifest kind may not be null, {}", contextMessage.get(), manifest);
     }
 
-    if (StringUtils.isEmpty(manifest.getName())) {
+    if (Strings.isNullOrEmpty(manifest.getName())) {
       log.warn("{}: manifest name may not be null, {}", contextMessage.get(), manifest);
     }
 
-    if (StringUtils.isEmpty(manifest.getNamespace()) && kindProperties.isNamespaced()) {
+    if (Strings.isNullOrEmpty(manifest.getNamespace()) && kindProperties.isNamespaced()) {
       log.warn("{}: manifest namespace may not be null, {}", contextMessage.get(), manifest);
     }
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -20,6 +20,8 @@ import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITA
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.Kind.KUBERNETES_METRIC;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.cats.agent.AgentIntervalAware;
@@ -62,14 +64,14 @@ public class KubernetesMetricCachingAgent extends KubernetesV2CachingAgent
   }
 
   @Override
-  protected List<KubernetesKind> primaryKinds() {
-    return Collections.emptyList();
+  protected ImmutableList<KubernetesKind> primaryKinds() {
+    return ImmutableList.of();
   }
 
   @Override
   public CacheResult loadData(ProviderCache providerCache) {
     if (!credentials.isMetricsEnabled()) {
-      return new DefaultCacheResult(Collections.emptyMap());
+      return new DefaultCacheResult(ImmutableMap.of());
     }
 
     log.info(getAgentType() + ": agent is starting");

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesMetricCachingAgent.java
@@ -35,7 +35,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPod
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -49,9 +48,8 @@ public class KubernetesMetricCachingAgent extends KubernetesV2CachingAgent
   @Getter protected String providerName = KubernetesCloudProvider.ID;
 
   @Getter
-  protected Collection<AgentDataType> providedDataTypes =
-      Collections.unmodifiableCollection(
-          Collections.singletonList(AUTHORITATIVE.forType(KUBERNETES_METRIC.toString())));
+  protected ImmutableList<AgentDataType> providedDataTypes =
+      ImmutableList.of(AUTHORITATIVE.forType(KUBERNETES_METRIC.toString()));
 
   protected KubernetesMetricCachingAgent(
       KubernetesNamedAccountCredentials<KubernetesV2Credentials> namedAccountCredentials,

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -17,18 +17,17 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -44,11 +43,10 @@ public class KubernetesUnregisteredCustomResourceCachingAgent
     super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount, agentInterval);
   }
 
-  public Collection<AgentDataType> getProvidedDataTypes() {
-    return Collections.unmodifiableSet(
-        primaryKinds().stream()
-            .map(k -> AUTHORITATIVE.forType(k.toString()))
-            .collect(Collectors.toSet()));
+  public ImmutableSet<AgentDataType> getProvidedDataTypes() {
+    return primaryKinds().stream()
+        .map(k -> AUTHORITATIVE.forType(k.toString()))
+        .collect(toImmutableSet());
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2CachingAgent.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentIntervalAware;
@@ -38,7 +39,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job.KubectlJobExecutor;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,8 +167,7 @@ public abstract class KubernetesV2CachingAgent
   }
 
   protected CacheResult buildCacheResult(KubernetesManifest resource) {
-    return buildCacheResult(
-        Collections.singletonMap(resource.getKind(), Collections.singletonList(resource)));
+    return buildCacheResult(ImmutableMap.of(resource.getKind(), ImmutableList.of(resource)));
   }
 
   protected CacheResult buildCacheResult(Map<KubernetesKind, List<KubernetesManifest>> resources) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -228,8 +228,8 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     CacheResult cacheResult = new DefaultCacheResult(new HashMap<>());
 
     log.info("{}: Evicting on demand '{}'", getAgentType(), key);
-    providerCache.evictDeletedItems(ON_DEMAND_TYPE, Collections.singletonList(key));
-    evictions.put(kind.toString(), Collections.singletonList(key));
+    providerCache.evictDeletedItems(ON_DEMAND_TYPE, ImmutableList.of(key));
+    evictions.put(kind.toString(), ImmutableList.of(key));
 
     return new OnDemandAgent.OnDemandResult(getOnDemandAgentType(), cacheResult, evictions);
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.CacheResult;
@@ -338,7 +339,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
   @Override
   public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
     if (!handleReadRequests()) {
-      return Collections.emptyList();
+      return ImmutableList.of();
     }
 
     List<KubernetesKind> primaryKinds = primaryKinds();

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -45,7 +45,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 @Slf4j
@@ -295,7 +294,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
       return null;
     }
 
-    if (StringUtils.isNotEmpty(namespace) && !credentials.getKindProperties(kind).isNamespaced()) {
+    if (!Strings.isNullOrEmpty(namespace) && !credentials.getKindProperties(kind).isNamespaced()) {
       log.warn(
           "{}: Kind {} is not namespace but namespace {} was provided, ignoring",
           getAgentType(),

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -22,6 +22,7 @@ import static com.netflix.spinnaker.clouddriver.cache.OnDemandAgent.OnDemandType
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.CacheResult;
@@ -268,7 +269,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
     String name;
     KubernetesKind kind;
 
-    if (StringUtils.isEmpty(account) || !getAccountName().equals(account)) {
+    if (Strings.isNullOrEmpty(account) || !getAccountName().equals(account)) {
       return null;
     }
 
@@ -285,7 +286,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
       }
 
       name = parsedName.getRight();
-      if (StringUtils.isEmpty(name)) {
+      if (Strings.isNullOrEmpty(name)) {
         return null;
       }
     } catch (Exception e) {
@@ -393,7 +394,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
   }
 
   private boolean handleNamespace(String namespace) {
-    if (StringUtils.isEmpty(namespace)) {
+    if (Strings.isNullOrEmpty(namespace)) {
       return handleClusterScopedResources();
     }
     return getNamespaces().contains(namespace);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
@@ -122,7 +122,7 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
 
   private static Set<Rule> inboundRules(V1NetworkPolicy policy) {
     if (policy.getSpec().getIngress() == null) {
-      return Collections.emptySet();
+      return ImmutableSet.of();
     }
     return policy.getSpec().getIngress().stream()
         .map(V1NetworkPolicyIngressRule::getPorts)
@@ -134,7 +134,7 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
 
   private static Set<Rule> outboundRules(V1NetworkPolicy policy) {
     if (policy.getSpec().getEgress() == null) {
-      return Collections.emptySet();
+      return ImmutableSet.of();
     }
     return policy.getSpec().getEgress().stream()
         .map(V1NetworkPolicyEgressRule::getPorts)

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2SecurityGroup.java
@@ -21,6 +21,7 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manife
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.NETWORKING_K8S_IO_V1;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion.NETWORKING_K8S_IO_V1BETA1;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
@@ -37,7 +38,6 @@ import io.kubernetes.client.openapi.models.V1NetworkPolicyEgressRule;
 import io.kubernetes.client.openapi.models.V1NetworkPolicyIngressRule;
 import io.kubernetes.client.openapi.models.V1NetworkPolicyPort;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -151,7 +151,7 @@ public class KubernetesV2SecurityGroup extends ManifestBasedModel implements Sec
         .setPortRanges(
             port == null
                 ? null
-                : new TreeSet<>(Collections.singletonList(new StringPortRange(port.toString()))));
+                : new TreeSet<>(ImmutableList.of(new StringPortRange(port.toString()))));
   }
 
   @Data

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/KubernetesV2ServerGroup.java
@@ -17,8 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model;
 
-import static java.util.Collections.singletonList;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -254,7 +252,7 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
     Map<String, Object> buildInfo = getBuildInfo();
     Set<String> images = (HashSet<String>) buildInfo.get("images");
     return () ->
-        singletonList(
+        ImmutableList.of(
             new ImageSummary() {
 
               @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/ManifestBasedModel.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/model/ManifestBasedModel.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
@@ -28,7 +29,6 @@ import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 
 @Slf4j
 public abstract class ManifestBasedModel {
@@ -87,7 +87,7 @@ public abstract class ManifestBasedModel {
         (Map<String, String>) getManifest().getOrDefault("metadata", new HashMap<>());
     String timestamp = metadata.get("creationTimestamp");
     try {
-      if (StringUtils.isNotEmpty(timestamp)) {
+      if (!Strings.isNullOrEmpty(timestamp)) {
         return (new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse(timestamp)).getTime();
       }
     } catch (ParseException e) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesCacheUtils.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesCacheUtils.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 
+import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.cats.cache.Cache;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.cache.RelationshipCacheFilter;
@@ -32,7 +33,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHand
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.ModelHandler;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,7 +119,7 @@ public class KubernetesCacheUtils {
 
   public Collection<CacheData> loadRelationshipsFromCache(
       CacheData source, String relationshipType) {
-    return loadRelationshipsFromCache(Collections.singleton(source), relationshipType);
+    return loadRelationshipsFromCache(ImmutableSet.of(source), relationshipType);
   }
 
   public Collection<CacheData> loadRelationshipsFromCache(

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ClusterProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ClusterProvider.java
@@ -24,6 +24,7 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.description.Spinnaker
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.LogicalKind.APPLICATIONS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.LogicalKind.CLUSTERS;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
@@ -38,7 +39,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -76,9 +76,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
     return groupByAccountName(
         translateClusters(
             cacheUtils.getTransitiveRelationship(
-                APPLICATIONS.toString(),
-                Collections.singletonList(applicationKey),
-                CLUSTERS.toString())));
+                APPLICATIONS.toString(), ImmutableList.of(applicationKey), CLUSTERS.toString())));
   }
 
   @Override
@@ -109,7 +107,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
             CLUSTERS.toString(), Keys.ClusterCacheKey.createKey(account, application, name))
         .map(
             entry -> {
-              Collection<CacheData> clusterData = Collections.singletonList(entry);
+              Collection<CacheData> clusterData = ImmutableList.of(entry);
               Set<KubernetesV2Cluster> result =
                   includeDetails
                       ? translateClustersWithRelationships(clusterData)
@@ -154,7 +152,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
                       .map(
                           k ->
                               cacheUtils.loadRelationshipsFromCache(
-                                  Collections.singletonList(cd), k.toString()))
+                                  ImmutableList.of(cd), k.toString()))
                       .flatMap(Collection::stream)
                       .collect(Collectors.toList());
 
@@ -163,7 +161,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
                       .map(
                           k ->
                               cacheUtils.loadRelationshipsFromCache(
-                                  Collections.singletonList(cd), k.toString()))
+                                  ImmutableList.of(cd), k.toString()))
                       .flatMap(Collection::stream)
                       .collect(Collectors.toList());
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
@@ -32,7 +32,6 @@ import com.netflix.spinnaker.clouddriver.model.InstanceProvider;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -109,7 +108,7 @@ public class KubernetesV2InstanceProvider
 
     // Short-circuit if pod cannot be found
     if (pod == null) {
-      return Collections.singletonList(
+      return ImmutableList.of(
           new ContainerLog("Error", "Failed to retrieve pod data; pod may have been deleted."));
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2InstanceProvider.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.ContainerLog;
@@ -119,7 +120,7 @@ public class KubernetesV2InstanceProvider
   private List<ContainerLog> getPodLogs(
       @Nonnull KubernetesV2Credentials credentials, @Nonnull V1Pod pod) {
     List<V1Container> initContainers =
-        Optional.ofNullable(pod.getSpec().getInitContainers()).orElse(Collections.emptyList());
+        Optional.ofNullable(pod.getSpec().getInitContainers()).orElse(ImmutableList.of());
     List<V1Container> containers = pod.getSpec().getContainers();
 
     return Stream.concat(initContainers.stream(), containers.stream())

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LiveManifestProvider.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2Manifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesPodMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.ManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -81,9 +81,9 @@ public class KubernetesV2LiveManifestProvider implements ManifestProvider<Kubern
     List<KubernetesManifest> events =
         includeEvents
             ? credentials.eventsFor(kind, namespace, parsedName.getRight())
-            : Collections.emptyList();
+            : ImmutableList.of();
 
-    List<KubernetesPodMetric.ContainerMetric> metrics = Collections.emptyList();
+    List<KubernetesPodMetric.ContainerMetric> metrics = ImmutableList.of();
     if (kind.equals(KubernetesKind.POD) && credentials.isMetricsEnabled()) {
       metrics =
           credentials.topPod(namespace, parsedName.getRight()).stream()
@@ -96,8 +96,8 @@ public class KubernetesV2LiveManifestProvider implements ManifestProvider<Kubern
   }
 
   @Override
-  public List<KubernetesV2Manifest> getClusterAndSortAscending(
+  public ImmutableList<KubernetesV2Manifest> getClusterAndSortAscending(
       String account, String location, String kind, String app, String cluster, Sort sort) {
-    return Collections.emptyList();
+    return ImmutableList.of();
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -22,9 +22,11 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.description.Spinnaker
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind.SERVER_GROUPS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.LogicalKind.APPLICATIONS;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.ApplicationCacheKey;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2LoadBalancer;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
@@ -32,7 +34,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -96,7 +97,7 @@ public class KubernetesV2LoadBalancerProvider
 
     CacheData loadBalancerData = optionalLoadBalancerData.get();
 
-    return new ArrayList<>(fromLoadBalancerCacheData(Collections.singletonList(loadBalancerData)));
+    return new ArrayList<>(fromLoadBalancerCacheData(ImmutableList.of(loadBalancerData)));
   }
 
   @Override
@@ -107,7 +108,7 @@ public class KubernetesV2LoadBalancerProvider
                 kind ->
                     cacheUtils.getTransitiveRelationship(
                         APPLICATIONS.toString(),
-                        Collections.singletonList(Keys.ApplicationCacheKey.createKey(application)),
+                        ImmutableList.of(ApplicationCacheKey.createKey(application)),
                         kind.toString()))
             .flatMap(Collection::stream)
             .collect(Collectors.toList());

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.LogicalKind.CLUSTERS;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
@@ -141,7 +142,7 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
                 .stream()
                 .map(KubernetesCacheDataConverter::getManifest)
                 .collect(Collectors.toList())
-            : Collections.emptyList();
+            : ImmutableList.of();
 
     String metricKey =
         Keys.MetricCacheKey.createKey(
@@ -150,7 +151,7 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
         cacheUtils
             .getSingleEntry(Keys.Kind.KUBERNETES_METRIC.toString(), metricKey)
             .map(KubernetesCacheDataConverter::getMetrics)
-            .orElse(Collections.emptyList());
+            .orElse(ImmutableList.of());
 
     return KubernetesV2ManifestBuilder.buildManifest(credentials, manifest, events, metrics);
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -33,7 +33,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.ManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -136,9 +135,7 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
         includeEvents
             ? cacheUtils
                 .getTransitiveRelationship(
-                    kind.toString(),
-                    Collections.singletonList(key),
-                    KubernetesKind.EVENT.toString())
+                    kind.toString(), ImmutableList.of(key), KubernetesKind.EVENT.toString())
                 .stream()
                 .map(KubernetesCacheDataConverter::getManifest)
                 .collect(Collectors.toList())

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.LogicalKind.CLUSTERS;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
@@ -37,7 +38,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -76,7 +76,7 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
     }
 
     KubernetesKind kind = parsedName.getLeft();
-    if (!credentials.getKindProperties(kind).isNamespaced() && StringUtils.isNotEmpty(location)) {
+    if (!credentials.getKindProperties(kind).isNamespaced() && !Strings.isNullOrEmpty(location)) {
       log.warn(
           "Kind {} is not namespaced, but namespace {} was provided (ignoring)", kind, location);
       location = "";

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2SearchProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2SearchProvider.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
@@ -33,7 +35,6 @@ import com.netflix.spinnaker.clouddriver.search.SearchResultSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -100,7 +101,7 @@ public class KubernetesV2SearchProvider implements SearchProvider {
   @Override
   public SearchResultSet search(
       String query, List<String> types, Integer pageNumber, Integer pageSize) {
-    return search(query, types, pageNumber, pageSize, Collections.emptyMap());
+    return search(query, types, pageNumber, pageSize, ImmutableMap.of());
   }
 
   @Override
@@ -221,7 +222,7 @@ public class KubernetesV2SearchProvider implements SearchProvider {
     typesToSearch.retainAll(allCaches);
 
     if (typesToSearch.isEmpty()) {
-      return Collections.emptyList();
+      return ImmutableList.of();
     }
 
     // Search caches directly

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ServerGroupManagerProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ServerGroupManagerProvider.java
@@ -21,6 +21,7 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.description.Spinnaker
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind.SERVER_GROUP_MANAGERS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys.LogicalKind.APPLICATIONS;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.model.KubernetesV2ServerGroupManager;
@@ -28,7 +29,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.dat
 import com.netflix.spinnaker.clouddriver.model.ServerGroupManagerProvider;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +60,7 @@ public class KubernetesV2ServerGroupManagerProvider
 
     Collection<CacheData> serverGroupManagerData =
         cacheUtils.getAllRelationshipsOfSpinnakerKind(
-            Collections.singletonList(applicationDatum), SERVER_GROUP_MANAGERS);
+            ImmutableList.of(applicationDatum), SERVER_GROUP_MANAGERS);
     Collection<CacheData> serverGroupData =
         cacheUtils.getAllRelationshipsOfSpinnakerKind(serverGroupManagerData, SERVER_GROUPS);
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/converter/manifest/KubernetesDeployManifestConverter.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/converter/manifest/KubernetesDeployManifestConverter.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.converter.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.DEPLOY_MANIFEST;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.view.provider.KubernetesV2ArtifactProvider;
@@ -35,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -96,7 +96,7 @@ public class KubernetesDeployManifestConverter extends AbstractAtomicOperationsC
             .flatMap(
                 singleManifest -> {
                   if (singleManifest == null
-                      || StringUtils.isEmpty(singleManifest.getKindName())
+                      || Strings.isNullOrEmpty(singleManifest.getKindName())
                       || !singleManifest.getKindName().equalsIgnoreCase(KIND_VALUE_LIST)) {
                     return Stream.of(singleManifest);
                   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.CustomKubernetesResource;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
@@ -26,7 +27,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.CustomKubernet
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 
 @Getter
 @Slf4j
@@ -43,7 +43,7 @@ public class KubernetesResourceProperties {
       CustomKubernetesResource customResource) {
     String deployPriority = customResource.getDeployPriority();
     int deployPriorityValue;
-    if (StringUtils.isEmpty(deployPriority)) {
+    if (Strings.isNullOrEmpty(deployPriority)) {
       deployPriorityValue = WORKLOAD_CONTROLLER_PRIORITY.getValue();
     } else {
       try {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifest.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.Data;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -130,7 +129,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   public String getNamespace() {
     String namespace = (String) getMetadata().get("namespace");
-    return StringUtils.isEmpty(namespace) ? "" : namespace;
+    return Strings.isNullOrEmpty(namespace) ? "" : namespace;
   }
 
   @JsonIgnore

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestAnnotater.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.netflix.frigga.Names;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.moniker.Moniker;
@@ -29,7 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 public class KubernetesManifestAnnotater {
@@ -98,7 +98,7 @@ public class KubernetesManifestAnnotater {
   // This is to read values that were annotated with the ObjectMapper with quotes, before we started
   // ignoring the quotes
   private static boolean looksLikeSerializedString(String value) {
-    if (StringUtils.isEmpty(value) || value.length() == 1) {
+    if (Strings.isNullOrEmpty(value) || value.length() == 1) {
       return false;
     }
 
@@ -179,7 +179,7 @@ public class KubernetesManifestAnnotater {
   public static Optional<Artifact> getArtifact(KubernetesManifest manifest) {
     Map<String, String> annotations = manifest.getAnnotations();
     String type = getAnnotation(annotations, TYPE, new TypeReference<String>() {});
-    if (StringUtils.isEmpty(type)) {
+    if (Strings.isNullOrEmpty(type)) {
       return Optional.empty();
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestLabeler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesManifestLabeler.java
@@ -18,11 +18,11 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 public class KubernetesManifestLabeler {
@@ -82,7 +82,7 @@ public class KubernetesManifestLabeler {
 
     String appManagedByValue = "spinnaker";
 
-    if (StringUtils.isNotEmpty(managedBySuffix)) {
+    if (!Strings.isNullOrEmpty(managedBySuffix)) {
       appManagedByValue = appManagedByValue + "-" + managedBySuffix;
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesMultiManifestOperationDescription.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesMultiManifestOperationDescription.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
@@ -27,7 +28,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 @EqualsAndHashCode(callSuper = true)
@@ -41,7 +41,7 @@ public class KubernetesMultiManifestOperationDescription
 
   @JsonIgnore
   public boolean isDynamic() {
-    return StringUtils.isEmpty(manifestName);
+    return Strings.isNullOrEmpty(manifestName);
   }
 
   public List<KubernetesCoordinates> getAllCoordinates() {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/KubernetesV2JobStatus.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/KubernetesV2JobStatus.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesModelUtil;
 import com.netflix.spinnaker.clouddriver.model.JobState;
 import com.netflix.spinnaker.clouddriver.model.JobStatus;
@@ -78,7 +79,7 @@ public class KubernetesV2JobStatus implements JobStatus, Serializable {
 
     if (succeeded < completions) {
       List<V1JobCondition> conditions = status.getConditions();
-      conditions = conditions != null ? conditions : Collections.emptyList();
+      conditions = conditions != null ? conditions : ImmutableList.of();
       Optional<V1JobCondition> condition = conditions.stream().filter(this::jobFailed).findFirst();
       return condition.isPresent() ? JobState.Failed : JobState.Running;
     }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.artifact;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
@@ -39,7 +40,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 
 @Slf4j
 public class KubernetesCleanupArtifactsOperation implements AtomicOperation<OperationResult> {
@@ -85,7 +85,7 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
           getTask().updateStatus(OP_NAME, "Deleting artifact '" + a + '"');
           KubernetesHandler handler = properties.getHandler();
           String name = a.getName();
-          if (StringUtils.isNotEmpty(a.getVersion())) {
+          if (!Strings.isNullOrEmpty(a.getVersion())) {
             name = String.join("-", name, a.getVersion());
           }
           result.merge(

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDelete.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/CanDelete.java
@@ -17,13 +17,13 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
+import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelectorList;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import io.kubernetes.client.openapi.models.V1DeleteOptions;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
@@ -47,8 +47,7 @@ public interface CanDelete {
             .map(n -> KubernetesManifest.getFullResourceName(kind(), n))
             .collect(Collectors.toSet());
 
-    result.setManifestNamesByNamespace(
-        new HashMap<>(Collections.singletonMap(namespace, fullNames)));
+    result.setManifestNamesByNamespace(new HashMap<>(ImmutableMap.of(namespace, fullNames)));
     return result;
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.EVENT;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCoreCachingAgent;
@@ -32,7 +33,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
 import io.kubernetes.client.openapi.models.V1Event;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,8 +89,7 @@ public class KubernetesEventHandler extends KubernetesHandler {
                             KubernetesCacheDataConverter.getResource(m, V1Event.class))))
             .filter(p -> p.getRight() != null)
             .collect(
-                Collectors.toMap(
-                    ImmutablePair::getLeft, p -> Collections.singletonList(p.getRight()))));
+                Collectors.toMap(ImmutablePair::getLeft, p -> ImmutableList.of(p.getRight()))));
   }
 
   private KubernetesManifest involvedManifest(V1Event event) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesEventHandler.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.EVENT;
 
+import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCoreCachingAgent;
@@ -37,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
 
@@ -101,9 +101,9 @@ public class KubernetesEventHandler extends KubernetesHandler {
     V1ObjectReference ref = event.getInvolvedObject();
 
     if (ref == null
-        || StringUtils.isEmpty(ref.getApiVersion())
-        || StringUtils.isEmpty(ref.getKind())
-        || StringUtils.isEmpty(ref.getName())) {
+        || Strings.isNullOrEmpty(ref.getApiVersion())
+        || Strings.isNullOrEmpty(ref.getKind())
+        || Strings.isNullOrEmpty(ref.getName())) {
       return null;
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
@@ -32,7 +32,6 @@ import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobCondition;
 import io.kubernetes.client.openapi.models.V1JobSpec;
 import io.kubernetes.client.openapi.models.V1JobStatus;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -104,7 +103,7 @@ public class KubernetesJobHandler extends KubernetesHandler implements ServerGro
 
     if (succeeded < completions) {
       List<V1JobCondition> conditions = status.getConditions();
-      conditions = conditions != null ? conditions : Collections.emptyList();
+      conditions = conditions != null ? conditions : ImmutableList.of();
       Optional<V1JobCondition> condition = conditions.stream().filter(this::jobFailed).findAny();
       if (condition.isPresent()) {
         return Status.defaultStatus().failed(condition.get().getMessage());

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesSecretHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesSecretHandler.java
@@ -19,13 +19,13 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler;
 
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.MOUNTABLE_DATA_PRIORITY;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesCoreCachingAgent;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentFactory;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest.Status;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.springframework.stereotype.Component;
@@ -45,7 +45,7 @@ public class KubernetesSecretHandler extends KubernetesHandler {
 
   @Override
   public List<String> sensitiveKeys() {
-    return Collections.singletonList("data");
+    return ImmutableList.of("data");
   }
 
   @Override

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -21,6 +21,7 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manife
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind.STATEFUL_SET;
 import static com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler.DeployPriority.WORKLOAD_CONTROLLER_PRIORITY;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.artifact.Replacer;
@@ -44,7 +45,6 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -199,7 +199,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
 
     for (KubernetesManifest manifest : allResources.getOrDefault(STATEFUL_SET, new ArrayList<>())) {
       String serviceName = KubernetesStatefulSetHandler.serviceName(manifest);
-      if (StringUtils.isEmpty(serviceName)) {
+      if (Strings.isNullOrEmpty(serviceName)) {
         continue;
       }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesStatefulSetHandler.java
@@ -37,7 +37,6 @@ import io.kubernetes.client.openapi.models.V1beta2RollingUpdateStatefulSetStrate
 import io.kubernetes.client.openapi.models.V1beta2StatefulSet;
 import io.kubernetes.client.openapi.models.V1beta2StatefulSetStatus;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -210,7 +209,7 @@ public class KubernetesStatefulSetHandler extends KubernetesHandler
       }
 
       KubernetesManifest service = services.get(key);
-      relationshipMap.put(manifest, Collections.singletonList(service));
+      relationshipMap.put(manifest, ImmutableList.of(service));
     }
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.job;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.gson.Gson;
@@ -83,7 +84,7 @@ public class KubectlJobExecutor {
 
   public String defaultNamespace(KubernetesV2Credentials credentials) {
     String configCurrentContext = configCurrentContext(credentials);
-    if (StringUtils.isEmpty(configCurrentContext)) {
+    if (Strings.isNullOrEmpty(configCurrentContext)) {
       return "";
     }
 
@@ -185,7 +186,7 @@ public class KubectlJobExecutor {
           "Failed to delete " + id + " from " + namespace + ": " + status.getError());
     }
 
-    if (StringUtils.isEmpty(status.getOutput())
+    if (Strings.isNullOrEmpty(status.getOutput())
         || status.getOutput().equals("No output from command.")
         || status.getOutput().startsWith("No resources found")) {
       return new ArrayList<>();
@@ -242,7 +243,7 @@ public class KubectlJobExecutor {
     }
 
     String stdout = status.getOutput();
-    if (StringUtils.isEmpty(stdout)) {
+    if (Strings.isNullOrEmpty(stdout)) {
       return new ArrayList<>();
     }
 
@@ -717,7 +718,7 @@ public class KubectlJobExecutor {
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       String errMsg = status.getError();
-      if (StringUtils.isEmpty(errMsg)) {
+      if (Strings.isNullOrEmpty(errMsg)) {
         errMsg = status.getOutput();
       }
       if (errMsg.contains("not patched")) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -168,7 +168,7 @@ public class KubectlJobExecutor {
       command.add("--grace-period=" + deleteOptions.getGracePeriodSeconds());
     }
 
-    if (StringUtils.isNotEmpty(deleteOptions.getPropagationPolicy())) {
+    if (!Strings.isNullOrEmpty(deleteOptions.getPropagationPolicy())) {
       throw new IllegalArgumentException(
           "Propagation policy is not yet supported as a delete option");
     }
@@ -177,7 +177,7 @@ public class KubectlJobExecutor {
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       String id;
-      if (StringUtils.isNotEmpty(name)) {
+      if (!Strings.isNullOrEmpty(name)) {
         id = kind + "/" + name;
       } else {
         id = labelSelectors.toString();
@@ -540,7 +540,7 @@ public class KubectlJobExecutor {
 
   private List<String> kubectlAuthPrefix(KubernetesV2Credentials credentials) {
     List<String> command = new ArrayList<>();
-    if (StringUtils.isNotEmpty(credentials.getKubectlExecutable())) {
+    if (!Strings.isNullOrEmpty(credentials.getKubectlExecutable())) {
       command.add(credentials.getKubectlExecutable());
     } else {
       command.add(executable);
@@ -562,12 +562,12 @@ public class KubectlJobExecutor {
       }
 
       String kubeconfigFile = credentials.getKubeconfigFile();
-      if (StringUtils.isNotEmpty(kubeconfigFile)) {
+      if (!Strings.isNullOrEmpty(kubeconfigFile)) {
         command.add("--kubeconfig=" + kubeconfigFile);
       }
 
       String context = credentials.getContext();
-      if (StringUtils.isNotEmpty(context)) {
+      if (!Strings.isNullOrEmpty(context)) {
         command.add("--context=" + context);
       }
     }
@@ -580,7 +580,7 @@ public class KubectlJobExecutor {
       KubernetesKind kind,
       String name,
       KubernetesSelectorList labelSelectors) {
-    if (StringUtils.isNotEmpty(name)) {
+    if (!Strings.isNullOrEmpty(name)) {
       command.add(kind + "/" + name);
     } else {
       command.add(kind.toString());
@@ -597,7 +597,7 @@ public class KubectlJobExecutor {
       KubernetesV2Credentials credentials, String namespace) {
     List<String> command = kubectlAuthPrefix(credentials);
 
-    if (StringUtils.isNotEmpty(namespace)) {
+    if (!Strings.isNullOrEmpty(namespace)) {
       command.add("--namespace=" + namespace);
     }
 
@@ -706,7 +706,7 @@ public class KubectlJobExecutor {
     }
 
     String mergeStrategy = options.getMergeStrategy().toString();
-    if (StringUtils.isNotEmpty(mergeStrategy)) {
+    if (!Strings.isNullOrEmpty(mergeStrategy)) {
       command.add("--type");
       command.add(mergeStrategy);
     }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -376,8 +376,7 @@ public class KubectlJobExecutor {
 
   public KubernetesManifest get(
       KubernetesV2Credentials credentials, KubernetesKind kind, String namespace, String name) {
-    List<String> command =
-        kubectlNamespacedGet(credentials, Collections.singletonList(kind), namespace);
+    List<String> command = kubectlNamespacedGet(credentials, ImmutableList.of(kind), namespace);
     command.add(name);
 
     JobResult<String> status = jobExecutor.runJob(new JobRequest(command));
@@ -402,8 +401,7 @@ public class KubectlJobExecutor {
   public ImmutableList<KubernetesManifest> eventsFor(
       KubernetesV2Credentials credentials, KubernetesKind kind, String namespace, String name) {
     List<String> command =
-        kubectlNamespacedGet(
-            credentials, Collections.singletonList(KubernetesKind.EVENT), namespace);
+        kubectlNamespacedGet(credentials, ImmutableList.of(KubernetesKind.EVENT), namespace);
     command.add("--field-selector");
     command.add(
         String.format(

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/job/KubectlJobExecutor.java
@@ -68,41 +68,6 @@ public class KubectlJobExecutor {
     this.oAuthExecutable = oAuthExecutable;
   }
 
-  private String configCurrentContext(KubernetesV2Credentials credentials) {
-    List<String> command = kubectlAuthPrefix(credentials);
-    command.add("config");
-    command.add("current-context");
-
-    JobResult<String> status = jobExecutor.runJob(new JobRequest(command));
-
-    if (status.getResult() != JobResult.Result.SUCCESS) {
-      throw new KubectlException("Failed get current configuration context");
-    }
-
-    return status.getOutput();
-  }
-
-  public String defaultNamespace(KubernetesV2Credentials credentials) {
-    String configCurrentContext = configCurrentContext(credentials);
-    if (Strings.isNullOrEmpty(configCurrentContext)) {
-      return "";
-    }
-
-    List<String> command = kubectlAuthPrefix(credentials);
-    command.add("config");
-    command.add("view");
-    command.add("-o");
-    String jsonPath = "{.contexts[?(@.name==\"" + configCurrentContext + "\")].context.namespace}";
-    command.add("\"jsonpath=" + jsonPath + "\"");
-
-    JobResult<String> status = jobExecutor.runJob(new JobRequest(command));
-
-    if (status.getResult() != JobResult.Result.SUCCESS) {
-      throw new KubectlException("Failed get current configuration context");
-    }
-    return status.getOutput();
-  }
-
   public String logs(
       KubernetesV2Credentials credentials, String namespace, String podName, String containerName) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.CanDelete;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
-import java.util.Collections;
 import java.util.List;
 
 public class KubernetesDeleteManifestOperation implements AtomicOperation<OperationResult> {
@@ -52,7 +52,7 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
     if (description.isDynamic()) {
       coordinates = description.getAllCoordinates();
     } else {
-      coordinates = Collections.singletonList(description.getPointCoordinates());
+      coordinates = ImmutableList.of(description.getPointCoordinates());
     }
 
     OperationResult result = new OperationResult();

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -42,7 +42,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 @Slf4j
@@ -171,7 +170,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
       Artifact artifact = converter.toArtifact(provider, manifest, description.getAccount());
 
       String version = artifact.getVersion();
-      if (StringUtils.isNotEmpty(version) && version.startsWith("v")) {
+      if (Strings.nullToEmpty(version).startsWith("v")) {
         try {
           moniker.setSequence(Integer.valueOf(version.substring(1)));
         } catch (NumberFormatException e) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
@@ -78,7 +79,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     List<KubernetesManifest> deployManifests = new ArrayList<>();
     if (inputManifests == null || inputManifests.isEmpty()) {
       log.warn("Relying on deprecated single manifest input: " + description.getManifest());
-      inputManifests = Collections.singletonList(description.getManifest());
+      inputManifests = ImmutableList.of(description.getManifest());
     }
 
     inputManifests = inputManifests.stream().filter(Objects::nonNull).collect(Collectors.toList());

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeployManifestOperation.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.op.manifest;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
@@ -101,7 +102,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
 
     for (KubernetesManifest manifest : inputManifests) {
       if (credentials.getKindProperties(manifest.getKind()).isNamespaced()
-          && !StringUtils.isEmpty(description.getNamespaceOverride())) {
+          && !Strings.isNullOrEmpty(description.getNamespaceOverride())) {
         manifest.setNamespace(description.getNamespaceOverride());
       }
 
@@ -163,7 +164,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
       KubernetesHandler deployer = properties.getHandler();
 
       Moniker moniker = cloneMoniker(description.getMoniker());
-      if (StringUtils.isEmpty(moniker.getCluster())) {
+      if (Strings.isNullOrEmpty(moniker.getCluster())) {
         moniker.setCluster(manifest.getFullResourceName());
       }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesSelector.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesSelector.java
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.security;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.Data;
-import org.apache.commons.lang3.StringUtils;
 
 @Data
 public class KubernetesSelector {
@@ -46,7 +46,7 @@ public class KubernetesSelector {
       @JsonProperty("kind") @Nonnull Kind kind,
       @JsonProperty("key") String key,
       @JsonProperty("values") List<String> values) {
-    if (StringUtils.isEmpty(key) && kind != Kind.ANY) {
+    if (Strings.isNullOrEmpty(key) && kind != Kind.ANY) {
       throw new IllegalArgumentException("Only an 'any' selector can have no key specified");
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesSelector.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesSelector.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
 import java.util.List;
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
@@ -43,7 +43,7 @@ public class KubernetesSelector {
 
   @JsonCreator
   public KubernetesSelector(
-      @JsonProperty("kind") @NotNull Kind kind,
+      @JsonProperty("kind") @Nonnull Kind kind,
       @JsonProperty("key") String key,
       @JsonProperty("values") List<String> values) {
     if (StringUtils.isEmpty(key) && kind != Kind.ANY) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesSelector.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesSelector.java
@@ -20,7 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.security;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
-import java.util.Collections;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.Data;
@@ -82,11 +82,11 @@ public class KubernetesSelector {
   }
 
   public static KubernetesSelector equals(String key, String value) {
-    return new KubernetesSelector(Kind.EQUALS, key, Collections.singletonList(value));
+    return new KubernetesSelector(Kind.EQUALS, key, ImmutableList.of(value));
   }
 
   public static KubernetesSelector notEquals(String key, String value) {
-    return new KubernetesSelector(Kind.NOT_EQUALS, key, Collections.singletonList(value));
+    return new KubernetesSelector(Kind.NOT_EQUALS, key, ImmutableList.of(value));
   }
 
   public static KubernetesSelector contains(String key, List<String> values) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesSelectorList.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesSelectorList.java
@@ -17,9 +17,10 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.security;
 
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesSelector.Kind;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -68,9 +69,7 @@ public class KubernetesSelectorList {
             .map(
                 kv ->
                     new KubernetesSelector(
-                        KubernetesSelector.Kind.EQUALS,
-                        kv.getKey(),
-                        Collections.singletonList(kv.getValue())))
+                        Kind.EQUALS, kv.getKey(), ImmutableList.of(kv.getValue())))
             .collect(Collectors.toList()));
   }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -322,11 +322,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   private ImmutableList<String> namespaceSupplier() {
     try {
       return jobExecutor
-          .list(
-              this,
-              Collections.singletonList(KubernetesKind.NAMESPACE),
-              "",
-              new KubernetesSelectorList())
+          .list(this, ImmutableList.of(KubernetesKind.NAMESPACE), "", new KubernetesSelectorList())
           .stream()
           .map(KubernetesManifest::getName)
           .collect(toImmutableList());
@@ -386,7 +382,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         namespace,
         () ->
             jobExecutor.list(
-                this, Collections.singletonList(kind), namespace, new KubernetesSelectorList()));
+                this, ImmutableList.of(kind), namespace, new KubernetesSelectorList()));
   }
 
   @Nonnull
@@ -396,7 +392,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         "list",
         kind,
         namespace,
-        () -> jobExecutor.list(this, Collections.singletonList(kind), namespace, selectors));
+        () -> jobExecutor.list(this, ImmutableList.of(kind), namespace, selectors));
   }
 
   @Nonnull
@@ -561,7 +557,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
 
   private <T> T runAndRecordMetrics(
       String action, KubernetesKind kind, String namespace, Supplier<T> op) {
-    return runAndRecordMetrics(action, Collections.singletonList(kind), namespace, op);
+    return runAndRecordMetrics(action, ImmutableList.of(kind), namespace, op);
   }
 
   private <T> T runAndRecordMetrics(

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -25,6 +25,7 @@ import static lombok.EqualsAndHashCode.Include;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.base.Strings;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -68,7 +69,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -572,7 +572,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
         "kinds",
         kinds.stream().map(KubernetesKind::toString).sorted().collect(Collectors.joining(",")));
     tags.put("account", accountName);
-    tags.put("namespace", StringUtils.isEmpty(namespace) ? "none" : namespace);
+    tags.put("namespace", Strings.isNullOrEmpty(namespace) ? "none" : namespace);
     tags.put("success", "true");
     long startTime = clock.monotonicTime();
     try {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2Credentials.java
@@ -369,8 +369,8 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
   }
 
   @Override
-  public List<LinkedDockerRegistryConfiguration> getDockerRegistries() {
-    return Collections.emptyList();
+  public ImmutableList<LinkedDockerRegistryConfiguration> getDockerRegistries() {
+    return ImmutableList.of();
   }
 
   public KubernetesManifest get(KubernetesKind kind, String namespace, String name) {

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/KubernetesValidationUtil.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.validator;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest;
@@ -29,7 +30,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.validation.Errors;
 
 @Slf4j
@@ -74,7 +74,7 @@ public class KubernetesValidationUtil {
   }
 
   private boolean validateNotEmpty(String attribute, String value) {
-    if (StringUtils.isEmpty(value)) {
+    if (Strings.isNullOrEmpty(value)) {
       reject("empty", attribute);
       return false;
     }
@@ -99,7 +99,7 @@ public class KubernetesValidationUtil {
       return false;
     }
 
-    if (StringUtils.isEmpty(namespace)) {
+    if (Strings.isNullOrEmpty(namespace)) {
       return true;
     }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/manifest/KubernetesDeleteManifestValidator.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/validator/manifest/KubernetesDeleteManifestValidator.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.v2.validator.manifest;
 
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.DELETE_MANIFEST;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoordinates;
@@ -26,7 +27,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
-import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -47,7 +47,7 @@ public class KubernetesDeleteManifestValidator
     if (description.isDynamic()) {
       coordinates = description.getAllCoordinates();
     } else {
-      coordinates = Collections.singletonList(description.getPointCoordinates());
+      coordinates = ImmutableList.of(description.getPointCoordinates());
     }
 
     for (KubernetesCoordinates coordinate : coordinates) {

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentialsSpec.groovy
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.security
 
+import com.google.common.collect.ImmutableList
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.AccountResourcePropertyRegistry
@@ -34,12 +35,12 @@ import spock.lang.Specification
 import java.nio.file.Files
 
 class KubernetesNamedAccountCredentialsSpec extends Specification {
-  KubernetesSpinnakerKindMap kindMap = new KubernetesSpinnakerKindMap(Collections.emptyList())
+  KubernetesSpinnakerKindMap kindMap = new KubernetesSpinnakerKindMap(ImmutableList.of())
   NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = new ConfigFileService()
   AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
-  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(Collections.emptyList())
+  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(ImmutableList.of())
   KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),
     namerRegistry,

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizableSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.caching
 
+import com.google.common.collect.ImmutableList
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.cats.module.CatsModule
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
@@ -44,7 +45,7 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
   KubernetesV2CachingAgentDispatcher agentDispatcher = Mock(KubernetesV2CachingAgentDispatcher)
   AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
-  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(Collections.emptyList())
+  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(ImmutableList.of())
 
   KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistrySpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/GlobalResourcePropertyRegistrySpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.v2.description
 
+import com.google.common.collect.ImmutableList
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesReplicaSetHandler
@@ -29,7 +30,7 @@ class GlobalResourcePropertyRegistrySpec extends Specification {
     def replicaSetHandler = new KubernetesReplicaSetHandler()
 
     when:
-    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(Collections.emptyList(), defaultHandler)
+    GlobalResourcePropertyRegistry registry = new GlobalResourcePropertyRegistry(ImmutableList.of(), defaultHandler)
 
     then:
     registry instanceof GlobalResourcePropertyRegistry

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/security/KubernetesV2CredentialsSpec.groovy
@@ -43,7 +43,7 @@ class KubernetesV2CredentialsSpec extends Specification {
   )
   NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = new ConfigFileService()
-  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(Collections.emptyList())
+  KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(ImmutableList.of())
 
   KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),


### PR DESCRIPTION
The main goal of this PR is to align `clouddriver-kubernetes-v2` on a single way of doing the following things:
* Checking if a string is `null` or empty
  * Standardize on Guava `Strings.*` and away from `StringUtils`
* Making an empty collection or a collection of a single element
  * Standardize on Guava (ex: `ImmutableList.of`, `ImmutableMap.of`, etc.)
* Annotating things as non-null or nullable
  * Standardize on `javax.annotation.*` (or the `NonNullByDefault` in kork which uses that annotation)

I've been moving things towards these as I touch code, but at this point it's easier to just make a PR to do this everywhere it can be done safely.  A minor benefit is that it will reduce distraction on future PRs.  A major benefit is that other contributors will find it much easier to see how to do something in the kubernetes codebase instead of seeing 2-3 different ways and needing to figure out which one is "right".  This will also increase the chance that new contributions will follow the above patterns, reducing the clean-up later.

* refactor(kubernetes): A few minor improvements to KubernetesKind 

  Use the new NonnullByDefault annotation, and remove a bunch of now redundant Nonnull annotations.

  Also, simplify fromString to use a Guava splitter, which avoids needing to use an array, and can simplify the logic. This is the only part of this PR that isn't a simple rewrite of one function to another, but the modified function here has a number of good tests on it.

* refactor(kubernetes): Standardize on Nonnull 

  There was only a single place using a different annotation; change it.

* refactor(kubernetes): Replace StringUtils.isEmpty with Guava 

  New code has been using isNullOrEmpty for a while; to reduce the overhead for people reading the code let's standardize on the guava version. Guava also has the advantage of encouraging nullToEmpty to eliminate nulls as soon as they arrive and allow later checks to avoid null-safety issues.

* refactor(kubernetes): Replace StringUtils.isNotEmpty with Guava 

  The motivation for this is in the last commit, but to make it easier to read, did the isNotEmpty change in a separate commit.

  In one case it was really easy to instead replace with nullToEmpty, so I did that instead.

* refactor(kubernetes): Replace Collections.empty... with Guava 

  In a lot of places we use Collections.emptyList(), emptyMap(), While it's not in the name of the function, the collection that is returned is actually immutable.

  Now that we've started adding lots of uses of Guava's immutable collections in the Kubernetes provider, it makes sense for these to also use the Guava types. This has a few advantages:
  * It reduces the burden on new contributors to figure out which of the two ways of doing the same thing they should use.
  * The more we have Immutable collections floating around, the more likely people will find that code in examples and use them in their contributions.
  * It's much more clear that the returned type is immutable
  * In some cases, this allows us to also upgrade the return type of the entire function to an immutable collection (when the only return path was the one we just updated)

  This change is safe because, as noted above, the collections were already immutable. (Wheras changing a mutable collection to immutable requires some care that it's not being mutated somewhere downstream.)

* refactor(kubernetes): Replace singleton collections with Guava 

  The rationale is in the last commit; this commit does the same thing the last commit did with empty collections and does it for singleton collections. Again, as these are already immutable, the change is safe and actually makes it easier in some cases for the caller to realize the returned collection is immutable.

* refactor(kubernetes): Remove unused functions 

  I removed the last place these two functions were used last week; I noticed they were still here and unused while making the last commits; just remove them entirely.
