### PR TITLE
fix(kubernetes/IRSA): Update aws-iam-authenticator to 0.5.0

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -15,7 +15,7 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VER
   chmod +x kubectl && \
   mv ./kubectl /usr/local/bin/kubectl
 
-RUN wget https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && \
+RUN wget https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator && \
   chmod +x ./aws-iam-authenticator && \
   mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator && \
   ln -sf /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -3,24 +3,24 @@ MAINTAINER sig-platform@spinnaker.io
 COPY clouddriver-web/build/install/clouddriver /opt/clouddriver
 
 RUN apt-get update && apt-get install -y curl gnupg && \
-    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://packages.cloud.google.com/apt cloud-sdk-bionic main" > /etc/apt/sources.list.d/cloud-sdk.list && \
-    apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y \
-      openjdk-11-jre-headless \
-      wget \
-      google-cloud-sdk \
-      google-cloud-sdk-app-engine-java \
-      google-cloud-sdk-app-engine-go \
-      kubectl \
-      python-pip && \
-    pip install awscli==1.16.258 --upgrade && \
-    rm -rf ~/.config/gcloud
+  curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+  echo "deb https://packages.cloud.google.com/apt cloud-sdk-bionic main" > /etc/apt/sources.list.d/cloud-sdk.list && \
+  apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y \
+  openjdk-11-jre-headless \
+  wget \
+  google-cloud-sdk \
+  google-cloud-sdk-app-engine-java \
+  google-cloud-sdk-app-engine-go \
+  kubectl \
+  python-pip && \
+  pip install awscli==1.16.258 --upgrade && \
+  rm -rf ~/.config/gcloud
 
-RUN curl -o  /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x /usr/local/bin/aws-iam-authenticator && \
-    ln -s    /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
+RUN curl -o  /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator && \
+  chmod +x /usr/local/bin/aws-iam-authenticator && \
+  ln -s    /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
 
 RUN adduser --disabled-login --system spinnaker
 RUN mkdir -p /opt/clouddriver/plugins && chown -R spinnaker:nogroup /opt/clouddriver/plugins

--- a/Dockerfile.ubuntu-java8
+++ b/Dockerfile.ubuntu-java8
@@ -3,24 +3,24 @@ MAINTAINER sig-platform@spinnaker.io
 COPY clouddriver-web/build/install/clouddriver /opt/clouddriver
 
 RUN apt-get update && apt-get install -y curl gnupg && \
-    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://packages.cloud.google.com/apt cloud-sdk-bionic main" > /etc/apt/sources.list.d/cloud-sdk.list && \
-    apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y \
-      openjdk-8-jre-headless \
-      wget \
-      google-cloud-sdk \
-      google-cloud-sdk-app-engine-java \
-      google-cloud-sdk-app-engine-go \
-      kubectl \
-      python-pip && \
-    pip install awscli==1.16.258 --upgrade && \
-    rm -rf ~/.config/gcloud
+  curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+  echo "deb https://packages.cloud.google.com/apt cloud-sdk-bionic main" > /etc/apt/sources.list.d/cloud-sdk.list && \
+  apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y \
+  openjdk-8-jre-headless \
+  wget \
+  google-cloud-sdk \
+  google-cloud-sdk-app-engine-java \
+  google-cloud-sdk-app-engine-go \
+  kubectl \
+  python-pip && \
+  pip install awscli==1.16.258 --upgrade && \
+  rm -rf ~/.config/gcloud
 
-RUN curl -o  /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x /usr/local/bin/aws-iam-authenticator && \
-    ln -s    /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
+RUN curl -o  /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.8/2020-04-16/bin/linux/amd64/aws-iam-authenticator && \
+  chmod +x /usr/local/bin/aws-iam-authenticator && \
+  ln -s    /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
 
 RUN adduser --disabled-login --system spinnaker
 RUN mkdir -p /opt/clouddriver/plugins && chown -R spinnaker:nogroup /opt/clouddriver/plugins


### PR DESCRIPTION
It looks like the aws-iam-authenticator version 0.4.0 currently installed during docker build does not work with IRSA.
After downloading aws-iam-authenticator version 0.5.0, the same as in halyard then it works fine and I can see that when communicating with other EKS cluster that it is using the correct role and not the role on the node.  