### PR TITLE
fix(build): Reduce Xmx and Xms

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -7,5 +7,5 @@ MAINTAINER sig-platform@spinnaker.io
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
-ENV GRADLE_OPTS "-Xmx7g -Xms6g"
+ENV GRADLE_OPTS "-Xmx4g -Xms2g"
 CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true clouddriver-web:installDist -x test


### PR DESCRIPTION
Our container builds run on a machine with only 7.2 GB of memory; while we do want to give a lot to the JVM we should leave a bit more for the everything else.

I was able to succesfully build the containers with these settings, so let's use them.