### PR TITLE
fix(sql): Store dates as string instead of maps

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlCacheConfiguration.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlCacheConfiguration.kt
@@ -1,8 +1,6 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.netflix.discovery.EurekaClient
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.AgentScheduler
@@ -102,6 +100,7 @@ class SqlCacheConfiguration {
     cacheMetrics: SqlCacheMetrics,
     dynamicConfigService: DynamicConfigService,
     sqlConstraints: SqlConstraints,
+    mapper: ObjectMapper,
     @Value("\${sql.cache.async-pool-size:0}") poolSize: Int,
     @Value("\${sql.table-namespace:#{null}}") tableNamespace: String?
   ): NamedCacheFactory {
@@ -125,9 +124,6 @@ class SqlCacheConfiguration {
     if (dispatcher != null) {
       log.info("Configured coroutine context with newFixedThreadPoolContext of $poolSize threads")
     }
-
-    // stores dates like java.time.Instant as a String with the format "2017-04-06T16:29:44.947869272Z" instead of a Map
-    val mapper = ObjectMapper().registerModule(JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     return SqlNamedCacheFactory(
       jooq,

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlCacheConfiguration.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlCacheConfiguration.kt
@@ -1,6 +1,8 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.netflix.discovery.EurekaClient
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.cats.agent.AgentScheduler
@@ -124,9 +126,12 @@ class SqlCacheConfiguration {
       log.info("Configured coroutine context with newFixedThreadPoolContext of $poolSize threads")
     }
 
+    // stores dates like java.time.Instant as a String with the format "2017-04-06T16:29:44.947869272Z" instead of a Map
+    val mapper = ObjectMapper().registerModule(JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
     return SqlNamedCacheFactory(
       jooq,
-      ObjectMapper(),
+      mapper,
       dispatcher,
       clock,
       sqlProperties.retries,


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5706

Modifies the way dates (like java.time.Instant) are stored in sql, storing them as strings instead of a map.

Example of docker image date stored in redis: `"date": "2017-06-23T00:57:26.841792489Z"`

Example of docker image date stored in sql before this change: `"date": { "nano": 499754581, "epochSecond": 1591115020 }`

After the change in sql: `"date":"2020-06-02T16:23:45.284504313Z"`