### PR TITLE
fix(saga): Complete sagas only once all commands are finalized

### DIFF
--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/SagaService.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/SagaService.kt
@@ -19,7 +19,6 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.saga.exceptions.SagaIntegrationException
 import com.netflix.spinnaker.clouddriver.saga.exceptions.SagaMissingRequiredCommandException
 import com.netflix.spinnaker.clouddriver.saga.exceptions.SagaNotFoundException
-import com.netflix.spinnaker.clouddriver.saga.exceptions.SagaSystemException
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaAction
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaFlow
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaFlowIterator
@@ -30,7 +29,6 @@ import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
-import org.springframework.core.ResolvableType
 
 /**
  * The main brains of the Saga library. Orchestrates the progression of a [Saga] until its completion.
@@ -87,7 +85,7 @@ class SagaService(
       log.debug("Applying saga action ${action.javaClass.simpleName} for ${saga.name}/${saga.id}")
 
       val requiredCommand: Class<SagaCommand> = getRequiredCommand(action)
-      if (!saga.completed(requiredCommand)) {
+      if (!saga.finalizedCommand(requiredCommand)) {
         val stepCommand = saga.getNextCommand(requiredCommand)
           ?: throw SagaMissingRequiredCommandException("Missing required command ${requiredCommand.simpleName}")
 
@@ -192,20 +190,8 @@ class SagaService(
     return exception
   }
 
-  private fun getRequiredCommand(action: SagaAction<SagaCommand>): Class<SagaCommand> {
-    val actionType = ResolvableType.forClass(SagaAction::class.java, action.javaClass)
-    actionType.resolve()
-
-    val commandType = actionType.getGeneric(0)
-    commandType.resolve()
-
-    val rawClass = commandType.rawClass!!
-    if (SagaCommand::class.java.isAssignableFrom(rawClass)) {
-      @Suppress("UNCHECKED_CAST")
-      return rawClass as Class<SagaCommand>
-    }
-    throw SagaSystemException("Resolved next action is not a SagaCommand: ${rawClass.simpleName}")
-  }
+  private fun getRequiredCommand(action: SagaAction<SagaCommand>): Class<SagaCommand> =
+    getCommandTypeFromAction(action.javaClass)
 
   override fun setApplicationContext(applicationContext: ApplicationContext) {
     this.applicationContext = applicationContext

--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/events.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/events.kt
@@ -137,6 +137,29 @@ class SagaConditionEvaluated(
 ) : AbstractSagaEvent()
 
 /**
+ * An event type that finalizes a [SagaCommand]
+ */
+interface CommandFinalizer : SagaEvent {
+
+  /**
+   * The command name that was finalized.
+   */
+  val command: String
+
+  /**
+   * Returns whether or not the given [candidateCommand] was finalized by this event.
+   */
+  fun matches(candidateCommand: Class<out SagaCommand>): Boolean =
+    candidateCommand.getAnnotation(JsonTypeName::class.java)?.value == command
+}
+
+@JsonTypeName("sagaCommandSkipped")
+class SagaCommandSkipped(
+  override val command: String,
+  val reason: String
+) : AbstractSagaEvent(), CommandFinalizer
+
+/**
  * The root event type for all mutating [Saga] operations.
  */
 interface SagaCommand : SagaEvent
@@ -153,12 +176,8 @@ interface SagaRollbackCommand : SagaCommand
  */
 @JsonTypeName("sagaCommandCompleted")
 class SagaCommandCompleted(
-  val command: String
-) : AbstractSagaEvent() {
-
-  fun matches(candidateCommand: Class<out SagaCommand>): Boolean =
-    candidateCommand.getAnnotation(JsonTypeName::class.java)?.value == command
-}
+  override val command: String
+) : AbstractSagaEvent(), CommandFinalizer
 
 /**
  * A [SagaCommand] wrapper for [SagaAction]s that need to return more than one [SagaCommand].

--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/flow/SagaFlowIterator.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/flow/SagaFlowIterator.kt
@@ -15,13 +15,16 @@
  */
 package com.netflix.spinnaker.clouddriver.saga.flow
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.netflix.spinnaker.clouddriver.saga.SagaCommand
 import com.netflix.spinnaker.clouddriver.saga.SagaCommandCompleted
+import com.netflix.spinnaker.clouddriver.saga.SagaCommandSkipped
 import com.netflix.spinnaker.clouddriver.saga.SagaConditionEvaluated
 import com.netflix.spinnaker.clouddriver.saga.exceptions.SagaNotFoundException
 import com.netflix.spinnaker.clouddriver.saga.exceptions.SagaSystemException
 import com.netflix.spinnaker.clouddriver.saga.flow.seekers.SagaCommandCompletedEventSeeker
 import com.netflix.spinnaker.clouddriver.saga.flow.seekers.SagaCommandEventSeeker
+import com.netflix.spinnaker.clouddriver.saga.getCommandTypeFromAction
 import com.netflix.spinnaker.clouddriver.saga.models.Saga
 import com.netflix.spinnaker.clouddriver.saga.persistence.SagaRepository
 import com.netflix.spinnaker.kork.exceptions.SystemException
