### PR TITLE
feat(aws): Support IPv6 for launch template backed ASGs

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -100,8 +100,11 @@ class AutoScalingWorker {
   private List<AmazonBlockDevice> blockDevices
   private Map<String, String> tags
   private List<AmazonAsgLifecycleHook> lifecycleHooks
+
+  /** Launch Templates properties **/
   private Boolean setLaunchTemplate
   private Boolean requireIMDSv2
+  private Boolean associateIpV6Address
 
   private int minInstances
   private int maxInstances
@@ -179,7 +182,7 @@ class AutoScalingWorker {
 
       final LaunchTemplate launchTemplate = regionScopedProvider
         .getLaunchTemplateService()
-        .createLaunchTemplate(settings, DefaultLaunchConfigurationBuilder.createName(settings), requireIMDSv2)
+        .createLaunchTemplate(settings, DefaultLaunchConfigurationBuilder.createName(settings), requireIMDSv2, associateIpV6Address)
       launchTemplateSpecification = new LaunchTemplateSpecification(
         launchTemplateId: launchTemplate.launchTemplateId, version: launchTemplate.latestVersionNumber)
     } else {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -104,7 +104,7 @@ class AutoScalingWorker {
   /** Launch Templates properties **/
   private Boolean setLaunchTemplate
   private Boolean requireIMDSv2
-  private Boolean associateIpV6Address
+  private Boolean associateIPv6Address
 
   private int minInstances
   private int maxInstances
@@ -182,7 +182,7 @@ class AutoScalingWorker {
 
       final LaunchTemplate launchTemplate = regionScopedProvider
         .getLaunchTemplateService()
-        .createLaunchTemplate(settings, DefaultLaunchConfigurationBuilder.createName(settings), requireIMDSv2, associateIpV6Address)
+        .createLaunchTemplate(settings, DefaultLaunchConfigurationBuilder.createName(settings), requireIMDSv2, associateIPv6Address)
       launchTemplateSpecification = new LaunchTemplateSpecification(
         launchTemplateId: launchTemplate.launchTemplateId, version: launchTemplate.latestVersionNumber)
     } else {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -64,6 +64,12 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
    */
   Boolean requireIMDSv2 = false
 
+  /**
+   * Associate an IPv6 address
+   * This is a Launch Template only feature
+   */
+  Boolean associateIpV6Address = false
+
   Collection<OperationEvent> events = []
 
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -68,7 +68,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
    * Associate an IPv6 address
    * This is a Launch Template only feature
    */
-  Boolean associateIpV6Address = false
+  Boolean associateIPv6Address = false
 
   Collection<OperationEvent> events = []
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -304,7 +304,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         lifecycleHooks: getLifecycleHooks(account, description),
         setLaunchTemplate: description.setLaunchTemplate,
         requireIMDSv2: description.requireIMDSv2,
-        associateIpV6Address: description.associateIpV6Address
+        associateIPv6Address: description.associateIPv6Address
       )
 
       def asgName = autoScalingWorker.deploy()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -303,7 +303,8 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         tags: applyAppStackDetailTags(deployDefaults, description).tags,
         lifecycleHooks: getLifecycleHooks(account, description),
         setLaunchTemplate: description.setLaunchTemplate,
-        requireIMDSv2: description.requireIMDSv2
+        requireIMDSv2: description.requireIMDSv2,
+        associateIpV6Address: description.associateIpV6Address
       )
 
       def asgName = autoScalingWorker.deploy()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -138,7 +138,7 @@ public class LaunchTemplateService {
     request.withNetworkInterfaces(
         new LaunchTemplateInstanceNetworkInterfaceSpecificationRequest()
             .withAssociatePublicIpAddress(settings.getAssociatePublicIpAddress())
-            .withIpv6AddressCount(associateIPv6Address != null && associateIPv6Address ? 1 : 0)
+            .withIpv6AddressCount(associateIPv6Address ? 1 : 0)
             .withGroups(settings.getSecurityGroups())
             .withDeviceIndex(0));
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -85,7 +85,7 @@ public class LaunchTemplateService {
       LaunchConfigurationSettings settings,
       String launchTemplateName,
       Boolean requireIMDSv2,
-      Boolean associateIpV6Address) {
+      Boolean associateIPv6Address) {
     final RequestLaunchTemplateData request =
         new RequestLaunchTemplateData()
             .withImageId(settings.getAmi())
@@ -138,7 +138,7 @@ public class LaunchTemplateService {
     request.withNetworkInterfaces(
         new LaunchTemplateInstanceNetworkInterfaceSpecificationRequest()
             .withAssociatePublicIpAddress(settings.getAssociatePublicIpAddress())
-            .withIpv6AddressCount(associateIpV6Address != null && associateIpV6Address ? 1 : 0)
+            .withIpv6AddressCount(associateIPv6Address != null && associateIPv6Address ? 1 : 0)
             .withGroups(settings.getSecurityGroups())
             .withDeviceIndex(0));
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -82,7 +82,10 @@ public class LaunchTemplateService {
   }
 
   public LaunchTemplate createLaunchTemplate(
-      LaunchConfigurationSettings settings, String launchTemplateName, Boolean requireIMDSv2) {
+      LaunchConfigurationSettings settings,
+      String launchTemplateName,
+      Boolean requireIMDSv2,
+      Boolean associateIpV6Address) {
     final RequestLaunchTemplateData request =
         new RequestLaunchTemplateData()
             .withImageId(settings.getAmi())
@@ -135,6 +138,7 @@ public class LaunchTemplateService {
     request.withNetworkInterfaces(
         new LaunchTemplateInstanceNetworkInterfaceSpecificationRequest()
             .withAssociatePublicIpAddress(settings.getAssociatePublicIpAddress())
+            .withIpv6AddressCount(associateIpV6Address != null && associateIpV6Address ? 1 : 0)
             .withGroups(settings.getSecurityGroups())
             .withDeviceIndex(0));
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorkerUnitSpec.groovy
@@ -115,7 +115,7 @@ class AutoScalingWorkerUnitSpec extends Specification {
     and:
     mockAutoScalingWorker.setLaunchTemplate = true
     regionScopedProvider.getLaunchTemplateService() >> Mock(LaunchTemplateService) {
-      createLaunchTemplate(_,_,_) >> new LaunchTemplate(launchTemplateId: "id", latestVersionNumber: 0, launchTemplateName: "lt")
+      createLaunchTemplate(_,_,_,_) >> new LaunchTemplate(launchTemplateId: "id", latestVersionNumber: 0, launchTemplateName: "lt")
     }
 
     when:
@@ -153,7 +153,7 @@ class AutoScalingWorkerUnitSpec extends Specification {
     String asgName = autoScalingWorker.deploy()
 
     then:
-    1 * launchTemplateService.createLaunchTemplate(_,_,_) >>
+    1 * launchTemplateService.createLaunchTemplate(_,_,_,_) >>
       new LaunchTemplate(launchTemplateId: "id", latestVersionNumber: 0, launchTemplateName: "lt")
     1 * clusterProvider.getCluster('myasg', 'test', 'myasg') >> {
       new Cluster.SimpleCluster(type: 'aws', serverGroups: [


### PR DESCRIPTION
- assign IPv6 address to instances when `associateIpV6Address` is true


@caseyhebebrand I decided not to overload `associatePublicIpAddress` for IPv6 since that creates a public IPv4 address.
Instead I added `associateIpV6Address` that can be set independently of `associatePublicIpAddress` and avoid coupling the two.
