### PR TITLE
feat(plugins): move DescriptionValidator to clouddriver-api

### DIFF
--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.java
@@ -18,8 +18,10 @@
 package com.netflix.spinnaker.clouddriver.deploy;
 
 import com.netflix.spinnaker.clouddriver.orchestration.VersionedCloudProviderOperation;
+import com.netflix.spinnaker.kork.annotations.Beta;
 import java.util.List;
 
+@Beta
 public abstract class DescriptionValidator<T> implements VersionedCloudProviderOperation {
   public static String getValidatorName(String description) {
     return description + "Validator";

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.deploy;
+
+import com.netflix.spinnaker.clouddriver.orchestration.VersionedCloudProviderOperation;
+import java.util.List;
+
+public abstract class DescriptionValidator<T> implements VersionedCloudProviderOperation {
+  public static String getValidatorName(String description) {
+    return description + "Validator";
+  }
+
+  public abstract void validate(List priorDescriptions, T description, ValidationErrors errors);
+}

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/ValidationErrors.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/ValidationErrors.java
@@ -17,14 +17,17 @@
 
 package com.netflix.spinnaker.clouddriver.deploy;
 
-import com.netflix.spinnaker.clouddriver.orchestration.VersionedCloudProviderOperation;
-import java.util.List;
-import org.springframework.validation.Errors;
+public interface ValidationErrors {
 
-public abstract class DescriptionValidator<T> implements VersionedCloudProviderOperation {
-  public static String getValidatorName(String description) {
-    return description + "Validator";
-  }
+  void reject(String errorCode);
 
-  public abstract void validate(List priorDescriptions, T description, Errors errors);
+  void reject(String errorCode, String defaultMessage);
+
+  void reject(String errorCode, Object[] errorArgs, String defaultMessage);
+
+  void rejectValue(String field, String errorCode);
+
+  void rejectValue(String field, String errorCode, String defaultMessage);
+
+  void rejectValue(String field, String errorCode, Object[] errorArgs, String defaultMessage);
 }

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/ValidationErrors.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/ValidationErrors.java
@@ -17,6 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.deploy;
 
+import com.netflix.spinnaker.kork.annotations.Beta;
+
+@Beta
 public interface ValidationErrors {
 
   void reject(String errorCode);

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/AbstractStartStopAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/AbstractStartStopAppengineDescriptionValidator.groovy
@@ -19,9 +19,9 @@ package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.StartStopAppengineDescription
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.validation.Errors
 
 
 abstract class AbstractStartStopAppengineDescriptionValidator extends DescriptionValidator<StartStopAppengineDescription> {
@@ -34,7 +34,7 @@ abstract class AbstractStartStopAppengineDescriptionValidator extends Descriptio
   abstract String getDescriptionName()
 
   @Override
-  void validate(List priorDescriptions, StartStopAppengineDescription description, Errors errors) {
+  void validate(List priorDescriptions, StartStopAppengineDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator(descriptionName, errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeleteAppengineLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeleteAppengineLoadBalancerDescriptionValidator.groovy
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
 import com.netflix.spinnaker.clouddriver.appengine.AppengineOperation
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.DeleteAppengineLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AppengineOperation(AtomicOperations.DELETE_LOAD_BALANCER)
 @Component("deleteAppengineLoadBalancerDescriptionValidator")
@@ -32,7 +32,7 @@ class DeleteAppengineLoadBalancerDescriptionValidator extends DescriptionValidat
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DeleteAppengineLoadBalancerDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteAppengineLoadBalancerDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator("deleteAppengineLoadBalancerAtomicOperationDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidator.groovy
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
 import com.netflix.spinnaker.clouddriver.appengine.AppengineOperation
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.DeployAppengineDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AppengineOperation(AtomicOperations.CREATE_SERVER_GROUP)
 @Component("deployAppengineDescriptionValidator")
@@ -32,7 +32,7 @@ class DeployAppengineDescriptionValidator extends DescriptionValidator<DeployApp
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DeployAppengineDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeployAppengineDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator("deployAppengineAtomicOperationDescription", errors)
 
     if (!helper.validateCredentials(description.accountName, accountCredentialsProvider)) {

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DestroyAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DestroyAppengineDescriptionValidator.groovy
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
 import com.netflix.spinnaker.clouddriver.appengine.AppengineOperation
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.DestroyAppengineDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AppengineOperation(AtomicOperations.DESTROY_SERVER_GROUP)
 @Component("destroyAppengineDescriptionValidator")
@@ -32,7 +32,7 @@ class DestroyAppengineDescriptionValidator extends DescriptionValidator<DestroyA
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DestroyAppengineDescription description, Errors errors) {
+  void validate(List priorDescriptions, DestroyAppengineDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator("destroyAppengineAtomicOperationDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DisableAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DisableAppengineDescriptionValidator.groovy
@@ -21,11 +21,11 @@ import com.netflix.spinnaker.clouddriver.appengine.deploy.description.EnableDisa
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AppengineOperation(AtomicOperations.DISABLE_SERVER_GROUP)
 @Component("disableAppengineDescriptionValidator")
@@ -40,7 +40,7 @@ class DisableAppengineDescriptionValidator extends DescriptionValidator<EnableDi
   AppengineClusterProvider appengineClusterProvider
 
   @Override
-  void validate(List priorDescriptions, EnableDisableAppengineDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableAppengineDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator("disableAppengineAtomicOperationDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/EnableAppengineDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/EnableAppengineDescriptionValidator.groovy
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.clouddriver.appengine.AppengineOperation
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.EnableDisableAppengineDescription
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AppengineOperation(AtomicOperations.ENABLE_SERVER_GROUP)
 @Component("enableAppengineDescriptionValidator")
@@ -36,7 +36,7 @@ class EnableAppengineDescriptionValidator extends DescriptionValidator<EnableDis
   AppengineClusterProvider appengineClusterProvider
 
   @Override
-  void validate(List priorDescriptions, EnableDisableAppengineDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableAppengineDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator("enableAppengineAtomicOperationDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StandardAppengineAttributeValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StandardAppengineAttributeValidator.groovy
@@ -29,17 +29,17 @@ import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineInstan
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 
 class StandardAppengineAttributeValidator {
   static final namePattern = /^[a-z0-9]+([-a-z0-9]*[a-z0-9])?$/
   static final prefixPattern = /^[a-z0-9]+$/
 
   String context
-  Errors errors
+  ValidationErrors errors
 
-  StandardAppengineAttributeValidator(String context, Errors errors) {
+  StandardAppengineAttributeValidator(String context, ValidationErrors errors) {
     this.context = context
     this.errors = errors
   }

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/TerminateAppengineInstancesDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/TerminateAppengineInstancesDescriptionValidator.groovy
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.clouddriver.appengine.AppengineOperation
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.TerminateAppengineInstancesDescription
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineInstanceProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AppengineOperation(AtomicOperations.TERMINATE_INSTANCES)
 @Component("terminateAppengineInstancesDescriptionValidator")
@@ -36,7 +36,7 @@ class TerminateAppengineInstancesDescriptionValidator extends DescriptionValidat
   AppengineInstanceProvider appengineInstanceProvider
 
   @Override
-  void validate(List priorDescriptions, TerminateAppengineInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, TerminateAppengineInstancesDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator("terminateAppengineInstancesAtomicOperationDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/UpsertAppengineAutoscalingPolicyDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/UpsertAppengineAutoscalingPolicyDescriptionValidator.groovy
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.clouddriver.appengine.AppengineOperation
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.UpsertAppengineAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AppengineOperation(AtomicOperations.UPSERT_SCALING_POLICY)
 @Component
@@ -36,7 +36,7 @@ class UpsertAppengineAutoscalingPolicyDescriptionValidator extends DescriptionVa
   AppengineClusterProvider appengineClusterProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertAppengineAutoscalingPolicyDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertAppengineAutoscalingPolicyDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator("upsertAppengineAutoscalingPolicyAtomicOperationDescription", errors)
 
     if (!helper.validateCredentials(description.accountName, accountCredentialsProvider)) {

--- a/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/UpsertAppengineLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-appengine/src/main/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/UpsertAppengineLoadBalancerDescriptionValidator.groovy
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.clouddriver.appengine.AppengineOperation
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.UpsertAppengineLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AppengineOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
 @Component("upsertAppengineLoadBalancerDescriptionValidator")
@@ -36,7 +36,7 @@ class UpsertAppengineLoadBalancerDescriptionValidator extends DescriptionValidat
   AppengineClusterProvider appengineClusterProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertAppengineLoadBalancerDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertAppengineLoadBalancerDescription description, ValidationErrors errors) {
     def helper = new StandardAppengineAttributeValidator("upsertAppengineLoadBalancerAtomicOperationDescription", errors)
 
     if (!helper.validateCredentials(description.accountName, accountCredentialsProvider)) {

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeleteAppengineLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeleteAppengineLoadBalancerDescriptionValidatorSpec.groovy
@@ -19,9 +19,9 @@ package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.DeleteAppengineLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -53,7 +53,7 @@ class DeleteAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
   void "pass validation with proper description inputs"() {
     setup:
       def description = new DeleteAppengineLoadBalancerDescription(accountName: ACCOUNT_NAME, loadBalancerName: LOAD_BALANCER_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -65,7 +65,7 @@ class DeleteAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
   void "description with loadBalancerName == \"default\" fails validation"() {
     setup:
       def description = new DeleteAppengineLoadBalancerDescription(accountName: ACCOUNT_NAME, loadBalancerName: "default")
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -78,7 +78,7 @@ class DeleteAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
   void "null input fails validation"() {
     setup:
       def description = new DeleteAppengineLoadBalancerDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DeployAppengineDescriptionValidatorSpec.groovy
@@ -21,9 +21,9 @@ import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppengineGitCredent
 import com.netflix.spinnaker.clouddriver.appengine.gitClient.AppengineGitCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -74,7 +74,7 @@ class DeployAppengineDescriptionValidatorSpec extends Specification {
         stopPreviousVersion: true,
         credentials: credentials,
         gitCredentialType: AppengineGitCredentialType.NONE)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -93,7 +93,7 @@ class DeployAppengineDescriptionValidatorSpec extends Specification {
         configFilepaths: CONFIG_FILEPATHS,
         credentials: credentials,
         gitCredentialType: AppengineGitCredentialType.NONE)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -105,7 +105,7 @@ class DeployAppengineDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new DeployAppengineDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DestroyAppengineDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DestroyAppengineDescriptionValidatorSpec.groovy
@@ -19,9 +19,9 @@ package com.netflix.spinnaker.clouddriver.appengine.deploy.validators
 import com.netflix.spinnaker.clouddriver.appengine.deploy.description.DestroyAppengineDescription
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -53,7 +53,7 @@ class DestroyAppengineDescriptionValidatorSpec extends Specification {
   void "pass validation with proper description inputs"() {
     setup:
       def description = new DestroyAppengineDescription(accountName: ACCOUNT_NAME, serverGroupName: SERVER_GROUP_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -65,7 +65,7 @@ class DestroyAppengineDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new DestroyAppengineDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DisableAppengineDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/DisableAppengineDescriptionValidatorSpec.groovy
@@ -24,9 +24,9 @@ import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineCluste
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineLoadBalancerProvider
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -73,7 +73,7 @@ class DisableAppengineDescriptionValidatorSpec extends Specification {
         credentials: credentials
       )
 
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
       def loadBalancerWithValidAllocationsForDescription = new AppengineLoadBalancer(
         split: new AppengineTrafficSplit(allocations: [(SERVER_GROUP_NAME): 0.5, "another-server-group": 0.5])
@@ -102,7 +102,7 @@ class DisableAppengineDescriptionValidatorSpec extends Specification {
         credentials: credentials
       )
 
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
       def loadBalancerWithInvalidAllocationsForDescription = new AppengineLoadBalancer(
         split: new AppengineTrafficSplit(allocations: [(SERVER_GROUP_NAME): 1])
@@ -134,7 +134,7 @@ class DisableAppengineDescriptionValidatorSpec extends Specification {
         credentials: credentials
       )
 
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -160,7 +160,7 @@ class DisableAppengineDescriptionValidatorSpec extends Specification {
         credentials: credentials
       )
 
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/EnableAppengineDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/EnableAppengineDescriptionValidatorSpec.groovy
@@ -21,9 +21,9 @@ import com.netflix.spinnaker.clouddriver.appengine.model.AppengineServerGroup
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -69,7 +69,7 @@ class EnableAppengineDescriptionValidatorSpec extends Specification {
         credentials: credentials
       )
 
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -94,7 +94,7 @@ class EnableAppengineDescriptionValidatorSpec extends Specification {
         credentials: credentials
       )
 
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StandardAppengineAttributeValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StandardAppengineAttributeValidatorSpec.groovy
@@ -22,10 +22,10 @@ import com.netflix.spinnaker.clouddriver.appengine.model.AppengineTrafficSplit
 import com.netflix.spinnaker.clouddriver.appengine.model.ShardBy
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -63,7 +63,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "validate non-empty valid"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errors)
       def label = "attribute"
 
@@ -90,7 +90,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "validate non-empty invalid"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errors)
       def label = "attribute"
 
@@ -112,7 +112,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "validate by regex valid"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errors)
       def label = "attribute"
 
@@ -124,7 +124,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "validate by regex invalid"() {
     setup:
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     def validator = new StandardAppengineAttributeValidator(DECORATOR, errors)
     def label = "attribute"
     def regex = /\w{3}-\w{6}/
@@ -137,7 +137,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "credentials reject (empty)"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
 
     when:
@@ -155,7 +155,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "credentials reject (unknown)"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
 
     when:
@@ -167,7 +167,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "credentials accept"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
 
     when:
@@ -178,7 +178,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "git credentials reject"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
 
     when:
@@ -192,7 +192,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "git credentials reject (empty)"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
 
     when:
@@ -204,7 +204,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "git credentials accept"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
 
     when:
@@ -216,7 +216,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "details accept"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "label"
 
@@ -243,7 +243,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "details reject"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "label"
 
@@ -274,7 +274,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "application accept"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "label"
 
@@ -296,7 +296,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "application reject"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "label"
 
@@ -321,7 +321,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "stack accept"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "label"
 
@@ -343,7 +343,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "stack reject"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "label"
 
@@ -363,7 +363,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
   @Unroll
   void "allocations accept"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "allocations"
 
@@ -382,7 +382,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
   @Unroll
   void "allocations reject (wrong number of decimal places)"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "allocations"
 
@@ -400,7 +400,7 @@ class StandardAppengineAttributeValidatorSpec extends Specification {
 
   void "allocations reject (does not sum to 1)"() {
     setup:
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
       def validator = new StandardAppengineAttributeValidator(DECORATOR, errorsMock)
       def label = "allocations"
 

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StartAppengineDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/StartAppengineDescriptionValidatorSpec.groovy
@@ -23,9 +23,9 @@ import com.netflix.spinnaker.clouddriver.appengine.model.ScalingPolicyType
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -66,7 +66,7 @@ class StartAppengineDescriptionValidatorSpec extends Specification {
         serverGroupName: SERVER_GROUP_NAME,
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       validator.appengineClusterProvider = Mock(AppengineClusterProvider)
       validator.appengineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
 
@@ -92,7 +92,7 @@ class StartAppengineDescriptionValidatorSpec extends Specification {
         serverGroupName: SERVER_GROUP_NAME,
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       validator.appengineClusterProvider = Mock(AppengineClusterProvider)
       validator.appengineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
 
@@ -119,7 +119,7 @@ class StartAppengineDescriptionValidatorSpec extends Specification {
         serverGroupName: SERVER_GROUP_NAME,
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       validator.appengineClusterProvider = Mock(AppengineClusterProvider)
       validator.appengineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> null
 
@@ -135,7 +135,7 @@ class StartAppengineDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new StartStopAppengineDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/TerminateAppengineInstancesDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/TerminateAppengineInstancesDescriptionValidatorSpec.groovy
@@ -21,9 +21,9 @@ import com.netflix.spinnaker.clouddriver.appengine.model.AppengineInstance
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineInstanceProvider
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -74,7 +74,7 @@ class TerminateAppengineInstancesDescriptionValidatorSpec extends Specification 
         instanceIds: INSTANCE_IDS,
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -90,7 +90,7 @@ class TerminateAppengineInstancesDescriptionValidatorSpec extends Specification 
         instanceIds: ["instance-does-not-exist"],
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -108,7 +108,7 @@ class TerminateAppengineInstancesDescriptionValidatorSpec extends Specification 
         instanceIds: ["instance-missing-fields"],
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -122,7 +122,7 @@ class TerminateAppengineInstancesDescriptionValidatorSpec extends Specification 
   void "null input fails validation"() {
     setup:
      def description = new TerminateAppengineInstancesDescription()
-     def errors = Mock(Errors)
+     def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/UpsertAppengineAutoscalingPolicyDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/UpsertAppengineAutoscalingPolicyDescriptionValidatorSpec.groovy
@@ -23,9 +23,9 @@ import com.netflix.spinnaker.clouddriver.appengine.model.ScalingPolicyType
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -70,7 +70,7 @@ class UpsertAppengineAutoscalingPolicyDescriptionValidatorSpec extends Specifica
       env: AppengineServerGroup.Environment.STANDARD,
       scalingPolicy: new AppengineScalingPolicy(type: ScalingPolicyType.AUTOMATIC))
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     validator.appengineClusterProvider = Mock(AppengineClusterProvider)
     validator.appengineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
 
@@ -92,7 +92,7 @@ class UpsertAppengineAutoscalingPolicyDescriptionValidatorSpec extends Specifica
       maxIdleInstances: 20)
     def serverGroup = new AppengineServerGroup(env: env, scalingPolicy: new AppengineScalingPolicy(type: type))
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     validator.appengineClusterProvider = Mock(AppengineClusterProvider)
     validator.appengineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
 
@@ -120,7 +120,7 @@ class UpsertAppengineAutoscalingPolicyDescriptionValidatorSpec extends Specifica
       credentials: credentials,
       minIdleInstances: 10,
       maxIdleInstances: 20)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     validator.appengineClusterProvider = Mock(AppengineClusterProvider)
     validator.appengineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> null
 
@@ -144,7 +144,7 @@ class UpsertAppengineAutoscalingPolicyDescriptionValidatorSpec extends Specifica
     def serverGroup = new AppengineServerGroup(env: AppengineServerGroup.Environment.STANDARD,
                                                scalingPolicy: new AppengineScalingPolicy(type: ScalingPolicyType.AUTOMATIC))
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     validator.appengineClusterProvider = Mock(AppengineClusterProvider)
     validator.appengineClusterProvider.getServerGroup(ACCOUNT_NAME, REGION, SERVER_GROUP_NAME) >> serverGroup
 

--- a/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/UpsertAppengineLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-appengine/src/test/groovy/com/netflix/spinnaker/clouddriver/appengine/deploy/validators/UpsertAppengineLoadBalancerDescriptionValidatorSpec.groovy
@@ -23,9 +23,9 @@ import com.netflix.spinnaker.clouddriver.appengine.model.ShardBy
 import com.netflix.spinnaker.clouddriver.appengine.provider.view.AppengineClusterProvider
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineCredentials
 import com.netflix.spinnaker.clouddriver.appengine.security.AppengineNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -94,7 +94,7 @@ class UpsertAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
         split: validSplit,
         migrateTraffic: MIGRATE_TRAFFIC,
         credentials: credentials)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -114,7 +114,7 @@ class UpsertAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
         split: validSplit,
         migrateTraffic: MIGRATE_TRAFFIC,
         credentials: credentials)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -134,7 +134,7 @@ class UpsertAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
         migrateTraffic: true,
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -173,7 +173,7 @@ class UpsertAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
         migrateTraffic: migrateTraffic,
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -209,7 +209,7 @@ class UpsertAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
         migrateTraffic: MIGRATE_TRAFFIC,
         credentials: credentials
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -229,7 +229,7 @@ class UpsertAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
         split: invalidSplit,
         migrateTraffic: MIGRATE_TRAFFIC,
         credentials: credentials)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -243,7 +243,7 @@ class UpsertAppengineLoadBalancerDescriptionValidatorSpec extends Specification 
   void "null input fails validation"() {
     setup:
       def description = new UpsertAppengineLoadBalancerDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractEnableDisableAsgDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractEnableDisableAsgDescriptionValidator.groovy
@@ -16,11 +16,11 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableAsgDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 
 abstract class AbstractEnableDisableAsgDescriptionValidator extends AmazonDescriptionValidationSupport<EnableDisableAsgDescription> {
   @Override
-  void validate(List priorDescriptions, EnableDisableAsgDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableAsgDescription description, ValidationErrors errors) {
     validateAsgs description, errors
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidator.groovy
@@ -17,11 +17,11 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("allowLaunchDescriptionValidator")
 class AllowLaunchDescriptionValidator extends DescriptionValidator<AllowLaunchDescription> {
@@ -29,7 +29,7 @@ class AllowLaunchDescriptionValidator extends DescriptionValidator<AllowLaunchDe
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, AllowLaunchDescription description, Errors errors) {
+  void validate(List priorDescriptions, AllowLaunchDescription description, ValidationErrors errors) {
     if (!description.amiName) {
       errors.rejectValue("amiName", "allowLaunchDescription.amiName.empty")
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AmazonDescriptionValidationSupport.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AmazonDescriptionValidationSupport.groovy
@@ -20,13 +20,13 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCr
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 
 public  abstract class AmazonDescriptionValidationSupport<T extends AbstractAmazonCredentialsDescription> extends DescriptionValidator<T> {
 
-  abstract void validate(List priorDescriptions, T description, Errors errors)
+  abstract void validate(List priorDescriptions, T description, ValidationErrors errors)
 
-  void validateAsgs(T description, Errors errors) {
+  void validateAsgs(T description, ValidationErrors errors) {
     if (!description.asgs) {
       errors.rejectValue("asgs", "${description.getClass().simpleName}.empty")
     } else {
@@ -36,7 +36,7 @@ public  abstract class AmazonDescriptionValidationSupport<T extends AbstractAmaz
     }
   }
 
-  void validateAsgDescription(T description, AsgDescription asgDescription, Errors errors) {
+  void validateAsgDescription(T description, AsgDescription asgDescription, ValidationErrors errors) {
     def key = description.getClass().simpleName
     if (!asgDescription.serverGroupName) {
       errors.rejectValue("serverGroupName", "${key}.serverGroupName.empty")
@@ -49,7 +49,7 @@ public  abstract class AmazonDescriptionValidationSupport<T extends AbstractAmaz
     }
   }
 
-  void validateAsgsWithCapacity(T description, Errors errors) {
+  void validateAsgsWithCapacity(T description, ValidationErrors errors) {
     if (!description.asgs) {
       errors.rejectValue("asgs", "${description.getClass().simpleName}.empty")
     } else {
@@ -59,23 +59,23 @@ public  abstract class AmazonDescriptionValidationSupport<T extends AbstractAmaz
     }
   }
 
-  void validateAsgDescriptionWithCapacity(T description, ResizeAsgDescription.AsgTargetDescription asgDescription, Errors errors) {
+  void validateAsgDescriptionWithCapacity(T description, ResizeAsgDescription.AsgTargetDescription asgDescription, ValidationErrors errors) {
     validateAsgDescription description, asgDescription, errors
     validateCapacity asgDescription, errors
   }
 
-  void validateAsgName(T description, Errors errors) {
+  void validateAsgName(T description, ValidationErrors errors) {
     def key = description.getClass().simpleName
     if (!description.asgName) {
       errors.rejectValue("asgName", "${key}.asgName.empty")
     }
   }
 
-  void validateRegion(T description, String regionName, String errorKey, Errors errors) {
+  void validateRegion(T description, String regionName, String errorKey, ValidationErrors errors) {
     validateRegions(description, regionName ? [regionName] : [], errorKey, errors, "region")
   }
 
-  void validateRegions(T description, Collection<String> regionNames, String errorKey, Errors errors, String attributeName = "regions") {
+  void validateRegions(T description, Collection<String> regionNames, String errorKey, ValidationErrors errors, String attributeName = "regions") {
     if (!regionNames) {
       errors.rejectValue(attributeName, "${errorKey}.${attributeName}.empty")
     } else {
@@ -86,7 +86,7 @@ public  abstract class AmazonDescriptionValidationSupport<T extends AbstractAmaz
     }
   }
 
-  void validateAsgNameAndRegionAndInstanceIds(T description, Errors errors) {
+  void validateAsgNameAndRegionAndInstanceIds(T description, ValidationErrors errors) {
     def key = description.class.simpleName
     if (description.asgName) {
       validateAsgName(description, errors)
@@ -104,7 +104,7 @@ public  abstract class AmazonDescriptionValidationSupport<T extends AbstractAmaz
     }
   }
 
-  static void validateCapacity(def description, Errors errors) {
+  static void validateCapacity(def description, ValidationErrors errors) {
     Integer min = description.capacity.min
     Integer max = description.capacity.max
     Integer desired = description.capacity.desired

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AttachClassicLinkVpcDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AttachClassicLinkVpcDescriptionValidator.groovy
@@ -17,16 +17,16 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AttachClassicLinkVpcDescription
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.ATTACH_CLASSIC_LINK_VPC)
 @Component("attachClassicLinkVpcDescriptionValidator")
 class AttachClassicLinkVpcDescriptionValidator extends AmazonDescriptionValidationSupport<AttachClassicLinkVpcDescription> {
   @Override
-  void validate(List priorDescriptions, AttachClassicLinkVpcDescription description, Errors errors) {
+  void validate(List priorDescriptions, AttachClassicLinkVpcDescription description, ValidationErrors errors) {
     def key = AttachClassicLinkVpcDescription.class.simpleName
     if (!description.instanceId) {
       errors.rejectValue("instanceId", "${key}.instanceId.invalid")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidator.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
@@ -26,7 +27,6 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("basicAmazonDeployDescriptionValidator")
 @AmazonOperation(AtomicOperations.CREATE_SERVER_GROUP)
@@ -35,7 +35,7 @@ class BasicAmazonDeployDescriptionValidator extends AmazonDescriptionValidationS
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, BasicAmazonDeployDescription description, Errors errors) {
+  void validate(List priorDescriptions, BasicAmazonDeployDescription description, ValidationErrors errors) {
     def credentials = null
 
     if (!description.credentials) {
@@ -76,19 +76,19 @@ class BasicAmazonDeployDescriptionValidator extends AmazonDescriptionValidationS
   }
 
   enum BlockDeviceRules {
-    deviceNameNotNull({ AmazonBlockDevice device, Errors errors ->
+    deviceNameNotNull({ AmazonBlockDevice device, ValidationErrors errors ->
       if (!device.deviceName) {
         errors.rejectValue "blockDevices", "basicAmazonDeployDescription.block.device.not.named", [] as String[], "Device name is required for block device"
       }
     }),
 
-    ephemeralConfigWrong({ AmazonBlockDevice device, Errors errors ->
+    ephemeralConfigWrong({ AmazonBlockDevice device, ValidationErrors errors ->
       if (device.virtualName && (device.deleteOnTermination != null || device.iops || device.size || device.snapshotId || device.volumeType)) {
         errors.rejectValue "blockDevices", "basicAmazonDeployDescription.block.device.ephemeral.config", [device.virtualName] as String[], "Ephemeral block device $device.deviceName with EBS configuration parameters"
       }
     }),
 
-    ebsConfigWrong({ AmazonBlockDevice device, Errors errors ->
+    ebsConfigWrong({ AmazonBlockDevice device, ValidationErrors errors ->
       if (!device.virtualName && !device.size) {
         errors.rejectValue "blockDevices", "basicAmazonDeployDescription.block.device.ebs.config", [device.deviceName] as String[], "EBS device $device.deviceName missing required value size"
       }
@@ -103,11 +103,11 @@ class BasicAmazonDeployDescriptionValidator extends AmazonDescriptionValidationS
       this.validationRule = validationRule
     }
 
-    void validateDevice(AmazonBlockDevice device, Errors errors) {
+    void validateDevice(AmazonBlockDevice device, ValidationErrors errors) {
       validationRule(device, errors)
     }
 
-    static void validate(AmazonBlockDevice device, Errors errors) {
+    static void validate(AmazonBlockDevice device, ValidationErrors errors) {
       for (rule in values()) {
         rule.validateDevice device, errors
       }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/CreateAmazonLoadBalancerDescriptionValidator.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/CreateAmazonLoadBalancerDescriptionValidator.java
@@ -24,13 +24,13 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoad
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerV2Description;
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonLoadBalancerType;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @AmazonOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
 @Component("createAmazonLoadBalancerDescriptionValidator")
@@ -40,7 +40,7 @@ class CreateAmazonLoadBalancerDescriptionValidator
       List<UpsertAmazonLoadBalancerV2Description.Action> actions,
       Set<String> allTargetGroupNames,
       Set<String> unusedTargetGroupNames,
-      Errors errors) {
+      ValidationErrors errors) {
     for (UpsertAmazonLoadBalancerV2Description.Action action : actions) {
       if (action.getType().equals("forward")) {
         String targetGroupName = action.getTargetGroupName();
@@ -63,7 +63,9 @@ class CreateAmazonLoadBalancerDescriptionValidator
 
   @Override
   public void validate(
-      List priorDescriptions, UpsertAmazonLoadBalancerDescription description, Errors errors) {
+      List priorDescriptions,
+      UpsertAmazonLoadBalancerDescription description,
+      ValidationErrors errors) {
     // Common fields to validate
     if (description.getName() == null && description.getClusterName() == null) {
       errors.rejectValue(
@@ -183,7 +185,7 @@ class CreateAmazonLoadBalancerDescriptionValidator
   private void validateLambdaTargetGroup(
       UpsertAmazonLoadBalancerV2Description albDescription,
       UpsertAmazonLoadBalancerV2Description.TargetGroup targetGroup,
-      Errors errors) {
+      ValidationErrors errors) {
     // Add lambda specific validation, if required.
     if (!AmazonLoadBalancerType.APPLICATION
         .toString()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/CreateNetworkInterfaceDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/CreateNetworkInterfaceDescriptionValidator.groovy
@@ -16,13 +16,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.CreateNetworkInterfaceDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("createNetworkInterfaceDescriptionValidator")
 class CreateNetworkInterfaceDescriptionValidator extends AmazonDescriptionValidationSupport<CreateNetworkInterfaceDescription> {
   @Override
-  void validate(List priorDescriptions, CreateNetworkInterfaceDescription description, Errors errors) {
+  void validate(List priorDescriptions, CreateNetworkInterfaceDescription description, ValidationErrors errors) {
     Set<String> regions = description.availabilityZonesGroupedByRegion?.keySet()
     if (!regions) {
       errors.rejectValue "regions", "createNetworkInterfaceDescription.regions.not.supplied"

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAlarmDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAlarmDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAlarmDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("deleteAlarmDescriptionValidator")
 class DeleteAlarmDescriptionValidator extends AmazonDescriptionValidationSupport<DeleteAlarmDescription> {
   @Override
-  void validate(List priorDescriptions, DeleteAlarmDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteAlarmDescription description, ValidationErrors errors) {
     validateRegions(description, [description.region], "deleteAlarmDescription", errors)
 
     if (!description.names) {
@@ -32,7 +32,7 @@ class DeleteAlarmDescriptionValidator extends AmazonDescriptionValidationSupport
 
   }
 
-  static void rejectNull(String field, Errors errors) {
+  static void rejectNull(String field, ValidationErrors errors) {
     errors.rejectValue(field, "deleteAlarmDescription.${field}.not.nullable")
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonLoadBalancerDescriptionValidator.groovy
@@ -17,17 +17,17 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAmazonLoadBalancerDescription
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.DELETE_LOAD_BALANCER)
 @Component("deleteAmazonLoadBalancerDescriptionValidator")
 class DeleteAmazonLoadBalancerDescriptionValidator extends AmazonDescriptionValidationSupport<DeleteAmazonLoadBalancerDescription> {
 
   @Override
-  void validate(List priorDescriptions, DeleteAmazonLoadBalancerDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteAmazonLoadBalancerDescription description, ValidationErrors errors) {
     validateRegions(description, description.regions, "deleteAmazonLoadBalancerDescription", errors)
     if (!description.loadBalancerName) {
       errors.rejectValue "loadBalancerName", "deleteAmazonLoadBalancerDescription.loadBalancerName.empty"

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonSnapshotDescriptionValidator.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonSnapshotDescriptionValidator.java
@@ -20,12 +20,12 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation;
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAmazonSnapshotDescription;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @AmazonOperation(AtomicOperations.DELETE_SNAPSHOT)
 @Component
@@ -42,7 +42,9 @@ public class DeleteAmazonSnapshotDescriptionValidator
 
   @Override
   public void validate(
-      List priorDescriptions, DeleteAmazonSnapshotDescription description, Errors errors) {
+      List priorDescriptions,
+      DeleteAmazonSnapshotDescription description,
+      ValidationErrors errors) {
     String key = DeleteAmazonSnapshotDescription.class.getSimpleName();
     validateRegion(description, description.getRegion(), key, errors);
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAsgTagsDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAsgTagsDescriptionValidator.groovy
@@ -16,13 +16,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAsgTagsDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("deleteAsgTagsDescriptionValidator")
 class DeleteAsgTagsDescriptionValidator extends AmazonDescriptionValidationSupport<DeleteAsgTagsDescription> {
   @Override
-  void validate(List priorDescriptions, DeleteAsgTagsDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteAsgTagsDescription description, ValidationErrors errors) {
     validateAsgs description, errors
     description.tagKeys.each {
       if (!it) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteScalingPolicyDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteScalingPolicyDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteScalingPolicyDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("deleteScalingPolicyDescriptionValidator")
 class DeleteScalingPolicyDescriptionValidator extends AmazonDescriptionValidationSupport<DeleteScalingPolicyDescription> {
   @Override
-  void validate(List priorDescriptions, DeleteScalingPolicyDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteScalingPolicyDescription description, ValidationErrors errors) {
     validateRegions(description, [description.region], "deleteScalingPolicyDescription", errors)
 
     if (!description.serverGroupName && !description.asgName) {
@@ -36,7 +36,7 @@ class DeleteScalingPolicyDescriptionValidator extends AmazonDescriptionValidatio
 
   }
 
-  static void rejectNull(String field, Errors errors) {
+  static void rejectNull(String field, ValidationErrors errors) {
     errors.rejectValue(field, "deleteScalingPolicyDescription.${field}.not.nullable")
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteSecurityGroupDescriptionValidator.groovy
@@ -18,11 +18,11 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteSecurityGroupDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.DELETE_SECURITY_GROUP)
 @Component("deleteSecurityGroupDescriptionValidator")
@@ -32,7 +32,7 @@ class DeleteSecurityGroupDescriptionValidator extends AmazonDescriptionValidatio
     AmazonClientProvider amazonClientProvider
 
     @Override
-    void validate(List priorDescriptions, DeleteSecurityGroupDescription description, Errors errors) {
+    void validate(List priorDescriptions, DeleteSecurityGroupDescription description, ValidationErrors errors) {
         validateRegions(description, description.regions, "deleteSecurityGroupDescription", errors)
         if (!description.securityGroupName) {
             errors.rejectValue "securityGroupName", "deleteSecurityGroupDescription.securityGroupName.empty"

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeregisterInstancesFromLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeregisterInstancesFromLoadBalancerDescriptionValidator.groovy
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractRegionAsgInstanceIdsDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.DEREGISTER_INSTANCES_FROM_LOAD_BALANCER)
 @Component("deregisterInstancesFromLoadBalancerDescriptionValidator")
 class DeregisterInstancesFromLoadBalancerDescriptionValidator extends AmazonDescriptionValidationSupport<AbstractRegionAsgInstanceIdsDescription> {
   @Override
-  void validate(List priorDescriptions, AbstractRegionAsgInstanceIdsDescription description, Errors errors) {
+  void validate(List priorDescriptions, AbstractRegionAsgInstanceIdsDescription description, ValidationErrors errors) {
     validateAsgNameAndRegionAndInstanceIds(description, errors)
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DestroyAsgDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DestroyAsgDescriptionValidator.groovy
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DestroyAsgDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.DESTROY_SERVER_GROUP)
 @Component("destroyAsgDescriptionValidator")
 class DestroyAsgDescriptionValidator extends AmazonDescriptionValidationSupport<DestroyAsgDescription> {
   @Override
-  void validate(List priorDescriptions, DestroyAsgDescription description, Errors errors) {
+  void validate(List priorDescriptions, DestroyAsgDescription description, ValidationErrors errors) {
     validateAsgs description, errors
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DetachInstancesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DetachInstancesDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DetachInstancesDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("detachInstancesDescriptionValidator")
 class DetachInstancesDescriptionValidator extends AmazonDescriptionValidationSupport<DetachInstancesDescription> {
   @Override
-  void validate(List priorDescriptions, DetachInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, DetachInstancesDescription description, ValidationErrors errors) {
     def key = DetachInstancesDescription.class.simpleName
     description.instanceIds.each {
       if (!it) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DisableInstancesInDiscoveryDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DisableInstancesInDiscoveryDescriptionValidator.groovy
@@ -17,14 +17,14 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableInstanceDiscoveryDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("disableInstancesInDiscoveryDescriptionValidator")
 class DisableInstancesInDiscoveryDescriptionValidator
     extends AmazonDescriptionValidationSupport<EnableDisableInstanceDiscoveryDescription> {
   @Override
-  void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, ValidationErrors errors) {
     def key = description.class.simpleName
     validateAsgNameAndRegionAndInstanceIds(description, errors)
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/EnableInstancesInDiscoveryDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/EnableInstancesInDiscoveryDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableInstanceDiscoveryDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("enableInstancesInDiscoveryDescriptionValidator")
 class EnableInstancesInDiscoveryDescriptionValidator
     extends AmazonDescriptionValidationSupport<EnableDisableInstanceDiscoveryDescription> {
-  void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, ValidationErrors errors) {
     def key = description.class.simpleName
     validateAsgNameAndRegionAndInstanceIds(description, errors)
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ModifyAsgLaunchConfigurationDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ModifyAsgLaunchConfigurationDescriptionValidator.groovy
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyAsgLaunchConfigurationDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.UPDATE_LAUNCH_CONFIG)
 @Component("modifyAsgLaunchConfigurationDescriptionValidator")
@@ -33,7 +33,7 @@ class ModifyAsgLaunchConfigurationDescriptionValidator extends AmazonDescription
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, ModifyAsgLaunchConfigurationDescription description, Errors errors) {
+  void validate(List priorDescriptions, ModifyAsgLaunchConfigurationDescription description, ValidationErrors errors) {
     def key = ModifyAsgLaunchConfigurationDescription.class.simpleName
     validateRegion(description, description.region, key, errors)
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/RebootInstancesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/RebootInstancesDescriptionValidator.groovy
@@ -17,16 +17,16 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.RebootInstancesDescription
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.REBOOT_INSTANCES)
 @Component("rebootInstancesDescriptionValidator")
 class RebootInstancesDescriptionValidator extends AmazonDescriptionValidationSupport<RebootInstancesDescription> {
   @Override
-  void validate(List priorDescriptions, RebootInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, RebootInstancesDescription description, ValidationErrors errors) {
     def key = RebootInstancesDescription.class.simpleName
     if (!description.instanceIds) {
       errors.rejectValue("instanceIds", "${key}.instanceIds.empty")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/RegisterInstancesWithLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/RegisterInstancesWithLoadBalancerDescriptionValidator.groovy
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractRegionAsgInstanceIdsDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.REGISTER_INSTANCES_WITH_LOAD_BALANCER)
 @Component("registerInstancesWithLoadBalancerDescriptionValidator")
 class RegisterInstancesWithLoadBalancerDescriptionValidator extends AmazonDescriptionValidationSupport<AbstractRegionAsgInstanceIdsDescription> {
   @Override
-  void validate(List priorDescriptions, AbstractRegionAsgInstanceIdsDescription description, Errors errors) {
+  void validate(List priorDescriptions, AbstractRegionAsgInstanceIdsDescription description, ValidationErrors errors) {
     validateAsgNameAndRegionAndInstanceIds(description, errors)
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResizeAsgDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResizeAsgDescriptionValidator.groovy
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("resizeAsgDescriptionValidator")
 @AmazonOperation(AtomicOperations.RESIZE_SERVER_GROUP)
 class ResizeAsgDescriptionValidator extends AmazonDescriptionValidationSupport<ResizeAsgDescription> {
   @Override
-  void validate(List priorDescriptions, ResizeAsgDescription description, Errors errors) {
+  void validate(List priorDescriptions, ResizeAsgDescription description, ValidationErrors errors) {
     validateAsgsWithCapacity description, errors
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResumeAsgProcessesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResumeAsgProcessesDescriptionValidator.groovy
@@ -17,13 +17,13 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResumeAsgProcessesDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 class ResumeAsgProcessesDescriptionValidator extends AmazonDescriptionValidationSupport<ResumeAsgProcessesDescription> {
   @Override
-  void validate(List priorDescriptions, ResumeAsgProcessesDescription description, Errors errors) {
+  void validate(List priorDescriptions, ResumeAsgProcessesDescription description, ValidationErrors errors) {
     validateAsgs description, errors
     def invalidProcessTypes = description.processes.findAll { !AutoScalingProcessType.parse(it) }
     if (invalidProcessTypes) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/SuspendAsgProcessesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/SuspendAsgProcessesDescriptionValidator.groovy
@@ -17,13 +17,13 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.SuspendAsgProcessesDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AutoScalingProcessType
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 class SuspendAsgProcessesDescriptionValidator extends AmazonDescriptionValidationSupport<SuspendAsgProcessesDescription> {
   @Override
-  void validate(List priorDescriptions, SuspendAsgProcessesDescription description, Errors errors) {
+  void validate(List priorDescriptions, SuspendAsgProcessesDescription description, ValidationErrors errors) {
     validateAsgs description, errors
     def invalidProcessTypes = description.processes.findAll { !AutoScalingProcessType.parse(it) }
     if (invalidProcessTypes) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstanceAndDecrementAsgDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstanceAndDecrementAsgDescriptionValidator.groovy
@@ -17,16 +17,16 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.TerminateInstanceAndDecrementAsgDescription
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.TERMINATE_INSTANCE_AND_DECREMENT)
 @Component("terminateInstanceAndDecrementAsgDescriptionValidator")
 class TerminateInstanceAndDecrementAsgDescriptionValidator extends AmazonDescriptionValidationSupport<TerminateInstanceAndDecrementAsgDescription> {
   @Override
-  void validate(List priorDescriptions, TerminateInstanceAndDecrementAsgDescription description, Errors errors) {
+  void validate(List priorDescriptions, TerminateInstanceAndDecrementAsgDescription description, ValidationErrors errors) {
     def key = TerminateInstanceAndDecrementAsgDescription.class.simpleName
 
     validateAsgName description, errors

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstancesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstancesDescriptionValidator.groovy
@@ -16,16 +16,16 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.TerminateInstancesDescription
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.TERMINATE_INSTANCES)
 @Component("terminateInstancesDescriptionValidator")
 class TerminateInstancesDescriptionValidator extends AmazonDescriptionValidationSupport<TerminateInstancesDescription> {
   @Override
-  void validate(List priorDescriptions, TerminateInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, TerminateInstancesDescription description, ValidationErrors errors) {
     def key = TerminateInstancesDescription.class.simpleName
     description.instanceIds.each {
       if (!it) {

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpdateInstancesDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpdateInstancesDescriptionValidator.groovy
@@ -18,16 +18,16 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpdateInstancesDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.UPDATE_INSTANCES)
 @Component("updateInstancesDescriptionValidator")
 class UpdateInstancesDescriptionValidator extends AmazonDescriptionValidationSupport<UpdateInstancesDescription> {
 
   @Override
-  void validate(List priorDescriptions, UpdateInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpdateInstancesDescription description, ValidationErrors errors) {
     if (!description.serverGroupName) {
       errors.rejectValue("name", "updateSecurityGroupsDescription.name.not.nullable")
     }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAlarmDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAlarmDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAlarmDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("upsertAlarmDescriptionValidator")
 class UpsertAlarmDescriptionValidator extends AmazonDescriptionValidationSupport<UpsertAlarmDescription> {
   @Override
-  void validate(List priorDescriptions, UpsertAlarmDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertAlarmDescription description, ValidationErrors errors) {
     validateRegions(description, [description.region], "upsertAlarmDescription", errors)
 
     if (!description.metricName) {
@@ -52,7 +52,7 @@ class UpsertAlarmDescriptionValidator extends AmazonDescriptionValidationSupport
 
   }
 
-  static void rejectNull(String field, Errors errors) {
+  static void rejectNull(String field, ValidationErrors errors) {
     errors.rejectValue(field, "upsertAlarmDescription.${field}.not.nullable")
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidator.groovy
@@ -19,9 +19,9 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonDNSDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("upsertAmazonDNSDescriptionValidator")
 class UpsertAmazonDNSDescriptionValidator extends AmazonDescriptionValidationSupport<UpsertAmazonDNSDescription> {
@@ -31,7 +31,7 @@ class UpsertAmazonDNSDescriptionValidator extends AmazonDescriptionValidationSup
   AmazonClientProvider amazonClientProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertAmazonDNSDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertAmazonDNSDescription description, ValidationErrors errors) {
     def upstreamElb = priorDescriptions.find { it instanceof UpsertAmazonLoadBalancerDescription }
     if (!upstreamElb && !description.target) {
       errors.rejectValue("target", "upsertAmazonDNSDescription.target.empty")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgLifecycleHookDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgLifecycleHookDescriptionValidator.groovy
@@ -17,14 +17,14 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgLifecycleHookDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("upsertAsgLifecycleHookDescriptionValidator")
 class UpsertAsgLifecycleHookDescriptionValidator extends AmazonDescriptionValidationSupport<UpsertAsgLifecycleHookDescription> {
 
   @Override
-  void validate(List priorDescriptions, UpsertAsgLifecycleHookDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertAsgLifecycleHookDescription description, ValidationErrors errors) {
     validateRegions(description, [description.region], "upsertAsgLifecycleHookDescription", errors)
 
     if (!description.serverGroupName) {
@@ -48,7 +48,7 @@ class UpsertAsgLifecycleHookDescriptionValidator extends AmazonDescriptionValida
     }
   }
 
-  static void rejectNull(String field, Errors errors) {
+  static void rejectNull(String field, ValidationErrors errors) {
     errors.rejectValue(field, "upsertAsgLifecycleHookDescription.${field}.not.nullable")
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgTagsDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgTagsDescriptionValidator.groovy
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgTagsDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.UPSERT_SERVER_GROUP_TAGS)
 @Component("upsertAsgTagsDescriptionValidator")
 class UpsertAsgTagsDescriptionValidator extends AmazonDescriptionValidationSupport<UpsertAsgTagsDescription> {
   @Override
-  void validate(List priorDescriptions, UpsertAsgTagsDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertAsgTagsDescription description, ValidationErrors errors) {
     validateAsgs description, errors
     if (!description.tags) {
       errors.rejectValue("tags", "upsertAsgTagsDescription.tags.empty")

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertScalingPolicyDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertScalingPolicyDescriptionValidator.groovy
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AdjustmentType
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertScalingPolicyDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("upsertScalingPolicyDescriptionValidator")
 class UpsertScalingPolicyDescriptionValidator extends AmazonDescriptionValidationSupport<UpsertScalingPolicyDescription> {
   @Override
-  void validate(List priorDescriptions, UpsertScalingPolicyDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertScalingPolicyDescription description, ValidationErrors errors) {
     validateRegions(description, [description.region], "upsertScalingPolicyDescription", errors)
 
     if (!description.serverGroupName && !description.asgName) {
@@ -48,7 +48,7 @@ class UpsertScalingPolicyDescriptionValidator extends AmazonDescriptionValidatio
     }
   }
 
-  static void rejectNull(String field, Errors errors) {
+  static void rejectNull(String field, ValidationErrors errors) {
     errors.rejectValue(field, "upsertScalingPolicyDescription.${field}.not.nullable")
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.AmazonOperation
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.aws.model.SecurityGroupNotFoundException
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AmazonOperation(AtomicOperations.UPSERT_SECURITY_GROUP)
 @Component("upsertSecurityGroupDescriptionValidator")
@@ -32,7 +32,7 @@ class UpsertSecurityGroupDescriptionValidator extends AmazonDescriptionValidatio
   RegionScopedProviderFactory regionScopedProviderFactory
 
   @Override
-  void validate(List priorDescriptions, UpsertSecurityGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertSecurityGroupDescription description, ValidationErrors errors) {
     if (!description.name) {
       errors.rejectValue("name", "upsertSecurityGroupDescription.name.not.nullable")
     }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractConfiguredRegionAndInstanceIdsValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractConfiguredRegionAndInstanceIdsValidatorSpec.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -36,7 +36,7 @@ abstract class AbstractConfiguredRegionAndInstanceIdsValidatorSpec extends Speci
     setup:
     def description = getDescription()
     description.credentials = description.credentials ?: TestCredential.named('test')
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -52,7 +52,7 @@ abstract class AbstractConfiguredRegionAndInstanceIdsValidatorSpec extends Speci
     def description = getDescription()
     description.instanceIds = [""]
     description.region = "us-west-1"
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -68,7 +68,7 @@ abstract class AbstractConfiguredRegionAndInstanceIdsValidatorSpec extends Speci
     description.credentials = description.credentials ?: TestCredential.named('test')
     description.region = "us-west-5"
     description.instanceIds = ["i-123456"]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractConfiguredRegionsValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AbstractConfiguredRegionsValidatorSpec.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AsgDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -37,7 +37,7 @@ abstract class AbstractConfiguredRegionsValidatorSpec extends Specification {
     setup:
     def description = getDescription()
     description.credentials = TestCredential.named('test')
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -53,7 +53,7 @@ abstract class AbstractConfiguredRegionsValidatorSpec extends Specification {
     description.asgs = [new AsgDescription(
       region: "us-east-5"
     )]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AllowLaunchDescriptionValidatorSpec.groovy
@@ -16,10 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AllowLaunchDescription
-import org.springframework.validation.Errors
 import spock.lang.Specification
 
 class AllowLaunchDescriptionValidatorSpec extends Specification {
@@ -28,7 +28,7 @@ class AllowLaunchDescriptionValidatorSpec extends Specification {
     setup:
     AllowLaunchDescriptionValidator validator = new AllowLaunchDescriptionValidator()
     def description = new AllowLaunchDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -45,7 +45,7 @@ class AllowLaunchDescriptionValidatorSpec extends Specification {
     def credentialsHolder = Mock(AccountCredentialsProvider)
     validator.accountCredentialsProvider = credentialsHolder
     def description = new AllowLaunchDescription(targetAccount: "foo")
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AttachClassicLinkVpcDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/AttachClassicLinkVpcDescriptionValidatorSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AttachClassicLinkVpcDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -34,7 +34,7 @@ class AttachClassicLinkVpcDescriptionValidatorSpec extends Specification {
   void "invalid instanceId fails validation"() {
     setup:
     def description = new AttachClassicLinkVpcDescription(vpcId: "vpc-123")
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -46,7 +46,7 @@ class AttachClassicLinkVpcDescriptionValidatorSpec extends Specification {
   void "invalid vpcId fails validation"() {
     setup:
     def description = new AttachClassicLinkVpcDescription(instanceId: "i-123")
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -59,7 +59,7 @@ class AttachClassicLinkVpcDescriptionValidatorSpec extends Specification {
     setup:
     def description = new AttachClassicLinkVpcDescription(credentials: TestCredential.named('test'))
     description.region = "us-west-5"
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/BasicAmazonDeployDescriptionValidatorSpec.groovy
@@ -17,12 +17,12 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.BasicAmazonDeployDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AmazonBlockDevice
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -48,7 +48,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
     setup:
     def description = new BasicAmazonDeployDescription(application: "foo", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, availabilityZones: ["us-east-1": []],
       capacity: [min: 1, max: 1, desired: 1], subnetType: "internal")
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -61,7 +61,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
     setup:
     def description = new BasicAmazonDeployDescription(application: "foo", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, availabilityZones: ["us-east-1": []],
       capacity: [min: 1, max: 1, desired: 1], associatePublicIpAddress: true)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -80,7 +80,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
     def description = new BasicAmazonDeployDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -98,7 +98,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
     setup:
     def description = new BasicAmazonDeployDescription(application: "foo", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, availabilityZones: ["us-east-1": []])
     description.capacity = [ min, max, desired ]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -127,7 +127,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
   void "unconfigured region fails validation"() {
     setup:
     def description = new BasicAmazonDeployDescription(application: "foo", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, availabilityZones: ["eu-west-5": []])
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -139,7 +139,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
   void "unconfigured account region fails validation"() {
     setup:
     def description = new BasicAmazonDeployDescription(application: "foo", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, availabilityZones: ["us-west-2": []])
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -153,7 +153,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
     setup:
     def description = new BasicAmazonDeployDescription(application: "foo", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, availabilityZones: ["us-east-1": []],
       capacity: [min: 1, max: 1, desired: 1], subnetType: "internal", blockDevices: [blockDevice])
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -177,7 +177,7 @@ class BasicAmazonDeployDescriptionValidatorSpec extends Specification {
     ]
     def description = new BasicAmazonDeployDescription(application: "foo", amiName: "foo", instanceType: "foo", credentials: amazonCredentials, availabilityZones: ["us-east-1": []],
       capacity: [min: 1, max: 1, desired: 1], subnetType: "internal", blockDevices: blockDevices)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/CreateNetworkInterfaceDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/CreateNetworkInterfaceDescriptionValidatorSpec.groovy
@@ -19,7 +19,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.CreateNetworkInterfaceDescription
 import com.netflix.spinnaker.clouddriver.aws.model.AwsNetworkInterface
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class CreateNetworkInterfaceDescriptionValidatorSpec extends Specification {
         secondaryPrivateIpAddresses: ["127.0.0.2", "127.0.0.3"]
       )
     )
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -59,7 +59,7 @@ class CreateNetworkInterfaceDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
     def description = new CreateNetworkInterfaceDescription(credentials: credentials)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -74,7 +74,7 @@ class CreateNetworkInterfaceDescriptionValidatorSpec extends Specification {
   void "unconfigured region fails validation"() {
     setup:
     def description = new CreateNetworkInterfaceDescription(credentials: credentials, availabilityZonesGroupedByRegion: ["eu-west-5": []])
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAmazonLoadBalancerDescriptionValidatorSpec.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAmazonLoadBalancerDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -29,7 +29,7 @@ class DeleteAmazonLoadBalancerDescriptionValidatorSpec extends Specification {
 
   void "should fail validation with invalid load balancer name"() {
     setup:
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     def description = new DeleteAmazonLoadBalancerDescription(regions: ["us-east-1"], credentials: Stub(NetflixAmazonCredentials))
 
     when:
@@ -44,7 +44,7 @@ class DeleteAmazonLoadBalancerDescriptionValidatorSpec extends Specification {
     def creds = TestCredential.named('test')
     def description = new DeleteAmazonLoadBalancerDescription(loadBalancerName: "foo--frontend", credentials: creds)
     description.regions = ["us-east-5"]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAsgTagsDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteAsgTagsDescriptionValidatorSpec.groovy
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteAsgTagsDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 
 class DeleteAsgTagsDescriptionValidatorSpec extends AbstractConfiguredRegionsValidatorSpec {
 
@@ -35,7 +35,7 @@ class DeleteAsgTagsDescriptionValidatorSpec extends AbstractConfiguredRegionsVal
     setup:
     def description = new DeleteAsgTagsDescription()
     description.tagKeys = [null]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteSecurityGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DeleteSecurityGroupDescriptionValidatorSpec.groovy
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.DeleteSecurityGroupDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -38,7 +38,7 @@ class DeleteSecurityGroupDescriptionValidatorSpec extends Specification {
 
   void "should fail validation with invalid security group name"() {
     setup:
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     def description = new DeleteSecurityGroupDescription(regions: ["us-east-1"], credentials: Stub(NetflixAmazonCredentials))
     validator.amazonClientProvider = amazonClientProvider
 
@@ -54,7 +54,7 @@ class DeleteSecurityGroupDescriptionValidatorSpec extends Specification {
     def creds = TestCredential.named('test')
     def description = new DeleteSecurityGroupDescription(securityGroupName: "foo", credentials: creds)
     description.regions = ["us-east-5"]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DisableInstancesInDiscoveryValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/DisableInstancesInDiscoveryValidatorSpec.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableInstanceDiscoveryDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 
 class DisableInstancesInDiscoveryValidatorSpec extends AbstractConfiguredRegionAndInstanceIdsValidatorSpec {
   @Override
@@ -42,7 +42,7 @@ class DisableInstancesInDiscoveryValidatorSpec extends AbstractConfiguredRegionA
     description.instanceIds = ["i-123456"]
     description.credentials = TestCredential.named('test')
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     getDescriptionValidator().validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/EnableInstancesInDiscoveryValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/EnableInstancesInDiscoveryValidatorSpec.groovy
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.EnableDisableInstanceDiscoveryDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 
 class EnableInstancesInDiscoveryValidatorSpec extends AbstractConfiguredRegionAndInstanceIdsValidatorSpec {
   @Override
@@ -42,7 +42,7 @@ class EnableInstancesInDiscoveryValidatorSpec extends AbstractConfiguredRegionAn
     description.instanceIds = ["i-123456"]
     description.credentials = TestCredential.named('test')
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     getDescriptionValidator().validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResizeAsgDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResizeAsgDescriptionValidatorSpec.groovy
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResizeAsgDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -40,7 +40,7 @@ class ResizeAsgDescriptionValidatorSpec extends Specification {
       )],
       credentials: Stub(NetflixAmazonCredentials)
     )
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -60,7 +60,7 @@ class ResizeAsgDescriptionValidatorSpec extends Specification {
     setup:
     def description = new ResizeAsgDescription()
     description.credentials = TestCredential.named('test')
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -76,7 +76,7 @@ class ResizeAsgDescriptionValidatorSpec extends Specification {
     description.asgs = [new ResizeAsgDescription.AsgTargetDescription(
       region: "us-east-5"
     )]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResumeAsgProcessesDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/ResumeAsgProcessesDescriptionValidatorSpec.groovy
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ResumeAsgProcessesDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Specification
 
 class ResumeAsgProcessesDescriptionValidatorSpec extends Specification {
@@ -38,7 +38,7 @@ class ResumeAsgProcessesDescriptionValidatorSpec extends Specification {
       ],
       processes: ["Launch", "Terminate"]
     )
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -61,7 +61,7 @@ class ResumeAsgProcessesDescriptionValidatorSpec extends Specification {
       ],
       processes: ["Laugh", "Terminate"]
     )
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/SuspendAsgProcessesDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/SuspendAsgProcessesDescriptionValidatorSpec.groovy
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AsgDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.SuspendAsgProcessesDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Specification
 
 class SuspendAsgProcessesDescriptionValidatorSpec extends Specification {
@@ -38,7 +38,7 @@ class SuspendAsgProcessesDescriptionValidatorSpec extends Specification {
       ],
       processes: ["Launch", "Terminate"]
     )
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -61,7 +61,7 @@ class SuspendAsgProcessesDescriptionValidatorSpec extends Specification {
       ],
       processes: ["Laugh", "Terminate"]
     )
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstanceAndDecrementAsgDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstanceAndDecrementAsgDescriptionValidatorSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.TerminateInstanceAndDecrementAsgDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -34,7 +34,7 @@ class TerminateInstanceAndDecrementAsgDescriptionValidatorSpec extends Specifica
   void "empty description fails validation"() {
     setup:
     def description = new TerminateInstanceAndDecrementAsgDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -49,7 +49,7 @@ class TerminateInstanceAndDecrementAsgDescriptionValidatorSpec extends Specifica
     setup:
     def description = new TerminateInstanceAndDecrementAsgDescription(credentials: TestCredential.named('test'))
     description.region = "us-west-5"
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstancesDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/TerminateInstancesDescriptionValidatorSpec.groovy
@@ -20,7 +20,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.TerminateInstancesDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -36,7 +36,7 @@ class TerminateInstancesDescriptionValidatorSpec extends Specification {
   void "invalid instanceIds fail validation"() {
     setup:
     def description = new TerminateInstancesDescription(instanceIds: [""])
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -49,7 +49,7 @@ class TerminateInstancesDescriptionValidatorSpec extends Specification {
     setup:
     def description = new TerminateInstancesDescription(credentials: TestCredential.named('test'))
     description.region = "us-west-5"
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonDNSDescriptionValidatorSpec.groovy
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.validators.UpsertAmazonDNSDe
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonDNSDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -35,7 +35,7 @@ class UpsertAmazonDNSDescriptionValidatorSpec extends Specification {
   void "empty description fails validation"() {
     setup:
     def description = new UpsertAmazonDNSDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -51,7 +51,7 @@ class UpsertAmazonDNSDescriptionValidatorSpec extends Specification {
     setup:
     def description = new UpsertAmazonDNSDescription()
     description.target = "foo"
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -70,7 +70,7 @@ class UpsertAmazonDNSDescriptionValidatorSpec extends Specification {
     setup:
     def elbDescription = new UpsertAmazonLoadBalancerDescription()
     def description = new UpsertAmazonDNSDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([elbDescription], description, errors)
@@ -85,7 +85,7 @@ class UpsertAmazonDNSDescriptionValidatorSpec extends Specification {
     description.type = "CNAME"
     description.target = "foo.netflix.net."
     description.hostedZoneName = "netflix.net."
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     def route53 = Mock(AmazonRoute53)
     validator.amazonClientProvider = Mock(AmazonClientProvider)
     validator.amazonClientProvider.getAmazonRoute53(_, _, true) >> route53

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonLoadBalancerClassicDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAmazonLoadBalancerClassicDescriptionValidatorSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.aws.TestCredential
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAmazonLoadBalancerClassicDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -39,7 +39,7 @@ class UpsertAmazonLoadBalancerClassicDescriptionValidatorSpec extends Specificat
 
   void "empty parameters fails validation"() {
     setup:
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -53,7 +53,7 @@ class UpsertAmazonLoadBalancerClassicDescriptionValidatorSpec extends Specificat
   void "unconfigured region is rejected"() {
     setup:
     description.availabilityZones = ["us-west-5": ["us-west-5a"]]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -65,7 +65,7 @@ class UpsertAmazonLoadBalancerClassicDescriptionValidatorSpec extends Specificat
   void "availability zone not configured for account is rejected"() {
     setup:
     description.availabilityZones = ["us-west-1": ["us-west-1c"]]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -78,7 +78,7 @@ class UpsertAmazonLoadBalancerClassicDescriptionValidatorSpec extends Specificat
   void "subnetType supercedes availabilityZones"() {
     setup:
     description.subnetType = "internal"
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -90,7 +90,7 @@ class UpsertAmazonLoadBalancerClassicDescriptionValidatorSpec extends Specificat
   void "availabilityZones if not subnetType"() {
     setup:
     description.availabilityZones = ["us-west-1": ["us-west-1a"]]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgTagsDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertAsgTagsDescriptionValidatorSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.aws.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertAsgTagsDescription
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 
 class UpsertAsgTagsDescriptionValidatorSpec extends AbstractConfiguredRegionsValidatorSpec {
 
@@ -35,7 +35,7 @@ class UpsertAsgTagsDescriptionValidatorSpec extends AbstractConfiguredRegionsVal
   void "empty tags fails validation"() {
     setup:
     def description = new UpsertAsgTagsDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -48,7 +48,7 @@ class UpsertAsgTagsDescriptionValidatorSpec extends AbstractConfiguredRegionsVal
     setup:
     def description = new UpsertAsgTagsDescription()
     description.tags = ["tag": null]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidatorSpec.groovy
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.clouddriver.aws.deploy.description.UpsertSecurityGr
 import com.netflix.spinnaker.clouddriver.aws.model.SecurityGroupNotFoundException
 import com.netflix.spinnaker.clouddriver.aws.services.RegionScopedProviderFactory
 import com.netflix.spinnaker.clouddriver.aws.services.SecurityGroupService
-import org.springframework.validation.Errors
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -32,7 +32,7 @@ class UpsertSecurityGroupDescriptionValidatorSpec extends Specification {
   @Subject validator = new UpsertSecurityGroupDescriptionValidator()
 
   SecurityGroupService securityGroupService = Mock(SecurityGroupService)
-  Errors errors = Mock(Errors)
+  ValidationErrors errors = Mock(ValidationErrors)
 
   final description = new UpsertSecurityGroupDescription(
     credentials: TestCredential.named('test'),
@@ -50,7 +50,7 @@ class UpsertSecurityGroupDescriptionValidatorSpec extends Specification {
 
   def setup() {
     securityGroupService = Mock(SecurityGroupService)
-    errors = Mock(Errors)
+    errors = Mock(ValidationErrors)
     def regionScopedProviderFactory = Mock(RegionScopedProviderFactory)
     def regionScopedProvider = Mock(RegionScopedProviderFactory.RegionScopedProvider)
     regionScopedProvider.getSecurityGroupService() >> securityGroupService

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/StandardAzureAttributeValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/common/StandardAzureAttributeValidator.groovy
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.clouddriver.azure.common
 
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 
 class StandardAzureAttributeValidator {
   /**
@@ -29,7 +29,7 @@ class StandardAzureAttributeValidator {
   /**
    * Bound at construction, this is used to collect validation errors.
    */
-  Errors errors
+  ValidationErrors errors
 
   /**
    * Constructs validator for standard attributes added by GCE.
@@ -37,7 +37,7 @@ class StandardAzureAttributeValidator {
    * @param context The owner of the attributes to be validated is typically a {@code *Description} class.
    * @param errors  Accumulates and reports on the validation errors over the lifetime of this validator.
    */
-  StandardAzureAttributeValidator(String context, Errors errors) {
+  StandardAzureAttributeValidator(String context, ValidationErrors errors) {
     this.context = context
     this.errors = errors
   }

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/DeleteAzureAppGatewayAtomicOperationValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/DeleteAzureAppGatewayAtomicOperationValidator.groovy
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.validat
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("deleteAzureAppGatewayDescriptionValidator")
 class DeleteAzureAppGatewayAtomicOperationValidator extends
@@ -32,7 +32,7 @@ class DeleteAzureAppGatewayAtomicOperationValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, AzureAppGatewayDescription description, Errors errors) {
+  void validate(List priorDescriptions, AzureAppGatewayDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("deletetAzureAppGatewayDescriptionValidator", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/UpsertAzureAppGatewayAtomicOperationValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/ops/validators/UpsertAzureAppGatewayAtomicOperationValidator.groovy
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.ops.validat
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("upsertAzureAppGatewayDescriptionValidator")
 class UpsertAzureAppGatewayAtomicOperationValidator extends
@@ -35,7 +35,7 @@ class UpsertAzureAppGatewayAtomicOperationValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, AzureAppGatewayDescription description, Errors errors) {
+  void validate(List priorDescriptions, AzureAppGatewayDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("upsertAzureAppGatewayDescriptionValidator", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/validators/DeleteAzureLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/validators/DeleteAzureLoadBalancerDescriptionValidator.groovy
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.ops.valid
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.DeleteAzureLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("deleteAzureLoadBalancerDescriptionValidator")
 class DeleteAzureLoadBalancerDescriptionValidator extends
@@ -31,7 +31,7 @@ class DeleteAzureLoadBalancerDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DeleteAzureLoadBalancerDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteAzureLoadBalancerDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("deleteAzureLoadBalancerDescription", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/validators/UpsertAzureLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/ops/validators/UpsertAzureLoadBalancerDescriptionValidator.groovy
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.ops.valid
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("upsertAzureLoadBalancerDescriptionValidator")
 class UpsertAzureLoadBalancerDescriptionValidator extends
@@ -33,7 +33,7 @@ class UpsertAzureLoadBalancerDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, AzureLoadBalancerDescription description, Errors errors) {
+  void validate(List priorDescriptions, AzureLoadBalancerDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("upsertAzureLoadBalancerDescription", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/validators/DeleteAzureSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/validators/DeleteAzureSecurityGroupDescriptionValidator.groovy
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.ops.vali
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.model.DeleteAzureSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("deleteAzureSecurityGroupDescriptionValidator")
 class DeleteAzureSecurityGroupDescriptionValidator extends
@@ -31,7 +31,7 @@ class DeleteAzureSecurityGroupDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DeleteAzureSecurityGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteAzureSecurityGroupDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("deleteAzureSecurityGroupDescription", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/validators/UpsertAzureSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/securitygroup/ops/validators/UpsertAzureSecurityGroupDescriptionValidator.groovy
@@ -17,12 +17,12 @@
 package com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.ops.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.model.UpsertAzureSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("upsertAzureSecurityGroupDescriptionValidator")
 class UpsertAzureSecurityGroupDescriptionValidator extends
@@ -32,7 +32,7 @@ class UpsertAzureSecurityGroupDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertAzureSecurityGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertAzureSecurityGroupDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("UpsertAzureSecurityGroupDescription", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/AzureServerGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/AzureServerGroupDescriptionValidator.groovy
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.valida
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("azureServerGroupDescriptionValidator")
 class AzureServerGroupDescriptionValidator extends
@@ -32,7 +32,7 @@ class AzureServerGroupDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, AzureServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, AzureServerGroupDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("azureServerGroupDescription", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DestroyAzureServerGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DestroyAzureServerGroupDescriptionValidator.groovy
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.clouddriver.azure.AzureOperation
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
 @Component("DestroyAzureServerGroupDescriptionValidator")
@@ -34,7 +34,7 @@ class DestroyAzureServerGroupDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, EnableDisableDestroyAzureServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableDestroyAzureServerGroupDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("EnableDisableDestroyAzureServerGroupDescription", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DisableAzureServerGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/DisableAzureServerGroupDescriptionValidator.groovy
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.clouddriver.azure.AzureOperation
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AzureOperation(AtomicOperations.DISABLE_SERVER_GROUP)
 @Component("disableAzureServerGroupDescriptionValidator")
@@ -34,7 +34,7 @@ class DisableAzureServerGroupDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, EnableDisableDestroyAzureServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableDestroyAzureServerGroupDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("EnableDisableDestroyAzureServerGroupDescription", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/EnableAzureServerGroupDescriptionValidator.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/validators/EnableAzureServerGroupDescriptionValidator.groovy
@@ -20,11 +20,11 @@ import com.netflix.spinnaker.clouddriver.azure.AzureOperation
 import com.netflix.spinnaker.clouddriver.azure.common.StandardAzureAttributeValidator
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @AzureOperation(AtomicOperations.ENABLE_SERVER_GROUP)
 @Component("enableAzureServerGroupDescriptionValidator")
@@ -34,7 +34,7 @@ class EnableAzureServerGroupDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, EnableDisableDestroyAzureServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableDestroyAzureServerGroupDescription description, ValidationErrors errors) {
     def helper = new StandardAzureAttributeValidator("EnableDisableDestroyAzureServerGroupDescription", errors)
 
     helper.validateCredentials(description.credentials, accountCredentialsProvider)

--- a/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/deploy/validators/UpsertAzureLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/deploy/validators/UpsertAzureLoadBalancerDescriptionValidatorSpec.groovy
@@ -20,12 +20,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model.AzureLoadBalancer
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
 import com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.ops.converters.UpsertAzureLoadBalancerAtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.ops.validators.UpsertAzureLoadBalancerDescriptionValidator
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -149,7 +149,7 @@ class UpsertAzureLoadBalancerDescriptionValidatorSpec extends Specification {
 
       def description = converter.convertDescription(input)
       description.credentials = azureCredentials
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidationErrors.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidationErrors.groovy
@@ -21,7 +21,7 @@ import org.springframework.validation.Errors
 import org.springframework.validation.FieldError
 import org.springframework.validation.ObjectError
 
-class DescriptionValidationErrors extends AbstractErrors {
+class DescriptionValidationErrors extends AbstractErrors implements ValidationErrors {
   Object description
   List<ObjectError> globalErrors = new ArrayList<ObjectError>();
   List<FieldError> fieldErrors = new ArrayList<FieldError>();

--- a/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistrySpec.groovy
+++ b/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/orchestration/AnnotationsBasedAtomicOperationsRegistrySpec.groovy
@@ -18,11 +18,11 @@ package com.netflix.spinnaker.clouddriver.orchestration
 
 import com.netflix.spinnaker.clouddriver.core.CloudProvider
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.validation.Errors
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -172,7 +172,7 @@ class AnnotationsBasedAtomicOperationsRegistrySpec extends Specification {
   @TestProviderOperation("operationDescription")
   static class TestValidator extends DescriptionValidator {
     @Override
-    void validate(List priorDescriptions, Object description, Errors errors) {
+    void validate(List priorDescriptions, Object description, ValidationErrors errors) {
     }
   }
 

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/AbstractDcosDescriptionValidatorSupport.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/AbstractDcosDescriptionValidatorSupport.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 
 abstract class AbstractDcosDescriptionValidatorSupport<T extends AbstractDcosCredentialsDescription> extends DescriptionValidator<T> {
 
@@ -35,7 +34,7 @@ abstract class AbstractDcosDescriptionValidatorSupport<T extends AbstractDcosCre
   }
 
   @Override
-  void validate(List priorDescriptions, T description, Errors errors) {
+  void validate(List priorDescriptions, T description, ValidationErrors errors) {
     if (!description.dcosCluster || description.dcosCluster.trim().empty) {
       errors.rejectValue "dcosCluster", "${descriptionName}.dcosCluster.empty"
     }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceAndDecrementDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceAndDecrementDescriptionValidator.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.TERMINATE_INSTANCE_AND_DECREMENT)
@@ -37,7 +36,7 @@ class TerminateDcosInstanceAndDecrementDescriptionValidator extends AbstractDcos
   }
 
   @Override
-  void validate(List priorDescriptions, TerminateDcosInstancesAndDecrementDescription description, Errors errors) {
+  void validate(List priorDescriptions, TerminateDcosInstancesAndDecrementDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
     if (!description.instanceIds) {
       errors.rejectValue "instanceIds", "${descriptionName}.instanceIds.empty"

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceDescriptionValidator.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.TERMINATE_INSTANCES)
@@ -37,7 +36,7 @@ class TerminateDcosInstanceDescriptionValidator extends AbstractDcosDescriptionV
   }
 
   @Override
-  void validate(List priorDescriptions, TerminateDcosInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, TerminateDcosInstancesDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
     if (!description.instanceIds) {
       errors.rejectValue "instanceIds", "${descriptionName}.instanceIds.empty"

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/job/RunDcosJobDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/job/RunDcosJobDescriptionValidator.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.RUN_JOB)
@@ -37,7 +36,7 @@ class RunDcosJobDescriptionValidator extends AbstractDcosDescriptionValidatorSup
   }
 
   @Override
-  void validate(List priorDescriptions, RunDcosJobDescription description, Errors errors) {
+  void validate(List priorDescriptions, RunDcosJobDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
     if (!description.general?.id) {
       errors.rejectValue "general.id", "${descriptionName}.general.id.empty"

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/DeleteDcosLoadBalancerAtomicOperationDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/DeleteDcosLoadBalancerAtomicOperationDescriptionValidator.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.DELETE_LOAD_BALANCER)
@@ -37,7 +36,7 @@ class DeleteDcosLoadBalancerAtomicOperationDescriptionValidator extends Abstract
   }
 
   @Override
-  void validate(List priorDescriptions, DeleteDcosLoadBalancerAtomicOperationDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteDcosLoadBalancerAtomicOperationDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
 
     // TODO Regex name validation for DC/OS apps

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/UpsertDcosLoadBalancerAtomicOperationDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/UpsertDcosLoadBalancerAtomicOperationDescriptionValidator.groovy
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
@@ -37,7 +36,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidator extends Abstract
   }
 
   @Override
-  void validate(List priorDescriptions, UpsertDcosLoadBalancerAtomicOperationDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertDcosLoadBalancerAtomicOperationDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
 
     // TODO Regex name validation for DC/OS apps

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/AbstractDcosServerGroupValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/AbstractDcosServerGroupValidator.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.clouddriver.dcos.deploy.util.id.DcosSpinnakerAppId
 import com.netflix.spinnaker.clouddriver.dcos.deploy.util.id.MarathonPathId
 import com.netflix.spinnaker.clouddriver.dcos.deploy.validators.AbstractDcosDescriptionValidatorSupport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 
 abstract class AbstractDcosServerGroupValidator<T extends AbstractDcosServerGroupDescription> extends AbstractDcosDescriptionValidatorSupport<T> {
 
@@ -31,7 +30,7 @@ abstract class AbstractDcosServerGroupValidator<T extends AbstractDcosServerGrou
   }
 
   @Override
-  void validate(List priorDescriptions, AbstractDcosServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, AbstractDcosServerGroupDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
 
     if (!description.region || description.region.empty) {

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DeployDcosServerGroupDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DeployDcosServerGroupDescriptionValidator.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.CREATE_SERVER_GROUP)
@@ -38,7 +37,7 @@ class DeployDcosServerGroupDescriptionValidator extends AbstractDcosDescriptionV
   }
 
   @Override
-  void validate(List priorDescriptions, DeployDcosServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeployDcosServerGroupDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
 
     if (!description.region || description.region.empty) {

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DestroyDcosServerGroupDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DestroyDcosServerGroupDescriptionValidator.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.DESTROY_SERVER_GROUP)
@@ -35,7 +34,7 @@ class DestroyDcosServerGroupDescriptionValidator extends AbstractDcosServerGroup
   }
 
   @Override
-  void validate(List priorDescriptions, DestroyDcosServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, DestroyDcosServerGroupDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
   }
 }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DisableDcosServerGroupDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DisableDcosServerGroupDescriptionValidator.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.DISABLE_SERVER_GROUP)
@@ -35,7 +34,7 @@ class DisableDcosServerGroupDescriptionValidator extends AbstractDcosServerGroup
   }
 
   @Override
-  void validate(List priorDescriptions, DisableDcosServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, DisableDcosServerGroupDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
   }
 }

--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/ResizeDcosServerGroupDescriptionValidator.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/ResizeDcosServerGroupDescriptionValidator.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @DcosOperation(AtomicOperations.RESIZE_SERVER_GROUP)
@@ -35,7 +34,7 @@ class ResizeDcosServerGroupDescriptionValidator extends AbstractDcosServerGroupV
   }
 
   @Override
-  void validate(List priorDescriptions, ResizeDcosServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, ResizeDcosServerGroupDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
 
     if (description.targetSize == null || description.targetSize < 0) {

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceAndDecrementDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceAndDecrementDescriptionValidatorSpec.groovy
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Cerner Corporation
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.instance.TerminateDcosInstancesAndDecrementDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Subject
 
 class TerminateDcosInstanceAndDecrementDescriptionValidatorSpec extends BaseSpecification {
@@ -39,7 +39,7 @@ class TerminateDcosInstanceAndDecrementDescriptionValidatorSpec extends BaseSpec
     void "validate should give errors when given an empty TerminateDcosInstancesAndDecrementDescription"() {
         setup:
             def description = new TerminateDcosInstancesAndDecrementDescription(credentials: null, region: null,  instanceIds: [])
-            def errorsMock = Mock(Errors)
+            def errorsMock = Mock(ValidationErrors)
         when:
             validator.validate([], description, errorsMock)
         then:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceDescriptionValidatorSpec.groovy
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Cerner Corporation
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.instance.TerminateDcosInstancesDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Subject
 
 class TerminateDcosInstanceDescriptionValidatorSpec extends BaseSpecification {
@@ -39,7 +39,7 @@ class TerminateDcosInstanceDescriptionValidatorSpec extends BaseSpecification {
     void "validate should give errors when given an empty TerminateDcosInstancesDescription"() {
         setup:
             def description = new TerminateDcosInstancesDescription(credentials: null, dcosCluster: null, instanceIds: [])
-            def errorsMock = Mock(Errors)
+            def errorsMock = Mock(ValidationErrors)
         when:
             validator.validate([], description, errorsMock)
         then:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/job/RunDcosJobValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/job/RunDcosJobValidatorSpec.groovy
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.job.RunDcosJobDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Subject
 
 class RunDcosJobValidatorSpec extends BaseSpecification {
@@ -39,7 +39,7 @@ class RunDcosJobValidatorSpec extends BaseSpecification {
     void "validate should give errors when given an empty RunDcosJobDescription"() {
         setup:
             def description = new RunDcosJobDescription(credentials: null, dcosCluster: null, general: null)
-            def errorsMock = Mock(Errors)
+            def errorsMock = Mock(ValidationErrors)
         when:
             validator.validate([], description, errorsMock)
         then:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Cerner Corporation
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.loadbalancer
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.DeleteDcosLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Subject
 
@@ -51,7 +51,7 @@ class DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -67,7 +67,7 @@ class DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -87,7 +87,7 @@ class DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.loadbalancer
 import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.UpsertDcosLoadBalancerAtomicOperationDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Subject
 
@@ -59,7 +59,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -83,7 +83,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -106,7 +106,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -131,7 +131,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -156,7 +156,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -183,7 +183,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -207,7 +207,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)
@@ -233,7 +233,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Base
       it
     }
 
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errorsMock)

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DeployDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DeployDcosServerGroupDescriptionValidatorSpec.groovy
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DeployDcosServerGroupDescription
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Subject
 
 class DeployDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
@@ -38,7 +38,7 @@ class DeployDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
     setup:
     def description = new DeployDcosServerGroupDescription(account: null, dcosCluster: null, credentials: null, application: null, desiredCapacity: -1,
                                                            cpus: -1, mem: -1, disk: -1, gpus: -1)
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
     when:
     validator.validate([], description, errorsMock)
     then:
@@ -60,7 +60,7 @@ class DeployDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
     setup:
     def description = new DeployDcosServerGroupDescription(region: '-iNv.aLiD-', credentials: defaultCredentialsBuilder().account(BAD_ACCOUNT).build(),
                                                            application: '-iNv.aLiD-', dcosCluster: "", desiredCapacity: 1, cpus: 1, mem: 512, disk: 0, gpus: 0)
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
     when:
     validator.validate([], description, errorsMock)
     then:
@@ -82,7 +82,7 @@ class DeployDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
     setup:
     def description = new DeployDcosServerGroupDescription(region: DEFAULT_REGION, dcosCluster: DEFAULT_REGION, credentials: testCredentials, application: "test",
                                                            desiredCapacity: 1, cpus: 1, mem: 512, disk: 0, gpus: 0)
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
     when:
     validator.validate([], description, errorsMock)
     then:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DestroyDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DestroyDcosServerGroupDescriptionValidatorSpec.groovy
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DestroyDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Subject
 
 class DestroyDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
@@ -40,7 +40,7 @@ class DestroyDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give errors when given an empty DestroyDcosServerGroupDescription"() {
     setup:
       def description = new DestroyDcosServerGroupDescription(region: null, dcosCluster: null, credentials: null, serverGroupName: null)
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
     when:
       validator.validate([], description, errorsMock)
     then:
@@ -56,7 +56,7 @@ class DestroyDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give errors when given an invalid DestroyDcosServerGroupDescription"() {
     setup:
       def description = new DestroyDcosServerGroupDescription(region: INVALID_MARATHON_PART, dcosCluster: "", credentials: defaultCredentialsBuilder().account(BAD_ACCOUNT).build(), serverGroupName: INVALID_MARATHON_PART)
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
     when:
       validator.validate([], description, errorsMock)
     then:
@@ -72,7 +72,7 @@ class DestroyDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give no errors when given an valid DestroyDcosServerGroupDescription"() {
     setup:
     def description = new DestroyDcosServerGroupDescription(region: DEFAULT_REGION, dcosCluster: DEFAULT_REGION, credentials: testCredentials, serverGroupName: 'test')
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
     when:
     validator.validate([], description, errorsMock)
     then:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DisableDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DisableDcosServerGroupDescriptionValidatorSpec.groovy
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DisableDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Subject
 
 class DisableDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
@@ -40,7 +40,7 @@ class DisableDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give errors when given an empty DestroyDcosServerGroupDescription"() {
     setup:
       def description = new DisableDcosServerGroupDescription(region: null, dcosCluster: null, credentials: null, serverGroupName: null)
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
     when:
       validator.validate([], description, errorsMock)
     then:
@@ -56,7 +56,7 @@ class DisableDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give errors when given an invalid DestroyDcosServerGroupDescription"() {
     setup:
       def description = new DisableDcosServerGroupDescription(region: INVALID_MARATHON_PART, dcosCluster: "", credentials: defaultCredentialsBuilder().account(BAD_ACCOUNT).build(), serverGroupName: INVALID_MARATHON_PART)
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
     when:
       validator.validate([], description, errorsMock)
     then:
@@ -72,7 +72,7 @@ class DisableDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give no errors when given an valid DestroyDcosServerGroupDescription"() {
     setup:
     def description = new DisableDcosServerGroupDescription(region: DEFAULT_REGION, dcosCluster: DEFAULT_REGION, credentials: testCredentials, serverGroupName: 'test')
-    def errorsMock = Mock(Errors)
+    def errorsMock = Mock(ValidationErrors)
     when:
     validator.validate([], description, errorsMock)
     then:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/ResizeDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/ResizeDcosServerGroupDescriptionValidatorSpec.groovy
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.clouddriver.dcos.security.DcosAccountCredentials
 import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.ResizeDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Subject
 
 class ResizeDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
@@ -40,7 +40,7 @@ class ResizeDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give errors when given an empty ResizeDcosServerGroupDescription"() {
     setup:
       def description = new ResizeDcosServerGroupDescription(region: null, dcosCluster: null, credentials: null, serverGroupName: null, targetSize: null)
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
     when:
       validator.validate([], description, errorsMock)
     then:
@@ -57,7 +57,7 @@ class ResizeDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give errors when given an invalid DestroyDcosServerGroupDescription"() {
     setup:
       def description = new ResizeDcosServerGroupDescription(region: INVALID_MARATHON_PART, dcosCluster: "", credentials: defaultCredentialsBuilder().account(BAD_ACCOUNT).build(), serverGroupName: INVALID_MARATHON_PART, targetSize: -1)
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
     when:
       validator.validate([], description, errorsMock)
     then:
@@ -74,7 +74,7 @@ class ResizeDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   void "validate should give no errors when given an valid DestroyDcosServerGroupDescription"() {
     setup:
       def description = new ResizeDcosServerGroupDescription(region: DEFAULT_REGION, dcosCluster: DEFAULT_REGION, credentials: testCredentials, serverGroupName: 'test', targetSize: 0)
-      def errorsMock = Mock(Errors)
+      def errorsMock = Mock(ValidationErrors)
     when:
       validator.validate([], description, errorsMock)
     then:

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CloneServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CloneServiceAtomicOperationValidator.java
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.CLONE_SERVER_GROUP)
 @Component("cloneServiceAtomicOperationValidator")
 public class CloneServiceAtomicOperationValidator extends DescriptionValidator {
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
 
     // TODO - Implement this stub
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CommonValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/CommonValidator.java
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.AbstractAmazonCredentialsDescription;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.springframework.validation.Errors;
 
 abstract class CommonValidator extends DescriptionValidator {
   String errorKey;
@@ -35,7 +35,7 @@ abstract class CommonValidator extends DescriptionValidator {
   void validateRegions(
       AbstractAmazonCredentialsDescription credentialsDescription,
       Collection<String> regionNames,
-      Errors errors,
+      ValidationErrors errors,
       String attributeName) {
     if (regionNames.isEmpty()) {
       rejectValue(errors, attributeName, "empty");
@@ -53,7 +53,7 @@ abstract class CommonValidator extends DescriptionValidator {
 
   boolean validateCredentials(
       AbstractAmazonCredentialsDescription credentialsDescription,
-      Errors errors,
+      ValidationErrors errors,
       String attributeName) {
     if (credentialsDescription.getCredentials() == null) {
       rejectValue(errors, attributeName, "not.nullable");
@@ -62,7 +62,7 @@ abstract class CommonValidator extends DescriptionValidator {
     return true;
   }
 
-  void validateCapacity(Errors errors, ServerGroup.Capacity capacity) {
+  void validateCapacity(ValidationErrors errors, ServerGroup.Capacity capacity) {
     if (capacity != null) {
       boolean desiredNotNull = capacity.getDesired() != null;
       boolean minNotNull = capacity.getMin() != null;
@@ -101,12 +101,12 @@ abstract class CommonValidator extends DescriptionValidator {
     }
   }
 
-  void rejectValue(Errors errors, String field, String reason) {
+  void rejectValue(ValidationErrors errors, String field, String reason) {
     errors.rejectValue(field, errorKey + "." + field + "." + reason);
   }
 
   private void positivityCheck(
-      boolean isNotNull, Integer capacity, String fieldName, Errors errors) {
+      boolean isNotNull, Integer capacity, String fieldName, ValidationErrors errors) {
     if (isNotNull && capacity < 0) {
       rejectValue(errors, "capacity." + fieldName, "invalid");
     }

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DeleteScalingPolicyAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/DeleteScalingPolicyAtomicOperationValidator.java
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.DELETE_SCALING_POLICY)
 @Component("deleteScalingPolicyAtomicOperationValidator")
 public class DeleteScalingPolicyAtomicOperationValidator extends DescriptionValidator {
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
 
     // TODO - Implement this stub
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServerGroupDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServerGroupDescriptionValidator.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 import com.amazonaws.services.ecs.model.PlacementStrategy;
 import com.amazonaws.services.ecs.model.PlacementStrategyType;
 import com.google.common.collect.Sets;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CreateServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
@@ -27,7 +28,6 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.CREATE_SERVER_GROUP)
 @Component("ecsCreateServerGroupDescriptionValidator")
@@ -50,7 +50,7 @@ public class EcsCreateServerGroupDescriptionValidator extends CommonValidator {
   }
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
     CreateServerGroupDescription createServerGroupDescription =
         (CreateServerGroupDescription) description;
 
@@ -175,7 +175,7 @@ public class EcsCreateServerGroupDescriptionValidator extends CommonValidator {
   }
 
   private void validateTargetGroupMappings(
-      CreateServerGroupDescription createServerGroupDescription, Errors errors) {
+      CreateServerGroupDescription createServerGroupDescription, ValidationErrors errors) {
     if (createServerGroupDescription.getTargetGroupMappings() != null
         && !createServerGroupDescription.getTargetGroupMappings().isEmpty()) {
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ResizeServiceDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ResizeServiceDescriptionValidator.java
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ResizeServiceDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.RESIZE_SERVER_GROUP)
 @Component("resizeServiceAtomicOperationValidator")
@@ -33,7 +33,7 @@ public class ResizeServiceDescriptionValidator extends CommonValidator {
   }
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
     ResizeServiceDescription typedDescription = (ResizeServiceDescription) description;
 
     boolean validCredentials = validateCredentials(typedDescription, errors, "credentials");

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ServerGroupDescriptionValidator.java
@@ -16,10 +16,10 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ModifyServiceDescription;
 import java.util.Collections;
 import java.util.List;
-import org.springframework.validation.Errors;
 
 public class ServerGroupDescriptionValidator extends CommonValidator {
 
@@ -28,7 +28,7 @@ public class ServerGroupDescriptionValidator extends CommonValidator {
   }
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
     ModifyServiceDescription typeDescription = (ModifyServiceDescription) description;
 
     boolean validCredentials = validateCredentials(typeDescription, errors, "credentials");

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StartServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StartServiceAtomicOperationValidator.java
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.START_SERVER_GROUP)
 @Component("startServiceAtomicOperationValidator")
 public class StartServiceAtomicOperationValidator extends DescriptionValidator {
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
 
     // TODO - Implement this stub
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StopServiceAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/StopServiceAtomicOperationValidator.java
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.STOP_SERVER_GROUP)
 @Component("stopServiceAtomicOperationValidator")
 public class StopServiceAtomicOperationValidator extends DescriptionValidator {
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
 
     // TODO - Implement this stub
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/TerminateInstancesDescriptionValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/TerminateInstancesDescriptionValidator.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.TerminateInstancesDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
@@ -23,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.TERMINATE_INSTANCES)
 @Component("ecsTerminateInstancesDescriptionValidator")
@@ -37,7 +37,7 @@ public class TerminateInstancesDescriptionValidator extends CommonValidator {
   }
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
     TerminateInstancesDescription typedDescription = (TerminateInstancesDescription) description;
     boolean validCredentials = validateCredentials(typedDescription, errors, "credentials");
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpdateServiceAndTaskConfigAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpdateServiceAndTaskConfigAtomicOperationValidator.java
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.UPDATE_LAUNCH_CONFIG)
 @Component("updateServiceAndTaskConfigAtomicOperationValidator")
 public class UpdateServiceAndTaskConfigAtomicOperationValidator extends DescriptionValidator {
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
 
     // TODO - Implement this stub
 

--- a/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpsertScalingPolicyAtomicOperationValidator.java
+++ b/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/UpsertScalingPolicyAtomicOperationValidator.java
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.ecs.EcsOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @EcsOperation(AtomicOperations.UPSERT_SCALING_POLICY)
 @Component("upsertScalingPolicyAtomicOperationValidator")
 public class UpsertScalingPolicyAtomicOperationValidator extends DescriptionValidator {
 
   @Override
-  public void validate(List priorDescriptions, Object description, Errors errors) {
+  public void validate(List priorDescriptions, Object description, ValidationErrors errors) {
 
     // TODO - Implement this stub
 

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/AbstractValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/AbstractValidatorSpec.groovy
@@ -19,9 +19,9 @@ package com.netflix.spinnaker.clouddriver.ecs.deploy.validators
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.ecs.TestCredential
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.AbstractECSDescription
-import org.springframework.validation.Errors
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -58,7 +58,7 @@ abstract class AbstractValidatorSpec extends Specification {
     def description = getDescription()
     description.credentials = TestCredential.named('test')
     description.region = 'wrong-region-test'
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     if(testRegion) {
@@ -75,7 +75,7 @@ abstract class AbstractValidatorSpec extends Specification {
     given:
     def description = getNulledDescription()
     def descriptionName = getDescriptionName()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     def nullProperties = notNullableProperties()
 
     when:
@@ -91,7 +91,7 @@ abstract class AbstractValidatorSpec extends Specification {
     given:
     def description = getInvalidDescription()
     def descriptionName = getDescriptionName()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     def invalidFields = invalidProperties()
 
@@ -107,7 +107,7 @@ abstract class AbstractValidatorSpec extends Specification {
   void 'should pass validation'() {
     given:
     def description = getDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServergroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/EcsCreateServergroupDescriptionValidatorSpec.groovy
@@ -19,11 +19,11 @@ package com.netflix.spinnaker.clouddriver.ecs.deploy.validators
 import com.amazonaws.services.ecs.model.PlacementStrategy
 import com.amazonaws.services.ecs.model.PlacementStrategyType
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.ecs.TestCredential
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.AbstractECSDescription
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.CreateServerGroupDescription
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
-import org.springframework.validation.Errors
 
 class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec {
 
@@ -31,7 +31,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     given:
     def description = (CreateServerGroupDescription) getDescription()
     description.capacity = null
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -44,7 +44,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     given:
     def description = (CreateServerGroupDescription) getDescription()
     description.capacity.setDesired(9001)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -57,7 +57,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     given:
     def description = (CreateServerGroupDescription) getDescription()
     description.capacity.setDesired(0)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -70,7 +70,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     given:
     def description = (CreateServerGroupDescription) getDescription()
     description.availabilityZones = ['us-west-1': ['us-west-1a'], 'us-west-2': ['us-west-2a']]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -83,7 +83,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     given:
     def description = (CreateServerGroupDescription) getDescription()
     description.availabilityZones = ['us-west-1': []]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -96,7 +96,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     given:
     def description = (CreateServerGroupDescription) getDescription()
     description.environmentVariables = ['SERVER_GROUP':'invalid', 'tag_1':'valid_tag']
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -109,7 +109,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     given:
     def description = getDescription()
     description.environmentVariables = ['TAG_1':'valid_tag_1', 'TAG_2':'valid_tag_2']
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -123,7 +123,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     def description = getDescription()
     description.containerPort = null
     description.targetGroup = null
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -136,7 +136,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     given:
     def description = getDescription()
     description.useTaskDefinitionArtifact = true
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -151,7 +151,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     description.targetGroup = null
     description.loadBalancedContainer = 'load-balanced-container'
     description.useTaskDefinitionArtifact = true
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -173,7 +173,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     description.dockerImageAddress = null
     description.useTaskDefinitionArtifact = true
     description.targetGroupMappings = [targetGroupMappings]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -195,7 +195,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     description.dockerImageAddress = null
     description.useTaskDefinitionArtifact = true
     description.targetGroupMappings = [targetGroupMappings]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -215,7 +215,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     description.targetGroup = null
     description.containerPort = null
     description.targetGroupMappings = [targetGroupMappings]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -235,7 +235,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     description.targetGroup = null
     description.containerPort = null
     description.targetGroupMappings = [targetGroupMappings]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -255,7 +255,7 @@ class EcsCreateServergroupDescriptionValidatorSpec extends AbstractValidatorSpec
     description.targetGroup = null
     description.containerPort = null
     description.targetGroupMappings = [targetGroupMappings]
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ResizeDescriptionValidatorSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/deploy/validators/ResizeDescriptionValidatorSpec.groovy
@@ -17,11 +17,11 @@
 package com.netflix.spinnaker.clouddriver.ecs.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.ecs.TestCredential
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.AbstractECSDescription
 import com.netflix.spinnaker.clouddriver.ecs.deploy.description.ResizeServiceDescription
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
-import org.springframework.validation.Errors
 
 class ResizeDescriptionValidatorSpec extends AbstractValidatorSpec {
 
@@ -29,7 +29,7 @@ class ResizeDescriptionValidatorSpec extends AbstractValidatorSpec {
     given:
     def description = (ResizeServiceDescription) getDescription()
     description.capacity = null
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -42,7 +42,7 @@ class ResizeDescriptionValidatorSpec extends AbstractValidatorSpec {
     given:
     def description = (ResizeServiceDescription) getDescription()
     description.capacity.setDesired(9001)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -55,7 +55,7 @@ class ResizeDescriptionValidatorSpec extends AbstractValidatorSpec {
     given:
     def description = (ResizeServiceDescription) getDescription()
     description.capacity.setDesired(0)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/validators/BulkUpsertEntityTagsDescriptionValidator.java
+++ b/clouddriver-elasticsearch/src/main/java/com/netflix/spinnaker/clouddriver/elasticsearch/validators/BulkUpsertEntityTagsDescriptionValidator.java
@@ -17,11 +17,11 @@
 package com.netflix.spinnaker.clouddriver.elasticsearch.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.elasticsearch.descriptions.BulkUpsertEntityTagsDescription;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @Component("bulkUpsertEntityTagsDescriptionValidator")
 public class BulkUpsertEntityTagsDescriptionValidator
@@ -32,7 +32,9 @@ public class BulkUpsertEntityTagsDescriptionValidator
 
   @Override
   public void validate(
-      List priorDescriptions, BulkUpsertEntityTagsDescription description, Errors errors) {
+      List priorDescriptions,
+      BulkUpsertEntityTagsDescription description,
+      ValidationErrors errors) {
     if (description.entityTags != null && description.entityTags.size() > maxConcurrentBulkTags) {
       errors.rejectValue(
           "entityTags.length",

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/AbandonAndDecrementGoogleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/AbandonAndDecrementGoogleServerGroupDescriptionValidator.groovy
@@ -17,11 +17,11 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.AbandonAndDecrementGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("abandonAndDecrementGoogleServerGroupDescriptionValidator")
 class AbandonAndDecrementGoogleServerGroupDescriptionValidator extends DescriptionValidator<AbandonAndDecrementGoogleServerGroupDescription> {
@@ -29,7 +29,7 @@ class AbandonAndDecrementGoogleServerGroupDescriptionValidator extends Descripti
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, AbandonAndDecrementGoogleServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, AbandonAndDecrementGoogleServerGroupDescription description, ValidationErrors errors) {
     StandardGceAttributeValidator helper = new StandardGceAttributeValidator("abandonAndDecrementGoogleServerGroupDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/AbstractEnableDisableGoogleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/AbstractEnableDisableGoogleServerGroupDescriptionValidator.groovy
@@ -17,17 +17,17 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.EnableDisableGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.validation.Errors
 
 abstract class AbstractEnableDisableGoogleServerGroupDescriptionValidator extends DescriptionValidator<EnableDisableGoogleServerGroupDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, EnableDisableGoogleServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableGoogleServerGroupDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("enableDisableGoogleServerGroupDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/BasicGoogleDeployDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/BasicGoogleDeployDescriptionValidator.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.CREATE_SERVER_GROUP)
 @Component("basicGoogleDeployDescriptionValidator")
@@ -36,7 +36,7 @@ class BasicGoogleDeployDescriptionValidator extends DescriptionValidator<BasicGo
   private GoogleConfiguration.DeployDefaults googleDeployDefaults
 
   @Override
-  void validate(List priorDescriptions, BasicGoogleDeployDescription description, Errors errors) {
+  void validate(List priorDescriptions, BasicGoogleDeployDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("basicGoogleDeployDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CopyLastGoogleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CopyLastGoogleServerGroupDescriptionValidator.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.CLONE_SERVER_GROUP)
 @Component("copyLastGoogleServerGroupDescriptionValidator")
@@ -36,7 +36,7 @@ class CopyLastGoogleServerGroupDescriptionValidator extends DescriptionValidator
   private GoogleConfiguration.DeployDefaults googleDeployDefaults
 
   @Override
-  void validate(List priorDescriptions, BasicGoogleDeployDescription description, Errors errors) {
+  void validate(List priorDescriptions, BasicGoogleDeployDescription description, ValidationErrors errors) {
     // Passing 'copyLastGoogleServerGroupDescription' rather than 'basicGoogleDeployDescription'
     // here is a judgement call. The intent is to provide the context in which the validation
     // is performed rather than the actual type name being validated. The string is lower-cased

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CreateGoogleInstanceDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CreateGoogleInstanceDescriptionValidator.groovy
@@ -17,12 +17,12 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.deploy.description.CreateGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("createGoogleInstanceDescriptionValidator")
 class CreateGoogleInstanceDescriptionValidator extends DescriptionValidator<CreateGoogleInstanceDescription> {
@@ -33,7 +33,7 @@ class CreateGoogleInstanceDescriptionValidator extends DescriptionValidator<Crea
   private GoogleConfiguration.DeployDefaults googleDeployDefaults
 
   @Override
-  void validate(List priorDescriptions, CreateGoogleInstanceDescription description, Errors errors) {
+  void validate(List priorDescriptions, CreateGoogleInstanceDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("createGoogleInstanceDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleAutoscalingPolicyDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleAutoscalingPolicyDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.DELETE_SCALING_POLICY)
 @Component
@@ -32,7 +32,7 @@ class DeleteGoogleAutoscalingPolicyDescriptionValidator extends DescriptionValid
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DeleteGoogleAutoscalingPolicyDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteGoogleAutoscalingPolicyDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("deleteGoogleScalingPolicyDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleLoadBalancerDescriptionValidator.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerType
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.DELETE_LOAD_BALANCER)
 @Component("deleteGoogleLoadBalancerDescriptionValidator")
@@ -34,7 +34,7 @@ class DeleteGoogleLoadBalancerDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DeleteGoogleLoadBalancerDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteGoogleLoadBalancerDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("deleteGoogleLoadBalancerDescription", errors)
 
     def loadBalancerType = description.loadBalancerType

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleSecurityGroupDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.DELETE_SECURITY_GROUP)
 @Component
@@ -32,7 +32,7 @@ class DeleteGoogleSecurityGroupDescriptionValidator extends DescriptionValidator
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DeleteGoogleSecurityGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, DeleteGoogleSecurityGroupDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("deleteGoogleSecurityGroupDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeregisterInstancesFromGoogleLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeregisterInstancesFromGoogleLoadBalancerDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeregisterInstancesFromGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.DEREGISTER_INSTANCES_FROM_LOAD_BALANCER)
 @Component("deregisterInstancesFromGoogleLoadBalancerDescriptionValidator")
@@ -34,7 +34,7 @@ class DeregisterInstancesFromGoogleLoadBalancerDescriptionValidator
 
   @Override
   void validate(List priorDescriptions,
-                DeregisterInstancesFromGoogleLoadBalancerDescription description, Errors errors) {
+                DeregisterInstancesFromGoogleLoadBalancerDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("deregisterInstancesFromGoogleLoadBalancerDescription", errors)
 
     helper.validateNameList(description.loadBalancerNames, "loadBalancerName")

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DestroyGoogleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DestroyGoogleServerGroupDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DestroyGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.DESTROY_SERVER_GROUP)
 @Component("destroyGoogleServerGroupDescriptionValidator")
@@ -32,7 +32,7 @@ class DestroyGoogleServerGroupDescriptionValidator extends DescriptionValidator<
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, DestroyGoogleServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, DestroyGoogleServerGroupDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("destroyGoogleServerGroupDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/ModifyGoogleServerGroupInstanceTemplateDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/ModifyGoogleServerGroupInstanceTemplateDescriptionValidator.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.ModifyGoogleServerGroupInstanceTemplateDescription
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.UPDATE_LAUNCH_CONFIG)
 @Component("modifyGoogleServerGroupInstanceTemplateDescriptionValidator")
@@ -36,7 +36,7 @@ class ModifyGoogleServerGroupInstanceTemplateDescriptionValidator extends Descri
   private GoogleConfiguration.DeployDefaults googleDeployDefaults
 
   @Override
-  void validate(List priorDescriptions, ModifyGoogleServerGroupInstanceTemplateDescription description, Errors errors) {
+  void validate(List priorDescriptions, ModifyGoogleServerGroupInstanceTemplateDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("modifyGoogleServerGroupInstanceTemplateDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/RebootGoogleInstancesDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/RebootGoogleInstancesDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RebootGoogleInstancesDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.REBOOT_INSTANCES)
 @Component
@@ -32,7 +32,7 @@ class RebootGoogleInstancesDescriptionValidator extends DescriptionValidator<Reb
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, RebootGoogleInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, RebootGoogleInstancesDescription description, ValidationErrors errors) {
     StandardGceAttributeValidator helper = new StandardGceAttributeValidator("rebootGoogleInstancesDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/RegisterInstancesWithGoogleLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/RegisterInstancesWithGoogleLoadBalancerDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RegisterInstancesWithGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.REGISTER_INSTANCES_WITH_LOAD_BALANCER)
 @Component("registerInstancesWithGoogleLoadBalancerDescriptionValidator")
@@ -34,7 +34,7 @@ class RegisterInstancesWithGoogleLoadBalancerDescriptionValidator
 
   @Override
   void validate(List priorDescriptions,
-                RegisterInstancesWithGoogleLoadBalancerDescription description, Errors errors) {
+                RegisterInstancesWithGoogleLoadBalancerDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("registerInstancesWithGoogleLoadBalancerDescription", errors)
 
     helper.validateNameList(description.loadBalancerNames, "loadBalancerName")

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/ResizeGoogleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/ResizeGoogleServerGroupDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.RESIZE_SERVER_GROUP)
 @Component("resizeGoogleServerGroupDescriptionValidator")
@@ -32,7 +32,7 @@ class ResizeGoogleServerGroupDescriptionValidator extends DescriptionValidator<O
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, def description, Errors errors) {
+  void validate(List priorDescriptions, def description, ValidationErrors errors) {
     // If the target server group has an Autoscaler configured the converter will return an
     // UpsertGoogleAutoscalingPolicyDescription instead of a ResizeGoogleServerGroupDescription.
     if (description in UpsertGoogleAutoscalingPolicyDescription) {

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/SetStatefulDiskDescriptionValidator.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/SetStatefulDiskDescriptionValidator.java
@@ -17,12 +17,12 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation;
 import com.netflix.spinnaker.clouddriver.google.deploy.description.SetStatefulDiskDescription;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @GoogleOperation(AtomicOperations.SET_STATEFUL_DISK)
 @Component
@@ -31,7 +31,7 @@ public class SetStatefulDiskDescriptionValidator
 
   @Override
   public void validate(
-      List priorDescriptions, SetStatefulDiskDescription description, Errors errors) {
+      List priorDescriptions, SetStatefulDiskDescription description, ValidationErrors errors) {
     StandardGceAttributeValidator helper =
         new StandardGceAttributeValidator("setStatefulDiskDescription", errors);
     helper.validateRegion(description.getRegion(), description.getCredentials());

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidator.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.GCEUtil
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BaseGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoHealingPolicy
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
-import org.springframework.validation.Errors
 
 /**
  * Common validation routines for standard description attributes.
@@ -77,7 +77,7 @@ class StandardGceAttributeValidator {
   /**
    * Bound at construction, this is used to collect validation errors.
    */
-  Errors errors
+  ValidationErrors errors
 
   /**
    * Constructs validator for standard attributes added by GCE.
@@ -85,7 +85,7 @@ class StandardGceAttributeValidator {
    * @param context The owner of the attributes to be validated is typically a {@code *Description} class.
    * @param errors  Accumulates and reports on the validation errors over the lifetime of this validator.
    */
-  StandardGceAttributeValidator(String context, Errors errors) {
+  StandardGceAttributeValidator(String context, ValidationErrors errors) {
     this.context = context
     this.errors = errors
   }
@@ -311,7 +311,7 @@ class StandardGceAttributeValidator {
     def vCpuCount = customTypeMatcher.group(2).toDouble()
     def memory = customTypeMatcher.group(3).toDouble()
     def memoryInGbs = memory / 1024
-    
+
     // Memory per vCPU must be between .5 GB and 8 GB
     def maxMemory = vCpuCount * 8
     def minMemory = Math.ceil((0.5 * vCpuCount) * 4) / 4

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StatefullyUpdateBootImageDescriptionValidator.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StatefullyUpdateBootImageDescriptionValidator.java
@@ -17,16 +17,18 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.google.deploy.description.StatefullyUpdateBootImageDescription;
 import java.util.List;
-import org.springframework.validation.Errors;
 
 public class StatefullyUpdateBootImageDescriptionValidator
     extends DescriptionValidator<StatefullyUpdateBootImageDescription> {
 
   @Override
   public void validate(
-      List priorDescriptions, StatefullyUpdateBootImageDescription description, Errors errors) {
+      List priorDescriptions,
+      StatefullyUpdateBootImageDescription description,
+      ValidationErrors errors) {
     StandardGceAttributeValidator helper =
         new StandardGceAttributeValidator("statefullyUpdateBootImageDescription", errors);
     helper.validateRegion(description.getRegion(), description.getCredentials());

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/TerminateAndDecrementGoogleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/TerminateAndDecrementGoogleServerGroupDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.TerminateAndDecrementGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.TERMINATE_INSTANCE_AND_DECREMENT)
 @Component("terminateAndDecrementGoogleServerGroupDescriptionValidator")
@@ -32,7 +32,7 @@ class TerminateAndDecrementGoogleServerGroupDescriptionValidator extends Descrip
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, TerminateAndDecrementGoogleServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, TerminateAndDecrementGoogleServerGroupDescription description, ValidationErrors errors) {
     StandardGceAttributeValidator helper = new StandardGceAttributeValidator("terminateAndDecrementGoogleServerGroupDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/TerminateGoogleInstancesDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/TerminateGoogleInstancesDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.TerminateGoogleInstancesDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.TERMINATE_INSTANCES)
 @Component
@@ -32,7 +32,7 @@ class TerminateGoogleInstancesDescriptionValidator extends DescriptionValidator<
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, TerminateGoogleInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, TerminateGoogleInstancesDescription description, ValidationErrors errors) {
     StandardGceAttributeValidator helper = new StandardGceAttributeValidator("terminateGoogleInstancesDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleAutoscalingPolicyDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleAutoscalingPolicyDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.UPSERT_SCALING_POLICY)
 @Component("upsertGoogleScalingPolicyDescriptionValidator")
@@ -34,7 +34,7 @@ class UpsertGoogleAutoscalingPolicyDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertGoogleAutoscalingPolicyDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertGoogleAutoscalingPolicyDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("upsertGoogleScalingPolicyDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleImageTagsDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleImageTagsDescriptionValidator.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleImageTagsDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleServerGroupTagsDescription
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.UPSERT_IMAGE_TAGS)
 @Component
@@ -33,7 +33,7 @@ class UpsertGoogleImageTagsDescriptionValidator extends DescriptionValidator<Ups
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertGoogleImageTagsDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertGoogleImageTagsDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("upsertGoogleImageTagsDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleLoadBalancerDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleLoadBalancerDescriptionValidator.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.model.callbacks.Utils
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
 @Component("upsertGoogleLoadBalancerDescriptionValidator")
@@ -42,7 +42,7 @@ class UpsertGoogleLoadBalancerDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertGoogleLoadBalancerDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertGoogleLoadBalancerDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("upsertGoogleLoadBalancerDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleSecurityGroupDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleSecurityGroupDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.UPSERT_SECURITY_GROUP)
 @Component
@@ -33,7 +33,7 @@ class UpsertGoogleSecurityGroupDescriptionValidator extends
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertGoogleSecurityGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertGoogleSecurityGroupDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("upsertGoogleSecurityGroupDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleServerGroupTagsDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleServerGroupTagsDescriptionValidator.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.GoogleOperation
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleServerGroupTagsDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @GoogleOperation(AtomicOperations.UPSERT_SERVER_GROUP_TAGS)
 @Component("upsertGoogleServerGroupTagsDescriptionValidator")
@@ -32,7 +32,7 @@ class UpsertGoogleServerGroupTagsDescriptionValidator extends DescriptionValidat
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, UpsertGoogleServerGroupTagsDescription description, Errors errors) {
+  void validate(List priorDescriptions, UpsertGoogleServerGroupTagsDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("upsertGoogleServerGroupTagsDescription", errors)
 
     helper.validateCredentials(description.accountName, accountCredentialsProvider)

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/discovery/AbstractEnableDisableInstancesInDiscoveryDescriptionValidator.groovy
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/discovery/AbstractEnableDisableInstancesInDiscoveryDescriptionValidator.groovy
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators.discovery
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.GoogleInstanceListDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.validators.StandardGceAttributeValidator
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.validation.Errors
 
 abstract class AbstractEnableDisableInstancesInDiscoveryDescriptionValidator extends DescriptionValidator<GoogleInstanceListDescription> {
   @Autowired
   AccountCredentialsProvider accountCredentialsProvider
 
   @Override
-  void validate(List priorDescriptions, GoogleInstanceListDescription description, Errors errors) {
+  void validate(List priorDescriptions, GoogleInstanceListDescription description, ValidationErrors errors) {
     def helper = new StandardGceAttributeValidator("googleInstanceListDescription", errors)
 
     helper.validateNotEmpty(description.instanceIds, "instanceIds")

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/AbandonAndDecrementGoogleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/AbandonAndDecrementGoogleServerGroupDescriptionValidatorSpec.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.AbandonAndDecrementGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.google.security.TestDefaults
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -60,7 +60,7 @@ class AbandonAndDecrementGoogleServerGroupDescriptionValidatorSpec extends Speci
                                                             instanceIds: INSTANCE_IDS,
                                                             accountName: ACCOUNT_NAME,
                                                             credentials: credentials)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -72,7 +72,7 @@ class AbandonAndDecrementGoogleServerGroupDescriptionValidatorSpec extends Speci
   void "invalid instanceIds fail validation"() {
     setup:
       def description = new AbandonAndDecrementGoogleServerGroupDescription(instanceIds: [""], serverGroupName: SERVER_GROUP_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -84,7 +84,7 @@ class AbandonAndDecrementGoogleServerGroupDescriptionValidatorSpec extends Speci
   void "null input fails validation"() {
     setup:
       def description = new AbandonAndDecrementGoogleServerGroupDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/BasicGoogleDeployDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/BasicGoogleDeployDescriptionValidatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleDisk
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -83,7 +83,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
                                                          region: region,
                                                          zone: zone,
                                                          accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -108,7 +108,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
                                                          instanceType: INSTANCE_TYPE,
                                                          zone: ZONE,
                                                          accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -128,7 +128,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
                                                          zone: ZONE,
                                                          tags: TAGS,
                                                          accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
      validator.validate([], description, errors)
@@ -148,7 +148,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
                                                          zone: ZONE,
                                                          tags: TAGS,
                                                          accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -169,7 +169,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
                                                          regional: true,
                                                          region: REGION,
                                                          accountName: ACCOUNT_NAME)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -190,7 +190,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
   void "invalid targetSize fails validation"() {
     setup:
       def description = new BasicGoogleDeployDescription(targetSize: -1)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -203,7 +203,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
   void "invalid capacity (min: #min, max: #max, desired: #desired) fails validation"() {
     setup:
       def description = new BasicGoogleDeployDescription(capacity: [min: min, max: max, desired: desired])
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def matchingCalls = 0
 
     when:
@@ -233,7 +233,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
 
   void "invalid disk sizeGb fails validation"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], new BasicGoogleDeployDescription(disks: [DISK_NO_SIZE]), errors)
@@ -274,7 +274,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
 
   void "missing disk type fails validation"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], new BasicGoogleDeployDescription(disks: [DISK_NO_TYPE]), errors)
@@ -285,7 +285,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
 
   void "invalid number of persistent disks fails validation"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], new BasicGoogleDeployDescription(disks: [DISK_LOCAL_SSD]), errors)
@@ -306,7 +306,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
 
   void "source image specified directly on boot persistent disk fails validation"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], new BasicGoogleDeployDescription(disks: [DISK_PD_STANDARD_WITH_SOURCE_IMAGE]), errors)
@@ -335,7 +335,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
 
   void "missing source image on non-boot persistent disk fails validation"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], new BasicGoogleDeployDescription(disks: [DISK_PD_STANDARD, DISK_PD_STANDARD_2]), errors)
@@ -370,7 +370,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
 
   void "invalid local ssd settings fails validation"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], new BasicGoogleDeployDescription(disks: [DISK_LOCAL_SSD_NO_AUTO_DELETE]), errors)
@@ -393,7 +393,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new BasicGoogleDeployDescription(regional: regional)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -417,7 +417,7 @@ class BasicGoogleDeployDescriptionValidatorSpec extends Specification {
 
   void "nonsensical autoscaling policy min, max or cooldown fails validation"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], new BasicGoogleDeployDescription(autoscalingPolicy: [minNumReplicas: -5]), errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CopyLastGoogleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CopyLastGoogleServerGroupDescriptionValidatorSpec.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -55,7 +55,7 @@ class CopyLastGoogleServerGroupDescriptionValidatorSpec extends Specification {
       def description = new BasicGoogleDeployDescription(source: [region: REGION,
                                                                   serverGroupName: ANCESTOR_SERVER_GROUP_NAME],
                                                          accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -75,7 +75,7 @@ class CopyLastGoogleServerGroupDescriptionValidatorSpec extends Specification {
                                                          source: [region: REGION,
                                                                   serverGroupName: ANCESTOR_SERVER_GROUP_NAME],
                                                          accountName: ACCOUNT_NAME)
-        def errors = Mock(Errors)
+        def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -87,7 +87,7 @@ class CopyLastGoogleServerGroupDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new BasicGoogleDeployDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CreateGoogleInstanceDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/CreateGoogleInstanceDescriptionValidatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.deploy.description.CreateGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleDisk
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -57,7 +57,7 @@ class CreateGoogleInstanceDescriptionValidatorSpec extends Specification {
                                                             disks: [DISK_PD_SSD, DISK_LOCAL_SSD],
                                                             zone: ZONE,
                                                             accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -69,7 +69,7 @@ class CreateGoogleInstanceDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new CreateGoogleInstanceDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleAutoscalingPolicyDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleAutoscalingPolicyDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class DeleteGoogleAutoscalingPolicyDescriptionValidatorSpec extends Specificatio
     def description = new DeleteGoogleAutoscalingPolicyDescription(serverGroupName: SERVER_GROUP_NAME,
       accountName: ACCOUNT_NAME,
       region: REGION)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -59,7 +59,7 @@ class DeleteGoogleAutoscalingPolicyDescriptionValidatorSpec extends Specificatio
   void "null input fails validation"() {
     setup:
     def description = new DeleteGoogleAutoscalingPolicyDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleLoadBalancerDescriptionValidatorSpec.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.model.loadbalancing.GoogleLoadBalancerType
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -52,7 +52,7 @@ class DeleteGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
           region: REGION,
           loadBalancerType: GoogleLoadBalancerType.NETWORK,
           accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -68,7 +68,7 @@ class DeleteGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
           region: REGION,
           loadBalancerType: GoogleLoadBalancerType.NETWORK,
           accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -85,7 +85,7 @@ class DeleteGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
           region: null,
           loadBalancerType: GoogleLoadBalancerType.NETWORK,
           accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -97,7 +97,7 @@ class DeleteGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new DeleteGoogleLoadBalancerDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleSecurityGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeleteGoogleSecurityGroupDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeleteGoogleSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -45,7 +45,7 @@ class DeleteGoogleSecurityGroupDescriptionValidatorSpec extends Specification {
     setup:
       def description = new DeleteGoogleSecurityGroupDescription(securityGroupName: SECURITY_GROUP_NAME,
                                                                  accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -57,7 +57,7 @@ class DeleteGoogleSecurityGroupDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new DeleteGoogleSecurityGroupDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeregisterInstancesFromGoogleLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DeregisterInstancesFromGoogleLoadBalancerDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DeregisterInstancesFromGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -50,7 +50,7 @@ class DeregisterInstancesFromGoogleLoadBalancerDescriptionValidatorSpec extends 
         instanceIds: INSTANCE_IDS,
         region: REGION,
         accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -62,7 +62,7 @@ class DeregisterInstancesFromGoogleLoadBalancerDescriptionValidatorSpec extends 
   void "null input fails validation"() {
     setup:
       def description = new DeregisterInstancesFromGoogleLoadBalancerDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DestroyGoogleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DestroyGoogleServerGroupDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.DestroyGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class DestroyGoogleServerGroupDescriptionValidatorSpec extends Specification {
       def description = new DestroyGoogleServerGroupDescription(serverGroupName: SERVER_GROUP_NAME,
                                                                 region: REGION,
                                                                 accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -59,7 +59,7 @@ class DestroyGoogleServerGroupDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new DestroyGoogleServerGroupDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DisableGoogleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/DisableGoogleServerGroupDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.EnableDisableGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class DisableGoogleServerGroupDescriptionValidatorSpec extends Specification {
       def description = new EnableDisableGoogleServerGroupDescription(serverGroupName: SERVER_GROUP_NAME,
                                                                       region: REGION,
                                                                       accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -59,7 +59,7 @@ class DisableGoogleServerGroupDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new EnableDisableGoogleServerGroupDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/EnableDisableGoogleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/EnableDisableGoogleServerGroupDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.EnableDisableGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class EnableDisableGoogleServerGroupDescriptionValidatorSpec extends Specificati
       def description = new EnableDisableGoogleServerGroupDescription(serverGroupName: SERVER_GROUP_NAME,
                                                                       region: REGION,
                                                                       accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -59,7 +59,7 @@ class EnableDisableGoogleServerGroupDescriptionValidatorSpec extends Specificati
   void "null input fails validation"() {
     setup:
       def description = new EnableDisableGoogleServerGroupDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/ModifyGoogleServerGroupInstanceTemplateDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/ModifyGoogleServerGroupInstanceTemplateDescriptionValidatorSpec.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.config.GoogleConfiguration
 import com.netflix.spinnaker.clouddriver.google.deploy.description.ModifyGoogleServerGroupInstanceTemplateDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -57,7 +57,7 @@ class ModifyGoogleServerGroupInstanceTemplateDescriptionValidatorSpec extends Sp
       def description = new ModifyGoogleServerGroupInstanceTemplateDescription(serverGroupName: SERVER_GROUP_NAME,
                                                                                region: REGION,
                                                                                accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -76,7 +76,7 @@ class ModifyGoogleServerGroupInstanceTemplateDescriptionValidatorSpec extends Sp
                                                                                tags: TAGS,
                                                                                network: NETWORK,
                                                                                accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -88,7 +88,7 @@ class ModifyGoogleServerGroupInstanceTemplateDescriptionValidatorSpec extends Sp
   void "null input fails validation"() {
     setup:
       def description = new ModifyGoogleServerGroupInstanceTemplateDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/RebootGoogleInstancesDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/RebootGoogleInstancesDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RebootGoogleInstancesDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class RebootGoogleInstancesDescriptionValidatorSpec extends Specification {
       def description = new RebootGoogleInstancesDescription(zone: ZONE,
                                                             instanceIds: INSTANCE_IDS,
                                                             accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -59,7 +59,7 @@ class RebootGoogleInstancesDescriptionValidatorSpec extends Specification {
   void "invalid instanceIds fail validation"() {
     setup:
       def description = new RebootGoogleInstancesDescription(instanceIds: [""])
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -71,7 +71,7 @@ class RebootGoogleInstancesDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new RebootGoogleInstancesDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/RegisterInstancesWithGoogleLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/RegisterInstancesWithGoogleLoadBalancerDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.RegisterInstancesWithGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -50,7 +50,7 @@ class RegisterInstancesWithGoogleLoadBalancerDescriptionValidatorSpec extends Sp
         instanceIds: INSTANCE_IDS,
         region: REGION,
         accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -62,7 +62,7 @@ class RegisterInstancesWithGoogleLoadBalancerDescriptionValidatorSpec extends Sp
   void "null input fails validation"() {
     setup:
       def description = new RegisterInstancesWithGoogleLoadBalancerDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/ResizeGoogleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/ResizeGoogleServerGroupDescriptionValidatorSpec.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.ResizeGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -50,7 +50,7 @@ class ResizeGoogleServerGroupDescriptionValidatorSpec extends Specification {
                                                                targetSize: TARGET_SIZE,
                                                                region: REGION,
                                                                accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -62,7 +62,7 @@ class ResizeGoogleServerGroupDescriptionValidatorSpec extends Specification {
   void "invalid targetSize fails validation"() {
     setup:
       def description = new ResizeGoogleServerGroupDescription(targetSize: -1)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -74,7 +74,7 @@ class ResizeGoogleServerGroupDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new ResizeGoogleServerGroupDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -92,7 +92,7 @@ class ResizeGoogleServerGroupDescriptionValidatorSpec extends Specification {
           region: REGION,
           accountName: ACCOUNT_NAME
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       // no description.capacity set.
@@ -128,7 +128,7 @@ class ResizeGoogleServerGroupDescriptionValidatorSpec extends Specification {
       def description = new UpsertGoogleAutoscalingPolicyDescription(serverGroupName: SERVER_GROUP_NAME,
                                                                      region: REGION,
                                                                      accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/SetStatefulDiskDescriptionValidatorTest.java
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/SetStatefulDiskDescriptionValidatorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidationErrors;
 import com.netflix.spinnaker.clouddriver.google.deploy.description.SetStatefulDiskDescription;
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
@@ -28,8 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.springframework.validation.BeanPropertyBindingResult;
-import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 
@@ -60,7 +59,7 @@ public class SetStatefulDiskDescriptionValidatorTest {
     description.setServerGroupName("testapp-v000");
     description.setDeviceName("testapp-v000-1");
 
-    Errors errors = new BeanPropertyBindingResult(description, "description");
+    DescriptionValidationErrors errors = new DescriptionValidationErrors(description);
 
     validator.validate(ImmutableList.of(), description, errors);
 
@@ -71,7 +70,7 @@ public class SetStatefulDiskDescriptionValidatorTest {
   public void testNoFields() {
     SetStatefulDiskDescription description = new SetStatefulDiskDescription();
 
-    Errors errors = new BeanPropertyBindingResult(description, "description");
+    DescriptionValidationErrors errors = new DescriptionValidationErrors(description);
 
     validator.validate(ImmutableList.of(), description, errors);
 
@@ -89,7 +88,7 @@ public class SetStatefulDiskDescriptionValidatorTest {
     description.setServerGroupName("testapp-v000");
     description.setDeviceName("testapp-v000-1");
 
-    Errors errors = new BeanPropertyBindingResult(description, "description");
+    DescriptionValidationErrors errors = new DescriptionValidationErrors(description);
 
     validator.validate(ImmutableList.of(), description, errors);
 

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/StandardGceAttributeValidatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BaseGoogleInstanceDescription
 import com.netflix.spinnaker.clouddriver.google.deploy.description.BasicGoogleDeployDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoHealingPolicy
@@ -26,7 +27,6 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -100,7 +100,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "generic non-empty ok"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def label = "testAttribute"
 
@@ -130,7 +130,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
   @Unroll
   void "expect non-empty ok with numeric values"() {
     setup:
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     def validator = new StandardGceAttributeValidator(DECORATOR, errors)
     def label = "testAttribute"
 
@@ -145,7 +145,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "expect non-empty to fail with empty"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def label = "testAttribute"
 
@@ -164,7 +164,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "nonNegativeInt ok if non-negative"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def label = "testAttribute"
 
@@ -186,7 +186,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "nonNegativeInt invalid if negative"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def label = "testAttribute"
 
@@ -199,7 +199,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid generic name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -216,7 +216,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
   void "invalid generic name"() {
     setup:
       def label = "label"
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -228,7 +228,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "validate simple account name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -239,7 +239,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "empty account name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -257,7 +257,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "unknown account name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -270,7 +270,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid server group name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -286,7 +286,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid server group name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -298,7 +298,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid region name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -309,7 +309,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid region name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -333,7 +333,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid zone name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -344,7 +344,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid zone name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -368,7 +368,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid network name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -384,7 +384,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid network name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -396,7 +396,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid image name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -417,7 +417,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid image name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -435,7 +435,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid image artifact"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def artifact = Artifact.ArtifactBuilder.newInstance().type("gce/image").build()
 
@@ -447,7 +447,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "missing image artifact"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -459,7 +459,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid image artifact type"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def artifact = Artifact.ArtifactBuilder.newInstance().type("github/file").build()
 
@@ -472,7 +472,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid instance name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -488,7 +488,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid instance name"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -500,7 +500,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid instance type"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -516,7 +516,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid instance type"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -528,7 +528,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid custom instance type"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -559,7 +559,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid custom instance type"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -608,7 +608,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid name list"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -629,7 +629,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid name list"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -647,7 +647,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "mixed valid/invalid name list"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -666,7 +666,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid instance ids"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -687,7 +687,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid instance ids"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -705,7 +705,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "mixed valid/invalid instance ids"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -724,7 +724,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid in range exclusive"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def label = "testAttribute"
 
@@ -738,7 +738,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid in range exclusive"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def label = "testAttribute"
 
@@ -752,7 +752,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid basic scaling policy"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
       def scalingPolicy = new GoogleAutoscalingPolicy(
         minNumReplicas: 1,
@@ -769,7 +769,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "valid complex scaling policy"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
       def scalingPolicy = new GoogleAutoscalingPolicy(
@@ -791,7 +791,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid autoscaler min, max or cooldown"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -827,7 +827,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid autoscaler loadBalancingUtilization or cpuUtilization"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -851,7 +851,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid autoscaler customMetricUtilizations" () {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -878,7 +878,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
   @Unroll
   void "valid autoHealer maxUnavailable with fixed=#fixed and percent=#percent"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:
@@ -903,7 +903,7 @@ class StandardGceAttributeValidatorSpec extends Specification {
 
   void "invalid autoHealer maxUnavailable"() {
     setup:
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
       def validator = new StandardGceAttributeValidator(DECORATOR, errors)
 
     when:

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/TerminateAndDecrementGoogleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/TerminateAndDecrementGoogleServerGroupDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.TerminateAndDecrementGoogleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class TerminateAndDecrementGoogleServerGroupDescriptionValidatorSpec extends Spe
     setup:
       def description = new TerminateAndDecrementGoogleServerGroupDescription(
           region: REGION, serverGroupName: SERVER_GROUP_NAME, instanceIds: INSTANCE_IDS, accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -59,7 +59,7 @@ class TerminateAndDecrementGoogleServerGroupDescriptionValidatorSpec extends Spe
   void "invalid instanceIds fail validation"() {
     setup:
       def description = new TerminateAndDecrementGoogleServerGroupDescription(instanceIds: [""], serverGroupName: SERVER_GROUP_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -71,7 +71,7 @@ class TerminateAndDecrementGoogleServerGroupDescriptionValidatorSpec extends Spe
   void "null input fails validation"() {
     setup:
       def description = new TerminateAndDecrementGoogleServerGroupDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/TerminateGoogleInstancesDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/TerminateGoogleInstancesDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.TerminateGoogleInstancesDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -49,7 +49,7 @@ class TerminateGoogleInstancesDescriptionValidatorSpec extends Specification {
       def description = new TerminateGoogleInstancesDescription(zone: ZONE,
                                                                 instanceIds: INSTANCE_IDS,
                                                                 accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -64,7 +64,7 @@ class TerminateGoogleInstancesDescriptionValidatorSpec extends Specification {
                                                                 serverGroupName: MANAGED_INSTANCE_GROUP_NAME,
                                                                 instanceIds: INSTANCE_IDS,
                                                                 accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -78,7 +78,7 @@ class TerminateGoogleInstancesDescriptionValidatorSpec extends Specification {
       def description = new TerminateGoogleInstancesDescription(serverGroupName: MANAGED_INSTANCE_GROUP_NAME,
                                                                 instanceIds: INSTANCE_IDS,
                                                                 accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -90,7 +90,7 @@ class TerminateGoogleInstancesDescriptionValidatorSpec extends Specification {
   void "fail validation without managed instance group and no zone"() {
     setup:
       def description = new TerminateGoogleInstancesDescription(instanceIds: INSTANCE_IDS, accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -102,7 +102,7 @@ class TerminateGoogleInstancesDescriptionValidatorSpec extends Specification {
   void "invalid instanceIds fail validation"() {
     setup:
       def description = new TerminateGoogleInstancesDescription(instanceIds: [""])
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -114,7 +114,7 @@ class TerminateGoogleInstancesDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new TerminateGoogleInstancesDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleAutoscalingPolicyDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleAutoscalingPolicyDescriptionValidatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleAutoscalingPolicyDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoHealingPolicy
 import com.netflix.spinnaker.clouddriver.google.model.GoogleAutoscalingPolicy
@@ -24,7 +25,6 @@ import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -76,7 +76,7 @@ class UpsertGoogleAutoscalingPolicyDescriptionValidatorSpec extends Specificatio
       autoscalingPolicy: GOOGLE_SCALING_POLICY,
       autoHealingPolicy: GOOGLE_AUTOHEALING_POLICY,
       accountName: ACCOUNT_NAME)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -91,7 +91,7 @@ class UpsertGoogleAutoscalingPolicyDescriptionValidatorSpec extends Specificatio
       region: REGION,
       serverGroupName: SERVER_GROUP_NAME,
       accountName: ACCOUNT_NAME)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -104,7 +104,7 @@ class UpsertGoogleAutoscalingPolicyDescriptionValidatorSpec extends Specificatio
   void "null input fails validation"() {
     setup:
     def description = new UpsertGoogleAutoscalingPolicyDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleImageTagsDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleImageTagsDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleImageTagsDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class UpsertGoogleImageTagsDescriptionValidatorSpec extends Specification {
       def description = new UpsertGoogleImageTagsDescription(imageName: IMAGE_NAME,
                                                              tags: TAGS,
                                                              accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -61,7 +61,7 @@ class UpsertGoogleImageTagsDescriptionValidatorSpec extends Specification {
       def description = new UpsertGoogleImageTagsDescription(imageName: IMAGE_NAME,
                                                              tags: [:],
                                                              accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -75,7 +75,7 @@ class UpsertGoogleImageTagsDescriptionValidatorSpec extends Specification {
       def description = new UpsertGoogleImageTagsDescription(imageName: IMAGE_NAME,
                                                              tags: TAGS + ['some-key-2': ''],
                                                              accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -88,7 +88,7 @@ class UpsertGoogleImageTagsDescriptionValidatorSpec extends Specification {
     setup:
       def description = new UpsertGoogleImageTagsDescription(imageName: IMAGE_NAME,
                                                              accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -102,7 +102,7 @@ class UpsertGoogleImageTagsDescriptionValidatorSpec extends Specification {
       def description = new UpsertGoogleImageTagsDescription(imageName: IMAGE_NAME,
                                                              tags: TAGS + ['': 'some-val-2'],
                                                              accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -114,7 +114,7 @@ class UpsertGoogleImageTagsDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new UpsertGoogleImageTagsDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleLoadBalancerDescriptionValidatorSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.converters.UpsertGoogleLoadBalancerAtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleLoadBalancerDescription
 import com.netflix.spinnaker.clouddriver.google.model.GoogleHealthCheck
@@ -25,7 +26,6 @@ import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -88,7 +88,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
           ipAddress: "1.1.1.1",
           ipProtocol: "TCP",
           portRange: "80-82")
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -105,7 +105,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
           region: REGION,
           accountName: ACCOUNT_NAME,
           instances: [INSTANCE])
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -133,7 +133,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
           ipAddress: "1.1.1.1",
           ipProtocol: "ABC",
           portRange: "80-82")
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -145,7 +145,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new UpsertGoogleLoadBalancerDescription(loadBalancerType: GoogleLoadBalancerType.NETWORK)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -199,7 +199,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ]
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -224,7 +224,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         "hostRules"       : null,
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -276,7 +276,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ]
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -329,7 +329,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ]
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -359,7 +359,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -379,7 +379,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         "backendService"  : null,
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -403,7 +403,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -427,7 +427,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -457,7 +457,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -481,7 +481,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -504,7 +504,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -523,7 +523,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         "backendService"  : null,
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -546,7 +546,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -569,7 +569,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -598,7 +598,7 @@ class UpsertGoogleLoadBalancerDescriptionValidatorSpec extends Specification {
         ],
       ]
       def description = converter.convertDescription(input)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleSecurityGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleSecurityGroupDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleSecurityGroupDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -65,7 +65,7 @@ class UpsertGoogleSecurityGroupDescriptionValidatorSpec extends Specification {
           targetTags: [TARGET_TAG],
           accountName: ACCOUNT_NAME
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -81,7 +81,7 @@ class UpsertGoogleSecurityGroupDescriptionValidatorSpec extends Specification {
           network: NETWORK_NAME,
           accountName: ACCOUNT_NAME
       )
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -93,7 +93,7 @@ class UpsertGoogleSecurityGroupDescriptionValidatorSpec extends Specification {
   void "null input fails validation"() {
     setup:
       def description = new UpsertGoogleSecurityGroupDescription(network: "")
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleServerGroupTagsDescriptionValidatorSpec.groovy
+++ b/clouddriver-google/src/test/groovy/com/netflix/spinnaker/clouddriver/google/deploy/validators/UpsertGoogleServerGroupTagsDescriptionValidatorSpec.groovy
@@ -16,12 +16,12 @@
 
 package com.netflix.spinnaker.clouddriver.google.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.google.deploy.description.UpsertGoogleServerGroupTagsDescription
 import com.netflix.spinnaker.clouddriver.google.security.FakeGoogleCredentials
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials
 import com.netflix.spinnaker.clouddriver.security.DefaultAccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -49,7 +49,7 @@ class UpsertGoogleServerGroupTagsDescriptionValidatorSpec extends Specification 
                                                                    region: REGION,
                                                                    tags: TAGS,
                                                                    accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -64,7 +64,7 @@ class UpsertGoogleServerGroupTagsDescriptionValidatorSpec extends Specification 
                                                                    region: REGION,
                                                                    tags: [],
                                                                    accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -79,7 +79,7 @@ class UpsertGoogleServerGroupTagsDescriptionValidatorSpec extends Specification 
                                                                    region: REGION,
                                                                    tags: null,
                                                                    accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -94,7 +94,7 @@ class UpsertGoogleServerGroupTagsDescriptionValidatorSpec extends Specification 
                                                                    region: REGION,
                                                                    tags: TAGS + "",
                                                                    accountName: ACCOUNT_NAME)
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)
@@ -106,7 +106,7 @@ class UpsertGoogleServerGroupTagsDescriptionValidatorSpec extends Specification 
   void "null input fails validation"() {
     setup:
       def description = new UpsertGoogleServerGroupTagsDescription()
-      def errors = Mock(Errors)
+      def errors = Mock(ValidationErrors)
 
     when:
       validator.validate([], description, errors)

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtil.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials;
@@ -30,14 +31,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.validation.Errors;
 
 @Slf4j
 public class KubernetesValidationUtil {
   private final String context;
-  private final Errors errors;
+  private final ValidationErrors errors;
 
-  public KubernetesValidationUtil(String context, Errors errors) {
+  public KubernetesValidationUtil(String context, ValidationErrors errors) {
     this.context = context;
     this.errors = errors;
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/artifact/KubernetesArtifactCleanupValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/artifact/KubernetesArtifactCleanupValidator.java
@@ -20,13 +20,13 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.artifact;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.CLEANUP_ARTIFACTS;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.artifact.KubernetesCleanupArtifactsDescription;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(CLEANUP_ARTIFACTS)
 @Component
@@ -36,5 +36,7 @@ public class KubernetesArtifactCleanupValidator
 
   @Override
   public void validate(
-      List priorDescriptions, KubernetesCleanupArtifactsDescription description, Errors errors) {}
+      List priorDescriptions,
+      KubernetesCleanupArtifactsDescription description,
+      ValidationErrors errors) {}
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeleteManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeleteManifestValidator.java
@@ -21,6 +21,7 @@ import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.D
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeleteManifestDescription;
@@ -29,7 +30,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(DELETE_MANIFEST)
 @Component
@@ -39,7 +39,9 @@ public class KubernetesDeleteManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions, KubernetesDeleteManifestDescription description, Errors errors) {
+      List priorDescriptions,
+      KubernetesDeleteManifestDescription description,
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("deleteKubernetesManifest", errors);
     List<KubernetesCoordinates> coordinates;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeployManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeployManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.DEPLOY_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
@@ -28,7 +29,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(DEPLOY_MANIFEST)
 @Component
@@ -38,7 +38,9 @@ public class KubernetesDeployManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions, KubernetesDeployManifestDescription description, Errors errors) {
+      List priorDescriptions,
+      KubernetesDeployManifestDescription description,
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("deployKubernetesManifest", errors);
     if (!util.validateNotEmpty("moniker", description)) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDisableManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDisableManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.DISABLE_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesEnableDisableManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(DISABLE_MANIFEST)
 @Component
@@ -39,7 +39,7 @@ public class KubernetesDisableManifestValidator
   public void validate(
       List priorDescriptions,
       KubernetesEnableDisableManifestDescription description,
-      Errors errors) {
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("disableKubernetesManifest", errors);
     if (!util.validateV2Credentials(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesEnableManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesEnableManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.ENABLE_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesEnableDisableManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(ENABLE_MANIFEST)
 @Component
@@ -39,7 +39,7 @@ public class KubernetesEnableManifestValidator
   public void validate(
       List priorDescriptions,
       KubernetesEnableDisableManifestDescription description,
-      Errors errors) {
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("enableKubernetesManifest", errors);
     if (!util.validateV2Credentials(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPatchManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPatchManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.PATCH_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesPatchManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(PATCH_MANIFEST)
 @Component
@@ -38,7 +38,9 @@ public class KubernetesPatchManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions, KubernetesPatchManifestDescription description, Errors errors) {
+      List priorDescriptions,
+      KubernetesPatchManifestDescription description,
+      ValidationErrors errors) {
     KubernetesValidationUtil util = new KubernetesValidationUtil("patchKubernetesManifest", errors);
 
     if (!util.validateNotEmpty("patchBody", description.getPatchBody())) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPauseRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPauseRolloutManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.PAUSE_ROLLOUT_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesPauseRolloutManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(PAUSE_ROLLOUT_MANIFEST)
 @Component
@@ -39,7 +39,7 @@ public class KubernetesPauseRolloutManifestValidator
   public void validate(
       List priorDescriptions,
       KubernetesPauseRolloutManifestDescription description,
-      Errors errors) {
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("pauseRolloutKubernetesManifest", errors);
     if (!util.validateV2Credentials(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesResumeRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesResumeRolloutManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.RESUME_ROLLOUT_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesResumeRolloutManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(RESUME_ROLLOUT_MANIFEST)
 @Component
@@ -39,7 +39,7 @@ public class KubernetesResumeRolloutManifestValidator
   public void validate(
       List priorDescriptions,
       KubernetesResumeRolloutManifestDescription description,
-      Errors errors) {
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("resumeRolloutKubernetesManifest", errors);
     if (!util.validateV2Credentials(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesRollingRestartManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesRollingRestartManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.ROLLING_RESTART_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesRollingRestartManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(ROLLING_RESTART_MANIFEST)
 @Component
@@ -44,7 +44,7 @@ public class KubernetesRollingRestartManifestValidator
   public void validate(
       List priorDescriptions,
       KubernetesRollingRestartManifestDescription description,
-      Errors errors) {
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("rollingRestartKubernetesManifest", errors);
     if (!util.validateV2Credentials(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesScaleManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesScaleManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.SCALE_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesScaleManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(SCALE_MANIFEST)
 @Component
@@ -37,7 +37,9 @@ public class KubernetesScaleManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions, KubernetesScaleManifestDescription description, Errors errors) {
+      List priorDescriptions,
+      KubernetesScaleManifestDescription description,
+      ValidationErrors errors) {
     KubernetesValidationUtil util = new KubernetesValidationUtil("scaleKubernetesManifest", errors);
     if (!util.validateV2Credentials(
         provider,

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesUndoRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesUndoRolloutManifestValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.manifest;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.UNDO_ROLLOUT_MANIFEST;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesUndoRolloutManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(UNDO_ROLLOUT_MANIFEST)
 @Component
@@ -37,7 +37,9 @@ public class KubernetesUndoRolloutManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions, KubernetesUndoRolloutManifestDescription description, Errors errors) {
+      List priorDescriptions,
+      KubernetesUndoRolloutManifestDescription description,
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("undoRolloutKubernetesManifest", errors);
     if (!util.validateV2Credentials(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/servergroup/KubernetesResizeServerGroupValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/servergroup/KubernetesResizeServerGroupValidator.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.validator.servergroup;
 import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.RESIZE_SERVER_GROUP;
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator;
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.servergroup.KubernetesResizeServerGroupDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.validator.KubernetesValidationUtil;
@@ -27,7 +28,6 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @KubernetesOperation(RESIZE_SERVER_GROUP)
 @Component
@@ -37,7 +37,9 @@ public class KubernetesResizeServerGroupValidator
 
   @Override
   public void validate(
-      List priorDescriptions, KubernetesResizeServerGroupDescription description, Errors errors) {
+      List priorDescriptions,
+      KubernetesResizeServerGroupDescription description,
+      ValidationErrors errors) {
     KubernetesValidationUtil util =
         new KubernetesValidationUtil("deployKubernetesManifest", errors);
     if (!util.validateV2Credentials(

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtilSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtilSpec.groovy
@@ -18,12 +18,12 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.validator
 
 import com.google.common.collect.ImmutableList
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import org.springframework.validation.Errors
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -33,7 +33,7 @@ class KubernetesValidationUtilSpec extends Specification {
   @Unroll
   void "wiring of kind/namespace validation"() {
     given:
-    Errors errors = Mock(Errors)
+    ValidationErrors errors = Mock(ValidationErrors)
     String kubernetesAccount = "testAccount"
     def namespaces = ImmutableList.of("test-namespace")
     def omitNamespaces = ImmutableList.of("omit-namespace")
@@ -70,7 +70,7 @@ class KubernetesValidationUtilSpec extends Specification {
   @Unroll
   void "validation of namespaces"() {
     given:
-    Errors errors = Mock(Errors)
+    ValidationErrors errors = Mock(ValidationErrors)
     KubernetesV2Credentials credentials = Mock(KubernetesV2Credentials)
     KubernetesValidationUtil kubernetesValidationUtil = new KubernetesValidationUtil("currentContext", errors);
 

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/BasicOracleDeployDescriptionValidator.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/BasicOracleDeployDescriptionValidator.groovy
@@ -9,19 +9,17 @@
 
 package com.netflix.spinnaker.clouddriver.oracle.deploy.validator
 
-import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.oracle.OracleOperation
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.BasicOracleDeployDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @OracleOperation(AtomicOperations.CREATE_SERVER_GROUP)
 @Component("basicOracleDeployDescriptionValidator")
 class BasicOracleDeployDescriptionValidator extends StandardOracleAttributeValidator<BasicOracleDeployDescription> {
 
   @Override
-  void validate(List priorDescriptions, BasicOracleDeployDescription description, Errors errors) {
+  void validate(List priorDescriptions, BasicOracleDeployDescription description, ValidationErrors errors) {
     context = "basicOracleDeployDescriptionValidator"
     validateNotEmptyString(errors, description.application, "application")
     if (description.loadBalancerId) {

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/DestroyOracleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/DestroyOracleServerGroupDescriptionValidator.groovy
@@ -13,14 +13,13 @@ import com.netflix.spinnaker.clouddriver.oracle.OracleOperation
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.DestroyOracleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @OracleOperation(AtomicOperations.DESTROY_SERVER_GROUP)
 @Component("destroyOracleServerGroupDescriptionValidator")
 class DestroyOracleServerGroupDescriptionValidator extends StandardOracleAttributeValidator<DestroyOracleServerGroupDescription> {
 
   @Override
-  void validate(List priorDescriptions, DestroyOracleServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, DestroyOracleServerGroupDescription description, ValidationErrors errors) {
     context = "destroyServerGroupDescription"
     validateNotEmptyString(errors, description.accountName, "accountName")
     validateNotEmptyString(errors, description.region, "region")

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/EnableDisableOracleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/EnableDisableOracleServerGroupDescriptionValidator.groovy
@@ -11,13 +11,12 @@ package com.netflix.spinnaker.clouddriver.oracle.deploy.validator
 
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.EnableDisableOracleServerGroupDescription
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component("enableDisableOracleServerGroupDescriptionValidator")
 class EnableDisableOracleServerGroupDescriptionValidator extends StandardOracleAttributeValidator<EnableDisableOracleServerGroupDescription> {
 
   @Override
-  void validate(List priorDescriptions, EnableDisableOracleServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableOracleServerGroupDescription description, ValidationErrors errors) {
     context = "enableDisableServerGroupDescription"
     validateNotEmptyString(errors, description.region, "region")
     validateNotEmptyString(errors, description.accountName, "accountName")

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/ResizeOracleServerGroupDescriptionValidator.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/ResizeOracleServerGroupDescriptionValidator.groovy
@@ -13,14 +13,13 @@ import com.netflix.spinnaker.clouddriver.oracle.OracleOperation
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.ResizeOracleServerGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @OracleOperation(AtomicOperations.RESIZE_SERVER_GROUP)
 @Component("resizeOracleServerGroupDescriptionValidator")
 class ResizeOracleServerGroupDescriptionValidator extends StandardOracleAttributeValidator<ResizeOracleServerGroupDescription> {
 
   @Override
-  void validate(List priorDescriptions, ResizeOracleServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, ResizeOracleServerGroupDescription description, ValidationErrors errors) {
     context = "resizeServerGroupDescription"
     validateNotEmptyString(errors, description.serverGroupName, "serverGroupName")
     validateNotEmptyString(errors, description.region, "region")

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/StandardOracleAttributeValidator.groovy
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/StandardOracleAttributeValidator.groovy
@@ -9,15 +9,13 @@
 
 package com.netflix.spinnaker.clouddriver.oracle.deploy.validator
 
-import org.springframework.validation.Errors
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
-import com.netflix.spinnaker.clouddriver.orchestration.VersionedCloudProviderOperation
 
 abstract class StandardOracleAttributeValidator<T> extends DescriptionValidator<T> {
 
   protected String context
 
-  def validateNotEmptyString(Errors errors, String value, String attribute) {
+  def validateNotEmptyString(ValidationErrors errors, String value, String attribute) {
     if (!value) {
       errors.rejectValue(attribute, "${context}.${attribute}.empty")
       return false
@@ -25,7 +23,7 @@ abstract class StandardOracleAttributeValidator<T> extends DescriptionValidator<
     return true
   }
 
-  def validateNonNegative(Errors errors, int value, String attribute) {
+  def validateNonNegative(ValidationErrors errors, int value, String attribute) {
     def result
     if (value >= 0) {
       result = true
@@ -36,7 +34,7 @@ abstract class StandardOracleAttributeValidator<T> extends DescriptionValidator<
     result
   }
 
-  def validatePositive(Errors errors, int value, String attribute) {
+  def validatePositive(ValidationErrors errors, int value, String attribute) {
     def result
     if (value > 0) {
       result = true
@@ -46,8 +44,8 @@ abstract class StandardOracleAttributeValidator<T> extends DescriptionValidator<
     }
     result
   }
-  
-  def validateCapacity(Errors errors, Integer min, Integer max, Integer desired) {
+
+  def validateCapacity(ValidationErrors errors, Integer min, Integer max, Integer desired) {
     if (min != null && max != null && min > max) {
       errors.rejectValue "capacity", "${context}.capacity.transposed",
         [min, max] as String[],
@@ -61,8 +59,8 @@ abstract class StandardOracleAttributeValidator<T> extends DescriptionValidator<
       }
     }
   }
-  
-  def validateLimit(Errors errors, String value, int limit, String attribute) {
+
+  def validateLimit(ValidationErrors errors, String value, int limit, String attribute) {
     if (!value) {
       errors.rejectValue(attribute, "${context}.${attribute}.empty")
       return false
@@ -72,7 +70,7 @@ abstract class StandardOracleAttributeValidator<T> extends DescriptionValidator<
     return true
   }
 
-  def validateNotNull(Errors errors, Object value, String attribute) {
+  def validateNotNull(ValidationErrors errors, Object value, String attribute) {
     if (!value) {
       errors.rejectValue(attribute, "${context}.${attribute}.null")
       return false

--- a/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/UpsertLoadBalancerDescriptionValidator.java
+++ b/clouddriver-oracle/src/main/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/UpsertLoadBalancerDescriptionValidator.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
 
 @OracleOperation(AtomicOperations.UPSERT_LOAD_BALANCER)
 @Component("upsertLoadBalancerDescriptionValidator")
@@ -28,7 +27,7 @@ class UpsertLoadBalancerDescriptionValidator
   @SuppressWarnings("rawtypes")
   @Override
   public void validate(
-      List priorDescriptions, UpsertLoadBalancerDescription description, Errors errors) {
+      List priorDescriptions, UpsertLoadBalancerDescription description, ValidationErrors errors) {
     context = "upsertLoadBalancerDescriptionValidator";
     validateNotEmptyString(errors, description.getApplication(), "application");
     if (description.getLoadBalancerId() == null) {

--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/BasicOracleDeployDescriptionValidatorSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/BasicOracleDeployDescriptionValidatorSpec.groovy
@@ -11,7 +11,6 @@ package com.netflix.spinnaker.clouddriver.oracle.deploy.validator
 
 import com.netflix.spinnaker.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.BasicOracleDeployDescription
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -26,7 +25,7 @@ class BasicOracleDeployDescriptionValidatorSpec extends Specification {
   void "invalid description fails validation"() {
     setup:
     def description = new BasicOracleDeployDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -49,7 +48,7 @@ class BasicOracleDeployDescriptionValidatorSpec extends Specification {
       application: "spinnaker-test-v000"
     )
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -70,7 +69,7 @@ class BasicOracleDeployDescriptionValidatorSpec extends Specification {
       capacity: new ServerGroup.Capacity(min: 3, max: 1)
     )
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -90,7 +89,7 @@ class BasicOracleDeployDescriptionValidatorSpec extends Specification {
       targetSize: -1
     )
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/DestroyOracleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/DestroyOracleServerGroupDescriptionValidatorSpec.groovy
@@ -9,7 +9,6 @@
 package com.netflix.spinnaker.clouddriver.oracle.deploy.validator
 
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.DestroyOracleServerGroupDescription
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -25,7 +24,7 @@ class DestroyOracleServerGroupDescriptionValidatorSpec extends Specification {
   void "invalid description fails validation"() {
     setup:
     def description = new DestroyOracleServerGroupDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -44,7 +43,7 @@ class DestroyOracleServerGroupDescriptionValidatorSpec extends Specification {
       serverGroupName: "my-group-01"
     )
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/EnableDisableOracleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/EnableDisableOracleServerGroupDescriptionValidatorSpec.groovy
@@ -9,7 +9,6 @@
 package com.netflix.spinnaker.clouddriver.oracle.deploy.validator
 
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.EnableDisableOracleServerGroupDescription
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -25,7 +24,7 @@ class EnableDisableOracleServerGroupDescriptionValidatorSpec extends Specificati
   void "invalid description fails validation"() {
     setup:
     def description = new EnableDisableOracleServerGroupDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -41,7 +40,7 @@ class EnableDisableOracleServerGroupDescriptionValidatorSpec extends Specificati
       region: "us-phoenix-1",
       accountName: "DEFAULT"
     )
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/ResizeOracleServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/ResizeOracleServerGroupDescriptionValidatorSpec.groovy
@@ -9,7 +9,6 @@
 package com.netflix.spinnaker.clouddriver.oracle.deploy.validator
 
 import com.netflix.spinnaker.clouddriver.oracle.deploy.description.ResizeOracleServerGroupDescription
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -24,7 +23,7 @@ class ResizeOracleServerGroupDescriptionValidatorSpec extends Specification {
   void "invalid description fails validation"() {
     setup:
     def description = new ResizeOracleServerGroupDescription()
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)
@@ -43,7 +42,7 @@ class ResizeOracleServerGroupDescriptionValidatorSpec extends Specification {
       accountName: "DEFAULT"
     )
 
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], description, errors)

--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/StandardOracleAttributeValidatorSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/StandardOracleAttributeValidatorSpec.groovy
@@ -9,21 +9,20 @@
 
 package com.netflix.spinnaker.clouddriver.oracle.deploy.validator
 
-import org.springframework.validation.Errors
 import spock.lang.Specification
 
 class StandardOracleAttributeValidatorSpec extends Specification {
 
   void "validateNotEmptyString ok"() {
     setup:
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
     def validator = new StandardOracleAttributeValidator() {
       @Override
-      void validate(List priorDescriptions, def description, Errors err) {
+      void validate(List priorDescriptions, def description, ValidationErrors err) {
         context = "standardOracleAttributeValidator"
       }
     }
-    
+
     when:
     validator.validateNotEmptyString(errors, "DEFAULT", "accountName")
     then:

--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/UpsertLoadBalancerDescriptionValidatorSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/validator/UpsertLoadBalancerDescriptionValidatorSpec.groovy
@@ -22,17 +22,16 @@ import com.oracle.bmc.loadbalancer.LoadBalancerClient
 import com.oracle.bmc.loadbalancer.model.CreateLoadBalancerDetails
 import com.oracle.bmc.loadbalancer.requests.CreateLoadBalancerRequest
 import com.oracle.bmc.loadbalancer.responses.CreateLoadBalancerResponse
-import org.springframework.validation.Errors
 import spock.lang.Shared
 import spock.lang.Specification
 
 class UpsertLoadBalancerDescriptionValidatorSpec extends Specification {
-  
+
   @Shared ObjectMapper mapper = new ObjectMapper()
   @Shared UpsertOracleLoadBalancerAtomicOperationConverter converter
   @Shared UpsertLoadBalancerDescriptionValidator validator
   @Shared String context = 'upsertLoadBalancerDescriptionValidator.'
-  
+
 
   def setupSpec() {
     this.converter = new UpsertOracleLoadBalancerAtomicOperationConverter(objectMapper: mapper)
@@ -45,17 +44,17 @@ class UpsertLoadBalancerDescriptionValidatorSpec extends Specification {
     setup:
     def req = read('createLoadBalancer_invalidCert.json')
     def desc = converter.convertDescription(req[0].upsertLoadBalancer)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], desc, errors)
 
     then:
-    2 * errors.rejectValue('certificate.privateKey', 
+    2 * errors.rejectValue('certificate.privateKey',
       context + 'certificate.privateKey.empty')
-    2 * errors.rejectValue('certificate.certificateName', 
+    2 * errors.rejectValue('certificate.certificateName',
       context + 'certificate.certificateName.empty')
-    1 * errors.rejectValue('certificate.publicCertificate', 
+    1 * errors.rejectValue('certificate.publicCertificate',
       context + 'certificate.publicCertificate.empty')
   }
 
@@ -63,41 +62,41 @@ class UpsertLoadBalancerDescriptionValidatorSpec extends Specification {
     setup:
     def req = read('createLoadBalancer_invalidListener.json')
     def desc = converter.convertDescription(req[0].upsertLoadBalancer)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], desc, errors)
 
     then:
-    3 * errors.rejectValue('listener.defaultBackendSetName', 
+    3 * errors.rejectValue('listener.defaultBackendSetName',
       context + 'listener.defaultBackendSetName.empty')
-    2 * errors.rejectValue('listener.protocol', 
+    2 * errors.rejectValue('listener.protocol',
       context + 'listener.protocol.empty')
-    1 * errors.rejectValue('listener.port', 
+    1 * errors.rejectValue('listener.port',
       context + 'listener.port.null')
   }
-  
+
   def "Create LoadBalancer with invalid BackendSet"() {
     setup:
     def req = read('createLoadBalancer_invalidBackendSet.json')
     def desc = converter.convertDescription(req[0].upsertLoadBalancer)
-    def errors = Mock(Errors)
+    def errors = Mock(ValidationErrors)
 
     when:
     validator.validate([], desc, errors)
 
     then:
-    2 * errors.rejectValue('backendSet.name', 
+    2 * errors.rejectValue('backendSet.name',
       context + 'backendSet.name.exceedsLimit')
-    1 * errors.rejectValue('backendSet.healthChecker', 
+    1 * errors.rejectValue('backendSet.healthChecker',
       context + 'backendSet.healthChecker.null')
-    1 * errors.rejectValue('backendSet.policy', 
+    1 * errors.rejectValue('backendSet.policy',
       context + 'backendSet.policy.empty')
-    1 * errors.rejectValue('backendSet.healthChecker.protocol', 
+    1 * errors.rejectValue('backendSet.healthChecker.protocol',
       context + 'backendSet.healthChecker.protocol.empty')
-    1 * errors.rejectValue('backendSet.healthChecker.urlPath', 
+    1 * errors.rejectValue('backendSet.healthChecker.urlPath',
       context + 'backendSet.healthChecker.urlPath.empty')
-    1 * errors.rejectValue('backendSet.healthChecker.port', 
+    1 * errors.rejectValue('backendSet.healthChecker.port',
       context + 'backendSet.healthChecker.port.null')
   }
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/AbstractTitusDescriptionValidatorSupport.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/AbstractTitusDescriptionValidatorSupport.groovy
@@ -17,11 +17,11 @@
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.AbstractTitusCredentialsDescription
-import org.springframework.validation.Errors
 
 abstract class AbstractTitusDescriptionValidatorSupport<T extends AbstractTitusCredentialsDescription> extends DescriptionValidator<T> {
 
@@ -34,7 +34,7 @@ abstract class AbstractTitusDescriptionValidatorSupport<T extends AbstractTitusC
   }
 
   @Override
-  void validate(List priorDescriptions, T description, Errors errors) {
+  void validate(List priorDescriptions, T description, ValidationErrors errors) {
     if (!description.credentials) {
       errors.rejectValue "credentials", "${descriptionName}.credentials.empty"
     } else {
@@ -50,11 +50,11 @@ abstract class AbstractTitusDescriptionValidatorSupport<T extends AbstractTitusC
   }
 
 
-  static <T> void validateRegion(T description, String regionName, String errorKey, Errors errors) {
+  static <T> void validateRegion(T description, String regionName, String errorKey, ValidationErrors errors) {
     validateRegions(description, regionName ? [regionName] : [], errorKey, errors, "region")
   }
 
-  static <T> void validateRegions(T description, Collection<String> regionNames, String errorKey, Errors errors, String attributeName = "regions") {
+  static <T> void validateRegions(T description, Collection<String> regionNames, String errorKey, ValidationErrors errors, String attributeName = "regions") {
     if (!regionNames) {
       errors.rejectValue(attributeName, "${errorKey}.${attributeName}.empty")
     } else {
@@ -65,14 +65,14 @@ abstract class AbstractTitusDescriptionValidatorSupport<T extends AbstractTitusC
     }
   }
 
-  static <T> void validateAsgName(T description, Errors errors) {
+  static <T> void validateAsgName(T description, ValidationErrors errors) {
     def key = description.getClass().simpleName
     if (!description.asgName) {
       errors.rejectValue("asgName", "${key}.asgName.empty")
     }
   }
 
-  static <T> void validateAsgNameAndRegionAndInstanceIds(T description, Errors errors) {
+  static <T> void validateAsgNameAndRegionAndInstanceIds(T description, ValidationErrors errors) {
     def key = description.class.simpleName
     if (description.asgName) {
       validateAsgName(description, errors)

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DestroyTitusJobDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DestroyTitusJobDescriptionValidator.groovy
@@ -17,13 +17,13 @@
  */
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation
 import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentials
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.DestroyTitusJobDescription
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @TitusOperation(AtomicOperations.DESTROY_JOB)
@@ -34,7 +34,7 @@ class DestroyTitusJobDescriptionValidator extends AbstractTitusDescriptionValida
   }
 
   @Override
-  void validate(List priorDescriptions, DestroyTitusJobDescription description, Errors errors) {
+  void validate(List priorDescriptions, DestroyTitusJobDescription description, ValidationErrors errors) {
     super.validate(priorDescriptions, description, errors)
 
     if (!description.region) {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DestroyTitusServerGroupDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DestroyTitusServerGroupDescriptionValidator.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentia
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.DestroyTitusServerGroupDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @TitusOperation(AtomicOperations.DESTROY_SERVER_GROUP)
@@ -35,7 +35,7 @@ class DestroyTitusServerGroupDescriptionValidator extends AbstractTitusDescripti
   }
 
   @Override
-  void validate(List priorDescriptions, DestroyTitusServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, DestroyTitusServerGroupDescription description, ValidationErrors errors) {
 
     super.validate(priorDescriptions, description, errors)
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DisableTitusInstancesInDiscoveryDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DisableTitusInstancesInDiscoveryDescriptionValidator.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.EnableDisableInstanceDiscoveryDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @TitusOperation(AtomicOperations.DISABLE_INSTANCES_IN_DISCOVERY)
@@ -35,7 +35,7 @@ class DisableTitusInstancesInDiscoveryDescriptionValidator
   }
 
   @Override
-  void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, ValidationErrors errors) {
     def key = description.class.simpleName
     validateAsgNameAndRegionAndInstanceIds(description, errors)
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DisableTitusServerGroupDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/DisableTitusServerGroupDescriptionValidator.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentia
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.EnableDisableServerGroupDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @TitusOperation(AtomicOperations.DISABLE_SERVER_GROUP)
@@ -35,7 +35,7 @@ class DisableTitusServerGroupDescriptionValidator extends AbstractTitusDescripti
   }
 
   @Override
-  void validate(List priorDescriptions, EnableDisableServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableServerGroupDescription description, ValidationErrors errors) {
 
     super.validate(priorDescriptions, description, errors)
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/EnableTitusInstancesInDiscoveryDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/EnableTitusInstancesInDiscoveryDescriptionValidator.groovy
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.EnableDisableInstanceDiscoveryDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @TitusOperation(AtomicOperations.ENABLE_INSTANCES_IN_DISCOVERY)
@@ -33,7 +33,7 @@ class EnableTitusInstancesInDiscoveryDescriptionValidator extends AbstractTitusD
     super(accountCredentialsProvider, "enableInstacesInDiscoveryDescription")
   }
 
-  void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, Errors errors) {
+  void validate(List priorDescriptions, EnableDisableInstanceDiscoveryDescription description, ValidationErrors errors) {
     def key = description.class.simpleName
     validateAsgNameAndRegionAndInstanceIds(description, errors)
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/ResizeTitusServerGroupDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/ResizeTitusServerGroupDescriptionValidator.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentia
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.ResizeTitusServerGroupDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @TitusOperation(AtomicOperations.RESIZE_SERVER_GROUP)
@@ -35,7 +35,7 @@ class ResizeTitusServerGroupDescriptionValidator extends AbstractTitusDescriptio
   }
 
   @Override
-  void validate(List priorDescriptions, ResizeTitusServerGroupDescription description, Errors errors) {
+  void validate(List priorDescriptions, ResizeTitusServerGroupDescription description, ValidationErrors errors) {
 
     super.validate(priorDescriptions, description, errors)
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/TerminateTitusInstancesDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/TerminateTitusInstancesDescriptionValidator.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentia
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.TerminateTitusInstancesDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @TitusOperation(AtomicOperations.TERMINATE_INSTANCES)
@@ -35,7 +35,7 @@ class TerminateTitusInstancesDescriptionValidator extends AbstractTitusDescripti
   }
 
   @Override
-  void validate(List priorDescriptions, TerminateTitusInstancesDescription description, Errors errors) {
+  void validate(List priorDescriptions, TerminateTitusInstancesDescription description, ValidationErrors errors) {
 
     super.validate(priorDescriptions, description, errors)
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/TitusDeployDescriptionValidator.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/validators/TitusDeployDescriptionValidator.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.titus.deploy.validators
 
+import com.netflix.spinnaker.clouddriver.deploy.ValidationErrors
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import com.netflix.spinnaker.clouddriver.titus.TitusOperation
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.titus.credentials.NetflixTitusCredentia
 import com.netflix.spinnaker.clouddriver.titus.deploy.description.TitusDeployDescription
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import org.springframework.validation.Errors
 
 @Component
 @TitusOperation(AtomicOperations.CREATE_SERVER_GROUP)
@@ -35,7 +35,7 @@ class TitusDeployDescriptionValidator extends AbstractTitusDescriptionValidatorS
   }
 
   @Override
-  void validate(List priorDescriptions, TitusDeployDescription description, Errors errors) {
+  void validate(List priorDescriptions, TitusDeployDescription description, ValidationErrors errors) {
 
     super.validate(priorDescriptions, description, errors)
 


### PR DESCRIPTION
This allows plugins to implement DescriptionValidators via clouddriver-api. Unfortunately Spring's Errors class is used in the contract of DescriptionValidator.validate() and we can't put that dependency in clouddriver-api.
This PR creates ValidationErrors which hides Errors from Spring. ValidationErrors is just an interface that defines the reject methods in Errors. DescriptionValidationErrors now implements ValidationErrors as well.
All existing validators had to get their validate method updated to use ValidationErrors instead of Errors. Some tests also needed minor changes. That is the bulk of the changes and they are all derivative changes. The core changes are in DescriptionValidator and DescriptionValidationErrors.