### PR TITLE
perf(aws): Minor improvement to perf of /serverGroups endpoint

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -177,20 +177,22 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
     // lbs and images can span applications and can't currently be indexed by app
     Collection<CacheData> allLoadBalancers = resolveRelationshipDataForCollection(
       cacheResults[CLUSTERS.ns],
-      LOAD_BALANCERS.ns
+      LOAD_BALANCERS.ns,
+      RelationshipCacheFilter.none()
     )
     Collection<CacheData> allTargetGroups = resolveRelationshipDataForCollection(
       cacheResults[CLUSTERS.ns],
-      TARGET_GROUPS.ns
+      TARGET_GROUPS.ns,
+      RelationshipCacheFilter.none()
     )
 
     Collection<CacheData> allImages = []
     allImages.addAll(
-      resolveRelationshipDataForCollection(cacheResults[LAUNCH_CONFIGS.ns], IMAGES.ns)
+      resolveRelationshipDataForCollection(cacheResults[LAUNCH_CONFIGS.ns], IMAGES.ns, RelationshipCacheFilter.none())
     )
 
     allImages.addAll(
-      resolveRelationshipDataForCollection(cacheResults[LAUNCH_TEMPLATES.ns], IMAGES.ns)
+      resolveRelationshipDataForCollection(cacheResults[LAUNCH_TEMPLATES.ns], IMAGES.ns, RelationshipCacheFilter.none())
     )
 
     Map<String, AmazonLoadBalancer> loadBalancers = translateLoadBalancers(allLoadBalancers)
@@ -443,12 +445,6 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
     healths.each { healthEntry ->
       def instanceId = healthKeysToInstance.get(healthEntry.id)
       instances[instanceId].health << healthEntry.attributes
-    }
-
-    instances.values().each { instance ->
-      instance.isHealthy = instance.health.any { it.state == 'Up' } && instance.health.every {
-        it.state == 'Up' || it.state == 'Unknown'
-      }
     }
   }
 


### PR DESCRIPTION
Locally, this improves the performance for this endpoint by about 12% (for large applications)
Removing fetching a few relationships since they aren't used and also don't calculate `isHealthy` since it's not used/serialized
