### PR TITLE
fix(kubernetes): Revert fixes to ensure CRD events are reported in deploy stage

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKind.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKind.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NonnullByDefault
@@ -106,9 +105,9 @@ public class KubernetesKind {
   // kind is not in spinnaker's registry
   public static final KubernetesKind NONE = createWithAlias("none", null, KubernetesApiGroup.NONE);
 
-  @Getter private final String name;
+  private final String name;
   @EqualsAndHashCode.Include private final String lcName;
-  @Getter private final KubernetesApiGroup apiGroup;
+  private final KubernetesApiGroup apiGroup;
   @EqualsAndHashCode.Include @Nullable private final KubernetesApiGroup customApiGroup;
 
   private KubernetesKind(String name, @Nullable KubernetesApiGroup apiGroup) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -108,11 +108,6 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
-  public Map<String, String> getInvolvedObject() {
-    return getRequiredField(this, "involvedObject");
-  }
-
-  @JsonIgnore
   public String getName() {
     return (String) getMetadata().get("name");
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -30,7 +30,6 @@ import com.netflix.spinnaker.clouddriver.jobs.local.ReaderConsumer;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.JsonPatch;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPatchOptions;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiGroup;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
@@ -374,7 +373,7 @@ public class KubectlJobExecutor {
     command.add(
         String.format(
             "involvedObject.name=%s,involvedObject.kind=%s",
-            name, StringUtils.capitalize(kind.getName())));
+            name, StringUtils.capitalize(kind.toString())));
 
     JobResult<ImmutableList<KubernetesManifest>> status =
         jobExecutor.runJob(new JobRequest(command), parseManifestList());
@@ -388,13 +387,7 @@ public class KubectlJobExecutor {
       return ImmutableList.of();
     }
 
-    return status.getOutput().stream()
-        .filter(
-            x ->
-                x.getInvolvedObject()
-                    .getOrDefault("apiVersion", KubernetesApiGroup.NONE.toString())
-                    .startsWith(kind.getApiGroup().toString()))
-        .collect(ImmutableList.toImmutableList());
+    return status.getOutput();
   }
 
   @Nonnull


### PR DESCRIPTION
Reverts spinnaker/clouddriver#4753

While testing some unrelated changes, I noticed that there is a bug in the filtering logic that was added here.  In some cases (ex: `Pod`) we are filtering out all events so that events no longer appear in the UI.  It appears that while this improved the situation for CRDs, it caused a regression for at least some built-in kinds.  As this is kind of subtle and I'd like to see some test coverage before re-applying, reverting before cutting the 1.22 branches so that this bug is not present in 1.22. 