### PR TITLE
refactor(core): Clean up some dependencies

### DIFF
--- a/cats/cats-sql/cats-sql.gradle
+++ b/cats/cats-sql/cats-sql.gradle
@@ -43,6 +43,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.1.1"
   implementation("org.jooq:jooq")
   implementation "org.springframework.boot:spring-boot-starter-web"
+  implementation "com.google.guava:guava"
 
   testImplementation project(":cats:cats-test")
 

--- a/clouddriver-alicloud/clouddriver-alicloud.gradle
+++ b/clouddriver-alicloud/clouddriver-alicloud.gradle
@@ -28,6 +28,8 @@ dependencies {
   implementation 'com.aliyun:aliyun-java-sdk-ess:2.3.2'
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
+  implementation "org.codehaus.groovy:groovy-all"
+  implementation "org.apache.commons:commons-lang3"
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.mockito:mockito-core"

--- a/clouddriver-core/clouddriver-core.gradle
+++ b/clouddriver-core/clouddriver-core.gradle
@@ -10,6 +10,10 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
   testAnnotationProcessor "org.projectlombok:lombok"
 
+  // This is because some classes in this module use the Groovy @Immutable annotation,
+  // which appears to require consumers to have core groovy on the classpath
+  api "org.codehaus.groovy:groovy"
+
   implementation "net.logstash.logback:logstash-logback-encoder"
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"

--- a/clouddriver-kubernetes-v2/clouddriver-kubernetes-v2.gradle
+++ b/clouddriver-kubernetes-v2/clouddriver-kubernetes-v2.gradle
@@ -13,18 +13,17 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
   testAnnotationProcessor "org.projectlombok:lombok"
 
-  implementation "org.codehaus.groovy:groovy-all"
-
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-config"
   implementation "com.netflix.spinnaker.moniker:moniker"
   implementation "io.kubernetes:client-java:7.0.0"
-  implementation "org.springframework.boot:spring-boot-actuator"
-  implementation "org.springframework.boot:spring-boot-starter-web"
   implementation 'com.jayway.jsonpath:json-path:2.3.0'
   implementation "com.github.ben-manes.caffeine:guava"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "com.netflix.spinnaker.kork:kork-annotations"
+  implementation "com.netflix.spinnaker.kork:kork-exceptions"
+  implementation "org.springframework.security:spring-security-config"
+  implementation "com.netflix.spectator:spectator-api"
 
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.assertj:assertj-core"


### PR DESCRIPTION
I'm trying to reduce the amount of things on the compile path by cleaning up dependencies. This cuts a few things from the clouddriver-kubernetes-v2 module, and also adds a few things to other modules that are used but not explicity included. (This is to prepare for an upcoming kork bump where these things will not be automatically included for everyone.)