### PR TITLE
perf(kubernetes): Precompile find path for artifact replacers

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacer.java
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import lombok.Value;
@@ -56,53 +57,38 @@ public class ArtifactReplacer {
     this.replacers = ImmutableList.copyOf(replacers);
   }
 
-  private static ImmutableList<Artifact> filterKubernetesArtifactsByNamespaceAndAccount(
-      String namespace, String account, List<Artifact> artifacts) {
+  private static ImmutableList<Artifact> filterArtifacts(
+      @Nonnull String namespace, @Nonnull String account, List<Artifact> artifacts) {
     return artifacts.stream()
-        // Keep artifacts that either aren't k8s, or are in the same namespace and account as our
-        // manifest
-        .filter(
-            a -> {
-              String type = a.getType();
-              if (Strings.isNullOrEmpty(type)) {
-                log.warn("Artifact {} without a type, ignoring", a);
-                return false;
-              }
-
-              if (!type.startsWith("kubernetes/")) {
-                return true;
-              }
-
-              boolean locationMatches;
-              String location = a.getLocation();
-              if (Strings.isNullOrEmpty(location)) {
-                locationMatches = Strings.isNullOrEmpty(namespace);
-              } else {
-                locationMatches = location.equals(namespace);
-              }
-
-              boolean accountMatches;
-              String artifactAccount = getAccount(a);
-              // If the artifact fails to provide an account, we'll assume this was unintentional
-              // and match anyways
-              accountMatches =
-                  Strings.isNullOrEmpty(artifactAccount) || artifactAccount.equals(account);
-
-              return accountMatches && locationMatches;
-            })
+        .filter(a -> !Strings.isNullOrEmpty(a.getType()))
+        .filter(nonKubernetes().or(namespaceMatches(namespace).and(accountMatches(account))))
         .collect(toImmutableList());
   }
 
-  private static String getAccount(Artifact artifact) {
-    return Strings.nullToEmpty((String) artifact.getMetadata("account"));
+  private static Predicate<Artifact> nonKubernetes() {
+    return a -> !a.getType().startsWith("kubernetes/");
+  }
+
+  private static Predicate<Artifact> namespaceMatches(@Nonnull String namespace) {
+    return a -> Strings.nullToEmpty(a.getLocation()).equals(namespace);
+  }
+
+  private static Predicate<Artifact> accountMatches(@Nonnull String account) {
+    return a -> {
+      String artifactAccount = Strings.nullToEmpty((String) a.getMetadata("account"));
+      // If the artifact fails to provide an account, assume this was unintentional and match
+      // anyways
+      return artifactAccount.isEmpty() || artifactAccount.equals(account);
+    };
   }
 
   @Nonnull
   public ReplaceResult replaceAll(
-      KubernetesManifest input, List<Artifact> artifacts, String namespace, String account) {
+      KubernetesManifest input,
+      List<Artifact> artifacts,
+      @Nonnull String namespace,
+      @Nonnull String account) {
     log.debug("Doing replacement on {} using {}", input, artifacts);
-    ImmutableList<Artifact> filteredArtifacts =
-        filterKubernetesArtifactsByNamespaceAndAccount(namespace, account, artifacts);
     DocumentContext document;
     try {
       document = JsonPath.using(configuration).parse(mapper.writeValueAsString(input));
@@ -111,6 +97,7 @@ public class ArtifactReplacer {
       throw new RuntimeException(e);
     }
 
+    ImmutableList<Artifact> filteredArtifacts = filterArtifacts(namespace, account, artifacts);
     ImmutableSet.Builder<Artifact> replacedArtifacts = new ImmutableSet.Builder<>();
     replacers.forEach(
         replacer ->

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacer.java
@@ -33,6 +33,7 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
@@ -93,8 +94,7 @@ public class ArtifactReplacer {
     try {
       document = JsonPath.using(configuration).parse(mapper.writeValueAsString(input));
     } catch (JsonProcessingException e) {
-      log.error("Malformed manifest", e);
-      throw new RuntimeException(e);
+      throw new UncheckedIOException("Malformed manifest", e);
     }
 
     ImmutableList<Artifact> filteredArtifacts = filterArtifacts(namespace, account, artifacts);
@@ -108,8 +108,7 @@ public class ArtifactReplacer {
           mapper.readValue(document.jsonString(), KubernetesManifest.class),
           replacedArtifacts.build());
     } catch (IOException e) {
-      log.error("Malformed Document Context", e);
-      throw new RuntimeException(e);
+      throw new UncheckedIOException("Malformed manifest", e);
     }
   }
 
@@ -119,7 +118,7 @@ public class ArtifactReplacer {
     try {
       document = JsonPath.using(configuration).parse(mapper.writeValueAsString(input));
     } catch (JsonProcessingException e) {
-      throw new RuntimeException("Malformed manifest", e);
+      throw new UncheckedIOException("Malformed manifest", e);
     }
 
     return replacers.stream()

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesArtifactConverter.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.artifact;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.ArtifactProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 
@@ -37,7 +38,7 @@ public abstract class KubernetesArtifactConverter {
 
   public abstract String getDeployedName(Artifact artifact);
 
-  protected final String getType(KubernetesManifest manifest) {
-    return String.join("/", KubernetesCloudProvider.ID, manifest.getKind().toString());
+  protected final String artifactType(KubernetesKind kind) {
+    return String.join("/", KubernetesCloudProvider.ID, kind.toString());
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesUnversionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesUnversionedArtifactConverter.java
@@ -31,7 +31,7 @@ final class KubernetesUnversionedArtifactConverter extends KubernetesArtifactCon
   public Artifact toArtifact(
       ArtifactProvider provider, KubernetesManifest manifest, String account) {
     return Artifact.builder()
-        .type(getType(manifest))
+        .type(artifactType(manifest.getKind()))
         .name(manifest.getName())
         .location(manifest.getNamespace())
         .reference(manifest.getName())

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesUnversionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesUnversionedArtifactConverter.java
@@ -20,8 +20,6 @@ package com.netflix.spinnaker.clouddriver.kubernetes.artifact;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.ArtifactProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import java.util.HashMap;
-import java.util.Map;
 
 final class KubernetesUnversionedArtifactConverter extends KubernetesArtifactConverter {
   static final KubernetesUnversionedArtifactConverter INSTANCE =
@@ -32,17 +30,12 @@ final class KubernetesUnversionedArtifactConverter extends KubernetesArtifactCon
   @Override
   public Artifact toArtifact(
       ArtifactProvider provider, KubernetesManifest manifest, String account) {
-    String type = getType(manifest);
-    String name = manifest.getName();
-    String location = manifest.getNamespace();
-    Map<String, Object> metadata = new HashMap<>();
-    metadata.put("account", account);
     return Artifact.builder()
-        .type(type)
-        .name(name)
-        .location(location)
-        .reference(name)
-        .metadata(metadata)
+        .type(getType(manifest))
+        .name(manifest.getName())
+        .location(manifest.getNamespace())
+        .reference(manifest.getName())
+        .putMetadata("account", account)
         .build();
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
@@ -43,7 +43,7 @@ final class KubernetesVersionedArtifactConverter extends KubernetesArtifactConve
       ArtifactProvider provider, KubernetesManifest manifest, @Nonnull String account) {
     String version = getVersion(provider, account, manifest);
     return Artifact.builder()
-        .type(getType(manifest))
+        .type(artifactType(manifest.getKind()))
         .name(manifest.getName())
         .location(manifest.getNamespace())
         .version(version)
@@ -65,7 +65,7 @@ final class KubernetesVersionedArtifactConverter extends KubernetesArtifactConve
       ArtifactProvider provider, @Nonnull String account, KubernetesManifest manifest) {
     ImmutableList<Artifact> priorVersions =
         provider.getArtifacts(
-            getType(manifest), manifest.getName(), manifest.getNamespace(), account);
+            artifactType(manifest.getKind()), manifest.getName(), manifest.getNamespace(), account);
 
     Optional<String> maybeVersion = findMatchingVersion(priorVersions, manifest);
     if (maybeVersion.isPresent()) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
@@ -135,7 +135,7 @@ final class KubernetesVersionedArtifactConverter extends KubernetesArtifactConve
       KubernetesManifest manifest =
           objectMapper.convertValue(rawLastAppliedConfiguration, KubernetesManifest.class);
       return Optional.of(manifest);
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       log.warn("Malformed lastAppliedConfiguration entry in {}: ", artifact, e);
       return Optional.empty();
     }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.artifact;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.ArtifactProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -40,7 +42,7 @@ final class KubernetesVersionedArtifactConverter extends KubernetesArtifactConve
 
   @Override
   public Artifact toArtifact(
-      ArtifactProvider provider, KubernetesManifest manifest, String account) {
+      ArtifactProvider provider, KubernetesManifest manifest, @Nonnull String account) {
     String type = getType(manifest);
     String name = manifest.getName();
     String location = manifest.getNamespace();
@@ -71,12 +73,9 @@ final class KubernetesVersionedArtifactConverter extends KubernetesArtifactConve
       String type,
       String name,
       String location,
-      String account,
+      @Nonnull String account,
       KubernetesManifest manifest) {
-    List<Artifact> priorVersions =
-        provider.getArtifacts(type, name, location).stream()
-            .filter(a -> account.equals(a.getMetadata("account")))
-            .collect(Collectors.toList());
+    ImmutableList<Artifact> priorVersions = provider.getArtifacts(type, name, location, account);
 
     Optional<String> maybeVersion = findMatchingVersion(priorVersions, manifest);
     if (maybeVersion.isPresent()) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/ArtifactProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/ArtifactProvider.java
@@ -17,9 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 
+import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
-import java.util.List;
 
 public interface ArtifactProvider {
-  List<Artifact> getArtifacts(String type, String name, String location);
+  ImmutableList<Artifact> getArtifacts(String type, String name, String location, String account);
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
@@ -77,12 +77,15 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
   }
 
   public ReplaceResult replaceArtifacts(
-      KubernetesManifest manifest, List<Artifact> artifacts, String account) {
+      KubernetesManifest manifest, List<Artifact> artifacts, @Nonnull String account) {
     return artifactReplacer.replaceAll(manifest, artifacts, manifest.getNamespace(), account);
   }
 
   public ReplaceResult replaceArtifacts(
-      KubernetesManifest manifest, List<Artifact> artifacts, String namespace, String account) {
+      KubernetesManifest manifest,
+      List<Artifact> artifacts,
+      @Nonnull String namespace,
+      @Nonnull String account) {
     return artifactReplacer.replaceAll(manifest, artifacts, namespace, account);
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPatchManifestOperation.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.op.manifest;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.netflix.spinnaker.clouddriver.data.task.Task;
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository;
@@ -115,7 +116,10 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
         objectMapper.convertValue(description.getPatchBody(), KubernetesManifest.class);
     ReplaceResult replaceResult =
         patchHandler.replaceArtifacts(
-            manifest, allArtifacts, objToPatch.getNamespace(), description.getAccount());
+            manifest,
+            allArtifacts,
+            Strings.nullToEmpty(objToPatch.getNamespace()),
+            description.getAccount());
 
     if (description.getRequiredArtifacts() != null) {
       Set<ArtifactKey> unboundArtifacts =

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverterTest.java
@@ -50,20 +50,6 @@ final class KubernetesVersionedArtifactConverterTest {
   private static final String ARTIFACT_TYPE = "kubernetes/pod";
 
   @Test
-  public void checkArtifactAcrossAccount() {
-    ArtifactProvider provider = mock(ArtifactProvider.class);
-    when(provider.getArtifacts(ARTIFACT_TYPE, NAME, NAMESPACE))
-        .thenReturn(
-            ImmutableList.of(
-                Artifact.builder().putMetadata("account", "account1").version("v003").build(),
-                Artifact.builder().putMetadata("account", "account2").version("v005").build()));
-
-    Artifact artifact = converter.toArtifact(provider, getStubManifest(), "account1");
-    assertThat(artifact).isNotNull();
-    assertThat(artifact.getVersion()).isEqualTo("v004");
-  }
-
-  @Test
   void inferVersionedArtifactProperties() {
     String name =
         converter.getDeployedName(
@@ -95,7 +81,7 @@ final class KubernetesVersionedArtifactConverterTest {
     String version2 = "v002";
 
     ArtifactProvider provider = mock(ArtifactProvider.class);
-    when(provider.getArtifacts(ARTIFACT_TYPE, NAME, NAMESPACE))
+    when(provider.getArtifacts(ARTIFACT_TYPE, NAME, NAMESPACE, ACCOUNT))
         .thenReturn(
             ImmutableList.of(
                 Artifact.builder()
@@ -117,7 +103,7 @@ final class KubernetesVersionedArtifactConverterTest {
   @MethodSource("versionTestCases")
   void correctlyPicksNextVersion(VersionTestCase testCase) {
     ArtifactProvider provider = mock(ArtifactProvider.class);
-    when(provider.getArtifacts(ARTIFACT_TYPE, NAME, NAMESPACE))
+    when(provider.getArtifacts(ARTIFACT_TYPE, NAME, NAMESPACE, ACCOUNT))
         .thenReturn(
             testCase.getExistingVersions().stream()
                 .map(v -> Artifact.builder().putMetadata("account", ACCOUNT).version(v).build())

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverterTest.java
@@ -119,12 +119,15 @@ final class KubernetesVersionedArtifactConverterTest {
         new VersionTestCase(ImmutableList.of("v000"), "v001"),
         new VersionTestCase(ImmutableList.of(), "v000"),
         new VersionTestCase(ImmutableList.of("v001"), "v002"),
+        new VersionTestCase(ImmutableList.of("abc", "", "v001"), "v002"),
         new VersionTestCase(ImmutableList.of("v001", "v002", "v003"), "v004"),
         new VersionTestCase(ImmutableList.of("v000", "v002", "v003"), "v004"),
         new VersionTestCase(ImmutableList.of("v002", "v000", "v001"), "v003"),
         new VersionTestCase(ImmutableList.of("v000", "v001", "v003"), "v004"),
         new VersionTestCase(ImmutableList.of("v001", "v000", "v003"), "v004"),
-        new VersionTestCase(ImmutableList.of("v1000"), "v1001"));
+        new VersionTestCase(ImmutableList.of("v999"), "v1000"),
+        new VersionTestCase(ImmutableList.of("v1000"), "v1001"),
+        new VersionTestCase(ImmutableList.of("v12345", "v98765"), "v98766"));
   }
 
   @RequiredArgsConstructor

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ReplacerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ReplacerTest.java
@@ -68,7 +68,7 @@ import org.junit.runner.RunWith;
  * The goal of this class is to do a test on each of the statically-defined replacers in {@link
  * Replacer}. Given {@link Replacer} has only package-private functions and users would only be
  * consuming these wrapped in an {@link ArtifactReplacer} we will do the same here; for each {@link
- * Replacer}, we wrap it in an {@link ArtifactReplacer} and check that it can find an replace the
+ * Replacer}, we wrap it in an {@link ArtifactReplacer} and check that it can find and replace the
  * expected artifacts on a Kubernetes object.
  *
  * <p>While {@link ArtifactReplacerTest} is focused more on the logic of {@link ArtifactReplacer}

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ReplacerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ReplacerTest.java
@@ -1,0 +1,1043 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.artifact;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.gson.Gson;
+import com.netflix.spinnaker.clouddriver.kubernetes.artifact.ArtifactReplacer.ReplaceResult;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import io.kubernetes.client.openapi.JSON;
+import io.kubernetes.client.openapi.models.V1ConfigMapEnvSource;
+import io.kubernetes.client.openapi.models.V1ConfigMapEnvSourceBuilder;
+import io.kubernetes.client.openapi.models.V1ConfigMapKeySelector;
+import io.kubernetes.client.openapi.models.V1ConfigMapKeySelectorBuilder;
+import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSource;
+import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSourceBuilder;
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ContainerBuilder;
+import io.kubernetes.client.openapi.models.V1CrossVersionObjectReferenceBuilder;
+import io.kubernetes.client.openapi.models.V1EnvFromSource;
+import io.kubernetes.client.openapi.models.V1EnvFromSourceBuilder;
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1EnvVarBuilder;
+import io.kubernetes.client.openapi.models.V1EnvVarSource;
+import io.kubernetes.client.openapi.models.V1EnvVarSourceBuilder;
+import io.kubernetes.client.openapi.models.V1HorizontalPodAutoscaler;
+import io.kubernetes.client.openapi.models.V1HorizontalPodAutoscalerBuilder;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodBuilder;
+import io.kubernetes.client.openapi.models.V1ReplicaSet;
+import io.kubernetes.client.openapi.models.V1ReplicaSetBuilder;
+import io.kubernetes.client.openapi.models.V1SecretEnvSource;
+import io.kubernetes.client.openapi.models.V1SecretEnvSourceBuilder;
+import io.kubernetes.client.openapi.models.V1SecretKeySelector;
+import io.kubernetes.client.openapi.models.V1SecretKeySelectorBuilder;
+import io.kubernetes.client.openapi.models.V1SecretVolumeSource;
+import io.kubernetes.client.openapi.models.V1SecretVolumeSourceBuilder;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeBuilder;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+/**
+ * The goal of this class is to do a test on each of the statically-defined replacers in {@link
+ * Replacer}. Given {@link Replacer} has only package-private functions and users would only be
+ * consuming these wrapped in an {@link ArtifactReplacer} we will do the same here; for each {@link
+ * Replacer}, we wrap it in an {@link ArtifactReplacer} and check that it can find an replace the
+ * expected artifacts on a Kubernetes object.
+ *
+ * <p>While {@link ArtifactReplacerTest} is focused more on the logic of {@link ArtifactReplacer}
+ * (ex: do we properly filter artifacts by namespace/account) this class focuses on ensuring that
+ * each static replacer works as expected.
+ */
+@RunWith(JUnitPlatform.class)
+final class ReplacerTest {
+  // We serialized generated Kubernetes metadata objects with JSON io.kubernetes.client.openapi.JSON
+  // so that they match what we get back from kubectl.  We'll just gson from converting to a
+  // KubernetesManifest because that's what we currently use to parse the result from kubectl and
+  // we want this test to be realistic.
+  private static final JSON json = new JSON();
+  private static final Gson gson = new Gson();
+
+  private static final String NAMESPACE = "ns";
+  private static final String ACCOUNT = "my-account";
+
+  @Test
+  void findReplicaSetDockerImages() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.dockerImage()));
+    KubernetesManifest replicaSet = getReplicaSetWithContainers();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(replicaSet);
+    assertThat(artifacts).hasSize(2);
+
+    Map<String, Artifact> byReference =
+        artifacts.stream().collect(toImmutableMap(Artifact::getReference, a -> a));
+
+    assertThat(byReference.get("gcr.io/my-repository/my-image:my-tag"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("docker/image");
+              assertThat(artifact.getName()).isEqualTo("gcr.io/my-repository/my-image");
+              assertThat(artifact.getReference()).isEqualTo("gcr.io/my-repository/my-image:my-tag");
+            });
+
+    assertThat(byReference.get("gcr.io/my-other-repository/some-image"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("docker/image");
+              assertThat(artifact.getName()).isEqualTo("gcr.io/my-other-repository/some-image");
+              assertThat(artifact.getReference())
+                  .isEqualTo("gcr.io/my-other-repository/some-image");
+            });
+  }
+
+  @Test
+  void replaceReplicaSetDockerImages() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.dockerImage()));
+    KubernetesManifest replicaSet = getReplicaSetWithContainers();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("docker/image")
+            .name("gcr.io/my-other-repository/some-image")
+            .reference("gcr.io/my-other-repository/some-image:some-tag")
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(
+            replicaSet, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1ReplicaSet replacedReplicaSet =
+        KubernetesCacheDataConverter.getResource(replaceResult.getManifest(), V1ReplicaSet.class);
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .extracting(V1Container::getImage)
+        .containsExactly(
+            // Only the second image should have been replaced.
+            "gcr.io/my-repository/my-image:my-tag",
+            "gcr.io/my-other-repository/some-image:some-tag");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  private KubernetesManifest getReplicaSetWithContainers() {
+    String replicaSet =
+        json.serialize(
+            new V1ReplicaSetBuilder()
+                .withNewSpec()
+                .withNewTemplate()
+                .withNewSpec()
+                .addToContainers(
+                    new V1ContainerBuilder()
+                        .withName("my-image-with-tag")
+                        .withImage("gcr.io/my-repository/my-image:my-tag")
+                        .build())
+                .addToContainers(
+                    new V1ContainerBuilder()
+                        .withName("my-image-without-tag")
+                        .withImage("gcr.io/my-other-repository/some-image")
+                        .build())
+                .endSpec()
+                .endTemplate()
+                .endSpec()
+                .build());
+    return gson.fromJson(replicaSet, KubernetesManifest.class);
+  }
+
+  @Test
+  void findPodDockerImages() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.podDockerImage()));
+    KubernetesManifest pod = getPod();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(pod);
+    assertThat(artifacts).hasSize(2);
+
+    Map<String, Artifact> byReference =
+        artifacts.stream().collect(toImmutableMap(Artifact::getReference, a -> a));
+
+    assertThat(byReference.get("gcr.io/my-repository/my-image:my-tag"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("docker/image");
+              assertThat(artifact.getName()).isEqualTo("gcr.io/my-repository/my-image:my-tag");
+              assertThat(artifact.getReference()).isEqualTo("gcr.io/my-repository/my-image:my-tag");
+            });
+
+    assertThat(byReference.get("gcr.io/my-other-repository/some-image"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("docker/image");
+              assertThat(artifact.getName()).isEqualTo("gcr.io/my-other-repository/some-image");
+              assertThat(artifact.getReference())
+                  .isEqualTo("gcr.io/my-other-repository/some-image");
+            });
+  }
+
+  @Test
+  void replacePodDockerImages() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.podDockerImage()));
+    KubernetesManifest pod = getPod();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("docker/image")
+            .name("gcr.io/my-other-repository/some-image")
+            .reference("gcr.io/my-other-repository/some-image:some-tag")
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(pod, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1Pod replacedPod =
+        KubernetesCacheDataConverter.getResource(replaceResult.getManifest(), V1Pod.class);
+    assertThat(replacedPod.getSpec().getContainers())
+        .extracting(V1Container::getImage)
+        .containsExactly(
+            // Only the second image should have been replaced.
+            "gcr.io/my-repository/my-image:my-tag",
+            "gcr.io/my-other-repository/some-image:some-tag");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  private KubernetesManifest getPod() {
+    String pod =
+        json.serialize(
+            new V1PodBuilder()
+                .withNewSpec()
+                .addNewContainer()
+                .withName("my-image-with-tag")
+                .withImage("gcr.io/my-repository/my-image:my-tag")
+                .endContainer()
+                .addNewContainer()
+                .withName("my-image-without-tag")
+                .withImage("gcr.io/my-other-repository/some-image")
+                .endContainer()
+                .endSpec()
+                .build());
+    return gson.fromJson(pod, KubernetesManifest.class);
+  }
+
+  @Test
+  void findConfigMapVolume() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.configMapVolume()));
+    KubernetesManifest replicaSet = getReplicaSetWithVolumes();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(replicaSet);
+    assertThat(artifacts).hasSize(2);
+
+    Map<String, Artifact> byReference =
+        artifacts.stream().collect(toImmutableMap(Artifact::getReference, a -> a));
+
+    assertThat(byReference.get("first-config-map"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/configMap");
+              assertThat(artifact.getName()).isEqualTo("first-config-map");
+              assertThat(artifact.getReference()).isEqualTo("first-config-map");
+            });
+
+    assertThat(byReference.get("second-config-map"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/configMap");
+              assertThat(artifact.getName()).isEqualTo("second-config-map");
+              assertThat(artifact.getReference()).isEqualTo("second-config-map");
+            });
+  }
+
+  @Test
+  void replaceConfigMapVolume() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.configMapVolume()));
+    KubernetesManifest replicaSet = getReplicaSetWithVolumes();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/configMap")
+            .name("second-config-map")
+            .location(NAMESPACE)
+            .version("v003")
+            .reference("second-config-map-v003")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(
+            replicaSet, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1ReplicaSet replacedReplicaSet =
+        KubernetesCacheDataConverter.getResource(replaceResult.getManifest(), V1ReplicaSet.class);
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getVolumes())
+        .extracting(V1Volume::getConfigMap)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1ConfigMapVolumeSource::getName)
+        .containsExactly(
+            // Only the second config map should have been replaced.
+            "first-config-map", "second-config-map-v003");
+
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getVolumes())
+        .extracting(V1Volume::getSecret)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1SecretVolumeSource::getSecretName)
+        .containsExactly(
+            // No secrets should have been replaced.
+            "first-secret", "second-secret");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  @Test
+  void findSecretVolume() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.secretVolume()));
+    KubernetesManifest replicaSet = getReplicaSetWithVolumes();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(replicaSet);
+    assertThat(artifacts).hasSize(2);
+
+    Map<String, Artifact> byReference =
+        artifacts.stream().collect(toImmutableMap(Artifact::getReference, a -> a));
+
+    assertThat(byReference.get("first-secret"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/secret");
+              assertThat(artifact.getName()).isEqualTo("first-secret");
+              assertThat(artifact.getReference()).isEqualTo("first-secret");
+            });
+
+    assertThat(byReference.get("second-secret"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/secret");
+              assertThat(artifact.getName()).isEqualTo("second-secret");
+              assertThat(artifact.getReference()).isEqualTo("second-secret");
+            });
+  }
+
+  @Test
+  void replaceSecretVolume() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.secretVolume()));
+    KubernetesManifest replicaSet = getReplicaSetWithVolumes();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/secret")
+            .name("first-secret")
+            .location(NAMESPACE)
+            .version("v007")
+            .reference("first-secret-v007")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(
+            replicaSet, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1ReplicaSet replacedReplicaSet =
+        KubernetesCacheDataConverter.getResource(replaceResult.getManifest(), V1ReplicaSet.class);
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getVolumes())
+        .extracting(V1Volume::getConfigMap)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1ConfigMapVolumeSource::getName)
+        .containsExactly(
+            // No config maps should have been replaced.
+            "first-config-map", "second-config-map");
+
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getVolumes())
+        .extracting(V1Volume::getSecret)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1SecretVolumeSource::getSecretName)
+        .containsExactly(
+            // Only the first secret should have been replaced.
+            "first-secret-v007", "second-secret");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  private KubernetesManifest getReplicaSetWithVolumes() {
+    String replicaSet =
+        json.serialize(
+            new V1ReplicaSetBuilder()
+                .withNewSpec()
+                .withNewTemplate()
+                .withNewSpec()
+                .addToVolumes(
+                    new V1VolumeBuilder()
+                        .withConfigMap(
+                            new V1ConfigMapVolumeSourceBuilder()
+                                .withName("first-config-map")
+                                .build())
+                        .build())
+                .addToVolumes(
+                    new V1VolumeBuilder()
+                        .withConfigMap(
+                            new V1ConfigMapVolumeSourceBuilder()
+                                .withName("second-config-map")
+                                .build())
+                        .build())
+                .addToVolumes(
+                    new V1VolumeBuilder()
+                        .withSecret(
+                            new V1SecretVolumeSourceBuilder()
+                                .withSecretName("first-secret")
+                                .build())
+                        .build())
+                .addToVolumes(
+                    new V1VolumeBuilder()
+                        .withSecret(
+                            new V1SecretVolumeSourceBuilder()
+                                .withSecretName("second-secret")
+                                .build())
+                        .build())
+                .endSpec()
+                .endTemplate()
+                .endSpec()
+                .build());
+    return gson.fromJson(replicaSet, KubernetesManifest.class);
+  }
+
+  @Test
+  void findConfigMapKeyValue() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.configMapKeyValue()));
+    KubernetesManifest replicaSet = getReplicaSetWithKeyRefs();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(replicaSet);
+    assertThat(artifacts).hasSize(2);
+
+    Map<String, Artifact> byReference =
+        artifacts.stream().collect(toImmutableMap(Artifact::getReference, a -> a));
+
+    assertThat(byReference.get("first-name"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/configMap");
+              assertThat(artifact.getName()).isEqualTo("first-name");
+              assertThat(artifact.getReference()).isEqualTo("first-name");
+            });
+
+    assertThat(byReference.get("second-name"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/configMap");
+              assertThat(artifact.getName()).isEqualTo("second-name");
+              assertThat(artifact.getReference()).isEqualTo("second-name");
+            });
+  }
+
+  @Test
+  void replaceConfigMapKeyValue() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.configMapKeyValue()));
+    KubernetesManifest replicaSet = getReplicaSetWithKeyRefs();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/configMap")
+            .name("first-name")
+            .location(NAMESPACE)
+            .version("v006")
+            .reference("first-name-v006")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(
+            replicaSet, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1ReplicaSet replacedReplicaSet =
+        KubernetesCacheDataConverter.getResource(replaceResult.getManifest(), V1ReplicaSet.class);
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .flatExtracting(V1Container::getEnv)
+        .extracting(V1EnvVar::getValueFrom)
+        .extracting(V1EnvVarSource::getConfigMapKeyRef)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1ConfigMapKeySelector::getName)
+        .containsExactly(
+            // We should have replaced both references to the first name.
+            "first-name-v006", "first-name-v006", "second-name");
+
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .flatExtracting(V1Container::getEnv)
+        .extracting(V1EnvVar::getValueFrom)
+        .extracting(V1EnvVarSource::getSecretKeyRef)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1SecretKeySelector::getName)
+        .containsExactly(
+            // We should not have replaced any secret references.
+            "first-name", "second-name", "second-name");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  @Test
+  void findSecretKeyValue() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.secretKeyValue()));
+    KubernetesManifest replicaSet = getReplicaSetWithKeyRefs();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(replicaSet);
+    assertThat(artifacts).hasSize(2);
+
+    Map<String, Artifact> byReference =
+        artifacts.stream().collect(toImmutableMap(Artifact::getReference, a -> a));
+
+    assertThat(byReference.get("first-name"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/secret");
+              assertThat(artifact.getName()).isEqualTo("first-name");
+              assertThat(artifact.getReference()).isEqualTo("first-name");
+            });
+
+    assertThat(byReference.get("second-name"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/secret");
+              assertThat(artifact.getName()).isEqualTo("second-name");
+              assertThat(artifact.getReference()).isEqualTo("second-name");
+            });
+  }
+
+  @Test
+  void replaceSecretKeyValue() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.secretKeyValue()));
+    KubernetesManifest replicaSet = getReplicaSetWithKeyRefs();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/secret")
+            .name("second-name")
+            .location(NAMESPACE)
+            .version("v009")
+            .reference("second-name-v009")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(
+            replicaSet, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1ReplicaSet replacedReplicaSet =
+        KubernetesCacheDataConverter.getResource(replaceResult.getManifest(), V1ReplicaSet.class);
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .flatExtracting(V1Container::getEnv)
+        .extracting(V1EnvVar::getValueFrom)
+        .extracting(V1EnvVarSource::getConfigMapKeyRef)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1ConfigMapKeySelector::getName)
+        .containsExactly(
+            // We should not have replaced any config map references.
+            "first-name", "first-name", "second-name");
+
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .flatExtracting(V1Container::getEnv)
+        .extracting(V1EnvVar::getValueFrom)
+        .extracting(V1EnvVarSource::getSecretKeyRef)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1SecretKeySelector::getName)
+        .containsExactly(
+            // We should have replaced both references to second-name.
+            "first-name", "second-name-v009", "second-name-v009");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  private KubernetesManifest getReplicaSetWithKeyRefs() {
+    String replicaSet =
+        json.serialize(
+            new V1ReplicaSetBuilder()
+                .withNewSpec()
+                .withNewTemplate()
+                .withNewSpec()
+                .addToContainers(
+                    new V1ContainerBuilder()
+                        .withName("my-image-with-tag")
+                        .withEnv(
+                            new V1EnvVarBuilder()
+                                .withValueFrom(
+                                    new V1EnvVarSourceBuilder()
+                                        .withConfigMapKeyRef(
+                                            new V1ConfigMapKeySelectorBuilder()
+                                                .withName("first-name")
+                                                .withKey("first-key")
+                                                .build())
+                                        .build())
+                                .build(),
+                            new V1EnvVarBuilder()
+                                .withValueFrom(
+                                    new V1EnvVarSourceBuilder()
+                                        .withConfigMapKeyRef(
+                                            new V1ConfigMapKeySelectorBuilder()
+                                                // Second key also from the first config map
+                                                .withName("first-name")
+                                                .withKey("second-key")
+                                                .build())
+                                        .build())
+                                .build(),
+                            new V1EnvVarBuilder()
+                                .withValueFrom(
+                                    new V1EnvVarSourceBuilder()
+                                        .withConfigMapKeyRef(
+                                            new V1ConfigMapKeySelectorBuilder()
+                                                .withName("second-name")
+                                                .withKey("third-key")
+                                                .build())
+                                        .build())
+                                .build(),
+                            new V1EnvVarBuilder()
+                                .withValueFrom(
+                                    new V1EnvVarSourceBuilder()
+                                        .withSecretKeyRef(
+                                            new V1SecretKeySelectorBuilder()
+                                                .withName("first-name")
+                                                .withKey("first-key")
+                                                .build())
+                                        .build())
+                                .build(),
+                            new V1EnvVarBuilder()
+                                .withValueFrom(
+                                    new V1EnvVarSourceBuilder()
+                                        .withSecretKeyRef(
+                                            new V1SecretKeySelectorBuilder()
+                                                .withName("second-name")
+                                                .withKey("second-key")
+                                                .build())
+                                        .build())
+                                .build(),
+                            new V1EnvVarBuilder()
+                                .withValueFrom(
+                                    new V1EnvVarSourceBuilder()
+                                        .withSecretKeyRef(
+                                            new V1SecretKeySelectorBuilder()
+                                                // Third key also from the second secret
+                                                .withName("second-name")
+                                                .withKey("third-key")
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .endSpec()
+                .endTemplate()
+                .endSpec()
+                .build());
+    return gson.fromJson(replicaSet, KubernetesManifest.class);
+  }
+
+  @Test
+  void findConfigMapEnvFrom() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.configMapEnv()));
+    KubernetesManifest replicaSet = getReplicaSetWithEnvFrom();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(replicaSet);
+    assertThat(artifacts).hasSize(2);
+
+    Map<String, Artifact> byReference =
+        artifacts.stream().collect(toImmutableMap(Artifact::getReference, a -> a));
+
+    assertThat(byReference.get("config-map-name"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/configMap");
+              assertThat(artifact.getName()).isEqualTo("config-map-name");
+              assertThat(artifact.getReference()).isEqualTo("config-map-name");
+            });
+
+    assertThat(byReference.get("shared-name"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/configMap");
+              assertThat(artifact.getName()).isEqualTo("shared-name");
+              assertThat(artifact.getReference()).isEqualTo("shared-name");
+            });
+  }
+
+  @Test
+  void replaceConfigMapEnvFrom() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.configMapEnv()));
+    KubernetesManifest replicaSet = getReplicaSetWithEnvFrom();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/configMap")
+            .name("shared-name")
+            .location(NAMESPACE)
+            .version("v020")
+            .reference("shared-name-v020")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(
+            replicaSet, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1ReplicaSet replacedReplicaSet =
+        KubernetesCacheDataConverter.getResource(replaceResult.getManifest(), V1ReplicaSet.class);
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .flatExtracting(V1Container::getEnvFrom)
+        .extracting(V1EnvFromSource::getConfigMapRef)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1ConfigMapEnvSource::getName)
+        .containsExactly(
+            // We should have replaced only shared-name.
+            "config-map-name", "shared-name-v020");
+
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .flatExtracting(V1Container::getEnvFrom)
+        .extracting(V1EnvFromSource::getSecretRef)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1SecretEnvSource::getName)
+        .containsExactly(
+            // We should not have replaced any secret references, even the one with the same name as
+            // the artifact.
+            "secret-name", "shared-name");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  @Test
+  void findSecretEnvFrom() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.secretEnv()));
+    KubernetesManifest replicaSet = getReplicaSetWithEnvFrom();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(replicaSet);
+    assertThat(artifacts).hasSize(2);
+
+    Map<String, Artifact> byReference =
+        artifacts.stream().collect(toImmutableMap(Artifact::getReference, a -> a));
+
+    assertThat(byReference.get("secret-name"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/secret");
+              assertThat(artifact.getName()).isEqualTo("secret-name");
+              assertThat(artifact.getReference()).isEqualTo("secret-name");
+            });
+
+    assertThat(byReference.get("shared-name"))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/secret");
+              assertThat(artifact.getName()).isEqualTo("shared-name");
+              assertThat(artifact.getReference()).isEqualTo("shared-name");
+            });
+  }
+
+  @Test
+  void replaceSecretEnvFrom() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.secretEnv()));
+    KubernetesManifest replicaSet = getReplicaSetWithEnvFrom();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/secret")
+            .name("shared-name")
+            .location(NAMESPACE)
+            .version("v987")
+            .reference("shared-name-v987")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(
+            replicaSet, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1ReplicaSet replacedReplicaSet =
+        KubernetesCacheDataConverter.getResource(replaceResult.getManifest(), V1ReplicaSet.class);
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .flatExtracting(V1Container::getEnvFrom)
+        .extracting(V1EnvFromSource::getConfigMapRef)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1ConfigMapEnvSource::getName)
+        .containsExactly(
+            // We should not have replaced any config map references, even the one with the same
+            // name as the artifact.
+            "config-map-name", "shared-name");
+
+    assertThat(replacedReplicaSet.getSpec().getTemplate().getSpec().getContainers())
+        .flatExtracting(V1Container::getEnvFrom)
+        .extracting(V1EnvFromSource::getSecretRef)
+        .filteredOn(Objects::nonNull)
+        .extracting(V1SecretEnvSource::getName)
+        .containsExactly(
+            // We should not have replaced any secret references, even the one with the same name as
+            // the artifact.
+            "secret-name", "shared-name-v987");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  private KubernetesManifest getReplicaSetWithEnvFrom() {
+    String replicaSet =
+        json.serialize(
+            new V1ReplicaSetBuilder()
+                .withNewSpec()
+                .withNewTemplate()
+                .withNewSpec()
+                .addToContainers(
+                    new V1ContainerBuilder()
+                        .withName("my-image-with-tag")
+                        .withEnvFrom(
+                            // Give them both the same name so we can ensure we don't mix
+                            // secrets/configMaps
+                            new V1EnvFromSourceBuilder()
+                                .withConfigMapRef(
+                                    new V1ConfigMapEnvSourceBuilder()
+                                        .withName("config-map-name")
+                                        .build())
+                                .build(),
+                            new V1EnvFromSourceBuilder()
+                                .withConfigMapRef(
+                                    new V1ConfigMapEnvSourceBuilder()
+                                        .withName("shared-name")
+                                        .build())
+                                .build(),
+                            new V1EnvFromSourceBuilder()
+                                .withSecretRef(
+                                    new V1SecretEnvSourceBuilder().withName("secret-name").build())
+                                .build(),
+                            new V1EnvFromSourceBuilder()
+                                .withSecretRef(
+                                    new V1SecretEnvSourceBuilder().withName("shared-name").build())
+                                .build())
+                        .build())
+                .endSpec()
+                .endTemplate()
+                .endSpec()
+                .build());
+    return gson.fromJson(replicaSet, KubernetesManifest.class);
+  }
+
+  @Test
+  void findHpaDeployment() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.hpaDeployment()));
+    KubernetesManifest hpa = getHpaForDeployment();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(hpa);
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/deployment");
+              assertThat(artifact.getName()).isEqualTo("my-deployment");
+              assertThat(artifact.getReference()).isEqualTo("my-deployment");
+            });
+  }
+
+  @Test
+  void findHpaDeploymentIgnoresReplicaSet() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.hpaDeployment()));
+    KubernetesManifest hpa = getHpaForReplicaSet();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(hpa);
+    assertThat(artifacts).isEmpty();
+  }
+
+  @Test
+  void replaceHpaDeployment() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.hpaDeployment()));
+    KubernetesManifest hpa = getHpaForDeployment();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/deployment")
+            .name("my-deployment")
+            .location(NAMESPACE)
+            .version("v020")
+            .reference("my-deployment-v020")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(hpa, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1HorizontalPodAutoscaler replacedHpa =
+        KubernetesCacheDataConverter.getResource(
+            replaceResult.getManifest(), V1HorizontalPodAutoscaler.class);
+    assertThat(replacedHpa.getSpec().getScaleTargetRef().getName()).isEqualTo("my-deployment-v020");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  @Test
+  void findHpaReplicaSet() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.hpaReplicaSet()));
+    KubernetesManifest hpa = getHpaForReplicaSet();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(hpa);
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts))
+        .satisfies(
+            artifact -> {
+              assertThat(artifact).isNotNull();
+              assertThat(artifact.getType()).isEqualTo("kubernetes/replicaSet");
+              assertThat(artifact.getName()).isEqualTo("my-replica-set");
+              assertThat(artifact.getReference()).isEqualTo("my-replica-set");
+            });
+  }
+
+  @Test
+  void findHpaReplicaSetIgnoresDeployment() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.hpaReplicaSet()));
+    KubernetesManifest hpa = getHpaForDeployment();
+
+    Set<Artifact> artifacts = artifactReplacer.findAll(hpa);
+    assertThat(artifacts).isEmpty();
+  }
+
+  @Test
+  void replaceHpaReplicaSet() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.hpaReplicaSet()));
+    KubernetesManifest hpa = getHpaForReplicaSet();
+
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/replicaSet")
+            .name("my-replica-set")
+            .location(NAMESPACE)
+            .version("v020")
+            .reference("my-replica-set-v013")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(hpa, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1HorizontalPodAutoscaler replacedHpa =
+        KubernetesCacheDataConverter.getResource(
+            replaceResult.getManifest(), V1HorizontalPodAutoscaler.class);
+    assertThat(replacedHpa.getSpec().getScaleTargetRef().getName())
+        .isEqualTo("my-replica-set-v013");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).hasSize(1);
+    assertThat(Iterables.getOnlyElement(artifacts)).isEqualTo(inputArtifact);
+  }
+
+  @Test
+  void replaceHpaWrongArtifact() {
+    ArtifactReplacer artifactReplacer =
+        new ArtifactReplacer(ImmutableList.of(Replacer.hpaReplicaSet()));
+    KubernetesManifest hpa = getHpaForReplicaSet();
+
+    // The input artifact has the correct name but is of type deployment; we should not replace
+    // the reference.
+    Artifact inputArtifact =
+        Artifact.builder()
+            .type("kubernetes/deployment")
+            .name("my-replica-set")
+            .location(NAMESPACE)
+            .version("v020")
+            .reference("my-replica-set-v013")
+            .putMetadata("account", ACCOUNT)
+            .build();
+    ReplaceResult replaceResult =
+        artifactReplacer.replaceAll(hpa, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
+
+    V1HorizontalPodAutoscaler replacedHpa =
+        KubernetesCacheDataConverter.getResource(
+            replaceResult.getManifest(), V1HorizontalPodAutoscaler.class);
+    assertThat(replacedHpa.getSpec().getScaleTargetRef().getName()).isEqualTo("my-replica-set");
+
+    Set<Artifact> artifacts = replaceResult.getBoundArtifacts();
+    assertThat(artifacts).isEmpty();
+  }
+
+  private KubernetesManifest getHpaForDeployment() {
+    String hpa =
+        json.serialize(
+            new V1HorizontalPodAutoscalerBuilder()
+                .withNewSpec()
+                .withScaleTargetRef(
+                    new V1CrossVersionObjectReferenceBuilder()
+                        .withKind("deployment")
+                        .withName("my-deployment")
+                        .build())
+                .endSpec()
+                .build());
+    return gson.fromJson(hpa, KubernetesManifest.class);
+  }
+
+  private KubernetesManifest getHpaForReplicaSet() {
+    String hpa =
+        json.serialize(
+            new V1HorizontalPodAutoscalerBuilder()
+                .withNewSpec()
+                .withScaleTargetRef(
+                    new V1CrossVersionObjectReferenceBuilder()
+                        .withKind("replicaSet")
+                        .withName("my-replica-set")
+                        .build())
+                .endSpec()
+                .build());
+    return gson.fromJson(hpa, KubernetesManifest.class);
+  }
+}

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -474,7 +474,8 @@ final class KubernetesDataProviderIntegrationTest {
   @Test
   void getArtifacts(SoftAssertions softly) {
     List<Artifact> artifacts =
-        artifactProvider.getArtifacts("kubernetes/replicaSet", "backend", "backend-ns");
+        artifactProvider.getArtifacts(
+            "kubernetes/replicaSet", "backend", "backend-ns", ACCOUNT_NAME);
     softly.assertThat(artifacts).hasSize(2);
     softly
         .assertThat(artifacts)
@@ -495,14 +496,24 @@ final class KubernetesDataProviderIntegrationTest {
   @Test
   void getArtifactsWrongType(SoftAssertions softly) {
     List<Artifact> artifacts =
-        artifactProvider.getArtifacts("kubernetes/deployment", "backend", "backend-ns");
+        artifactProvider.getArtifacts(
+            "kubernetes/deployment", "backend", "backend-ns", ACCOUNT_NAME);
     softly.assertThat(artifacts).isEmpty();
   }
 
   @Test
   void getArtifactsWrongNamespace(SoftAssertions softly) {
     List<Artifact> artifacts =
-        artifactProvider.getArtifacts("kubernetes/replicaSet", "backend", "frontend-ns");
+        artifactProvider.getArtifacts(
+            "kubernetes/replicaSet", "backend", "frontend-ns", ACCOUNT_NAME);
+    softly.assertThat(artifacts).isEmpty();
+  }
+
+  @Test
+  void getArtifactsWrongAccount(SoftAssertions softly) {
+    List<Artifact> artifacts =
+        artifactProvider.getArtifacts(
+            "kubernetes/replicaSet", "backend", "backend-ns", "wrong-account");
     softly.assertThat(artifacts).isEmpty();
   }
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -75,6 +75,7 @@ import com.netflix.spinnaker.clouddriver.model.ServerGroupSummary;
 import com.netflix.spinnaker.clouddriver.search.SearchResultSet;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
 import com.netflix.spinnaker.clouddriver.security.MapBackedAccountCredentialsRepository;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
 import com.netflix.spinnaker.kork.configserver.ConfigFileService;
 import java.util.Collection;
@@ -156,6 +157,8 @@ final class KubernetesDataProviderIntegrationTest {
       new KubernetesV2SearchProvider(cacheUtils, kindMap, objectMapper, accountResolver);
   private static KubernetesV2ServerGroupManagerProvider serverGroupManagerProvider =
       new KubernetesV2ServerGroupManagerProvider(cacheUtils);
+  private static KubernetesV2ArtifactProvider artifactProvider =
+      new KubernetesV2ArtifactProvider(cacheUtils, objectMapper);
 
   @BeforeAll
   static void prepareCache() {
@@ -466,6 +469,41 @@ final class KubernetesDataProviderIntegrationTest {
                         .put("region", "backend-ns")
                         .put("type", "instances")
                         .build()));
+  }
+
+  @Test
+  void getArtifacts(SoftAssertions softly) {
+    List<Artifact> artifacts =
+        artifactProvider.getArtifacts("kubernetes/replicaSet", "backend", "backend-ns");
+    softly.assertThat(artifacts).hasSize(2);
+    softly
+        .assertThat(artifacts)
+        .allSatisfy(
+            artifact -> {
+              softly.assertThat(artifact.getType()).isEqualTo("kubernetes/replicaSet");
+              softly.assertThat(artifact.getName()).isEqualTo("backend");
+              softly.assertThat(artifact.getLocation()).isEqualTo("backend-ns");
+              softly
+                  .assertThat(Optional.ofNullable((String) artifact.getMetadata("account")))
+                  .contains(ACCOUNT_NAME);
+            });
+    // Order matters here because we're expecting to get the artifacts back in the order they were
+    // created.
+    softly.assertThat(artifacts).extracting(Artifact::getVersion).containsExactly("v014", "v015");
+  }
+
+  @Test
+  void getArtifactsWrongType(SoftAssertions softly) {
+    List<Artifact> artifacts =
+        artifactProvider.getArtifacts("kubernetes/deployment", "backend", "backend-ns");
+    softly.assertThat(artifacts).isEmpty();
+  }
+
+  @Test
+  void getArtifactsWrongNamespace(SoftAssertions softly) {
+    List<Artifact> artifacts =
+        artifactProvider.getArtifacts("kubernetes/replicaSet", "backend", "frontend-ns");
+    softly.assertThat(artifacts).isEmpty();
   }
 
   private static KubectlJobExecutor getJobExecutor() {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
@@ -64,6 +64,7 @@ final class KubernetesDeployManifestOperationTest {
           ImmutableList.of(new KubernetesReplicaSetHandler(), new KubernetesServiceHandler()),
           new KubernetesUnregisteredCustomResourceHandler());
   private static final Namer<KubernetesManifest> NAMER = new KubernetesManifestNamer();
+  private static final String ACCOUNT = "my-account";
 
   @BeforeEach
   void setTask() {
@@ -163,6 +164,7 @@ final class KubernetesDeployManifestOperationTest {
                         KubernetesDeployManifestOperationTest.class, manifest)))
             .setMoniker(new Moniker())
             .setSource(KubernetesDeployManifestDescription.Source.text);
+    deployManifestDescription.setAccount(ACCOUNT);
     deployManifestDescription.setCredentials(getNamedAccountCredentials());
     return deployManifestDescription;
   }
@@ -217,7 +219,8 @@ final class KubernetesDeployManifestOperationTest {
 
   private static OperationResult deploy(KubernetesDeployManifestDescription description) {
     ArtifactProvider provider = mock(ArtifactProvider.class);
-    when(provider.getArtifacts(any(String.class), any(String.class), any(String.class)))
+    when(provider.getArtifacts(
+            any(String.class), any(String.class), any(String.class), any(String.class)))
         .thenReturn(ImmutableList.of());
     return new KubernetesDeployManifestOperation(description, provider).operate(ImmutableList.of());
   }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
@@ -194,7 +194,8 @@ final class KubernetesRunJobOperationTest {
   private static OperationResult operate(
       KubernetesRunJobOperationDescription description, boolean appendSuffix) {
     ArtifactProvider provider = mock(ArtifactProvider.class);
-    when(provider.getArtifacts(any(String.class), any(String.class), any(String.class)))
+    when(provider.getArtifacts(
+            any(String.class), any(String.class), any(String.class), any(String.class)))
         .thenReturn(ImmutableList.of());
     return new KubernetesRunJobOperation(description, provider, appendSuffix)
         .operate(ImmutableList.of());


### PR DESCRIPTION
* test(kubernetes): Add some tests on ArtifactProvider and Replacers 

  Let's add a few tests on the ArtifactProvider. As it depends on an implicit contract with the caching agent, let's use the integration test rather than mock a lot of CacheData items that look like how the caching agent currently stores data.

  In a recent PR, we converted the ArtifactReplacer tests to Java and also improved the test coverage. While these covered the general interface of ArtifactReplacer by using a few specific replacers, we still don't have good test coverage of all of the replacers defined in Replacer.java.

  This is important as the functionality of these replacers is almost entirely encoded by complex JsonPath expressions, and I'd like to refactor these to be cleaner.

  This commit adds a ReplacerTest class that goes through each defined replacer and tries to use it to find and replace artifacts. This should provide sufficient coverage that we can refactor these replacers with confidence.

* refactor(kubernetes): Push account filtering to artifact provider 

  All consumers of the artifact provider immediately filter the results to a particular account; let's push this logic to the artifact provider so they don't need to.

  This removes the need for the checkArtifactAcrossAccount test, which ensures that the versioned artifact converter, as it is now replaced by a test on the artifact provider itself to ensure that it only returns artifacts for a single account.

* refactor(kubernetes): Use filters in JsonPath expressions 

  The Replacer class contains two compilcated strings representing a JsonPath; in all cases these are almost identical. Let's replace this logic with something a bit more clear.  Ideally we'd not need to use JsonPath because we would have a strongly-typed object and would be able to use that, but for now let's at least improve this code (and open up some performance improvements to come).

  First, findPath and replacePath are always of the exact same form; we build a query to find certain nodes. The findPath grabs all of them while the replacePath filters them to ones matching a supplied artifact. In addition to duplicating logic, the syntax of filter conditions is very hard to read.

  The JsonPath library allows you to put a placeholder [?] to represent a filter condition, then bind it to a supplied object representing the condition. This is exactly what we want; we want the same query in all cases but to bind to "match everything" in the find case and to bind to "match this artifact" in the replace case.

  Let's require the replacers to supply a path with a [?] placeholder, and then to supply a filter to determine whether to match a particular artifact. There are two replacers that also require filtering for the find case, so we'll allow this as an optional field (but will default to finding everything).

  Also add a NonnullByDefault to the class which replaces the need for some individual Nonnull annotations.

* perf(kubernetes): Precompile find path for artifact replacers 

  The find path for artifact replacers is completely known a the time the object is constructed. Let's pre-compile it so that we don't need to do this compilation every time we look up artifats (which is every time we return a manfiest from the /manifests endpoint).

  We can't do the same with the replace query as it depends on the input artifact. This isn't as much of an issue as we only replace during a deploy rather than any time you request an existing manifest. But let's slightly simplify the API by having the constructor handle composing the find/replace queries.

* refactor(kubernetes): Clean up filterArtifacts function 

  Rename the verbose filterKubernetesArtifactsByNamespaceAndAccount to simply filterArtifacts.

  To make the logic more clear split it out into a few predicates and use those predicates in the filter logic.

  Finally, require namespace to be non-null and push that requirement outward. In one case there's something we don't know for sure is non-null so convert it with nullToEmpty.

* refactor(kubernetes): Simplify findGreatestUnusedVersion 

  There are a few simplifications to make here:
  (1) We don't need to collect all the prior version to a sorted array then grab the last element; we can just use max() to find the maximum used version. This is slightly more efficient, O(N) vs O(N log N) but really just makes the code simpler.
  (2) We don't need to special-case the case of a version >= 1000; the format string v%03d means pad to a *minimum* width of 3, and handles numbers greater than 999 just fine.

  Let's also add a couple of tests to the already good test coverage to be sure.

* refactor(kubernetes): Clean up exception handling 

  We don't need to log right before throwing an exception; a log message is only useful when suppressing the exception, as it's going to show up in the logs anyway.

  When catching an IOException wrap it in an UncheckedIOException rather than a RuntimeException.

  Finally, don't catch a generic Exception, instead catch a RuntimeException.

* refactor(kubernetes): Inline some variables 

  In both implementations of toArtifact we store a bunch of fields from a KubernetesManifest to local variables in order to use them a few lines later. This just adds more indirection and is confusing; just read the fields we need from the KubernetesManifest.

  Also getVersion should just take the KubernetesManifest itself; it's just confusing to extract a bunch of fields into a long list of arguments instead of just passing the manifest itself.

* refactor(kubernetes): Minor cleanup of find/replace logic 

  The find function can return a Stream as it's only used in one place and the collection it returns is immediately converted to a Stream.

  Minorly refactor the replace function as well.  The goal here is just to make it more clear which functions have side effects by not having them deeply nested in other functions.

* refactor(kubernetes): Rename getType to getArtifactType 

  Also it should just accept a kind rather than a full manifest, as it only needs the kind.

* refactor(kubernetes): Clean up nameFromReference 

  This is really minor, but the function is hard to read because it switches from checking index >=0 to index < 0 partway through; let's make it symmetric.

  Also make the class final; it has a private constructor in any case so it already is effectively final.
