### PR TITLE
feat(core): Support before/after lifecycles for AtomicOperations

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.groovy
@@ -17,13 +17,6 @@
 package com.netflix.spinnaker.clouddriver.deploy
 
 import com.netflix.spinnaker.clouddriver.orchestration.VersionedCloudProviderOperation
-import com.netflix.spinnaker.clouddriver.security.resources.AccountNameable
-import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
-import com.netflix.spinnaker.clouddriver.security.resources.ResourcesNameable
-import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Errors
 
 public abstract class DescriptionValidator<T> implements VersionedCloudProviderOperation {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperation.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperation.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.events.OperationEvent;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * An AtomicOperation is the most fundamental, low-level unit of work in a workflow. Implementations
@@ -36,7 +37,34 @@ public interface AtomicOperation<R> {
    */
   R operate(List priorOutputs);
 
+  /** Returns whether or not the AtomicOperation supports the given {@link OperationLifecycle}. */
+  default boolean supportsLifecycle(OperationLifecycle lifecycle) {
+    return false;
+  }
+
+  /** Logic for {@code OperationLifecycle.BEFORE}. */
+  @Nullable
+  default Object beforeOperate() {
+    return null;
+  }
+
+  /** Logic for {@code OperationLifecycle.AFTER}. */
+  @Nullable
+  default Object afterOperate() {
+    return null;
+  }
+
   default Collection<OperationEvent> getEvents() {
     return Collections.emptyList();
+  }
+
+  /**
+   * Available lifecycle hooks that an AtomicOperation can implement additional logic for.
+   *
+   * <p>Orca will automatically call these lifecycles for every AtomicOperation.
+   */
+  enum OperationLifecycle {
+    BEFORE,
+    AFTER;
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
@@ -113,6 +113,7 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
             TimedCallable.forClosure(registry, thisOp) {
               results << atomicOperation.operate(results)
 
+              // TODO(rz): OperationEvents seem like a half-step towards "after" logic... maybe this can disappear?
               atomicOperation.events.each { OperationEvent event ->
                 operationEventHandlers.each {
                   try {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/LifecycleAwareAtomicOperation.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/LifecycleAwareAtomicOperation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.clouddriver.orchestration;
+
+import static java.lang.String.format;
+
+import com.netflix.spinnaker.kork.exceptions.SystemException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wrapper class for {@link AtomicOperation}s that support lifecycles.
+ *
+ * <p>This is an internal class used by {@link OperationsService} to correctly invoke lifecycle
+ * methods when requested, without having to do intrusive refactors of a {@link
+ * OrchestrationProcessor}.
+ *
+ * <p>Since {@link DefaultOrchestrationProcessor} does not actually care what the return object type
+ * of an AtomicOperation is, we can safely use {@code Object} as the return type for before/after
+ * operations.
+ */
+public class LifecycleAwareAtomicOperation implements AtomicOperation<Object> {
+
+  private static final Logger log = LoggerFactory.getLogger(LifecycleAwareAtomicOperation.class);
+
+  private final AtomicOperation<?> atomicOperation;
+  private final AtomicOperation.OperationLifecycle operationLifecycle;
+
+  public LifecycleAwareAtomicOperation(
+      AtomicOperation<?> atomicOperation, OperationLifecycle operationLifecycle) {
+    this.atomicOperation = atomicOperation;
+    this.operationLifecycle = operationLifecycle;
+  }
+
+  @Override
+  public Object operate(List priorOutputs) {
+    log.debug(
+        "Running '{}' lifecycle for '{}'",
+        operationLifecycle,
+        atomicOperation.getClass().getSimpleName());
+    switch (operationLifecycle) {
+      case BEFORE:
+        return atomicOperation.beforeOperate();
+      case AFTER:
+        return atomicOperation.afterOperate();
+      default:
+        throw new SystemException(format("Unsupported lifecycle: '%s'", operationLifecycle));
+    }
+  }
+}

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/OperationsService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/OperationsService.java
@@ -91,24 +91,26 @@ public class OperationsService {
   }
 
   @Nonnull
-  public List<AtomicOperation> collectAtomicOperations(@Nonnull List<Map<String, Map>> inputs) {
+  public ResolvedAtomicOperations collectAtomicOperations(@Nonnull List<Map<String, Map>> inputs) {
     return collectAtomicOperations(null, inputs);
   }
 
   @Nonnull
-  public List<AtomicOperation> collectAtomicOperations(
+  public ResolvedAtomicOperations collectAtomicOperations(
       @Nullable String cloudProvider, @Nonnull List<Map<String, Map>> inputs) {
     List<AtomicOperationBindingResult> results = convert(cloudProvider, inputs);
 
-    List<AtomicOperation> atomicOperations = new ArrayList<>();
+    List<AtomicOperation<?>> atomicOperations = new ArrayList<>();
     results.forEach(
         bindingResult -> {
           if (bindingResult.errors.hasErrors()) {
             throw new DescriptionValidationException(bindingResult.errors);
           }
-          atomicOperations.add(bindingResult.atomicOperation);
+          if (bindingResult.supportsLifecycle) {
+            atomicOperations.add(bindingResult.atomicOperation);
+          }
         });
-    return atomicOperations;
+    return new ResolvedAtomicOperations(atomicOperations, atomicOperations.isEmpty());
   }
 
   private List<AtomicOperationBindingResult> convert(
@@ -204,7 +206,20 @@ public class OperationsService {
                                 .increment();
                           }
 
-                          return new AtomicOperationBindingResult(atomicOperation, errors);
+                          if (operationInput.isLifecycleOperation()) {
+                            if (!atomicOperation.supportsLifecycle(
+                                operationInput.operationLifecycle)) {
+                              // Not supporting a lifecycle is not an error condition. It's OK!
+                              return new AtomicOperationBindingResult(
+                                  atomicOperation, errors, false);
+                            } else {
+                              atomicOperation =
+                                  new LifecycleAwareAtomicOperation(
+                                      atomicOperation, operationInput.operationLifecycle);
+                            }
+                          }
+
+                          return new AtomicOperationBindingResult(atomicOperation, errors, true);
                         }))
         .collect(Collectors.toList());
   }
@@ -290,6 +305,7 @@ public class OperationsService {
   public static class AtomicOperationBindingResult {
     private AtomicOperation atomicOperation;
     private Errors errors;
+    private boolean supportsLifecycle;
   }
 
   @Data
@@ -298,11 +314,22 @@ public class OperationsService {
     @Nullable private String accountName;
     @Nullable private String account;
     @Nullable private String cloudProvider;
+    @Nullable private AtomicOperation.OperationLifecycle operationLifecycle;
+
+    public boolean isLifecycleOperation() {
+      return operationLifecycle != null;
+    }
 
     @Nullable
     public String computeAccountName() {
       return Optional.ofNullable(credentials)
           .orElse(Optional.ofNullable(accountName).orElse(account));
     }
+  }
+
+  @Value
+  public static class ResolvedAtomicOperations {
+    private List<AtomicOperation<?>> atomicOperations;
+    private boolean unsupportedLifecycle;
   }
 }


### PR DESCRIPTION
Continued POC for moving cloud provider logic in Orca into Clouddriver.

This allows AtomicOperations to define `before` and `after` lifecycles that they can do logic on. 

For any `cloudOperationStage` in Orca, 3 requests into Clouddriver would always be made, resulting in `1..3` kato tasks to be run, each task run and monitored in sequence. If an `AtomicOperation` does not support one or both operations, no error is raised, but a `200` will be returned with an empty `StartOperationResult` response: Orca would take this as a cue that no lifecycle is registered and it can continue on its way.

These lifecycles would be invoked by Orca injecting a `operationLifecycle` key into a cloud operation description, with either the value `BEFORE`, `AFTER` or `null`. When `null` is provided, the actual `operate` method of an `AtomicOperation` will be invoked.

⚠️ Obviously this PR is incomplete and janky. Just wanted to hack something together that would work and be largely unobtrusive to current code.