### PR TITLE
fix(aws/cache): index authoritative clusters by application

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -203,8 +203,12 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
       allImages
     )
 
-    Collection<AmazonCluster> clusters = cacheResults[CLUSTERS.ns].collect { clusterData ->
+    Collection<AmazonCluster> clusters = cacheResults[CLUSTERS.ns].findResults { clusterData ->
       Map<String, String> clusterKey = Keys.parse(clusterData.id)
+
+      if (clusterKey == null) {
+        return null
+      }
 
       AmazonCluster cluster = new AmazonCluster()
       cluster.accountName = clusterKey.account
@@ -214,7 +218,7 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
       cluster.loadBalancers = clusterData.relationships[LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) }
       cluster.targetGroups = clusterData.relationships[TARGET_GROUPS.ns]?.findResults { targetGroups.get(it) }
 
-      cluster
+      return cluster
     }
 
     return clusters


### PR DESCRIPTION
Adds an application attribute to authoritative clusters so that the lookup by application succeeds.

Also includes relationships from the cluster to the server groups we are crawling