### PR TITLE
fix(aws/cache): include informative results in CatsClusterCachingAgent

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonAuthoritativeClustersAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonAuthoritativeClustersAgent.java
@@ -26,7 +26,8 @@ public class AmazonAuthoritativeClustersAgent extends CatsClusterCachingAgent {
     super(
         Keys.getServerGroupKey("*", "*", "*", "*"),
         Keys::parse,
-        sg -> Keys.getClusterKey(sg.get("cluster"), sg.get("application"), sg.get("account")));
+        sg -> Keys.getClusterKey(sg.get("cluster"), sg.get("application"), sg.get("account")),
+        Keys::getApplicationKey);
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -214,9 +214,9 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
       cluster.accountName = clusterKey.account
       cluster.name = clusterKey.cluster
 
-      cluster.serverGroups = clusterData.relationships[SERVER_GROUPS.ns]?.findResults { serverGroups.get(it) }
-      cluster.loadBalancers = clusterData.relationships[LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) }
-      cluster.targetGroups = clusterData.relationships[TARGET_GROUPS.ns]?.findResults { targetGroups.get(it) }
+      cluster.serverGroups = clusterData.relationships[SERVER_GROUPS.ns]?.findResults { serverGroups.get(it) } ?: []
+      cluster.loadBalancers = clusterData.relationships[LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) } ?: []
+      cluster.targetGroups = clusterData.relationships[TARGET_GROUPS.ns]?.findResults { targetGroups.get(it) } ?: []
 
       return cluster
     }
@@ -251,20 +251,20 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
       AmazonCluster cluster = new AmazonCluster()
       cluster.accountName = clusterKey.account
       cluster.name = clusterKey.cluster
-      cluster.serverGroups = clusterDataEntry.relationships[SERVER_GROUPS.ns]?.findResults { serverGroups.get(it) }
+      cluster.serverGroups = clusterDataEntry.relationships[SERVER_GROUPS.ns]?.findResults { serverGroups.get(it) } ?: []
 
       if (includeDetails) {
-        cluster.loadBalancers = clusterDataEntry.relationships[LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) }
-        cluster.targetGroups = clusterDataEntry.relationships[TARGET_GROUPS.ns]?.findResults { targetGroups.get(it) }
+        cluster.loadBalancers = clusterDataEntry.relationships[LOAD_BALANCERS.ns]?.findResults { loadBalancers.get(it) } ?: []
+        cluster.targetGroups = clusterDataEntry.relationships[TARGET_GROUPS.ns]?.findResults { targetGroups.get(it) } ?: []
       } else {
         cluster.loadBalancers = clusterDataEntry.relationships[LOAD_BALANCERS.ns]?.collect { loadBalancerKey ->
           Map parts = Keys.parse(loadBalancerKey)
           new AmazonLoadBalancer(name: parts.loadBalancer, account: parts.account, region: parts.region)
-        }
+        } ?: []
         cluster.targetGroups = clusterDataEntry.relationships[TARGET_GROUPS.ns]?.collect { targetGroupKey ->
           Map parts = Keys.parse(targetGroupKey)
           new AmazonTargetGroup(name: parts.loadBalancer, account: parts.account, region: parts.region)
-        }
+        } ?: []
       }
       cluster
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonAuthoritativeClustersAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonAuthoritativeClustersAgentSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.clouddriver.aws.data.Keys
 import org.hamcrest.Matchers
 import spock.lang.Specification
 
+import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.APPLICATIONS
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.CLUSTERS
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS;
 
@@ -38,8 +39,13 @@ class AmazonAuthoritativeClustersAgentSpec extends Specification {
     1 * providerCache.filterIdentifiers(SERVER_GROUPS.ns, Keys.getServerGroupKey('*','*', '*', '*')) >> sgIds
     1 * providerCache.existingIdentifiers(SERVER_GROUPS.ns, _) >> sgIds
 
-    result.cacheResults.size() == 1
+    result.cacheResults.size() == 3
+    result.cacheResults.containsKey(CLUSTERS.ns)
+    result.cacheResults.containsKey(SERVER_GROUPS.ns)
+    result.cacheResults.containsKey(APPLICATIONS.ns)
     result.cacheResults[CLUSTERS.ns].size() == expectedSize
+    result.cacheResults[SERVER_GROUPS.ns].size() == sgIds.size()
+    result.cacheResults[APPLICATIONS.ns].size() == 1
     Matchers.containsInAnyOrder(expected.toArray()).matches(result.cacheResults[CLUSTERS.ns]*.id)
     Matchers.containsInAnyOrder("foo-main", "foo-staging").matches(result.cacheResults[CLUSTERS.ns]*.attributes["name"])
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusAuthoritativeClustersAgent.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/caching/agents/TitusAuthoritativeClustersAgent.java
@@ -26,7 +26,8 @@ public class TitusAuthoritativeClustersAgent extends CatsClusterCachingAgent {
     super(
         Keys.getServerGroupKey("*", "*", "*", "*"),
         Keys::parse,
-        sg -> Keys.getClusterKey(sg.get("cluster"), sg.get("application"), sg.get("account")));
+        sg -> Keys.getClusterKey(sg.get("cluster"), sg.get("application"), sg.get("account")),
+        Keys::getApplicationKey);
   }
 
   @Override


### PR DESCRIPTION
This is still missing the cluster -> loadBalancers relationship that used to be populated.
For now there are some defaults to empty collection on the AmazonClusterProvider to prevent
NullPointerExceptions, I will follow up with an update to add cluster -> loadBalancer and
cluster -> targetGroup relationships as a separate change