### PR TITLE
fix(provider/kubernetes): Allow inheritance of KubectlJobExecutor

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -59,7 +59,7 @@ public class KubectlJobExecutor {
   private final Gson gson = new Gson();
 
   @Autowired
-  KubectlJobExecutor(
+  public KubectlJobExecutor(
       JobExecutor jobExecutor,
       @Value("${kubernetes.kubectl.executable:kubectl}") String executable,
       @Value("${kubernetes.o-auth.executable:oauth2l}") String oAuthExecutable) {


### PR DESCRIPTION
Making the constructor public would let the class be extended in a Spinnaker plugin (different class loader) and would allow users to use a different behavior when interacting with kubectl.
