### PR TITLE
refactor(core): Fix warning fetching operation version

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/OperationsService.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/OperationsService.java
@@ -243,17 +243,12 @@ public class OperationsService {
 
   private ProviderVersion getOperationVersion(OperationInput operation) {
     final String accountName = operation.computeAccountName();
-    if (accountName == null) {
-      log.warn("Unable to get account name from operation: {}", operation);
-    } else {
-      try {
-        AccountCredentials credentials = accountCredentialsRepository.getOne(accountName);
-        return credentials.getProviderVersion();
-      } catch (Exception e) {
-        log.warn("Unable to determine provider version for account {}", accountName, e);
-      }
+    Optional<AccountCredentials> credentials =
+        Optional.ofNullable(accountName).map(accountCredentialsRepository::getOne);
+    if (!credentials.isPresent()) {
+      log.warn("Unable to find account with name {}", accountName);
     }
-    return ProviderVersion.v1;
+    return credentials.map(AccountCredentials::getProviderVersion).orElse(ProviderVersion.v1);
   }
 
   /**


### PR DESCRIPTION
The code to fetch the version of an operation catches any Exception. The only actual exception that can occur is a null-pointer exception of credentials.getOne returns null. Let's just make the code null-safe and remove all catch and warning logic.

One of the main motivations of this is that ProviderVersion is no longer even relevant now that the Kubernetes V1 provider has been removed from the code. Logging a warning related to being unable to fetch the provider version just confuses debugging; if the account doesn't exist, that itself is the problem, so we should note that in the warning, rather than that we couldn't fetch the version.