### PR TITLE
refactor(kubernetes): Clean up data provider classes

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroupManager.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroupManager.java
@@ -33,7 +33,7 @@ public interface ServerGroupManager {
 
   Moniker getMoniker();
 
-  Set<ServerGroupSummary> getServerGroups();
+  Set<? extends ServerGroupSummary> getServerGroups();
 
   String getRegion();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Application.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Application.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import lombok.Value;
 
 @Value
-public class KubernetesV2Application implements Application {
+public final class KubernetesV2Application implements Application {
   private final String name;
   private final Map<String, Set<String>> clusterNames;
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Cluster.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Cluster.java
@@ -20,13 +20,10 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.model.Cluster;
-import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
-import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import com.netflix.spinnaker.moniker.Moniker;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.Data;
 
 @Data
@@ -35,8 +32,8 @@ public class KubernetesV2Cluster implements Cluster {
   private Moniker moniker;
   private String type = KubernetesCloudProvider.ID;
   private String accountName;
-  private Set<ServerGroup> serverGroups = new HashSet<>();
-  private Set<LoadBalancer> loadBalancers = new HashSet<>();
+  private Set<KubernetesV2ServerGroup> serverGroups = new HashSet<>();
+  private Set<KubernetesV2LoadBalancer> loadBalancers = new HashSet<>();
   private String application;
 
   public KubernetesV2Cluster(String rawKey) {
@@ -52,10 +49,7 @@ public class KubernetesV2Cluster implements Cluster {
       List<KubernetesV2ServerGroup> serverGroups,
       List<KubernetesV2LoadBalancer> loadBalancers) {
     this(rawKey);
-    this.serverGroups =
-        serverGroups.stream().map(sg -> (ServerGroup) sg).collect(Collectors.toSet());
-
-    this.loadBalancers =
-        loadBalancers.stream().map(sg -> (LoadBalancer) sg).collect(Collectors.toSet());
+    this.serverGroups = new HashSet<>(serverGroups);
+    this.loadBalancers = new HashSet<>(loadBalancers);
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Cluster.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Cluster.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.model.Cluster;
@@ -24,31 +25,31 @@ import com.netflix.spinnaker.moniker.Moniker;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.Data;
+import lombok.Value;
 
-@Data
-public class KubernetesV2Cluster implements Cluster {
-  private String name;
-  private Moniker moniker;
-  private String type = KubernetesCloudProvider.ID;
-  private String accountName;
-  private Set<KubernetesV2ServerGroup> serverGroups = new HashSet<>();
-  private Set<KubernetesV2LoadBalancer> loadBalancers = new HashSet<>();
-  private String application;
+@Value
+public final class KubernetesV2Cluster implements Cluster {
+  private final String name;
+  private final Moniker moniker;
+  private final String type = KubernetesCloudProvider.ID;
+  private final String accountName;
+  private final Set<KubernetesV2ServerGroup> serverGroups;
+  private final Set<KubernetesV2LoadBalancer> loadBalancers;
+  private final String application;
 
   public KubernetesV2Cluster(String rawKey) {
-    Keys.ClusterCacheKey key = (Keys.ClusterCacheKey) Keys.parseKey(rawKey).get();
-    this.name = key.getName();
-    this.accountName = key.getAccount();
-    this.application = key.getApplication();
-    this.moniker = Moniker.builder().cluster(name).app(application).build();
+    this(rawKey, ImmutableList.of(), ImmutableList.of());
   }
 
   public KubernetesV2Cluster(
       String rawKey,
       List<KubernetesV2ServerGroup> serverGroups,
       List<KubernetesV2LoadBalancer> loadBalancers) {
-    this(rawKey);
+    Keys.ClusterCacheKey key = (Keys.ClusterCacheKey) Keys.parseKey(rawKey).get();
+    this.name = key.getName();
+    this.accountName = key.getAccount();
+    this.application = key.getApplication();
+    this.moniker = Moniker.builder().cluster(name).app(application).build();
     this.serverGroups = new HashSet<>(serverGroups);
     this.loadBalancers = new HashSet<>(loadBalancers);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Health.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Health.java
@@ -23,12 +23,12 @@ import com.netflix.spinnaker.clouddriver.model.HealthState;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import java.util.Map;
-import lombok.Data;
+import lombok.Value;
 
-@Data
+@Value
 // TODO(lwander): match spec described here
 // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
-public class KubernetesV2Health implements Health {
+public final class KubernetesV2Health implements Health {
   private final HealthState state;
   private final String source;
   private final String type;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Instance.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Instance.java
@@ -31,24 +31,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.Data;
+import javax.validation.constraints.Null;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 @EqualsAndHashCode(callSuper = true)
-@Data
-@NoArgsConstructor
 @Slf4j
-public class KubernetesV2Instance extends ManifestBasedModel implements Instance {
-  private Long launchTime;
-  private List<Map<String, Object>> health = new ArrayList<>();
-  private KubernetesManifest manifest;
-  private Keys.InfrastructureCacheKey key;
+@Value
+public final class KubernetesV2Instance extends ManifestBasedModel implements Instance {
+  private final List<Map<String, Object>> health;
+  private final KubernetesManifest manifest;
+  private final Keys.InfrastructureCacheKey key;
+
+  @Null
+  @Override
+  public Long getLaunchTime() {
+    return null;
+  }
 
   private KubernetesV2Instance(KubernetesManifest manifest, String key) {
     this.manifest = manifest;
     this.key = (Keys.InfrastructureCacheKey) Keys.parseKey(key).get();
+    this.health = new ArrayList<>();
 
     V1PodStatus status =
         KubernetesCacheDataConverter.getResource(this.manifest.getStatus(), V1PodStatus.class);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
@@ -76,7 +76,7 @@ public class KubernetesV2LoadBalancer extends ManifestBasedModel
                         KubernetesV2ServerGroupCacheData.builder()
                             .serverGroupData(d)
                             .instanceData(serverGroupToInstanceData.get(d.getId()))
-                            .loadBalancerData(ImmutableList.of(cd))
+                            .loadBalancerKeys(ImmutableList.of(cd.getId()))
                             .build()))
             .filter(Objects::nonNull)
             .map(KubernetesV2ServerGroup::toLoadBalancerServerGroup)

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
@@ -27,24 +27,23 @@ import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 @EqualsAndHashCode(callSuper = true)
-@Data
 @Slf4j
-public class KubernetesV2LoadBalancer extends ManifestBasedModel
+@Value
+public final class KubernetesV2LoadBalancer extends ManifestBasedModel
     implements LoadBalancer, LoadBalancerProvider.Details {
-  private Set<LoadBalancerServerGroup> serverGroups = new HashSet<>();
-  private KubernetesManifest manifest;
-  private Keys.InfrastructureCacheKey key;
+  private final Set<LoadBalancerServerGroup> serverGroups;
+  private final KubernetesManifest manifest;
+  private final Keys.InfrastructureCacheKey key;
 
   private KubernetesV2LoadBalancer(
       KubernetesManifest manifest, String key, Set<LoadBalancerServerGroup> serverGroups) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +56,7 @@ public class KubernetesV2LoadBalancer extends ManifestBasedModel
   public static KubernetesV2LoadBalancer fromCacheData(
       CacheData cd,
       List<CacheData> serverGroupData,
-      Map<String, List<CacheData>> serverGroupToInstanceData) {
+      Map<String, ? extends Collection<CacheData>> serverGroupToInstanceData) {
     if (cd == null) {
       return null;
     }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2SecurityGroup.java
@@ -50,21 +50,22 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 @EqualsAndHashCode(callSuper = true)
-@Data
 @Slf4j
-public class KubernetesV2SecurityGroup extends ManifestBasedModel implements SecurityGroup {
+@Value
+public final class KubernetesV2SecurityGroup extends ManifestBasedModel implements SecurityGroup {
   private static final ImmutableSet<KubernetesApiVersion> SUPPORTED_API_VERSIONS =
       ImmutableSet.of(EXTENSIONS_V1BETA1, NETWORKING_K8S_IO_V1BETA1, NETWORKING_K8S_IO_V1);
 
-  private KubernetesManifest manifest;
-  private Keys.InfrastructureCacheKey key;
-  private String id;
+  private final KubernetesManifest manifest;
+  private final Keys.InfrastructureCacheKey key;
+  private final String id;
 
-  private Set<Rule> inboundRules;
-  private Set<Rule> outboundRules;
+  private final Set<Rule> inboundRules;
+  private final Set<Rule> outboundRules;
 
   @Override
   public String getApplication() {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
@@ -144,24 +144,8 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
   }
 
   public static KubernetesV2ServerGroup fromCacheData(KubernetesV2ServerGroupCacheData cacheData) {
-    CacheData cd = cacheData.getServerGroupData();
-    List<CacheData> instanceData = cacheData.getInstanceData();
-    List<Keys.InfrastructureCacheKey> serverGroupManagerKeys =
-        cacheData.getServerGroupManagerKeys();
-    if (cd == null) {
-      return null;
-    }
-
-    if (instanceData == null) {
-      instanceData = new ArrayList<>();
-    }
-
-    if (serverGroupManagerKeys == null) {
-      serverGroupManagerKeys = new ArrayList<>();
-    }
-
     List<ServerGroupManagerSummary> serverGroupManagers =
-        serverGroupManagerKeys.stream()
+        cacheData.getServerGroupManagerKeys().stream()
             .map(
                 k ->
                     ServerGroupManagerSummary.builder()
@@ -171,15 +155,16 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
                         .build())
             .collect(Collectors.toList());
 
-    KubernetesManifest manifest = KubernetesCacheDataConverter.getManifest(cd);
+    KubernetesManifest manifest =
+        KubernetesCacheDataConverter.getManifest(cacheData.getServerGroupData());
 
     if (manifest == null) {
-      log.warn("Cache data {} inserted without a manifest", cd.getId());
+      log.warn("Cache data {} inserted without a manifest", cacheData.getServerGroupData().getId());
       return null;
     }
 
     List<KubernetesV2Instance> instances =
-        instanceData.stream()
+        cacheData.getInstanceData().stream()
             .map(KubernetesV2Instance::fromCacheData)
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
@@ -210,7 +195,12 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
     loadBalancers.addAll(explicitLoadBalancers);
 
     return new KubernetesV2ServerGroup(
-        manifest, cd.getId(), instances, loadBalancers, serverGroupManagers, disabled);
+        manifest,
+        cacheData.getServerGroupData().getId(),
+        instances,
+        loadBalancers,
+        serverGroupManagers,
+        disabled);
   }
 
   public KubernetesV2ServerGroupSummary toServerGroupSummary() {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ArtifactReplacer;
@@ -45,26 +46,26 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.Data;
+import javax.validation.constraints.Null;
 import lombok.EqualsAndHashCode;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 @EqualsAndHashCode(callSuper = true)
-@Data
 @Slf4j
-public class KubernetesV2ServerGroup extends ManifestBasedModel implements ServerGroup {
-  private Boolean disabled;
-  private Set<String> zones = new HashSet<>();
-  private Set<KubernetesV2Instance> instances = new HashSet<>();
-  private Set<String> loadBalancers = new HashSet<>();
-  private Set<String> securityGroups = new HashSet<>();
-  private List<ServerGroupManagerSummary> serverGroupManagers = new ArrayList<>();
-  private Map<String, Object> launchConfig = new HashMap<>();
-  private Capacity capacity = new Capacity();
-  private ImageSummary imageSummary;
-  private ImagesSummary imagesSummary;
-  private KubernetesManifest manifest;
-  private Keys.InfrastructureCacheKey key;
+@Value
+public final class KubernetesV2ServerGroup extends ManifestBasedModel implements ServerGroup {
+  private final boolean disabled;
+  private final Set<KubernetesV2Instance> instances;
+  private final Set<String> loadBalancers;
+  private final List<ServerGroupManagerSummary> serverGroupManagers;
+  private final Capacity capacity;
+  private final KubernetesManifest manifest;
+  private final Keys.InfrastructureCacheKey key;
+
+  private final Set<String> zones = ImmutableSet.of();
+  private final Set<String> securityGroups = ImmutableSet.of();
+  private final Map<String, Object> launchConfig = ImmutableMap.of();
 
   @JsonIgnore
   private static final ArtifactReplacer dockerImageReplacer =
@@ -191,7 +192,7 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
             .map(Keys::parseKey)
             .filter(Optional::isPresent)
             .map(Optional::get)
-            .map(k -> (Keys.InfrastructureCacheKey) k)
+            .map(k -> (InfrastructureCacheKey) k)
             .map(k -> KubernetesManifest.getFullResourceName(k.getKubernetesKind(), k.getName()))
             .collect(Collectors.toSet());
 
@@ -229,6 +230,13 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
         .isDisabled(isDisabled())
         .cloudProvider(KubernetesCloudProvider.ID)
         .build();
+  }
+
+  @Deprecated
+  @Null
+  @Override
+  public ImageSummary getImageSummary() {
+    return null;
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
@@ -21,11 +21,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
-import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ArtifactReplacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.artifact.Replacer;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.InfrastructureCacheKey;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.KubernetesV2ServerGroupCacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
@@ -146,6 +146,11 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
   public static KubernetesV2ServerGroup fromCacheData(KubernetesV2ServerGroupCacheData cacheData) {
     List<ServerGroupManagerSummary> serverGroupManagers =
         cacheData.getServerGroupManagerKeys().stream()
+            .map(Keys::parseKey)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .filter(k -> k instanceof InfrastructureCacheKey)
+            .map(k -> (InfrastructureCacheKey) k)
             .map(
                 k ->
                     ServerGroupManagerSummary.builder()
@@ -182,8 +187,7 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
             .collect(Collectors.toSet());
 
     Set<String> loadBalancers =
-        cacheData.getLoadBalancerData().stream()
-            .map(CacheData::getId)
+        cacheData.getLoadBalancerKeys().stream()
             .map(Keys::parseKey)
             .filter(Optional::isPresent)
             .map(Optional::get)

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
@@ -32,11 +32,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestAnnotater;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestTraffic;
 import com.netflix.spinnaker.clouddriver.model.HealthState;
-import com.netflix.spinnaker.clouddriver.model.Instance;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import com.netflix.spinnaker.clouddriver.model.ServerGroupManager.ServerGroupManagerSummary;
-import com.netflix.spinnaker.clouddriver.model.ServerGroupSummary;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -57,7 +55,7 @@ import lombok.extern.slf4j.Slf4j;
 public class KubernetesV2ServerGroup extends ManifestBasedModel implements ServerGroup {
   private Boolean disabled;
   private Set<String> zones = new HashSet<>();
-  private Set<Instance> instances = new HashSet<>();
+  private Set<KubernetesV2Instance> instances = new HashSet<>();
   private Set<String> loadBalancers = new HashSet<>();
   private Set<String> securityGroups = new HashSet<>();
   private List<ServerGroupManagerSummary> serverGroupManagers = new ArrayList<>();
@@ -223,7 +221,7 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
         cacheData.getServerGroupManagerKeys());
   }
 
-  public ServerGroupSummary toServerGroupSummary() {
+  public KubernetesV2ServerGroupSummary toServerGroupSummary() {
     return KubernetesV2ServerGroupSummary.builder()
         .name(getName())
         .account(getAccount())
@@ -238,7 +236,7 @@ public class KubernetesV2ServerGroup extends ManifestBasedModel implements Serve
         .detachedInstances(new HashSet<>())
         .instances(
             instances.stream()
-                .map(i -> ((KubernetesV2Instance) i).toLoadBalancerInstance())
+                .map(KubernetesV2Instance::toLoadBalancerInstance)
                 .collect(Collectors.toSet()))
         .name(getName())
         .region(getRegion())

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.K
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.KubernetesV2ServerGroupManagerCacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.ServerGroupManager;
-import com.netflix.spinnaker.clouddriver.model.ServerGroupSummary;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -41,10 +40,10 @@ public class KubernetesV2ServerGroupManager extends ManifestBasedModel
     implements ServerGroupManager {
   private KubernetesManifest manifest;
   private Keys.InfrastructureCacheKey key;
-  private Set<ServerGroupSummary> serverGroups;
+  private Set<KubernetesV2ServerGroupSummary> serverGroups;
 
   private KubernetesV2ServerGroupManager(
-      KubernetesManifest manifest, String key, Set<ServerGroupSummary> serverGroups) {
+      KubernetesManifest manifest, String key, Set<KubernetesV2ServerGroupSummary> serverGroups) {
     this.manifest = manifest;
     this.key = (Keys.InfrastructureCacheKey) Keys.parseKey(key).get();
     this.serverGroups = serverGroups;
@@ -67,7 +66,7 @@ public class KubernetesV2ServerGroupManager extends ManifestBasedModel
       return null;
     }
 
-    Set<ServerGroupSummary> serverGroups =
+    Set<KubernetesV2ServerGroupSummary> serverGroups =
         serverGroupData.stream()
             .map(
                 data ->

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
@@ -49,8 +49,10 @@ public class KubernetesV2ServerGroupManager extends ManifestBasedModel
     this.serverGroups = serverGroups;
   }
 
-  private static KubernetesV2ServerGroupManager fromCacheData(
-      CacheData cd, List<CacheData> serverGroupData) {
+  public static KubernetesV2ServerGroupManager fromCacheData(
+      KubernetesV2ServerGroupManagerCacheData data) {
+    CacheData cd = data.getServerGroupManagerData();
+    List<CacheData> serverGroupData = data.getServerGroupData();
     if (cd == null) {
       return null;
     }
@@ -69,10 +71,10 @@ public class KubernetesV2ServerGroupManager extends ManifestBasedModel
     Set<KubernetesV2ServerGroupSummary> serverGroups =
         serverGroupData.stream()
             .map(
-                data ->
+                sg ->
                     KubernetesV2ServerGroup.fromCacheData(
                         KubernetesV2ServerGroupCacheData.builder()
-                            .serverGroupData(data)
+                            .serverGroupData(sg)
                             .instanceData(new ArrayList<>())
                             .loadBalancerData(new ArrayList<>())
                             .build()))
@@ -81,10 +83,5 @@ public class KubernetesV2ServerGroupManager extends ManifestBasedModel
             .collect(Collectors.toSet());
 
     return new KubernetesV2ServerGroupManager(manifest, cd.getId(), serverGroups);
-  }
-
-  public static KubernetesV2ServerGroupManager fromCacheData(
-      KubernetesV2ServerGroupManagerCacheData data) {
-    return fromCacheData(data.getServerGroupManagerData(), data.getServerGroupData());
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
@@ -17,15 +17,12 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model;
 
-import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.KubernetesV2ServerGroupCacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.KubernetesV2ServerGroupManagerCacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.ServerGroupManager;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -51,37 +48,25 @@ public class KubernetesV2ServerGroupManager extends ManifestBasedModel
 
   public static KubernetesV2ServerGroupManager fromCacheData(
       KubernetesV2ServerGroupManagerCacheData data) {
-    CacheData cd = data.getServerGroupManagerData();
-    List<CacheData> serverGroupData = data.getServerGroupData();
-    if (cd == null) {
-      return null;
-    }
-
-    if (serverGroupData == null) {
-      serverGroupData = new ArrayList<>();
-    }
-
-    KubernetesManifest manifest = KubernetesCacheDataConverter.getManifest(cd);
-
+    KubernetesManifest manifest =
+        KubernetesCacheDataConverter.getManifest(data.getServerGroupManagerData());
     if (manifest == null) {
-      log.warn("Cache data {} inserted without a manifest", cd.getId());
+      log.warn(
+          "Cache data {} inserted without a manifest", data.getServerGroupManagerData().getId());
       return null;
     }
 
     Set<KubernetesV2ServerGroupSummary> serverGroups =
-        serverGroupData.stream()
+        data.getServerGroupData().stream()
             .map(
                 sg ->
                     KubernetesV2ServerGroup.fromCacheData(
-                        KubernetesV2ServerGroupCacheData.builder()
-                            .serverGroupData(sg)
-                            .instanceData(new ArrayList<>())
-                            .loadBalancerData(new ArrayList<>())
-                            .build()))
+                        KubernetesV2ServerGroupCacheData.builder().serverGroupData(sg).build()))
             .filter(Objects::nonNull)
             .map(KubernetesV2ServerGroup::toServerGroupSummary)
             .collect(Collectors.toSet());
 
-    return new KubernetesV2ServerGroupManager(manifest, cd.getId(), serverGroups);
+    return new KubernetesV2ServerGroupManager(
+        manifest, data.getServerGroupManagerData().getId(), serverGroups);
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
@@ -26,18 +26,18 @@ import com.netflix.spinnaker.clouddriver.model.ServerGroupManager;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 @EqualsAndHashCode(callSuper = true)
-@Data
 @Slf4j
-public class KubernetesV2ServerGroupManager extends ManifestBasedModel
+@Value
+public final class KubernetesV2ServerGroupManager extends ManifestBasedModel
     implements ServerGroupManager {
-  private KubernetesManifest manifest;
-  private Keys.InfrastructureCacheKey key;
-  private Set<KubernetesV2ServerGroupSummary> serverGroups;
+  private final KubernetesManifest manifest;
+  private final Keys.InfrastructureCacheKey key;
+  private final Set<KubernetesV2ServerGroupSummary> serverGroups;
 
   private KubernetesV2ServerGroupManager(
       KubernetesManifest manifest, String key, Set<KubernetesV2ServerGroupSummary> serverGroups) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupSummary.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupSummary.java
@@ -19,20 +19,16 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model;
 
 import com.netflix.spinnaker.clouddriver.model.ServerGroupSummary;
 import com.netflix.spinnaker.moniker.Moniker;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
-public class KubernetesV2ServerGroupSummary implements ServerGroupSummary {
-  private String name;
-  private String account;
-  private String namespace;
-  private Moniker moniker;
+@Value
+public final class KubernetesV2ServerGroupSummary implements ServerGroupSummary {
+  private final String name;
+  private final String account;
+  private final String namespace;
+  private final Moniker moniker;
 
   public String getRegion() {
     return namespace;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ApplicationProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ApplicationProvider.java
@@ -22,7 +22,6 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.LogicalK
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.ClusterCacheKey;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Application;
-import com.netflix.spinnaker.clouddriver.model.Application;
 import com.netflix.spinnaker.clouddriver.model.ApplicationProvider;
 import java.util.Collection;
 import java.util.List;
@@ -43,7 +42,7 @@ public class KubernetesV2ApplicationProvider implements ApplicationProvider {
   }
 
   @Override
-  public Set<? extends Application> getApplications(boolean expand) {
+  public Set<KubernetesV2Application> getApplications(boolean expand) {
     // TODO(lwander) performance optimization: rely on expand parameter to make a more
     // cache-efficient call
     String clusterGlobKey = ClusterCacheKey.createKey("*", "*", "*");
@@ -62,7 +61,7 @@ public class KubernetesV2ApplicationProvider implements ApplicationProvider {
   }
 
   @Override
-  public Application getApplication(String name) {
+  public KubernetesV2Application getApplication(String name) {
     String clusterGlobKey = ClusterCacheKey.createKey("*", name, "*");
     List<ClusterCacheKey> keys =
         cacheUtils.getAllKeysMatchingPattern(CLUSTERS.toString(), clusterGlobKey).stream()

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ClusterProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ClusterProvider.java
@@ -279,13 +279,6 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
       List<CacheData> clusterServerGroups =
           clusterToServerGroups.getOrDefault(clusterDatum.getId(), new ArrayList<>());
 
-      List<CacheData> clusterLoadBalancers =
-          clusterServerGroups.stream()
-              .map(CacheData::getId)
-              .map(id -> serverGroupToLoadBalancers.getOrDefault(id, new ArrayList<>()))
-              .flatMap(Collection::stream)
-              .collect(Collectors.toList());
-
       List<KubernetesV2ServerGroup> serverGroups =
           clusterServerGroups.stream()
               .map(
@@ -307,7 +300,10 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
               .collect(Collectors.toList());
 
       List<KubernetesV2LoadBalancer> loadBalancers =
-          clusterLoadBalancers.stream()
+          clusterServerGroups.stream()
+              .map(CacheData::getId)
+              .map(id -> serverGroupToLoadBalancers.getOrDefault(id, new ArrayList<>()))
+              .flatMap(Collection::stream)
               .map(
                   cd ->
                       KubernetesV2LoadBalancer.fromCacheData(
@@ -320,6 +316,6 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
       result.add(new KubernetesV2Cluster(clusterDatum.getId(), serverGroups, loadBalancers));
     }
 
-    return result.stream().filter(Objects::nonNull).collect(Collectors.toSet());
+    return result;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ClusterProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ClusterProvider.java
@@ -209,7 +209,6 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
 
   private Set<KubernetesV2Cluster> translateClusters(Collection<CacheData> clusterData) {
     return clusterData.stream()
-        .filter(Objects::nonNull)
         .map(clusterDatum -> new KubernetesV2Cluster(clusterDatum.getId()))
         .collect(Collectors.toSet());
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -77,7 +77,7 @@ public class KubernetesV2LoadBalancerProvider
   }
 
   @Override
-  public List<LoadBalancerProvider.Details> byAccountAndRegionAndName(
+  public List<KubernetesV2LoadBalancer> byAccountAndRegionAndName(
       String account, String namespace, String fullName) {
     Pair<KubernetesKind, String> parsedName;
     try {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -88,7 +88,7 @@ public class KubernetesV2LoadBalancerProvider
 
     KubernetesKind kind = parsedName.getLeft();
     String name = parsedName.getRight();
-    String key = Keys.InfrastructureCacheKey.createKey(kind, account, name, name);
+    String key = Keys.InfrastructureCacheKey.createKey(kind, account, namespace, name);
 
     Optional<CacheData> optionalLoadBalancerData = cacheUtils.getSingleEntry(kind.toString(), key);
     if (!optionalLoadBalancerData.isPresent()) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/data/KubernetesV2ServerGroupCacheData.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/data/KubernetesV2ServerGroupCacheData.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
-import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.Collection;
 import java.util.Objects;
@@ -34,19 +33,19 @@ import lombok.Value;
 public class KubernetesV2ServerGroupCacheData implements KubernetesV2CacheData {
   private final CacheData serverGroupData;
   private final Collection<CacheData> instanceData;
-  private final Collection<CacheData> loadBalancerData;
-  private final Collection<Keys.InfrastructureCacheKey> serverGroupManagerKeys;
+  private final Collection<String> loadBalancerKeys;
+  private final Collection<String> serverGroupManagerKeys;
 
   @Builder
   @ParametersAreNullableByDefault
   private KubernetesV2ServerGroupCacheData(
       @Nonnull CacheData serverGroupData,
       Collection<CacheData> instanceData,
-      Collection<CacheData> loadBalancerData,
-      Collection<Keys.InfrastructureCacheKey> serverGroupManagerKeys) {
+      Collection<String> loadBalancerKeys,
+      Collection<String> serverGroupManagerKeys) {
     this.serverGroupData = Objects.requireNonNull(serverGroupData);
     this.instanceData = Optional.ofNullable(instanceData).orElseGet(ImmutableList::of);
-    this.loadBalancerData = Optional.ofNullable(loadBalancerData).orElseGet(ImmutableList::of);
+    this.loadBalancerKeys = Optional.ofNullable(loadBalancerKeys).orElseGet(ImmutableList::of);
     this.serverGroupManagerKeys =
         Optional.ofNullable(serverGroupManagerKeys).orElseGet(ImmutableList::of);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/data/KubernetesV2ServerGroupCacheData.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/data/KubernetesV2ServerGroupCacheData.java
@@ -17,20 +17,41 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
-import java.util.List;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
 
-@Data
-@Builder
+@NonnullByDefault
+@Value
 public class KubernetesV2ServerGroupCacheData implements KubernetesV2CacheData {
-  private CacheData serverGroupData;
-  private List<CacheData> instanceData;
-  private List<CacheData> loadBalancerData;
-  private List<Keys.InfrastructureCacheKey> serverGroupManagerKeys;
+  private final CacheData serverGroupData;
+  private final Collection<CacheData> instanceData;
+  private final Collection<CacheData> loadBalancerData;
+  private final Collection<Keys.InfrastructureCacheKey> serverGroupManagerKeys;
 
+  @Builder
+  @ParametersAreNullableByDefault
+  private KubernetesV2ServerGroupCacheData(
+      @Nonnull CacheData serverGroupData,
+      Collection<CacheData> instanceData,
+      Collection<CacheData> loadBalancerData,
+      Collection<Keys.InfrastructureCacheKey> serverGroupManagerKeys) {
+    this.serverGroupData = Objects.requireNonNull(serverGroupData);
+    this.instanceData = Optional.ofNullable(instanceData).orElseGet(ImmutableList::of);
+    this.loadBalancerData = Optional.ofNullable(loadBalancerData).orElseGet(ImmutableList::of);
+    this.serverGroupManagerKeys =
+        Optional.ofNullable(serverGroupManagerKeys).orElseGet(ImmutableList::of);
+  }
+
+  @Override
   public CacheData primaryData() {
     return serverGroupData;
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/data/KubernetesV2ServerGroupManagerCacheData.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/data/KubernetesV2ServerGroupManagerCacheData.java
@@ -17,17 +17,32 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
-import java.util.List;
+import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNullableByDefault;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
 
-@Data
-@Builder
+@NonnullByDefault
+@Value
 public class KubernetesV2ServerGroupManagerCacheData implements KubernetesV2CacheData {
-  private CacheData serverGroupManagerData;
-  private List<CacheData> serverGroupData;
+  private final CacheData serverGroupManagerData;
+  private final Collection<CacheData> serverGroupData;
 
+  @Builder
+  @ParametersAreNullableByDefault
+  private KubernetesV2ServerGroupManagerCacheData(
+      @Nonnull CacheData serverGroupManagerData, Collection<CacheData> serverGroupData) {
+    this.serverGroupManagerData = Objects.requireNonNull(serverGroupManagerData);
+    this.serverGroupData = Optional.ofNullable(serverGroupData).orElseGet(ImmutableList::of);
+  }
+
+  @Override
   public CacheData primaryData() {
     return serverGroupManagerData;
   }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -405,9 +405,8 @@ final class KubernetesDataProviderIntegrationTest {
     List<KubernetesV2LoadBalancer> results =
         loadBalancerProvider.byAccountAndRegionAndName(
             ACCOUNT_NAME, "frontend-ns", "service frontend");
-    // TODO(ezimanyi): This is a bug; we are not properly looking up the load balancer, so always
-    // return null
-    assertThat(results).isNull();
+    assertThat(results).hasSize(1);
+    assertFrontendLoadBalancer(softly, results.iterator().next());
   }
 
   @Test

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -43,6 +43,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.Kubernete
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2LoadBalancer;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroup;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroupManager;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroupSummary;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.AccountResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
@@ -66,7 +67,6 @@ import com.netflix.spinnaker.clouddriver.model.Application;
 import com.netflix.spinnaker.clouddriver.model.HealthState;
 import com.netflix.spinnaker.clouddriver.model.Instance;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerInstance;
-import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider.Details;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
 import com.netflix.spinnaker.clouddriver.model.ServerGroup;
 import com.netflix.spinnaker.clouddriver.model.ServerGroupManager.ServerGroupManagerSummary;
@@ -326,12 +326,11 @@ final class KubernetesDataProviderIntegrationTest {
 
   @Test
   void getApplicationsUnexpanded(SoftAssertions softly) {
-    Set<? extends Application> result = applicationProvider.getApplications(false);
+    Set<KubernetesV2Application> result = applicationProvider.getApplications(false);
     softly.assertThat(result).hasSize(2);
 
     Map<String, KubernetesV2Application> applicationLookup =
-        result.stream()
-            .collect(toImmutableMap(Application::getName, a -> (KubernetesV2Application) a));
+        result.stream().collect(toImmutableMap(Application::getName, a -> a));
 
     KubernetesV2Application frontendApplication = applicationLookup.get("frontendapp");
     softly.assertThat(frontendApplication).isNotNull();
@@ -349,12 +348,11 @@ final class KubernetesDataProviderIntegrationTest {
   @Test
   void getApplicationsExpanded(SoftAssertions softly) {
     // This is the same as the unexpanded test, as it seems like we ignore the flag.
-    Set<? extends Application> result = applicationProvider.getApplications(true);
+    Set<KubernetesV2Application> result = applicationProvider.getApplications(true);
     softly.assertThat(result).hasSize(2);
 
     Map<String, KubernetesV2Application> applicationLookup =
-        result.stream()
-            .collect(toImmutableMap(Application::getName, a -> (KubernetesV2Application) a));
+        result.stream().collect(toImmutableMap(Application::getName, a -> a));
 
     KubernetesV2Application frontendApplication = applicationLookup.get("frontendapp");
     softly.assertThat(frontendApplication).isNotNull();
@@ -371,8 +369,7 @@ final class KubernetesDataProviderIntegrationTest {
 
   @Test
   void getApplication(SoftAssertions softly) {
-    KubernetesV2Application result =
-        (KubernetesV2Application) applicationProvider.getApplication("backendapp");
+    KubernetesV2Application result = applicationProvider.getApplication("backendapp");
     assertThat(result).isNotNull();
     assertBackendApplication(softly, result);
   }
@@ -405,7 +402,7 @@ final class KubernetesDataProviderIntegrationTest {
 
   @Test
   void getLoadBalancersByName(SoftAssertions softly) {
-    List<Details> results =
+    List<KubernetesV2LoadBalancer> results =
         loadBalancerProvider.byAccountAndRegionAndName(
             ACCOUNT_NAME, "frontend-ns", "service frontend");
     // TODO(ezimanyi): This is a bug; we are not properly looking up the load balancer, so always
@@ -550,8 +547,7 @@ final class KubernetesDataProviderIntegrationTest {
       // finding all relationships to it). This should be fixed to return it only once.
       softly.assertThat(cluster.getLoadBalancers()).hasSize(4);
       if (!cluster.getLoadBalancers().isEmpty()) {
-        assertFrontendLoadBalancer(
-            softly, (KubernetesV2LoadBalancer) cluster.getLoadBalancers().iterator().next());
+        assertFrontendLoadBalancer(softly, cluster.getLoadBalancers().iterator().next());
       }
     } else {
       softly.assertThat(cluster.getServerGroups()).isEmpty();
@@ -560,7 +556,7 @@ final class KubernetesDataProviderIntegrationTest {
   }
 
   private void assertFrontendServerGroups(
-      SoftAssertions softly, Collection<? extends ServerGroup> serverGroups) {
+      SoftAssertions softly, Collection<KubernetesV2ServerGroup> serverGroups) {
     softly.assertThat(serverGroups).hasSize(2);
     softly
         .assertThat(serverGroups)
@@ -568,8 +564,7 @@ final class KubernetesDataProviderIntegrationTest {
         .containsExactlyInAnyOrder(
             "replicaSet frontend-5c6559f75f", "replicaSet frontend-64545c4c54");
     Map<String, KubernetesV2ServerGroup> serverGroupLookup =
-        serverGroups.stream()
-            .collect(toImmutableMap(ServerGroup::getName, sg -> (KubernetesV2ServerGroup) sg));
+        serverGroups.stream().collect(toImmutableMap(ServerGroup::getName, sg -> sg));
 
     KubernetesV2ServerGroup currentServerGroup =
         serverGroupLookup.get("replicaSet frontend-5c6559f75f");
@@ -663,11 +658,10 @@ final class KubernetesDataProviderIntegrationTest {
   }
 
   private void assertFrontendCurrentServerGroupInstances(
-      SoftAssertions softly, Collection<? extends Instance> instances) {
+      SoftAssertions softly, Collection<KubernetesV2Instance> instances) {
     softly.assertThat(instances).hasSize(2);
     Map<String, KubernetesV2Instance> instanceLookup =
-        instances.stream()
-            .collect(toImmutableMap(Instance::getName, i -> (KubernetesV2Instance) i));
+        instances.stream().collect(toImmutableMap(Instance::getName, i -> i));
 
     KubernetesV2Instance firstInstance = instanceLookup.get("477dcf19-be44-4853-88fd-1d9aedfcddba");
     softly.assertThat(firstInstance).isNotNull();
@@ -811,7 +805,7 @@ final class KubernetesDataProviderIntegrationTest {
   }
 
   private void assertFrontendServerGroupSummaries(
-      SoftAssertions softly, Collection<ServerGroupSummary> serverGroups) {
+      SoftAssertions softly, Collection<KubernetesV2ServerGroupSummary> serverGroups) {
     softly.assertThat(serverGroups).hasSize(2);
     Map<String, ServerGroupSummary> serverGroupLookup =
         serverGroups.stream().collect(toImmutableMap(ServerGroupSummary::getName, sg -> sg));
@@ -925,8 +919,7 @@ final class KubernetesDataProviderIntegrationTest {
       softly.assertThat(cluster.getLoadBalancers()).hasSize(1);
       // If soft assertion above already failed, don't try to further validate.
       if (!cluster.getLoadBalancers().isEmpty()) {
-        assertBackendLoadBalancer(
-            softly, (KubernetesV2LoadBalancer) cluster.getLoadBalancers().iterator().next());
+        assertBackendLoadBalancer(softly, cluster.getLoadBalancers().iterator().next());
       }
     } else {
       softly.assertThat(cluster.getServerGroups()).isEmpty();
@@ -935,15 +928,14 @@ final class KubernetesDataProviderIntegrationTest {
   }
 
   private void assertBackendServerGroups(
-      SoftAssertions softly, Collection<? extends ServerGroup> serverGroups) {
+      SoftAssertions softly, Collection<KubernetesV2ServerGroup> serverGroups) {
     softly.assertThat(serverGroups).hasSize(2);
     softly
         .assertThat(serverGroups)
         .extracting(ServerGroup::getName)
         .containsExactlyInAnyOrder("replicaSet backend-v014", "replicaSet backend-v015");
     Map<String, KubernetesV2ServerGroup> serverGroupLookup =
-        serverGroups.stream()
-            .collect(toImmutableMap(ServerGroup::getName, sg -> (KubernetesV2ServerGroup) sg));
+        serverGroups.stream().collect(toImmutableMap(ServerGroup::getName, sg -> sg));
 
     KubernetesV2ServerGroup currentServerGroup = serverGroupLookup.get("replicaSet backend-v015");
     softly.assertThat(currentServerGroup).isNotNull();
@@ -994,8 +986,7 @@ final class KubernetesDataProviderIntegrationTest {
     softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
     softly.assertThat(serverGroup.getInstances()).hasSize(1);
     if (!serverGroup.getInstances().isEmpty()) {
-      assertBackendPriorServerGroupInstance(
-          softly, (KubernetesV2Instance) serverGroup.getInstances().iterator().next());
+      assertBackendPriorServerGroupInstance(softly, serverGroup.getInstances().iterator().next());
     }
   }
 
@@ -1031,8 +1022,7 @@ final class KubernetesDataProviderIntegrationTest {
     softly.assertThat(serverGroup.getCloudProvider()).isEqualTo("kubernetes");
     softly.assertThat(serverGroup.getInstances()).hasSize(1);
     if (!serverGroup.getInstances().isEmpty()) {
-      assertBackendCurrentServerGroupInstance(
-          softly, (KubernetesV2Instance) serverGroup.getInstances().iterator().next());
+      assertBackendCurrentServerGroupInstance(softly, serverGroup.getInstances().iterator().next());
     }
   }
 


### PR DESCRIPTION
* refactor(kubernetes): Improve typing in view classes 

  In a number of places we store data in these classes as the interface type rather than as the concrete type, and then need to cast to the Kubernetes-specific implementation. Instead, let's keep everything concrete in the Kubernetes classes to avoid this casting.

  In some cases, using the interface type can be useful (ie, if we don't want certain implementation-specific functions to be visible). But in this case the primary use for these data classes is serializing them and sending them to another microservice (and eventually to deck). Regardless of the type we are storing it in, we are still fully serializing the instance fields, so the effective contract is that callers expect to find Kubernetes-specific fields here. (That's the reason the tests were casting to the specific type, so that they could verify things in the serialized results.)

* refactor(kubernetes): Inline some functions in data provider 

  As a first pass to simplifying the Kubernetes data providers, inline a few functions. While this makes the calling function longer, it will be simpler because we won't be passing as many custom map objects across function boundaries. As the later commits will show, we'll also better be able to simplify things when the logic is all in one function.

* refactor(kubernetes): Inline a variable in cluster provider 

  A small commit, inlining a variable that is only used in one place and can be just created in place rather than stored as a local variable.

  Also removed the needless null filtering in the return from the function; the only things in this set are the results of calling new KubernetesV2Cluster(...) which can never be null.

* refactor(kubernetes): Replace mutating set with collector 

  Small change to update the return of this function to use a collector instead of mutating a set.

* refactor(kubernetes): Clean up null safety in KubernetesCacheUtils 

  There are a lot of unnecessary null checks in KubernetesCacheUtils and in code that calls those functions, because pretty much every function assumes a Collection<CacheData> might contain null elements.

  At first, I had this commit filtering the results from all calls to the cache (on the assumption that the cache might return a collection containing null elements if you requested an id that didn't exist). But I checked all of the current implementations of Cache, and all of them ensure filter nulls from the result.
  (In the SQL case we even know this statically as it returns a MutableCollection<CacheData> rather than a MutableCollection<CacheData?>.

  To avoid the unnecessary duplicate work, just remove filtering of the Collection<CacheData> that we get back from the cache. Then as long we we don't ourselves create a Collection<CacheData> with null elements, we can be sure that all such collections don't have nulls.

  This greatly simplifies the code, and also likely has performance benefits as we no longer need to iterate over every result from calling the cache, just to create a new collection.

  Finally, this commit does not fully update all downstream logic to remove null checks.  We can update those places as we change them.

* refactor(kubernetes): Improve CacheData classes 

  Make these classes shallowly immutable, and null-safe simplifying their use in callers.

  Also change some fields to a generic Collection in cases where we don't care what particular Collection we have, which will make future refactoring easier.

* refactor(kubernetes): Replace full cache data with keys instead 

  KubernetesV2ServerGroupCacheData requires a full Collection<CacheData> of the load balancer data, but only ever uses the associated keys. Instead, just require the actual keys, which means that callers can avoid doing extra lookups to the cache, simplifying the logic and improving performance.

  Note that this commit does not actually change the calling logic to stop fetching the no-longer-needed CacheData objects, it just pushes the CacheData::getId to the caller. That simplification will come later.

  In the case of serverGroupManagerKeys, we're currently requiring a parsed key. Encapsulate this logic better (and match what we now do for load balancers) by accepting the key as a string and parsing the keys as needed.

* refactor(kubernetes): Make model classes and fields final 

* refactor(kubernetes): A few simplifications in cluster provider 

  Simplify the grouper to just use a grouping collector, and rename some functions to more clearly indicate their effects.

* fix(kubernetes): Fix load balancer lookup 

  We were passing the name where the namespace should have been.
