### PR TITLE
feat(titus): Lookup server group names when converting TitusDeployDescription

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -21,14 +21,13 @@ import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import com.netflix.spinnaker.clouddriver.deploy.DeployDescription
 import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent
 import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
-import com.netflix.spinnaker.clouddriver.security.resources.ResourcesNameable
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
 
 @AutoClone
 @Canonical
 class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription implements
-  DeployDescription, ApplicationNameable, ResourcesNameable {
+  DeployDescription, ApplicationNameable {
   String application
   String amiName
   String stack
@@ -115,16 +114,6 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   @Override
   Collection<String> getApplications() {
     return [application]
-  }
-
-  @Override
-  Collection<String> getNames() {
-    return securityGroupNames ?: []
-  }
-
-  @Override
-  boolean requiresAuthorization() {
-    return false
   }
 
   @Canonical

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
@@ -346,16 +346,12 @@ class CloudDriverConfig {
 
   @Bean
   DescriptionAuthorizer descriptionAuthorizer(Registry registry,
-                                              ObjectMapper objectMapper,
                                               Optional<FiatPermissionEvaluator> fiatPermissionEvaluator,
-                                              SecurityConfig.OperationsSecurityConfigurationProperties opsSecurityConfigProps,
-                                              DynamicConfigService dynamicConfigService) {
+                                              SecurityConfig.OperationsSecurityConfigurationProperties opsSecurityConfigProps) {
     return new DescriptionAuthorizer(
       registry,
-      objectMapper,
       fiatPermissionEvaluator,
-      opsSecurityConfigProps,
-      dynamicConfigService
+      opsSecurityConfigProps
     )
   }
 

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerSpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionAuthorizerSpec.groovy
@@ -34,14 +34,13 @@ class DescriptionAuthorizerSpec extends Specification {
   def registry = new NoopRegistry()
   def evaluator = Mock(FiatPermissionEvaluator)
   def opsSecurityConfigProps
-  def dynamicConfigService = Mock(DynamicConfigService)
 
   @Subject
   DescriptionAuthorizer authorizer
 
   def setup() {
     opsSecurityConfigProps = new SecurityConfig.OperationsSecurityConfigurationProperties()
-    authorizer = new DescriptionAuthorizer(registry, new ObjectMapper(), Optional.of(evaluator), opsSecurityConfigProps, dynamicConfigService)
+    authorizer = new DescriptionAuthorizer(registry, Optional.of(evaluator), opsSecurityConfigProps)
   }
 
   def "should authorize passed description"() {

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ResourcesNameable.java
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/resources/ResourcesNameable.java
@@ -36,14 +36,4 @@ public interface ResourcesNameable {
         .map(name -> Names.parseName(name).getApp())
         .collect(Collectors.toList());
   }
-
-  /**
-   * Determine if the resource should be authz evaluated by the {@link
-   * com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator}.
-   *
-   * @return boolean
-   */
-  default boolean requiresAuthorization() {
-    return true;
-  }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/TitusDeployDescription.java
@@ -30,6 +30,7 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
   private String subnet;
   private List<String> zones = new ArrayList<>();
   private List<String> securityGroups = new ArrayList<>();
+  private List<String> securityGroupNames = new ArrayList<>();
   private List<String> targetGroups = new ArrayList<>();
   private List<String> softConstraints;
   private List<String> hardConstraints;
@@ -237,6 +238,14 @@ public class TitusDeployDescription extends AbstractTitusCredentialsDescription
 
   public void setSecurityGroups(List<String> securityGroups) {
     this.securityGroups = securityGroups;
+  }
+
+  public List<String> getSecurityGroupNames() {
+    return securityGroupNames;
+  }
+
+  public void setSecurityGroupNames(List<String> securityGroupNames) {
+    this.securityGroupNames = securityGroupNames;
   }
 
   public List<String> getTargetGroups() {


### PR DESCRIPTION
-Additionally, removes requiresAuthorization from `ResourcesNameable` and removes `BasicAmazonDeployDescription` implementation of `ResourcesNameable`.  We will instead be requiring authorization on these resources via an implementation of `AllowedAccountsValidator` which runs prior to `DescriptionAuthorizer`.
