### PR TITLE
fix(ecs): add null check for target group cache data

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TargetHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TargetHealthCachingAgent.java
@@ -122,7 +122,10 @@ public class TargetHealthCachingAgent extends AbstractEcsAwsAwareCachingAgent<Ec
     // TODO: refine search key instead of filtering these cache results
     List<EcsTargetGroup> tgList =
         cacheClient.find(targetGroupKeys).stream()
-            .filter(t -> t.getTargetGroupArn().contains(account.getAccountId()))
+            .filter(
+                t ->
+                    t.getTargetGroupArn() != null
+                        && t.getTargetGroupArn().contains(account.getAccountId()))
             .collect(Collectors.toList());
 
     return tgList.stream().map(EcsTargetGroup::getTargetGroupArn).collect(Collectors.toSet());


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5816

### Testing
1. added `'should handle null targetGroupArn in cache data'` test, reproduced error
2. added null check, test passes 🎉 