### PR TITLE
chore(*): Remove Oracle, DCOS, and Alicloud from project

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -25,16 +25,16 @@
 rootProject.name = "clouddriver"
 
 def cloudProviderProjects = [
-  'alicloud' : [':clouddriver-alicloud'],
+//  'alicloud' : [':clouddriver-alicloud'],
   'appengine':  [':clouddriver-appengine', ':clouddriver-google-common'],
   'aws': [':clouddriver-aws', ':clouddriver-ecs', ':clouddriver-eureka', ':clouddriver-elasticsearch-aws', ':clouddriver-lambda'], // Pull cd-eureka separate "Discover" platform, along with cd-consul?
   'azure': [':clouddriver-azure'],
   'cloudfoundry': [':clouddriver-cloudfoundry'],
-  'dcos': [':clouddriver-dcos'],
+//  'dcos': [':clouddriver-dcos'],
   'gce': [':clouddriver-consul', ':clouddriver-google', ':clouddriver-google-common'],
   'huaweicloud': [':clouddriver-huaweicloud'],
   'kubernetes': [':clouddriver-kubernetes'],
-  'oracle': [':clouddriver-oracle'],
+//  'oracle': [':clouddriver-oracle'],
   'tencentcloud': [':clouddriver-tencentcloud']
 ]
 cloudProviderProjects.put('gcp', cloudProviderProjects['appengine'] + cloudProviderProjects['gce'] + cloudProviderProjects['kubernetes'])


### PR DESCRIPTION
Following no action from any contributors or stakeholders for Oracle, DCOS, or Alicloud, these cloud providers are being removed from the project. The first step is removing the code from the build, but will eventually lead to complete removal of the code.

* [Notice for Alicloud](https://github.com/spinnaker/governance/issues/122)
* [Notice for DCOS](https://github.com/spinnaker/governance/issues/125)
* [Notice for Oracle](https://github.com/spinnaker/governance/issues/127)