### PR TITLE
fix(aws): Resolve BasicAmazonDeployDescription NPE when returning names of loadBalancers, targetGroups, and securityGroupNames

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -107,7 +107,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
 
   @Override
   Collection<String> getNames() {
-    return loadBalancers + targetGroups + securityGroupNames
+    return (loadBalancers ?: []) + (targetGroups ?: []) + (securityGroupNames ?: [])
   }
 
   @Override


### PR DESCRIPTION
This is the safest way to resolve this issue.  Setting an empty list default on the properties would work too, but I don't trust that all usages check for an empty list and my confidence in writing more Groovy at this point is at -1.