### PR TITLE
feat(provider/cf): add stack property for buildpack lifecycle

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v2.Resource;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.*;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Package;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3.Process;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.model.*;
 import com.netflix.spinnaker.clouddriver.model.HealthState;
 import java.io.File;
@@ -534,7 +535,7 @@ public class Applications {
   public CloudFoundryServerGroup createApplication(
       String appName,
       CloudFoundrySpace space,
-      List<String> buildpacks,
+      DeployCloudFoundryServerGroupDescription.ApplicationAttributes applicationAttributes,
       @Nullable Map<String, String> environmentVariables)
       throws CloudFoundryApiException {
     Map<String, ToOneRelationship> relationships = new HashMap<>();
@@ -544,7 +545,7 @@ public class Applications {
             () ->
                 api.createApplication(
                     new CreateApplication(
-                        appName, relationships, environmentVariables, buildpacks)))
+                        appName, relationships, environmentVariables, applicationAttributes)))
         .map(this::map)
         .orElseThrow(
             () ->

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
@@ -150,6 +150,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
                           .flatMap(route -> route.values().stream())
                           .collect(toList()));
               attrs.setEnv(app.getEnv());
+              attrs.setStack(app.getStack());
               return attrs;
             })
         .get();
@@ -178,5 +179,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
     @Nullable private List<Map<String, String>> routes;
 
     @Nullable private Map<String, String> env;
+
+    @Nullable private String stack;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
@@ -62,5 +62,7 @@ public class DeployCloudFoundryServerGroupDescription
     @Nullable private Map<String, String> env;
 
     @Nullable private List<String> services;
+
+    @Nullable private String stack;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -190,7 +190,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
             .createApplication(
                 description.getServerGroupName(),
                 description.getSpace(),
-                description.getApplicationAttributes().getBuildpacks(),
+                description.getApplicationAttributes(),
                 getEnvironmentVars(description));
     getTask()
         .updateStatus(

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateApplicationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/model/v3/CreateApplicationTest.java
@@ -18,9 +18,10 @@ package com.netflix.spinnaker.clouddriver.cloudfoundry.client.model.v3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.clouddriver.cloudfoundry.deploy.description.DeployCloudFoundryServerGroupDescription;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -31,11 +32,50 @@ class CreateApplicationTest {
     ToOneRelationship toOneRelationship = new ToOneRelationship(new Relationship("space-guid"));
     Map<String, ToOneRelationship> relationships =
         Collections.singletonMap("relationship", toOneRelationship);
-    List<String> buildpacks = Arrays.asList("buildpackOne", "buildpackTwo");
+    DeployCloudFoundryServerGroupDescription.ApplicationAttributes applicationAttributes =
+        new DeployCloudFoundryServerGroupDescription.ApplicationAttributes();
+    applicationAttributes.setBuildpacks(ImmutableList.of("buildpackOne", "buildpackTwo"));
     CreateApplication createApplication =
-        new CreateApplication("some-application", relationships, null, buildpacks);
+        new CreateApplication("some-application", relationships, null, applicationAttributes);
 
-    assertThat(createApplication.getLifecycle().getData().get("buildpacks")).isEqualTo(buildpacks);
+    assertThat(createApplication.getLifecycle().getData().get("buildpacks"))
+        .isEqualTo(applicationAttributes.getBuildpacks());
+  }
+
+  @Test
+  void getLifecycleShouldReturnWithBuildpackAndWithStack() {
+    ToOneRelationship toOneRelationship = new ToOneRelationship(new Relationship("space-guid"));
+    Map<String, ToOneRelationship> relationships =
+        Collections.singletonMap("relationship", toOneRelationship);
+    DeployCloudFoundryServerGroupDescription.ApplicationAttributes applicationAttributes =
+        new DeployCloudFoundryServerGroupDescription.ApplicationAttributes();
+    applicationAttributes.setBuildpacks(ImmutableList.of("buildpackOne"));
+    applicationAttributes.setStack("cflinuxfs3");
+    CreateApplication createApplication =
+        new CreateApplication("some-application", relationships, null, applicationAttributes);
+
+    Map<String, Object> data =
+        ImmutableMap.of(
+            "buildpacks", applicationAttributes.getBuildpacks(),
+            "stack", applicationAttributes.getStack());
+
+    assertThat(createApplication.getLifecycle().getData()).isEqualTo(data);
+  }
+
+  @Test
+  void getLifecycleShouldReturnWithoutBuildpackAndWithStack() {
+    ToOneRelationship toOneRelationship = new ToOneRelationship(new Relationship("space-guid"));
+    Map<String, ToOneRelationship> relationships =
+        Collections.singletonMap("relationship", toOneRelationship);
+    DeployCloudFoundryServerGroupDescription.ApplicationAttributes applicationAttributes =
+        new DeployCloudFoundryServerGroupDescription.ApplicationAttributes();
+    applicationAttributes.setStack("cflinuxfs3");
+    CreateApplication createApplication =
+        new CreateApplication("some-application", relationships, null, applicationAttributes);
+
+    Map<String, Object> data = ImmutableMap.of("stack", applicationAttributes.getStack());
+
+    assertThat(createApplication.getLifecycle().getData()).isEqualTo(data);
   }
 
   @Test
@@ -44,8 +84,10 @@ class CreateApplicationTest {
         new ToOneRelationship(new Relationship("relationship-guid"));
     Map<String, ToOneRelationship> relationships =
         Collections.singletonMap("relationship", toOneRelationship);
+    DeployCloudFoundryServerGroupDescription.ApplicationAttributes applicationAttributes =
+        new DeployCloudFoundryServerGroupDescription.ApplicationAttributes();
     CreateApplication createApplication =
-        new CreateApplication("some-application", relationships, null, null);
+        new CreateApplication("some-application", relationships, null, applicationAttributes);
 
     assertThat(createApplication.getLifecycle()).isNull();
   }

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperationTest.java
@@ -142,12 +142,16 @@ class DeployCloudFoundryServerGroupAtomicOperationTest
 
   private void verifyInOrder(final Applications apps, Supplier<VerificationMode> calls) {
     final InOrder inOrder = Mockito.inOrder(apps, cloudFoundryClient.getServiceInstances());
+    DeployCloudFoundryServerGroupDescription.ApplicationAttributes applicationAttributes =
+        new DeployCloudFoundryServerGroupDescription.ApplicationAttributes();
+    applicationAttributes.setBuildpacks(
+        io.vavr.collection.List.of("buildpack1", "buildpack2").asJava());
     inOrder
         .verify(apps)
         .createApplication(
             "app1-stack1-detail1-v000",
             CloudFoundrySpace.builder().id("space1Id").name("space1").build(),
-            io.vavr.collection.List.of("buildpack1", "buildpack2").asJava(),
+            getDeployCloudFoundryServerGroupDescription(true).getApplicationAttributes(),
             HashMap.of("token", "ASDF").toJavaMap());
     inOrder.verify(apps).uploadPackageBits(eq("serverGroupId_package"), any());
     inOrder.verify(apps).createBuild("serverGroupId_package");


### PR DESCRIPTION
Stack is the root filesystem to use with the buildpack, for example cflinuxfs3. This property wasn't currently available today in the spinnaker cf manifest so we added it per customer requirements. I also refactored the createApplication method so that we can easily add more application attributes in the future without needing to modify the method signature. I also added tests that confirm the functionality and to ensure it's not a breaking change to possible existing implementations.