@@ -109,15 +112,50 @@ class SagaFlowIterator(
         log.debug("Condition '${predicate.name}' previously evaluated: $previousEvaluationResult")
       }
       ?: predicate.test(latestSaga)
-        .also {
-          log.debug("Condition '${predicate.name}' result: $it")
-          latestSaga.addEvent(SagaConditionEvaluated(nextStep.predicate.name, it))
+        .also { conditionResult ->
+          log.debug("Condition '${predicate.name}' result: $conditionResult")
+          latestSaga.addEvent(SagaConditionEvaluated(nextStep.predicate.name, conditionResult))
+
+          if (!conditionResult) {
+            skipConditionalCommands(nextStep.nestedBuilder.steps)
+          }
         }
 
     if (result) {
       steps.addAll(index, nextStep.nestedBuilder.steps)
     }
     steps.remove(nextStep)
+  }
+
+  /**
+   * When a conditional branch is not taken, we'll have one or more commands in the event log that were
+   * meant to start that branch. This method will find all of these commands and finalize them with a
+   * [SagaCommandSkipped] event.
+   */
+  private fun skipConditionalCommands(conditionalSteps: List<SagaFlow.Step>) {
+    // Read the unused SagaFlow steps for all commands to skip.
+    val skippedCommandTypes = conditionalSteps
+      .filterIsInstance<SagaFlow.ActionStep>()
+      .mapNotNull {
+        getCommandTypeFromAction(it.action).getAnnotation(JsonTypeName::class.java)?.value
+      }
+
+    // Search the existing event log for commands that have not been completed. For each incomplete
+    // command, check against [skippedCommandTypes] for any matches, adding [SagaCommandSkipped] for
+    // each match.
+    latestSaga.getEvents()
+      .filterIsInstance<SagaCommand>()
+      .filter {
+        latestSaga.getEvents()
+          .filterIsInstance<SagaCommandCompleted>()
+          .none { completed -> completed.matches(it.javaClass) }
+      }
+      .forEach {
+        val commandName = it.javaClass.getAnnotation(JsonTypeName::class.java)?.value
+        if (commandName != null && skippedCommandTypes.contains(commandName)) {
+          latestSaga.addEvent(SagaCommandSkipped(commandName, "Condition evaluated against running branch"))
+        }
+      }
   }
 
   /**

--- a/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/models/Saga.kt
+++ b/clouddriver-saga/src/main/kotlin/com/netflix/spinnaker/clouddriver/saga/models/Saga.kt
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.clouddriver.saga.models
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.google.common.annotations.VisibleForTesting
+import com.netflix.spinnaker.clouddriver.saga.CommandFinalizer
 import com.netflix.spinnaker.clouddriver.saga.SagaCommand
-import com.netflix.spinnaker.clouddriver.saga.SagaCommandCompleted
 import com.netflix.spinnaker.clouddriver.saga.SagaCompleted
 import com.netflix.spinnaker.clouddriver.saga.SagaEvent
 import com.netflix.spinnaker.clouddriver.saga.SagaLogAppended
@@ -116,21 +116,23 @@ class Saga(
         }
       }
 
-  internal fun completed(command: Class<SagaCommand>): Boolean {
-    return getEvents().filterIsInstance<SagaCommandCompleted>().any { it.matches(command) }
+  internal fun finalizedCommand(command: Class<SagaCommand>): Boolean {
+    return getEvents()
+      .filterIsInstance<CommandFinalizer>()
+      .any { it.matches(command) }
   }
 
   internal fun getNextCommand(requiredCommand: Class<SagaCommand>): SagaCommand? {
     return getEvents()
       .filterIsInstance<SagaCommand>()
-      .filterNot { completed(it.javaClass) }
+      .filterNot { finalizedCommand(it.javaClass) }
       .firstOrNull { requiredCommand.isAssignableFrom(it.javaClass) }
   }
 
   internal fun hasUnappliedCommands(): Boolean {
     return getEvents().plus(pendingEvents)
       .filterIsInstance<SagaCommand>()
-      .filterNot { completed(it.javaClass) }
+      .filterNot { finalizedCommand(it.javaClass) }
       .any()
   }
 


### PR DESCRIPTION
Building on #4820.

We had a problem where Sagas were being marked as completed, despite not all commands being completed. This change adds `CommandFinalizer` which `SagaCommandSkipped` (new) and `SagaCommandCompleted` implement, allowing us to only complete a Saga once all commands in the event log have been "finalized".

When in a branching scenario, Sagas will pre-emptively add commands for conditional branches into the event log. When a branch is _not_ taken, it previously left some commands lingering, making completed logic a little flaky. Now, when a branch is not taken, its steps will be scanned for actions that match commands already on the event log, adding `SagaCommandSkipped` to keep the event log cleaner.

While doing this work, I've identified some ways to make Sagas more ergonomic for developers both in writing Sagas, as well as in testing them. I will likely look to investigate these changes in the near future.