### PR TITLE
fix(aws): Fixing launch template agent name getting truncated in sql

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgent.java
@@ -181,7 +181,7 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
 
   @Override
   public String getAgentType() {
-    return String.format("%s/%s/%s", account.getName(), region, getClass());
+    return String.format("%s/%s/%s", account.getName(), region, getClass().getSimpleName());
   }
 
   @Override


### PR DESCRIPTION
- using simple class name vs the toString of Class (oops)

Stacktrace: 
```
org.springframework.dao.DataIntegrityViolationException: jOOQ; SQL [insert into cats_v1_b_launchTemplates (id, agent, application, body_hash, body, last_updated) values (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?) on duplicate key update application = values(application), body_hash = values(body_hash), body = values(body), last_updated = values(last_updated) -- agentClass: someaccount/us-west-1/class com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLaunchTemplateCachingAgent putCacheResult]; Data truncation: Data too long for column 'agent' at row 1; nested exception is com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'agent' at row 1
```