### PR TITLE
refactor(artifacts): Remove mutations of artifacts

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
@@ -95,8 +95,9 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
     String artifactAccount = artifact.getArtifactAccount();
     if (CloudFoundryArtifactCredentials.TYPE.equals(artifact.getType())) {
       CloudFoundryCredentials credentials = getCredentialsObject(artifactAccount);
-      artifact.setUuid(
-          getServerGroupId(artifact.getName(), artifact.getLocation(), credentials.getClient()));
+      String uuid =
+          getServerGroupId(artifact.getName(), artifact.getLocation(), credentials.getClient());
+      converted.setApplicationArtifact(artifact.toBuilder().uuid(uuid).build());
       return new CloudFoundryArtifactCredentials(credentials.getClient());
     }
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/ops/CreateServerGroupAtomicOperation.java
@@ -409,7 +409,11 @@ public class CreateServerGroupAtomicOperation
         || taskDefArtifact.getArtifactAccount().isEmpty()
             && description.getTaskDefinitionArtifactAccount() != null
             && !description.getTaskDefinitionArtifactAccount().isEmpty()) {
-      taskDefArtifact.setArtifactAccount(description.getTaskDefinitionArtifactAccount());
+      taskDefArtifact =
+          taskDefArtifact
+              .toBuilder()
+              .artifactAccount(description.getTaskDefinitionArtifactAccount())
+              .build();
     }
     try {
       InputStream artifactInput = artifactDownloader.download(taskDefArtifact);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
@@ -78,9 +78,6 @@ public class KubernetesCacheDataConverter {
     try {
       KubernetesManifest lastAppliedConfiguration =
           KubernetesManifestAnnotater.getLastAppliedConfiguration(manifest);
-      if (artifact.getMetadata() == null) {
-        artifact.setMetadata(new HashMap<>());
-      }
       artifact.getMetadata().put("lastAppliedConfiguration", lastAppliedConfiguration);
       artifact.getMetadata().put("account", account);
     } catch (Exception e) {


### PR DESCRIPTION
In an upcoming kork release, artifacts will become immutable to prevent confusing bugs where (primarily in orca) we are mutating copies of what we think we are mutating. There are a small number of places in clouddriver where artifacts are mutated, but these can be replaced by returning a copy with the desired changed.