### PR TITLE
fix(ha): Fix deploying RO clouddriver with Halyard

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -350,7 +350,7 @@ spring:
   profiles: ro
 
 redis:
-  connection: ${services.redisRo.baseUrl}
+  connection: ${services.redisRo.baseUrl:${services.redis.baseUrl}}
 
 caching:
   writeEnabled: false


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5736

My recent change to push the -ro config for clouddriver down to the base config breaks deploying RO clouddriver with Halyard because it sets the redis endpoint to redisRo.baseUrl, which is not set by Halyard. This should default to redis.baseUrl to handle this case.