### PR TITLE
refactor(artifacts): Update artifact code to use new metadata accessor

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
@@ -32,7 +32,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -153,13 +152,7 @@ final class GitRepoArtifactCredentials implements ArtifactCredentials {
   }
 
   private String artifactSubPath(Artifact artifact) {
-    String target = "";
-    Map<String, Object> metadata = artifact.getMetadata();
-    if (metadata != null) {
-      target = (String) metadata.getOrDefault("subPath", "");
-    }
-
-    return target;
+    return Strings.nullToEmpty((String) artifact.getMetadata("subPath"));
   }
 
   private String artifactVersion(Artifact artifact) {

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -287,10 +287,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
     Map<String, Object> buildInfo = null;
     final Artifact applicationArtifact = description.getApplicationArtifact();
     if (applicationArtifact != null) {
-      final Map<String, Object> metadata = applicationArtifact.getMetadata();
-      if (metadata != null) {
-        buildInfo = (Map<String, Object>) applicationArtifact.getMetadata().get("build");
-      }
+      buildInfo = (Map<String, Object>) applicationArtifact.getMetadata("build");
     }
     if (buildInfo == null) {
       final Map<String, Object> trigger = description.getTrigger();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacer.java
@@ -35,7 +35,6 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import lombok.Value;
@@ -95,12 +94,7 @@ public class ArtifactReplacer {
   }
 
   private static String getAccount(Artifact artifact) {
-    String account = "";
-    Map<String, Object> metadata = artifact.getMetadata();
-    if (metadata != null) {
-      account = (String) metadata.getOrDefault("account", "");
-    }
-    return account;
+    return Strings.nullToEmpty((String) artifact.getMetadata("account"));
   }
 
   @Nonnull

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
@@ -130,11 +130,7 @@ final class KubernetesVersionedArtifactConverter extends KubernetesArtifactConve
   }
 
   private Optional<KubernetesManifest> getLastAppliedConfiguration(Artifact artifact) {
-    if (artifact.getMetadata() == null) {
-      return Optional.empty();
-    }
-
-    Object rawLastAppliedConfiguration = artifact.getMetadata().get("lastAppliedConfiguration");
+    Object rawLastAppliedConfiguration = artifact.getMetadata("lastAppliedConfiguration");
 
     if (rawLastAppliedConfiguration == null) {
       return Optional.empty();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
@@ -68,21 +68,12 @@ public class KubernetesCacheDataConverter {
   private static Optional<Keys.CacheKey> convertAsArtifact(
       KubernetesCacheData kubernetesCacheData, String account, KubernetesManifest manifest) {
     String namespace = manifest.getNamespace();
-    Optional<Artifact> optional = KubernetesManifestAnnotater.getArtifact(manifest);
+    Optional<Artifact> optional = KubernetesManifestAnnotater.getArtifact(manifest, account);
     if (!optional.isPresent()) {
       return Optional.empty();
     }
 
     Artifact artifact = optional.get();
-
-    try {
-      KubernetesManifest lastAppliedConfiguration =
-          KubernetesManifestAnnotater.getLastAppliedConfiguration(manifest);
-      artifact.getMetadata().put("lastAppliedConfiguration", lastAppliedConfiguration);
-      artifact.getMetadata().put("account", account);
-    } catch (Exception e) {
-      log.warn("Unable to get last applied configuration from {}: ", manifest, e);
-    }
 
     if (artifact.getType() == null) {
       log.debug(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
@@ -176,12 +176,15 @@ public class KubernetesManifestAnnotater {
     storeAnnotation(annotations, VERSION, artifact.getVersion());
   }
 
-  public static Optional<Artifact> getArtifact(KubernetesManifest manifest) {
+  public static Optional<Artifact> getArtifact(KubernetesManifest manifest, String account) {
     Map<String, String> annotations = manifest.getAnnotations();
     String type = getAnnotation(annotations, TYPE, new TypeReference<String>() {});
     if (Strings.isNullOrEmpty(type)) {
       return Optional.empty();
     }
+
+    KubernetesManifest lastAppliedConfiguration =
+        KubernetesManifestAnnotater.getLastAppliedConfiguration(manifest);
 
     return Optional.of(
         Artifact.builder()
@@ -189,6 +192,8 @@ public class KubernetesManifestAnnotater {
             .name(getAnnotation(annotations, NAME, new TypeReference<String>() {}))
             .location(getAnnotation(annotations, LOCATION, new TypeReference<String>() {}))
             .version(getAnnotation(annotations, VERSION, new TypeReference<String>() {}))
+            .putMetadata("lastAppliedConfiguration", lastAppliedConfiguration)
+            .putMetadata("account", account)
             .build());
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -104,7 +104,7 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
     }
 
     int maxVersionHistory = optionalMaxVersionHistory.getAsInt();
-    Optional<Artifact> optional = KubernetesManifestAnnotater.getArtifact(manifest);
+    Optional<Artifact> optional = KubernetesManifestAnnotater.getArtifact(manifest, accountName);
     if (!optional.isPresent()) {
       return new ArrayList<>();
     }
@@ -114,8 +114,7 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
     List<Artifact> artifacts =
         artifactProvider
             .getArtifacts(artifact.getType(), artifact.getName(), artifact.getLocation()).stream()
-            .filter(
-                a -> a.getMetadata() != null && accountName.equals(a.getMetadata().get("account")))
+            .filter(a -> accountName.equals(a.getMetadata("account")))
             .collect(Collectors.toList());
 
     if (maxVersionHistory >= artifacts.size()) {


### PR DESCRIPTION
* refactor(kubernetes): Avoid mutating artifact metadata

  There's only one place where we mutate the artifact metadata map, and it's in the Kubernetes provider. Rather than get an artifact then add the metadata later, let's just move the logic to add that metdata to the place where we create the artifact, avoiding the need to mutate the metadata.

* refactor(artifacts): Update artifact code to use new metadata accessor

  The accessor to get the full metadata of an artifact as a map is deprecated; replace calls to it with the accessor for a specific key.

  The reason the function to return the entire map is deprecated is so that we can eventually make the map immutable; it's much safer to make that change if we've first updated callers to be unaware that the map exists at all an instead give them a function to get the information they want.

  In most cases this actually simplifies the calling code as we can remove null-checks that are now handled by the exposed API function.