### PR TITLE
fix(ecs): make targetgroup service set mutable

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProvider.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcsLoadBalancerProvider.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.ecs.provider.view;
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.TARGET_GROUPS;
 
 import com.amazonaws.services.ecs.model.LoadBalancer;
+import com.google.common.collect.Sets;
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider;
 import com.netflix.spinnaker.clouddriver.aws.data.ArnUtils;
 import com.netflix.spinnaker.clouddriver.ecs.EcsCloudProvider;
@@ -158,7 +159,7 @@ public class EcsLoadBalancerProvider implements LoadBalancerProvider<EcsLoadBala
             serviceList.add(service.getServiceName());
             targetGroupToServicesMap.put(tgArn, serviceList);
           } else {
-            Set<String> srcServices = Collections.singleton(service.getServiceName());
+            Set<String> srcServices = Sets.newHashSet(service.getServiceName());
             targetGroupToServicesMap.put(tgArn, srcServices);
           }
         }


### PR DESCRIPTION
Initializing set of services mapped to a target group as mutable so additional services can be added if found. Previously, EcsLoadBalancerProvider would return `java.lang.UnsupportedOperationException` when trying to add a second service to an existing set.

## testing
ECS target groups mapped to multiple services/server groups display properly
<img width="441" alt="multi_sg_tg" src="https://user-images.githubusercontent.com/34254888/80155576-d4bcce80-8576-11ea-931f-a53862866aea.PNG">
