### PR TITLE
fix(aws): Skip AMI Sharing and Tag Syncing if Owner is not Managed by…

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
@@ -94,12 +94,12 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
     }
 
     if (amiLocation == ResolvedAmiLocation.TARGET && !ownerCredentials) {
-      task.updateStatus BASE_PHASE, "AMI found in target account and owner not managed: skipping allow launch and tag syncing"
+      task.updateStatus BASE_PHASE, "AMI found in target account, but the AMI owner account is unmanaged: skipping allow launch and tag syncing"
       return resolvedAmi
     }
 
     if (amiLocation == ResolvedAmiLocation.SOURCE && !ownerCredentials) {
-      task.updateStatus BASE_PHASE, "AMI found in source account but owner is not managed, unable to share AMI"
+      task.updateStatus BASE_PHASE, "AMI found in source account, but the owner account is unmanaged: unable to share AMI"
       throw new IllegalArgumentException("Unable to find owner of resolved AMI $resolvedAmi")
     }
 

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/AllowLaunchAtomicOperation.groovy
@@ -77,18 +77,30 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
       return resolvedAmi
     }
 
-    // If the AMI was created/owned by a different account, switch to using that for modifying the image
+    def ownerCredentials = sourceCredentials
+    def ownerAmazonEC2 = sourceAmazonEC2
+    // If the AMI was created/owned by a different account that is also managed by
+    // Spinnaker, switch to using that for modifying the image
     if (resolvedAmi.ownerId != sourceCredentials.accountId) {
       if (resolvedAmi.getRegion()) {
-        sourceCredentials = accountCredentialsProvider.all.find { accountCredentials ->
+        ownerCredentials = accountCredentialsProvider.all.find { accountCredentials ->
           accountCredentials instanceof NetflixAmazonCredentials &&
             ((AmazonCredentials) accountCredentials).accountId == resolvedAmi.ownerId
         } as NetflixAmazonCredentials
       }
-      if (!sourceCredentials) {
-        throw new IllegalArgumentException("Unable to find owner of resolved AMI $resolvedAmi")
+      if (ownerCredentials) {
+        ownerAmazonEC2 = amazonClientProvider.getAmazonEC2(ownerCredentials, description.region, true)
       }
-      sourceAmazonEC2 = amazonClientProvider.getAmazonEC2(sourceCredentials, description.region, true)
+    }
+
+    if (amiLocation == ResolvedAmiLocation.TARGET && !ownerCredentials) {
+      task.updateStatus BASE_PHASE, "AMI found in target account and owner not managed: skipping allow launch and tag syncing"
+      return resolvedAmi
+    }
+
+    if (amiLocation == ResolvedAmiLocation.SOURCE && !ownerCredentials) {
+      task.updateStatus BASE_PHASE, "AMI found in source account but owner is not managed, unable to share AMI"
+      throw new IllegalArgumentException("Unable to find owner of resolved AMI $resolvedAmi")
     }
 
     if (amiLocation == ResolvedAmiLocation.TARGET) {
@@ -97,22 +109,22 @@ class AllowLaunchAtomicOperation implements AtomicOperation<ResolvedAmiResult> {
       task.updateStatus BASE_PHASE, "Allowing launch of $description.amiName from $description.account/$description.region to $description.targetAccount"
 
       OperationPoller.retryWithBackoff({ o ->
-        sourceAmazonEC2.modifyImageAttribute(new ModifyImageAttributeRequest().withImageId(resolvedAmi.amiId).withLaunchPermission(
-          new LaunchPermissionModifications().withAdd(new LaunchPermission().withUserId(targetCredentials.accountId))))
-      }, 500, 3)
+          ownerAmazonEC2.modifyImageAttribute(new ModifyImageAttributeRequest().withImageId(resolvedAmi.amiId).withLaunchPermission(
+            new LaunchPermissionModifications().withAdd(new LaunchPermission().withUserId(targetCredentials.accountId))))
+        }, 500, 3)
     }
 
-    if (sourceCredentials == targetCredentials) {
+    if (ownerCredentials == targetCredentials) {
       task.updateStatus BASE_PHASE, "Tag replication not required"
     } else {
       def request = new DescribeTagsRequest().withFilters(new Filter("resource-id").withValues(resolvedAmi.amiId))
       Closure<Set<Tag>> getTags = { DescribeTagsRequest req, TagsRetriever ret ->
         new HashSet<Tag>(ret.retrieve(req).collect { new Tag(it.key, it.value) })
       }.curry(request)
-      Set<Tag> sourceTags = getTags(new TagsRetriever(sourceAmazonEC2))
+      Set<Tag> sourceTags = getTags(new TagsRetriever(ownerAmazonEC2))
       if (sourceTags.isEmpty()) {
         Thread.sleep(200)
-        sourceTags = getTags(new TagsRetriever(sourceAmazonEC2))
+        sourceTags = getTags(new TagsRetriever(ownerAmazonEC2))
       }
       if (sourceTags.isEmpty()) {
         task.updateStatus BASE_PHASE, "WARNING: empty tag set returned from DescribeTags, skipping tag sync"


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5920

This changes `AllowLaunchAtomicOperation` which is used to ensure AMI is shared with the target account so that it can be launched.

I this PR there are three accounts to consider

1. Source Account: Clouddriver managing account
2. Target Account: Clouddriver managed account
3. Owner Account: Owner of the AMI

**Previously**, when the credentials of the Owner account is not found, it will throw an exception and fail the task.
However, it is possible that that Owner AMI is not managed by Spinnaker and I believe we should not fail on such cases.

**Now**, if the owner account is not managed by Spinnaker, it will skip both image sharing & tag syncing. If the image can be resolved in target account, sharing is skipped (this is current behavior). Tag syncing will also need because without the owner's credentials, neither of the accounts assumed to have the permission to read the original AMI's tags.

It will still throw an exception if the AMI is found in the source account but we cannot find the owner credentials to share it to the target account.

Credit to @mfreebairn-r7  for analyzing the root cause of the problem.