### PR TITLE
fix(kubernetes): Fail with a useful message if manifest not found

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesEnableDisableManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesEnableDisableManifestDescription.java
@@ -17,16 +17,27 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.description.manifest;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class KubernetesEnableDisableManifestDescription
+public final class KubernetesEnableDisableManifestDescription
     extends KubernetesManifestOperationDescription {
-  int targetPercentage = 100;
+  private int targetPercentage = 100;
   // optional: can be inferred from the annotations as well
-  List<String> loadBalancers = new ArrayList<>();
+  @Nonnull private ImmutableList<String> loadBalancers = ImmutableList.of();
+
+  @Nonnull
+  public KubernetesEnableDisableManifestDescription setLoadBalancers(
+      @Nullable List<String> loadBalancers) {
+    this.loadBalancers =
+        Optional.ofNullable(loadBalancers).map(ImmutableList::copyOf).orElseGet(ImmutableList::of);
+    return this;
+  }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.netflix.frigga.Names;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.moniker.Moniker;
@@ -237,7 +238,7 @@ public class KubernetesManifestAnnotater {
 
   public static void setTraffic(KubernetesManifest manifest, KubernetesManifestTraffic traffic) {
     Map<String, String> annotations = manifest.getAnnotations();
-    List<String> loadBalancers = traffic.getLoadBalancers();
+    ImmutableList<String> loadBalancers = traffic.getLoadBalancers();
 
     if (annotations.containsKey(LOAD_BALANCERS)) {
       KubernetesManifestTraffic currentTraffic = getTraffic(manifest);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.netflix.frigga.Names;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.ArrayList;
@@ -227,6 +228,7 @@ public class KubernetesManifestAnnotater {
         .build();
   }
 
+  @NonnullByDefault
   public static KubernetesManifestTraffic getTraffic(KubernetesManifest manifest) {
     Map<String, String> annotations = manifest.getAnnotations();
 
@@ -236,6 +238,7 @@ public class KubernetesManifestAnnotater {
     return new KubernetesManifestTraffic(loadBalancers);
   }
 
+  @NonnullByDefault
   public static void setTraffic(KubernetesManifest manifest, KubernetesManifestTraffic traffic) {
     Map<String, String> annotations = manifest.getAnnotations();
     ImmutableList<String> loadBalancers = traffic.getLoadBalancers();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTraffic.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTraffic.java
@@ -17,14 +17,23 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.description.manifest;
 
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import java.util.Optional;
+import javax.annotation.ParametersAreNullableByDefault;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-@AllArgsConstructor
 @EqualsAndHashCode
 @Getter
-public class KubernetesManifestTraffic {
-  private List<String> loadBalancers;
+@NonnullByDefault
+public final class KubernetesManifestTraffic {
+  private final ImmutableList<String> loadBalancers;
+
+  @ParametersAreNullableByDefault
+  public KubernetesManifestTraffic(List<String> loadBalancers) {
+    this.loadBalancers =
+        Optional.ofNullable(loadBalancers).map(ImmutableList::copyOf).orElseGet(ImmutableList::of);
+  }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanLoadBalance.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanLoadBalance.java
@@ -23,8 +23,10 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourceProperty
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import java.util.List;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang3.tuple.Pair;
 
+@ParametersAreNonnullByDefault
 public interface CanLoadBalance {
   void attach(KubernetesManifest loadBalancer, KubernetesManifest target);
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesServiceHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesServiceHandler.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -178,6 +179,7 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
   }
 
   @Override
+  @ParametersAreNonnullByDefault
   public void attach(KubernetesManifest loadBalancer, KubernetesManifest target) {
     Map<String, String> labels = target.getSpecTemplateLabels().orElse(target.getLabels());
     ImmutableMap<String, String> selector = getSelector(loadBalancer);
@@ -209,6 +211,7 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
   }
 
   @Override
+  @ParametersAreNonnullByDefault
   public List<JsonPatch> attachPatch(KubernetesManifest loadBalancer, KubernetesManifest target) {
     String pathPrefix = pathPrefix(target);
     Map<String, String> labels = labels(target);
@@ -225,6 +228,7 @@ public class KubernetesServiceHandler extends KubernetesHandler implements CanLo
   }
 
   @Override
+  @ParametersAreNonnullByDefault
   public List<JsonPatch> detachPatch(KubernetesManifest loadBalancer, KubernetesManifest target) {
     String pathPrefix = pathPrefix(target);
     Map<String, String> labels = labels(target);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -41,6 +41,7 @@ import java.io.EOFException;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.WillClose;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -339,6 +340,7 @@ public class KubectlJobExecutor {
     return null;
   }
 
+  @Nullable
   public KubernetesManifest get(
       KubernetesV2Credentials credentials, KubernetesKind kind, String namespace, String name) {
     List<String> command = kubectlNamespacedGet(credentials, ImmutableList.of(kind), namespace);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -62,7 +62,7 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
   private List<String> determineLoadBalancers(KubernetesManifest target) {
     getTask().updateStatus(OP_NAME, "Getting load balancer list to " + getVerbName() + "...");
     List<String> result = description.getLoadBalancers();
-    if (result != null && !result.isEmpty()) {
+    if (!result.isEmpty()) {
       getTask().updateStatus(OP_NAME, "Using supplied list [" + String.join(", ", result) + "]");
     } else {
       KubernetesManifestTraffic traffic = KubernetesManifestAnnotater.getTraffic(target);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -99,7 +99,7 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
                 () ->
                     new IllegalStateException(
                         String.format(
-                            "Could not find load balancer. (kind: %s, name: %s, namespace: %s",
+                            "Could not find load balancer. (kind: %s, name: %s, namespace: %s)",
                             name.getLeft(), name.getRight(), target.getNamespace())));
 
     List<JsonPatch> patch = patchResource(loadBalancerHandler, loadBalancer, target);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -34,9 +34,13 @@ import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.HasPods;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang.WordUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
+@ParametersAreNonnullByDefault
 public abstract class AbstractKubernetesEnableDisableManifestOperation
     implements AtomicOperation<OperationResult> {
   private final KubernetesEnableDisableManifestDescription description;
@@ -60,7 +64,8 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
     return TaskRepository.threadLocalTask.get();
   }
 
-  private List<String> determineLoadBalancers(KubernetesManifest target) {
+  @Nonnull
+  private List<String> determineLoadBalancers(@Nonnull KubernetesManifest target) {
     getTask().updateStatus(OP_NAME, "Getting load balancer list to " + getVerbName() + "...");
     ImmutableList<String> result = description.getLoadBalancers();
     if (!result.isEmpty()) {
@@ -89,7 +94,13 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
     CanLoadBalance loadBalancerHandler =
         CanLoadBalance.lookupProperties(credentials.getResourcePropertyRegistry(), name);
     KubernetesManifest loadBalancer =
-        credentials.get(name.getLeft(), target.getNamespace(), name.getRight());
+        Optional.ofNullable(credentials.get(name.getLeft(), target.getNamespace(), name.getRight()))
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        String.format(
+                            "Could not find load balancer. (kind: %s, name: %s, namespace: %s",
+                            name.getLeft(), name.getRight(), target.getNamespace())));
 
     List<JsonPatch> patch = patchResource(loadBalancerHandler, loadBalancer, target);
 
@@ -126,7 +137,14 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
     getTask().updateStatus(OP_NAME, "Starting " + getVerbName() + " operation...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
     KubernetesManifest target =
-        credentials.get(coordinates.getKind(), coordinates.getNamespace(), coordinates.getName());
+        Optional.ofNullable(
+                credentials.get(
+                    coordinates.getKind(), coordinates.getNamespace(), coordinates.getName()))
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        String.format(
+                            "Could not find kubernetes manifest: %s", coordinates.toString())));
     determineLoadBalancers(target).forEach(l -> op(l, target));
 
     getTask()

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.op.manifest;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.JsonPatch;
@@ -61,7 +62,7 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
 
   private List<String> determineLoadBalancers(KubernetesManifest target) {
     getTask().updateStatus(OP_NAME, "Getting load balancer list to " + getVerbName() + "...");
-    List<String> result = description.getLoadBalancers();
+    ImmutableList<String> result = description.getLoadBalancers();
     if (!result.isEmpty()) {
       getTask().updateStatus(OP_NAME, "Using supplied list [" + String.join(", ", result) + "]");
     } else {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesV2Credentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesV2Credentials.java
@@ -62,6 +62,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -366,6 +367,7 @@ public class KubernetesV2Credentials implements KubernetesCredentials {
     return ImmutableList.of();
   }
 
+  @Nullable
   public KubernetesManifest get(KubernetesKind kind, String namespace, String name) {
     return runAndRecordMetrics(
         "get", kind, namespace, () -> jobExecutor.get(this, kind, namespace, name));

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesEnableDisableManifestDescriptionTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesEnableDisableManifestDescriptionTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.description.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesEnableDisableManifestDescriptionTest {
+  private static final JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final int DEFAULT_TARGET_PERCENTAGE = 100;
+
+  @Test
+  void deserializeEmpty() throws Exception {
+    String serialized = jsonFactory.objectNode().toString();
+    KubernetesEnableDisableManifestDescription description =
+        objectMapper.readValue(serialized, KubernetesEnableDisableManifestDescription.class);
+    assertThat(description.getLoadBalancers()).isNotNull();
+    assertThat(description.getLoadBalancers()).isEmpty();
+    assertThat(description.getTargetPercentage()).isEqualTo(DEFAULT_TARGET_PERCENTAGE);
+  }
+
+  @Test
+  void deserializeNullLoadBalancers() throws Exception {
+    String serialized =
+        jsonFactory
+            .objectNode()
+            .<ObjectNode>set("loadBalancers", jsonFactory.nullNode())
+            .toString();
+    KubernetesEnableDisableManifestDescription description =
+        objectMapper.readValue(serialized, KubernetesEnableDisableManifestDescription.class);
+    assertThat(description.getLoadBalancers()).isNotNull();
+    assertThat(description.getLoadBalancers()).isEmpty();
+  }
+
+  @Test
+  void deserializEmptyLoadBalancers() throws Exception {
+    String serialized =
+        jsonFactory
+            .objectNode()
+            .<ObjectNode>set("loadBalancers", jsonFactory.arrayNode())
+            .toString();
+    KubernetesEnableDisableManifestDescription description =
+        objectMapper.readValue(serialized, KubernetesEnableDisableManifestDescription.class);
+    assertThat(description.getLoadBalancers()).isNotNull();
+    assertThat(description.getLoadBalancers()).isEmpty();
+  }
+
+  @Test
+  void deserializNonEmptyLoadBalancers() throws Exception {
+    String serialized =
+        jsonFactory
+            .objectNode()
+            .<ObjectNode>set("loadBalancers", jsonFactory.arrayNode().add("abc").add("def"))
+            .toString();
+    KubernetesEnableDisableManifestDescription description =
+        objectMapper.readValue(serialized, KubernetesEnableDisableManifestDescription.class);
+    assertThat(description.getLoadBalancers()).isNotNull();
+    assertThat(description.getLoadBalancers()).containsExactly("abc", "def");
+  }
+
+  @Test
+  void deserializeTargetPercentage() throws Exception {
+    String serialized = jsonFactory.objectNode().put("targetPercentage", 50).toString();
+    KubernetesEnableDisableManifestDescription description =
+        objectMapper.readValue(serialized, KubernetesEnableDisableManifestDescription.class);
+    assertThat(description.getTargetPercentage()).isEqualTo(50);
+  }
+
+  @Test
+  void deserializeManifestNameLocation() throws Exception {
+    String serialized =
+        jsonFactory
+            .objectNode()
+            .put("manifestName", "replicaSet my-rs")
+            .put("location", "my-namespace")
+            .toString();
+    KubernetesEnableDisableManifestDescription description =
+        objectMapper.readValue(serialized, KubernetesEnableDisableManifestDescription.class);
+    assertThat(description.getManifestName()).isEqualTo("replicaSet my-rs");
+    assertThat(description.getLocation()).isEqualTo("my-namespace");
+  }
+}

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTrafficTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTrafficTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.description.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesManifestTrafficTest {
+  @Test
+  final void createNullTraffic() {
+    KubernetesManifestTraffic traffic = new KubernetesManifestTraffic(null);
+    assertThat(traffic.getLoadBalancers()).isNotNull();
+    assertThat(traffic.getLoadBalancers()).isEmpty();
+  }
+
+  @Test
+  final void createEmptyTraffic() {
+    KubernetesManifestTraffic traffic = new KubernetesManifestTraffic(ImmutableList.of());
+    assertThat(traffic.getLoadBalancers()).isEmpty();
+  }
+
+  @Test
+  final void createNonEmptyTraffic() {
+    KubernetesManifestTraffic traffic =
+        new KubernetesManifestTraffic(ImmutableList.of("abc", "def"));
+    assertThat(traffic.getLoadBalancers()).containsExactly("abc", "def");
+  }
+
+  @Test
+  final void listIsImmutable() {
+    List<String> loadBalancers = new ArrayList<>();
+    loadBalancers.add("abc");
+    KubernetesManifestTraffic traffic = new KubernetesManifestTraffic(loadBalancers);
+    assertThat(traffic.getLoadBalancers()).containsExactly("abc");
+
+    loadBalancers.add("def");
+    assertThat(traffic.getLoadBalancers()).containsExactly("abc");
+  }
+}


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5843 where an NPE was thrown instead of a useful error message about what Kubernetes object could not be found.

* refactor(kubernetes): Clean up EnableDisableManifestDescription

  Mostly the goal here is to make loadBalancers Nonnull, which required overriding the lombok-generated accessor so that we can translate a null that's passed in to an empty list. While here, make the list immutable.

  Also add some tests, particularly on deserialization.

  I did *not* make the class immutable because one must draw some line at which to stop refactoring.

* refactor(kubernetes): Make KubernetesManifestTraffic null-safe

  Also make it immutable, and add some tests.

* fix(kubernetes): Fail with a useful message if manifest not found

  This commit adds nullity annotations to a number of functions related to the disable manifest stage so that we can better understand what can be null.

  It then throws a useful error message when a requested manifest is null, preventing what was a downstream error far from the actual issue (and that had less information about the error).