### PR TITLE
chore(build): removed UTF8 "smart quotes"

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/BintrayResolver.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/ivy/settings/BintrayResolver.java
@@ -29,7 +29,7 @@ final class BintrayResolver extends Resolver<org.apache.ivy.plugins.resolver.Bin
   @Nullable
   private String subject;
 
-  /** User’s repository name. */
+  /** User's repository name. */
   @JacksonXmlProperty(isAttribute = true)
   @Nullable
   private String repo;

--- a/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryPackage.java
+++ b/clouddriver-cloudfoundry/src/main/java/com/netflix/spinnaker/clouddriver/cloudfoundry/model/CloudFoundryPackage.java
@@ -22,7 +22,7 @@ import lombok.Builder;
 import lombok.Value;
 
 /*
- * A package is an application’s ‘source code’; either raw bits for your application or a pointer to these bits.
+ * A package is an application's 'source code'; either raw bits for your application or a pointer to these bits.
  */
 @Value
 @Builder


### PR DESCRIPTION
<kbd>![](https://p-qKFvWn.b3.n0.cdn.getcloudapp.com/items/lluY4zRL/safkajdflkasdjf.png?v=b5e663894145199d7a55ab8387e91585)</kbd>


This was causing some errors with the build