### PR TITLE
refactor(kubernetes): Move name parsing logic to KubernetesCoordinates

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/Keys.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import java.util.Arrays;
@@ -310,6 +311,11 @@ public class Keys {
     public static String createKey(
         KubernetesKind kubernetesKind, String account, String namespace, String name) {
       return createKeyFromParts(kind, kubernetesKind, account, namespace, name);
+    }
+
+    public static String createKey(String account, KubernetesCoordinates coords) {
+      return createKeyFromParts(
+          kind, coords.getKind(), account, coords.getNamespace(), coords.getName());
     }
 
     public static String createKey(KubernetesManifest manifest, String account) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2CachingAgent.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.cats.provider.ProviderCache;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesCachingPolicy;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesCachingProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKindProperties;
@@ -164,9 +165,19 @@ public abstract class KubernetesV2CachingAgent
     return result;
   }
 
+  /**
+   * Deprecated in favor {@link
+   * KubernetesV2CachingAgent#loadPrimaryResource(KubernetesCoordinates)}.
+   */
+  @Deprecated
   protected KubernetesManifest loadPrimaryResource(
       KubernetesKind kind, String namespace, String name) {
-    return credentials.get(kind, namespace, name);
+    return loadPrimaryResource(
+        KubernetesCoordinates.builder().kind(kind).namespace(namespace).name(name).build());
+  }
+
+  protected KubernetesManifest loadPrimaryResource(KubernetesCoordinates coordinates) {
+    return credentials.get(coordinates);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.InfrastructureCacheKey;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.data.KubernetesV2ServerGroupCacheData;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
@@ -193,13 +194,11 @@ public final class KubernetesV2ServerGroup implements KubernetesResource, Server
     KubernetesManifestTraffic traffic = KubernetesManifestAnnotater.getTraffic(manifest);
     Set<String> explicitLoadBalancers =
         traffic.getLoadBalancers().stream()
-            .map(KubernetesManifest::fromFullResourceName)
-            .map(
-                p ->
-                    KubernetesManifest.getFullResourceName(
-                        p.getLeft(),
-                        p.getRight())) // this ensures the names are serialized correctly when
-            // the get merged below
+            // TODO(ezimanyi): Leaving this logic and the comment below, but I'm not sure that we
+            // still need the logic to parse then re-serialize the name.
+            // this ensures the names are serialized correctly when the get merged below
+            .map(lb -> KubernetesCoordinates.builder().fullResourceName(lb).build())
+            .map(c -> KubernetesManifest.getFullResourceName(c.getKind(), c.getName()))
             .collect(Collectors.toSet());
 
     Set<String> loadBalancers =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2InstanceProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2InstanceProvider.java
@@ -18,9 +18,7 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 
 import com.google.common.collect.ImmutableList;
-import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
-import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Instance;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
@@ -60,26 +58,11 @@ public class KubernetesV2InstanceProvider
   }
 
   @Override
