### PR TITLE
feat(saga): Support awaiting cloud state conditions before proceding

### DIFF
--- a/clouddriver-saga-test/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/AbstractSagaTest.kt
+++ b/clouddriver-saga-test/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/AbstractSagaTest.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.saga.persistence.SagaRepository
 import dev.minutest.junit.JUnit5Minutests
 import io.mockk.every
 import io.mockk.mockk
+import java.time.Clock
 import org.springframework.context.ApplicationContext
 
 abstract class AbstractSagaTest : JUnit5Minutests {
@@ -52,7 +53,7 @@ abstract class AbstractSagaTest : JUnit5Minutests {
       }
       registerBeans(applicationContext, *options.registerTypes.toTypedArray())
 
-      sagaService = SagaService(sagaRepository, NoopRegistry()).apply {
+      sagaService = SagaService(sagaRepository, NoopRegistry(), Clock.systemDefaultZone()).apply {
         setApplicationContext(applicationContext)
       }
     }
@@ -72,6 +73,12 @@ abstract class AbstractSagaTest : JUnit5Minutests {
   protected fun registerBeans(applicationContext: ApplicationContext, vararg clazz: Class<*>) {
     clazz.forEach {
       every { applicationContext.getBean(eq(it)) } returns it.newInstance()
+    }
+  }
+
+  protected fun registerBeans(applicationContext: ApplicationContext, vararg obj: Any) {
+    obj.forEach {
+      every { applicationContext.getBean(eq(it::class.java)) } returns it
     }
   }
 }

--- a/clouddriver-saga-test/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/types.kt
+++ b/clouddriver-saga-test/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/types.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.saga
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction
 import com.netflix.spinnaker.clouddriver.saga.models.Saga
+import java.util.function.Function
 import java.util.function.Predicate
 import org.springframework.core.Ordered.HIGHEST_PRECEDENCE
 import org.springframework.core.annotation.Order
@@ -67,4 +68,11 @@ class Action3 : SagaAction<DoAction3> {
 class ShouldBranchPredicate : Predicate<Saga> {
   override fun test(t: Saga): Boolean =
     t.getEvents().filterIsInstance<ShouldBranch>().isNotEmpty()
+}
+
+class AwaitCondition : Function<Saga, Boolean> {
+  var condition: Boolean = false
+
+  override fun apply(t: Saga): Boolean =
+    condition
 }

--- a/clouddriver-saga/clouddriver-saga.gradle
+++ b/clouddriver-saga/clouddriver-saga.gradle
@@ -16,6 +16,7 @@ dependencies {
   implementation "org.hibernate.validator:hibernate-validator"
 
   testImplementation project(":clouddriver-saga-test")
+  testImplementation "com.netflix.spinnaker.kork:kork-test"
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.junit.platform:junit-platform-runner"

--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/config/SagaAutoConfiguration.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/config/SagaAutoConfiguration.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.saga.persistence.DefaultSagaRepository
 import com.netflix.spinnaker.clouddriver.saga.persistence.SagaRepository
 import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer.ClassSubtypeLocator
 import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer.SubtypeLocator
+import java.time.Clock
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -44,9 +45,10 @@ open class SagaAutoConfiguration {
   @Bean
   open fun sagaService(
     sagaRepository: SagaRepository,
-    registry: Registry
+    registry: Registry,
+    clock: Clock
   ): SagaService =
-    SagaService(sagaRepository, registry)
+    SagaService(sagaRepository, registry, clock)
 
   @Bean
   open fun sagaEventSubtypeLocator(): SubtypeLocator {

--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/exceptions/IllegalSagaFlowStateException.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/exceptions/IllegalSagaFlowStateException.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.clouddriver.saga.exceptions
+
+/**
+ * Thrown when a [SagaFlow] has gotten into an irrecoverable state.
+ */
+class IllegalSagaFlowStateException(state: String) : SagaSystemException(
+  "Illegal SagaFlow state: $state"
+) {
+  init {
+    retryable = false
+  }
+}

--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/exceptions/SagaAwaitConditionTimeoutException.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/exceptions/SagaAwaitConditionTimeoutException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.clouddriver.saga.exceptions
+
+class SagaAwaitConditionTimeoutException : SagaSystemException(
+  "Timed out while waiting for condition"
+) {
+  init {
+    retryable = true
+  }
+}

--- a/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/SagaSystemTest.kt
+++ b/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/SagaSystemTest.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.saga.config.SagaAutoConfiguration
 import com.netflix.spinnaker.clouddriver.saga.persistence.SagaRepository
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import java.time.Clock
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
@@ -57,5 +58,8 @@ class SagaSystemTest : JUnit5Minutests {
   open class DependencyConfiguration {
     @Bean
     open fun registry(): Registry = NoopRegistry()
+
+    @Bean
+    open fun clock(): Clock = Clock.systemDefaultZone()
   }
 }

--- a/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/examples/SpringExampleTest.kt
+++ b/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/examples/SpringExampleTest.kt
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.clouddriver.saga.flow.SagaFlow
 import com.netflix.spinnaker.clouddriver.saga.models.Saga
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import java.time.Clock
 import java.util.function.Predicate
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
@@ -44,6 +45,7 @@ import strikt.assertions.isEqualTo
  * Shows an example of how to wire up a Saga using Spring!
  */
 class SpringExampleTest : JUnit5Minutests {
+
   fun tests() = rootContext<ApplicationContextRunner> {
     context("a saga flow") {
       fixture {
@@ -81,6 +83,9 @@ class SpringExampleTest : JUnit5Minutests {
   open class DependencyConfiguration {
     @Bean
     open fun registry(): Registry = NoopRegistry()
+
+    @Bean
+    open fun clock(): Clock = Clock.systemDefaultZone()
 
     @Bean
     open fun action1(): Action1 = Action1()

--- a/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/flow/SagaFlowIteratorTest.kt
+++ b/clouddriver-saga/src/test/kotlin/com/netflix/spinnaker/clouddriver/saga/flow/SagaFlowIteratorTest.kt
@@ -20,13 +20,24 @@ import com.netflix.spinnaker.clouddriver.saga.AbstractSagaTest
 import com.netflix.spinnaker.clouddriver.saga.Action1
 import com.netflix.spinnaker.clouddriver.saga.Action2
 import com.netflix.spinnaker.clouddriver.saga.Action3
+import com.netflix.spinnaker.clouddriver.saga.AwaitCondition
 import com.netflix.spinnaker.clouddriver.saga.SagaCommandCompleted
 import com.netflix.spinnaker.clouddriver.saga.ShouldBranch
 import com.netflix.spinnaker.clouddriver.saga.ShouldBranchPredicate
+import com.netflix.spinnaker.clouddriver.saga.exceptions.SagaAwaitConditionTimeoutException
+import com.netflix.spinnaker.kork.test.time.MutableClock
 import dev.minutest.rootContext
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
 import strikt.api.expect
+import strikt.api.expectThat
+import strikt.api.expectThrows
 import strikt.assertions.isA
+import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
 import strikt.assertions.isTrue
 
 class SagaFlowIteratorTest : AbstractSagaTest() {
@@ -34,55 +45,132 @@ class SagaFlowIteratorTest : AbstractSagaTest() {
   fun tests() = rootContext<Fixture> {
     fixture { Fixture() }
 
-    test("iterates top-level actions only") {
-      expect {
-        that(subject.hasNext()).isTrue()
-        that(subject.next()).get { action }.isA<Action1>()
-        that(subject.hasNext()).isTrue()
-        that(subject.next()).get { action }.isA<Action3>()
-        that(subject.hasNext()).isFalse()
+    context("basic iterator progression") {
+      val flow = SagaFlow()
+        .then(Action1::class.java)
+        .on(ShouldBranchPredicate::class.java) {
+          it.then(Action2::class.java)
+        }
+        .then(Action3::class.java)
+
+      test("iterates top-level actions only") {
+        val subject = createSubject(flow)
+        expect {
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).get { action }.isA<Action1>()
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).get { action }.isA<Action3>()
+          that(subject.hasNext()).isFalse()
+        }
+      }
+
+      test("iterates conditional actions") {
+        val subject = createSubject(flow)
+
+        saga.addEventForTest(ShouldBranch())
+
+        expect {
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).get { action }.isA<Action1>()
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).get { action }.isA<Action2>()
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).get { action }.isA<Action3>()
+          that(subject.hasNext()).isFalse()
+        }
+      }
+
+      test("seeks iterator with partially applied saga") {
+        val subject = createSubject(flow)
+
+        saga.addEventForTest(SagaCommandCompleted("doAction1"))
+        saga.addEventForTest(ShouldBranch())
+
+        expect {
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).get { action }.isA<Action2>()
+          that(subject.next()).get { action }.isA<Action3>()
+          that(subject.hasNext()).isFalse()
+        }
       }
     }
 
-    test("iterates conditional actions") {
-      saga.addEventForTest(ShouldBranch())
+    context("await condition") {
+      val flow = SagaFlow()
+        .then(Action1::class.java)
+        .await(AwaitCondition::class.java, Duration.ofMillis(10), Duration.ofMillis(5))
+        .then(Action2::class.java)
 
-      expect {
-        that(subject.hasNext()).isTrue()
-        that(subject.next()).get { action }.isA<Action1>()
-        that(subject.hasNext()).isTrue()
-        that(subject.next()).get { action }.isA<Action2>()
-        that(subject.hasNext()).isTrue()
-        that(subject.next()).get { action }.isA<Action3>()
-        that(subject.hasNext()).isFalse()
+      val clock = MutableClock(Instant.now())
+
+      test("does not iterate to next step while condition is false") {
+        val subject = createSubject(flow, clock)
+
+        saga.addEventForTest(SagaCommandCompleted("doAction1"))
+
+        expect {
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).and {
+            get { action }.isNull()
+            get { control }.isNotNull().and {
+              get { delay.toMillis() }.isEqualTo(5)
+            }
+          }
+        }
+
+        clock.incrementBy(Duration.ofMillis(5))
+
+        expect {
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).and {
+            get { action }.isNull()
+            get { control }.isNotNull()
+          }
+        }
       }
-    }
 
-    test("seeks iterator with partially applied saga") {
-      saga.addEventForTest(SagaCommandCompleted("doAction1"))
-      saga.addEventForTest(ShouldBranch())
+      test("exception thrown after timeout and noTimeout provided") {
+        val subject = createSubject(flow, clock)
 
-      expect {
-        that(subject.hasNext()).isTrue()
-        that(subject.next()).get { action }.isA<Action2>()
-        that(subject.next()).get { action }.isA<Action3>()
-        that(subject.hasNext()).isFalse()
+        saga.addEventForTest(SagaCommandCompleted("doAction1"))
+        clock.incrementBy(Duration.ofMillis(100))
+
+        expectThrows<SagaAwaitConditionTimeoutException> { subject.hasNext() }
+      }
+
+      test("onTimeout SagaFlow run after timeout") {
+        val timeoutFlow = SagaFlow()
+          .then(Action1::class.java)
+          .await(AwaitCondition::class.java, Duration.ofMillis(10), Duration.ofMillis(5)) {
+            it.then(Action2::class.java)
+          }
+
+        val subject = createSubject(timeoutFlow, clock)
+
+        saga.addEventForTest(SagaCommandCompleted("doAction1"))
+
+        // First hasNext sets the startTime, then we fast-forward after the timeout
+        expectThat(subject.hasNext()).isTrue()
+        clock.incrementBy(Duration.ofMillis(100))
+
+        expect {
+          that(subject.hasNext()).isTrue()
+          that(subject.next()).get { action }.isA<Action2>()
+        }
       }
     }
   }
 
   private inner class Fixture : BaseSagaFixture() {
-    val flow = SagaFlow()
-      .then(Action1::class.java)
-      .on(ShouldBranchPredicate::class.java) {
-        it.then(Action2::class.java)
-      }
-      .then(Action3::class.java)
 
-    val subject = SagaFlowIterator(sagaRepository, applicationContext, saga, flow)
+    val awaitCondition = AwaitCondition()
 
     init {
       sagaRepository.save(saga)
+      registerBeans(applicationContext, awaitCondition)
     }
+
+    fun createSubject(flow: SagaFlow, clock: Clock = Clock.systemDefaultZone()) =
+      SagaFlowIterator(sagaRepository, applicationContext, clock, saga, flow)
   }
 }


### PR DESCRIPTION
Continued effort to remove cloud provider specific logic in Orca. I'm going through Orca trying to find all areas of `orca-clouddriver` where we do conditional logic based on which cloud provider we're dealing with. My end goal is that Orca does not contain any cloud provider logic and just passes the heavy lifting down to clouddriver.

Right now I'm working on [ResizeServerGroupStage](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/ResizeServerGroupStage.groovy). I don't really understand `pre/postStatic` or `pre/postDynamic`, but the general flow is when this stage starts, if we're dealing with AWS, wrap the resize operation in suspend / resume scaling processes so that autoscaling doesn't go trampling.

This seems like just the perfect thing for clouddriver to do:

1. Suspend scaling processes.
2. Set the new capacity for the server group.
3. Wait for the desired capacity to equal actual capacity.
4. Resume scaling processes.

In order for Clouddriver to take this entire flow over, it needs to be able to wait for state, so I added `await` to the Saga code to provide this basic utility. Essentially, this would then allow us to express `ResizeAsgAtomicOperation` in the AWS provider as a `Saga` that looks something like so:

```java
new SagaFlow()
  .then(SuspendScalingProcesses.class)
  .then(ResizeServerGroup.class)
  // condition: Function<Saga, Boolean>, ttl: Duration, interval: Duration
  .await(WaitForDesiredCapacityMatch.class, Duration.ofMinutes(5), Duration.ofSeconds(30))
  .then(ResumeScalingProcesses.class);
```

In doing this, the `FlowIterator` would then periodically invoke `WaitForDesiredCapacityMatch` on `interval` (30 seconds) to check the server group state. Once the state matches, we can move on with life.

Doing this work would allow us to have a totally cloud provider agnostic resize stage.