### PR TITLE
Fix(titus): Additional checks while setting command

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/model/JobDescription.java
@@ -550,7 +550,7 @@ public class JobDescription {
       containerBuilder.addEntryPoint(entryPoint);
     }
 
-    if (cmd != null) {
+    if (cmd != null || !cmd.isEmpty()) {
       containerBuilder.addCommand(cmd);
     }
 


### PR DESCRIPTION
- don't set `command` if its empty