### PR TITLE
chore(kubernetes): Bump kubectl version

### DIFF
--- a/Dockerfile.java8
+++ b/Dockerfile.java8
@@ -2,7 +2,7 @@ FROM alpine:3.11
 MAINTAINER sig-platform@spinnaker.io
 COPY clouddriver-web/build/install/clouddriver /opt/clouddriver
 
-ENV KUBECTL_VERSION v1.16.9
+ENV KUBECTL_VERSION v1.17.6
 
 RUN apk --no-cache add --update bash wget unzip openjdk8 'python2>2.7.9' && \
   wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -2,7 +2,7 @@ FROM alpine:3.11
 MAINTAINER sig-platform@spinnaker.io
 COPY clouddriver-web/build/install/clouddriver /opt/clouddriver
 
-ENV KUBECTL_VERSION v1.16.0
+ENV KUBECTL_VERSION v1.17.6
 
 RUN apk --no-cache add --update bash wget unzip openjdk11 'python2>2.7.9' && \
   wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && \


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5715.

Let's bump to 1.17.x of kubectl for the next Spinnaker release. Currently Kubernetes is on 1.18.x, but to try to maximize overlap with the version users are running we'll stay at 1.17.x.

This means that we'll officially support 1.16-1.18 (as kubectl allows a +/- 1 version skew with the cluster). In practice this should not cause issues for users on <=1.15 as I don't believe in practice there are generally changes that break talking to old clusters. This does allow users on 1.17 to start to use new fields.