### PR TITLE
fix(kubernetes): return kubernetes server group managers

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupManagerController.java
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupManagerController.java
@@ -38,13 +38,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/applications/{application}/serverGroupManagers")
 public class ServerGroupManagerController {
-  final List<ServerGroupManagerProvider<ServerGroupManager>> serverGroupManagerProviders;
+  final List<ServerGroupManagerProvider<? extends ServerGroupManager>> serverGroupManagerProviders;
 
   final RequestQueue requestQueue;
 
   @Autowired
   public ServerGroupManagerController(
-      List<ServerGroupManagerProvider<ServerGroupManager>> serverGroupManagerProviders,
+      List<ServerGroupManagerProvider<? extends ServerGroupManager>> serverGroupManagerProviders,
       RequestQueue requestQueue) {
     this.serverGroupManagerProviders = serverGroupManagerProviders;
     this.requestQueue = requestQueue;


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5754

"I love bounded wildcards."

-- Winston Churchill

(For the  Java-11 refactor, we parameterized `ServerGroupManagerProvider` with `ServerGroupManager`, but the Kubernetes implementation of this provider is actually parameterized with a subclass of `ServerGroupManager`, so we were failing to pick up that implementation and never returning any Deployment or Stateful Set details, manifesting in the UI errors reported in that GH issue.)