### PR TITLE
fix(titus): minor clean up for titus and orchestrator

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/DefaultOrchestrationProcessor.groovy
@@ -124,7 +124,11 @@ class DefaultOrchestrationProcessor implements OrchestrationProcessor {
                 }
               }
 
-              task.updateStatus(TASK_PHASE, "Orchestration completed.")
+              if (task.status?.failed) {
+                task.updateStatus(TASK_PHASE, "Orchestration completed with errors, see prior task logs.")
+              } else {
+                task.updateStatus(TASK_PHASE, "Orchestration completed.")
+              }
             }.call()
           } catch (AtomicOperationException e) {
             task.updateStatus TASK_PHASE, "Orchestration failed: ${atomicOperation.class.simpleName} | ${e.class.simpleName}: [${e.errors.join(', ')}]"

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusClient.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/client/TitusClient.java
@@ -94,9 +94,6 @@ public interface TitusClient {
   /** @return */
   public TitusHealth getHealth();
 
-  /** @return */
-  public List<Job> getAllJobsWithTasks();
-
   /**
    * For use in TitusV2ClusterCachingAgent
    *

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/client/RegionScopedTitusClientSpec.groovy
@@ -102,29 +102,6 @@ class RegionScopedTitusClientSpec extends Specification {
     logger.info("job by name {}", job);
     job != null
 
-    logger.info("Jobs request: {}", new Date());
-    List<Job> jobs = titusClient.getAllJobsWithTasks();
-    logger.info("Jobs response: {}", new Date());
-    logger.info("Jobs");
-    logger.info("-----------------------------------------------------------------------------------------------");
-    logger.info("Jobs count: {}", jobs.size());
-
-    // ******************************************************************************************************************
-    when:
-    int i = 7;
-    boolean found = false;
-    while (--i > 0) {
-      Job queriedJob = titusClient.getAllJobsWithTasks().find { it.id == jobId }
-      if (queriedJob) {
-        found = true;
-        break;
-      }
-      Thread.sleep(15 * 1000L);
-    }
-
-    then:
-    found
-
     // ******************************************************************************************************************
 
     when:
@@ -180,27 +157,7 @@ class RegionScopedTitusClientSpec extends Specification {
     then:
     terminated
 
-    when:
     logger.info("Successfully terminated job {}" + terminatedJob);
-
-    int k = 14;
-    boolean foundAfterTermination = true;
-    while (--k > 0) {
-      List<Job> queriedJobs = titusClient.getAllJobsWithTasks();
-      if (!queriedJobs.contains(job)) {
-        foundAfterTermination = false;
-        logger.info("Did NOT find job {} in the list of jobs. Terminate successful.", jobId);
-        break;
-      }
-      Thread.sleep(10 * 1000L);
-    }
-
-    if (foundAfterTermination) {
-      System.err.println("ERROR: Even after terminate, job was FOUND in the list of jobs: " + jobId);
-    }
-
-    then:
-    !foundAfterTermination
 
   }
 }


### PR DESCRIPTION
* Remove all references to "jobIds" feature flag as it's no longer a thing
* Remove dangerous (and unused) call getAllTasks
* Also, the default orchestrator will mark the task as "Orchestration complete" even though the task might have failed. This is very confusing in orca as it shows `error: orchestration complete`. Add some more words about failed tasks

