### PR TITLE
fix(provider/cf): fix stop server group state checking

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/StopCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/StopCloudFoundryServerGroupAtomicOperation.java
@@ -49,7 +49,9 @@ public class StopCloudFoundryServerGroupAtomicOperation implements AtomicOperati
     ProcessStats.State state =
         operationPoller.waitForOperation(
             () -> client.getApplications().getProcessState(description.getServerGroupId()),
-            inProgressState -> inProgressState != ProcessStats.State.STARTING,
+            inProgressState ->
+                inProgressState != ProcessStats.State.STARTING
+                    && inProgressState != ProcessStats.State.RUNNING,
             null,
             getTask(),
             description.getServerGroupName(),


### PR DESCRIPTION
StopServerGroup operation is only checking that the state is != STARTING. It should also include a != RUNNING since this is one of the outcomes for state. This creates a bug where the operationsPoller completes successfully because the state is != STARTING. When the state is RUNNING, it will proceed and an exception will be thrown. This fix will allow CF enough time to stop the application and correctly show state. 