### PR TITLE
fix(titus): Re-enable saga retry on INVALID_ARGUMENT error due to rate exceeded

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusExceptionHandler.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusExceptionHandler.java
@@ -57,17 +57,13 @@ public class TitusExceptionHandler implements SagaExceptionHandler {
       return false;
     }
 
-    // There is a particular operation in CloudDriver WRT attaching a server group to a load
-    // balancer that does not behave as expected when retrying due to a rate exceeded error.
-    // We will disable retrying on this specific error until that issue has been debugged and
-    // resolved.
-    // boolean rateExceeded = statusRuntimeExceptionMessage.toLowerCase().contains("rate exceeded");
+    boolean rateExceeded = statusRuntimeExceptionMessage.toLowerCase().contains("rate exceeded");
     boolean assumeRoleError =
         statusRuntimeExceptionMessage.toLowerCase().contains("jobiamvalidator")
             && statusRuntimeExceptionMessage
                 .toLowerCase()
                 .contains("titus cannot assume into role");
 
-    return assumeRoleError;
+    return rateExceeded || assumeRoleError;
   }
 }


### PR DESCRIPTION
In https://github.com/spinnaker/clouddriver/pull/4796 we resolved an issue wherein a saga retry would skip a command under certain scenarios.  The particular failure scenario we had around retrying this error was due to that bug - now that it is fixed we should be able to safely retry here.
