### PR TITLE
chore(kubernetes): Pull latest kubectl patch release

### DIFF
--- a/Dockerfile.java8
+++ b/Dockerfile.java8
@@ -2,7 +2,7 @@ FROM alpine:3.11
 MAINTAINER sig-platform@spinnaker.io
 COPY clouddriver-web/build/install/clouddriver /opt/clouddriver
 
-ENV KUBECTL_VERSION v1.16.0
+ENV KUBECTL_VERSION v1.16.9
 
 RUN apk --no-cache add --update bash wget unzip openjdk8 'python2>2.7.9' && \
   wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && \


### PR DESCRIPTION
We're currently using kubectl 1.16.0 in the docker container; let's bump that to the latest patch release, 1.16.9.

I'm not pulling in a new minor version, as kubectl only allows a skew of +/- 1 minor version from the API, so bumping to 1.17.x could potentially break users on Kubernetes 1.15. Keeping us on 1.16.x allows us to have full support for anyone on Kubernetes 1.15-1.17.