### PR TITLE
fix(aws): delete some unnecessary code

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
@@ -7,8 +7,6 @@ import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.cats.sql.cache.SqlCache
-import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.CLUSTERS
-import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.NAMED_IMAGES
 import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.ON_DEMAND
 import kotlin.contracts.ExperimentalContracts
 import org.slf4j.LoggerFactory
@@ -164,28 +162,6 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
   ) {
     try {
       MDC.put("agentClass", "$source putCacheResult")
-
-      // TODO every source type should have an authoritative agent and every agent should be authoritative for something
-      // TODO terrible hack because no AWS agent is authoritative for clusters, fix in ClusterCachingAgent
-      // TODO same with namedImages - fix in AWS ImageCachingAgent
-      if (
-        source.contains("clustercaching", ignoreCase = true) &&
-        !authoritativeTypes.contains(CLUSTERS.ns) &&
-        cacheResult.cacheResults
-          .any {
-            it.key.startsWith(CLUSTERS.ns)
-          }
-      ) {
-        authoritativeTypes.add(CLUSTERS.ns)
-      } else if (
-        source.contains("imagecaching", ignoreCase = true) &&
-        cacheResult.cacheResults
-          .any {
-            it.key.startsWith(NAMED_IMAGES.ns)
-          }
-      ) {
-        authoritativeTypes.add(NAMED_IMAGES.ns)
-      }
 
       cacheResult.cacheResults
         .filter {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusV2ClusterCachingAgent.java
@@ -77,10 +77,10 @@ public class TitusV2ClusterCachingAgent
   static final java.util.Set<AgentDataType> types =
       Collections.unmodifiableSet(
           Stream.of(
+                  AUTHORITATIVE.forType(CLUSTERS.ns),
                   AUTHORITATIVE.forType(SERVER_GROUPS.ns),
                   AUTHORITATIVE.forType(APPLICATIONS.ns),
                   INFORMATIVE.forType(IMAGES.ns),
-                  INFORMATIVE.forType(CLUSTERS.ns),
                   INFORMATIVE.forType(TARGET_GROUPS.ns))
               .collect(Collectors.toSet()));
 


### PR DESCRIPTION
It looks like you fixed these two TODOs in #3401, but missed TitusV2ClusterCachingAgent. Is this safe? Happy to roll back if you aren't sure, but I figured I'd clean this up while I was looking at it for #4570.