### PR TITLE
fix(*): Fix gradle deprecation warnings

### DIFF
--- a/clouddriver-docker/clouddriver-docker.gradle
+++ b/clouddriver-docker/clouddriver-docker.gradle
@@ -5,7 +5,7 @@ dependencies {
   implementation project(":cats:cats-core")
 
   compileOnly "org.projectlombok:lombok"
-  testCompile "org.projectlombok:lombok"
+  testCompileOnly "org.projectlombok:lombok"
 
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"

--- a/clouddriver-elasticsearch-aws/clouddriver-elasticsearch-aws.gradle
+++ b/clouddriver-elasticsearch-aws/clouddriver-elasticsearch-aws.gradle
@@ -18,12 +18,21 @@ dependencies {
   implementation "com.netflix.frigga:frigga"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
-  implementation("io.searchbox:jest:2.0.3") {
-    force = true
-  }
+  implementation("io.searchbox:jest")
   implementation "org.codehaus.groovy:groovy-all"
-  implementation("org.elasticsearch:elasticsearch:2.4.1") {
-    force = true
-  }
+  implementation("org.elasticsearch:elasticsearch")
   implementation "org.springframework.boot:spring-boot-starter-web"
+
+  constraints {
+    implementation("io.searchbox:jest") {
+      version {
+        strictly "2.0.3"
+      }
+    }
+    implementation("org.elasticsearch:elasticsearch") {
+      version {
+        strictly "2.4.1"
+      }
+    }
+  }
 }

--- a/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
+++ b/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
@@ -8,19 +8,27 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.squareup.retrofit:retrofit"
   implementation "org.codehaus.groovy:groovy-all"
-  implementation("org.elasticsearch:elasticsearch:6.8.6") {
-    force = true
-  }
-
-  implementation("io.searchbox:jest:6.3.1") {
-    force = true
-  }
+  implementation("org.elasticsearch:elasticsearch")
+  implementation("io.searchbox:jest")
   implementation "org.springframework.boot:spring-boot-starter-web"
 
-  testCompile "org.testcontainers:elasticsearch:1.12.5"
+  testCompileOnly "org.testcontainers:elasticsearch:1.12.5"
   testImplementation "cglib:cglib-nodep"
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
+
+  constraints {
+    implementation("io.searchbox:jest") {
+      version {
+        strictly "6.3.1"
+      }
+    }
+    implementation("org.elasticsearch:elasticsearch") {
+      version {
+        strictly "6.8.6"
+      }
+    }
+  }
 }

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -48,7 +48,7 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  testCompile "org.projectlombok:lombok"
+  testCompileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"
   testAnnotationProcessor "org.projectlombok:lombok"
 

--- a/clouddriver-tencentcloud/clouddriver-tencentcloud.gradle
+++ b/clouddriver-tencentcloud/clouddriver-tencentcloud.gradle
@@ -8,7 +8,7 @@ dependencies {
   implementation project(":clouddriver-security")
 
   compileOnly "org.projectlombok:lombok"
-  testCompile "org.projectlombok:lombok"
+  testCompileOnly "org.projectlombok:lombok"
   annotationProcessor "org.projectlombok:lombok"
   testAnnotationProcessor "org.projectlombok:lombok"
 

--- a/gradle/spek.gradle
+++ b/gradle/spek.gradle
@@ -27,10 +27,10 @@ dependencies {
   testImplementation "org.jetbrains.spek:spek-subject-extension"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 
-  testRuntime "org.junit.platform:junit-platform-launcher"
-  testRuntime "org.junit.jupiter:junit-jupiter-engine"
-  testRuntime "org.junit.vintage:junit-vintage-engine"
-  testRuntime "org.jetbrains.spek:spek-junit-platform-engine"
+  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+  testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+  testRuntimeOnly "org.jetbrains.spek:spek-junit-platform-engine"
 
   testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin"
   testImplementation "io.strikt:strikt-core"


### PR DESCRIPTION
Because I'm in a warning-fixing mood this week...this fixes the warning when running builds that deprecated features are used.

These were all pretty easy to fix:
* Instead of force, need to use version constraints
* Instead of testCompile/testRuntime, need to use testCompileOnly/testRuntimeOnly.