### PR TITLE
fix(kubeconfig): Don't hash missing kubeconfig files

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubeconfigFileHasher.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubeconfigFileHasher.java
@@ -20,13 +20,14 @@ package com.netflix.spinnaker.clouddriver.kubernetes.security;
 import com.google.common.hash.Hashing;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class KubeconfigFileHasher {
 
-  public static String hashKubeconfigFile(String filepath) {
-    if (filepath == null || filepath.isEmpty()) {
+  public static String hashKubeconfigFile(@Nonnull String filepath) {
+    if (filepath.isEmpty()) {
       return "";
     }
     try {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubeconfigFileHasher.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubeconfigFileHasher.java
@@ -26,6 +26,9 @@ import lombok.extern.slf4j.Slf4j;
 public class KubeconfigFileHasher {
 
   public static String hashKubeconfigFile(String filepath) {
+    if (filepath == null || filepath.isEmpty()) {
+      return "";
+    }
     try {
       byte[] contents = Files.readAllBytes(Paths.get(filepath));
       return Hashing.sha256().hashBytes(contents).toString();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialFactory.java
@@ -43,10 +43,6 @@ public interface KubernetesCredentialFactory<C extends KubernetesCredentials> {
   default String getKubeconfigFile(
       ConfigFileService configFileService,
       KubernetesConfigurationProperties.ManagedAccount managedAccount) {
-    if (managedAccount.isServiceAccount()) {
-      return "";
-    }
-
     if (StringUtils.isNotEmpty(managedAccount.getKubeconfigFile())) {
       return configFileService.getLocalPath(managedAccount.getKubeconfigFile());
     }
@@ -56,6 +52,6 @@ public interface KubernetesCredentialFactory<C extends KubernetesCredentials> {
           managedAccount.getKubeconfigContents(), managedAccount.getName());
     }
 
-    return System.getProperty("user.home") + "/.kube/config";
+    return "";
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialFactory.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialFactory.java
@@ -43,6 +43,10 @@ public interface KubernetesCredentialFactory<C extends KubernetesCredentials> {
   default String getKubeconfigFile(
       ConfigFileService configFileService,
       KubernetesConfigurationProperties.ManagedAccount managedAccount) {
+    if (managedAccount.isServiceAccount()) {
+      return "";
+    }
+
     if (StringUtils.isNotEmpty(managedAccount.getKubeconfigFile())) {
       return configFileService.getLocalPath(managedAccount.getKubeconfigFile());
     }


### PR DESCRIPTION
When a kubernetes account is configured with `serviceAccount: true` instead of a kubeconfig file, this exception is shown in clouddriver logs when trying to derive the hash of the missing kubeconfig:
```
2020-07-31 22:01:52.545  WARN 1 --- [           main] c.n.s.c.k.security.KubeconfigFileHasher  : failed to hash kubeconfig file at /home/spinnaker/.kube/config: {}

java.nio.file.NoSuchFileException: /home/spinnaker/.kube/config
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[na:na]
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[na:na]
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116) ~[na:na]
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219) ~[na:na]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:370) ~[na:na]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:421) ~[na:na]
        at java.base/java.nio.file.Files.readAllBytes(Files.java:3205) ~[na:na]
        at com.netflix.spinnaker.clouddriver.kubernetes.security.KubeconfigFileHasher.hashKubeconfigFile(KubeconfigFileHasher.java:30) ~[clouddriver-kubernetes.jar:na]
        at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials.<init>(KubernetesV2Credentials.java:177) ~[clouddriver-kubernetes.jar:na]
        at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials.<init>(KubernetesV2Credentials.java:74) ~[clouddriver-kubernetes.jar:na]
        at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials$Factory.build(KubernetesV2Credentials.java:715) ~[clouddriver-kubernetes.jar:na]
        at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials$Factory.build(KubernetesV2Credentials.java:688) ~[clouddriver-kubernetes.jar:na]
        at com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials.<init>(KubernetesNamedAccountCredentials.java:77) ~[clouddriver-kubernetes.jar:na]
        at com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesV2ProviderSynchronizable.lambda$setup$1(KubernetesV2ProviderSynchronizable.java:73) ~[clouddriver-kubernetes.jar:na]
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[na:na]
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654) ~[na:na]
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[na:na]
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[na:na]
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[na:na]
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:na]
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[na:na]
        at com.netflix.spinnaker.clouddriver.kubernetes.caching.KubernetesV2ProviderSynchronizable.setup(KubernetesV2ProviderSynchronizable.java:75) ~[clouddriver-kubernetes.jar:na]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
        at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor$LifecycleElement.invoke(InitDestroyAnnotationBeanPostProcessor.java:389) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor$LifecycleMetadata.invokeInitMethods(InitDestroyAnnotationBeanPostProcessor.java:333) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.postProcessBeforeInitialization(InitDestroyAnnotationBeanPostProcessor.java:157) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:416) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1788) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:595) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:517) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:323) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:321) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:276) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.addCandidateEntry(DefaultListableBeanFactory.java:1503) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.findAutowireCandidates(DefaultListableBeanFactory.java:1467) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveMultipleBeans(DefaultListableBeanFactory.java:1358) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1245) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1207) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:885) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:789) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:228) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1358) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1204) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:557) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:517) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:323) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:321) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:879) ~[spring-beans-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:878) ~[spring-context-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:550) ~[spring-context-5.2.4.RELEASE.jar:5.2.4.RELEASE]
        at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:141) ~[spring-boot-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:747) ~[spring-boot-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397) ~[spring-boot-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:315) ~[spring-boot-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:140) ~[spring-boot-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.boot.builder.SpringApplicationBuilder$run$0.call(Unknown Source) ~[na:na]
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47) ~[groovy-2.5.11.jar:2.5.11]
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115) ~[groovy-2.5.11.jar:2.5.11]
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:127) ~[groovy-2.5.11.jar:2.5.11]
        at com.netflix.spinnaker.clouddriver.Main.main(Main.groovy:78) ~[clouddriver-web.jar:na]
```
If dynamic accounts are enabled, this exception is printed on every refresh cycle.