### PR TITLE
chore(build): take includeCloudProviders out of gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 fiatVersion=1.18.3
-includeCloudProviders=all
 korkVersion=7.37.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.0.0-rc.3

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,8 +33,10 @@ cloudProviderProjects.put('gcp', cloudProviderProjects['appengine'] + cloudProvi
 cloudProviderProjects.put('titus', cloudProviderProjects['aws'] + ':clouddriver-titus' + ':clouddriver-docker')
 cloudProviderProjects.put('all', cloudProviderProjects.collectMany {_, proj -> proj}) // Include all cloud providers.
 
+String icp = settings.ext.has('includeCloudProviders') ? settings.ext.get('includeCloudProviders') : 'all'
+
 // Set as an ext variable so that build scripts can access it
-gradle.ext.includedCloudProviderProjects = includeCloudProviders.split(',')
+gradle.ext.includedCloudProviderProjects = icp.split(',')
   .collectMany { cloudProviderProjects[it.toLowerCase()] }
   .toSet()
   .toList()


### PR DESCRIPTION
Moves the default of all into settings.gradle if otherwise unspecified, but this allows a local development
environment to override the value in ~/.gradle/gradle.properties