### PR TITLE
fix(cats/sql): Enforce max length on agent/rel_agent value by hashing if necessary

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNames.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNames.kt
@@ -75,6 +75,24 @@ class SqlNames(
     throw IllegalArgumentException("property sql.table-namespace $tableNamespace is too long")
   }
 
+  /**
+   * Truncates the agent string if too long to fit in @SqlConstraints.maxAgentLength
+   * @return agent string to store
+   */
+  @VisibleForTesting
+  internal fun checkAgentName(agent: String?): String? {
+    if (agent == null) {
+      return null
+    }
+    if (agent.length <= sqlConstraints.maxAgentLength) {
+      return agent
+    }
+
+    val hash = Hashing.murmur3_128().hashBytes((agent).toByteArray()).toString().substring(0..15)
+    val available = sqlConstraints.maxAgentLength - hash.length - 1
+    return agent.substring(0..available) + hash
+  }
+
   companion object {
     private val schemaVersion = SqlSchemaVersion.current()
     private val typeSanitization = """[^A-Za-z0-9_]""".toRegex()

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgent.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgent.kt
@@ -175,7 +175,7 @@ class SqlUnknownAgentCleanupAgent(
         .map { it.typeName }
         .toSet()
 
-      result = Pair(agents.map { it.agentType }.toSet(), dataTypes)
+      result = Pair(agents.mapNotNull { sqlNames.checkAgentName(it.agentType) }.toSet(), dataTypes)
     }
     return result
   }

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConstraints.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConstraints.kt
@@ -23,4 +23,5 @@ class SqlConstraints {
   var maxTableNameLength: Int = 64
   // 352 * 2 + 64 (max rel_type length) == 768; 768 * 4 (utf8mb4) == 3072 == Aurora's max index length
   var maxIdLength: Int = 352
+  var maxAgentLength: Int = 127
 }

--- a/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamesTest.kt
+++ b/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamesTest.kt
@@ -41,6 +41,22 @@ class SqlNamesTest : JUnit5Minutests {
     }
   }
 
+  fun agentTests() = rootContext<SqlNames> {
+    fixture {
+      SqlNames()
+    }
+    listOf(
+      Pair(null, null),
+      Pair("myagent", "myagent"),
+      Pair("abcdefghij".repeat(20), "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabb43b982e477772f")
+    ).forEach { test ->
+      test("max length of table name is checked: ${test.first}") {
+        expectThat(checkAgentName(test.first))
+          .isEqualTo(test.second)
+      }
+    }
+  }
+
   private inner class TableName(
     val name: String,
     val suffix: String,

--- a/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamesTest.kt
+++ b/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamesTest.kt
@@ -17,8 +17,10 @@ package com.netflix.spinnaker.cats.sql.cache
 
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import strikt.api.expect
 import strikt.api.expectThat
-import strikt.assertions.isEqualTo
+import strikt.assertions.*
+import java.lang.IllegalArgumentException
 
 class SqlNamesTest : JUnit5Minutests {
 
@@ -48,11 +50,23 @@ class SqlNamesTest : JUnit5Minutests {
     listOf(
       Pair(null, null),
       Pair("myagent", "myagent"),
-      Pair("abcdefghij".repeat(20), "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabb43b982e477772f")
+      Pair("abcdefghij".repeat(20),
+        "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdebb43b982e477772faa2e899f65d0a86b"),
+      Pair("abcdefghij".repeat(10) + ":" + "abcdefghij".repeat(10),
+        "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij:20f5a9d8d3f4f18cfec8a40eda"),
+      Pair("abcdefghij:" + "abcdefghij".repeat(20),
+        "abcdefghij:abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcd5bfa5c163877f247769cd6b488dff339")
     ).forEach { test ->
       test("max length of table name is checked: ${test.first}") {
         expectThat(checkAgentName(test.first))
           .isEqualTo(test.second)
+      }
+    }
+
+    test("do not accept types that are too long") {
+      expect {
+        that(kotlin.runCatching { checkAgentName("abcdefghij".repeat(20) + ":abcdefghij") }
+          .exceptionOrNull()).isA<IllegalArgumentException>()
       }
     }
   }

--- a/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamesTest.kt
+++ b/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamesTest.kt
@@ -17,10 +17,11 @@ package com.netflix.spinnaker.cats.sql.cache
 
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import java.lang.IllegalArgumentException
 import strikt.api.expect
 import strikt.api.expectThat
-import strikt.assertions.*
-import java.lang.IllegalArgumentException
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
 
 class SqlNamesTest : JUnit5Minutests {
 


### PR DESCRIPTION
Prior to this change, the agent name could go over the max column length. This hashes the end of the agent string so it stays under `sql.constraints.maxAgentLength` (defaults to 127).

As far as I can tell, the actual `rel_agent` value is only used to get the type so this should work as long as the type itself is not too long. I'd appreciate someone with more intimate knowledge of that code to confirm (@robzienert ?)

Fixes https://github.com/spinnaker/spinnaker/issues/5600