### PR TITLE
refactor(kubernetes): Fix a few warning types

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -21,7 +21,6 @@ tasks.withType(JavaCompile) {
 
     // Temporarily suppressed warnings. These are here only while we fix or
     // suppress the warnings in these categories.
-    '-Xlint:-deprecation',
     '-Xlint:-rawtypes',
     '-Xlint:-unchecked',
   ]

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/artifact/KubernetesCleanupArtifactsConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/artifact/KubernetesCleanupArtifactsConverter.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.ArtifactProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.artifact.KubernetesCleanupArtifactsDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.artifact.KubernetesCleanupArtifactsOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
@@ -37,12 +38,12 @@ public class KubernetesCleanupArtifactsConverter
   @Autowired ArtifactProvider artifactProvider;
 
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<OperationResult> convertOperation(Map<String, Object> input) {
     return new KubernetesCleanupArtifactsOperation(convertDescription(input), artifactProvider);
   }
 
   @Override
-  public KubernetesCleanupArtifactsDescription convertDescription(Map input) {
+  public KubernetesCleanupArtifactsDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesCleanupArtifactsDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/job/KubernetesRunJobOperationConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/job/KubernetesRunJobOperationConverter.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesV2ArtifactProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.job.KubernetesRunJobOperationDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubernetesRunJobDeploymentResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.job.KubernetesRunJobOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
@@ -46,12 +47,13 @@ public class KubernetesRunJobOperationConverter extends AbstractAtomicOperations
   }
 
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<KubernetesRunJobDeploymentResult> convertOperation(
+      Map<String, Object> input) {
     return new KubernetesRunJobOperation(convertDescription(input), artifactProvider, appendSuffix);
   }
 
   @Override
