### PR TITLE
fix(titus): Fetch ipv4 and ipv6 from titus api

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Task.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Task.java
@@ -42,6 +42,9 @@ public class Task {
     containerIp = grpcTask.getTaskContextOrDefault("task.containerIp", null);
     //  The agentId will be used temporarily by deck to lookup IPv6 until Titus API is updated.
     agentId = grpcTask.getTaskContextOrDefault("agent.instanceId", null);
+    // Fetch ipv4 and ipv6 address from titus api if present
+    ipv4Address = grpcTask.getTaskContextOrDefault("task.containerIPv4", null);
+    ipv6Address = grpcTask.getTaskContextOrDefault("task.containerIPv6", null);
     logLocation = new HashMap<>();
     logLocation.put("ui", grpcTask.getLogLocation().getUi().getUrl());
     logLocation.put("liveStream", grpcTask.getLogLocation().getLiveStream().getUrl());
@@ -81,6 +84,9 @@ public class Task {
   private String snapshots;
   private String containerIp;
   private String agentId;
+  private String ipv4Address;
+  private String ipv6Address;
+
   private Map<String, Object> logLocation;
 
   public String getId() {
@@ -229,5 +235,21 @@ public class Task {
 
   public Map<String, Object> getLogLocation() {
     return logLocation;
+  }
+
+  public String getIpv4Address() {
+    return ipv4Address;
+  }
+
+  public void setIpv4Address(String ipv4Address) {
+    this.ipv4Address = ipv4Address;
+  }
+
+  public String getIpv6Address() {
+    return ipv6Address;
+  }
+
+  public void setIpv6Address(String ipv6Address) {
+    this.ipv6Address = ipv6Address;
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -108,11 +108,11 @@ class TitusInstance implements Instance {
   }
 
   String getIpv4Address() {
-    ipv4Address
+    return ipv4Address
   }
 
   String getIpv6Address() {
-    ipv6Address
+    return ipv6Address
   }
 
   String getHostIp() {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -49,6 +49,8 @@ class TitusInstance implements Instance {
   final String cloudProvider = TitusCloudProvider.ID
   String privateIpAddress
   String agentId
+  String ipv4Address
+  String ipv6Address
 
   TitusInstance() {}
 
@@ -87,6 +89,9 @@ class TitusInstance implements Instance {
     privateIpAddress = task.containerIp ?: task.data?.ipAddresses?.nfvpc
 
     agentId = task.agentId
+
+    ipv4Address = task.ipv4Address
+    ipv6Address = task.ipv6Address
   }
 
   @Override
@@ -100,6 +105,14 @@ class TitusInstance implements Instance {
 
   String getAgentId() {
     agentId
+  }
+
+  String getIpv4Address() {
+    ipv4Address
+  }
+
+  String getIpv6Address() {
+    ipv6Address
   }
 
   String getHostIp() {


### PR DESCRIPTION
Today we use `agentId` to infer the `instanceId` and make an additional call to `/instance` endpoint to get the `ipv6Address` from the `networkInterface`

This change is to get the `ipv4` and `ipv6` addresses from Titus API directly . `ipv4` address is transitioning from `titus.containerIp` to `task.containerIPv4`

Todo : once these changes are merged and things are tested , we can remove the agentId and containerIp fields