### PR TITLE
feat(provider/aws): Encryption with specific KMS key id

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilder.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/DefaultLaunchConfigurationBuilder.groovy
@@ -86,7 +86,8 @@ class DefaultLaunchConfigurationBuilder implements LaunchConfigurationBuilder {
           deleteOnTermination: mapping.ebs.deleteOnTermination,
           iops: mapping.ebs.iops,
           snapshotId: mapping.ebs.snapshotId,
-          encrypted: mapping.ebs.encrypted)
+          encrypted: mapping.ebs.encrypted,
+          kmsKeyId: mapping.ebs.kmsKeyId)
       } else {
         new AmazonBlockDevice(deviceName: mapping.deviceName, virtualName: mapping.virtualName)
       }
@@ -251,6 +252,9 @@ class DefaultLaunchConfigurationBuilder implements LaunchConfigurationBuilder {
             }
             if (encrypted) {
               ebs.withEncrypted(encrypted)
+            }
+            if (kmsKeyId) {
+              ebs.withKmsKeyId(kmsKeyId)
             }
           }
           mapping.withEbs(ebs)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonBlockDevice.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonBlockDevice.groovy
@@ -75,4 +75,8 @@ class AmazonBlockDevice {
    */
   Boolean encrypted
 
+  /**
+   *  The KMS key Id to encrypt the EBS volume
+   */
+  String kmsKeyId
 }


### PR DESCRIPTION
AWS EBS can be encrypted by CMK and it is supported by AWS API.
But it is not implemented in spinnaker. https://github.com/spinnaker/spinnaker/issues/5745 is related issue.

EBS block storage can be configured by editing json object.
I added `kmsKeyId` in `AmazonBlockDevice` class and it is used to request AWS API to create launch configuration.

But I have no idea how to test this code block I added.
Please let me know if you have some ideas.