### PR TITLE
perf(kubernetes): Reduce latency of streaming job executor

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
@@ -36,7 +36,7 @@ public class JobExecutorLocal implements JobExecutor {
   // library, it is not worth the effort at this point.
   // This executor is only used to parsing the output of a job when running in streaming mode; the
   // main thread waits on the job while the output parsing is sent to the executor.
-  private final ExecutorService executor = Executors.newCachedThreadPool();
+  private final ExecutorService executorService = Executors.newCachedThreadPool();
   private final long timeoutMinutes;
 
   public JobExecutorLocal(long timeoutMinutes) {
@@ -98,7 +98,7 @@ public class JobExecutorLocal implements JobExecutor {
 
     // Send a task to the executor to consume the output from the job.
     Future<T> futureResult =
-        this.executor.submit(
+        executorService.submit(
             () ->
                 consumer.consume(
                     new BufferedReader(new InputStreamReader(new PipedInputStream(stdOut)))));

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
@@ -21,11 +21,22 @@ import com.netflix.spinnaker.clouddriver.jobs.JobRequest;
 import com.netflix.spinnaker.clouddriver.jobs.JobResult;
 import java.io.*;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.exec.*;
 
 @Slf4j
 public class JobExecutorLocal implements JobExecutor {
+  // We don't actually use this executor to run the jobs as we're deferring to the Apache Commons
+  // library to do this. Ideally we'd refactor this class to use ProcessBuilder, but given that
+  // the main consumer is the Kubernetes provider and we have plans to refactor it to use a client
+  // library, it is not worth the effort at this point.
+  // This executor is only used to parsing the output of a job when running in streaming mode; the
+  // main thread waits on the job while the output parsing is sent to the executor.
+  private final ExecutorService executor = Executors.newCachedThreadPool();
   private final long timeoutMinutes;
 
   public JobExecutorLocal(long timeoutMinutes) {
@@ -82,33 +93,32 @@ public class JobExecutorLocal implements JobExecutor {
       throws IOException {
     PipedOutputStream stdOut = new PipedOutputStream();
     ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
-
     Executor executor =
         buildExecutor(new PumpStreamHandler(stdOut, stdErr, jobRequest.getInputStream()));
-    DefaultExecuteResultHandler resultHandler = new DefaultExecuteResultHandler();
-    executor.execute(jobRequest.getCommandLine(), jobRequest.getEnvironment(), resultHandler);
+
+    // Send a task to the executor to consume the output from the job.
+    Future<T> futureResult =
+        this.executor.submit(
+            () ->
+                consumer.consume(
+                    new BufferedReader(new InputStreamReader(new PipedInputStream(stdOut)))));
+    int exitValue = executor.execute(jobRequest.getCommandLine(), jobRequest.getEnvironment());
 
     T result;
     try {
-      result =
-          consumer.consume(new BufferedReader(new InputStreamReader(new PipedInputStream(stdOut))));
-    } catch (IOException e) {
-      throw new JobExecutionException(
-          String.format("Error parsing output of job: %s", jobRequest.toString()), e);
-    }
-
-    try {
-      resultHandler.waitFor();
+      result = futureResult.get();
     } catch (InterruptedException e) {
       executor.getWatchdog().destroyProcess();
       Thread.currentThread().interrupt();
       throw new JobExecutionException(
           String.format("Interrupted while executing job: %s", jobRequest.toString()), e);
+    } catch (ExecutionException e) {
+      throw new JobExecutionException(
+          String.format("Error parsing output of job: %s", jobRequest.toString()), e.getCause());
     }
 
     return JobResult.<T>builder()
-        .result(
-            resultHandler.getExitValue() == 0 ? JobResult.Result.SUCCESS : JobResult.Result.FAILURE)
+        .result(exitValue == 0 ? JobResult.Result.SUCCESS : JobResult.Result.FAILURE)
         .killed(executor.getWatchdog().killedProcess())
         .output(result)
         .error(stdErr.toString())


### PR DESCRIPTION
Now that we always live lookup events when loading a manifest, the latency of that call becomes more important. (It was always important for users with liveManifestCalls, but now becomes important for everyone.)

In general, for kubectl calls that might return multiple items, we parse the output as it is produced to avoid needing to buffer a lot of intermediate data. We do this by requesting asynchronous execution of the job, then using
the main thread to parse any output from the job as it is produced.

It turns out that the apache-commons library we use adds a fair amount of latency for quick asynchronous jobs. This is because the .waitFor() function on the resultHandler just does a poll/sleep loop to wait for the forked process to finish, which causes us to often wait quite a bit longer than necessary. This matters much less for long jobs (or for background processes) but for responding to user requests and in cases where the call is fast (which is
usually the case for getting events where there are often none) this is significant.

Instead of requesting the job to run asynchronously and using the main thread to parse the output, let's do the opposite. We'll send an asynchronous request to parse the output, then run the job synchronously on the main thread. This avoids the issues with latency because none of these threads poll.

Ideally we'd move away from this commons-exec library and just use ProcessBuilder, but given that we'll soon move
clouddriver-kubernetes to use the client library, it's not worth the effort at this point.

In my testing, this reduced the average time for a call to get manifests from 268ms to 210ms (a 22% reduction); the reduction of ~50ms roughly matches the polling freqency from before, which makes sense as now we don't need to wait a polling cycle to return.