### PR TITLE
feat(titus): Adding support for command for titus jobs

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/Job.java
@@ -38,6 +38,7 @@ public class Job {
   private String user;
   private String version;
   private String entryPoint;
+  private String cmd;
   private String iamProfile;
   private String capacityGroup;
   private Boolean inService;
@@ -132,6 +133,9 @@ public class Job {
     digest = grpcJob.getJobDescriptor().getContainer().getImage().getDigest();
     entryPoint =
         grpcJob.getJobDescriptor().getContainer().getEntryPointList().stream()
+            .collect(Collectors.joining(" "));
+    cmd =
+        grpcJob.getJobDescriptor().getContainer().getCommandList().stream()
             .collect(Collectors.joining(" "));
     capacityGroup = grpcJob.getJobDescriptor().getCapacityGroup();
     cpu = (int) grpcJob.getJobDescriptor().getContainer().getResources().getCpu();
@@ -360,6 +364,14 @@ public class Job {
 
   public void setEntryPoint(String entryPoint) {
     this.entryPoint = entryPoint;
+  }
+
+  public String getCmd() {
+    return cmd;
+  }
+
+  public void setCmd(String cmd) {
+    this.cmd = cmd;
   }
 
   public int getInstances() {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
@@ -59,6 +59,7 @@ public class JobDescription {
   private Boolean inService;
 
   private String entryPoint;
+  private String cmd;
   private String iamProfile;
   private String capacityGroup;
   private Efs efs;
@@ -112,6 +113,7 @@ public class JobDescription {
             ? request.getContainerAttributes()
             : new HashMap<>();
     entryPoint = request.getEntryPoint();
+    cmd = request.getCmd();
     iamProfile = request.getIamProfile();
     capacityGroup = request.getCapacityGroup();
     securityGroups = request.getSecurityGroups();
@@ -356,6 +358,14 @@ public class JobDescription {
     this.entryPoint = entryPoint;
   }
 
+  public String getCmd() {
+    return cmd;
+  }
+
+  public void setCmd(String cmd) {
+    this.cmd = cmd;
+  }
+
   public String getIamProfile() {
     return iamProfile;
   }
@@ -538,6 +548,10 @@ public class JobDescription {
 
     if (entryPoint != null) {
       containerBuilder.addEntryPoint(entryPoint);
+    }
+
+    if (cmd != null) {
+      containerBuilder.addCommand(cmd);
     }
 
     if (!containerAttributes.isEmpty()) {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/SubmitJobRequest.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/SubmitJobRequest.java
@@ -79,6 +79,7 @@ public class SubmitJobRequest {
   private String detail;
   private String user;
   private String entryPoint;
+  private String cmd;
   private String iamProfile;
   private String capacityGroup;
   @Builder.Default private Boolean inService = true;

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/PrepareTitusDeploy.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/PrepareTitusDeploy.java
@@ -305,6 +305,7 @@ public class PrepareTitusDeploy extends AbstractTitusDeployAction
         orDefault(description.getRuntimeLimitSecs(), sourceJob.getRuntimeLimitSecs()));
     description.setEfs(orDefault(description.getEfs(), sourceJob.getEfs()));
     description.setEntryPoint(orDefault(description.getEntryPoint(), sourceJob.getEntryPoint()));
+    description.setCmd(orDefault(description.getCmd(), sourceJob.getCmd()));
     description.setIamProfile(orDefault(description.getIamProfile(), sourceJob.getIamProfile()));
     description.setCapacityGroup(
         orDefault(description.getCapacityGroup(), sourceJob.getCapacityGroup()));

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
@@ -43,6 +43,7 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
   private Map<String, String> labels = new LinkedHashMap<>();
   private Map<String, String> containerAttributes = new LinkedHashMap<>();
   private String entryPoint;
+  private String cmd;
   private String iamProfile;
   private String capacityGroup;
   private String user;
@@ -125,6 +126,7 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
             .stack(stack)
             .detail(freeFormDetails)
             .entryPoint(entryPoint)
+            .cmd(cmd)
             .iamProfile(iamProfile)
             .capacityGroup(capacityGroup)
             .labels(labels)
@@ -336,6 +338,14 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
 
   public void setEntryPoint(String entryPoint) {
     this.entryPoint = entryPoint;
+  }
+
+  public String getCmd() {
+    return cmd;
+  }
+
+  public void setCmd(String cmd) {
+    this.cmd = cmd;
   }
 
   public String getIamProfile() {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusServerGroup.groovy
@@ -42,6 +42,7 @@ class TitusServerGroup implements ServerGroup, Serializable {
   final String type = TitusCloudProvider.ID
   final String cloudProvider = TitusCloudProvider.ID
   String entryPoint
+  String cmd
   String awsAccount
   String accountId
   String iamProfile
@@ -84,6 +85,7 @@ class TitusServerGroup implements ServerGroup, Serializable {
     image << [dockerImageVersion: job.version]
     image << [dockerImageDigest: job.digest]
     entryPoint = job.entryPoint
+    cmd = job.cmd
     iamProfile = job.iamProfile
     resources.cpu = job.cpu
     resources.memory = job.memory


### PR DESCRIPTION
- Adding support for `COMMAND` which is supported in Titus along with `ENTRYPOINT` 
- making changes to deck after this is merged.