### PR TITLE
fix(gce): Fix cluster caching on the SQL backend

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
@@ -169,7 +169,8 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
       // TODO terrible hack because no AWS agent is authoritative for clusters, fix in ClusterCachingAgent
       // TODO same with namedImages - fix in AWS ImageCachingAgent
       if (
-        source.contains("clustercaching", ignoreCase = true) &&
+        (source.contains("clustercaching", ignoreCase = true) ||
+          source.matches(Regex(".*/Google(Zonal|Regional)ServerGroupCachingAgent"))) &&
         !authoritativeTypes.contains(CLUSTERS.ns) &&
         cacheResult.cacheResults
           .any {


### PR DESCRIPTION
This is fixed on master as #4570, but I don't think it's safe enough to cherry-pick that. This is a significantly hackier fix, but it's safer since it only affects users using the SQL backend, which apparently isn't working anyway.

This is against the release-1.20.x branch, and then I'll cherry-pick it back to 1.19 and 1.18.