### PR TITLE
fix(provider/cf): use moniker object for application name

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/CloudFoundryRunJobOperationDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/CloudFoundryRunJobOperationDescription.java
@@ -17,26 +17,17 @@
 
 package com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description;
 
-import com.netflix.frigga.Names;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundryServerGroup;
-import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable;
-import java.util.Collection;
-import java.util.Collections;
 import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class CloudFoundryRunJobOperationDescription extends AbstractCloudFoundryDescription
-    implements ApplicationNameable {
+public class CloudFoundryRunJobOperationDescription
+    extends AbstractCloudFoundryServerGroupDescription {
 
   private CloudFoundryServerGroup serverGroup;
   @Nullable private String jobName;
   private String command;
-
-  @Override
-  public Collection<String> getApplications() {
-    return Collections.singletonList(Names.parseName(serverGroup.getName()).getApp());
-  }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.artifacts.config.ArtifactCredentials;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.CloudFoundrySpace;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -46,16 +44,6 @@ public class DeployCloudFoundryServerGroupDescription
   @JsonIgnore private ArtifactCredentials artifactCredentials;
 
   @JsonIgnore private ApplicationAttributes applicationAttributes;
-
-  @Override
-  public String getAccount() {
-    return accountName;
-  }
-
-  @Override
-  public Collection<String> getApplications() {
-    return Collections.singletonList(application);
-  }
 
   @Data
   public static class ApplicationAttributes {


### PR DESCRIPTION
We have ensured that orca is now passing moniker objects with tasks so this is the partner change that will now use those moniker objects for application name. Now all operations that use AccountNamable and ApplicationNamable use the same logic for cloudfoundry operations.