### PR TITLE
refactor(kubernetes): Further improvements to Kubernetes data providers

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
@@ -17,20 +17,13 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Multimap;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
-import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.KubernetesV2ServerGroupCacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerServerGroup;
-import java.util.Collection;
-import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -52,28 +45,6 @@ public final class KubernetesV2LoadBalancer extends ManifestBasedModel
     this.manifest = manifest;
     this.key = (Keys.InfrastructureCacheKey) Keys.parseKey(key).get();
     this.serverGroups = serverGroups;
-  }
-
-  @Nullable
-  @ParametersAreNonnullByDefault
-  public static KubernetesV2LoadBalancer fromCacheData(
-      CacheData cd,
-      Collection<CacheData> serverGroupData,
-      Multimap<String, CacheData> serverGroupToInstanceData) {
-    return fromCacheData(
-        cd,
-        serverGroupData.stream()
-            .map(
-                d ->
-                    KubernetesV2ServerGroup.fromCacheData(
-                        KubernetesV2ServerGroupCacheData.builder()
-                            .serverGroupData(d)
-                            .instanceData(serverGroupToInstanceData.get(d.getId()))
-                            .loadBalancerKeys(ImmutableList.of(cd.getId()))
-                            .build()))
-            .filter(Objects::nonNull)
-            .map(KubernetesV2ServerGroup::toLoadBalancerServerGroup)
-            .collect(toImmutableSet()));
   }
 
   @Nullable

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
@@ -22,6 +22,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.ImmutableSetMultimap.flatteningToImmutableSetMultimap;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -105,6 +106,12 @@ class KubernetesCacheUtils {
   Collection<CacheData> getRelationships(CacheData cacheData, String relationshipType) {
     return cache.getAll(
         relationshipType, relationshipKeys(cacheData, relationshipType).collect(toImmutableSet()));
+  }
+
+  /** Gets the data for all relationships of a given Spinnaker kind for a single CacheData item. */
+  ImmutableCollection<CacheData> getRelationships(
+      CacheData cacheData, SpinnakerKind spinnakerKind) {
+    return getRelationships(ImmutableList.of(cacheData), spinnakerKind).get(cacheData.getId());
   }
 
   /**

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
@@ -111,16 +111,12 @@ class KubernetesCacheUtils {
    * Gets the data for all relationships of a given Spinnaker kind for a collection of CacheData
    * items.
    */
-  ImmutableCollection<CacheData> getRelationships(
+  ImmutableMultimap<String, CacheData> getRelationships(
       Collection<CacheData> cacheData, SpinnakerKind spinnakerKind) {
-    // TODO(ezimanyi): We're relying on collecting to a Set for deduplication, which isn't great
-    // because CacheData doesn't override equals so we're only deduplicating references.
-    // This is fine because getRelationships does return at most one reference per id, but
-    // is somewhat fragile.
-    return relationshipTypes(spinnakerKind)
-        .map(kind -> getRelationships(cacheData, kind).values())
-        .flatMap(Collection::stream)
-        .collect(toImmutableSet());
+    ImmutableListMultimap.Builder<String, CacheData> result = ImmutableListMultimap.builder();
+    relationshipTypes(spinnakerKind)
+        .forEach(type -> result.putAll(getRelationships(cacheData, type)));
+    return result.build();
   }
 
   /** Gets the data for all relationships of a given type for a collection of CacheData items. */

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
@@ -40,8 +40,11 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -169,6 +172,15 @@ class KubernetesCacheUtils {
   RelationshipCacheFilter getCacheFilter(Collection<SpinnakerKind> spinnakerKinds) {
     return RelationshipCacheFilter.include(
         spinnakerKinds.stream().flatMap(this::relationshipTypes).toArray(String[]::new));
+  }
+
+  /**
+   * Returns a Predicate that returns true the first time it sees a CacheData with a given id, and
+   * false all subsequent times.
+   */
+  Predicate<CacheData> distinctById() {
+    Set<String> seen = new HashSet<>();
+    return cd -> seen.add(cd.getId());
   }
 
   KubernetesHandler getHandler(KubernetesV2CacheData cacheData) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
@@ -155,6 +155,15 @@ class KubernetesCacheUtils {
     return kindMap.translateSpinnakerKind(spinnakerKind).stream().map(KubernetesKind::toString);
   }
 
+  /**
+   * Given a collection of Spinnaker kinds, return a cache filter restricting relationships to those
+   * kinds.
+   */
+  RelationshipCacheFilter getCacheFilter(Collection<SpinnakerKind> spinnakerKinds) {
+    return RelationshipCacheFilter.include(
+        spinnakerKinds.stream().flatMap(this::relationshipTypes).toArray(String[]::new));
+  }
+
   KubernetesHandler getHandler(KubernetesV2CacheData cacheData) {
     Keys.InfrastructureCacheKey key =
         (Keys.InfrastructureCacheKey) Keys.parseKey(cacheData.primaryData().getId()).get();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesCacheUtils.java
@@ -140,19 +140,6 @@ class KubernetesCacheUtils {
         Multimaps.transformValues(relKeys, relData::get), Objects::nonNull);
   }
 
-  /*
-   * Builds a map of all keys belonging to `sourceKind` that are related to any entries in `targetData`
-   */
-  ImmutableMultimap<String, CacheData> mapByRelationship(
-      Collection<CacheData> targetData, SpinnakerKind sourceKind) {
-    ImmutableListMultimap.Builder<String, CacheData> builder = ImmutableListMultimap.builder();
-    targetData.forEach(
-        datum ->
-            getRelationshipKeys(datum, sourceKind)
-                .forEach(sourceKey -> builder.put(sourceKey, datum)));
-    return builder.build();
-  }
-
   /** Returns a stream of all relationships of a given type for a given CacheData. */
   private Stream<String> relationshipKeys(CacheData cacheData, String type) {
     Collection<String> relationships = cacheData.getRelationships().get(type);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ClusterProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ClusterProvider.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.LogicalKind.APPLICATIONS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.LogicalKind.CLUSTERS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind.INSTANCES;
@@ -220,9 +219,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
                                       .serverGroupData(cd)
                                       .instanceData(serverGroupToInstances.get(cd.getId()))
                                       .loadBalancerKeys(
-                                          serverGroupToLoadBalancers.get(cd.getId()).stream()
-                                              .map(CacheData::getId)
-                                              .collect(toImmutableList()))
+                                          cacheUtils.getRelationshipKeys(cd, LOAD_BALANCERS))
                                       .serverGroupManagerKeys(
                                           cacheUtils.getRelationshipKeys(cd, SERVER_GROUP_MANAGERS))
                                       .build()))

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ClusterProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ClusterProvider.java
@@ -187,6 +187,7 @@ public class KubernetesV2ClusterProvider implements ClusterProvider<KubernetesV2
                   loadServerGroups(clusterServerGroups);
               List<KubernetesV2LoadBalancer> loadBalancers =
                   cacheUtils.getRelationships(clusterServerGroups, LOAD_BALANCERS).values().stream()
+                      .filter(cacheUtils.distinctById())
                       .map(
                           cd ->
                               KubernetesV2LoadBalancer.fromCacheData(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -17,7 +17,6 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.LogicalKind.APPLICATIONS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind.INSTANCES;
@@ -34,7 +33,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.ApplicationCach
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2LoadBalancer;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroup;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.KubernetesV2ServerGroupCacheData;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
@@ -57,13 +55,10 @@ import org.springframework.stereotype.Component;
 public class KubernetesV2LoadBalancerProvider
     implements LoadBalancerProvider<KubernetesV2LoadBalancer> {
   private final KubernetesCacheUtils cacheUtils;
-  private final KubernetesSpinnakerKindMap kindMap;
 
   @Autowired
-  KubernetesV2LoadBalancerProvider(
-      KubernetesCacheUtils cacheUtils, KubernetesSpinnakerKindMap kindMap) {
+  KubernetesV2LoadBalancerProvider(KubernetesCacheUtils cacheUtils) {
     this.cacheUtils = cacheUtils;
-    this.kindMap = kindMap;
   }
 
   @Override
@@ -112,10 +107,9 @@ public class KubernetesV2LoadBalancerProvider
         .map(
             applicationData ->
                 fromLoadBalancerCacheData(
-                    kindMap.translateSpinnakerKind(LOAD_BALANCERS).stream()
-                        .map(kind -> cacheUtils.getRelationships(applicationData, kind.toString()))
-                        .flatMap(Collection::stream)
-                        .collect(toImmutableList())))
+                    cacheUtils
+                        .getRelationships(ImmutableList.of(applicationData), LOAD_BALANCERS)
+                        .get(applicationData.getId())))
         .orElseGet(ImmutableSet::of);
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -107,9 +107,7 @@ public class KubernetesV2LoadBalancerProvider
         .map(
             applicationData ->
                 fromLoadBalancerCacheData(
-                    cacheUtils
-                        .getRelationships(ImmutableList.of(applicationData), LOAD_BALANCERS)
-                        .get(applicationData.getId())))
+                    cacheUtils.getRelationships(applicationData, LOAD_BALANCERS)))
         .orElseGet(ImmutableSet::of);
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -118,14 +118,10 @@ public class KubernetesV2LoadBalancerProvider
 
   private Set<KubernetesV2LoadBalancer> fromLoadBalancerCacheData(
       List<CacheData> loadBalancerData) {
-    Collection<CacheData> serverGroupData =
-        cacheUtils.getRelationships(loadBalancerData, SERVER_GROUPS);
-    Collection<CacheData> instanceData = cacheUtils.getRelationships(serverGroupData, INSTANCES);
-
     ImmutableMultimap<String, CacheData> loadBalancerToServerGroups =
-        cacheUtils.mapByRelationship(serverGroupData, LOAD_BALANCERS);
+        cacheUtils.getRelationships(loadBalancerData, SERVER_GROUPS);
     ImmutableMultimap<String, CacheData> serverGroupToInstances =
-        cacheUtils.mapByRelationship(instanceData, SERVER_GROUPS);
+        cacheUtils.getRelationships(loadBalancerToServerGroups.values(), INSTANCES);
 
     return loadBalancerData.stream()
         .map(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ServerGroupManagerProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ServerGroupManagerProvider.java
@@ -21,6 +21,7 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.LogicalK
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind.SERVER_GROUPS;
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind.SERVER_GROUP_MANAGERS;
 
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.netflix.spinnaker.cats.cache.CacheData;
@@ -30,7 +31,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.K
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.ServerGroupManagerHandler;
 import com.netflix.spinnaker.clouddriver.model.ServerGroupManagerProvider;
-import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -59,13 +59,13 @@ public class KubernetesV2ServerGroupManagerProvider
       return null;
     }
 
-    Collection<CacheData> serverGroupManagerData =
-        cacheUtils.getRelationships(ImmutableList.of(applicationDatum), SERVER_GROUP_MANAGERS);
-    Collection<CacheData> serverGroupData =
-        cacheUtils.getRelationships(serverGroupManagerData, SERVER_GROUPS);
+    ImmutableCollection<CacheData> serverGroupManagerData =
+        cacheUtils
+            .getRelationships(ImmutableList.of(applicationDatum), SERVER_GROUP_MANAGERS)
+            .get(applicationDatum.getId());
 
     ImmutableMultimap<String, CacheData> managerToServerGroupMap =
-        cacheUtils.mapByRelationship(serverGroupData, SERVER_GROUP_MANAGERS);
+        cacheUtils.getRelationships(serverGroupManagerData, SERVER_GROUPS);
 
     return serverGroupManagerData.stream()
         .map(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ServerGroupManagerProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ServerGroupManagerProvider.java
@@ -22,7 +22,6 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.description.Spinnaker
 import static com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind.SERVER_GROUP_MANAGERS;
 
 import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
@@ -60,9 +59,7 @@ public class KubernetesV2ServerGroupManagerProvider
     }
 
     ImmutableCollection<CacheData> serverGroupManagerData =
-        cacheUtils
-            .getRelationships(ImmutableList.of(applicationDatum), SERVER_GROUP_MANAGERS)
-            .get(applicationDatum.getId());
+        cacheUtils.getRelationships(applicationDatum, SERVER_GROUP_MANAGERS);
 
     ImmutableMultimap<String, CacheData> managerToServerGroupMap =
         cacheUtils.getRelationships(serverGroupManagerData, SERVER_GROUPS);

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -147,7 +147,7 @@ final class KubernetesDataProviderIntegrationTest {
   private static KubernetesV2ApplicationProvider applicationProvider =
       new KubernetesV2ApplicationProvider(cacheUtils);
   private static KubernetesV2ClusterProvider clusterProvider =
-      new KubernetesV2ClusterProvider(cacheUtils, kindMap);
+      new KubernetesV2ClusterProvider(cacheUtils);
   private static KubernetesV2InstanceProvider instanceProvider =
       new KubernetesV2InstanceProvider(cacheUtils, accountResolver);
   private static KubernetesV2LoadBalancerProvider loadBalancerProvider =

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -551,9 +551,7 @@ final class KubernetesDataProviderIntegrationTest {
 
     if (includeDetails) {
       assertFrontendServerGroups(softly, cluster.getServerGroups());
-      // TODO(ezimanyi): The same load balancer is being returned multiple times (likely due to
-      // finding all relationships to it). This should be fixed to return it only once.
-      softly.assertThat(cluster.getLoadBalancers()).hasSize(2);
+      softly.assertThat(cluster.getLoadBalancers()).hasSize(1);
       if (!cluster.getLoadBalancers().isEmpty()) {
         assertFrontendLoadBalancer(softly, cluster.getLoadBalancers().iterator().next());
       }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -299,6 +299,15 @@ final class KubernetesDataProviderIntegrationTest {
   }
 
   @Test
+  void getServerGroupWithManager(SoftAssertions softly) {
+    KubernetesV2ServerGroup serverGroup =
+        clusterProvider.getServerGroup(
+            ACCOUNT_NAME, "frontend-ns", "replicaSet frontend-5c6559f75f");
+    assertThat(serverGroup).isNotNull();
+    assertFrontendCurrentServerGroup(softly, serverGroup);
+  }
+
+  @Test
   void getServerGroupWrongNamespace(SoftAssertions softly) {
     KubernetesV2ServerGroup serverGroup =
         clusterProvider.getServerGroup(ACCOUNT_NAME, "frontend-ns", "replicaSet backend-v014");

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -151,7 +151,7 @@ final class KubernetesDataProviderIntegrationTest {
   private static KubernetesV2InstanceProvider instanceProvider =
       new KubernetesV2InstanceProvider(cacheUtils, accountResolver);
   private static KubernetesV2LoadBalancerProvider loadBalancerProvider =
-      new KubernetesV2LoadBalancerProvider(cacheUtils, kindMap);
+      new KubernetesV2LoadBalancerProvider(cacheUtils);
   private static KubernetesV2SearchProvider searchProvider =
       new KubernetesV2SearchProvider(cacheUtils, kindMap, objectMapper, accountResolver);
   private static KubernetesV2ServerGroupManagerProvider serverGroupManagerProvider =


### PR DESCRIPTION
* refactor(kubernetes): Add Multimap-returning getRelationships 

  This commit only affects CacheData, in preparation for some changes visible outside the class. Most notably, we'll update getRelationships to return a MultiMap when we pass in a Collection of CacheData items. This allows the caller to see the association between the input data and the output relationships, rather than flattening it to a collection where it's not possible to determine which of the output CacheData items is related to each of the input ones.

  In this commit, we're not taking advantage of this; in fact the two callers have been updated to:
  * Just call .values() to flatten the result
  * Query the cache directly instead of using getRelationships

  But in the next commit we'll push this information outward one more level of calls, which will the allow consumers to use the information to avoid duplicate work.

  Also update getRelationshipKeys to collect to a Set. The general idea is that we'll collect keys (String) to a Set to dedupliate but data (CacheData) to a List as deduplication by reference is not valuable.  (I left one TODO in a case where we are deduplicating by reference but will fix that.)

* refactor(kubernetes): Keep track of relationships when fetching 

  In a number of places, we have a Collection of CacheData items, and we want to fetch all relationships of a particular kind. For example, we might have a List of server groups and want to load all instances.

  Currently we returned a flattened collection of all the related types, forcing the caller to then iterate through it to recompute which instance is associated with which server group.

  Greatly simplify this (and improve performance) by returning a MultiMap from getRelationships. This means, for example, that the caller can then look up the instances related to a given server group id, without needing to build another map.

* refactor(kubernetes): Look up related load balancer keys directly 

  When constructing a server group, we look up the full data for related load balancers, and then only keep the key. Instead let's look up only the keys. As this isn't making any cache calls, we don't need to keep the full map outside the loop, and can just look up the needed data inside the loop.

* refactor(kubernetes): Extract loadServerGroups to a function 

  It returns a Map so we can later get the constructed server group by id, though we are not yet using that feature.

* refactor(kubernetes): Load balancer constructor accepts server groups 

  The fromCacheData method to create a LoadBalancer requires all the cache data to create server groups as well; but in some cases we will already have constructed server groups. It will be simpler and more performant to just pass these existing server groups to fromCacheData.

  Add a (as yet unused) fromCacheData that takes a set of LoadBalancerServerGroups and uses those. Refactor the existing fromCacheData to pass the LoadBalancerServerGroups it constructs to this new constructor.

* refactor(kubernetes): Use new fromCacheData in cluster provider 

  Let's use the new fromCacheData we just created and pass in the server groups that we have already built.

  This also removes the last use of mapByRelationship, so we can remove the function.

* refactor(kubernetes): Minor cleanup in loadClusters 

  Now that only serverGroupToInstances is only used in loadClusters, look up that data in the function rather than require the caller to look it up.

  Similarly, the construction of the stream over load balancers is just a really complex way of getting the values of the MultiMap; use that instead.

* refactor(kubernetes): Remove the old version of fromCacheData 

  It was only used in one place; let's move the logic there.

* refactor(kubernetes): Update getServerGroup to call existing function 

  getServerGroup has its own logic for constructing server groups; instead call the loadServerGroups function we just wrote.

  This commit also fixes a bug; we were only loading load balancer and instance relationships with the cache data, so we never returned any server group managers.

  The integration tests didn't catch this because they were exercising the function only for a non-deployment-managed replica set. Add a test to catch this case.

  It's interesting that we only do this optimization of filtering relationships when loading a single server group, whereas it probably would be much more beneficial in the endpoints that return many. I'll leave this for now, but may revisit.

* refactor(kubernetes): Extract relationshipFilter logic 

  I'm honestly not sure that the benefit of creating this relationship filter for a single server group is worth it, but we'll keep the logic for now.  Let's at least store the cache filter as an instance field so that we can re-use it, and abstract away the logic for creating it.

  I'm not going to include filter logic in other places as I think the correct fix for improving performance here is just to cut down the relationships we store in the cache to those that are actually needed, rather than add logic for ignoring most of them.

* refactor(kubernetes): Fix one more case of manually using kindMap 

  There is now a function for this.

* refactor(kubernetes): Add helper function for looking up a item 

  We made callers accept a MultiMap then look up the one id of interest; let's do that instead for callers.

* fix(kubernetes): Stop returning multiple copies of load balancer 

  The issue was that we were building the load balancer once per attached server group.

  All of the refactors up to now have not fixed it (though we did reduce the number of times it is returned from 4 to 2).

  The reason at this point is because .values() on a multimap returns items multiple times if they map to multiple keys. Let's apply a distinct on the stream that only takes the first for each id.

  We could have just done a regular distinct() because the result of getRelationships always maps a key to the same reference (so we don't have multiple instances of each load balancer, just multiple pointers to the same one).  But I did not want to have to debug this issue if that ever changes, so let's be explicit and keep the first one we encounter with each id.
