### PR TITLE
chore(build): bump up gradle memory max to 7gb

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -7,5 +7,5 @@ MAINTAINER sig-platform@spinnaker.io
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
-ENV GRADLE_OPTS "-Xmx6g -Xms6g"
+ENV GRADLE_OPTS "-Xmx7g -Xms6g"
 CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true clouddriver-web:installDist -x test


### PR DESCRIPTION
it looks like Google Cloud Build `compile` step is exiting with 137. Maybe Gradle needs more memory.


<kbd>![](https://p-qKFvWn.b3.n0.cdn.getcloudapp.com/items/DOuxvG71/Image%202020-08-07%20at%2019.24.23.png?v=6082595a8b8980f3d173bdbda3855083)</kbd>