### PR TITLE
fix(gce): use the new ScaleInControl autoscaler API

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/GCEUtil.groovy
@@ -847,18 +847,19 @@ class GCEUtil {
         }
       }
 
-      if (scaleDownControl) {
-        def scaledDownReplicasInput = scaleDownControl.maxScaledDownReplicas
-        def maxScaledDownReplicas = null
-        if (scaledDownReplicasInput != null) {
-          maxScaledDownReplicas = FixedOrPercent.newInstance()
-            .setFixed(scaledDownReplicasInput.fixed)
-            .setPercent(scaledDownReplicasInput.percent)
+      if (scaleInControl) {
+        def scaledInReplicasInput = scaleInControl.maxScaledInReplicas
+        FixedOrPercent maxScaledInReplicas = null
+        if (scaledInReplicasInput != null) {
+          maxScaledInReplicas = new FixedOrPercent(
+            fixed: scaledInReplicasInput.fixed,
+            percent: scaledInReplicasInput.percent
+          )
         }
-        gceAutoscalingPolicy.scaleDownControl =
-          new AutoscalingPolicyScaleDownControl(
-            maxScaledDownReplicas: maxScaledDownReplicas,
-            timeWindowSec: scaleDownControl.timeWindowSec)
+        gceAutoscalingPolicy.scaleInControl =
+          new AutoscalingPolicyScaleInControl(
+            maxScaledInReplicas: maxScaledInReplicas,
+            timeWindowSec: scaleInControl.timeWindowSec)
       }
 
       new Autoscaler(name: serverGroupName,

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -229,14 +229,14 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
       }
     }
 
-    // If scaleDownControl is completely absent, we leave the previous value.
+    // If scaleInControl is completely absent, we leave the previous value.
     // To remove it, set it to an empty object.
-    if (update.scaleDownControl != null) {
-      def scaleDownControl = update.scaleDownControl
-      if (scaleDownControl.timeWindowSec != null && scaleDownControl.maxScaledDownReplicas != null) {
-        newDescription.scaleDownControl = scaleDownControl
+    if (update.scaleInControl != null) {
+      def scaleInControl = update.scaleInControl
+      if (scaleInControl.timeWindowSec != null && scaleInControl.maxScaledInReplicas != null) {
+        newDescription.scaleInControl = scaleInControl
       } else {
-        newDescription.scaleDownControl = null
+        newDescription.scaleInControl = null
       }
     }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleAutoscalingPolicy.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/model/GoogleAutoscalingPolicy.groovy
@@ -18,11 +18,13 @@ package com.netflix.spinnaker.clouddriver.google.model
 
 import groovy.transform.AutoClone
 import groovy.transform.Canonical
+import groovy.transform.CompileStatic
 import groovy.transform.ToString
 
 @AutoClone
 @Canonical
 @ToString(includeNames = true)
+@CompileStatic
 class GoogleAutoscalingPolicy {
   Integer minNumReplicas
   Integer maxNumReplicas
@@ -31,7 +33,7 @@ class GoogleAutoscalingPolicy {
   CpuUtilization cpuUtilization
   LoadBalancingUtilization loadBalancingUtilization
   List<CustomMetricUtilization> customMetricUtilizations
-  ScaleDownControl scaleDownControl
+  ScaleInControl scaleInControl
   AutoscalingMode mode
 
   @ToString(includeNames = true)
@@ -57,8 +59,8 @@ class GoogleAutoscalingPolicy {
     }
   }
 
-  static class ScaleDownControl {
-    FixedOrPercent maxScaledDownReplicas
+  static class ScaleInControl {
+    FixedOrPercent maxScaledInReplicas
     Integer timeWindowSec
   }
 

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgent.java
@@ -43,7 +43,7 @@ import com.google.api.services.compute.model.AutoscalingPolicy;
 import com.google.api.services.compute.model.AutoscalingPolicyCpuUtilization;
 import com.google.api.services.compute.model.AutoscalingPolicyCustomMetricUtilization;
 import com.google.api.services.compute.model.AutoscalingPolicyLoadBalancingUtilization;
-import com.google.api.services.compute.model.AutoscalingPolicyScaleDownControl;
+import com.google.api.services.compute.model.AutoscalingPolicyScaleInControl;
 import com.google.api.services.compute.model.DistributionPolicy;
 import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.InstanceGroupManager;
@@ -85,7 +85,7 @@ import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy.Cu
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy.CustomMetricUtilization.UtilizationTargetType;
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy.FixedOrPercent;
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy.LoadBalancingUtilization;
-import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy.ScaleDownControl;
+import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy.ScaleInControl;
 import com.netflix.spinnaker.clouddriver.google.model.GoogleDistributionPolicy;
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstance;
 import com.netflix.spinnaker.clouddriver.google.model.GoogleInstances;
@@ -922,7 +922,7 @@ abstract class AbstractGoogleServerGroupCachingAgent
     output.setMaxNumReplicas(input.getMaxNumReplicas());
     output.setMinNumReplicas(input.getMinNumReplicas());
     output.setMode(valueOf(AutoscalingMode.class, input.getMode()));
-    output.setScaleDownControl(convertScaleDownControl(input.getScaleDownControl()));
+    output.setScaleInControl(convertScaleInControl(input.getScaleInControl()));
     return output;
   }
 
@@ -969,20 +969,20 @@ abstract class AbstractGoogleServerGroupCachingAgent
     return output;
   }
 
-  private static ScaleDownControl convertScaleDownControl(
-      @Nullable AutoscalingPolicyScaleDownControl input) {
+  private static ScaleInControl convertScaleInControl(
+      @Nullable AutoscalingPolicyScaleInControl input) {
     if (input == null) {
       return null;
     }
-    FixedOrPercent maxScaledDownReplicas = null;
-    if (input.getMaxScaledDownReplicas() != null) {
-      maxScaledDownReplicas = new FixedOrPercent();
-      maxScaledDownReplicas.setFixed(input.getMaxScaledDownReplicas().getFixed());
-      maxScaledDownReplicas.setPercent(input.getMaxScaledDownReplicas().getPercent());
+    FixedOrPercent maxScaledInReplicas = null;
+    if (input.getMaxScaledInReplicas() != null) {
+      maxScaledInReplicas = new FixedOrPercent();
+      maxScaledInReplicas.setFixed(input.getMaxScaledInReplicas().getFixed());
+      maxScaledInReplicas.setPercent(input.getMaxScaledInReplicas().getPercent());
     }
-    ScaleDownControl output = new ScaleDownControl();
+    ScaleInControl output = new ScaleInControl();
     output.setTimeWindowSec(input.getTimeWindowSec());
-    output.setMaxScaledDownReplicas(maxScaledDownReplicas);
+    output.setMaxScaledInReplicas(maxScaledInReplicas);
     return output;
   }
 

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/AbstractGoogleServerGroupCachingAgentTest.java
@@ -33,7 +33,7 @@ import com.google.api.services.compute.model.AutoscalingPolicy;
 import com.google.api.services.compute.model.AutoscalingPolicyCpuUtilization;
 import com.google.api.services.compute.model.AutoscalingPolicyCustomMetricUtilization;
 import com.google.api.services.compute.model.AutoscalingPolicyLoadBalancingUtilization;
-import com.google.api.services.compute.model.AutoscalingPolicyScaleDownControl;
+import com.google.api.services.compute.model.AutoscalingPolicyScaleInControl;
 import com.google.api.services.compute.model.DistributionPolicy;
 import com.google.api.services.compute.model.DistributionPolicyZoneConfiguration;
 import com.google.api.services.compute.model.FixedOrPercent;
@@ -738,10 +738,10 @@ class AbstractGoogleServerGroupCachingAgentTest {
                         .setUtilizationTarget(911.23)
                         .setUtilizationTargetType("GAUGE"),
                     new AutoscalingPolicyCustomMetricUtilization()))
-            .setScaleDownControl(
-                new AutoscalingPolicyScaleDownControl()
+            .setScaleInControl(
+                new AutoscalingPolicyScaleInControl()
                     .setTimeWindowSec(10111)
-                    .setMaxScaledDownReplicas(new FixedOrPercent().setFixed(123).setPercent(456)));
+                    .setMaxScaledInReplicas(new FixedOrPercent().setFixed(123).setPercent(456)));
 
     InstanceGroupManager instanceGroupManager =
         new InstanceGroupManager().setName("myServerGroup").setZone(ZONE_URL);
@@ -769,11 +769,9 @@ class AbstractGoogleServerGroupCachingAgentTest {
     assertThat(converted.getMaxNumReplicas()).isEqualTo(input.getMaxNumReplicas());
     assertThat(converted.getMinNumReplicas()).isEqualTo(input.getMinNumReplicas());
     assertThat(converted.getMode().toString()).isEqualTo(input.getMode());
-    assertThat(converted.getScaleDownControl().getTimeWindowSec()).isEqualTo(10111);
-    assertThat(converted.getScaleDownControl().getMaxScaledDownReplicas().getFixed())
-        .isEqualTo(123);
-    assertThat(converted.getScaleDownControl().getMaxScaledDownReplicas().getPercent())
-        .isEqualTo(456);
+    assertThat(converted.getScaleInControl().getTimeWindowSec()).isEqualTo(10111);
+    assertThat(converted.getScaleInControl().getMaxScaledInReplicas().getFixed()).isEqualTo(123);
+    assertThat(converted.getScaleInControl().getMaxScaledInReplicas().getPercent()).isEqualTo(456);
 
     assertThat(converted.getCustomMetricUtilizations())
         .hasSize(input.getCustomMetricUtilizations().size());
@@ -823,7 +821,7 @@ class AbstractGoogleServerGroupCachingAgentTest {
     assertThat(converted.getMaxNumReplicas()).isNull();
     assertThat(converted.getMinNumReplicas()).isNull();
     assertThat(converted.getMode()).isNull();
-    assertThat(converted.getScaleDownControl()).isNull();
+    assertThat(converted.getScaleInControl()).isNull();
   }
 
   public static AbstractGoogleServerGroupCachingAgent createCachingAgent(


### PR DESCRIPTION
I also changed the clouddriver API for this functionality to match the new terminology. Since the only client of this API (deck) has it hidden behind a feature flag, I felt okay about breaking the API to make the code less confusing.

See spinnaker/deck#8372