### PR TITLE
fix(*): Fix syntax of CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
-clouddriver-kubernetes.*    @maggieneterval @ezimanyi @ethanfrogers
-clouddriver-google.*        @maggieneterval @ezimanyi @plumpy
+clouddriver-kubernetes/    @maggieneterval @ezimanyi @ethanfrogers
+clouddriver-google/        @maggieneterval @ezimanyi @plumpy
 
-clouddriver-saga.*          @robzienert @cfieber
-clouddriver-core.*          @robzienert @cfieber
+clouddriver-saga/          @robzienert @cfieber
+clouddriver-core/          @robzienert @cfieber
 
-clouddriver-aws.*           @jeyrschabu @aravindmd
-clouddriver-titus.*         @jeyrschabu @aravindmd
+clouddriver-aws/           @jeyrschabu @aravindmd
+clouddriver-titus/         @jeyrschabu @aravindmd


### PR DESCRIPTION
The CODEOWNERS entries were only matching files with that pattern, not the full subdirectories. In practice this meant that any change to the .gradle file in the subproject would trigger a review request from code owners but no other changes would.