### PR TITLE
perf(kubernetes): Request metrics and events in parallel

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/jobs/local/JobExecutorLocal.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.clouddriver.jobs.local;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutionException;
 import com.netflix.spinnaker.clouddriver.jobs.JobExecutor;
 import com.netflix.spinnaker.clouddriver.jobs.JobRequest;
@@ -36,7 +37,9 @@ public class JobExecutorLocal implements JobExecutor {
   // library, it is not worth the effort at this point.
   // This executor is only used to parsing the output of a job when running in streaming mode; the
   // main thread waits on the job while the output parsing is sent to the executor.
-  private final ExecutorService executorService = Executors.newCachedThreadPool();
+  private final ExecutorService executorService =
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder().setNameFormat(getClass().getSimpleName() + "-%d").build());
   private final long timeoutMinutes;
 
   public JobExecutorLocal(long timeoutMinutes) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
@@ -22,6 +22,7 @@ import static com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.LogicalK
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Manifest;
@@ -52,7 +53,9 @@ import org.springframework.stereotype.Component;
 public class KubernetesManifestProvider {
   private final KubernetesCacheUtils cacheUtils;
   private final KubernetesAccountResolver accountResolver;
-  private final ExecutorService executorService = Executors.newCachedThreadPool();
+  private final ExecutorService executorService =
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder().setNameFormat(getClass().getSimpleName() + "-%d").build());
 
   @Autowired
   public KubernetesManifestProvider(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
@@ -17,14 +17,17 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.LogicalKind.CLUSTERS;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Manifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric.ContainerMetric;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
@@ -34,6 +37,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +52,7 @@ import org.springframework.stereotype.Component;
 public class KubernetesManifestProvider {
   private final KubernetesCacheUtils cacheUtils;
   private final KubernetesAccountResolver accountResolver;
+  private final ExecutorService executorService = Executors.newCachedThreadPool();
 
   @Autowired
   public KubernetesManifestProvider(
@@ -69,26 +77,45 @@ public class KubernetesManifestProvider {
       return null;
     }
 
+    Future<List<KubernetesManifest>> events =
+        includeEvents
+            ? executorService.submit(() -> credentials.eventsFor(coords))
+            : Futures.immediateFuture(ImmutableList.of());
+
+    Future<List<ContainerMetric>> metrics =
+        includeEvents
+                && coords.getKind().equals(KubernetesKind.POD)
+                && credentials.isMetricsEnabled()
+            ? executorService.submit(() -> getPodMetrics(credentials, coords))
+            : Futures.immediateFuture(ImmutableList.of());
+
     KubernetesManifest manifest = credentials.get(coords);
     if (manifest == null) {
+      events.cancel(true);
+      metrics.cancel(true);
       return null;
     }
 
-    List<KubernetesManifest> events =
-        includeEvents ? credentials.eventsFor(coords) : ImmutableList.of();
-
-    List<KubernetesPodMetric.ContainerMetric> metrics = ImmutableList.of();
-    if (includeEvents
-        && coords.getKind().equals(KubernetesKind.POD)
-        && credentials.isMetricsEnabled()) {
-      metrics =
-          credentials.topPod(coords).stream()
-              .map(KubernetesPodMetric::getContainerMetrics)
-              .flatMap(Collection::stream)
-              .collect(Collectors.toList());
+    try {
+      return KubernetesV2ManifestBuilder.buildManifest(
+          credentials, manifest, events.get(), metrics.get());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      events.cancel(true);
+      metrics.cancel(true);
+      log.warn("Interrupted while fetching manifest: {}", coords);
+      return null;
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e.getCause());
     }
+  }
 
-    return KubernetesV2ManifestBuilder.buildManifest(credentials, manifest, events, metrics);
+  private ImmutableList<ContainerMetric> getPodMetrics(
+      KubernetesCredentials credentials, KubernetesCoordinates coords) {
+    return credentials.topPod(coords).stream()
+        .map(KubernetesPodMetric::getContainerMetrics)
+        .flatMap(Collection::stream)
+        .collect(toImmutableList());
   }
 
   @Nullable

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesPodHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesPodHandler.java
@@ -29,7 +29,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
-import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -69,8 +68,8 @@ public class KubernetesPodHandler extends KubernetesHandler {
 
   @Override
   public Status status(KubernetesManifest manifest) {
-    V1Pod pod = KubernetesCacheDataConverter.getResource(manifest, V1Pod.class);
-    V1PodStatus status = pod.getStatus();
+    V1PodStatus status =
+        KubernetesCacheDataConverter.getResource(manifest.getStatus(), V1PodStatus.class);
 
     if (status == null) {
       return Status.noneReported();


### PR DESCRIPTION
* perf(kubernetes): Only deserialize pod status

  Rather than convert the entire manifest to a V1Pod, only convert the status as that's all this function is using.

  Ideally we'd only do a single conversion to the full appropriate type when we get a value back from the cluster, and pass that around, but as long as we're still doing these ad-hoc intercoversions, it's worth avoiding doing more than we need.

* perf(kubernetes): Request metrics and events in parallel

  When deck requests a manifest, it wants the events and metrics as well. This means that we make 3 sequential calls to the cluster, each with a bit of latency, that ends up making the overall call longer than needed.

  Let's speed this up by sending the event and metrics requests to an executor pool that runs them on a separate thread. This allows us to only wait as long as the longest request instead of the sum of all of the request times.