### PR TITLE
fix(entity tags): Restore NotFoundException handling

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
@@ -118,6 +118,7 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
                   try {
                     it.handle(event)
                   } catch (e) {
+                    log.warn("Error handling event (${event}): ${atomicOperation.class.simpleName}", e)
                     task.updateStatus TASK_PHASE, "Error handling event (${event}): ${atomicOperation.class.simpleName} | ${e.class.simpleName}: [${e.message}]"
                   }
                 }

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperation.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/ops/DeleteEntityTagsAtomicOperation.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.DeleteEntity
 import com.netflix.spinnaker.clouddriver.elasticsearch.model.ElasticSearchEntityTagsProvider;
 import com.netflix.spinnaker.clouddriver.model.EntityTags;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -54,7 +55,7 @@ public class DeleteEntityTagsAtomicOperation implements AtomicOperation<Void> {
     EntityTags currentTags;
     try {
       currentTags = front50Service.getEntityTags(entityTagsDescription.getId());
-    } catch (RetrofitError e) {
+    } catch (RetrofitError | NotFoundException e) {
       getTask()
           .updateStatus(
               BASE_PHASE, format("Did not find %s in Front50", entityTagsDescription.getId()));


### PR DESCRIPTION
After https://github.com/spinnaker/clouddriver/pull/4325
Retrofit 404's are now converted to NotFoundException, this made the entitytag cleaner on ASG creation not handle the case when no entity tag exists.