-  public KubernetesRunJobOperationDescription convertDescription(Map input) {
+  public KubernetesRunJobOperationDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesRunJobOperationDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeleteManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeleteManifestConverter.java
@@ -22,6 +22,7 @@ import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.D
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeleteManifestDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDeleteManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
@@ -32,12 +33,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class KubernetesDeleteManifestConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<OperationResult> convertOperation(Map<String, Object> input) {
     return new KubernetesDeleteManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesDeleteManifestDescription convertDescription(Map input) {
+  public KubernetesDeleteManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesDeleteManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeployManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDeployManifestConverter.java
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.Kubern
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesDeployManifestDescription;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDeployManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
@@ -58,12 +59,12 @@ public class KubernetesDeployManifestConverter extends AbstractAtomicOperationsC
   }
 
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<OperationResult> convertOperation(Map<String, Object> input) {
     return new KubernetesDeployManifestOperation(convertDescription(input), artifactProvider);
   }
 
   @Override
-  public KubernetesDeployManifestDescription convertDescription(Map input) {
+  public KubernetesDeployManifestDescription convertDescription(Map<String, Object> input) {
     KubernetesDeployManifestDescription mainDescription =
         KubernetesAtomicOperationConverterHelper.convertDescription(
             input, this, KubernetesDeployManifestDescription.class);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDisableManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesDisableManifestConverter.java
@@ -22,6 +22,7 @@ import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.D
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesEnableDisableManifestDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesDisableManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
@@ -32,12 +33,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class KubernetesDisableManifestConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<OperationResult> convertOperation(Map<String, Object> input) {
     return new KubernetesDisableManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesEnableDisableManifestDescription convertDescription(Map input) {
+  public KubernetesEnableDisableManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesEnableDisableManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesEnableManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesEnableManifestConverter.java
@@ -22,6 +22,7 @@ import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.E
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesEnableDisableManifestDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesEnableManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
@@ -32,12 +33,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class KubernetesEnableManifestConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<OperationResult> convertOperation(Map<String, Object> input) {
     return new KubernetesEnableManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesEnableDisableManifestDescription convertDescription(Map input) {
+  public KubernetesEnableDisableManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesEnableDisableManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesPatchManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesPatchManifestConverter.java
@@ -22,6 +22,7 @@ import static com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations.P
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesOperation;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.converters.KubernetesAtomicOperationConverterHelper;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesPatchManifestDescription;
+import com.netflix.spinnaker.clouddriver.kubernetes.op.OperationResult;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.manifest.KubernetesPatchManifestOperation;
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation;
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport;
@@ -32,12 +33,12 @@ import org.springframework.stereotype.Component;
 @KubernetesOperation(PATCH_MANIFEST)
 public class KubernetesPatchManifestConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<OperationResult> convertOperation(Map<String, Object> input) {
     return new KubernetesPatchManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesPatchManifestDescription convertDescription(Map input) {
+  public KubernetesPatchManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesPatchManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesPauseRolloutManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesPauseRolloutManifestConverter.java
@@ -33,12 +33,12 @@ import org.springframework.stereotype.Component;
 public class KubernetesPauseRolloutManifestConverter
     extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<Void> convertOperation(Map<String, Object> input) {
     return new KubernetesPauseRolloutManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesPauseRolloutManifestDescription convertDescription(Map input) {
+  public KubernetesPauseRolloutManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesPauseRolloutManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesResumeRolloutManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesResumeRolloutManifestConverter.java
@@ -33,12 +33,12 @@ import org.springframework.stereotype.Component;
 public class KubernetesResumeRolloutManifestConverter
     extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<Void> convertOperation(Map<String, Object> input) {
     return new KubernetesResumeRolloutManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesResumeRolloutManifestDescription convertDescription(Map input) {
+  public KubernetesResumeRolloutManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesResumeRolloutManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesRollingRestartManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesRollingRestartManifestConverter.java
@@ -33,12 +33,12 @@ import org.springframework.stereotype.Component;
 public class KubernetesRollingRestartManifestConverter
     extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<Void> convertOperation(Map<String, Object> input) {
     return new KubernetesRollingRestartManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesRollingRestartManifestDescription convertDescription(Map input) {
+  public KubernetesRollingRestartManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesRollingRestartManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesScaleManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesScaleManifestConverter.java
@@ -32,12 +32,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class KubernetesScaleManifestConverter extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<Void> convertOperation(Map<String, Object> input) {
     return new KubernetesScaleManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesScaleManifestDescription convertDescription(Map input) {
+  public KubernetesScaleManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesScaleManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesUndoRolloutManifestConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/manifest/KubernetesUndoRolloutManifestConverter.java
@@ -33,12 +33,12 @@ import org.springframework.stereotype.Component;
 public class KubernetesUndoRolloutManifestConverter
     extends AbstractAtomicOperationsCredentialsSupport {
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<Void> convertOperation(Map<String, Object> input) {
     return new KubernetesUndoRolloutManifestOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesUndoRolloutManifestDescription convertDescription(Map input) {
+  public KubernetesUndoRolloutManifestDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesUndoRolloutManifestDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/servergroup/KubernetesResizeServerGroupConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/converter/servergroup/KubernetesResizeServerGroupConverter.java
@@ -34,12 +34,12 @@ public class KubernetesResizeServerGroupConverter
     extends AbstractAtomicOperationsCredentialsSupport {
 
   @Override
-  public AtomicOperation convertOperation(Map input) {
+  public AtomicOperation<Void> convertOperation(Map<String, Object> input) {
     return new KubernetesResizeServerGroupOperation(convertDescription(input));
   }
 
   @Override
-  public KubernetesResizeServerGroupDescription convertDescription(Map input) {
+  public KubernetesResizeServerGroupDescription convertDescription(Map<String, Object> input) {
     return KubernetesAtomicOperationConverterHelper.convertDescription(
         input, this, KubernetesResizeServerGroupDescription.class);
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/KubernetesAtomicOperationConverterHelper.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/deploy/converters/KubernetesAtomicOperationConverterHelper.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class KubernetesAtomicOperationConverterHelper {
   public static <T extends KubernetesAtomicOperationDescription> T convertDescription(
-      Map input,
+      Map<String, Object> input,
       AbstractAtomicOperationsCredentialsSupport credentialsSupport,
       Class<T> targetDescriptionType) {
     String account = (String) input.get("account");

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesDeleteManifestDescription.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesDeleteManifestDescription.java
@@ -32,7 +32,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class KubernetesDeleteManifestDescription extends KubernetesAtomicOperationDescription {
-  V1DeleteOptions options;
+  private V1DeleteOptions options;
   private String manifestName;
   private String location;
   private List<String> kinds = new ArrayList<>();
@@ -55,7 +55,6 @@ public class KubernetesDeleteManifestDescription extends KubernetesAtomicOperati
   }
 
   @JsonIgnore
-  @Deprecated
   public KubernetesCoordinates getPointCoordinates() {
     return KubernetesCoordinates.builder()
         .namespace(location)

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -37,11 +37,18 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Because this class maps the received Kubernetes manifest to an untyped map, it has no choice but
+ * to perform many unchecked casts when retrieving information. New logic should convert the
+ * manifest to an appropriate strongly-typed model object instead of adding more unchecked casts
+ * here. Methods that already perform unchecked casts are annotated to suppress them; please avoid
+ * adding more such methods if at all possible.
+ */
 public class KubernetesManifest extends HashMap<String, Object> {
   private static final Logger log = LoggerFactory.getLogger(KubernetesManifest.class);
   private static final ObjectMapper mapper = new ObjectMapper();
 
-  @Nullable private KubernetesKind computedKind;
+  @Nullable private transient KubernetesKind computedKind;
 
   @Override
   public KubernetesManifest clone() {
@@ -98,6 +105,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  @SuppressWarnings("unchecked")
   private Map<String, Object> getMetadata() {
     return Optional.ofNullable((Map<String, Object>) get("metadata"))
         .orElseThrow(() -> MalformedManifestException.missingField(this, "metadata"));
@@ -172,6 +180,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  @SuppressWarnings("unchecked")
   public KubernetesManifestSelector getManifestSelector() {
     if (!containsKey("spec")) {
       return null;
@@ -192,6 +201,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  @SuppressWarnings("unchecked")
   public Map<String, String> getLabels() {
     Map<String, String> result = (Map<String, String>) getMetadata().get("labels");
     if (result == null) {
@@ -203,6 +213,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  @SuppressWarnings("unchecked")
   public Map<String, String> getAnnotations() {
     Map<String, String> result = (Map<String, String>) getMetadata().get("annotations");
     if (result == null) {
@@ -214,6 +225,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  @SuppressWarnings("unchecked")
   public Double getReplicas() {
     if (!containsKey("spec")) {
       return null;
@@ -227,6 +239,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  @SuppressWarnings("unchecked")
   public void setReplicas(Double replicas) {
     if (!containsKey("spec")) {
       return;
@@ -240,6 +253,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  @SuppressWarnings("unchecked")
   public Optional<Map<String, String>> getSpecTemplateLabels() {
     if (!containsKey("spec")) {
       return Optional.empty();
@@ -274,6 +288,7 @@ public class KubernetesManifest extends HashMap<String, Object> {
   }
 
   @JsonIgnore
+  @SuppressWarnings("unchecked")
   public Optional<Map<String, String>> getSpecTemplateAnnotations() {
     if (!containsKey("spec")) {
       return Optional.empty();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesSourceCapacity.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesSourceCapacity.java
@@ -17,14 +17,19 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.description.manifest;
 
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 
 public class KubernetesSourceCapacity {
-
   public static Double getSourceCapacity(
       KubernetesManifest manifest, KubernetesCredentials credentials) {
     KubernetesManifest currentManifest =
-        credentials.get(manifest.getKind(), manifest.getNamespace(), manifest.getName());
+        credentials.get(
+            KubernetesCoordinates.builder()
+                .kind(manifest.getKind())
+                .namespace(manifest.getNamespace())
+                .name(manifest.getName())
+                .build());
     if (currentManifest != null) {
       return currentManifest.getReplicas();
     }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesV2JobStatus.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesV2JobStatus.java
@@ -28,12 +28,11 @@ import io.kubernetes.client.openapi.models.V1JobSpec;
 import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodStatus;
-import java.io.Serializable;
 import java.util.*;
 import lombok.Data;
 
 @Data
-public class KubernetesV2JobStatus implements JobStatus, Serializable {
+public class KubernetesV2JobStatus implements JobStatus {
 
   String name;
   String cluster;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -64,7 +64,7 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
   }
 
   @Override
-  public OperationResult operate(List priorOutputs) {
+  public OperationResult operate(List<OperationResult> priorOutputs) {
     OperationResult result = new OperationResult();
 
     List<Artifact> artifacts =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperation.java
@@ -55,7 +55,7 @@ public class KubernetesRunJobOperation
     return TaskRepository.threadLocalTask.get();
   }
 
-  public KubernetesRunJobDeploymentResult operate(List _unused) {
+  public KubernetesRunJobDeploymentResult operate(List<KubernetesRunJobDeploymentResult> _unused) {
     getTask().updateStatus(OP_NAME, "Running Kubernetes job...");
     KubernetesManifest jobSpec = this.description.getManifest();
     KubernetesKind kind = jobSpec.getKind();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/AbstractKubernetesEnableDisableManifestOperation.java
@@ -133,7 +133,7 @@ public abstract class AbstractKubernetesEnableDisableManifestOperation
   }
 
   @Override
-  public OperationResult operate(List priorOutputs) {
+  public OperationResult operate(List<OperationResult> priorOutputs) {
     getTask().updateStatus(OP_NAME, "Starting " + getVerbName() + " operation...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
     KubernetesManifest target =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeleteManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeleteManifestOperation.java
@@ -43,7 +43,7 @@ public class KubernetesDeleteManifestOperation implements AtomicOperation<Operat
   }
 
   @Override
-  public OperationResult operate(List priorOutputs) {
+  public OperationResult operate(List<OperationResult> priorOutputs) {
     getTask().updateStatus(OP_NAME, "Starting delete operation...");
     List<KubernetesCoordinates> coordinates;
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
@@ -65,7 +65,7 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
   }
 
   @Override
-  public OperationResult operate(List _unused) {
+  public OperationResult operate(List<OperationResult> _unused) {
     getTask().updateStatus(OP_NAME, "Beginning deployment of manifest...");
 
     List<KubernetesManifest> inputManifests = description.getManifests();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
@@ -71,8 +71,16 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     List<KubernetesManifest> inputManifests = description.getManifests();
     List<KubernetesManifest> deployManifests = new ArrayList<>();
     if (inputManifests == null || inputManifests.isEmpty()) {
-      log.warn("Relying on deprecated single manifest input: " + description.getManifest());
-      inputManifests = ImmutableList.of(description.getManifest());
+      // The stage currently only supports using the `manifests` field but we need to continue to
+      // check `manifest` for backwards compatibility until all existing stages have been updated.
+      @SuppressWarnings("deprecation")
+      KubernetesManifest manifest = description.getManifest();
+      log.warn(
+          "Relying on deprecated single manifest input (account: {}, kind: {}, name: {})",
+          accountName,
+          manifest.getKind(),
+          manifest.getName());
+      inputManifests = ImmutableList.of(manifest);
     }
 
     inputManifests = inputManifests.stream().filter(Objects::nonNull).collect(Collectors.toList());

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPatchManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPatchManifestOperation.java
@@ -55,7 +55,7 @@ public class KubernetesPatchManifestOperation implements AtomicOperation<Operati
   }
 
   @Override
-  public OperationResult operate(List _unused) {
+  public OperationResult operate(List<OperationResult> _unused) {
     updateStatus("Beginning patching of manifest");
     KubernetesCoordinates objToPatch = description.getPointCoordinates();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPauseRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesPauseRolloutManifestOperation.java
@@ -43,7 +43,7 @@ public class KubernetesPauseRolloutManifestOperation implements AtomicOperation<
   }
 
   @Override
-  public Void operate(List priorOutputs) {
+  public Void operate(List<Void> priorOutputs) {
     getTask().updateStatus(OP_NAME, "Starting pause rollout operation...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesResumeRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesResumeRolloutManifestOperation.java
@@ -43,7 +43,7 @@ public class KubernetesResumeRolloutManifestOperation implements AtomicOperation
   }
 
   @Override
-  public Void operate(List priorOutputs) {
+  public Void operate(List<Void> priorOutputs) {
     getTask().updateStatus(OP_NAME, "Starting resume rollout operation...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesRollingRestartManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesRollingRestartManifestOperation.java
@@ -43,7 +43,7 @@ public class KubernetesRollingRestartManifestOperation implements AtomicOperatio
   }
 
   @Override
-  public Void operate(List priorOutputs) {
+  public Void operate(List<Void> priorOutputs) {
     getTask().updateStatus(OP_NAME, "Starting rolling restart operation...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesScaleManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesScaleManifestOperation.java
@@ -42,7 +42,7 @@ public class KubernetesScaleManifestOperation implements AtomicOperation<Void> {
   }
 
   @Override
-  public Void operate(List priorOutputs) {
+  public Void operate(List<Void> priorOutputs) {
     getTask().updateStatus(OP_NAME, "Starting scale operation...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesUndoRolloutManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesUndoRolloutManifestOperation.java
@@ -43,7 +43,7 @@ public class KubernetesUndoRolloutManifestOperation implements AtomicOperation<V
   }
 
   @Override
-  public Void operate(List priorOutputs) {
+  public Void operate(List<Void> priorOutputs) {
     getTask().updateStatus(OP_NAME, "Starting undo rollout operation...");
     KubernetesCoordinates coordinates = description.getPointCoordinates();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/servergroup/KubernetesResizeServerGroupOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/servergroup/KubernetesResizeServerGroupOperation.java
@@ -42,7 +42,7 @@ public class KubernetesResizeServerGroupOperation implements AtomicOperation<Voi
   }
 
   @Override
-  public Void operate(List priorOutputs) {
+  public Void operate(List<Void> priorOutputs) {
     getTask().updateStatus(OP_NAME, "Starting resize operation...");
     KubernetesCoordinates coordinates = description.getCoordinates();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesNamedAccountCredentials.java
@@ -75,6 +75,20 @@ public class KubernetesNamedAccountCredentials
     this.credentials = credentialFactory.build(managedAccount);
   }
 
+  /**
+   * This method is deprecated and users should instead supply {@link
+   * KubernetesNamedAccountCredentials#permissions}. In order to continue to support users who have
+   * `requiredGroupMembership` in their account config, we still need to override this method. We'll
+   * need to either communicate the backwards-incompatible change or translate the supplied
+   * `requiredGroupMembership` into {@link KubernetesNamedAccountCredentials#permissions} before
+   * removing this override.
+   */
+  @Override
+  @SuppressWarnings("deprecation")
+  public List<String> getRequiredGroupMembership() {
+    return requiredGroupMembership;
+  }
+
   public List<String> getNamespaces() {
     return credentials.getDeclaredNamespaces();
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/artifact/KubernetesArtifactCleanupValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/artifact/KubernetesArtifactCleanupValidator.java
@@ -36,7 +36,7 @@ public class KubernetesArtifactCleanupValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesCleanupArtifactsDescription> priorDescriptions,
       KubernetesCleanupArtifactsDescription description,
       ValidationErrors errors) {}
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeleteManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeleteManifestValidator.java
@@ -39,7 +39,7 @@ public class KubernetesDeleteManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesDeleteManifestDescription> priorDescriptions,
       KubernetesDeleteManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeployManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDeployManifestValidator.java
@@ -38,7 +38,7 @@ public class KubernetesDeployManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesDeployManifestDescription> priorDescriptions,
       KubernetesDeployManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDisableManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesDisableManifestValidator.java
@@ -37,7 +37,7 @@ public class KubernetesDisableManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesEnableDisableManifestDescription> priorDescriptions,
       KubernetesEnableDisableManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesEnableManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesEnableManifestValidator.java
@@ -37,7 +37,7 @@ public class KubernetesEnableManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesEnableDisableManifestDescription> priorDescriptions,
       KubernetesEnableDisableManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPatchManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPatchManifestValidator.java
@@ -38,7 +38,7 @@ public class KubernetesPatchManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesPatchManifestDescription> priorDescriptions,
       KubernetesPatchManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util = new KubernetesValidationUtil("patchKubernetesManifest", errors);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPauseRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesPauseRolloutManifestValidator.java
@@ -37,7 +37,7 @@ public class KubernetesPauseRolloutManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesPauseRolloutManifestDescription> priorDescriptions,
       KubernetesPauseRolloutManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesResumeRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesResumeRolloutManifestValidator.java
@@ -37,7 +37,7 @@ public class KubernetesResumeRolloutManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesResumeRolloutManifestDescription> priorDescriptions,
       KubernetesResumeRolloutManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesRollingRestartManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesRollingRestartManifestValidator.java
@@ -42,7 +42,7 @@ public class KubernetesRollingRestartManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesRollingRestartManifestDescription> priorDescriptions,
       KubernetesRollingRestartManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesScaleManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesScaleManifestValidator.java
@@ -37,7 +37,7 @@ public class KubernetesScaleManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesScaleManifestDescription> priorDescriptions,
       KubernetesScaleManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util = new KubernetesValidationUtil("scaleKubernetesManifest", errors);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesUndoRolloutManifestValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/manifest/KubernetesUndoRolloutManifestValidator.java
@@ -37,7 +37,7 @@ public class KubernetesUndoRolloutManifestValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesUndoRolloutManifestDescription> priorDescriptions,
       KubernetesUndoRolloutManifestDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/servergroup/KubernetesResizeServerGroupValidator.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/servergroup/KubernetesResizeServerGroupValidator.java
@@ -37,7 +37,7 @@ public class KubernetesResizeServerGroupValidator
 
   @Override
   public void validate(
-      List priorDescriptions,
+      List<KubernetesResizeServerGroupDescription> priorDescriptions,
       KubernetesResizeServerGroupDescription description,
       ValidationErrors errors) {
     KubernetesValidationUtil util =


### PR DESCRIPTION
* refactor(kubernetes): Apply type bounds to implementations of AtomicOperation

  Now that the interfaces have type bounds, we can apply these to the implementations as well.

* refactor(kubernetes): Suppress some unchecked warnings

  KubernetesManifest is full of unchecked casts; let's just add a comment to the class and suppress the warnings for any methods that currently have unchecked casts.

  As noted in the comment, we should really try to stop relying on this class that extends HashMap and is full of these unsafe casts, but for now we'll just suppress the warnings.

  I have not enabled the Xlint:unchecked flag because there are still a few other unchecked warnings that I'll leave for later.

  Also let's make computedKind transient because the class implements Serializable. It doesn't really matter because we don't use java serialization, but is more correct because this is just a cached value that is stored to avoid re-computing.

* fix(kubernetes): Fix deprecation warnings

  This commit fixes the small number of deprecation warnings in clouddriver-kubernetes and enables deprecation compiler warnings.

  Notes:
  * getPointCoordinates was marked deprecated, but is still actively used in the Delete Manifest stage; there appers to have been no effort to actually deprecate it, so let's just remove the annotation.
  * Stop logging the full manifest when we hit the warning on that deprecated call; just the identifying info should be enough.
  * getRequiredGroupMembership is a field; to add the suppress annotation we need to write the lombok-generated accessor explicitly

  Also two small other fixes I noticed:
  * Make a field private
  * Remove Serializable from KubernetesV2Job status as we never use Java serialization.