### PR TITLE
refactor(kubernetes): Enable error-prone and compiler warnings

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id("net.ltgt.errorprone") version "1.2.1"
+}
+
 tasks.compileGroovy.enabled = false
 sourceSets.main.java.srcDirs = ['src/main/java']
 
@@ -21,9 +25,21 @@ tasks.withType(JavaCompile) {
     '-Xlint:-rawtypes',
     '-Xlint:-unchecked',
   ]
+
+  options.errorprone.disable(
+    "DefaultCharset",
+    "EmptyCatch",
+    "ImmutableEnumChecker",
+    "JdkObsolete",
+    "MissingOverride",
+    "StringSplitter",
+    "UnnecessaryParentheses",
+    "UnusedVariable"
+  )
 }
 
 dependencies {
+  errorprone("com.google.errorprone:error_prone_core:2.4.0")
   implementation project(":clouddriver-api")
   implementation project(":clouddriver-artifacts")
   implementation project(":clouddriver-core")

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -1,6 +1,28 @@
 tasks.compileGroovy.enabled = false
 sourceSets.main.java.srcDirs = ['src/main/java']
 
+tasks.withType(JavaCompile) {
+  options.compilerArgs += [
+    '-Xlint:all',
+
+    // This check ensures that all annotations are handled at compile time, but
+    // many of the annotations we use are not intended to be handled at compile
+    // time and are instead used at runtime.
+    '-Xlint:-processing',
+    // This check ensures that all classes implementing Serializable set the
+    // serialVersionUID. We don't use Java serialization, but some classes
+    // extend JDK classes implementing Serializable. Rather than add a
+    // meaningless serialVersionUID, just disable the warning.
+    '-Xlint:-serial',
+
+    // Temporarily suppressed warnings. These are here only while we fix or
+    // suppress the warnings in these categories.
+    '-Xlint:-deprecation',
+    '-Xlint:-rawtypes',
+    '-Xlint:-unchecked',
+  ]
+}
+
 dependencies {
   implementation project(":clouddriver-api")
   implementation project(":clouddriver-artifacts")

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -26,6 +26,8 @@ tasks.withType(JavaCompile) {
     '-Xlint:-unchecked',
   ]
 
+  // Temporarily disable error-prone checks that are generating warnings. These
+  // are only here while we fix or suppress the warnings in these categories.
   options.errorprone.disable(
     "DefaultCharset",
     "EmptyCatch",

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
@@ -131,11 +131,7 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
         deletedAccounts, catsModule); // delete caching agents
   }
 
-  /**
-   * Validate and save credentials to repository
-   *
-   * @param account
-   */
+  /** Validate and save credentials to repository */
   private void saveToCredentialsRepository(KubernetesNamedAccountCredentials account) {
     // Attempt to get namespaces to resolve any connectivity error without blocking /credentials
     List<String> namespaces = account.getCredentials().getDeclaredNamespaces();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2LoadBalancerProvider.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.Data;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -116,11 +115,5 @@ public class KubernetesV2LoadBalancerProvider
                         .collect(toImmutableSet())))
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
-  }
-
-  @Data
-  private static class Item implements LoadBalancerProvider.Item {
-    String name;
-    List<ByAccount> byAccounts = new ArrayList<>();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -48,15 +48,6 @@ public class KubernetesManifest extends HashMap<String, Object> {
     return (KubernetesManifest) super.clone();
   }
 
-  private static <T> T getRequiredField(KubernetesManifest manifest, String field) {
-    T res = (T) manifest.get(field);
-    if (res == null) {
-      throw MalformedManifestException.missingField(manifest, field);
-    }
-
-    return res;
-  }
-
   @JsonIgnore
   @Nonnull
   public KubernetesKind getKind() {
@@ -83,7 +74,8 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public String getKindName() {
-    return getRequiredField(this, "kind");
+    return Optional.ofNullable((String) get("kind"))
+        .orElseThrow(() -> MalformedManifestException.missingField(this, "kind"));
   }
 
   @JsonIgnore
@@ -94,7 +86,9 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   public KubernetesApiVersion getApiVersion() {
-    return KubernetesApiVersion.fromString(getRequiredField(this, "apiVersion"));
+    return Optional.ofNullable((String) get("apiVersion"))
+        .map(KubernetesApiVersion::fromString)
+        .orElseThrow(() -> MalformedManifestException.missingField(this, "apiVersion"));
   }
 
   @JsonIgnore
@@ -105,7 +99,8 @@ public class KubernetesManifest extends HashMap<String, Object> {
 
   @JsonIgnore
   private Map<String, Object> getMetadata() {
-    return getRequiredField(this, "metadata");
+    return Optional.ofNullable((Map<String, Object>) get("metadata"))
+        .orElseThrow(() -> MalformedManifestException.missingField(this, "metadata"));
   }
 
   @JsonIgnore

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
@@ -45,7 +45,7 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
 
   private final ArtifactReplacer artifactReplacer;
 
-  public KubernetesHandler() {
+  protected KubernetesHandler() {
     this.artifactReplacer = new ArtifactReplacer(artifactReplacers());
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -30,7 +30,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @ParametersAreNonnullByDefault
 public class KubernetesNamedAccountCredentials
     extends AbstractAccountCredentials<KubernetesCredentials> {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java
@@ -119,6 +119,8 @@ final class ArtifactReplacerTest {
     assertThat(artifact.getReference()).isEqualTo(testCase.getImage());
   }
 
+  // Called by @MethodSource which error-prone does not detect.
+  @SuppressWarnings("unused")
   private static Stream<ImageTestCase> imageArtifactTestCases() {
     return Stream.of(
         ImageTestCase.of("nginx:112", "nginx"),

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverterTest.java
@@ -113,6 +113,8 @@ final class KubernetesVersionedArtifactConverterTest {
     assertThat(artifact.getVersion()).isEqualTo(testCase.getNextVersion());
   }
 
+  // Called by @MethodSource which error-prone does not detect.
+  @SuppressWarnings("unused")
   private static Stream<VersionTestCase> versionTestCases() {
     return Stream.of(
         new VersionTestCase(ImmutableList.of("v000", "v001", "v002"), "v003"),

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesKindRegistryTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesKindRegistryTest.java
@@ -25,15 +25,12 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKindProperties;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
 @RunWith(JUnitPlatform.class)
 final class KubernetesKindRegistryTest {
-  private static final Function<KubernetesKind, Optional<KubernetesKindProperties>>
-      NOOP_CRD_LOOKUP = k -> Optional.empty();
   private static final KubernetesApiGroup CUSTOM_API_GROUP = KubernetesApiGroup.fromString("test");
   private static final KubernetesKind CUSTOM_KIND =
       KubernetesKind.from("customKind", CUSTOM_API_GROUP);


### PR DESCRIPTION
* fix(kubernetes): Fix errorprone TypeParameterUnusedInFormals 

  [TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts at invocations of the method, and it interacts badly with method overload resolution.

  This check is 100% correct here; the only advantage of using the generic here is that we can hide the casting in getRequiredField. In fact, let's just get rid of this method and force callers to do the casting; keeping the method just to throw the exception seems more confusing than inlining.

* fix(kubernetes): Fix error-prone issues 

  This fixes a few error-prone issues that were trivial to fix, and were easier than suppressing the whole warning class.

  [EmptyBlockTag] A block tag (@param, @return, @throws, @deprecated) has an empty description. Block tags without descriptions don't add much value for future readers of the code; consider removing the tag entirely or adding a description.

  In this case just delete the tag as the name is enough.

  [UnusedNestedClass] This nested class is unused, and can be removed.

  We were indeed not using this nested class.

  [PublicConstructorForAbstractClass] Constructors of on an abstract class can be declared protected as there is never a need for them to be public.

  [UnnecessaryLambda] Returning a lambda from a helper method or saving it in a constant is unnecessary; prefer to implement the functional interface method directly and use a method reference instead.

  Turns out we weren't using this lambda saved to a variable at all.

  [UnusedMethod] Private method is never used.

  error-prone doesn't seem to be able to detect that JUnit is using these as a MethodSource for parametrized tests; just suppress the warnings here.

  Finally, this isn't from error-prone, but there's a compiler warning that KubernetesNamedAccountCredentials overrides equals but doesn't call the super class. We don't want to do that here (because there's nothing in the super class and because we only want some explicitly-included fields) so add callSuper = false to stop the warning.

* refactor(kubernetes): Enable compilation warnings 

  This commit enables compilation warnings for clouddriver-kubernetes. It turns off a few categories that either generate too many false positives for our code (with a detailed comment) or that have too many actual issues we need to fix first.

  The plan is to fix the categories of issues one-by-one and re-enable them.

* feat(kubernetes): Add error-prone to clouddriver-kubernetes 

  This commit adds the error-prone static analysis checker to clouddriver-kubernetes. It disables any of the checks that have actual issues.

  The plan is that we can fix the issues in a given category then enable that category, until all of the issues are fixed.