-  public KubernetesV2Instance getInstance(String account, String location, String fullName) {
-    KubernetesCoordinates coords;
-    try {
-      coords =
-          KubernetesCoordinates.builder().namespace(location).fullResourceName(fullName).build();
-    } catch (IllegalArgumentException e) {
-      return null;
-    }
-
-    String key = Keys.InfrastructureCacheKey.createKey(account, coords);
-
-    Optional<CacheData> optionalInstanceData =
-        cacheUtils.getSingleEntry(coords.getKind().toString(), key);
-    if (!optionalInstanceData.isPresent()) {
-      return null;
-    }
-
-    CacheData instanceData = optionalInstanceData.get();
-
-    return KubernetesV2Instance.fromCacheData(instanceData);
+  public KubernetesV2Instance getInstance(String account, String namespace, String fullName) {
+    return cacheUtils
+        .getSingleEntry(account, namespace, fullName)
+        .map(KubernetesV2Instance::fromCacheData)
+        .orElse(null);
   }
 
   @Override

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2SecurityGroupProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2SecurityGroupProvider.java
@@ -20,10 +20,10 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2SecurityGroup;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.model.SecurityGroupProvider;
 import java.util.Collection;
 import java.util.Objects;
@@ -93,8 +93,8 @@ public class KubernetesV2SecurityGroupProvider
       boolean includeRules, String account, String fullName) {
     String name;
     try {
-      name = KubernetesManifest.fromFullResourceName(fullName).getRight();
-    } catch (Exception e) {
+      name = KubernetesCoordinates.builder().fullResourceName(fullName).build().getName();
+    } catch (IllegalArgumentException e) {
       return null;
     }
 
@@ -128,8 +128,8 @@ public class KubernetesV2SecurityGroupProvider
       String account, String namespace, String fullName, String _unused) {
     String name;
     try {
-      name = KubernetesManifest.fromFullResourceName(fullName).getRight();
-    } catch (Exception e) {
+      name = KubernetesCoordinates.builder().fullResourceName(fullName).build().getName();
+    } catch (IllegalArgumentException e) {
       return null;
     }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -395,16 +396,16 @@ public class KubernetesManifest extends HashMap<String, Object> {
     return cloneThis.equals(cloneOther);
   }
 
+  /**
+   * This method is deprecated in favor of creating a {@link KubernetesCoordinates} object using
+   * {@link KubernetesCoordinates.KubernetesCoordinatesBuilder#fullResourceName}, which has more
+   * clearly identified named than {@link Pair#getLeft()}) and {@link Pair#getRight()}).
+   */
+  @Deprecated
   public static Pair<KubernetesKind, String> fromFullResourceName(String fullResourceName) {
-    String[] split = fullResourceName.split(" ");
-    if (split.length != 2) {
-      throw new IllegalArgumentException("Expected a full resource name of the form <kind> <name>");
-    }
-
-    KubernetesKind kind = KubernetesKind.fromString(split[0]);
-    String name = split[1];
-
-    return new ImmutablePair<>(kind, name);
+    KubernetesCoordinates coords =
+        KubernetesCoordinates.builder().fullResourceName(fullResourceName).build();
+    return new ImmutablePair<>(coords.getKind(), coords.getName());
   }
 
   @Data

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestOperationDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestOperationDescription.java
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomic
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.tuple.Pair;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -32,12 +31,9 @@ public class KubernetesManifestOperationDescription extends KubernetesAtomicOper
 
   @JsonIgnore
   public KubernetesCoordinates getPointCoordinates() {
-    Pair<KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(manifestName);
-
     return KubernetesCoordinates.builder()
         .namespace(location)
-        .kind(parsedName.getLeft())
-        .name(parsedName.getRight())
+        .fullResourceName(manifestName)
         .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesMultiManifestOperationDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesMultiManifestOperationDescription.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.tuple.Pair;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -57,12 +56,9 @@ public class KubernetesMultiManifestOperationDescription
   @JsonIgnore
   @Deprecated
   public KubernetesCoordinates getPointCoordinates() {
-    Pair<KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(manifestName);
-
     return KubernetesCoordinates.builder()
         .namespace(location)
-        .kind(parsedName.getLeft())
-        .name(parsedName.getRight())
+        .fullResourceName(manifestName)
         .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesPatchManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesPatchManifestDescription.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.tuple.Pair;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -44,12 +43,9 @@ public class KubernetesPatchManifestDescription extends KubernetesAtomicOperatio
 
   @JsonIgnore
   public KubernetesCoordinates getPointCoordinates() {
-    Pair<KubernetesKind, String> parsedName = KubernetesManifest.fromFullResourceName(manifestName);
-
     return KubernetesCoordinates.builder()
         .namespace(location)
-        .kind(parsedName.getLeft())
-        .name(parsedName.getRight())
+        .fullResourceName(manifestName)
         .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/servergroup/KubernetesServerGroupOperationDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/servergroup/KubernetesServerGroupOperationDescription.java
@@ -20,11 +20,8 @@ package com.netflix.spinnaker.clouddriver.kubernetes.description.servergroup;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesAtomicOperationDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.tuple.Pair;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -35,13 +32,9 @@ public class KubernetesServerGroupOperationDescription
 
   @JsonIgnore
   public KubernetesCoordinates getCoordinates() {
-    Pair<KubernetesKind, String> parsedName =
-        KubernetesManifest.fromFullResourceName(serverGroupName);
-
     return KubernetesCoordinates.builder()
         .namespace(region)
-        .kind(parsedName.getLeft())
-        .name(parsedName.getRight())
+        .fullResourceName(serverGroupName)
         .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanLoadBalance.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanLoadBalance.java
@@ -18,13 +18,11 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.op.handler;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.description.JsonPatch;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesResourceProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import java.util.List;
 import javax.annotation.ParametersAreNonnullByDefault;
-import org.apache.commons.lang3.tuple.Pair;
 
 @ParametersAreNonnullByDefault
 public interface CanLoadBalance {
@@ -35,18 +33,11 @@ public interface CanLoadBalance {
   List<JsonPatch> attachPatch(KubernetesManifest loadBalancer, KubernetesManifest target);
 
   static CanLoadBalance lookupProperties(
-      ResourcePropertyRegistry registry, Pair<KubernetesKind, String> name) {
-    KubernetesResourceProperties loadBalancerProperties = registry.get(name.getLeft());
-
-    KubernetesHandler loadBalancerHandler = loadBalancerProperties.getHandler();
-    if (loadBalancerHandler == null) {
-      throw new IllegalArgumentException(
-          "No handler registered for " + name + ", are you sure it's a valid load balancer type?");
-    }
-
+      ResourcePropertyRegistry registry, KubernetesCoordinates coords) {
+    KubernetesHandler loadBalancerHandler = registry.get(coords.getKind()).getHandler();
     if (!(loadBalancerHandler instanceof CanLoadBalance)) {
       throw new IllegalArgumentException(
-          "No support for load balancing via " + name + " exists in Spinnaker");
+          "No support for load balancing via " + coords.getKind() + " exists in Spinnaker");
     }
 
     return (CanLoadBalance) loadBalancerHandler;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -603,11 +603,11 @@ public class KubectlJobExecutor {
   }
 
   public ImmutableList<KubernetesPodMetric> topPod(
-      KubernetesCredentials credentials, String namespace, String pod) {
+      KubernetesCredentials credentials, String namespace, @Nonnull String pod) {
     List<String> command = kubectlNamespacedAuthPrefix(credentials, namespace);
     command.add("top");
     command.add("po");
-    if (pod != null) {
+    if (!pod.isEmpty()) {
       command.add(pod);
     }
     command.add("--containers");

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.JsonPatch;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPatchOptions;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesEnableDisableManifestDescription;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestAnnotater;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestTraffic;
@@ -38,7 +37,6 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang.WordUtils;
-import org.apache.commons.lang3.tuple.Pair;
 
 @ParametersAreNonnullByDefault
 public abstract class AbstractKubernetesEnableDisableManifestOperation
@@ -80,9 +78,13 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
   }
 
   private void op(String loadBalancerName, KubernetesManifest target) {
-    Pair<KubernetesKind, String> name;
+    KubernetesCoordinates coords;
     try {
-      name = KubernetesManifest.fromFullResourceName(loadBalancerName);
+      coords =
+          KubernetesCoordinates.builder()
+              .namespace(target.getNamespace())
+              .fullResourceName(loadBalancerName)
+              .build();
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           String.format(
@@ -92,15 +94,13 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
     }
 
     CanLoadBalance loadBalancerHandler =
-        CanLoadBalance.lookupProperties(credentials.getResourcePropertyRegistry(), name);
+        CanLoadBalance.lookupProperties(credentials.getResourcePropertyRegistry(), coords);
     KubernetesManifest loadBalancer =
-        Optional.ofNullable(credentials.get(name.getLeft(), target.getNamespace(), name.getRight()))
+        Optional.ofNullable(credentials.get(coords))
             .orElseThrow(
                 () ->
                     new IllegalStateException(
-                        String.format(
-                            "Could not find load balancer. (kind: %s, name: %s, namespace: %s)",
-                            name.getLeft(), name.getRight(), target.getNamespace())));
+                        String.format("Could not find load balancer: %s.", coords)));
 
     List<JsonPatch> patch = patchResource(loadBalancerHandler, loadBalancer, target);
 
@@ -137,9 +137,7 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
     getTask().updateStatus(OP_NAME, "Starting " + getVerbName() + " operation...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
     KubernetesManifest target =
-        Optional.ofNullable(
-                credentials.get(
-                    coordinates.getKind(), coordinates.getNamespace(), coordinates.getName()))
+        Optional.ofNullable(credentials.get(coordinates))
             .orElseThrow(
                 () ->
                     new IllegalStateException(

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesManifestSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesManifestSpec.groovy
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest
 import groovy.text.SimpleTemplateEngine
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class KubernetesManifestSpec extends Specification {
   def objectMapper = new ObjectMapper()
@@ -71,22 +70,6 @@ class KubernetesManifestSpec extends Specification {
     manifest.getKind() == KIND
     manifest.getApiVersion() == API_VERSION
     manifest.getSpecTemplateAnnotations().get().get(KEY) == VALUE
-  }
-
-  @Unroll
-  void "correctly parses a fully qualified resource name #kind/#name"() {
-    expect:
-    def pair = KubernetesManifest.fromFullResourceName(fullResourceName)
-    pair.getRight() == name
-    pair.getLeft() == kind
-
-    where:
-    fullResourceName || kind                       | name
-    "replicaSet abc" || KubernetesKind.REPLICA_SET | "abc"
-    "rs abc"         || KubernetesKind.REPLICA_SET | "abc"
-    "service abc"    || KubernetesKind.SERVICE     | "abc"
-    "SERVICE abc"    || KubernetesKind.SERVICE     | "abc"
-    "ingress abc"    || KubernetesKind.INGRESS     | "abc"
   }
 
   void "correctly reads observedGeneration from status"() {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -45,6 +45,7 @@ import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent.OnDemandResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.*;
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestNamer;
@@ -127,9 +128,18 @@ final class KubernetesCoreCachingAgentTest {
         .thenAnswer(invocation -> kindProperties.get(invocation.getArgument(0)));
     when(credentials.getDeclaredNamespaces()).thenReturn(ImmutableList.of(NAMESPACE1, NAMESPACE2));
     when(credentials.getResourcePropertyRegistry()).thenReturn(resourcePropertyRegistry);
-    when(credentials.get(KubernetesKind.DEPLOYMENT, NAMESPACE1, DEPLOYMENT_NAME))
+    when(credentials.get(
+            KubernetesCoordinates.builder()
+                .kind(KubernetesKind.DEPLOYMENT)
+                .namespace(NAMESPACE1)
+                .name(DEPLOYMENT_NAME)
+                .build()))
         .thenReturn(deploymentManifest());
-    when(credentials.get(KubernetesKind.STORAGE_CLASS, "", STORAGE_CLASS_NAME))
+    when(credentials.get(
+            KubernetesCoordinates.builder()
+                .kind(KubernetesKind.STORAGE_CLASS)
+                .name(STORAGE_CLASS_NAME)
+                .build()))
         .thenReturn(storageClassManifest());
     when(credentials.list(any(List.class), any()))
         .thenAnswer(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2InstanceProviderTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2InstanceProviderTest.java
@@ -88,7 +88,8 @@ final class KubernetesV2InstanceProviderTest {
     KubernetesManifest manifest = getKubernetesManifest();
     attributes.put("manifest", manifest);
     when(cacheData.getAttributes()).thenReturn(attributes);
-    when(cacheUtils.getSingleEntry(KIND.toString(), CACHE_KEY)).thenReturn(Optional.of(cacheData));
+    when(cacheUtils.getSingleEntry(ACCOUNT, NAMESPACE, POD_FULL_NAME))
+        .thenReturn(Optional.of(cacheData));
     when(cacheData.getId()).thenReturn(CACHE_KEY);
 
     KubernetesV2Instance instance = provider.getInstance(ACCOUNT, NAMESPACE, POD_FULL_NAME);

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2InstanceProviderTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2InstanceProviderTest.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.cats.cache.CacheData;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Instance;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.ContainerLog;
@@ -118,7 +119,13 @@ final class KubernetesV2InstanceProviderTest {
   @Test
   void getConsoleOutputSuccess() {
     KubernetesManifest manifest = getKubernetesManifest();
-    when(credentials.get(KubernetesKind.POD, NAMESPACE, POD_NAME)).thenReturn(manifest);
+    when(credentials.get(
+            KubernetesCoordinates.builder()
+                .kind(KubernetesKind.POD)
+                .namespace(NAMESPACE)
+                .name(POD_NAME)
+                .build()))
+        .thenReturn(manifest);
     when(credentials.logs(anyString(), anyString(), anyString())).thenReturn(LOG_OUTPUT);
 
     List<ContainerLog> logs = provider.getConsoleOutput(ACCOUNT, NAMESPACE, POD_FULL_NAME);
@@ -137,7 +144,13 @@ final class KubernetesV2InstanceProviderTest {
     pod.getSpec().setInitContainers(null);
     KubernetesManifest manifest = json.deserialize(json.serialize(pod), KubernetesManifest.class);
 
-    when(credentials.get(KubernetesKind.POD, NAMESPACE, POD_NAME)).thenReturn(manifest);
+    when(credentials.get(
+            KubernetesCoordinates.builder()
+                .kind(KubernetesKind.POD)
+                .namespace(NAMESPACE)
+                .name(POD_NAME)
+                .build()))
+        .thenReturn(manifest);
     when(credentials.logs(anyString(), anyString(), anyString())).thenReturn(LOG_OUTPUT);
 
     List<ContainerLog> logs = provider.getConsoleOutput(ACCOUNT, NAMESPACE, POD_FULL_NAME);
@@ -151,7 +164,13 @@ final class KubernetesV2InstanceProviderTest {
   @Test
   void getConsoleOutputKubectlException() {
     KubernetesManifest manifest = getKubernetesManifest();
-    when(credentials.get(KubernetesKind.POD, NAMESPACE, POD_NAME)).thenReturn(manifest);
+    when(credentials.get(
+            KubernetesCoordinates.builder()
+                .kind(KubernetesKind.POD)
+                .namespace(NAMESPACE)
+                .name(POD_NAME)
+                .build()))
+        .thenReturn(manifest);
     when(credentials.logs(anyString(), anyString(), anyString()))
         .thenThrow(new KubectlJobExecutor.KubectlException(LOG_OUTPUT, null));
 
@@ -209,7 +228,13 @@ final class KubernetesV2InstanceProviderTest {
 
   @Test
   void getConsoleOutputPodNotFoundShouldReturnErrorContainerLog() {
-    when(credentials.get(KubernetesKind.POD, NAMESPACE, POD_NAME)).thenReturn(null);
+    when(credentials.get(
+            KubernetesCoordinates.builder()
+                .kind(KubernetesKind.POD)
+                .namespace(NAMESPACE)
+                .name(POD_NAME)
+                .build()))
+        .thenReturn(null);
 
     List<ContainerLog> logs = provider.getConsoleOutput(ACCOUNT, NAMESPACE, POD_FULL_NAME);
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesCoordinatesTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesCoordinatesTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.description;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesCoordinatesTest {
+  @ParameterizedTest
+  @MethodSource("parseNameCases")
+  void parseName(ParseTestCase testCase) {
+    KubernetesCoordinates coordinates =
+        KubernetesCoordinates.builder().fullResourceName(testCase.fullResourceName).build();
+
+    assertThat(coordinates.getKind()).isEqualTo(testCase.expectedKind);
+    assertThat(coordinates.getName()).isEqualTo(testCase.expectedName);
+  }
+
+  static Stream<ParseTestCase> parseNameCases() {
+    return Stream.of(
+        new ParseTestCase("replicaSet abc", KubernetesKind.REPLICA_SET, "abc"),
+        new ParseTestCase("replicaSet abc", KubernetesKind.REPLICA_SET, "abc"),
+        new ParseTestCase("rs abc", KubernetesKind.REPLICA_SET, "abc"),
+        new ParseTestCase("service abc", KubernetesKind.SERVICE, "abc"),
+        new ParseTestCase("SERVICE abc", KubernetesKind.SERVICE, "abc"),
+        new ParseTestCase("ingress abc", KubernetesKind.INGRESS, "abc"));
+  }
+
+  @RequiredArgsConstructor
+  private static class ParseTestCase {
+    final String fullResourceName;
+    final KubernetesKind expectedKind;
+    final String expectedName;
+  }
+}

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.ArtifactProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.ResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
@@ -193,11 +194,21 @@ final class KubernetesDeployManifestOperationTest {
                 KubernetesKindProperties.withDefaultProperties(
                     invocation.getArgument(0, KubernetesKind.class)));
     when(credentialsMock.getResourcePropertyRegistry()).thenReturn(resourcePropertyRegistry);
-    when(credentialsMock.get(KubernetesKind.SERVICE, "my-namespace", "my-service"))
+    when(credentialsMock.get(
+            KubernetesCoordinates.builder()
+                .kind(KubernetesKind.SERVICE)
+                .namespace("my-namespace")
+                .name("my-service")
+                .build()))
         .thenReturn(
             ManifestFetcher.getManifest(
                 KubernetesDeployManifestOperationTest.class, "deploy/service.yml"));
-    when(credentialsMock.get(KubernetesKind.SERVICE, "my-namespace", "my-service-no-selector"))
+    when(credentialsMock.get(
+            KubernetesCoordinates.builder()
+                .kind(KubernetesKind.SERVICE)
+                .namespace("my-namespace")
+                .name("my-service-no-selector")
+                .build()))
         .thenReturn(
             ManifestFetcher.getManifest(
                 KubernetesDeployManifestOperationTest.class, "deploy/service-no-selector.yml"));


### PR DESCRIPTION
* refactor(kubernetes): Move name parsing logic to KubernetesCoordinates 

  A lot of the Kubernetes logic parses a kind-name String into a Pair<KubernetesKind, String>. This leads to very unclear code as we are always calling Pair#getLeft and Pair#getRight instead of using more clearly-named functions. While Pairs might be reasonable for short-term holding of data in functions or streams, they quickly lead to complicated code when passed across function boundaries.

  We already have a KubernetesCoordinates class that represents a kind and a name (as well as a namespace). (And in most cases where we're parsing a kind-name string we also have a namespace around too.)

  Let's prepare to move clients to instead parse into KubernetesCoordinates. This change does the following:
  * Explicitly write out the auto-generated constructor and have it translate null to empty for name/namespace. This allows us to guarantee that none of the fields are null regardless of how the builder is used. We will explicitly prohibit null KubernetesKind because we are always passing in a non-null kind (as our kind parsing logic returns KubernetesKind.NONE instead of null).
  * Add a method to the builder fullResourceName that takes a "kind name" String and parses it to set both the kind and the name.  (The other auto-generated builder methods will still be injected by Lombok, so you can still call .name() or .kind() separately if you want.)
  * Deprecate KubernetesManifest.fromFullResourceName; update it to call the method we just wrote and wrap the result in a Pair.

* refactor(kubernetes): Add some functions that accept KubernetesCoordinates 

  There are a lot of places where we pass around a separate kind/namespace/name that would be much clearer if we could just directly pass KubernetesCoordinates
  (which avoids unpacking a nice object into individual parameters).

  Let's add a few of these functions where they will be useful, in all cases augmenting a function that accepts these separately to become one that accepts a KubernetesCoordinates. I've deprecated the old versions (and will update usages in a later commit) and rewritten them to call the new version.

  I had to make a small change to topPod, which was only checking if the pod was null (rather than null or empty); as we're going through KubernetesCoordinates now we will never have a null name as that will always be changed to empty string.

* refactor(kubernetes): Update descriptions to use new function 

  These all passed the Pair to a KubernetesCoordinatesBuilder anyway, so we can just do this inline now.

* refactor(kubernetes): Refactor other locations to use new function 

  The various Provider classes as well as the on-demand caching agent can be updated now to create a KubernetesCoordinates class instead of parsing the name into a Pair.

  This also simplifies later code in these functions, which can be updated to pass the KubernetesCoordinates on to other functions rather than extracting out the parts.

  While making this change, update the catch blocks around the name parsing to catch an IllegalArgumentException rather than a generic Exception.

* refactor(kubernetes): Use new functions in Operations 

  Same as the last two commits, but update the Operation classes to use KubernetesCoordinates instead of Pair<KubernetesKind, String>.

  I also removed a null-check in CanLoadBalance; a while back I made getHandler always non-null but didn't remove all the now-unnecessary ones.

* refactor(kubernetes): Extract some common logic in provider code 

  When doing the last refactor I realized that a number of providers have almost identical logic. Make a function in CacheUtils that takes an account/namespace/name and returns the corresponding cache data item so we don't need to keep duplicating this.

  One small change (which I considered doing before and commented on) is that we no longer filter relationships in the server group case. The performance benefits here are not worth the additional complexity of not re-using the code (particularly that we only do this filtering when requesting a single server group and not when requesting them all).

* test(kubernetes): Move tests on name parsing 

  Now that we've removed all uses of fromFullResourceName, let's move those tests to the function that we're recommending (and what the deprecated method itself calls). This just converts the exact same tests to Java and moves them.

  I'll leave this and the other deprecated methods around at least until after we cut the release so there is some time for anyone who might have a custom build to migrate.
