### PR TITLE
fix(dependencies): depend on only swagger-annotations for compile

### DIFF
--- a/clouddriver-web/clouddriver-web.gradle
+++ b/clouddriver-web/clouddriver-web.gradle
@@ -39,11 +39,11 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-config"
-  implementation "com.netflix.spinnaker.kork:kork-swagger"
   implementation "com.netflix.spinnaker.kork:kork-web"
   implementation("com.netflix.spinnaker.kork:kork-plugins")
   implementation "com.netflix.spinnaker.moniker:moniker"
   implementation "commons-io:commons-io"
+  implementation "io.swagger:swagger-annotations"
   implementation "org.codehaus.groovy:groovy-all"
   implementation "org.slf4j:slf4j-api"
   implementation "org.springframework.boot:spring-boot-starter-actuator"


### PR DESCRIPTION
kork-runtime brings in kork-swagger for the runtime component configuration