### PR TITLE
fix(docker): make DockerRegistryImageCachingAgent authoritative

### DIFF
--- a/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
+++ b/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgent.groovy
@@ -36,8 +36,8 @@ import static java.util.Collections.unmodifiableSet
 @Slf4j
 class DockerRegistryImageCachingAgent implements CachingAgent, AccountAware, AgentIntervalAware {
   static final Set<AgentDataType> types = unmodifiableSet([
-    AgentDataType.Authority.INFORMATIVE.forType(Keys.Namespace.TAGGED_IMAGE.ns),
-    AgentDataType.Authority.INFORMATIVE.forType(Keys.Namespace.IMAGE_ID.ns)
+    AgentDataType.Authority.AUTHORITATIVE.forType(Keys.Namespace.TAGGED_IMAGE.ns),
+    AgentDataType.Authority.AUTHORITATIVE.forType(Keys.Namespace.IMAGE_ID.ns)
   ] as Set)
 
   private DockerRegistryCredentials credentials


### PR DESCRIPTION
Closes: https://github.com/spinnaker/spinnaker/issues/5737

[This PR](https://github.com/spinnaker/clouddriver/pull/1132) made the DockerRegistryImageCachingAgent informative rather than authoritative "to prevent images from being deleted." However, based on [this issue](https://github.com/spinnaker/spinnaker/issues/5737), users expect deleted entities to be removed from the cache. Since the DockerRegistryImageCachingAgent fetches an exhaustive list of tags each run, I think it makes sense for it to be an authoritative agent.