### PR TITLE
fix(ecs): set IAMRoleCachingAgent AWS region

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskDefinitionCacheClient.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/cache/client/TaskDefinitionCacheClient.java
@@ -49,6 +49,7 @@ public class TaskDefinitionCacheClient extends AbstractCacheClient<TaskDefinitio
     taskDefinition.setTaskRoleArn((String) attributes.get("taskRoleArn"));
     taskDefinition.setCpu((String) attributes.get("cpu"));
     taskDefinition.setMemory((String) attributes.get("memory"));
+    taskDefinition.setNetworkMode((String) attributes.get("networkMode"));
 
     if (attributes.containsKey("containerDefinitions")) {
       List<Map<String, Object>> containerDefinitions =

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskDefinitionCachingAgent.java
@@ -75,6 +75,7 @@ public class TaskDefinitionCachingAgent extends AbstractEcsOnDemandAgent<TaskDef
     attributes.put("taskRoleArn", taskDefinition.getTaskRoleArn());
     attributes.put("memory", taskDefinition.getMemory());
     attributes.put("cpu", taskDefinition.getCpu());
+    attributes.put("networkMode", taskDefinition.getNetworkMode());
     return attributes;
   }
 


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5710

Previously, the default region was always being used, which results in the wrong endpoint being used for China regions.