### PR TITLE
chore(ecs): Refactor TaskHealthCachingAgent networking check

### DIFF
--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -129,27 +129,30 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
             Keys.getTaskDefinitionKey(accountName, region, service.getTaskDefinition());
         TaskDefinition taskDefinition = taskDefinitionCacheClient.get(taskDefinitionCacheKey);
 
-        if (isContainerMissingNetworking(task)) {
+        if (taskDefinition == null) {
           log.debug(
-              "Task '{}' is missing networking. Will not retrieve health.", task.getTaskArn());
+              "Provided task definition '{}' is null for service '{}'",
+              service.getTaskDefinition(),
+              service.getServiceName());
+          continue;
+        }
+
+        boolean lacksNetworkBindings = isTaskMissingNetworkBindings(task);
+        if (task.getContainers().isEmpty()
+            || (lacksNetworkBindings && isTaskMissingNetworkInterfaces(task))) {
+          log.debug(
+              "Task '{}' is missing networking. Will not retrieve load balancer health.",
+              task.getTaskArn());
           continue;
         }
 
         TaskHealth taskHealth = null;
-        Collection<Container> containers = task.getContainers();
-
-        for (Container container : containers) {
-          if (container.getNetworkBindings().size() >= 1) {
-            taskHealth =
-                inferHealthNetworkBindedContainer(
-                    targetHealthCacheClient,
-                    task,
-                    containerInstance,
-                    serviceName,
-                    service,
-                    taskDefinition);
-            break;
-          }
+        // ideally, could determine health check method by looking at taskDef.networkMode,
+        // however this isn't reliably cached yet, so reusing network binding check.
+        if (!lacksNetworkBindings) {
+          taskHealth =
+              inferHealthNetworkBindedContainer(
+                  targetHealthCacheClient, task, containerInstance, serviceName, service);
         }
 
         if (taskHealth == null) {
@@ -157,6 +160,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
               inferHealthNetworkInterfacedContainer(
                   targetHealthCacheClient, task, serviceName, service, taskDefinition);
         }
+
         log.debug("Task Health contains the following elements: {}", taskHealth);
 
         if (taskHealth != null) {
@@ -177,11 +181,6 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
       String serviceName,
       Service loadBalancerService,
       TaskDefinition taskDefinition) {
-
-    if (taskDefinition == null) {
-      log.debug("Provided task definition is null for task '{}'.", task.getTaskArn());
-      return null;
-    }
 
     List<LoadBalancer> loadBalancers = loadBalancerService.getLoadBalancers();
     log.debug("LoadBalancerService found {} load balancers.", loadBalancers.size());
@@ -215,7 +214,6 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
           describeTargetHealth(
               targetHealthCacheClient,
               task,
-              loadBalancerService,
               serviceName,
               loadBalancer.getTargetGroupArn(),
               networkInterface.getPrivateIpv4Address(),
@@ -251,12 +249,7 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
       Task task,
       ContainerInstance containerInstance,
       String serviceName,
-      Service loadBalancerService,
-      TaskDefinition taskDefinition) {
-    if (taskDefinition == null) {
-      log.debug("Provided task definition is null.");
-      return null;
-    }
+      Service loadBalancerService) {
 
     List<LoadBalancer> loadBalancers = loadBalancerService.getLoadBalancers();
     log.debug("LoadBalancerService found {} load balancers.", loadBalancers.size());
@@ -286,7 +279,6 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
           describeTargetHealth(
               targetHealthCacheClient,
               task,
-              loadBalancerService,
               serviceName,
               loadBalancer.getTargetGroupArn(),
               containerInstance.getEc2InstanceId(),
@@ -312,7 +304,6 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
   private TaskHealth describeTargetHealth(
       TargetHealthCacheClient targetHealthCacheClient,
       Task task,
-      Service loadBalancerService,
       String serviceName,
       String targetGroupArn,
       String targetId,
@@ -352,7 +343,9 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
     if (containers != null && !containers.isEmpty()) {
       for (Container container : containers) {
         for (NetworkBinding networkBinding : container.getNetworkBindings()) {
-          if (networkBinding.getContainerPort().intValue() == hostPort.intValue()) {
+          Integer containerPort = networkBinding.getContainerPort();
+
+          if (containerPort != null && containerPort.intValue() == hostPort.intValue()) {
             log.debug("Load balanced hostPort: {} found for container.", hostPort);
             return Optional.of(networkBinding.getHostPort());
           }
@@ -375,14 +368,6 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
     }
 
     return false;
-  }
-
-  private boolean isContainerMissingNetworking(Task task) {
-    if (task.getContainers().isEmpty()) {
-      return true;
-    }
-
-    return isTaskMissingNetworkBindings(task) && isTaskMissingNetworkInterfaces(task);
   }
 
   private boolean isTaskMissingNetworkBindings(Task task) {

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgent.java
@@ -129,14 +129,6 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
             Keys.getTaskDefinitionKey(accountName, region, service.getTaskDefinition());
         TaskDefinition taskDefinition = taskDefinitionCacheClient.get(taskDefinitionCacheKey);
 
-        if (taskDefinition == null) {
-          log.debug(
-              "Provided task definition '{}' is null for service '{}'",
-              service.getTaskDefinition(),
-              service.getServiceName());
-          continue;
-        }
-
         boolean lacksNetworkBindings = isTaskMissingNetworkBindings(task);
         if (task.getContainers().isEmpty()
             || (lacksNetworkBindings && isTaskMissingNetworkInterfaces(task))) {
@@ -181,6 +173,14 @@ public class TaskHealthCachingAgent extends AbstractEcsCachingAgent<TaskHealth>
       String serviceName,
       Service loadBalancerService,
       TaskDefinition taskDefinition) {
+
+    if (taskDefinition == null) {
+      log.debug(
+          "Provided task definition '{}' is null for task '{}'.",
+          loadBalancerService.getTaskDefinition(),
+          task.getTaskArn());
+      return null;
+    }
 
     List<LoadBalancer> loadBalancers = loadBalancerService.getLoadBalancers();
     log.debug("LoadBalancerService found {} load balancers.", loadBalancers.size());

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/provider/agent/TaskHealthCachingAgentSpec.groovy
@@ -327,6 +327,96 @@ class TaskHealthCachingAgentSpec extends Specification {
     taskHealthList == []
   }
 
+  def 'should skip tasks with no networking'() {
+    given:
+    ObjectMapper mapper = new ObjectMapper()
+    Map<String, Object> containerMap = mapper.convertValue(new Container(), Map.class)
+    def taskAttributes = [
+      taskId               : CommonCachingAgent.TASK_ID_1,
+      taskArn              : CommonCachingAgent.TASK_ARN_1,
+      startedAt            : new Date().getTime(),
+      containerInstanceArn : CommonCachingAgent.CONTAINER_INSTANCE_ARN_1,
+      group                : 'service:' + CommonCachingAgent.SERVICE_NAME_1,
+      containers           : Collections.singletonList(containerMap)
+    ]
+    def taskKey = Keys.getTaskKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_ID_1)
+    def taskCacheData = new DefaultCacheData(taskKey, taskAttributes, Collections.emptyMap())
+    providerCache.getAll(TASKS.toString(), _) >> Collections.singletonList(taskCacheData)
+
+    def taskDefAttributes = [
+      taskDefinitionArn    : CommonCachingAgent.TASK_DEFINITION_ARN_1
+    ]
+    def taskDefKey = Keys.getTaskDefinitionKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_DEFINITION_ARN_1)
+    def taskDefCacheData = new DefaultCacheData(taskDefKey, taskDefAttributes, Collections.emptyMap())
+    providerCache.get(TASK_DEFINITIONS.toString(), taskDefKey) >> taskDefCacheData
+
+    when:
+    def taskHealthList = agent.getItems(ecs, providerCache)
+
+    then:
+    taskHealthList == []
+  }
+
+  def 'should skip tasks with null network bindings'() {
+    given:
+    ObjectMapper mapper = new ObjectMapper()
+    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkBindings(null), Map.class)
+    def taskAttributes = [
+      taskId               : CommonCachingAgent.TASK_ID_1,
+      taskArn              : CommonCachingAgent.TASK_ARN_1,
+      startedAt            : new Date().getTime(),
+      containerInstanceArn : CommonCachingAgent.CONTAINER_INSTANCE_ARN_1,
+      group                : 'service:' + CommonCachingAgent.SERVICE_NAME_1,
+      containers           : Collections.singletonList(containerMap)
+    ]
+    def taskKey = Keys.getTaskKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_ID_1)
+    def taskCacheData = new DefaultCacheData(taskKey, taskAttributes, Collections.emptyMap())
+    providerCache.getAll(TASKS.toString(), _) >> Collections.singletonList(taskCacheData)
+
+    def taskDefAttributes = [
+      taskDefinitionArn    : CommonCachingAgent.TASK_DEFINITION_ARN_1
+    ]
+    def taskDefKey = Keys.getTaskDefinitionKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_DEFINITION_ARN_1)
+    def taskDefCacheData = new DefaultCacheData(taskDefKey, taskDefAttributes, Collections.emptyMap())
+    providerCache.get(TASK_DEFINITIONS.toString(), taskDefKey) >> taskDefCacheData
+
+    when:
+    def taskHealthList = agent.getItems(ecs, providerCache)
+
+    then:
+    taskHealthList == []
+  }
+
+  def 'should skip tasks with null network interfaces'() {
+    given:
+    ObjectMapper mapper = new ObjectMapper()
+    Map<String, Object> containerMap = mapper.convertValue(new Container().withNetworkInterfaces(null), Map.class)
+    def taskAttributes = [
+      taskId               : CommonCachingAgent.TASK_ID_1,
+      taskArn              : CommonCachingAgent.TASK_ARN_1,
+      startedAt            : new Date().getTime(),
+      containerInstanceArn : CommonCachingAgent.CONTAINER_INSTANCE_ARN_1,
+      group                : 'service:' + CommonCachingAgent.SERVICE_NAME_1,
+      containers           : Collections.singletonList(containerMap)
+    ]
+    def taskKey = Keys.getTaskKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_ID_1)
+    def taskCacheData = new DefaultCacheData(taskKey, taskAttributes, Collections.emptyMap())
+    providerCache.getAll(TASKS.toString(), _) >> Collections.singletonList(taskCacheData)
+
+    def taskDefAttributes = [
+      taskDefinitionArn    : CommonCachingAgent.TASK_DEFINITION_ARN_1
+    ]
+    def taskDefKey = Keys.getTaskDefinitionKey(CommonCachingAgent.ACCOUNT, CommonCachingAgent.REGION, CommonCachingAgent.TASK_DEFINITION_ARN_1)
+    def taskDefCacheData = new DefaultCacheData(taskDefKey, taskDefAttributes, Collections.emptyMap())
+    providerCache.get(TASK_DEFINITIONS.toString(), taskDefKey) >> taskDefCacheData
+
+    when:
+    def taskHealthList = agent.getItems(ecs, providerCache)
+
+    then:
+    taskHealthList == []
+  }
+
   def 'should get task health for task with some non-networked containers'() {
     given:
     ObjectMapper mapper = new ObjectMapper()


### PR DESCRIPTION
Previously, how to check task health forked based on looking for network bindings on each container. Whether the task contains network bindings was already being determined in a previous check, so this surfaces that value and forks based on that instead. 

Also adds test to ensure tasks with missing or null network bindings/interfaces are skipped.