### PR TITLE
refactor(core): deprecate ProviderVersion

### DIFF
--- a/clouddriver-alicloud/src/main/java/com/netflix/spinnaker/clouddriver/alicloud/security/AliCloudCredentials.java
+++ b/clouddriver-alicloud/src/main/java/com/netflix/spinnaker/clouddriver/alicloud/security/AliCloudCredentials.java
@@ -31,8 +31,6 @@ public class AliCloudCredentials extends AbstractAccountCredentials<AccountCrede
 
   private List<String> regions;
 
-  private String providerVersion;
-
   private List<String> requiredGroupMembership;
 
   public void setName(String name) {
@@ -53,10 +51,6 @@ public class AliCloudCredentials extends AbstractAccountCredentials<AccountCrede
 
   public void setAccessSecretKey(String accessSecretKey) {
     this.accessSecretKey = accessSecretKey;
-  }
-
-  public void setProviderVersion(String providerVersion) {
-    this.providerVersion = providerVersion;
   }
 
   @Override

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/VersionedCloudProviderOperation.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/VersionedCloudProviderOperation.java
@@ -28,7 +28,10 @@ public interface VersionedCloudProviderOperation {
    * applicable to accounts at this version.
    *
    * @return true i.f.f. this operations works on accounts at this version
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion} is deprecated.
+   *     This method will be removed in a future release.
    */
+  @Deprecated
   default boolean acceptsVersion(ProviderVersion version) {
     return ProviderVersion.v1.equals(version);
   }

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountCredentials.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/security/AccountCredentials.java
@@ -71,7 +71,10 @@ public interface AccountCredentials<T> {
    * By default every account is at version v1.
    *
    * @return the account's version.
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion} is deprecated.
+   *     This method will be removed in a future release.
    */
+  @Deprecated
   default ProviderVersion getProviderVersion() {
     return ProviderVersion.v1;
   }

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/security/ProviderVersion.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/security/ProviderVersion.java
@@ -19,7 +19,16 @@ package com.netflix.spinnaker.clouddriver.security;
 
 import com.netflix.spinnaker.kork.annotations.Beta;
 
+/**
+ * ProviderVersion allowed cloud provider operations to be versioned at the account level. The
+ * Kubernetes provider was the only cloud provider to version itself using ProviderVersion. Since
+ * the removal of the legacy (v1) Kubernetes provider, there are no cloud providers that support a
+ * non-default ProviderVersion.
+ *
+ * @deprecated ProviderVersion is deprecated and will be removed in a future release.
+ */
 @Beta
+@Deprecated
 public enum ProviderVersion {
   v1,
   v2

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/ApplicationContextAtomicOperationsRegistry.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/ApplicationContextAtomicOperationsRegistry.groovy
@@ -32,6 +32,22 @@ class ApplicationContextAtomicOperationsRegistry implements AtomicOperationsRegi
   ApplicationContext applicationContext
 
   @Override
+  AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider) {
+    return (AtomicOperationConverter) applicationContext.getBean(description)
+  }
+
+  @Override
+  DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider) {
+    return (DescriptionValidator) applicationContext.getBean(validator)
+  }
+
+  /**
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion}
+   * is deprecated. This method will be removed in a future release. Use
+   * {@link #getAtomicOperationConverter(String, String)} instead.
+   */
+  @Override
+  @Deprecated
   AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider, ProviderVersion version) {
     def result = (AtomicOperationConverter) applicationContext.getBean(description)
     if (!result.acceptsVersion(version)) {
@@ -41,7 +57,13 @@ class ApplicationContextAtomicOperationsRegistry implements AtomicOperationsRegi
     return result
   }
 
+  /**
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion}
+   * is deprecated. This method will be removed in a future release. Use
+   * {@link #getAtomicOperationDescriptionValidator(String, String)} instead.
+   */
   @Override
+  @Deprecated
   DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider, ProviderVersion version) {
     def result = (DescriptionValidator) applicationContext.getBean(validator)
     if (!result.acceptsVersion(version)) {

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationsRegistry.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationsRegistry.groovy
@@ -32,9 +32,30 @@ interface AtomicOperationsRegistry {
    *
    * @param description
    * @param cloudProvider
-   * @param providerVersion
    * @return
    */
+  AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider)
+
+  /**
+   *
+   * @param validator
+   * @param cloudProvider
+   * @return
+   */
+  @Nullable DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider)
+
+  /**
+   *
+   * @param description
+   * @param cloudProvider
+   * @param providerVersion
+   * @return
+   *
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion}
+   * is deprecated. This method will be removed in a future release. Use
+   * {@link #getAtomicOperationConverter(String, String)} instead.
+   */
+  @Deprecated
   AtomicOperationConverter getAtomicOperationConverter(String description, String cloudProvider, ProviderVersion version)
 
   /**
@@ -43,6 +64,11 @@ interface AtomicOperationsRegistry {
    * @param cloudProvider
    * @param providerVersion
    * @return
+   *
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion}
+   * is deprecated. This method will be removed in a future release. Use
+   * {@link #getAtomicOperationDescriptionValidator(String, String)} instead.
    */
+  @Deprecated
   @Nullable DescriptionValidator getAtomicOperationDescriptionValidator(String validator, String cloudProvider, ProviderVersion version)
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/VersionedOperationHelper.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/VersionedOperationHelper.java
@@ -25,8 +25,10 @@ import javax.annotation.Nullable;
 
 @NonnullByDefault
 public class VersionedOperationHelper {
-
-  /** @deprecated ProviderVersion is going away. */
+  /**
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion} is deprecated.
+   *     This method will be removed in a future release.
+   */
   @Deprecated
   static <T extends VersionedCloudProviderOperation> List<T> findVersionMatches(
       ProviderVersion version, List<T> converters) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/DeleteGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -32,7 +32,6 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
 import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import org.springframework.beans.factory.annotation.Autowired
 
 class DeleteGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation<Void>{
@@ -188,7 +187,7 @@ class DeleteGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
 
     if (templateOpMap?.instanceMetadata) {
       templateOpMap.instanceMetadata.remove(GCEUtil.AUTOSCALING_POLICY)
-      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce', ProviderVersion.v1)
+      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce')
       AtomicOperation templateOp = converter.convertOperation(templateOpMap)
       orchestrationProcessor.process([templateOp], UUID.randomUUID().toString())
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/UpsertGoogleAutoscalingPolicyAtomicOperation.groovy
@@ -35,7 +35,6 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
 import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import org.springframework.beans.factory.annotation.Autowired
 
 class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation<Void> {
@@ -390,7 +389,7 @@ class UpsertGoogleAutoscalingPolicyAtomicOperation extends GoogleAtomicOperation
     }
 
     if (templateOpMap.instanceMetadata) {
-      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce', ProviderVersion.v1)
+      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce')
       AtomicOperation templateOp = converter.convertOperation(templateOpMap)
       orchestrationProcessor.process([templateOp], UUID.randomUUID().toString())
     }

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/ops/loadbalancer/UpsertGoogleHttpLoadBalancerAtomicOperation.groovy
@@ -34,7 +34,6 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationsRegistry
 import com.netflix.spinnaker.clouddriver.orchestration.OrchestrationProcessor
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -594,7 +593,7 @@ class UpsertGoogleHttpLoadBalancerAtomicOperation extends UpsertGoogleLoadBalanc
         ]
       }
 
-      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce', ProviderVersion.v1)
+      def converter = atomicOperationsRegistry.getAtomicOperationConverter('modifyGoogleServerGroupInstanceTemplateDescription', 'gce')
       AtomicOperation templateOp = converter.convertOperation(templateOpMap)
       orchestrationProcessor.process([templateOp], UUID.randomUUID().toString())
     }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
@@ -57,11 +57,6 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
 
   @PostConstruct
   public void setup() {
-    if (kubernetesConfigurationProperties.getAccounts().stream()
-        .anyMatch(a -> ProviderVersion.v1.equals(a.getProviderVersion()))) {
-      throw new IllegalArgumentException(
-          "The legacy Kubernetes provider (V1) is no longer supported. Please migrate all Kubernetes accounts to the standard provider (V2).");
-    }
     Set<KubernetesNamedAccountCredentials<KubernetesV2Credentials>> allAccounts =
         kubernetesConfigurationProperties.getAccounts().stream()
             .map(
@@ -80,9 +75,7 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
     // we only want to initialize caching agents for new or updated accounts
     Set<KubernetesNamedAccountCredentials<KubernetesV2Credentials>> newAndChangedAccounts =
         ProviderUtils.buildThreadSafeSetOfAccounts(
-                accountCredentialsRepository,
-                KubernetesNamedAccountCredentials.class,
-                ProviderVersion.v2)
+                accountCredentialsRepository, KubernetesNamedAccountCredentials.class)
             .stream()
             .map(c -> (KubernetesNamedAccountCredentials<KubernetesV2Credentials>) c)
             .filter(account -> newAndChangedAccountNames.contains(account.getName()))
@@ -103,7 +96,6 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
     deleteAccounts(deletedAccounts);
 
     kubernetesConfigurationProperties.getAccounts().stream()
-        .filter(a -> ProviderVersion.v2.equals(a.getProviderVersion()))
         .map(
             managedAccount -> {
               KubernetesNamedAccountCredentials credentials =
@@ -159,7 +151,6 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
         accountCredentialsRepository.getAll().stream()
             .filter(
                 (AccountCredentials c) -> KubernetesCloudProvider.ID.equals(c.getCloudProvider()))
-            .filter((AccountCredentials c) -> ProviderVersion.v2.equals(c.getProviderVersion()))
             .map(AccountCredentials::getName)
             .collect(Collectors.toList());
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -16,7 +16,6 @@
  */
 package com.netflix.spinnaker.clouddriver.kubernetes.config;
 
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +29,6 @@ public class KubernetesConfigurationProperties {
   @Data
   public static class ManagedAccount {
     private String name;
-    private ProviderVersion providerVersion = ProviderVersion.v2;
     private String environment;
     private String accountType;
     private String context;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/artifact/KubernetesCleanupArtifactsConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/artifact/KubernetesCleanupArtifactsConverter.java
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.op.artifact.KubernetesCleanu
 import com.netflix.spinnaker.clouddriver.model.ArtifactProvider;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -46,10 +45,5 @@ public class KubernetesCleanupArtifactsConverter
   public KubernetesCleanupArtifactsDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesCleanupArtifactsDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/job/KubernetesRunJobOperationConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/job/KubernetesRunJobOperationConverter.java
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.job.KubernetesRu
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubernetesRunJobOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -55,10 +54,5 @@ public class KubernetesRunJobOperationConverter extends AbstractAtomicOperations
   public KubernetesRunJobOperationDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesRunJobOperationDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeleteManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeleteManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDeleteManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -41,10 +40,5 @@ public class KubernetesDeleteManifestConverter extends AbstractAtomicOperationsC
   public KubernetesDeleteManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesDeleteManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeployManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeployManifestConverter.java
@@ -30,7 +30,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDeploy
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -69,11 +68,6 @@ public class KubernetesDeployManifestConverter extends AbstractAtomicOperationsC
         KubernetesAtomicOperationConverterHelper.convertDescription(
             input, this, KubernetesDeployManifestDescription.class);
     return convertListDescription(mainDescription);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 
   /**

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDisableManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDisableManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDisableManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -41,10 +40,5 @@ public class KubernetesDisableManifestConverter extends AbstractAtomicOperations
   public KubernetesEnableDisableManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesEnableDisableManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesEnableManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesEnableManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesEnableManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -41,10 +40,5 @@ public class KubernetesEnableManifestConverter extends AbstractAtomicOperationsC
   public KubernetesEnableDisableManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesEnableDisableManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesPatchManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesPatchManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesPatchManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -41,10 +40,5 @@ public class KubernetesPatchManifestConverter extends AbstractAtomicOperationsCr
   public KubernetesPatchManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesPatchManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesPauseRolloutManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesPauseRolloutManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesPauseRolloutManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -42,10 +41,5 @@ public class KubernetesPauseRolloutManifestConverter
   public KubernetesPauseRolloutManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesPauseRolloutManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesResumeRolloutManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesResumeRolloutManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesResumeRolloutManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -42,10 +41,5 @@ public class KubernetesResumeRolloutManifestConverter
   public KubernetesResumeRolloutManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesResumeRolloutManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesRollingRestartManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesRollingRestartManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesRollingRestartManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -42,10 +41,5 @@ public class KubernetesRollingRestartManifestConverter
   public KubernetesRollingRestartManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesRollingRestartManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesScaleManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesScaleManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesScaleManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -41,10 +40,5 @@ public class KubernetesScaleManifestConverter extends AbstractAtomicOperationsCr
   public KubernetesScaleManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesScaleManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesUndoRolloutManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesUndoRolloutManifestConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesUndoRolloutManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -42,10 +41,5 @@ public class KubernetesUndoRolloutManifestConverter
   public KubernetesUndoRolloutManifestDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesUndoRolloutManifestDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/servergroup/KubernetesResizeServerGroupConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/servergroup/KubernetesResizeServerGroupConverter.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.servergroup.Kube
 import com.netflix.spinnaker.clouddriver.kubernetes.op.servergroup.KubernetesResizeServerGroupOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -43,10 +42,5 @@ public class KubernetesResizeServerGroupConverter
   public KubernetesResizeServerGroupDescription convertDescription(Map input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesResizeServerGroupDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -22,7 +22,6 @@ import static lombok.EqualsAndHashCode.Include;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties.ManagedAccount;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.LinkedDockerRegistryConfiguration;
 import com.netflix.spinnaker.clouddriver.security.AbstractAccountCredentials;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import java.util.*;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -37,8 +36,6 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials>
   private final String cloudProvider = "kubernetes";
 
   @Include private final String name;
-
-  @Include private final ProviderVersion providerVersion;
 
   @Include private final String environment;
 
@@ -57,7 +54,6 @@ public class KubernetesNamedAccountCredentials<C extends KubernetesCredentials>
   public KubernetesNamedAccountCredentials(
       ManagedAccount managedAccount, KubernetesCredentialFactory<C> credentialFactory) {
     this.name = managedAccount.getName();
-    this.providerVersion = managedAccount.getProviderVersion();
     this.environment =
         Optional.ofNullable(managedAccount.getEnvironment()).orElse(managedAccount.getName());
     this.accountType =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/artifact/KubernetesArtifactCleanupValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/artifact/KubernetesArtifactCleanupValidator.java
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.artifact.KubernetesCleanupArtifactsDescription;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -38,9 +37,4 @@ public class KubernetesArtifactCleanupValidator
   @Override
   public void validate(
       List priorDescriptions, KubernetesCleanupArtifactsDescription description, Errors errors) {}
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
-  }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeleteManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeleteManifestValidator.java
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordi
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeleteManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -56,10 +55,5 @@ public class KubernetesDeleteManifestValidator
         return;
       }
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeployManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeployManifestValidator.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -56,10 +55,5 @@ public class KubernetesDeployManifestValidator
         return;
       }
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDisableManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDisableManifestValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesEnableDisableManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -50,10 +49,5 @@ public class KubernetesDisableManifestValidator
         description.getPointCoordinates().getNamespace())) {
       return;
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesEnableManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesEnableManifestValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesEnableDisableManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -50,10 +49,5 @@ public class KubernetesEnableManifestValidator
         description.getPointCoordinates().getNamespace())) {
       return;
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPatchManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPatchManifestValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesPatchManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -62,10 +61,5 @@ public class KubernetesPatchManifestValidator
         description.getPointCoordinates().getNamespace())) {
       return;
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPauseRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPauseRolloutManifestValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesPauseRolloutManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -50,10 +49,5 @@ public class KubernetesPauseRolloutManifestValidator
         description.getPointCoordinates().getNamespace())) {
       return;
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesResumeRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesResumeRolloutManifestValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesResumeRolloutManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -50,10 +49,5 @@ public class KubernetesResumeRolloutManifestValidator
         description.getPointCoordinates().getNamespace())) {
       return;
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesRollingRestartManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesRollingRestartManifestValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesRollingRestartManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -55,10 +54,5 @@ public class KubernetesRollingRestartManifestValidator
         description.getPointCoordinates().getNamespace())) {
       return;
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesScaleManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesScaleManifestValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesScaleManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -47,10 +46,5 @@ public class KubernetesScaleManifestValidator
         description.getPointCoordinates().getNamespace())) {
       return;
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesUndoRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesUndoRolloutManifestValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesUndoRolloutManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -52,10 +51,5 @@ public class KubernetesUndoRolloutManifestValidator
     if (description.getNumRevisionsBack() == null && description.getRevision() == null) {
       util.reject("empty", "numRevisionsBack & revision");
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/servergroup/KubernetesResizeServerGroupValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/servergroup/KubernetesResizeServerGroupValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.servergroup.KubernetesResizeServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -50,10 +49,5 @@ public class KubernetesResizeServerGroupValidator
     }
 
     util.validateNotEmpty("capacity", description.getCapacity());
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v2;
   }
 }

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/converter/DeleteOracleLoadBalancerAtomicOperationConverter.java
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/converter/DeleteOracleLoadBalancerAtomicOperationConverter.java
@@ -14,7 +14,6 @@ import com.netflix.spinnaker.clouddriver.oracle.deploy.op.DeleteOracleLoadBalanc
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import groovy.util.logging.Slf4j;
 import java.util.Map;
 import org.springframework.stereotype.Component;
@@ -36,10 +35,5 @@ public class DeleteOracleLoadBalancerAtomicOperationConverter
   public DeleteLoadBalancerDescription convertDescription(Map input) {
     return OracleAtomicOperationConverterHelper.convertDescription(
         input, this, DeleteLoadBalancerDescription.class);
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v1;
   }
 }

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/BasicOracleDeployDescriptionValidator.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/BasicOracleDeployDescriptionValidator.groovy
@@ -13,14 +13,13 @@ import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.oracle.OracleOperation
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.BasicOracleDeployDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 
 @OracleOperation(AtomicOperations.CREATE_SERVER_GROUP)
 @Component("basicOracleDeployDescriptionValidator")
 class BasicOracleDeployDescriptionValidator extends StandardOracleAttributeValidator<BasicOracleDeployDescription> {
-  
+
   @Override
   void validate(List priorDescriptions, BasicOracleDeployDescription description, Errors errors) {
     context = "basicOracleDeployDescriptionValidator"

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/UpsertLoadBalancerDescriptionValidator.java
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/UpsertLoadBalancerDescriptionValidator.java
@@ -11,7 +11,6 @@ package com.netflix.spinnaker.clouddriver.oracle.deploy.validator;
 import com.netflix.spinnaker.clouddriver.oracle.OracleOperation;
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.UpsertLoadBalancerDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
-import com.netflix.spinnaker.clouddriver.security.ProviderVersion;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -93,10 +92,5 @@ class UpsertLoadBalancerDescriptionValidator
                 validateNotNull(errors, listener.getPort(), "listener.port");
               });
     }
-  }
-
-  @Override
-  public boolean acceptsVersion(ProviderVersion version) {
-    return version == ProviderVersion.v1;
   }
 }

--- a/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtils.groovy
+++ b/clouddriver-security/src/main/groovy/com/netflix/spinnaker/clouddriver/security/ProviderUtils.groovy
@@ -52,7 +52,12 @@ public class ProviderUtils {
 
   /**
    * Build a thread-safe set containing each account in the accountCredentialsRepository that is of type
-   * credentialsType, and (if specified) of provdierVersion version.
+   * credentialsType, and (if specified) of providerVersion version.
+   *
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion}
+   * is deprecated. This method will be removed in a future release. Use
+   * {@link #buildThreadSafeSetOfAccounts(AccountCredentialsRepository, Class<T>)}
+   * instead.
    */
   public static <T extends AccountCredentials> Set<T> buildThreadSafeSetOfAccounts(AccountCredentialsRepository accountCredentialsRepository, Class<T> credentialsType, ProviderVersion version) {
     buildThreadSafeSetOfAccounts(accountCredentialsRepository, credentialsType, null, version)
@@ -69,7 +74,13 @@ public class ProviderUtils {
   /**
    * Build a thread-safe set containing each account in the accountCredentialsRepository that is of type
    * credentialsType, (if specified) cloud provider, and (if specified) of providerVersion version.
+   *
+   * @deprecated {@link com.netflix.spinnaker.clouddriver.security.ProviderVersion}
+   * is deprecated. This method will be removed in a future release. Use
+   * {@link #buildThreadSafeSetOfAccounts(AccountCredentialsRepository, Class<T>, String)}
+   * instead.
    */
+  @Deprecated
   public static <T extends AccountCredentials> Set<T> buildThreadSafeSetOfAccounts(AccountCredentialsRepository accountCredentialsRepository, Class<T> credentialsType, String cloudProvider, ProviderVersion version) {
     def allAccounts = Collections.newSetFromMap(new ConcurrentHashMap<T, Boolean>())
     allAccounts.addAll(accountCredentialsRepository.all.findResults { credentialsType.isInstance(it) ? credentialsType.cast(it) : null })

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsController.groovy
@@ -72,7 +72,6 @@ class CredentialsController {
                                'cloudProvider',
                                'requiredGroupMembership',
                                'permissions',
-                               'providerVersion',
                                'accountId'])
     }
 

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerSpec.groovy
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/controllers/CredentialsControllerSpec.groovy
@@ -54,7 +54,7 @@ class CredentialsControllerSpec extends Specification {
 
     List<Map> parsedResponse = new JsonSlurper().parseText(result.response.contentAsString) as List
 
-    parsedResponse == [[name: "test", environment: "env", accountType: "acctType", cloudProvider: "testProvider", type: "testProvider", requiredGroupMembership: ["test"], permissions: [READ:["test"], WRITE:["test"]], challengeDestructiveActions: false, primaryAccount: false, providerVersion: "v1"]]
+    parsedResponse == [[name: "test", environment: "env", accountType: "acctType", cloudProvider: "testProvider", type: "testProvider", requiredGroupMembership: ["test"], permissions: [READ:["test"], WRITE:["test"]], challengeDestructiveActions: false, primaryAccount: false]]
   }
 
   static class TestNamedAccountCredentials extends AbstractAccountCredentials<Map> {


### PR DESCRIPTION
* feat(security): deprecate ProviderVersion enum and public methods that use ProviderVersion 

* feat(core): deprecate public interfaces and methods that use ProviderVersion, and remove ProviderVersion-dependent logic from private methods 

* refactor(alicloud): remove ProviderVersion from AliCloud 

  Although AliCloudCredentials is a public class, I think it should be safe to remove providerVersion because there are no non-default ProviderVersions configurable with Halyard, and this entire module is not even currently part of the OSS build.

* refactor(google): remove ProviderVersion from Google 

* refactor(core): remove acceptsVersion from cloud provider operations 

  Since we no longer filter by ProviderVersion in core, removes all uses of acceptsVersion(ProviderVersion) except those in public (now deprecated) methods and tests, which will be removed next release.

* refactor(kubernetes): remove ProviderVersion from Kubernetes accounts 

* refactor(web): remove providerVersion from CredentialsController 
