### PR TITLE
fix(artifacts): get subpath from location field and fallback to meta…

### DIFF
--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoArtifactCredentials.java
@@ -152,6 +152,9 @@ final class GitRepoArtifactCredentials implements ArtifactCredentials {
   }
 
   private String artifactSubPath(Artifact artifact) {
+    if (!Strings.nullToEmpty(artifact.getLocation()).isEmpty()) {
+      return artifact.getLocation();
+    }
     return Strings.nullToEmpty((String) artifact.getMetadata("subPath"));
   }
 


### PR DESCRIPTION
A `git/repo` artifact contains the subPath of a repository in the metadata. This cause some issues when Orca tries to identify `git/repo` artifacts that uses the same repo URL and branch name.

This change is about get the `subpath` from `location` field and if it isn't present will try to get the `subpath` from `metadata` as it currently works.