### PR TITLE
fix(aws): undo part of the perf improvement in #4692

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonClusterProvider.groovy
@@ -446,6 +446,12 @@ class AmazonClusterProvider implements ClusterProvider<AmazonCluster>, ServerGro
       def instanceId = healthKeysToInstance.get(healthEntry.id)
       instances[instanceId].health << healthEntry.attributes
     }
+
+    instances.values().each { instance ->
+      instance.isHealthy = instance.health.any { it.state == 'Up' } && instance.health.every {
+        it.state == 'Up' || it.state == 'Unknown'
+      }
+    }
   }
 
   private Collection<CacheData> resolveRelationshipDataForCollection(Collection<CacheData> sources, String relationship, CacheFilter cacheFilter = null) {


### PR DESCRIPTION
Apparently, some folks actually rely on the `isHealthy` attribute which I thought wasn't being serialized. It appears it is serialized via the `clusters` endpoint
