### PR TITLE
fix(ecs): update health status for running tasks

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationService.java
@@ -151,7 +151,7 @@ public class ContainerInformationService {
       case "ACTIVATING":
         return "Starting";
       case "RUNNING":
-        return "Unknown";
+        return "Up";
       default:
         return "Down";
     }

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/services/ContainerInformationServiceSpec.groovy
@@ -83,7 +83,7 @@ class ContainerInformationServiceSpec extends Specification {
       ],
       [
         instanceId: taskId,
-        state     : 'Unknown',
+        state     : 'Up',
         type      :'ecs',
         healthClass: 'platform'
       ]
@@ -192,7 +192,7 @@ class ContainerInformationServiceSpec extends Specification {
     'UNKNOWN'     | 'Starting'    | 'PROVISIONING'
     'UNKNOWN'     | 'Starting'    | 'PENDING'
     'UNKNOWN'     | 'Starting'    | 'ACTIVATING'
-    'UNKNOWN'     | 'Unknown'     | 'RUNNING'
+    'UNKNOWN'     | 'Up'          | 'RUNNING'
     'UNHEALTHY'   | 'Down'        | 'PROVISIONING'
     'UNHEALTHY'   | 'Down'        | 'PENDING'
     'UNHEALTHY'   | 'Down'        | 'ACTIVATING'
@@ -244,7 +244,7 @@ class ContainerInformationServiceSpec extends Specification {
     'HEALTHY'     | 'Starting'    | 'PROVISIONING'
     'HEALTHY'     | 'Starting'    | 'PENDING'
     'HEALTHY'     | 'Starting'    | 'ACTIVATING'
-    'HEALTHY'     | 'Unknown'     | 'RUNNING'
+    'HEALTHY'     | 'Up'          | 'RUNNING'
   }
 
   def 'should return a proper private address for a task'() {


### PR DESCRIPTION
Updates the container health status to Up for a RUNNING task rather than Unknown. Tested multiple scenarios successfully.

Fixes: https://github.com/spinnaker/spinnaker/issues/5741

<img width="242" alt="Screen Shot 2020-06-02 at 5 40 25 PM" src="https://user-images.githubusercontent.com/44981951/83597044-1a2bce80-a51b-11ea-9ab4-fd76c498cbdd.png">
