### PR TITLE
test(kubernetes): Add integration tests on caching views

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/GlobalKubernetesKindRegistry.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/GlobalKubernetesKindRegistry.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @NonnullByDefault
-final class GlobalKubernetesKindRegistry {
+public final class GlobalKubernetesKindRegistry {
   private final ImmutableMap<KubernetesKind, KubernetesKindProperties> nameMap;
 
   /**
@@ -44,7 +44,7 @@ final class GlobalKubernetesKindRegistry {
    * KubernetesKindProperties}.
    */
   @Autowired
-  GlobalKubernetesKindRegistry() {
+  public GlobalKubernetesKindRegistry() {
     this(KubernetesKindProperties.getGlobalKindProperties());
   }
 
@@ -52,7 +52,7 @@ final class GlobalKubernetesKindRegistry {
    * Creates a {@link GlobalKubernetesKindRegistry} populated with the supplied {@link
    * KubernetesKindProperties}.
    */
-  GlobalKubernetesKindRegistry(Iterable<KubernetesKindProperties> kubernetesKindProperties) {
+  public GlobalKubernetesKindRegistry(Iterable<KubernetesKindProperties> kubernetesKindProperties) {
     this.nameMap =
         StreamSupport.stream(kubernetesKindProperties.spliterator(), false)
             .collect(toImmutableMap(KubernetesKindProperties::getKubernetesKind, p -> p));

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesKindRegistry.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesKindRegistry.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
 @NonnullByDefault
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
-final class KubernetesKindRegistry {
+public final class KubernetesKindRegistry {
   private final Map<KubernetesKind, KubernetesKindProperties> kindMap = new ConcurrentHashMap<>();
   private final GlobalKubernetesKindRegistry globalKindRegistry;
   private final Function<KubernetesKind, Optional<KubernetesKindProperties>> crdLookup;
@@ -109,7 +109,7 @@ final class KubernetesKindRegistry {
   public static class Factory {
     private final GlobalKubernetesKindRegistry globalKindRegistry;
 
-    Factory(GlobalKubernetesKindRegistry globalKindRegistry) {
+    public Factory(GlobalKubernetesKindRegistry globalKindRegistry) {
       this.globalKindRegistry = globalKindRegistry;
     }
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -1,0 +1,1117 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.cats.mem.InMemoryNamedCacheFactory;
+import com.netflix.spinnaker.cats.provider.DefaultProviderRegistry;
+import com.netflix.spinnaker.cats.provider.ProviderRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesV2Provider;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesV2CachingAgentDispatcher;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Application;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Cluster;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Instance;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2LoadBalancer;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroup;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroupManager;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.AccountResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestNamer;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesDeploymentHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesPodHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesReplicaSetHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesServiceHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesUnregisteredCustomResourceHandler;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.ManifestFetcher;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubectlJobExecutor;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.GlobalKubernetesKindRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesKindRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesSelectorList;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials;
+import com.netflix.spinnaker.clouddriver.model.Application;
+import com.netflix.spinnaker.clouddriver.model.HealthState;
+import com.netflix.spinnaker.clouddriver.model.Instance;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider.Details;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
+import com.netflix.spinnaker.clouddriver.model.ServerGroupManager.ServerGroupManagerSummary;
+import com.netflix.spinnaker.clouddriver.model.ServerGroupSummary;
+import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
+import com.netflix.spinnaker.clouddriver.search.SearchResultSet;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository;
+import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
+import com.netflix.spinnaker.kork.configserver.ConfigFileService;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.mockito.internal.stubbing.defaultanswers.ReturnsSmartNulls;
+
+@ExtendWith(SoftAssertionsExtension.class)
+@RunWith(JUnitPlatform.class)
+final class KubernetesDataProviderIntegrationTest {
+  private static final String ACCOUNT_NAME = "my-account";
+  private static final Registry registry = new NoopRegistry();
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final KubernetesV2Provider kubernetesV2Provider = new KubernetesV2Provider();
+  private static final KubernetesV2CachingAgentDispatcher dispatcher =
+      new KubernetesV2CachingAgentDispatcher(objectMapper, registry);
+  private static final ImmutableList<KubernetesHandler> handlers =
+      ImmutableList.of(
+          new KubernetesDeploymentHandler(),
+          new KubernetesReplicaSetHandler(),
+          new KubernetesServiceHandler(),
+          new KubernetesPodHandler());
+  private static final KubernetesSpinnakerKindMap kindMap =
+      new KubernetesSpinnakerKindMap(handlers);
+  private static final GlobalResourcePropertyRegistry resourcePropertyRegistry =
+      new GlobalResourcePropertyRegistry(
+          handlers, new KubernetesUnregisteredCustomResourceHandler());
+  private static final AccountCredentialsRepository credentialsRepository =
+      new MapBackedAccountCredentialsRepository();
+  private static final KubernetesAccountResolver accountResolver =
+      new KubernetesAccountResolver(credentialsRepository, resourcePropertyRegistry);
+  private static final ProviderRegistry providerRegistry =
+      new DefaultProviderRegistry(
+          ImmutableList.of(kubernetesV2Provider), new InMemoryNamedCacheFactory());
+  private static final KubernetesCacheUtils cacheUtils =
+      new KubernetesCacheUtils(
+          providerRegistry.getProviderCache(kubernetesV2Provider.getProviderName()),
+          kindMap,
+          accountResolver);
+  private static final ImmutableSetMultimap<String, String> manifestsByNamespace =
+      ImmutableSetMultimap.<String, String>builder()
+          .putAll(
+              "backend-ns",
+              ImmutableSet.of(
+                  "backend-service.yml",
+                  "backend-rs-014.yml",
+                  "backend-pod-014.yml",
+                  "backend-rs-015.yml",
+                  "backend-pod-015.yml"))
+          .putAll(
+              "frontend-ns",
+              ImmutableSet.of(
+                  "frontend-service.yml",
+                  "frontend-deployment.yml",
+                  "frontend-rs-old.yml",
+                  "frontend-rs-new.yml",
+                  "frontend-pod-1.yml",
+                  "frontend-pod-2.yml"))
+          .build();
+
+  private static KubernetesV2ApplicationProvider applicationProvider =
+      new KubernetesV2ApplicationProvider(cacheUtils);
+  private static KubernetesV2ClusterProvider clusterProvider =
+      new KubernetesV2ClusterProvider(cacheUtils, kindMap);
+  private static KubernetesV2InstanceProvider instanceProvider =
+      new KubernetesV2InstanceProvider(cacheUtils, accountResolver);
+  private static KubernetesV2LoadBalancerProvider loadBalancerProvider =
+      new KubernetesV2LoadBalancerProvider(cacheUtils, kindMap);
+  private static KubernetesV2SearchProvider searchProvider =
+      new KubernetesV2SearchProvider(cacheUtils, kindMap, objectMapper, accountResolver);
+  private static KubernetesV2ServerGroupManagerProvider serverGroupManagerProvider =
+      new KubernetesV2ServerGroupManagerProvider(cacheUtils);
+
+  @BeforeAll
+  static void prepareCache() {
+    KubernetesNamedAccountCredentials<KubernetesV2Credentials> credentials =
+        getNamedAccountCredentials();
+    credentialsRepository.save(credentials.getName(), credentials);
+    dispatcher
+        .buildAllCachingAgents(credentials)
+        .forEach(agent -> agent.getAgentExecution(providerRegistry).executeAgent(agent));
+  }
+
+  @Test
+  void getClusters(SoftAssertions softly) {
+    Map<String, Set<KubernetesV2Cluster>> results = clusterProvider.getClusters();
+    assertThat(results).hasSize(1);
+    assertThat(results).containsKey(ACCOUNT_NAME);
+
+    Set<KubernetesV2Cluster> clusters = results.get(ACCOUNT_NAME);
+    assertThat(clusters).hasSize(4);
+
+    // TODO(ezimanyi): I don't think it's correct that we are returning services/load balancers as
+    // clusters. I believe that they are just being ignored by deck, and should be removed from
+    // the result of this call (likely with performance benefits). In any case, as seen in the
+    // assertions below, these load balancer clusters are not well formed and don't map to any
+    // server groups.
+    assertThat(clusters)
+        .extracting(KubernetesV2Cluster::getName)
+        .containsExactlyInAnyOrder(
+            "service frontend", "deployment frontend", "service backendlb", "replicaSet backend");
+
+    Map<String, KubernetesV2Cluster> clusterLookup =
+        clusters.stream().collect(toImmutableMap(KubernetesV2Cluster::getName, c -> c));
+
+    assertFrontendServiceCluster(softly, clusterLookup.get("service frontend"));
+    assertFrontendCluster(softly, clusterLookup.get("deployment frontend"), false);
+    assertBackendServiceCluster(softly, clusterLookup.get("service backendlb"));
+    assertBackendCluster(softly, clusterLookup.get("replicaSet backend"), false);
+  }
+
+  @Test
+  void getClustersForApplication(SoftAssertions softly) {
+    Map<String, Set<KubernetesV2Cluster>> results = clusterProvider.getClusterDetails("backendapp");
+    assertThat(results).hasSize(1);
+    assertThat(results).containsKey(ACCOUNT_NAME);
+
+    Set<KubernetesV2Cluster> clusters = results.get(ACCOUNT_NAME);
+    assertThat(clusters).hasSize(2);
+
+    assertThat(clusters)
+        .extracting(KubernetesV2Cluster::getName)
+        .containsExactlyInAnyOrder("service backendlb", "replicaSet backend");
+
+    Map<String, KubernetesV2Cluster> clusterLookup =
+        clusters.stream().collect(toImmutableMap(KubernetesV2Cluster::getName, c -> c));
+
+    assertBackendServiceCluster(softly, clusterLookup.get("service backendlb"));
+    assertBackendCluster(softly, clusterLookup.get("replicaSet backend"), false);
+  }
+
+  @Test
+  void getClustersForApplicationAndAccount(SoftAssertions softly) {
+    Set<KubernetesV2Cluster> clusters = clusterProvider.getClusters("backendapp", ACCOUNT_NAME);
+    assertThat(clusters).hasSize(2);
+
+    assertThat(clusters)
+        .extracting(KubernetesV2Cluster::getName)
+        .containsExactlyInAnyOrder("service backendlb", "replicaSet backend");
+
+    Map<String, KubernetesV2Cluster> clusterLookup =
+        clusters.stream().collect(toImmutableMap(KubernetesV2Cluster::getName, c -> c));
+
+    assertBackendServiceCluster(softly, clusterLookup.get("service backendlb"));
+    assertBackendCluster(softly, clusterLookup.get("replicaSet backend"), false);
+  }
+
+  @Test
+  void getClustersForApplicationAndWrongAccount(SoftAssertions softly) {
+    Set<KubernetesV2Cluster> clusters = clusterProvider.getClusters("backendapp", "non-existent");
+    assertThat(clusters).hasSize(0);
+  }
+
+  @Test
+  void getSingleCluster(SoftAssertions softly) {
+    KubernetesV2Cluster cluster =
+        clusterProvider.getCluster("frontendapp", ACCOUNT_NAME, "deployment frontend");
+    assertThat(cluster).isNotNull();
+    assertFrontendCluster(softly, cluster, false);
+  }
+
+  @Test
+  void getSingleClusterWithDetails(SoftAssertions softly) {
+    KubernetesV2Cluster cluster =
+        clusterProvider.getCluster("frontendapp", ACCOUNT_NAME, "deployment frontend", true);
+    assertThat(cluster).isNotNull();
+    assertFrontendCluster(softly, cluster, false);
+  }
+
+  @Test
+  void getSingleClusterWrongApp(SoftAssertions softly) {
+    KubernetesV2Cluster cluster =
+        clusterProvider.getCluster("backendapp", ACCOUNT_NAME, "deployment frontend");
+    assertThat(cluster).isNull();
+  }
+
+  @Test
+  void getClusterSummaries(SoftAssertions softly) {
+    Map<String, Set<KubernetesV2Cluster>> results =
+        clusterProvider.getClusterSummaries("backendapp");
+    assertThat(results).hasSize(1);
+    assertThat(results).containsKey(ACCOUNT_NAME);
+
+    Set<KubernetesV2Cluster> clusters = results.get(ACCOUNT_NAME);
+    assertThat(clusters).hasSize(2);
+
+    assertThat(clusters)
+        .extracting(KubernetesV2Cluster::getName)
+        .containsExactlyInAnyOrder("service backendlb", "replicaSet backend");
+
+    Map<String, KubernetesV2Cluster> clusterLookup =
+        clusters.stream().collect(toImmutableMap(KubernetesV2Cluster::getName, c -> c));
+
+    assertBackendServiceCluster(softly, clusterLookup.get("service backendlb"));
+    assertBackendCluster(softly, clusterLookup.get("replicaSet backend"), true);
+  }
+
+  @Test
+  void getServerGroup(SoftAssertions softly) {
+    KubernetesV2ServerGroup serverGroup =
+        clusterProvider.getServerGroup(ACCOUNT_NAME, "backend-ns", "replicaSet backend-v014");
+    assertThat(serverGroup).isNotNull();
+    assertBackendPriorServerGroup(softly, serverGroup);
+  }
+
+  @Test
+  void getServerGroupWrongNamespace(SoftAssertions softly) {
+    KubernetesV2ServerGroup serverGroup =
+        clusterProvider.getServerGroup(ACCOUNT_NAME, "frontend-ns", "replicaSet backend-v014");
+    assertThat(serverGroup).isNull();
+  }
+
+  @Test
+  void getServerGroupWithDetails(SoftAssertions softly) {
+    KubernetesV2ServerGroup serverGroup =
+        clusterProvider.getServerGroup(ACCOUNT_NAME, "backend-ns", "replicaSet backend-v014", true);
+    assertThat(serverGroup).isNotNull();
+    assertBackendPriorServerGroup(softly, serverGroup);
+  }
+
+  @Test
+  void getServerGroupWithoutDetails(SoftAssertions softly) {
+    KubernetesV2ServerGroup serverGroup =
+        clusterProvider.getServerGroup(
+            ACCOUNT_NAME, "backend-ns", "replicaSet backend-v014", false);
+    assertThat(serverGroup).isNotNull();
+    // Looks like we ignore the includeDetails flag, so this is the same serverGroup as when we do
+    // include details.
+    assertBackendPriorServerGroup(softly, serverGroup);
+  }
+
+  @Test
+  void getApplicationsUnexpanded(SoftAssertions softly) {
+    Set<? extends Application> result = applicationProvider.getApplications(false);
+    softly.assertThat(result).hasSize(2);
+
+    Map<String, KubernetesV2Application> applicationLookup =
+        result.stream()
+            .collect(toImmutableMap(Application::getName, a -> (KubernetesV2Application) a));
+
+    KubernetesV2Application frontendApplication = applicationLookup.get("frontendapp");
+    softly.assertThat(frontendApplication).isNotNull();
+    if (frontendApplication != null) {
+      assertFrontendApplication(softly, frontendApplication);
+    }
+
+    KubernetesV2Application backendApplication = applicationLookup.get("backendapp");
+    softly.assertThat(frontendApplication).isNotNull();
+    if (frontendApplication != null) {
+      assertBackendApplication(softly, backendApplication);
+    }
+  }
+
+  @Test
+  void getApplicationsExpanded(SoftAssertions softly) {
+    // This is the same as the unexpanded test, as it seems like we ignore the flag.
+    Set<? extends Application> result = applicationProvider.getApplications(true);
+    softly.assertThat(result).hasSize(2);
+
+    Map<String, KubernetesV2Application> applicationLookup =
+        result.stream()
+            .collect(toImmutableMap(Application::getName, a -> (KubernetesV2Application) a));
+
+    KubernetesV2Application frontendApplication = applicationLookup.get("frontendapp");
+    softly.assertThat(frontendApplication).isNotNull();
+    if (frontendApplication != null) {
+      assertFrontendApplication(softly, frontendApplication);
+    }
+
+    KubernetesV2Application backendApplication = applicationLookup.get("backendapp");
+    softly.assertThat(frontendApplication).isNotNull();
+    if (frontendApplication != null) {
+      assertBackendApplication(softly, backendApplication);
+    }
+  }
+
+  @Test
+  void getApplication(SoftAssertions softly) {
+    KubernetesV2Application result =
+        (KubernetesV2Application) applicationProvider.getApplication("backendapp");
+    assertThat(result).isNotNull();
+    assertBackendApplication(softly, result);
+  }
+
+  @Test
+  void getInstance(SoftAssertions softly) {
+    KubernetesV2Instance result =
+        instanceProvider.getInstance(ACCOUNT_NAME, "backend-ns", "pod backend-v015-vhglj");
+    assertThat(result).isNotNull();
+    assertBackendCurrentServerGroupInstance(softly, result);
+  }
+
+  @Test
+  void getServerGroupManagers(SoftAssertions softly) {
+    Set<KubernetesV2ServerGroupManager> results =
+        serverGroupManagerProvider.getServerGroupManagersByApplication("frontendapp");
+    assertThat(results).hasSize(1);
+    if (!results.isEmpty()) {
+      assertFrontEndServerGroupManager(softly, results.iterator().next());
+    }
+  }
+
+  @Test
+  void getApplicationLoadBalancers(SoftAssertions softly) {
+    Set<KubernetesV2LoadBalancer> results =
+        loadBalancerProvider.getApplicationLoadBalancers("frontendapp");
+    assertThat(results).hasSize(1);
+    assertFrontendLoadBalancer(softly, results.iterator().next());
+  }
+
+  @Test
+  void getLoadBalancersByName(SoftAssertions softly) {
+    List<Details> results =
+        loadBalancerProvider.byAccountAndRegionAndName(
+            ACCOUNT_NAME, "frontend-ns", "service frontend");
+    // TODO(ezimanyi): This is a bug; we are not properly looking up the load balancer, so always
+    // return null
+    assertThat(results).isNull();
+  }
+
+  @Test
+  void searchBackendReplicaSet(SoftAssertions softly) {
+    SearchResultSet resultSet = searchProvider.search("backend-v014", 1, 100);
+
+    softly.assertThat(resultSet.getQuery()).isEqualTo("backend-v014");
+    softly.assertThat(resultSet.getTotalMatches()).isEqualTo(2);
+
+    List<Map<String, Object>> results = resultSet.getResults();
+    softly.assertThat(results).hasSize(2);
+
+    Optional<Map<String, Object>> optionalRs =
+        results.stream().filter(r -> r.get("name").equals("replicaSet backend-v014")).findFirst();
+    softly.assertThat(optionalRs).isPresent();
+    optionalRs.ifPresent(
+        rs ->
+            softly
+                .assertThat(rs)
+                .containsAllEntriesOf(
+                    ImmutableMap.<String, String>builder()
+                        .put("account", ACCOUNT_NAME)
+                        .put("group", "replicaSet")
+                        .put("kubernetesKind", "replicaSet")
+                        .put("name", "replicaSet backend-v014")
+                        .put("namespace", "backend-ns")
+                        .put("provider", "kubernetes")
+                        .put("region", "backend-ns")
+                        .put("serverGroup", "replicaSet backend-v014")
+                        .put("type", "serverGroups")
+                        .build()));
+
+    Optional<Map<String, Object>> optionalPod =
+        results.stream().filter(r -> r.get("name").equals("pod backend-v014-xkvwh")).findFirst();
+    softly.assertThat(optionalPod).isPresent();
+    optionalPod.ifPresent(
+        pod ->
+            softly
+                .assertThat(pod)
+                .containsAllEntriesOf(
+                    ImmutableMap.<String, String>builder()
+                        .put("account", ACCOUNT_NAME)
+                        .put("group", "pod")
+                        .put("instanceId", "pod backend-v014-xkvwh")
+                        .put("kubernetesKind", "pod")
+                        .put("name", "pod backend-v014-xkvwh")
+                        .put("namespace", "backend-ns")
+                        .put("provider", "kubernetes")
+                        .put("region", "backend-ns")
+                        .put("type", "instances")
+                        .build()));
+  }
+
+  private static KubectlJobExecutor getJobExecutor() {
+    KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class, new ReturnsSmartNulls());
+    when(jobExecutor.list(
+            any(KubernetesV2Credentials.class),
+            anyList(),
+            any(String.class),
+            any(KubernetesSelectorList.class)))
+        .thenAnswer(
+            invocation ->
+                manifestsByNamespace.get(invocation.getArgument(2, String.class)).stream()
+                    .map(
+                        file ->
+                            ManifestFetcher.getManifest(
+                                KubernetesDataProviderIntegrationTest.class, file))
+                    .collect(toImmutableList()));
+    return jobExecutor;
+  }
+
+  private static KubernetesNamedAccountCredentials<KubernetesV2Credentials>
+      getNamedAccountCredentials() {
+    KubernetesConfigurationProperties.ManagedAccount managedAccount =
+        new KubernetesConfigurationProperties.ManagedAccount();
+    managedAccount.setName(ACCOUNT_NAME);
+    managedAccount.setNamespaces(manifestsByNamespace.keySet().asList());
+    managedAccount.setKinds(ImmutableList.of("deployment", "replicaSet", "service", "pod"));
+    managedAccount.setMetrics(false);
+
+    KubernetesV2Credentials.Factory credentialFactory =
+        new KubernetesV2Credentials.Factory(
+            new NoopRegistry(),
+            new NamerRegistry(ImmutableList.of(new KubernetesManifestNamer())),
+            getJobExecutor(),
+            new ConfigFileService(new CloudConfigResourceService()),
+            new AccountResourcePropertyRegistry.Factory(resourcePropertyRegistry),
+            new KubernetesKindRegistry.Factory(new GlobalKubernetesKindRegistry()),
+            kindMap);
+    return new KubernetesNamedAccountCredentials<>(managedAccount, credentialFactory);
+  }
+
+  // This is documenting the current cluster that is returned representing a service, but we
+  // probably should not return a cluster for a service at all.
+  private void assertFrontendServiceCluster(SoftAssertions softly, KubernetesV2Cluster cluster) {
+    softly.assertThat(cluster.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(cluster.getMoniker().getCluster()).isEqualTo("service frontend");
+    softly.assertThat(cluster.getType()).isEqualTo("kubernetes");
+    softly.assertThat(cluster.getAccountName()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(cluster.getServerGroups()).isEmpty();
+    softly.assertThat(cluster.getLoadBalancers()).isEmpty();
+    softly.assertThat(cluster.getApplication()).isEqualTo("frontendapp");
+  }
+
+  private void assertFrontendLoadBalancer(
+      SoftAssertions softly, KubernetesV2LoadBalancer loadBalancer) {
+    softly.assertThat(loadBalancer.getRegion()).isEqualTo("frontend-ns");
+    softly.assertThat(loadBalancer.getZone()).isEqualTo("frontend-ns");
+    softly.assertThat(loadBalancer.getAccount()).isEqualTo(ACCOUNT_NAME);
+    softly
+        .assertThat(loadBalancer.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "frontendapp",
+                "app.kubernetes.io/managed-by", "spinnaker"));
+    softly.assertThat(loadBalancer.getKind()).isEqualTo(KubernetesKind.SERVICE);
+    softly.assertThat(loadBalancer.getType()).isEqualTo("kubernetes");
+    softly.assertThat(loadBalancer.getProviderType()).isEqualTo("kubernetes");
+    softly.assertThat(loadBalancer.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(loadBalancer.getMoniker().getCluster()).isEqualTo("service frontend");
+    softly.assertThat(loadBalancer.getName()).isEqualTo("service frontend");
+    assertFrontendLoadBalancerServerGroups(softly, loadBalancer.getServerGroups());
+  }
+
+  private void assertFrontendCluster(
+      SoftAssertions softly, KubernetesV2Cluster cluster, boolean summary) {
+    softly.assertThat(cluster.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(cluster.getMoniker().getCluster()).isEqualTo("deployment frontend");
+    softly.assertThat(cluster.getType()).isEqualTo("kubernetes");
+    softly.assertThat(cluster.getAccountName()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(cluster.getName()).isEqualTo("deployment frontend");
+    softly.assertThat(cluster.getApplication()).isEqualTo("frontendapp");
+
+    if (summary) {
+      softly.assertThat(cluster.getServerGroups()).isEmpty();
+    } else {
+      assertFrontendServerGroups(softly, cluster.getServerGroups());
+    }
+
+    if (summary) {
+      softly.assertThat(cluster.getLoadBalancers()).isEmpty();
+    } else {
+      // TODO(ezimanyi): The same load balancer is being returned multiple times (likely due to
+      // finding all relationships to it). This should be fixed to return it only once.
+      softly.assertThat(cluster.getLoadBalancers()).hasSize(4);
+      assertFrontendLoadBalancer(
+          softly, (KubernetesV2LoadBalancer) cluster.getLoadBalancers().iterator().next());
+    }
+  }
+
+  private void assertFrontendServerGroups(
+      SoftAssertions softly, Collection<? extends ServerGroup> serverGroups) {
+    softly.assertThat(serverGroups).hasSize(2);
+    softly
+        .assertThat(serverGroups)
+        .extracting(ServerGroup::getName)
+        .containsExactlyInAnyOrder(
+            "replicaSet frontend-5c6559f75f", "replicaSet frontend-64545c4c54");
+    Map<String, KubernetesV2ServerGroup> serverGroupLookup =
+        serverGroups.stream()
+            .collect(toImmutableMap(ServerGroup::getName, sg -> (KubernetesV2ServerGroup) sg));
+
+    KubernetesV2ServerGroup currentServerGroup =
+        serverGroupLookup.get("replicaSet frontend-5c6559f75f");
+    softly.assertThat(currentServerGroup).isNotNull();
+    // If the soft assertion already failed; don't NPE trying to validate further.
+    if (currentServerGroup != null) {
+      assertFrontendCurrentServerGroup(softly, currentServerGroup);
+    }
+
+    KubernetesV2ServerGroup priorServerGroup =
+        serverGroupLookup.get("replicaSet frontend-64545c4c54");
+    softly.assertThat(currentServerGroup).isNotNull();
+    // If the soft assertion already failed; don't NPE trying to validate further.
+    if (currentServerGroup != null) {
+      assertFrontendPriorServerGroup(softly, priorServerGroup);
+    }
+  }
+
+  private void assertFrontendPriorServerGroup(
+      SoftAssertions softly, KubernetesV2ServerGroup serverGroup) {
+    softly.assertThat(serverGroup.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(serverGroup.getMoniker().getCluster()).isEqualTo("deployment frontend");
+    softly.assertThat(serverGroup.getMoniker().getSequence()).isEqualTo(1);
+    softly.assertThat(serverGroup.getCapacity().getDesired()).isEqualTo(0);
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getAccountName()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getKind()).isEqualTo(KubernetesKind.REPLICA_SET);
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet frontend-64545c4c54");
+    softly.assertThat(serverGroup.getInstanceCounts().getUp()).isEqualTo(0);
+    softly.assertThat(serverGroup.getInstanceCounts().getTotal()).isEqualTo(0);
+    softly.assertThat(serverGroup.getLoadBalancers()).containsExactly("service frontend");
+    softly.assertThat(serverGroup.getUid()).isEqualTo("13939207-d970-4e19-8f8d-ffcd353016ff");
+    // When using a deployment, the prior server group is not disabled as labels aren't changed;
+    // instead this server group is scaled down to 0 instances.
+    softly.assertThat(serverGroup.isDisabled()).isFalse();
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("frontend-ns");
+    softly.assertThat(serverGroup.getServerGroupManagers()).hasSize(1);
+    if (!serverGroup.getServerGroupManagers().isEmpty()) {
+      assertFrontEndServerGroupManagerSummary(
+          softly, serverGroup.getServerGroupManagers().iterator().next());
+    }
+    softly
+        .assertThat(serverGroup.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "frontendapp",
+                "app.kubernetes.io/managed-by", "spinnaker"));
+    softly.assertThat(serverGroup.getType()).isEqualTo("kubernetes");
+    softly
+        .assertThat((Collection<String>) serverGroup.getBuildInfo().get("images"))
+        .containsExactly("nginx:1.19.0");
+    softly.assertThat(serverGroup.getZone()).isEqualTo("frontend-ns");
+    softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroup.getInstances()).isEmpty();
+  }
+
+  private void assertFrontendCurrentServerGroup(
+      SoftAssertions softly, KubernetesV2ServerGroup serverGroup) {
+    softly.assertThat(serverGroup.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(serverGroup.getMoniker().getCluster()).isEqualTo("deployment frontend");
+    softly.assertThat(serverGroup.getMoniker().getSequence()).isEqualTo(2);
+    softly.assertThat(serverGroup.getCapacity().getDesired()).isEqualTo(2);
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getAccountName()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getKind()).isEqualTo(KubernetesKind.REPLICA_SET);
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet frontend-5c6559f75f");
+    softly.assertThat(serverGroup.getInstanceCounts().getUp()).isEqualTo(2);
+    softly.assertThat(serverGroup.getInstanceCounts().getTotal()).isEqualTo(2);
+    softly.assertThat(serverGroup.getLoadBalancers()).containsExactly("service frontend");
+    softly.assertThat(serverGroup.getUid()).isEqualTo("29630998-bdee-4586-ac64-45223d7ef7d5");
+    // When using a deployment, the prior server group is not disabled as labels aren't changed;
+    // instead this server group is scaled down to 0 instances.
+    softly.assertThat(serverGroup.isDisabled()).isFalse();
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("frontend-ns");
+    softly.assertThat(serverGroup.getServerGroupManagers()).hasSize(1);
+    if (!serverGroup.getServerGroupManagers().isEmpty()) {
+      assertFrontEndServerGroupManagerSummary(
+          softly, serverGroup.getServerGroupManagers().iterator().next());
+    }
+    softly
+        .assertThat(serverGroup.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "frontendapp",
+                "app.kubernetes.io/managed-by", "spinnaker"));
+    softly.assertThat(serverGroup.getType()).isEqualTo("kubernetes");
+    softly
+        .assertThat((Collection<String>) serverGroup.getBuildInfo().get("images"))
+        .containsExactly("nginx:1.19.1");
+    softly.assertThat(serverGroup.getZone()).isEqualTo("frontend-ns");
+    softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
+    assertFrontendCurrentServerGroupInstances(softly, serverGroup.getInstances());
+  }
+
+  private void assertFrontendCurrentServerGroupInstances(
+      SoftAssertions softly, Collection<? extends Instance> instances) {
+    softly.assertThat(instances).hasSize(2);
+    Map<String, KubernetesV2Instance> instanceLookup =
+        instances.stream()
+            .collect(toImmutableMap(Instance::getName, i -> (KubernetesV2Instance) i));
+
+    KubernetesV2Instance firstInstance = instanceLookup.get("477dcf19-be44-4853-88fd-1d9aedfcddba");
+    softly.assertThat(firstInstance).isNotNull();
+    if (firstInstance != null) {
+      assertFrontendFirstInstance(softly, firstInstance);
+    }
+
+    KubernetesV2Instance secondInstance =
+        instanceLookup.get("a2280982-e745-468f-9176-21ff1642fa8d");
+    softly.assertThat(firstInstance).isNotNull();
+    if (secondInstance != null) {
+      assertFrontendSecondInstance(softly, secondInstance);
+    }
+  }
+
+  private void assertFrontendFirstInstance(SoftAssertions softly, KubernetesV2Instance instance) {
+    softly.assertThat(instance.getAccount()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(instance.getRegion()).isEqualTo("frontend-ns");
+    softly.assertThat(instance.getZone()).isEqualTo("frontend-ns");
+    softly.assertThat(instance.getKind()).isEqualTo(KubernetesKind.POD);
+    softly.assertThat(instance.getHealthState()).isEqualTo(HealthState.Up);
+    softly.assertThat(instance.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getProviderType()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getType()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getHumanReadableName()).isEqualTo("pod frontend-5c6559f75f-4ml8h");
+    softly.assertThat(instance.getName()).isEqualTo("477dcf19-be44-4853-88fd-1d9aedfcddba");
+    softly
+        .assertThat(instance.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "load-balancer", "frontend",
+                "app.kubernetes.io/name", "frontendapp",
+                "app.kubernetes.io/managed-by", "spinnaker",
+                "app", "nginx"));
+    softly.assertThat(instance.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(instance.getMoniker().getCluster()).isEqualTo("deployment frontend");
+  }
+
+  private void assertFrontendSecondInstance(SoftAssertions softly, KubernetesV2Instance instance) {
+    softly.assertThat(instance.getAccount()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(instance.getRegion()).isEqualTo("frontend-ns");
+    softly.assertThat(instance.getZone()).isEqualTo("frontend-ns");
+    softly.assertThat(instance.getKind()).isEqualTo(KubernetesKind.POD);
+    softly.assertThat(instance.getHealthState()).isEqualTo(HealthState.Up);
+    softly.assertThat(instance.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getProviderType()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getType()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getHumanReadableName()).isEqualTo("pod frontend-5c6559f75f-6fdmt");
+    softly.assertThat(instance.getName()).isEqualTo("a2280982-e745-468f-9176-21ff1642fa8d");
+    softly
+        .assertThat(instance.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "load-balancer", "frontend",
+                "app.kubernetes.io/name", "frontendapp",
+                "app.kubernetes.io/managed-by", "spinnaker",
+                "app", "nginx"));
+    softly.assertThat(instance.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(instance.getMoniker().getCluster()).isEqualTo("deployment frontend");
+  }
+
+  private void assertFrontEndServerGroupManagerSummary(
+      SoftAssertions softly, ServerGroupManagerSummary summary) {
+    softly.assertThat(summary.getAccount()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(summary.getLocation()).isEqualTo("frontend-ns");
+    softly.assertThat(summary.getName()).isEqualTo("frontend");
+  }
+
+  private void assertFrontEndServerGroupManager(
+      SoftAssertions softly, KubernetesV2ServerGroupManager serverGroupManager) {
+    softly.assertThat(serverGroupManager.getType()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroupManager.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroupManager.getProviderType()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroupManager.getZone()).isEqualTo("frontend-ns");
+    softly.assertThat(serverGroupManager.getRegion()).isEqualTo("frontend-ns");
+    softly.assertThat(serverGroupManager.getAccount()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(serverGroupManager.getName()).isEqualTo("deployment frontend");
+    softly.assertThat(serverGroupManager.getKind()).isEqualTo(KubernetesKind.DEPLOYMENT);
+    softly.assertThat(serverGroupManager.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly
+        .assertThat(serverGroupManager.getMoniker().getCluster())
+        .isEqualTo("deployment frontend");
+    softly
+        .assertThat(serverGroupManager.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "frontendapp",
+                "app.kubernetes.io/managed-by", "spinnaker"));
+    assertFrontendServerGroupSummaries(softly, serverGroupManager.getServerGroups());
+  }
+
+  private void assertFrontendLoadBalancerServerGroups(
+      SoftAssertions softly, Collection<LoadBalancerServerGroup> serverGroups) {
+    softly.assertThat(serverGroups).hasSize(2);
+    Map<String, LoadBalancerServerGroup> serverGroupLookup =
+        serverGroups.stream().collect(toImmutableMap(LoadBalancerServerGroup::getName, sg -> sg));
+
+    LoadBalancerServerGroup priorServerGroup =
+        serverGroupLookup.get("replicaSet frontend-64545c4c54");
+    softly.assertThat(priorServerGroup).isNotNull();
+    if (priorServerGroup != null) {
+      assertFrontendPriorLoadBalancerServerGroup(softly, priorServerGroup);
+    }
+
+    LoadBalancerServerGroup currentServerGroup =
+        serverGroupLookup.get("replicaSet frontend-5c6559f75f");
+    softly.assertThat(currentServerGroup).isNotNull();
+    if (currentServerGroup != null) {
+      assertFrontendCurrentLoadBalancerServerGroup(softly, currentServerGroup);
+    }
+  }
+
+  private void assertFrontendPriorLoadBalancerServerGroup(
+      SoftAssertions softly, LoadBalancerServerGroup serverGroup) {
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet frontend-64545c4c54");
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("frontend-ns");
+    softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroup.getIsDisabled()).isFalse();
+    softly.assertThat(serverGroup.getDetachedInstances()).isEmpty();
+    softly.assertThat(serverGroup.getInstances()).isEmpty();
+  }
+
+  private void assertFrontendCurrentLoadBalancerServerGroup(
+      SoftAssertions softly, LoadBalancerServerGroup serverGroup) {
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet frontend-5c6559f75f");
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("frontend-ns");
+    softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroup.getIsDisabled()).isFalse();
+    softly.assertThat(serverGroup.getDetachedInstances()).isEmpty();
+    softly.assertThat(serverGroup.getInstances()).hasSize(2);
+    softly
+        .assertThat(serverGroup.getInstances())
+        .extracting(LoadBalancerInstance::getName)
+        .containsExactlyInAnyOrder(
+            "pod frontend-5c6559f75f-4ml8h", "pod frontend-5c6559f75f-6fdmt");
+    softly
+        .assertThat(serverGroup.getInstances())
+        .allMatch(sg -> sg.getZone().equals("frontend-ns"));
+  }
+
+  private void assertFrontendServerGroupSummaries(
+      SoftAssertions softly, Collection<ServerGroupSummary> serverGroups) {
+    softly.assertThat(serverGroups).hasSize(2);
+    Map<String, ServerGroupSummary> serverGroupLookup =
+        serverGroups.stream().collect(toImmutableMap(ServerGroupSummary::getName, sg -> sg));
+
+    ServerGroupSummary priorServerGroup = serverGroupLookup.get("replicaSet frontend-64545c4c54");
+    softly.assertThat(priorServerGroup).isNotNull();
+    if (priorServerGroup != null) {
+      assertFrontendPriorServerGroupSummary(softly, priorServerGroup);
+    }
+
+    ServerGroupSummary currentServerGroup = serverGroupLookup.get("replicaSet frontend-5c6559f75f");
+    softly.assertThat(currentServerGroup).isNotNull();
+    if (currentServerGroup != null) {
+      assertFrontendCurrentServerGroupSummary(softly, currentServerGroup);
+    }
+  }
+
+  private void assertFrontendPriorServerGroupSummary(
+      SoftAssertions softly, ServerGroupSummary serverGroup) {
+    softly.assertThat(serverGroup.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(serverGroup.getMoniker().getCluster()).isEqualTo("deployment frontend");
+    softly.assertThat(serverGroup.getMoniker().getSequence()).isEqualTo(1);
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet frontend-64545c4c54");
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("frontend-ns");
+  }
+
+  private void assertFrontendCurrentServerGroupSummary(
+      SoftAssertions softly, ServerGroupSummary serverGroup) {
+    softly.assertThat(serverGroup.getMoniker().getApp()).isEqualTo("frontendapp");
+    softly.assertThat(serverGroup.getMoniker().getCluster()).isEqualTo("deployment frontend");
+    softly.assertThat(serverGroup.getMoniker().getSequence()).isEqualTo(2);
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet frontend-5c6559f75f");
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("frontend-ns");
+  }
+
+  // This is documenting the current cluster that is returned representing a service, but we
+  // probably should not return a cluster for a service at all.
+  private void assertBackendServiceCluster(SoftAssertions softly, KubernetesV2Cluster cluster) {
+    softly.assertThat(cluster.getMoniker().getApp()).isEqualTo("backendapp");
+    softly.assertThat(cluster.getMoniker().getCluster()).isEqualTo("service backendlb");
+    softly.assertThat(cluster.getType()).isEqualTo("kubernetes");
+    softly.assertThat(cluster.getAccountName()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(cluster.getServerGroups()).isEmpty();
+    softly.assertThat(cluster.getLoadBalancers()).isEmpty();
+    softly.assertThat(cluster.getApplication()).isEqualTo("backendapp");
+  }
+
+  private void assertBackendLoadBalancer(
+      SoftAssertions softly, KubernetesV2LoadBalancer loadBalancer) {
+    softly.assertThat(loadBalancer.getRegion()).isEqualTo("backend-ns");
+    softly.assertThat(loadBalancer.getZone()).isEqualTo("backend-ns");
+    softly.assertThat(loadBalancer.getAccount()).isEqualTo(ACCOUNT_NAME);
+    softly
+        .assertThat(loadBalancer.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "backendapp",
+                "app.kubernetes.io/managed-by", "spinnaker"));
+    softly.assertThat(loadBalancer.getKind()).isEqualTo(KubernetesKind.SERVICE);
+    softly.assertThat(loadBalancer.getType()).isEqualTo("kubernetes");
+    softly.assertThat(loadBalancer.getProviderType()).isEqualTo("kubernetes");
+    softly.assertThat(loadBalancer.getMoniker().getApp()).isEqualTo("backendapp");
+    softly.assertThat(loadBalancer.getMoniker().getCluster()).isEqualTo("service backendlb");
+    softly.assertThat(loadBalancer.getName()).isEqualTo("service backendlb");
+    assertBackendLoadBalancerServerGroups(softly, loadBalancer.getServerGroups());
+  }
+
+  private void assertBackendLoadBalancerServerGroups(
+      SoftAssertions softly, Collection<LoadBalancerServerGroup> serverGroups) {
+    softly.assertThat(serverGroups).hasSize(1);
+
+    if (!serverGroups.isEmpty()) {
+      LoadBalancerServerGroup serverGroup = serverGroups.iterator().next();
+      assertBackendLoadBalancerServerGroup(softly, serverGroup);
+    }
+  }
+
+  private void assertBackendLoadBalancerServerGroup(
+      SoftAssertions softly, LoadBalancerServerGroup serverGroup) {
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet backend-v015");
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("backend-ns");
+    softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroup.getIsDisabled()).isFalse();
+    softly.assertThat(serverGroup.getDetachedInstances()).isEmpty();
+    softly.assertThat(serverGroup.getInstances()).hasSize(1);
+    if (!serverGroup.getInstances().isEmpty()) {
+      assertBackendLoadBalancerInstance(softly, serverGroup.getInstances().iterator().next());
+    }
+  }
+
+  private void assertBackendLoadBalancerInstance(
+      SoftAssertions softly, LoadBalancerInstance instance) {
+    softly.assertThat(instance.getName()).isEqualTo("pod backend-v015-vhglj");
+    softly.assertThat(instance.getZone()).isEqualTo("backend-ns");
+  }
+
+  private void assertBackendCluster(
+      SoftAssertions softly, KubernetesV2Cluster cluster, boolean summary) {
+    softly.assertThat(cluster.getMoniker().getApp()).isEqualTo("backendapp");
+    softly.assertThat(cluster.getMoniker().getCluster()).isEqualTo("replicaSet backend");
+    softly.assertThat(cluster.getType()).isEqualTo("kubernetes");
+    softly.assertThat(cluster.getAccountName()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(cluster.getName()).isEqualTo("replicaSet backend");
+    softly.assertThat(cluster.getApplication()).isEqualTo("backendapp");
+
+    if (summary) {
+      softly.assertThat(cluster.getServerGroups()).isEmpty();
+    } else {
+      assertBackendServerGroups(softly, cluster.getServerGroups());
+    }
+
+    if (summary) {
+      softly.assertThat(cluster.getLoadBalancers()).isEmpty();
+    } else {
+      softly.assertThat(cluster.getLoadBalancers()).hasSize(1);
+      // If soft assertion above already failed, don't try to further validate.
+      if (!cluster.getLoadBalancers().isEmpty()) {
+        assertBackendLoadBalancer(
+            softly, (KubernetesV2LoadBalancer) cluster.getLoadBalancers().iterator().next());
+      }
+    }
+  }
+
+  private void assertBackendServerGroups(
+      SoftAssertions softly, Collection<? extends ServerGroup> serverGroups) {
+    softly.assertThat(serverGroups).hasSize(2);
+    softly
+        .assertThat(serverGroups)
+        .extracting(ServerGroup::getName)
+        .containsExactlyInAnyOrder("replicaSet backend-v014", "replicaSet backend-v015");
+    Map<String, KubernetesV2ServerGroup> serverGroupLookup =
+        serverGroups.stream()
+            .collect(toImmutableMap(ServerGroup::getName, sg -> (KubernetesV2ServerGroup) sg));
+
+    KubernetesV2ServerGroup currentServerGroup = serverGroupLookup.get("replicaSet backend-v015");
+    softly.assertThat(currentServerGroup).isNotNull();
+    // If the soft assertion already failed; don't NPE trying to validate further.
+    if (currentServerGroup != null) {
+      assertBackendCurrentServerGroup(softly, currentServerGroup);
+    }
+
+    KubernetesV2ServerGroup priorServerGroup = serverGroupLookup.get("replicaSet backend-v014");
+    softly.assertThat(priorServerGroup).isNotNull();
+    // If the soft assertion already failed; don't NPE trying to validate further.
+    if (priorServerGroup != null) {
+      assertBackendPriorServerGroup(softly, priorServerGroup);
+    }
+  }
+
+  private void assertBackendPriorServerGroup(
+      SoftAssertions softly, KubernetesV2ServerGroup serverGroup) {
+    softly.assertThat(serverGroup.getMoniker().getApp()).isEqualTo("backendapp");
+    softly.assertThat(serverGroup.getMoniker().getCluster()).isEqualTo("replicaSet backend");
+    softly.assertThat(serverGroup.getMoniker().getSequence()).isEqualTo(14);
+    softly.assertThat(serverGroup.getCapacity().getDesired()).isEqualTo(1);
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getAccountName()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getKind()).isEqualTo(KubernetesKind.REPLICA_SET);
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet backend-v014");
+    softly.assertThat(serverGroup.getInstanceCounts().getUp()).isEqualTo(1);
+    softly.assertThat(serverGroup.getInstanceCounts().getTotal()).isEqualTo(1);
+    softly.assertThat(serverGroup.getLoadBalancers()).containsExactly("service backendlb");
+    softly.assertThat(serverGroup.getUid()).isEqualTo("ded56bd9-2034-4196-a7e4-b6b736c997ba");
+    // When using a replica set with traffic management, the prior server group is disabled.
+    softly.assertThat(serverGroup.isDisabled()).isTrue();
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("backend-ns");
+    softly.assertThat(serverGroup.getServerGroupManagers()).isEmpty();
+    softly
+        .assertThat(serverGroup.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "backendapp",
+                "moniker.spinnaker.io/sequence", "14",
+                "app.kubernetes.io/managed-by", "spinnaker"));
+    softly.assertThat(serverGroup.getType()).isEqualTo("kubernetes");
+    softly
+        .assertThat((Collection<String>) serverGroup.getBuildInfo().get("images"))
+        .containsExactly(
+            "gcr.io/my-gcr-repository/backend-service@sha256:2eefbb528a4619311555f92ea9b781af101c62f4c70b73c4a5e93d15624ba94c");
+    softly.assertThat(serverGroup.getZone()).isEqualTo("backend-ns");
+    softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroup.getInstances()).hasSize(1);
+    if (!serverGroup.getInstances().isEmpty()) {
+      assertBackendPriorServerGroupInstance(
+          softly, (KubernetesV2Instance) serverGroup.getInstances().iterator().next());
+    }
+  }
+
+  void assertBackendCurrentServerGroup(SoftAssertions softly, KubernetesV2ServerGroup serverGroup) {
+    softly.assertThat(serverGroup.getMoniker().getApp()).isEqualTo("backendapp");
+    softly.assertThat(serverGroup.getMoniker().getCluster()).isEqualTo("replicaSet backend");
+    softly.assertThat(serverGroup.getMoniker().getSequence()).isEqualTo(15);
+    softly.assertThat(serverGroup.getCapacity().getDesired()).isEqualTo(1);
+    softly.assertThat(serverGroup.getAccount()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getAccountName()).isEqualTo("my-account");
+    softly.assertThat(serverGroup.getKind()).isEqualTo(KubernetesKind.REPLICA_SET);
+    softly.assertThat(serverGroup.getName()).isEqualTo("replicaSet backend-v015");
+    softly.assertThat(serverGroup.getInstanceCounts().getUp()).isEqualTo(1);
+    softly.assertThat(serverGroup.getInstanceCounts().getTotal()).isEqualTo(1);
+    softly.assertThat(serverGroup.getLoadBalancers()).containsExactly("service backendlb");
+    softly.assertThat(serverGroup.getUid()).isEqualTo("518fdd80-8949-47c4-806e-1fd3ac1e1d3c");
+    softly.assertThat(serverGroup.isDisabled()).isFalse();
+    softly.assertThat(serverGroup.getRegion()).isEqualTo("backend-ns");
+    softly.assertThat(serverGroup.getServerGroupManagers()).isEmpty();
+    softly
+        .assertThat(serverGroup.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "backendapp",
+                "moniker.spinnaker.io/sequence", "15",
+                "app.kubernetes.io/managed-by", "spinnaker"));
+    softly.assertThat(serverGroup.getType()).isEqualTo("kubernetes");
+    softly
+        .assertThat((Collection<String>) serverGroup.getBuildInfo().get("images"))
+        .containsExactly(
+            "gcr.io/my-gcr-repository/backend-service@sha256:51f29a570a484fbae4da912199ff27ed21f91b1caf51564a9d3afe3a201c1f32");
+    softly.assertThat(serverGroup.getZone()).isEqualTo("backend-ns");
+    softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(serverGroup.getInstances()).hasSize(1);
+    if (!serverGroup.getInstances().isEmpty()) {
+      assertBackendCurrentServerGroupInstance(
+          softly, (KubernetesV2Instance) serverGroup.getInstances().iterator().next());
+    }
+  }
+
+  private void assertBackendPriorServerGroupInstance(
+      SoftAssertions softly, KubernetesV2Instance instance) {
+    softly.assertThat(instance.getAccount()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(instance.getRegion()).isEqualTo("backend-ns");
+    softly.assertThat(instance.getZone()).isEqualTo("backend-ns");
+    softly.assertThat(instance.getKind()).isEqualTo(KubernetesKind.POD);
+    softly.assertThat(instance.getHealthState()).isEqualTo(HealthState.Up);
+    softly.assertThat(instance.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getProviderType()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getType()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getHumanReadableName()).isEqualTo("pod backend-v014-xkvwh");
+    softly.assertThat(instance.getName()).isEqualTo("d05606fe-aa69-4f16-b56a-371c2313fe9c");
+    softly
+        .assertThat(instance.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "backendapp",
+                "app.kubernetes.io/managed-by", "spinnaker",
+                "app", "nginx"));
+    softly.assertThat(instance.getLabels()).doesNotContainEntry("load-balancer", "backend");
+    softly.assertThat(instance.getMoniker().getApp()).isEqualTo("backendapp");
+    softly.assertThat(instance.getMoniker().getCluster()).isEqualTo("replicaSet backend");
+  }
+
+  private void assertBackendCurrentServerGroupInstance(
+      SoftAssertions softly, KubernetesV2Instance instance) {
+    softly.assertThat(instance.getAccount()).isEqualTo(ACCOUNT_NAME);
+    softly.assertThat(instance.getRegion()).isEqualTo("backend-ns");
+    softly.assertThat(instance.getZone()).isEqualTo("backend-ns");
+    softly.assertThat(instance.getKind()).isEqualTo(KubernetesKind.POD);
+    softly.assertThat(instance.getHealthState()).isEqualTo(HealthState.Up);
+    softly.assertThat(instance.getCloudProvider()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getProviderType()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getType()).isEqualTo("kubernetes");
+    softly.assertThat(instance.getHumanReadableName()).isEqualTo("pod backend-v015-vhglj");
+    softly.assertThat(instance.getName()).isEqualTo("45db7673-e3d2-4746-9ecd-38f868f853e5");
+    softly
+        .assertThat(instance.getLabels())
+        .containsAllEntriesOf(
+            ImmutableMap.of(
+                "app.kubernetes.io/name", "backendapp",
+                "app.kubernetes.io/managed-by", "spinnaker",
+                "app", "nginx"));
+    softly.assertThat(instance.getLabels()).containsEntry("load-balancer", "backend");
+    softly.assertThat(instance.getMoniker().getApp()).isEqualTo("backendapp");
+    softly.assertThat(instance.getMoniker().getCluster()).isEqualTo("replicaSet backend");
+  }
+
+  void assertFrontendApplication(SoftAssertions softly, KubernetesV2Application application) {
+    softly.assertThat(application.getName()).isEqualTo("frontendapp");
+    softly
+        .assertThat(application.getAttributes())
+        .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("name", "frontendapp"));
+    softly.assertThat(application.getClusterNames()).hasSize(1);
+
+    Set<String> clusterNames = application.getClusterNames().get(ACCOUNT_NAME);
+    softly.assertThat(clusterNames).isNotNull();
+    if (clusterNames != null) {
+      softly
+          .assertThat(clusterNames)
+          .containsExactlyInAnyOrder("deployment frontend", "service frontend");
+    }
+  }
+
+  void assertBackendApplication(SoftAssertions softly, KubernetesV2Application application) {
+    softly.assertThat(application.getName()).isEqualTo("backendapp");
+    softly
+        .assertThat(application.getAttributes())
+        .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of("name", "backendapp"));
+    softly.assertThat(application.getClusterNames()).hasSize(1);
+
+    Set<String> clusterNames = application.getClusterNames().get(ACCOUNT_NAME);
+    softly.assertThat(clusterNames).isNotNull();
+    if (clusterNames != null) {
+      softly
+          .assertThat(clusterNames)
+          .containsExactlyInAnyOrder("service backendlb", "replicaSet backend");
+    }
+  }
+}

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-pod-014.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-pod-014.yml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: backend-ns
+    artifact.spinnaker.io/name: backend
+    artifact.spinnaker.io/type: kubernetes/replicaSet
+    artifact.spinnaker.io/version: v014
+    moniker.spinnaker.io/application: backendapp
+    moniker.spinnaker.io/cluster: replicaSet backend
+    moniker.spinnaker.io/sequence: "14"
+  creationTimestamp: "2020-07-24T14:08:00Z"
+  generateName: backend-v014-
+  labels:
+    app: nginx
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: backendapp
+    moniker.spinnaker.io/sequence: "14"
+  name: backend-v014-xkvwh
+  namespace: backend-ns
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: backend-v014
+    uid: ded56bd9-2034-4196-a7e4-b6b736c997ba
+  resourceVersion: "83985048"
+  selfLink: /api/v1/namespaces/backend-ns/pods/backend-v014-xkvwh
+  uid: d05606fe-aa69-4f16-b56a-371c2313fe9c
+spec:
+  containers:
+  - image: gcr.io/my-gcr-repository/backend-service@sha256:2eefbb528a4619311555f92ea9b781af101c62f4c70b73c4a5e93d15624ba94c
+    imagePullPolicy: IfNotPresent
+    name: backend-service
+    ports:
+    - containerPort: 4000
+      protocol: TCP
+    resources:
+      requests:
+        cpu: 10m
+        memory: 8Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts: []
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  initContainers: []
+  nodeName: gke-spinnaker-e2-small-c528c905-f1ub
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations: []
+  volumes: []
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T14:08:11Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T14:08:25Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T14:08:25Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T14:08:00Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: containerd://ab3d6b767a3dbb4524897ff8f6af035e2cfed8a58aa1451869e4377ee0489fa9
+    image: sha256:6146cbec26fd547a5975fb6a48c860455a13a50bc9a61c398c8bd0b41af8dbe7
+    imageID: gcr.io/my-gcr-repository/backend-service@sha256:2eefbb528a4619311555f92ea9b781af101c62f4c70b73c4a5e93d15624ba94c
+    lastState: {}
+    name: backend-service
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2020-07-24T14:08:23Z"
+  hostIP: 10.128.0.25
+  initContainerStatuses: []
+  phase: Running
+  podIP: 10.52.2.9
+  podIPs:
+  - ip: 10.52.2.9
+  qosClass: Burstable
+  startTime: "2020-07-24T14:08:00Z"

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-pod-015.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-pod-015.yml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: backend-ns
+    artifact.spinnaker.io/name: backend
+    artifact.spinnaker.io/type: kubernetes/replicaSet
+    artifact.spinnaker.io/version: v015
+    moniker.spinnaker.io/application: backendapp
+    moniker.spinnaker.io/cluster: replicaSet backend
+    moniker.spinnaker.io/sequence: "15"
+  creationTimestamp: "2020-07-24T17:59:52Z"
+  generateName: backend-v015-
+  labels:
+    app: nginx
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: backendapp
+    load-balancer: backend
+    moniker.spinnaker.io/sequence: "15"
+  name: backend-v015-vhglj
+  namespace: backend-ns
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: backend-v015
+    uid: 518fdd80-8949-47c4-806e-1fd3ac1e1d3c
+  resourceVersion: "83984595"
+  selfLink: /api/v1/namespaces/backend-ns/pods/backend-v015-vhglj
+  uid: 45db7673-e3d2-4746-9ecd-38f868f853e5
+spec:
+  containers:
+  - image: gcr.io/my-gcr-repository/backend-service@sha256:51f29a570a484fbae4da912199ff27ed21f91b1caf51564a9d3afe3a201c1f32
+    imagePullPolicy: IfNotPresent
+    name: backend-service
+    ports:
+    - containerPort: 4000
+      protocol: TCP
+    resources:
+      requests:
+        cpu: 10m
+        memory: 8Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts: []
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  initContainers: []
+  nodeName: gke-spinnaker-e2-small-c528c905-w20h
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations: []
+  volumes: []
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T17:59:56Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:00:07Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:00:07Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T17:59:52Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: containerd://a003e133b2b7d9e72dc2276776274f299e2267ce718d7493e5710bcfe68040dc
+    image: sha256:8dc352f819381bfb316dc470a30515e8538aace729e456c63eba775da7c5edf6
+    imageID: gcr.io/my-gcr-repository/backend-service@sha256:51f29a570a484fbae4da912199ff27ed21f91b1caf51564a9d3afe3a201c1f32
+    lastState: {}
+    name: backend-service
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2020-07-24T18:00:05Z"
+  hostIP: 10.128.0.14
+  initContainerStatuses: []
+  phase: Running
+  podIP: 10.52.1.15
+  podIPs:
+  - ip: 10.52.1.15
+  qosClass: Burstable
+  startTime: "2020-07-24T17:59:53Z"

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-rs-014.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-rs-014.yml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: backend-ns
+    artifact.spinnaker.io/name: backend
+    artifact.spinnaker.io/type: kubernetes/replicaSet
+    artifact.spinnaker.io/version: v014
+    moniker.spinnaker.io/application: backendapp
+    moniker.spinnaker.io/cluster: replicaSet backend
+    moniker.spinnaker.io/sequence: "14"
+    traffic.spinnaker.io/load-balancers: '["service backendlb"]'
+  creationTimestamp: "2020-07-15T01:39:59Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: backendapp
+    moniker.spinnaker.io/sequence: "14"
+  name: backend-v014
+  namespace: backend-ns
+  resourceVersion: "83985046"
+  selfLink: /apis/apps/v1/namespaces/backend-ns/replicasets/backend-v014
+  uid: ded56bd9-2034-4196-a7e4-b6b736c997ba
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      annotations:
+        artifact.spinnaker.io/location: backend-ns
+        artifact.spinnaker.io/name: backend
+        artifact.spinnaker.io/type: kubernetes/replicaSet
+        artifact.spinnaker.io/version: v014
+        moniker.spinnaker.io/application: kubernetes
+        moniker.spinnaker.io/cluster: replicaSet backend
+        moniker.spinnaker.io/sequence: "14"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/managed-by: spinnaker
+        app.kubernetes.io/name: kubernetes
+        moniker.spinnaker.io/sequence: "14"
+    spec:
+      containers:
+      - image: gcr.io/my-gcr-repository/backend-service@sha256:2eefbb528a4619311555f92ea9b781af101c62f4c70b73c4a5e93d15624ba94c
+        imagePullPolicy: IfNotPresent
+        name: backend-service
+        ports:
+        - containerPort: 4000
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 8Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 1
+  fullyLabeledReplicas: 1
+  observedGeneration: 2
+  readyReplicas: 1
+  replicas: 1

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-rs-015.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-rs-015.yml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: backend-ns
+    artifact.spinnaker.io/name: backend
+    artifact.spinnaker.io/type: kubernetes/replicaSet
+    artifact.spinnaker.io/version: v015
+    moniker.spinnaker.io/application: backendapp
+    moniker.spinnaker.io/cluster: replicaSet backend
+    moniker.spinnaker.io/sequence: "15"
+    traffic.spinnaker.io/load-balancers: '["service backendlb"]'
+  creationTimestamp: "2020-07-24T17:59:52Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: backendapp
+    moniker.spinnaker.io/sequence: "15"
+  name: backend-v015
+  namespace: backend-ns
+  resourceVersion: "83984596"
+  selfLink: /apis/apps/v1/namespaces/backend-ns/replicasets/backend-v015
+  uid: 518fdd80-8949-47c4-806e-1fd3ac1e1d3c
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      annotations:
+        artifact.spinnaker.io/location: backend-ns
+        artifact.spinnaker.io/name: backend
+        artifact.spinnaker.io/type: kubernetes/replicaSet
+        artifact.spinnaker.io/version: v015
+        moniker.spinnaker.io/application: kubernetes
+        moniker.spinnaker.io/cluster: replicaSet backend
+        moniker.spinnaker.io/sequence: "15"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/managed-by: spinnaker
+        app.kubernetes.io/name: kubernetes
+        load-balancer: backend
+        moniker.spinnaker.io/sequence: "15"
+    spec:
+      containers:
+      - image: gcr.io/my-gcr-repository/backend-service@sha256:51f29a570a484fbae4da912199ff27ed21f91b1caf51564a9d3afe3a201c1f32
+        imagePullPolicy: IfNotPresent
+        name: backend-service
+        ports:
+        - containerPort: 4000
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 8Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 1
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-service.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/backend-service.yml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: backend-ns
+    artifact.spinnaker.io/name: backendlb
+    artifact.spinnaker.io/type: kubernetes/service
+    moniker.spinnaker.io/application: backendapp
+    moniker.spinnaker.io/cluster: service backendlb
+  creationTimestamp: "2020-03-08T02:21:22Z"
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: backendapp
+  name: backendlb
+  namespace: backend-ns
+  resourceVersion: "76025043"
+  selfLink: /api/v1/namespaces/backend-ns/services/backendlb
+  uid: 7caf0eac-4850-4c12-a2f9-0bba063da35e
+spec:
+  clusterIP: 10.117.0.129
+  ports:
+  - port: 4000
+    protocol: TCP
+    targetPort: 4000
+  selector:
+    load-balancer: backend
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-deployment.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-deployment.yml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: frontend-ns
+    artifact.spinnaker.io/name: frontend
+    artifact.spinnaker.io/type: kubernetes/deployment
+    deployment.kubernetes.io/revision: "2"
+    moniker.spinnaker.io/application: frontendapp
+    moniker.spinnaker.io/cluster: deployment frontend
+  creationTimestamp: "2020-07-24T18:45:00Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: frontendapp
+  name: frontend
+  namespace: frontend-ns
+  resourceVersion: "84008208"
+  selfLink: /apis/apps/v1/namespaces/frontend-ns/deployments/frontend
+  uid: 4060c028-521b-4a81-ad44-b06ebee25f2e
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        artifact.spinnaker.io/location: frontend-ns
+        artifact.spinnaker.io/name: frontend
+        artifact.spinnaker.io/type: kubernetes/deployment
+        moniker.spinnaker.io/application: frontendapp
+        moniker.spinnaker.io/cluster: deployment frontend
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/managed-by: spinnaker
+        app.kubernetes.io/name: frontendapp
+        load-balancer: frontend
+    spec:
+      containers:
+      - image: nginx:1.19.1
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 2
+  conditions:
+  - lastTransitionTime: "2020-07-24T18:45:20Z"
+    lastUpdateTime: "2020-07-24T18:45:20Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2020-07-24T18:45:00Z"
+    lastUpdateTime: "2020-07-24T18:47:23Z"
+    message: ReplicaSet "frontend-5c6559f75f" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  observedGeneration: 2
+  readyReplicas: 2
+  replicas: 2
+  updatedReplicas: 2

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-pod-1.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-pod-1.yml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: frontend-ns
+    artifact.spinnaker.io/name: frontend
+    artifact.spinnaker.io/type: kubernetes/deployment
+    moniker.spinnaker.io/application: frontendapp
+    moniker.spinnaker.io/cluster: deployment frontend
+    sidecar.istio.io/inject: "false"
+  creationTimestamp: "2020-07-24T18:47:12Z"
+  generateName: frontend-5c6559f75f-
+  labels:
+    app: nginx
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: frontendapp
+    load-balancer: frontend
+    pod-template-hash: 5c6559f75f
+  name: frontend-5c6559f75f-4ml8h
+  namespace: frontend-ns
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: frontend-5c6559f75f
+    uid: 29630998-bdee-4586-ac64-45223d7ef7d5
+  resourceVersion: "84008199"
+  selfLink: /api/v1/namespaces/frontend-ns/pods/frontend-5c6559f75f-4ml8h
+  uid: 477dcf19-be44-4853-88fd-1d9aedfcddba
+spec:
+  containers:
+  - image: nginx:1.19.1
+    imagePullPolicy: IfNotPresent
+    name: nginx
+    ports:
+    - containerPort: 80
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-fhqgl
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: gke-spinnaker-e2-small-c528c905-f1ub
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: default-token-fhqgl
+    secret:
+      defaultMode: 420
+      secretName: default-token-fhqgl
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:47:12Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:47:23Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:47:23Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:47:12Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: containerd://fd37d96ba9d422884f9d83d7da37b6dd0e004b5090d92d2775e793544c53e58a
+    image: docker.io/library/nginx:1.19.1
+    imageID: docker.io/library/nginx@sha256:0e188877aa60537d1a1c6484b8c3929cfe09988145327ee47e8e91ddf6f76f5c
+    lastState: {}
+    name: nginx
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2020-07-24T18:47:22Z"
+  hostIP: 10.128.0.25
+  phase: Running
+  podIP: 10.52.2.25
+  podIPs:
+  - ip: 10.52.2.25
+  qosClass: BestEffort
+  startTime: "2020-07-24T18:47:12Z"

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-pod-2.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-pod-2.yml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: frontend-ns
+    artifact.spinnaker.io/name: frontend
+    artifact.spinnaker.io/type: kubernetes/deployment
+    moniker.spinnaker.io/application: frontendapp
+    moniker.spinnaker.io/cluster: deployment frontend
+    sidecar.istio.io/inject: "false"
+  creationTimestamp: "2020-07-24T18:47:01Z"
+  generateName: frontend-5c6559f75f-
+  labels:
+    app: nginx
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: frontendapp
+    load-balancer: frontend
+    pod-template-hash: 5c6559f75f
+  name: frontend-5c6559f75f-6fdmt
+  namespace: frontend-ns
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: frontend-5c6559f75f
+    uid: 29630998-bdee-4586-ac64-45223d7ef7d5
+  resourceVersion: "84008090"
+  selfLink: /api/v1/namespaces/frontend-ns/pods/frontend-5c6559f75f-6fdmt
+  uid: a2280982-e745-468f-9176-21ff1642fa8d
+spec:
+  containers:
+  - image: nginx:1.19.1
+    imagePullPolicy: IfNotPresent
+    name: nginx
+    ports:
+    - containerPort: 80
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-fhqgl
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: gke-spinnaker-e2-small-c528c905-w20h
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: default-token-fhqgl
+    secret:
+      defaultMode: 420
+      secretName: default-token-fhqgl
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:47:01Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:47:12Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:47:12Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2020-07-24T18:47:01Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: containerd://4156e8c60407052d85005381140b9417348a7a796119c93cf29f06701aca52f0
+    image: docker.io/library/nginx:1.19.1
+    imageID: docker.io/library/nginx@sha256:0e188877aa60537d1a1c6484b8c3929cfe09988145327ee47e8e91ddf6f76f5c
+    lastState: {}
+    name: nginx
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2020-07-24T18:47:11Z"
+  hostIP: 10.128.0.14
+  phase: Running
+  podIP: 10.52.1.17
+  podIPs:
+  - ip: 10.52.1.17
+  qosClass: BestEffort
+  startTime: "2020-07-24T18:47:01Z"

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-rs-new.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-rs-new.yml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: frontend-ns
+    artifact.spinnaker.io/name: frontend
+    artifact.spinnaker.io/type: kubernetes/deployment
+    deployment.kubernetes.io/desired-replicas: "2"
+    deployment.kubernetes.io/max-replicas: "3"
+    deployment.kubernetes.io/revision: "2"
+    moniker.spinnaker.io/application: frontendapp
+    moniker.spinnaker.io/cluster: deployment frontend
+  creationTimestamp: "2020-07-24T18:47:01Z"
+  generation: 2
+  labels:
+    app: nginx
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: frontendapp
+    load-balancer: frontend
+    pod-template-hash: 5c6559f75f
+  name: frontend-5c6559f75f
+  namespace: frontend-ns
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Deployment
+    name: frontend
+    uid: 4060c028-521b-4a81-ad44-b06ebee25f2e
+  resourceVersion: "84008200"
+  selfLink: /apis/apps/v1/namespaces/frontend-ns/replicasets/frontend-5c6559f75f
+  uid: 29630998-bdee-4586-ac64-45223d7ef7d5
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+      pod-template-hash: 5c6559f75f
+  template:
+    metadata:
+      annotations:
+        artifact.spinnaker.io/location: frontend-ns
+        artifact.spinnaker.io/name: frontend
+        artifact.spinnaker.io/type: kubernetes/deployment
+        moniker.spinnaker.io/application: frontendapp
+        moniker.spinnaker.io/cluster: deployment frontend
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/managed-by: spinnaker
+        app.kubernetes.io/name: frontendapp
+        load-balancer: frontend
+        pod-template-hash: 5c6559f75f
+    spec:
+      containers:
+      - image: nginx:1.19.1
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 2
+  fullyLabeledReplicas: 2
+  observedGeneration: 2
+  readyReplicas: 2
+  replicas: 2

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-rs-old.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-rs-old.yml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: frontend-ns
+    artifact.spinnaker.io/name: frontend
+    artifact.spinnaker.io/type: kubernetes/deployment
+    deployment.kubernetes.io/desired-replicas: "2"
+    deployment.kubernetes.io/max-replicas: "3"
+    deployment.kubernetes.io/revision: "1"
+    moniker.spinnaker.io/application: frontendapp
+    moniker.spinnaker.io/cluster: deployment frontend
+  creationTimestamp: "2020-07-24T18:45:00Z"
+  generation: 3
+  labels:
+    app: nginx
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: frontendapp
+    load-balancer: frontend
+    pod-template-hash: 64545c4c54
+  name: frontend-64545c4c54
+  namespace: frontend-ns
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Deployment
+    name: frontend
+    uid: 4060c028-521b-4a81-ad44-b06ebee25f2e
+  resourceVersion: "84008207"
+  selfLink: /apis/apps/v1/namespaces/frontend-ns/replicasets/frontend-64545c4c54
+  uid: 13939207-d970-4e19-8f8d-ffcd353016ff
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: nginx
+      pod-template-hash: 64545c4c54
+  template:
+    metadata:
+      annotations:
+        artifact.spinnaker.io/location: frontend-ns
+        artifact.spinnaker.io/name: frontend
+        artifact.spinnaker.io/type: kubernetes/deployment
+        moniker.spinnaker.io/application: frontendapp
+        moniker.spinnaker.io/cluster: deployment frontend
+      creationTimestamp: null
+      labels:
+        app: nginx
+        app.kubernetes.io/managed-by: spinnaker
+        app.kubernetes.io/name: frontendapp
+        load-balancer: frontend
+        pod-template-hash: 64545c4c54
+    spec:
+      containers:
+      - image: nginx:1.19.0
+        imagePullPolicy: IfNotPresent
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  observedGeneration: 3
+  replicas: 0

--- a/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-service.yml
+++ b/clouddriver-kubernetes/src/test/resources/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/frontend-service.yml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    artifact.spinnaker.io/location: frontend-ns
+    artifact.spinnaker.io/name: frontend
+    artifact.spinnaker.io/type: kubernetes/service
+    moniker.spinnaker.io/application: frontendapp
+    moniker.spinnaker.io/cluster: service frontend
+  creationTimestamp: "2020-07-24T18:41:17Z"
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: frontendapp
+  name: frontend
+  namespace: frontend-ns
+  resourceVersion: "84005141"
+  selfLink: /api/v1/namespaces/frontend-ns/services/frontend
+  uid: d7045409-18dc-4889-9b07-6126b0357435
+spec:
+  clusterIP: 10.117.5.201
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    load-balancer: frontend
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
There are currently almost no tests on any of the data providers in the Kubernetes provider. Before doing significant work in this area, we should add some test coverage to validate that the upcoming changes don't break anything.

As a lot of the classes are tightly-coupled without clearly defined interfaces between them, I decided to write an integration test that runs the caching agent for a few resources, then calls the data providers to ensure that the resulting data is as expected.

This tests the contract that should mostly stay consistent during the upcoming refactor. Even if we change what data is stored in the cache, we'll need to make sure that these providers still return the same data after a caching cycle is run.

Eventually we should write more unit tests, once there are stronger contracts between these providers and between them and the cache. But at this point I think a test at this level will give the most confidence that the upcoming changes don't break anything.

This is a very large class, as I only wanted to set up the data once, and the various providers all return different view of the same data so they can share some of the assert functions. Maybe there's a better way to split this up, but for the moment this seemed reasonable.

I used SoftAssertions so that you get a report of all the failures for each test at the end (rather than failing at the first issue) which should make debugging easier.

Finally, I had to make a few classes public. These aren't really intended to be used widely, but it's impossible to appropriately create a new KubernetesV2Credentials without them. Eventually we could/should make it easier to create said credentials for testing purposes, but for now this seemed better than making the test less realistic.  (Also as these are Spring components, and Spring can find package-private things, they are in a sense a bit exposed already. In fact the reason we need them exposed is because we're wiring up things as Spring would on startup.)