### PR TITLE
perf(kubernetes): Reduce duplicate work in on-demand cache refresh

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
@@ -59,4 +59,20 @@ public class KubernetesCoreCachingAgent extends KubernetesV2OnDemandCachingAgent
   protected List<KubernetesKind> primaryKinds() {
     return credentials.getGlobalKinds();
   }
+
+  /**
+   * See the comment on the super method for more details about why this function exists.
+   *
+   * <p>As noted there, we want the KubernetesCoreCachingAgent to handle all requests for pending
+   * on-demand cache refreshes to avoid duplicate work. But as users can have multiple cache threads
+   * for a given account, there may be multiple KubernetesCoreCachingAgent's for a single account,
+   * all of which would duplicate work if we sent the work to all of them.
+   *
+   * <p>In order to minimize duplicate work, we'll elect the agent with index 0 to handle all of
+   * these requests, and have it return all pending on-demand refresh requests (not just ones
+   * related to its slice of namespaces).
+   */
+  protected boolean handlePendingOnDemandRequests() {
+    return agentIndex == 0;
+  }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -338,11 +338,10 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
 
   @Override
   public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
-    if (!handleReadRequests()) {
+    if (!handlePendingOnDemandRequests()) {
       return ImmutableList.of();
     }
 
-    List<KubernetesKind> primaryKinds = primaryKinds();
     List<String> matchingKeys =
         providerCache.getIdentifiers(ON_DEMAND_TYPE).stream()
             .map(Keys::parseKey)
@@ -350,10 +349,7 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
             .map(Optional::get)
             .filter(k -> k instanceof Keys.InfrastructureCacheKey)
             .map(i -> (Keys.InfrastructureCacheKey) i)
-            .filter(
-                i ->
-                    i.getAccount().equals(getAccountName())
-                        && primaryKinds.contains(i.getKubernetesKind()))
+            .filter(i -> i.getAccount().equals(getAccountName()))
             .map(Keys.InfrastructureCacheKey::toString)
             .collect(Collectors.toList());
 
@@ -384,13 +380,25 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
   }
 
   /**
-   * When fetching on-demand requests, we delegate to single caching agent, as the read request from
-   * the cache will return results for all namespaces anyway. This way we avoid having all agents
-   * perform the same query and filter to their namespaces, only to then re-combine all the results
-   * in the end.
+   * When fetching on-demand requests, we delegate to single caching agent per account to avoid
+   * duplicate work. During caching cycles, when we make calls to kubernetes to fetch data about the
+   * cluster and write this data to the cache, there is often a performance benefit to sharding work
+   * among multiple agents so that it can happen in parallel.
+   *
+   * <p>When fetching on-demand requests, however, the current API is to return all on-demand
+   * requests without any filtering. As the cache is not designed for a caching agent to be able to
+   * query only its own on-demand requests, our options are: (1) Fan out to all the caching agents.
+   * Each agent fetches all on-demand requests, then filters down to the ones that it owns. Then
+   * combine these results to get the full set of on-demand requests. (2) Just pick a single caching
+   * agent and have it get all the on-demand requests and return them.
+   *
+   * <p>For performance reasons, we'll go with option (2) and delegate a single caching agent to
+   * return all on-demand cache requests for the account. As every account will have a
+   * KubernetesCoreCachingAgent, we'll have that agent handle on-demand requests (by overriding this
+   * function) while every other agent will ignore these.
    */
-  private boolean handleReadRequests() {
-    return agentIndex == 0;
+  protected boolean handlePendingOnDemandRequests() {
+    return false;
   }
 
   private boolean handleNamespace(String namespace) {


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5353.

The function to get pending cache refreshes for Kubernetes greatly duplicates work. The way it currently works is:
  * Every account has a number of caching agents responsible for caching certain types of data.
  * On-demand cache refreshes all go the same place in the cache so there is no way to ask the cache "give me all on-demand refreshes for agent X"
  * This means that when we ask an agent to give us on-demand cache refreshes for the data it owns, it fetches *all* on-demand cache refreshes, then post-filters that list in Java down to the ones that it owns.

This might be reasonable if an incoming request for pending on-demand requests had enough information to route it to a single caching agent; we could then send it to the relevant caching agent and use the results. But this is not the case; the only API exposed by clouddriver for pending on-demand requests returns all of them, without the ability to do any filtering (at least in the context of filtering more granularly than 'provider=kubernetes', 'type=manifest').

So what happens is this:
  * We get a request for all kubernetes pending on-demand cache updates
  * We forward this along to *all* kubernetes caching agents
  * Each of these agents queries the cache for *all* pending cache updates then filters the result down to the ones it owns.
  * We then combine all of these results to get the full set of pending cache updates.

This is greatly duplicating work and yields the same result as if we just asked one of the caching agents to return all the on-demand cache results. It actually used to be worse, as if a caching agent had multiple threads we would also fan out to each of the threads in that caching agent and have it do the same work; now at least we only do this once per agent (regardless of threads).

Where this is particularly troublesome is that some caching agents need information about the cluster to decide whether they own a piece of data
  (though arguably maybe this shouldn't be the case). For example, the CRD caching agent needs to query the cluster for what CRDs exist to decide if it owns a piece of data (by comparing the kind against the list of CRDs). This means that communication with a single cluster can degrade the performance of fetching cache refreshes, which is bad from a failure domain perspective.

To fix this, let's delegate a single instance (with thread 0) of KubernetesCoreCachingAgent to return the pending cache refreshes for each account. This completely removes the filtering logic, and also removes any need for the logic to talk to the cluster, which makes it robust to issues communicating with a cluster.

We are still duplicating the work for each account, which is not great.
(That is, each account will still fetch all the pending refreshes then filter down to ones for that account, before we finally combine them.) This is not great and should probably be addressed in the future (probably by just making the API allow you to specify an account you are interested in). But the big win here is that this filtering is much more efficient and does not require connectivity to your cluster so this should be a big improvement.
