### PR TITLE
fix(tencent): Fix compilation error due to import order

### DIFF
--- a/clouddriver-tencentcloud/src/main/java/com/netflix/spinnaker/clouddriver/tencentcloud/model/TencentCloudTargetHealth.java
+++ b/clouddriver-tencentcloud/src/main/java/com/netflix/spinnaker/clouddriver/tencentcloud/model/TencentCloudTargetHealth.java
@@ -20,7 +20,6 @@ import static com.netflix.spinnaker.clouddriver.model.HealthState.*;
 
 import com.netflix.spinnaker.clouddriver.model.Health;
 import com.netflix.spinnaker.clouddriver.model.HealthState;
-import com.netflix.spinnaker.clouddriver.tencentcloud.model.TencentCloudTargetHealth.LBHealthSummary.ServiceStatus;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
@@ -60,11 +59,11 @@ public class TencentCloudTargetHealth implements Health {
     HEALTHY,
     UNKNOWN;
 
-    public ServiceStatus toServiceStatus() {
+    public LBHealthSummary.ServiceStatus toServiceStatus() {
       if (this == TargetHealthStatus.HEALTHY) {
-        return ServiceStatus.InService;
+        return LBHealthSummary.ServiceStatus.InService;
       }
-      return ServiceStatus.OutOfService;
+      return LBHealthSummary.ServiceStatus.OutOfService;
     }
   }
 


### PR DESCRIPTION
This file is not compiling for my version of the JDK (openjdk 1.8.0_242) because we are importing the inner class before we import the Data annotation that the class is annotated with. It looks like this may have been fixed in later versions of the JDK, but let's avoid others running into this issue by fixing it.