### PR TITLE
fix(kubernetes): Don't delete caching agents of unmodified accounts after a refresh

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2Provider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2Provider.java
@@ -36,24 +36,22 @@ public class KubernetesV2Provider extends AgentSchedulerAware implements Provide
 
   private Collection<Agent> agents = emptyAgentCollection();
 
-  private Collection<Agent> nextAgentSet = emptyAgentCollection();
+  private Collection<Agent> stagedAgents = emptyAgentCollection();
 
   private static Collection<Agent> emptyAgentCollection() {
     return Collections.newSetFromMap(new ConcurrentHashMap<>());
   }
 
-  public void stageAllAgents(Collection<Agent> agents) {
-    nextAgentSet.addAll(agents);
+  public void stageAgents(Collection<Agent> agents) {
+    stagedAgents.addAll(agents);
   }
 
   public void clearStagedAgents() {
-    nextAgentSet.clear();
+    stagedAgents.clear();
   }
 
-  public void addStagedAgents() {
-    Collection<Agent> nextAgentSetCopy = emptyAgentCollection();
-    nextAgentSetCopy.addAll(nextAgentSet);
-    agents.addAll(nextAgentSetCopy);
+  public void promoteStagedAgents() {
+    agents.addAll(stagedAgents);
     clearStagedAgents();
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2Provider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2Provider.java
@@ -42,19 +42,19 @@ public class KubernetesV2Provider extends AgentSchedulerAware implements Provide
     return Collections.newSetFromMap(new ConcurrentHashMap<>());
   }
 
-  public void addAllAgents(Collection<Agent> agents) {
+  public void stageAllAgents(Collection<Agent> agents) {
     nextAgentSet.addAll(agents);
   }
 
-  public void clearNewAgentSet() {
+  public void clearStagedAgents() {
     nextAgentSet.clear();
   }
 
-  public void switchToNewAgents() {
+  public void addStagedAgents() {
     Collection<Agent> nextAgentSetCopy = emptyAgentCollection();
     nextAgentSetCopy.addAll(nextAgentSet);
-    agents = nextAgentSetCopy;
-    clearNewAgentSet();
+    agents.addAll(nextAgentSetCopy);
+    clearStagedAgents();
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
@@ -25,11 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurati
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials;
 import com.netflix.spinnaker.clouddriver.security.*;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
@@ -79,35 +75,32 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
 
   @Override
   public void synchronize() {
-    Set<String> newAndChangedAccounts = synchronizeAccountCredentials();
+    Set<String> newAndChangedAccountNames = synchronizeAccountCredentials();
 
     // we only want to initialize caching agents for new or updated accounts
-    Set<KubernetesNamedAccountCredentials<KubernetesV2Credentials>> allAccounts =
+    Set<KubernetesNamedAccountCredentials<KubernetesV2Credentials>> newAndChangedAccounts =
         ProviderUtils.buildThreadSafeSetOfAccounts(
                 accountCredentialsRepository,
                 KubernetesNamedAccountCredentials.class,
                 ProviderVersion.v2)
             .stream()
             .map(c -> (KubernetesNamedAccountCredentials<KubernetesV2Credentials>) c)
-            .filter(account -> newAndChangedAccounts.contains(account.getName()))
+            .filter(account -> newAndChangedAccountNames.contains(account.getName()))
             .collect(Collectors.toSet());
 
-    if (allAccounts.size() < 1) {
-      log.info(
-          "No changes detected to V2 Kubernetes accounts. Skipping caching agent synchronization.");
+    if (newAndChangedAccounts.size() < 1) {
+      log.info("No new or changed V2 Kubernetes accounts. Skipping caching agent synchronization.");
       return;
     }
 
-    log.info("Synchronizing {} caching agents for V2 Kubernetes accounts.", allAccounts.size());
-    synchronizeKubernetesV2Provider(allAccounts);
+    synchronizeKubernetesV2Provider(newAndChangedAccounts);
   }
 
   private Set<String> synchronizeAccountCredentials() {
     List<String> deletedAccounts = getDeletedAccountNames();
-    List<String> changedAccounts = new ArrayList<>();
     Set<String> newAndChangedAccounts = new HashSet<>();
 
-    deletedAccounts.forEach(accountCredentialsRepository::delete);
+    deleteAccounts(deletedAccounts);
 
     kubernetesConfigurationProperties.getAccounts().stream()
         .filter(a -> ProviderVersion.v2.equals(a.getProviderVersion()))
@@ -119,12 +112,8 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
               AccountCredentials existingCredentials =
                   accountCredentialsRepository.getOne(managedAccount.getName());
 
-              if (existingCredentials == null) {
-                // account didn't previously exist
-                newAndChangedAccounts.add(managedAccount.getName());
-              } else if (!existingCredentials.equals(credentials)) {
-                // account exists but has changed
-                changedAccounts.add(managedAccount.getName());
+              if (existingCredentials == null || !existingCredentials.equals(credentials)) {
+                // account didn't previously exist or exists but has changed
                 newAndChangedAccounts.add(managedAccount.getName());
               } else {
                 // Current credentials may contain memoized namespaces, we should keep if the
@@ -136,10 +125,19 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
         .filter(Objects::nonNull)
         .forEach(this::saveToCredentialsRepository);
 
-    ProviderUtils.unscheduleAndDeregisterAgents(deletedAccounts, catsModule);
-    ProviderUtils.unscheduleAndDeregisterAgents(changedAccounts, catsModule);
-
     return newAndChangedAccounts;
+  }
+
+  private void deleteAccounts(List<String> deletedAccounts) {
+    if (deletedAccounts.isEmpty()) {
+      return;
+    }
+    log.info(
+        "Deleted {} accounts, removing from repository and caching agents", deletedAccounts.size());
+    deletedAccounts.forEach(
+        accountCredentialsRepository::delete); // delete from endpoint /credentials
+    ProviderUtils.unscheduleAndDeregisterAgents(
+        deletedAccounts, catsModule); // delete caching agents
   }
 
   /**
@@ -178,10 +176,18 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
   }
 
   private void synchronizeKubernetesV2Provider(
-      Set<KubernetesNamedAccountCredentials<KubernetesV2Credentials>> allAccounts) {
+      Set<KubernetesNamedAccountCredentials<KubernetesV2Credentials>> newAndChangedAccounts) {
+
+    log.info(
+        "Synchronizing caching agents for {} new or changed V2 Kubernetes accounts.",
+        newAndChangedAccounts.size());
+
+    Set<String> accountNames = new HashSet<>();
 
     try {
-      for (KubernetesNamedAccountCredentials<KubernetesV2Credentials> credentials : allAccounts) {
+      for (KubernetesNamedAccountCredentials<KubernetesV2Credentials> credentials :
+          newAndChangedAccounts) {
+        accountNames.add(credentials.getName());
         List<Agent> newlyAddedAgents =
             kubernetesV2CachingAgentDispatcher.buildAllCachingAgents(credentials).stream()
                 .map(c -> (Agent) c)
@@ -189,12 +195,15 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
 
         log.info("Adding {} agents for account {}", newlyAddedAgents.size(), credentials.getName());
 
-        kubernetesV2Provider.addAllAgents(newlyAddedAgents);
+        kubernetesV2Provider.stageAllAgents(newlyAddedAgents);
       }
     } catch (Exception e) {
       log.warn("Error encountered scheduling new agents -- using old agent set instead", e);
-      kubernetesV2Provider.clearNewAgentSet();
+      kubernetesV2Provider.clearStagedAgents();
     }
+
+    // Remove existing agents belonging to changed accounts
+    ProviderUtils.unscheduleAndDeregisterAgents(accountNames, catsModule);
 
     // If there is an agent scheduler, then this provider has been through the AgentController in
     // the past.
@@ -205,6 +214,6 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
           kubernetesV2Provider, new ArrayList<>(kubernetesV2Provider.getNextAgentSet()));
     }
 
-    kubernetesV2Provider.switchToNewAgents();
+    kubernetesV2Provider.addStagedAgents();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
@@ -129,11 +129,9 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
   }
 
   private void deleteAccounts(List<String> deletedAccounts) {
-    if (deletedAccounts.isEmpty()) {
-      return;
-    }
     log.info(
-        "Deleted {} accounts, removing from repository and caching agents", deletedAccounts.size());
+        "{} accounts were deleted and need to be removed from repository and caching agents",
+        deletedAccounts.size());
     deletedAccounts.forEach(
         accountCredentialsRepository::delete); // delete from endpoint /credentials
     ProviderUtils.unscheduleAndDeregisterAgents(
@@ -194,11 +192,11 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
 
         log.info("Adding {} agents for account {}", newlyAddedAgents.size(), credentials.getName());
 
-        kubernetesV2Provider.stageAllAgents(newlyAddedAgents);
+        kubernetesV2Provider.stageAgents(newlyAddedAgents);
         stagedAccountNames.add(credentials.getName());
       } catch (Exception e) {
         log.warn(
-            "Error encountered scheduling new agents for account {} -- using old agent set instead",
+            "Error encountered scheduling new agents for account {} -- using its old agent set instead",
             credentials.getName(),
             e);
       }
@@ -213,9 +211,9 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
     // running system).
     if (kubernetesV2Provider.getAgentScheduler() != null) {
       ProviderUtils.rescheduleAgents(
-          kubernetesV2Provider, new ArrayList<>(kubernetesV2Provider.getNextAgentSet()));
+          kubernetesV2Provider, new ArrayList<>(kubernetesV2Provider.getStagedAgents()));
     }
 
-    kubernetesV2Provider.addStagedAgents();
+    kubernetesV2Provider.promoteStagedAgents();
   }
 }

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizableSpec.groovy
@@ -19,7 +19,16 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching
 
 import com.google.common.collect.ImmutableList
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.cats.agent.Agent
+import com.netflix.spinnaker.cats.agent.AgentExecution
+import com.netflix.spinnaker.cats.agent.AgentScheduler
+import com.netflix.spinnaker.cats.agent.ExecutionInstrumentation
 import com.netflix.spinnaker.cats.module.CatsModule
+import com.netflix.spinnaker.cats.module.CatsModuleAware
+import com.netflix.spinnaker.cats.provider.ProviderRegistry
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCoreCachingAgent
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesUnregisteredCustomResourceCachingAgent
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesV2CachingAgentDispatcher
@@ -30,16 +39,15 @@ import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestName
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
-import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion
+import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import com.netflix.spinnaker.kork.configserver.ConfigFileService
 import spock.lang.Specification
 
 class KubernetesV2ProviderSynchronizableSpec extends Specification {
 
   CatsModule catsModule = Mock(CatsModule)
-  AccountCredentialsRepository accountCredentialsRepository = Mock(AccountCredentialsRepository)
+  AccountCredentialsRepository accountCredentialsRepository
   NamerRegistry namerRegistry = new NamerRegistry([new KubernetesManifestNamer()])
   ConfigFileService configFileService = Mock(ConfigFileService)
   KubernetesV2Provider kubernetesV2Provider = new KubernetesV2Provider()
@@ -47,6 +55,9 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
   AccountResourcePropertyRegistry.Factory resourcePropertyRegistryFactory = Mock(AccountResourcePropertyRegistry.Factory)
   KubernetesKindRegistry.Factory kindRegistryFactory = Mock(KubernetesKindRegistry.Factory)
   KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap = new KubernetesSpinnakerKindMap(ImmutableList.of())
+  Registry spectatorRegistry = Mock(Registry)
+  ProviderRegistry providerRegistry = Mock(ProviderRegistry)
+  TestAgentScheduler scheduler
 
   KubernetesV2Credentials.Factory credentialFactory = new KubernetesV2Credentials.Factory(
     new NoopRegistry(),
@@ -59,6 +70,14 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
   )
 
   def synchronizeAccounts(KubernetesConfigurationProperties configurationProperties) {
+    catsModule.providerRegistry >> providerRegistry
+    providerRegistry.providers >> [kubernetesV2Provider]
+    kubernetesV2Provider.setAgentScheduler(scheduler)
+    for (KubernetesConfigurationProperties.ManagedAccount account in configurationProperties.accounts) {
+      def credentials = new KubernetesNamedAccountCredentials<KubernetesV2Credentials>(account, credentialFactory)
+      agentDispatcher.buildAllCachingAgents(credentials) >> agentsForCredentials(credentials)
+    }
+
     KubernetesV2ProviderSynchronizable synchronizable = new KubernetesV2ProviderSynchronizable(
       kubernetesV2Provider,
       accountCredentialsRepository,
@@ -71,21 +90,40 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
     synchronizable.synchronize()
   }
 
+  def agentsForCredentials(KubernetesNamedAccountCredentials... credentials) {
+    List<Agent> result = new ArrayList<>()
+    for (KubernetesNamedAccountCredentials creds in credentials) {
+      result << new KubernetesCoreCachingAgent(creds, null, spectatorRegistry, 0, 1, 1L)
+      result << new KubernetesUnregisteredCustomResourceCachingAgent(creds, null, spectatorRegistry, 0, 1, 1L)
+    }
+    return result
+  }
+
+  def prepareCachingAgents(KubernetesConfigurationProperties configurationProperties) {
+    List<Agent> agents = new ArrayList<>();
+    for (int i = 0; i < configurationProperties.accounts.size(); i++) {
+      KubernetesNamedAccountCredentials<KubernetesV2Credentials> account = configurationProperties.accounts[i] as KubernetesNamedAccountCredentials<KubernetesV2Credentials>
+      agents.add(new KubernetesCoreCachingAgent(account, null, spectatorRegistry, 0, 1, 1L))
+      agents.add(new KubernetesUnregisteredCustomResourceCachingAgent(account, null, spectatorRegistry, 0, 1, 1L))
+    }
+    kubernetesV2Provider.agents = agents
+  }
+
   void "is a no-op when there are no configured accounts"() {
     when:
     KubernetesConfigurationProperties kubernetesConfigurationProperties = new KubernetesConfigurationProperties()
-    accountCredentialsRepository.getAll() >> new HashSet<AccountCredentials>()
+    accountCredentialsRepository = new MapBackedAccountCredentialsRepository()
+    scheduler = new TestAgentScheduler(catsModule)
     synchronizeAccounts(kubernetesConfigurationProperties)
 
 
     then:
-    0 * accountCredentialsRepository.save(*_)
+    accountCredentialsRepository.all.size() == 0
+    kubernetesV2Provider.agents.size() == 0
+    scheduler.agents.size() == 0
   }
 
   void "correctly creates a v2 account and defaults properties"() {
-    given:
-    KubernetesNamedAccountCredentials credentials
-
     when:
     KubernetesConfigurationProperties configurationProperties = new KubernetesConfigurationProperties()
     configurationProperties.setAccounts([
@@ -94,13 +132,13 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
         namespaces: ["default"],
       )
     ])
-    accountCredentialsRepository.getAll() >> new HashSet<AccountCredentials>()
+    accountCredentialsRepository = new MapBackedAccountCredentialsRepository()
+    scheduler = new TestAgentScheduler(catsModule)
     synchronizeAccounts(configurationProperties)
 
     then:
-    1 * accountCredentialsRepository.save("test-account", _ as KubernetesNamedAccountCredentials) >> { _, creds ->
-      credentials = creds
-    }
+    accountCredentialsRepository.all.size() == 1
+    KubernetesNamedAccountCredentials credentials = accountCredentialsRepository.getOne("test-account") as KubernetesNamedAccountCredentials
 
     credentials.getName() == "test-account"
     credentials.getEnvironment() == "test-account"
@@ -115,5 +153,156 @@ class KubernetesV2ProviderSynchronizableSpec extends Specification {
     accountCredentials.isDebug() == false
     accountCredentials.isMetricsEnabled() == true
     accountCredentials.isLiveManifestCalls() == false
+
+    kubernetesV2Provider.agents.size() == 2
+    kubernetesV2Provider.agents.find { it.agentType == "test-account/KubernetesCoreCachingAgent[1/1]" } != null
+    kubernetesV2Provider.agents.find { it.agentType == "test-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+
+    scheduler.agents.size() == 2
+    scheduler.agents.find { it.agentType == "test-account/KubernetesCoreCachingAgent[1/1]" } != null
+    scheduler.agents.find { it.agentType == "test-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+  }
+
+  void "adds a new account and leaves other accounts unmodified"() {
+    when:
+    KubernetesConfigurationProperties configurationProperties = new KubernetesConfigurationProperties()
+    configurationProperties.setAccounts([ new KubernetesConfigurationProperties.ManagedAccount(
+      name: "new-account",
+      namespaces: ["default"],
+    ), new KubernetesConfigurationProperties.ManagedAccount(
+      name: "existing-account",
+      namespaces: ["default"],
+    ) ])
+    def existingAccountCredentials = new KubernetesNamedAccountCredentials<KubernetesV2Credentials>(
+      configurationProperties.getAccounts().get(1),
+      credentialFactory
+    )
+    accountCredentialsRepository = new MapBackedAccountCredentialsRepository()
+    accountCredentialsRepository.save("existing-account", existingAccountCredentials)
+    kubernetesV2Provider.agents = agentsForCredentials(existingAccountCredentials)
+    scheduler = new TestAgentScheduler(catsModule)
+    scheduler.agents = agentsForCredentials(existingAccountCredentials)
+    synchronizeAccounts(configurationProperties)
+
+    then:
+    accountCredentialsRepository.all.size() == 2
+    accountCredentialsRepository.getOne("existing-account") != null
+    accountCredentialsRepository.getOne("new-account") != null
+
+    kubernetesV2Provider.agents.size() == 4
+    kubernetesV2Provider.agents.find { it.agentType == "existing-account/KubernetesCoreCachingAgent[1/1]" } != null
+    kubernetesV2Provider.agents.find { it.agentType == "existing-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+    kubernetesV2Provider.agents.find { it.agentType == "new-account/KubernetesCoreCachingAgent[1/1]" } != null
+    kubernetesV2Provider.agents.find { it.agentType == "new-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+
+    scheduler.agents.size() == 4
+    scheduler.agents.find { it.agentType == "existing-account/KubernetesCoreCachingAgent[1/1]" } != null
+    scheduler.agents.find { it.agentType == "existing-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+    scheduler.agents.find { it.agentType == "new-account/KubernetesCoreCachingAgent[1/1]" } != null
+    scheduler.agents.find { it.agentType == "new-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+  }
+
+  void "deletes an account from repository and deletes its caching agents"() {
+    when:
+    KubernetesConfigurationProperties configurationProperties = new KubernetesConfigurationProperties()
+    configurationProperties.setAccounts([ new KubernetesConfigurationProperties.ManagedAccount(
+      name: "account-1",
+      namespaces: ["default"],
+    )])
+    def account1Creds = new KubernetesNamedAccountCredentials<KubernetesV2Credentials>(
+      configurationProperties.getAccounts().get(0),
+      credentialFactory
+    )
+    def account2Creds = new KubernetesNamedAccountCredentials<KubernetesV2Credentials>(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        name: "account-2",
+        namespaces: ["default"],
+      ),
+      credentialFactory
+    )
+    accountCredentialsRepository = new MapBackedAccountCredentialsRepository()
+    accountCredentialsRepository.save("account-1", account1Creds)
+    accountCredentialsRepository.save("account-2", account2Creds)
+    kubernetesV2Provider.agents = agentsForCredentials(account1Creds, account2Creds)
+    scheduler = new TestAgentScheduler(catsModule)
+    scheduler.agents = agentsForCredentials(account1Creds, account2Creds)
+    synchronizeAccounts(configurationProperties)
+
+    then:
+    accountCredentialsRepository.all.size() == 1
+    accountCredentialsRepository.getOne("account-1") != null
+
+    kubernetesV2Provider.agents.size() == 2
+    kubernetesV2Provider.agents.find { it.agentType == "account-1/KubernetesCoreCachingAgent[1/1]" } != null
+    kubernetesV2Provider.agents.find { it.agentType == "account-1/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+
+    scheduler.agents.size() == 2
+    scheduler.agents.find { it.agentType == "account-1/KubernetesCoreCachingAgent[1/1]" } != null
+    scheduler.agents.find { it.agentType == "account-1/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+  }
+
+  void "updates an existing account and leaves other accounts unmodified"() {
+    when:
+    KubernetesConfigurationProperties configurationProperties = new KubernetesConfigurationProperties()
+    configurationProperties.setAccounts([ new KubernetesConfigurationProperties.ManagedAccount(
+      name: "updated-account",
+      namespaces: ["default", "new-namespace"],
+    ), new KubernetesConfigurationProperties.ManagedAccount(
+      name: "unmodified-account",
+      namespaces: ["default"],
+    ) ])
+    def updatedAccount = new KubernetesNamedAccountCredentials<KubernetesV2Credentials>(
+      new KubernetesConfigurationProperties.ManagedAccount(
+        name: "updated-account",
+        namespaces: ["default"],
+      ),
+      credentialFactory
+    )
+    def unmodifiedAccount = new KubernetesNamedAccountCredentials<KubernetesV2Credentials>(
+      configurationProperties.accounts.get(1),
+      credentialFactory
+    )
+    accountCredentialsRepository = new MapBackedAccountCredentialsRepository()
+    accountCredentialsRepository.save("updated-account", updatedAccount)
+    accountCredentialsRepository.save("unmodified-account", unmodifiedAccount)
+    kubernetesV2Provider.agents = agentsForCredentials(updatedAccount, unmodifiedAccount)
+    scheduler = new TestAgentScheduler(catsModule)
+    scheduler.agents = agentsForCredentials(updatedAccount, unmodifiedAccount)
+    synchronizeAccounts(configurationProperties)
+
+    then:
+    accountCredentialsRepository.all.size() == 2
+    accountCredentialsRepository.getOne("updated-account") != null
+    (accountCredentialsRepository.getOne("updated-account") as KubernetesNamedAccountCredentials<KubernetesV2Credentials>).namespaces == ["default", "new-namespace"]
+    accountCredentialsRepository.getOne("unmodified-account") != null
+
+    kubernetesV2Provider.agents.size() == 4
+    kubernetesV2Provider.agents.find { it.agentType == "updated-account/KubernetesCoreCachingAgent[1/1]" } != null
+    ((kubernetesV2Provider.agents.find { it.agentType == "updated-account/KubernetesCoreCachingAgent[1/1]" } as KubernetesCoreCachingAgent).credentials as KubernetesV2Credentials).namespaces == ["default", "new-namespace"]
+    kubernetesV2Provider.agents.find { it.agentType == "updated-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+    kubernetesV2Provider.agents.find { it.agentType == "unmodified-account/KubernetesCoreCachingAgent[1/1]" } != null
+    kubernetesV2Provider.agents.find { it.agentType == "unmodified-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+
+    scheduler.agents.size() == 4
+    scheduler.agents.find { it.agentType == "updated-account/KubernetesCoreCachingAgent[1/1]" } != null
+    ((scheduler.agents.find { it.agentType == "updated-account/KubernetesCoreCachingAgent[1/1]" } as KubernetesCoreCachingAgent).credentials as KubernetesV2Credentials).namespaces == ["default", "new-namespace"]
+    scheduler.agents.find { it.agentType == "updated-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+    scheduler.agents.find { it.agentType == "unmodified-account/KubernetesCoreCachingAgent[1/1]" } != null
+    scheduler.agents.find { it.agentType == "unmodified-account/KubernetesUnregisteredCustomResourceCachingAgent[1/1]" } != null
+  }
+
+  class TestAgentScheduler extends CatsModuleAware implements AgentScheduler {
+    List<Agent> agents = new ArrayList<>()
+    TestAgentScheduler(CatsModule catsModule) {
+      this.catsModule = catsModule
+    }
+    @Override
+    void schedule(Agent agent, AgentExecution agentExecution, ExecutionInstrumentation executionInstrumentation) {
+      agents.add(agent)
+    }
+    @Override
+    void unschedule(Agent agent) {
+      agents.remove(agents.find { (it.agentType == agent.agentType) })
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5869

Instead of overwriting the collection of caching agents in `KubernetesV2Provider` by one that only has agents for new or changed accounts, new agents are added to the existing collection.

Old agents for changed accounts are removed by `ProviderUtils.unscheduleAndDeregisterAgents`, so there are no duplicate agents for changed accounts.

