### PR TITLE
refactor(core): Add type bounds to AtomicOperation classes

### DIFF
--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/deploy/DescriptionValidator.java
@@ -27,5 +27,5 @@ public abstract class DescriptionValidator<T> implements VersionedCloudProviderO
     return description + "Validator";
   }
 
-  public abstract void validate(List priorDescriptions, T description, ValidationErrors errors);
+  public abstract void validate(List<T> priorDescriptions, T description, ValidationErrors errors);
 }

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperation.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperation.java
@@ -37,7 +37,7 @@ public interface AtomicOperation<R> {
    * @param priorOutputs
    * @return parameterized type
    */
-  R operate(List priorOutputs);
+  R operate(List<R> priorOutputs);
 
   default Collection<OperationEvent> getEvents() {
     return Collections.emptyList();

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverter.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/clouddriver/orchestration/AtomicOperationConverter.java
@@ -34,7 +34,7 @@ public interface AtomicOperationConverter extends VersionedCloudProviderOperatio
    * @return atomic operation
    */
   @Nullable
-  AtomicOperation convertOperation(Map input);
+  AtomicOperation convertOperation(Map<String, Object> input);
 
   /**
    * This method takes a Map input and creates a description object, that will often be used by an
@@ -43,5 +43,5 @@ public interface AtomicOperationConverter extends VersionedCloudProviderOperatio
    * @param input
    * @return instance of an operation description object
    */
-  Object convertDescription(Map input);
+  Object convertDescription(Map<String, Object> input);
 }


### PR DESCRIPTION
These interfaces use raw types, which forces all implementations to do the same as well (as you can't override a raw type with a parametrized type).

I've added a few type bounds so that implementations can avoid using raw types; this should in no way affect clients that are still using raw types (as evidenced by the fact that I'm not changing any of the implementations here).

Obviously Map<String, Object> is not great as a parameter type, but that's what the Map actually is, and it's better than a raw Map.