### PR TITLE
fix(api): remove jackson annotations from model

### DIFF
--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonClusterSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonClusterSpec.groovy
@@ -18,11 +18,12 @@
 package com.netflix.spinnaker.clouddriver.aws.model
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.clouddriver.jackson.ClouddriverApiModule
 import spock.lang.Specification
 
 class AmazonClusterSpec extends Specification {
   void "should serialize null loadBalancers and serverGroups as empty arrays"() {
-    def objectMapper = new ObjectMapper()
+    def objectMapper = new ObjectMapper().registerModule(new ClouddriverApiModule())
 
     when:
     def nullCluster = objectMapper.convertValue(

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/config/CloudDriverConfig.groovy
@@ -41,6 +41,7 @@ import com.netflix.spinnaker.clouddriver.core.limits.ServiceLimitConfigurationBu
 import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
 import com.netflix.spinnaker.clouddriver.core.services.Front50Service
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionAuthorizer
+import com.netflix.spinnaker.clouddriver.jackson.ClouddriverApiModule
 import com.netflix.spinnaker.clouddriver.model.ApplicationProvider
 import com.netflix.spinnaker.clouddriver.model.CloudMetricProvider
 import com.netflix.spinnaker.clouddriver.model.ClusterProvider
@@ -136,7 +137,8 @@ class CloudDriverConfig {
         jacksonObjectMapperBuilder.serializationInclusion(JsonInclude.Include.NON_NULL)
         jacksonObjectMapperBuilder.failOnEmptyBeans(false)
         jacksonObjectMapperBuilder.failOnUnknownProperties(false)
-        jacksonObjectMapperBuilder.modules(new Jdk8Module(), new JavaTimeModule(), new KotlinModule())
+        jacksonObjectMapperBuilder.modules(
+          new Jdk8Module(), new JavaTimeModule(), new KotlinModule(), new ClouddriverApiModule())
       }
     }
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Cluster.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/Cluster.java
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.netflix.spinnaker.clouddriver.documentation.Empty;
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
 import com.netflix.spinnaker.moniker.Moniker;
@@ -69,7 +67,6 @@ public interface Cluster {
    * @return a set of {@link ServerGroup} objects or an empty set if none exist
    */
   @Empty
-  @JsonSerialize(nullsUsing = NullCollectionSerializer.class)
   Set<? extends ServerGroup> getServerGroups();
 
   /**
@@ -78,7 +75,6 @@ public interface Cluster {
    * @return a set of {@link LoadBalancer} objects or an empty set if none exist
    */
   @Empty
-  @JsonSerialize(nullsUsing = NullCollectionSerializer.class)
   // TODO(ttomsu): Why are load balancers associated with Clusters instead of ServerGroups?
   Set<? extends LoadBalancer> getLoadBalancers();
 
@@ -93,7 +89,6 @@ public interface Cluster {
     Set<LoadBalancer> loadBalancers;
   }
 
-  @JsonIgnore
   default Map<String, Object> getExtraAttributes() {
     return Collections.EMPTY_MAP;
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerProvider.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/LoadBalancerProvider.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.clouddriver.documentation.Empty;
 import java.util.List;
 import java.util.Set;
@@ -61,22 +60,18 @@ public interface LoadBalancerProvider<T extends LoadBalancer> {
   interface Item {
     String getName();
 
-    @JsonProperty("accounts")
     List<? extends ByAccount> getByAccounts();
   }
 
   interface ByAccount {
     String getName();
 
-    @JsonProperty("regions")
     List<? extends ByRegion> getByRegions();
   }
 
   interface ByRegion {
-    @JsonProperty("name")
     String getName();
 
-    @JsonProperty("loadBalancers")
     List<? extends Details> getLoadBalancers();
   }
 

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SecurityGroup.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/SecurityGroup.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.model;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule;
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
 import com.netflix.spinnaker.moniker.Moniker;
@@ -25,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 
 /** A representation of a security group */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 public interface SecurityGroup {
 
   /**

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/ServerGroup.java
@@ -16,11 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.model;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.netflix.spinnaker.clouddriver.documentation.Empty;
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry;
 import com.netflix.spinnaker.moniker.Moniker;
@@ -75,7 +70,6 @@ public interface ServerGroup {
    *
    * @return true if the server group is disabled; false otherwise
    */
-  @JsonGetter
   Boolean isDisabled();
 
   /**
@@ -156,7 +150,6 @@ public interface ServerGroup {
    * This represents all images deployed to the server group. For most providers, this will be a
    * singleton.
    */
-  @JsonIgnore
   ImagesSummary getImagesSummary();
 
   /**
@@ -165,7 +158,6 @@ public interface ServerGroup {
    *
    * <p>Deprecated in favor of getImagesSummary, which is a more generic getImageSummary.
    */
-  @JsonIgnore
   @Deprecated
   ImageSummary getImageSummary();
 
@@ -177,7 +169,6 @@ public interface ServerGroup {
     return new HashMap<>();
   }
 
-  @JsonIgnore
   default Map<String, Object> getExtraAttributes() {
     return Collections.EMPTY_MAP;
   }
@@ -241,7 +232,6 @@ public interface ServerGroup {
    * Cloud provider-specific data related to the build and VM image of the server group. Deprecated
    * in favor of Images summary
    */
-  @JsonInclude(NON_NULL)
   public static interface ImageSummary extends Summary {
     String getServerGroupName();
 
@@ -256,7 +246,6 @@ public interface ServerGroup {
   }
 
   /** Cloud provider-specific data related to the build and VM image of the server group. */
-  @JsonInclude(NON_NULL)
   public static interface ImagesSummary extends Summary {
     List<? extends ImageSummary> getSummaries();
   }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/securitygroups/Rule.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/model/securitygroups/Rule.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.clouddriver.model.securitygroups;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.SortedSet;
 import lombok.Data;
 import org.apache.commons.lang3.ObjectUtils;
@@ -27,7 +26,6 @@ import org.apache.commons.lang3.ObjectUtils;
  * @see IpRangeRule
  * @see SecurityGroupRule
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 public interface Rule {
   /**
    * The port ranges associated with this rule

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/ClouddriverApiModule.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/ClouddriverApiModule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.netflix.spinnaker.clouddriver.jackson.mixins.*;
+import com.netflix.spinnaker.clouddriver.model.Cluster;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
+import com.netflix.spinnaker.clouddriver.model.SecurityGroup;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
+import com.netflix.spinnaker.clouddriver.model.securitygroups.Rule;
+
+public class ClouddriverApiModule extends SimpleModule {
+
+  public ClouddriverApiModule() {
+    super("Clouddriver API");
+  }
+
+  @Override
+  public void setupModule(SetupContext context) {
+    super.setupModule(context);
+    context.setMixInAnnotations(SecurityGroup.class, SecurityGroupMixin.class);
+    context.setMixInAnnotations(Rule.class, RuleMixin.class);
+    context.setMixInAnnotations(Cluster.class, ClusterMixin.class);
+    context.setMixInAnnotations(ServerGroup.class, ServerGroupMixin.class);
+    context.setMixInAnnotations(ServerGroup.ImageSummary.class, ImageSummaryMixin.class);
+    context.setMixInAnnotations(ServerGroup.ImagesSummary.class, ImagesSummaryMixin.class);
+    context.setMixInAnnotations(
+        LoadBalancerProvider.Item.class, LoadBalancerProviderItemMixin.class);
+    context.setMixInAnnotations(
+        LoadBalancerProvider.ByAccount.class, LoadBalancerProviderByAccountMixin.class);
+    context.setMixInAnnotations(
+        LoadBalancerProvider.ByRegion.class, LoadBalancerProviderByRegionMixin.class);
+  }
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/ClusterMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/ClusterMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancer;
+import com.netflix.spinnaker.clouddriver.model.NullCollectionSerializer;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
+import java.util.Map;
+import java.util.Set;
+
+public interface ClusterMixin {
+
+  @JsonSerialize(nullsUsing = NullCollectionSerializer.class)
+  Set<? extends ServerGroup> getServerGroups();
+
+  @JsonSerialize(nullsUsing = NullCollectionSerializer.class)
+  Set<? extends LoadBalancer> getLoadBalancers();
+
+  @JsonIgnore
+  Map<String, Object> getExtraAttributes();
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/ImageSummaryMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/ImageSummaryMixin.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface ImageSummaryMixin {}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/ImagesSummaryMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/ImagesSummaryMixin.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface ImagesSummaryMixin {}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/LoadBalancerProviderByAccountMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/LoadBalancerProviderByAccountMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
+import java.util.List;
+
+public interface LoadBalancerProviderByAccountMixin {
+
+  @JsonProperty("regions")
+  List<? extends LoadBalancerProvider.ByRegion> getByRegions();
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/LoadBalancerProviderByRegionMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/LoadBalancerProviderByRegionMixin.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
+import java.util.List;
+
+public interface LoadBalancerProviderByRegionMixin {
+
+  @JsonProperty("name")
+  String getName();
+
+  @JsonProperty("loadBalancers")
+  List<? extends LoadBalancerProvider.Details> getLoadBalancers();
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/LoadBalancerProviderItemMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/LoadBalancerProviderItemMixin.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.spinnaker.clouddriver.model.LoadBalancerProvider;
+import java.util.List;
+
+public interface LoadBalancerProviderItemMixin {
+  @JsonProperty("accounts")
+  List<? extends LoadBalancerProvider.ByAccount> getByAccounts();
+}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/RuleMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/RuleMixin.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+public interface RuleMixin {}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/SecurityGroupMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/SecurityGroupMixin.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+public interface SecurityGroupMixin {}

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/ServerGroupMixin.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/jackson/mixins/ServerGroupMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Armory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.jackson.mixins;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.netflix.spinnaker.clouddriver.model.ServerGroup;
+import java.util.Map;
+
+public interface ServerGroupMixin {
+
+  @JsonGetter
+  Boolean isDisabled();
+
+  @JsonIgnore
+  ServerGroup.ImagesSummary getImagesSummary();
+
+  @JsonIgnore
+  ServerGroup.ImageSummary getImageSummary();
+
+  @JsonIgnore
+  Map<String, Object> getExtraAttributes();
+}


### PR DESCRIPTION
Not having the jackson annotations directly on the model allows them to more easily be moved to an external library without needing a Jackson dependency.
