### PR TITLE
fix(provider/cf): fix buildOnDemandCacheData

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgent.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toSet;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.netflix.frigga.Names;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.cats.agent.AgentDataType;
@@ -317,14 +318,13 @@ public class CloudFoundryServerGroupCachingAgent extends AbstractCloudFoundryCac
       return new DefaultCacheData(
           key,
           (int) TimeUnit.MINUTES.toSeconds(10), // ttl
-          io.vavr.collection.HashMap.<String, Object>of(
-                  "cacheTime",
-                  this.getInternalClock().instant().toEpochMilli(),
-                  "cacheResults",
-                  cacheViewMapper.writeValueAsString(cacheResult),
-                  "processedCount",
-                  0)
-              .toJavaMap(),
+          ImmutableMap.of(
+              "cacheTime",
+              this.getInternalClock().instant().toEpochMilli(),
+              "cacheResults",
+              cacheViewMapper.writeValueAsString(cacheResult),
+              "processedCount",
+              0),
           emptyMap(),
           this.getInternalClock());
     } catch (JsonProcessingException serializationException) {

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgentTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/provider/agent/CloudFoundryServerGroupCachingAgentTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
@@ -65,6 +66,60 @@ class CloudFoundryServerGroupCachingAgentTest {
   void before() {
     when(credentials.getClient()).thenReturn(cloudFoundryClient);
     when(credentials.getName()).thenReturn(accountName);
+  }
+
+  @Test
+  void buildOnDemandCacheDataShouldIncludeServerGroupAttributes() throws JsonProcessingException {
+
+    CloudFoundryInstance cloudFoundryInstance =
+        CloudFoundryInstance.builder().appGuid("instance-guid-1").key("instance-key").build();
+
+    CloudFoundryServerGroup onDemandCloudFoundryServerGroup =
+        CloudFoundryServerGroup.builder()
+            .name("serverGroupName")
+            .id("sg-guid-1")
+            .account(accountName)
+            .space(cloudFoundrySpace)
+            .diskQuota(1024)
+            .instances(singleton(cloudFoundryInstance))
+            .build();
+
+    Map<String, Collection<String>> serverGroupRelationships =
+        HashMap.<String, Collection<String>>of(
+                INSTANCES.getNs(),
+                singleton(Keys.getInstanceKey(accountName, cloudFoundryInstance.getName())),
+                LOAD_BALANCERS.getNs(),
+                emptyList())
+            .toJavaMap();
+
+    ResourceCacheData onDemandCacheResults =
+        new ResourceCacheData(
+            Keys.getServerGroupKey(
+                accountName,
+                onDemandCloudFoundryServerGroup.getName(),
+                onDemandCloudFoundryServerGroup.getRegion()),
+            cacheView(onDemandCloudFoundryServerGroup),
+            serverGroupRelationships);
+
+    CacheData cacheData =
+        cloudFoundryServerGroupCachingAgent.buildOnDemandCacheData(
+            Keys.getServerGroupKey(
+                accountName,
+                onDemandCloudFoundryServerGroup.getName(),
+                onDemandCloudFoundryServerGroup.getRegion()),
+            Collections.singletonMap(
+                SERVER_GROUPS.getNs(), Collections.singleton(onDemandCacheResults)));
+
+    ResourceCacheData result =
+        objectMapper
+            .readValue(
+                cacheData.getAttributes().get("cacheResults").toString(),
+                new TypeReference<Map<String, Collection<ResourceCacheData>>>() {})
+            .get("serverGroups").stream()
+            .findFirst()
+            .get();
+
+    assertThat(result).isEqualToComparingFieldByFieldRecursively(onDemandCacheResults);
   }
 
   @Test


### PR DESCRIPTION
CFSGcachingAgent was using the buildOnDemandCacheData method from the abstract class it extends from. The object mapper that was used in the abstract class doesn't serialize the object as we need it because it only serializes fields based on the view. This creates a problem when trying to serialize a CacheData object. The fix is to override this method and use the same logic, but use the objectMapper thats currently being used in the serverGroupCachingAgent class. The additional test covers and ensures that the ondemand cache object has the servergroup attributes it should have. This fix will also ensure that on demand cache is actually processed and not just skipped over because the resulting fields are null