### PR TITLE
perf(kubernetes): live lookups for dynamic target selection (part 1 of 2!)

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
@@ -117,7 +117,7 @@ public class KubernetesManifestProvider {
   }
 
   @Nullable
-  public List<KubernetesV2Manifest> getClusterAndSortAscending(
+  public List<KubernetesManifest> getClusterAndSortAscending(
       String account, String location, String kind, String cluster, Sort sort) {
     Optional<KubernetesCredentials> optionalCredentials = accountResolver.getCredentials(account);
     if (!optionalCredentials.isPresent()) {
@@ -133,11 +133,7 @@ public class KubernetesManifestProvider {
 
     return credentials.list(kubernetesKind, location).stream()
         .filter(m -> cluster.equals(KubernetesManifestAnnotater.getManifestCluster(m)))
-        .map(
-            m ->
-                KubernetesV2ManifestBuilder.buildManifest(
-                    credentials, m, ImmutableList.of(), ImmutableList.of()))
-        .sorted((m1, m2) -> handler.comparatorFor(sort).compare(m1.getManifest(), m2.getManifest()))
+        .sorted((m1, m2) -> handler.comparatorFor(sort).compare(m1, m2))
         .collect(Collectors.toList());
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
@@ -18,13 +18,10 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.LogicalKind.CLUSTERS;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
-import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesCacheDataConverter;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Manifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric;
@@ -32,9 +29,9 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMet
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesResourceProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestAnnotater;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -52,16 +49,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class KubernetesManifestProvider {
   private static final Logger log = LoggerFactory.getLogger(KubernetesManifestProvider.class);
-  private final KubernetesCacheUtils cacheUtils;
   private final KubernetesAccountResolver accountResolver;
   private final ExecutorService executorService =
       Executors.newCachedThreadPool(
           new ThreadFactoryBuilder().setNameFormat(getClass().getSimpleName() + "-%d").build());
 
   @Autowired
-  public KubernetesManifestProvider(
-      KubernetesAccountResolver accountResolver, KubernetesCacheUtils cacheUtils) {
-    this.cacheUtils = cacheUtils;
+  public KubernetesManifestProvider(KubernetesAccountResolver accountResolver) {
     this.accountResolver = accountResolver;
   }
 
@@ -124,36 +118,27 @@ public class KubernetesManifestProvider {
 
   @Nullable
   public List<KubernetesV2Manifest> getClusterAndSortAscending(
-      String account, String location, String kind, String app, String cluster, Sort sort) {
+      String account, String location, String kind, String cluster, Sort sort) {
     Optional<KubernetesCredentials> optionalCredentials = accountResolver.getCredentials(account);
     if (!optionalCredentials.isPresent()) {
       return null;
     }
     KubernetesCredentials credentials = optionalCredentials.get();
+    KubernetesKind kubernetesKind = KubernetesKind.fromString(kind);
 
     KubernetesResourceProperties properties =
-        credentials.getResourcePropertyRegistry().get(KubernetesKind.fromString(kind));
+        credentials.getResourcePropertyRegistry().get(kubernetesKind);
 
     KubernetesHandler handler = properties.getHandler();
 
-    return cacheUtils
-        .getSingleEntry(CLUSTERS.toString(), Keys.ClusterCacheKey.createKey(account, app, cluster))
+    return credentials.list(kubernetesKind, location).stream()
+        .filter(m -> cluster.equals(KubernetesManifestAnnotater.getManifestCluster(m)))
         .map(
-            c ->
-                cacheUtils.getRelationships(c, kind).stream()
-                    .map(
-                        cd ->
-                            KubernetesV2ManifestBuilder.buildManifest(
-                                credentials,
-                                KubernetesCacheDataConverter.getManifest(cd),
-                                ImmutableList.of(),
-                                ImmutableList.of()))
-                    .filter(m -> m.getLocation().equals(location))
-                    .sorted(
-                        (m1, m2) ->
-                            handler.comparatorFor(sort).compare(m1.getManifest(), m2.getManifest()))
-                    .collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+            m ->
+                KubernetesV2ManifestBuilder.buildManifest(
+                    credentials, m, ImmutableList.of(), ImmutableList.of()))
+        .sorted((m1, m2) -> handler.comparatorFor(sort).compare(m1.getManifest(), m2.getManifest()))
+        .collect(Collectors.toList());
   }
 
   public enum Sort {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/controllers/ManifestController.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/controllers/ManifestController.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.controllers;
 
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesManifestProvider.Sort;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest;
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue;
@@ -104,7 +105,7 @@ public class ManifestController {
       value =
           "/{account:.+}/{location:.+}/{kind:.+}/cluster/{app:.+}/{cluster:.+}/dynamic/{criteria:.+}",
       method = RequestMethod.GET)
-  KubernetesManifest getDynamicManifestFromCluster(
+  KubernetesCoordinates getDynamicManifestFromCluster(
       @PathVariable String account,
       @PathVariable String location,
       @PathVariable String kind,
@@ -137,12 +138,12 @@ public class ManifestController {
       switch (criteria) {
         case oldest:
         case smallest:
-          return manifests.get(0);
+          return KubernetesCoordinates.fromManifest(manifests.get(0));
         case newest:
         case largest:
-          return manifests.get(manifests.size() - 1);
+          return KubernetesCoordinates.fromManifest(manifests.get(manifests.size() - 1));
         case second_newest:
-          return manifests.get(manifests.size() - 2);
+          return KubernetesCoordinates.fromManifest(manifests.get(manifests.size() - 2));
         default:
           throw new IllegalArgumentException("Unknown criteria: " + criteria);
       }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/controllers/ManifestController.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/controllers/ManifestController.java
@@ -123,7 +123,7 @@ public class ManifestController {
               account,
               () ->
                   manifestProvider.getClusterAndSortAscending(
-                      account, location, kind, app, cluster, criteria.getSort()));
+                      account, location, kind, cluster, criteria.getSort()));
     } catch (Throwable t) {
       log.warn("Failed to read {}", request, t);
       return null;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/controllers/ManifestController.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/controllers/ManifestController.java
@@ -17,9 +17,9 @@
 
 package com.netflix.spinnaker.clouddriver.kubernetes.controllers;
 
-import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2Manifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesManifestProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesManifestProvider.Sort;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest;
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
@@ -104,7 +104,7 @@ public class ManifestController {
       value =
           "/{account:.+}/{location:.+}/{kind:.+}/cluster/{app:.+}/{cluster:.+}/dynamic/{criteria:.+}",
       method = RequestMethod.GET)
-  Manifest getDynamicManifestFromCluster(
+  KubernetesManifest getDynamicManifestFromCluster(
       @PathVariable String account,
       @PathVariable String location,
       @PathVariable String kind,
@@ -116,7 +116,7 @@ public class ManifestController {
             "(account: %s, location: %s, kind: %s, app %s, cluster: %s, criteria: %s)",
             account, location, kind, app, cluster, criteria);
 
-    List<KubernetesV2Manifest> manifests;
+    List<KubernetesManifest> manifests;
     try {
       manifests =
           requestQueue.execute(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesCoordinates.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesCoordinates.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.clouddriver.kubernetes.description;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.kork.annotations.FieldsAreNullableByDefault;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import java.util.List;
@@ -69,5 +70,20 @@ public class KubernetesCoordinates {
       this.name = parts.get(1);
       return this;
     }
+  }
+
+  /**
+   * Given a full KubernetesManifest object, parses out the kind, namespace, and name to create a
+   * corresponding KubernetesCoordinates object.
+   *
+   * @param manifest the manifest to parse
+   * @return the KubernetesCoordinates object
+   */
+  public static KubernetesCoordinates fromManifest(KubernetesManifest manifest) {
+    return KubernetesCoordinates.builder()
+        .kind(manifest.getKind())
+        .namespace(manifest.getNamespace())
+        .name(manifest.getName())
+        .build();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
@@ -299,4 +299,8 @@ public class KubernetesManifestAnnotater {
         new TypeReference<KubernetesManifest>() {},
         null);
   }
+
+  public static String getManifestCluster(KubernetesManifest manifest) {
+    return manifest.getAnnotations().get(CLUSTER);
+  }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -44,11 +44,13 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.Kubernete
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroup;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroupManager;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.model.KubernetesV2ServerGroupSummary;
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.KubernetesManifestProvider.Sort;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.AccountResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.GlobalResourcePropertyRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestNamer;
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesNamerRegistry;
 import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesDeploymentHandler;
@@ -159,6 +161,8 @@ final class KubernetesDataProviderIntegrationTest {
       new KubernetesV2ServerGroupManagerProvider(cacheUtils);
   private static KubernetesV2ArtifactProvider artifactProvider =
       new KubernetesV2ArtifactProvider(cacheUtils, objectMapper);
+  private static KubernetesManifestProvider manifestProvider =
+      new KubernetesManifestProvider(accountResolver);
 
   @BeforeAll
   static void prepareCache() {
@@ -517,6 +521,20 @@ final class KubernetesDataProviderIntegrationTest {
     softly.assertThat(artifacts).isEmpty();
   }
 
+  @Test
+  void getClusterAndSortAscending(SoftAssertions softly) {
+    List<KubernetesManifest> manifests =
+        manifestProvider.getClusterAndSortAscending(
+            ACCOUNT_NAME, "backend-ns", "replicaSet", "replicaSet backend", Sort.AGE);
+    softly.assertThat(manifests).isNotNull();
+    softly
+        .assertThat(
+            manifests.stream()
+                .map(KubernetesManifest::getFullResourceName)
+                .collect(toImmutableList()))
+        .containsExactly("replicaSet backend-v014", "replicaSet backend-v015");
+  }
+
   private static KubectlJobExecutor getJobExecutor() {
     KubectlJobExecutor jobExecutor = mock(KubectlJobExecutor.class, new ReturnsSmartNulls());
     when(jobExecutor.list(
@@ -531,6 +549,7 @@ final class KubernetesDataProviderIntegrationTest {
                         file ->
                             ManifestFetcher.getManifest(
                                 KubernetesDataProviderIntegrationTest.class, file))
+                    .filter(m -> invocation.getArgument(1, List.class).contains(m.getKind()))
                     .collect(toImmutableList()));
     return jobExecutor;
   }


### PR DESCRIPTION
* perf(kubernetes): live lookups for dynamic target selection 

* perf(kubernetes): avoid creating unnecessary KubernetesV2Manifest objects 

* perf(kubernetes): getDynamicManifestFromCluster returns only KubernetesCoordinates instead of entire manifest 

* test(kubernetes): add getClusterAndSortAscending to KubernetesDataProviderIntegrationTest 

  In a followup PR, will likely refactor getClusterAndSortAscending in order to:
  (1) move business logic out of the ManifestController and into the ManifestProvider; the controller shouldn't need to know anything about what largest/smallest/newest mean
  (2) expose a new endpoint for Orca to ask for all cluster siblings of a given resource (non-sorted) to support rollout strategies not relying on an up-to-date cache

  (So will add better test coverage once both contracts fully live in the provider)
