### PR TITLE
fix(core): Remove extraneous semicolons

### DIFF
--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/agent/AgentScheduler.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/agent/AgentScheduler.java
@@ -27,7 +27,6 @@ public interface AgentScheduler<T extends AgentLock> {
       ExecutionInstrumentation executionInstrumentation);
 
   default void unschedule(Agent agent) {}
-  ;
 
   /**
    * @return True iff this scheduler supports synchronization between LoadData and OnDemand cache
@@ -36,7 +35,6 @@ public interface AgentScheduler<T extends AgentLock> {
   default boolean isAtomic() {
     return false;
   }
-  ;
 
   /**
    * @param agent The agent being locked.
@@ -46,7 +44,6 @@ public interface AgentScheduler<T extends AgentLock> {
   default T tryLock(Agent agent) {
     return null;
   }
-  ;
 
   /**
    * @param lock The lock being released.
@@ -55,7 +52,6 @@ public interface AgentScheduler<T extends AgentLock> {
   default boolean tryRelease(T lock) {
     return false;
   }
-  ;
 
   /**
    * @param lock The lock being checked for validity.
@@ -64,5 +60,4 @@ public interface AgentScheduler<T extends AgentLock> {
   default boolean lockValid(T lock) {
     return false;
   }
-  ;
 }

--- a/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/agent/AgentSchedulerAware.java
+++ b/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/agent/AgentSchedulerAware.java
@@ -30,11 +30,9 @@ public abstract class AgentSchedulerAware {
   public void setAgentScheduler(AgentScheduler agentScheduler) {
     this.agentScheduler = agentScheduler;
   }
-  ;
 
   /** Get this object's agent scheduler. */
   public AgentScheduler getAgentScheduler() {
     return agentScheduler;
   }
-  ;
 }

--- a/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
+++ b/clouddriver-appengine/src/main/java/com/netflix/spinnaker/clouddriver/appengine/artifacts/GcsStorageService.java
@@ -47,7 +47,6 @@ public class GcsStorageService {
   public static interface VisitorOperation {
     void visit(StorageObject storageObj) throws IOException;
   }
-  ;
 
   public static class Factory {
     private String applicationName_;
@@ -94,7 +93,6 @@ public class GcsStorageService {
       return credentials;
     }
   }
-  ;
 
   private Storage storage_;
 


### PR DESCRIPTION
The upgrade to google-java-format pulled semicolons after methods to be on the next line (probably to make them more visible because they are in general not necessary); let's just remove them.