### PR TITLE
feat(provider/cf): add command property to manifest

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -582,7 +582,7 @@ public class Applications {
     }
     if (command != null && command.isEmpty()) {
       throw new IllegalArgumentException(
-          "Buildpack commands cannot be empty. Either a custom command is provided or set to null to use the original buildpack command.");
+          "Buildpack commands cannot be empty. Please specify a custom command or set it to null to use the original buildpack command.");
     }
 
     safelyCall(() -> api.updateProcess(guid, new UpdateProcess(command, healthCheck)));

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/client/Applications.java
@@ -580,6 +580,11 @@ public class Applications {
     if (healthCheckEndpoint != null && !healthCheckEndpoint.isEmpty() && healthCheck != null) {
       healthCheck.setData(new Process.HealthCheckData().setEndpoint(healthCheckEndpoint));
     }
+    if (command != null && command.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Buildpack commands cannot be empty. Either a custom command is provided or set to null to use the original buildpack command.");
+    }
+
     safelyCall(() -> api.updateProcess(guid, new UpdateProcess(command, healthCheck)));
   }
 

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverter.java
@@ -151,6 +151,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
                           .collect(toList()));
               attrs.setEnv(app.getEnv());
               attrs.setStack(app.getStack());
+              attrs.setCommand(app.getCommand());
               return attrs;
             })
         .get();
@@ -181,5 +182,7 @@ public class DeployCloudFoundryServerGroupAtomicOperationConverter
     @Nullable private Map<String, String> env;
 
     @Nullable private String stack;
+
+    @Nullable private String command;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/description/DeployCloudFoundryServerGroupDescription.java
@@ -64,5 +64,7 @@ public class DeployCloudFoundryServerGroupDescription
     @Nullable private List<String> services;
 
     @Nullable private String stack;
+
+    @Nullable private String command;
   }
 }

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/ops/DeployCloudFoundryServerGroupAtomicOperation.java
@@ -94,7 +94,8 @@ public class DeployCloudFoundryServerGroupAtomicOperation
 
     buildDroplet(packageId, serverGroup.getId(), description);
     scaleApplication(serverGroup.getId(), description);
-    if (description.getApplicationAttributes().getHealthCheckType() != null) {
+    if (description.getApplicationAttributes().getHealthCheckType() != null
+        || description.getApplicationAttributes().getCommand() != null) {
       updateProcess(serverGroup.getId(), description);
     }
 
@@ -423,7 +424,7 @@ public class DeployCloudFoundryServerGroupAtomicOperation
         .getApplications()
         .updateProcess(
             serverGroupId,
-            null,
+            description.getApplicationAttributes().getCommand(),
             description.getApplicationAttributes().getHealthCheckType(),
             description.getApplicationAttributes().getHealthCheckHttpEndpoint());
     getTask().updateStatus(PHASE, "Updated process '" + description.getServerGroupName() + "'");

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/deploy/converters/DeployCloudFoundryServerGroupAtomicOperationConverterTest.java
@@ -147,7 +147,9 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                                 List.of(HashMap.of("route", "www.example.com/foo").toJavaMap())
                                     .asJava(),
                                 "env",
-                                HashMap.of("token", "ASDF").toJavaMap())
+                                HashMap.of("token", "ASDF").toJavaMap(),
+                                "command",
+                                "some-command")
                             .toJavaMap())
                     .asJava())
             .toJavaMap();
@@ -163,7 +165,8 @@ class DeployCloudFoundryServerGroupAtomicOperationConverterTest {
                 .setBuildpacks(List.of("buildpack1", "buildpack2").asJava())
                 .setServices(List.of("service1").asJava())
                 .setRoutes(List.of("www.example.com/foo").asJava())
-                .setEnv(HashMap.of("token", "ASDF").toJavaMap()));
+                .setEnv(HashMap.of("token", "ASDF").toJavaMap())
+                .setCommand("some-command"));
   }
 
   @Test


### PR DESCRIPTION
The command property will override the existing buildpack command. Some buildpacks require that you specify a custom command so this was needed to satisfy those requirements. Command was partially implemented so there wasn't a ton that was needed in order for this to work. CloudFoundry states that if you want a buildpack to use its original command then you must pass _null_ explicitly as a command. The assumption here is that when you are deploying an application you can either set a custom command or leave the command off the manifest. If command is not included, it will use the default command specified by the buildpack. There was already testing in place to cover the core logic but I did add some minor modifications to ensure the field was being converted correctly.