### PR TITLE
fix(cache): adds a proper authoritative clusters source for aws/titus

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
@@ -7,8 +7,6 @@ import com.netflix.spinnaker.cats.cache.DefaultCacheData
 import com.netflix.spinnaker.cats.cache.WriteableCache
 import com.netflix.spinnaker.cats.provider.ProviderCache
 import com.netflix.spinnaker.cats.sql.cache.SqlCache
-import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.CLUSTERS
-import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.NAMED_IMAGES
 import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.ON_DEMAND
 import kotlin.contracts.ExperimentalContracts
 import org.slf4j.LoggerFactory
@@ -164,28 +162,6 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
   ) {
     try {
       MDC.put("agentClass", "$source putCacheResult")
-
-      // TODO every source type should have an authoritative agent and every agent should be authoritative for something
-      // TODO terrible hack because no AWS agent is authoritative for clusters, fix in ClusterCachingAgent
-      // TODO same with namedImages - fix in AWS ImageCachingAgent
-      if (
-        source.contains("clustercaching", ignoreCase = true) &&
-        !authoritativeTypes.contains(CLUSTERS.ns) &&
-        cacheResult.cacheResults
-          .any {
-            it.key.startsWith(CLUSTERS.ns)
-          }
-      ) {
-        authoritativeTypes.add(CLUSTERS.ns)
-      } else if (
-        source.contains("imagecaching", ignoreCase = true) &&
-        cacheResult.cacheResults
-          .any {
-            it.key.startsWith(NAMED_IMAGES.ns)
-          }
-      ) {
-        authoritativeTypes.add(NAMED_IMAGES.ns)
-      }
 
       cacheResult.cacheResults
         .filter {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CatsClusterCachingAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/agent/CatsClusterCachingAgent.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.agent;
+
+import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.CLUSTERS;
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS;
+
+import com.netflix.spinnaker.cats.agent.AgentDataType;
+import com.netflix.spinnaker.cats.agent.CacheResult;
+import com.netflix.spinnaker.cats.agent.CachingAgent;
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.DefaultCacheData;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An Authoritative caching agent for clusters where cluster existence is derived from existing
+ * server groups in cache.
+ */
+public abstract class CatsClusterCachingAgent implements CachingAgent {
+  private static final Collection<AgentDataType> dataTypes =
+      Collections.unmodifiableCollection(Collections.singleton(AUTHORITATIVE.forType(CLUSTERS.ns)));
+
+  private final String serverGroupsGlob;
+  private final Function<String, Map<String, String>> keyParser;
+  private final Function<Map<String, String>, String> clusterKeyBuilder;
+  private final String clusterNameAttribute;
+
+  /**
+   * @param serverGroupsGlob The search glob to look up all server groups for the provider (e.g.
+   *     Keys.getServerGroupKey("*", "*", "*", "*"))
+   * @param keyParser A parser for the server group and cluster keys for the provider
+   * @param clusterKeyBuilder Given a parsed server group key as a map, supplies the associated
+   *     cluster key
+   *     <p>Uses 'cluster' as the clusterNameAttribute
+   */
+  public CatsClusterCachingAgent(
+      String serverGroupsGlob,
+      Function<String, Map<String, String>> keyParser,
+      Function<Map<String, String>, String> clusterKeyBuilder) {
+    this(serverGroupsGlob, keyParser, clusterKeyBuilder, "cluster");
+  }
+
+  /**
+   * @param serverGroupsGlob The search glob to look up all server groups for the provider (e.g.
+   *     Keys.getServerGroupKey("*", "*", "*", "*"))
+   * @param keyParser A parser for the server group and cluster keys for the provider
+   * @param clusterKeyBuilder Given a parsed server group key as a map, supplies the associated
+   *     cluster key
+   * @param clusterNameAttribute The attribute name in the parsed cluster key that represents the
+   *     cluster's name
+   */
+  public CatsClusterCachingAgent(
+      String serverGroupsGlob,
+      Function<String, Map<String, String>> keyParser,
+      Function<Map<String, String>, String> clusterKeyBuilder,
+      String clusterNameAttribute) {
+    this.serverGroupsGlob = serverGroupsGlob;
+    this.keyParser = keyParser;
+    this.clusterKeyBuilder = clusterKeyBuilder;
+    this.clusterNameAttribute = clusterNameAttribute;
+  }
+
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
+    return dataTypes;
+  }
+
+  @Override
+  public CacheResult loadData(ProviderCache providerCache) {
+    Collection<String> serverGroups =
+        providerCache.filterIdentifiers(SERVER_GROUPS.ns, serverGroupsGlob);
+    Collection<String> existing = providerCache.existingIdentifiers(SERVER_GROUPS.ns, serverGroups);
+    Set<String> clusterKeys =
+        existing.stream()
+            .map(keyParser)
+            .filter(Objects::nonNull)
+            .map(clusterKeyBuilder)
+            .collect(Collectors.toSet());
+
+    Collection<CacheData> clusterData =
+        clusterKeys.stream()
+            .map(
+                s -> {
+                  Map<String, String> clusterAttributes = keyParser.apply(s);
+                  return new DefaultCacheData(
+                      s,
+                      Collections.singletonMap("name", clusterAttributes.get(clusterNameAttribute)),
+                      Collections.emptyMap());
+                })
+            .collect(Collectors.toList());
+
+    return new DefaultCacheResult(Collections.singletonMap(CLUSTERS.ns, clusterData));
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonAuthoritativeClustersAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonAuthoritativeClustersAgent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.agent;
+
+import com.netflix.spinnaker.clouddriver.aws.agent.CatsClusterCachingAgent;
+import com.netflix.spinnaker.clouddriver.aws.data.Keys;
+import com.netflix.spinnaker.clouddriver.aws.provider.AwsProvider;
+
+public class AmazonAuthoritativeClustersAgent extends CatsClusterCachingAgent {
+
+  public AmazonAuthoritativeClustersAgent() {
+    super(
+        Keys.getServerGroupKey("*", "*", "*", "*"),
+        Keys::parse,
+        sg -> Keys.getClusterKey(sg.get("cluster"), sg.get("application"), sg.get("account")));
+  }
+
+  @Override
+  public String getAgentType() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public String getProviderName() {
+    return AwsProvider.PROVIDER_NAME;
+  }
+}

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -68,9 +68,9 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
   private static final TypeReference<Map<String, Object>> ATTRIBUTES = new TypeReference<Map<String, Object>>() {}
 
   static final Set<AgentDataType> types = Collections.unmodifiableSet([
-    AUTHORITATIVE.forType(CLUSTERS.ns),
     AUTHORITATIVE.forType(SERVER_GROUPS.ns),
     AUTHORITATIVE.forType(APPLICATIONS.ns),
+    INFORMATIVE.forType(CLUSTERS.ns),
     INFORMATIVE.forType(LOAD_BALANCERS.ns),
     INFORMATIVE.forType(TARGET_GROUPS.ns),
     INFORMATIVE.forType(LAUNCH_CONFIGS.ns),

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/config/AwsProviderConfig.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.cats.agent.Agent
 import com.netflix.spinnaker.cats.agent.AgentProvider
 import com.netflix.spinnaker.clouddriver.aws.AmazonCloudProvider
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonApplicationLoadBalancerCachingAgent
+import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonAuthoritativeClustersAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCertificateCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonCloudFormationCachingAgent
 import com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonLaunchTemplateCachingAgent
@@ -125,6 +126,12 @@ class AwsProviderConfig {
 
     //only index public images once per region
     Set<String> publicRegions = []
+
+    // If there is an agent scheduler, then this provider has been through the AgentController in the past.
+    //  We only need to add the AmazonAuthoritativeClustersAgent once.
+    if (!awsProvider.agentScheduler) {
+      newlyAddedAgents << new AmazonAuthoritativeClustersAgent();
+    }
 
     //sort the accounts in case of a reconfigure, we are more likely to re-index the public images in the same caching agent
     //TODO(cfieber)-rework this is after rework of AWS Image/NamedImage keys

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonAuthoritativeClustersAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonAuthoritativeClustersAgentSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.provider.agent
+
+import com.netflix.spinnaker.cats.provider.ProviderCache
+import com.netflix.spinnaker.clouddriver.aws.data.Keys
+import org.hamcrest.Matchers
+import spock.lang.Specification
+
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.CLUSTERS
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS;
+
+class AmazonAuthoritativeClustersAgentSpec extends Specification {
+
+  def providerCache = Mock(ProviderCache)
+  def subject = new AmazonAuthoritativeClustersAgent()
+
+  def "caches clusters"() {
+
+    when:
+    def result = subject.loadData(providerCache)
+
+    then:
+    1 * providerCache.filterIdentifiers(SERVER_GROUPS.ns, Keys.getServerGroupKey('*','*', '*', '*')) >> sgIds
+    1 * providerCache.existingIdentifiers(SERVER_GROUPS.ns, _) >> sgIds
+
+    result.cacheResults.size() == 1
+    result.cacheResults[CLUSTERS.ns].size() == expectedSize
+    Matchers.containsInAnyOrder(expected.toArray()).matches(result.cacheResults[CLUSTERS.ns]*.id)
+    Matchers.containsInAnyOrder("foo-main", "foo-staging").matches(result.cacheResults[CLUSTERS.ns]*.attributes["name"])
+
+    where:
+    sgIds = [
+      Keys.getServerGroupKey("foo-main-v123", "prod", "us-east-1"),
+      Keys.getServerGroupKey("foo-main-v122", "prod", "us-east-1"),
+      Keys.getServerGroupKey("foo-main-v124", "prod", "us-west-2"),
+      Keys.getServerGroupKey("foo-main-v123", "prod", "us-west-2"),
+      Keys.getServerGroupKey("foo-staging-v122", "test", "us-east-1"),
+      Keys.getServerGroupKey("foo-staging-v124", "test", "us-east-1")
+    ]
+    expected = [
+      Keys.getClusterKey("foo-main", "foo","prod"),
+      Keys.getClusterKey("foo-staging", "foo","test")
+    ]
+    expectedSize = expected.size()
+
+  }
+}

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/TitusCachingProviderConfig.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.titus.TitusClientProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusCloudProvider
+import com.netflix.spinnaker.clouddriver.titus.caching.agents.TitusAuthoritativeClustersAgent
 import com.netflix.spinnaker.clouddriver.titus.caching.agents.TitusInstanceCachingAgent
 import com.netflix.spinnaker.clouddriver.titus.caching.agents.TitusStreamingUpdateAgent
 import com.netflix.spinnaker.clouddriver.titus.caching.agents.TitusV2ClusterCachingAgent
@@ -94,6 +95,7 @@ class TitusCachingProviderConfig {
         }
       }
     }
+    agents << new TitusAuthoritativeClustersAgent()
     new TitusCachingProvider(agents, cachingSchemaUtilProvider)
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusAuthoritativeClustersAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusAuthoritativeClustersAgent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.titus.caching.agents;
+
+import com.netflix.spinnaker.clouddriver.aws.agent.CatsClusterCachingAgent;
+import com.netflix.spinnaker.clouddriver.titus.caching.Keys;
+import com.netflix.spinnaker.clouddriver.titus.caching.TitusCachingProvider;
+
+public class TitusAuthoritativeClustersAgent extends CatsClusterCachingAgent {
+
+  public TitusAuthoritativeClustersAgent() {
+    super(
+        Keys.getServerGroupKey("*", "*", "*", "*"),
+        Keys::parse,
+        sg -> Keys.getClusterKey(sg.get("cluster"), sg.get("application"), sg.get("account")));
+  }
+
+  @Override
+  public String getAgentType() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public String getProviderName() {
+    return TitusCachingProvider.PROVIDER_NAME;
+  }
+}


### PR DESCRIPTION
incorporates the SqlProviderCache clean up from #4608