### PR TITLE
fix(provider/cf): getClusters NAMES_ONLY shouldn't fully hydrate

### DIFF
--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepository.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepository.java
@@ -105,7 +105,7 @@ public class CacheRepository {
     CloudFoundryCluster cluster =
         objectMapper.convertValue(
             clusterData.getAttributes().get("resource"), CloudFoundryCluster.class);
-    if (detail.equals(Detail.NONE)) {
+    if (detail.equals(Detail.NONE) || detail.equals(Detail.NAMES_ONLY)) {
       return cluster.withServerGroups(emptySet());
     }
     return cluster.withServerGroups(

--- a/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
+++ b/clouddriver-cloudfoundry/src/test/java/com/netflix/spinnaker/clouddriver/cloudfoundry/cache/CacheRepositoryTest.java
@@ -157,14 +157,7 @@ class CacheRepositoryTest {
             });
 
     assertThat(repo.findClusterByKey(clusterKey, NAMES_ONLY))
-        .hasValueSatisfying(
-            cluster ->
-                assertThat(cluster.getServerGroups())
-                    .hasOnlyOneElementSatisfying(
-                        serverGroup -> {
-                          assertThat(serverGroup.getLoadBalancers()).isEmpty();
-                          assertThat(serverGroup.getInstances()).isNotEmpty();
-                        }));
+        .hasValueSatisfying(cluster -> assertThat(cluster.getServerGroups()).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
This fix should help improve the latency of /projects/{project}/clusters within CloudFoundry. Since each of the clusters will get fully hydrated with subsequent calls, there is no need to fully hydrate before hand without changing the existing core logic. 