### PR TITLE
refactor(kubernetes): A few other code cleanup changes

### DIFF
--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/Replacer.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/Replacer.java
@@ -82,9 +82,7 @@ public class Replacer {
 
   @Nonnull
   ImmutableCollection<Artifact> getArtifacts(DocumentContext document) {
-    return mapper
-        .<List<String>>convertValue(findAll(document), new TypeReference<List<String>>() {})
-        .stream()
+    return mapper.convertValue(findAll(document), new TypeReference<List<String>>() {}).stream()
         .map(this::artifactFromReference)
         .collect(toImmutableList());
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/KubernetesV2ProviderSynchronizable.java
@@ -130,7 +130,7 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
               return credentials;
             })
         .filter(Objects::nonNull)
-        .forEach(a -> saveToCredentialsRepository(a));
+        .forEach(this::saveToCredentialsRepository);
 
     ProviderUtils.unscheduleAndDeregisterAgents(deletedAccounts, catsModule);
     ProviderUtils.unscheduleAndDeregisterAgents(changedAccounts, catsModule);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/agent/KubernetesCacheDataConverter.java
@@ -318,10 +318,6 @@ public class KubernetesCacheDataConverter {
       return;
     }
 
-    if (manifest.getKind() == null) {
-      log.warn("{}: manifest kind may not be null, {}", contextMessage.get(), manifest);
-    }
-
     if (Strings.isNullOrEmpty(manifest.getName())) {
       log.warn("{}: manifest name may not be null, {}", contextMessage.get(), manifest);
     }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -147,7 +147,7 @@ public class KubernetesV2LoadBalancerProvider
   }
 
   @Data
