### PR TITLE
fix(build): Match GRADLE_OPTS in Dockerfile with CI build

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -7,5 +7,5 @@ MAINTAINER sig-platform@spinnaker.io
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
-ENV GRADLE_OPTS -Xmx4g
+ENV GRADLE_OPTS "-Xmx6g -Xms6g"
 CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true clouddriver-web:installDist -x test


### PR DESCRIPTION
CI build recently updated to: https://github.com/spinnaker/clouddriver/blob/master/.github/workflows/build.yml#L10

Last night's build failed with insufficient memory for the JRE: https://console.cloud.google.com/cloud-build/builds/b9082103-af03-496a-b280-7857120b9190;step=2?organizationId=433637338589&project=spinnaker-community