### PR TITLE
feat(azure): Removing Azure from cloud providers

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ def cloudProviderProjects = [
 //  'alicloud' : [':clouddriver-alicloud'],
   'appengine':  [':clouddriver-appengine', ':clouddriver-google-common'],
   'aws': [':clouddriver-aws', ':clouddriver-ecs', ':clouddriver-eureka', ':clouddriver-elasticsearch-aws', ':clouddriver-lambda'], // Pull cd-eureka separate "Discover" platform, along with cd-consul?
-  'azure': [':clouddriver-azure'],
+//  'azure': [':clouddriver-azure'],
   'cloudfoundry': [':clouddriver-cloudfoundry'],
 //  'dcos': [':clouddriver-dcos'],
   'gce': [':clouddriver-consul', ':clouddriver-google', ':clouddriver-google-common'],


### PR DESCRIPTION
Azure has still not submitted for formation of a SIG, despite numerous attempts to bring them under conformance of cloud provider requirements.