-  private class Item implements LoadBalancerProvider.Item {
+  private static class Item implements LoadBalancerProvider.Item {
     String name;
     List<ByAccount> byAccounts = new ArrayList<>();
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/caching/view/provider/KubernetesV2ManifestProvider.java
@@ -34,9 +34,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHand
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -115,7 +115,6 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
             c ->
                 cacheUtils.loadRelationshipsFromCache(c, kind).stream()
                     .map(cd -> fromCacheData(cd, credentials, false))
-                    .filter(Objects::nonNull)
                     .filter(m -> m.getLocation().equals(location))
                     .sorted(
                         (m1, m2) ->
@@ -124,6 +123,7 @@ public class KubernetesV2ManifestProvider implements ManifestProvider<Kubernetes
         .orElse(new ArrayList<>());
   }
 
+  @Nonnull
   private KubernetesV2Manifest fromCacheData(
       CacheData data, KubernetesV2Credentials credentials, boolean includeEvents) {
     KubernetesManifest manifest = KubernetesCacheDataConverter.getManifest(data);

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/KubernetesResourceProperties.java
@@ -47,7 +47,7 @@ public class KubernetesResourceProperties {
       deployPriorityValue = WORKLOAD_CONTROLLER_PRIORITY.getValue();
     } else {
       try {
-        deployPriorityValue = Integer.valueOf(deployPriority);
+        deployPriorityValue = Integer.parseInt(deployPriority);
       } catch (NumberFormatException e) {
         deployPriorityValue =
             KubernetesHandler.DeployPriority.fromString(deployPriority).getValue();

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindProperties.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/description/manifest/KubernetesKindProperties.java
@@ -107,6 +107,6 @@ public class KubernetesKindProperties {
 
   public enum ResourceScope {
     CLUSTER,
-    NAMESPACE;
+    NAMESPACE
   }
 }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/model/Manifest.java
@@ -108,7 +108,7 @@ public interface Manifest {
 
   @Data
   @Builder
-  public static class Warning {
+  class Warning {
     private String type;
     private String message;
   }

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/handler/KubernetesJobHandler.java
@@ -105,11 +105,9 @@ public class KubernetesJobHandler extends KubernetesHandler implements ServerGro
       List<V1JobCondition> conditions = status.getConditions();
       conditions = conditions != null ? conditions : ImmutableList.of();
       Optional<V1JobCondition> condition = conditions.stream().filter(this::jobFailed).findAny();
-      if (condition.isPresent()) {
-        return Status.defaultStatus().failed(condition.get().getMessage());
-      } else {
-        return Status.defaultStatus().unstable("Waiting for jobs to finish");
-      }
+      return condition
+          .map(v1JobCondition -> Status.defaultStatus().failed(v1JobCondition.getMessage()))
+          .orElseGet(() -> Status.defaultStatus().unstable("Waiting for jobs to finish"));
     }
 
     return Status.defaultStatus();

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesDeleteManifestOperation.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesCoo
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesDeleteManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.OperationResult;
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.CanDelete;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
@@ -64,7 +63,7 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
               credentials.getResourcePropertyRegistry().get(c.getKind());
           KubernetesHandler deployer = properties.getHandler();
 
-          if (!(deployer instanceof CanDelete)) {
+          if (deployer == null) {
             throw new IllegalArgumentException("Resource with " + c + " does not support delete");
           }
 

--- a/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes-v2/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/v2/op/manifest/KubernetesPatchManifestOperation.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
 public class KubernetesPatchManifestOperation implements AtomicOperation<OperationResult> {
@@ -45,7 +44,7 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
   private final KubernetesV2Credentials credentials;
   private static final String OP_NAME = "PATCH_KUBERNETES_MANIFEST";
 
-  @Autowired private ObjectMapper objectMapper;
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   public KubernetesPatchManifestOperation(KubernetesPatchManifestDescription description) {
     this.description = description;

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesUnversionedArtifactConverterSpec.groovy
@@ -34,7 +34,7 @@ class KubernetesUnversionedArtifactConverterSpec extends Specification {
       .name(name)
       .build()
 
-    def converter = new KubernetesUnversionedArtifactConverter()
+    def converter = KubernetesUnversionedArtifactConverter.INSTANCE
     converter.getDeployedName(artifact) == "$name"
 
     where:

--- a/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
+++ b/clouddriver-kubernetes-v2/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v2/artifact/KubernetesVersionedArtifactConverterSpec.groovy
@@ -38,7 +38,7 @@ class KubernetesVersionedArtifactConverterSpec extends Specification {
       .version(version)
       .build()
 
-    def converter = new KubernetesVersionedArtifactConverter()
+    def converter = KubernetesVersionedArtifactConverter.INSTANCE
     converter.getDeployedName(artifact) == "$name-$version"
 
     where:
@@ -58,7 +58,7 @@ class KubernetesVersionedArtifactConverterSpec extends Specification {
 
     artifactProvider.getArtifacts(type, name, location) >> artifacts
 
-    def converter = new KubernetesVersionedArtifactConverter()
+    def converter = KubernetesVersionedArtifactConverter.INSTANCE
 
     then:
     converter.getVersion(artifactProvider, type, name, location, null) == expected
@@ -98,7 +98,7 @@ class KubernetesVersionedArtifactConverterSpec extends Specification {
 
     artifactProvider.getArtifacts(type, name, location) >> artifacts
 
-    def converter = new KubernetesVersionedArtifactConverter()
+    def converter = KubernetesVersionedArtifactConverter.INSTANCE
 
     then:
     converter.getVersion(artifactProvider, type, name, location, manifest1) == version1


### PR DESCRIPTION
Every now and then I run the IntelliJ inspections and clean up things that are easy. This is a batch of those:
  * Don't use private constructor in tests; use singleton that is
    package-private
  * Replace if present with functional style
  * Removed unchecked warnings from ManifestController by using a
    parametrized ManifestProvider
  * Remove redundant static final from inner class of interface (as
    these are implied)
  * Remove unnecessary semicolon
  * Replace Integer.valueOf with .parseInt, which doesn't box
  * Use lambda in stream
  * Make inner class static as it doesn't reference non-static
    members of outer class
  * Remove null check on non-null variable
  * Remove Autowired field from class that's not a Spring component