### PR TITLE
fix(kubernetes): Do a live lookup in the artifact provider

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverter.java
@@ -67,7 +67,7 @@ final class KubernetesVersionedArtifactConverter extends KubernetesArtifactConve
       ArtifactProvider provider, @Nonnull String account, KubernetesManifest manifest) {
     ImmutableList<Artifact> priorVersions =
         provider.getArtifacts(
-            artifactType(manifest.getKind()), manifest.getName(), manifest.getNamespace(), account);
+            manifest.getKind(), manifest.getName(), manifest.getNamespace(), account);
 
     Optional<String> maybeVersion = findMatchingVersion(priorVersions, manifest);
     if (maybeVersion.isPresent()) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/Keys.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/Keys.java
@@ -41,6 +41,7 @@ public class Keys {
    */
   public enum Kind {
     LOGICAL,
+    @Deprecated
     ARTIFACT,
     INFRASTRUCTURE;
 
@@ -130,7 +131,7 @@ public class Keys {
         case LOGICAL:
           return Optional.of(parseLogicalKey(parts));
         case ARTIFACT:
-          return Optional.of(new ArtifactCacheKey(parts));
+          return Optional.empty();
         case INFRASTRUCTURE:
           return Optional.of(new InfrastructureCacheKey(parts));
         default:
@@ -180,42 +181,6 @@ public class Keys {
     @Override
     public final String getGroup() {
       return getLogicalKind().toString();
-    }
-  }
-
-  @EqualsAndHashCode(callSuper = true)
-  @Getter
-  @RequiredArgsConstructor
-  public static class ArtifactCacheKey extends CacheKey {
-    @Getter private static final Kind kind = Kind.ARTIFACT;
-    private final String type;
-    private final String name;
-    private final String location;
-    private final String version;
-
-    protected ArtifactCacheKey(String[] parts) {
-      if (parts.length != 6) {
-        throw new IllegalArgumentException("Malformed artifact key" + Arrays.toString(parts));
-      }
-
-      type = parts[2];
-      name = parts[3];
-      location = parts[4];
-      version = parts[5];
-    }
-
-    public static String createKey(String type, String name, String location, String version) {
-      return createKeyFromParts(kind, type, name, location, version);
-    }
-
-    @Override
-    public String toString() {
-      return createKeyFromParts(kind, type, name, location, version);
-    }
-
-    @Override
-    public String getGroup() {
-      return kind.toString();
     }
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
@@ -35,7 +35,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKindProperties;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest.OwnerReference;
-import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestAnnotater;
 import com.netflix.spinnaker.kork.annotations.NonnullByDefault;
 import com.netflix.spinnaker.moniker.Moniker;
 import com.netflix.spinnaker.moniker.Namer;
@@ -59,22 +58,6 @@ public class KubernetesCacheDataConverter {
   // todo(lwander) investigate if this can cause flapping in UI for on demand updates -- no
   // consensus on this yet.
   @Getter private static final List<KubernetesKind> stickyKinds = Arrays.asList(SERVICE, POD);
-
-  static void convertAsArtifact(
-      KubernetesCacheData kubernetesCacheData, String account, KubernetesManifest manifest) {
-    KubernetesManifestAnnotater.getArtifact(manifest, account)
-        .ifPresent(
-            artifact -> {
-              kubernetesCacheData.addItem(
-                  new Keys.ArtifactCacheKey(
-                      artifact.getType(),
-                      artifact.getName(),
-                      artifact.getLocation(),
-                      artifact.getVersion()),
-                  ImmutableMap.of(
-                      "artifact", artifact, "creationTimestamp", manifest.getCreationTimestamp()));
-            });
-  }
 
   @NonnullByDefault
   public static CacheData mergeCacheData(CacheData current, CacheData added) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
@@ -42,6 +42,9 @@ public class KubernetesCoreCachingAgent extends KubernetesV2OnDemandCachingAgent
   }
 
   public Collection<AgentDataType> getProvidedDataTypes() {
+    // The ARTIFACT kind is deprecated; no new entries of this type will be created. We are leaving
+    // it in the authoritative types for now so that existing entries get evicted.
+    @SuppressWarnings("deprecation")
     Stream<String> logicalTypes =
         Stream.of(Keys.LogicalKind.APPLICATIONS, Keys.LogicalKind.CLUSTERS, Keys.Kind.ARTIFACT)
             .map(Enum::toString);

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2CachingAgent.java
@@ -229,8 +229,6 @@ public abstract class KubernetesV2CachingAgent
                     credentials.getNamer(),
                     rs,
                     relationships.getOrDefault(rs, ImmutableList.of()));
-                KubernetesCacheDataConverter.convertAsArtifact(
-                    kubernetesCacheData, accountName, rs);
               } catch (RuntimeException e) {
                 log.warn("{}: Failure converting {}", getAgentType(), rs, e);
               }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/ArtifactProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/ArtifactProvider.java
@@ -18,8 +18,10 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 
 import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 
 public interface ArtifactProvider {
-  ImmutableList<Artifact> getArtifacts(String type, String name, String location, String account);
+  ImmutableList<Artifact> getArtifacts(
+      KubernetesKind kind, String name, String location, String account);
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ArtifactProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ArtifactProvider.java
@@ -22,7 +22,9 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.Comparator;
 import javax.annotation.Nonnull;
@@ -42,7 +44,8 @@ public class KubernetesV2ArtifactProvider implements ArtifactProvider {
 
   @Override
   public ImmutableList<Artifact> getArtifacts(
-      String type, String name, String location, @Nonnull String account) {
+      KubernetesKind kind, String name, String location, @Nonnull String account) {
+    String type = String.join("/", KubernetesCloudProvider.ID, kind.toString());
     String key = Keys.ArtifactCacheKey.createKey(type, name, location, "*");
     return cacheUtils.getAllDataMatchingPattern(Keys.Kind.ARTIFACT.toString(), key).stream()
         .sorted(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ArtifactProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesV2ArtifactProvider.java
@@ -19,44 +19,40 @@ package com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.netflix.spinnaker.cats.cache.CacheData;
-import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
-import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestAnnotater;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KubernetesV2ArtifactProvider implements ArtifactProvider {
-  private final KubernetesCacheUtils cacheUtils;
-  private final ObjectMapper objectMapper;
+  private final KubernetesAccountResolver accountResolver;
 
   @Autowired
-  KubernetesV2ArtifactProvider(KubernetesCacheUtils cacheUtils, ObjectMapper objectMapper) {
-    this.cacheUtils = cacheUtils;
-    this.objectMapper = objectMapper;
+  KubernetesV2ArtifactProvider(KubernetesAccountResolver accountResolver) {
+    this.accountResolver = accountResolver;
   }
 
   @Override
   public ImmutableList<Artifact> getArtifacts(
       KubernetesKind kind, String name, String location, @Nonnull String account) {
-    String type = String.join("/", KubernetesCloudProvider.ID, kind.toString());
-    String key = Keys.ArtifactCacheKey.createKey(type, name, location, "*");
-    return cacheUtils.getAllDataMatchingPattern(Keys.Kind.ARTIFACT.toString(), key).stream()
-        .sorted(
-            Comparator.comparing(
-                cd -> (String) cd.getAttributes().getOrDefault("creationTimestamp", "")))
-        .map(this::cacheDataToArtifact)
-        .filter(a -> account.equals(a.getMetadata("account")))
+    return accountResolver
+        .getCredentials(account)
+        .map(credentials -> credentials.list(kind, location).stream())
+        .orElseGet(Stream::empty)
+        .sorted(Comparator.comparing(KubernetesManifest::getCreationTimestamp))
+        .map(m -> KubernetesManifestAnnotater.getArtifact(m, account))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .filter(a -> Strings.nullToEmpty(a.getName()).equals(name))
         .collect(toImmutableList());
-  }
-
-  private Artifact cacheDataToArtifact(CacheData cacheData) {
-    return objectMapper.convertValue(cacheData.getAttributes().get("artifact"), Artifact.class);
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java
@@ -116,7 +116,7 @@ public class KubernetesCleanupArtifactsOperation implements AtomicOperation<Oper
 
     ImmutableList<Artifact> artifacts =
         artifactProvider.getArtifacts(
-            artifact.getType(), artifact.getName(), artifact.getLocation(), accountName);
+            manifest.getKind(), artifact.getName(), artifact.getLocation(), accountName);
     if (maxVersionHistory >= artifacts.size()) {
       return ImmutableList.of();
     } else {

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysSpec.groovy
@@ -187,20 +187,4 @@ class KeysSpec extends Specification {
     Keys.LogicalKind.APPLICATIONS | "applications"
     Keys.LogicalKind.CLUSTERS     | "clusters"
   }
-
-  def "serialization and deserialization are inverses"() {
-    when:
-    def parsed = Keys.parseKey(key).get()
-
-    then:
-    parsed.toString() == key
-
-    where:
-    key << [
-      "kubernetes.v2:artifact:kubernetes/replicaSet:spinnaker-io:docs-site:v046",
-      "kubernetes.v2:infrastructure:secret:k8s:spin:spinnaker",
-      "kubernetes.v2:logical:applications:spinnaker",
-      "kubernetes.v2:logical:clusters:k8s:docs:docs-site"
-    ]
-  }
 }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/KubernetesVersionedArtifactConverterTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.view.provider.ArtifactProvider;
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.stream.Stream;
@@ -81,7 +82,7 @@ final class KubernetesVersionedArtifactConverterTest {
     String version2 = "v002";
 
     ArtifactProvider provider = mock(ArtifactProvider.class);
-    when(provider.getArtifacts(ARTIFACT_TYPE, NAME, NAMESPACE, ACCOUNT))
+    when(provider.getArtifacts(KubernetesKind.fromString(KIND), NAME, NAMESPACE, ACCOUNT))
         .thenReturn(
             ImmutableList.of(
                 Artifact.builder()
@@ -103,7 +104,7 @@ final class KubernetesVersionedArtifactConverterTest {
   @MethodSource("versionTestCases")
   void correctlyPicksNextVersion(VersionTestCase testCase) {
     ArtifactProvider provider = mock(ArtifactProvider.class);
-    when(provider.getArtifacts(ARTIFACT_TYPE, NAME, NAMESPACE, ACCOUNT))
+    when(provider.getArtifacts(KubernetesKind.fromString(KIND), NAME, NAMESPACE, ACCOUNT))
         .thenReturn(
             testCase.getExistingVersions().stream()
                 .map(v -> Artifact.builder().putMetadata("account", ACCOUNT).version(v).build())

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysTest.java
@@ -31,7 +31,6 @@ final class KeysTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "kubernetes.v2:artifact:kubernetes/replicaSet:spinnaker-io:docs-site:v046",
         "kubernetes.v2:infrastructure:secret:k8s:spin:spinnaker",
         "kubernetes.v2:logical:applications:spinnaker",
         "kubernetes.v2:logical:clusters:k8s:docs:docs-site"

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.clouddriver.kubernetes.caching;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.CacheKey;
+import java.util.Optional;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+final class KeysTest {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "kubernetes.v2:artifact:kubernetes/replicaSet:spinnaker-io:docs-site:v046",
+        "kubernetes.v2:infrastructure:secret:k8s:spin:spinnaker",
+        "kubernetes.v2:logical:applications:spinnaker",
+        "kubernetes.v2:logical:clusters:k8s:docs:docs-site"
+      })
+  void roundTripParse(String key) {
+    Optional<CacheKey> parsed = Keys.parseKey(key);
+
+    assertThat(parsed).isPresent();
+    assertThat(parsed.get().toString()).isEqualTo(key);
+  }
+}

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -576,6 +576,11 @@ final class KubernetesCoreCachingAgentTest {
     }
   }
 
+  /**
+   * See comment in {@link KubernetesCoreCachingAgent#getProvidedDataTypes()} for why we are
+   * continuing to use the deprecated Keys.Kind.ARTIFACT.
+   */
+  @SuppressWarnings("deprecation")
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 10})
   public void authoritativeForLogicalTypes(int numAgents) {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -479,7 +479,7 @@ final class KubernetesDataProviderIntegrationTest {
   void getArtifacts(SoftAssertions softly) {
     List<Artifact> artifacts =
         artifactProvider.getArtifacts(
-            "kubernetes/replicaSet", "backend", "backend-ns", ACCOUNT_NAME);
+            KubernetesKind.REPLICA_SET, "backend", "backend-ns", ACCOUNT_NAME);
     softly.assertThat(artifacts).hasSize(2);
     softly
         .assertThat(artifacts)
@@ -501,7 +501,7 @@ final class KubernetesDataProviderIntegrationTest {
   void getArtifactsWrongType(SoftAssertions softly) {
     List<Artifact> artifacts =
         artifactProvider.getArtifacts(
-            "kubernetes/deployment", "backend", "backend-ns", ACCOUNT_NAME);
+            KubernetesKind.DEPLOYMENT, "backend", "backend-ns", ACCOUNT_NAME);
     softly.assertThat(artifacts).isEmpty();
   }
 
@@ -509,7 +509,7 @@ final class KubernetesDataProviderIntegrationTest {
   void getArtifactsWrongNamespace(SoftAssertions softly) {
     List<Artifact> artifacts =
         artifactProvider.getArtifacts(
-            "kubernetes/replicaSet", "backend", "frontend-ns", ACCOUNT_NAME);
+            KubernetesKind.REPLICA_SET, "backend", "frontend-ns", ACCOUNT_NAME);
     softly.assertThat(artifacts).isEmpty();
   }
 
@@ -517,7 +517,7 @@ final class KubernetesDataProviderIntegrationTest {
   void getArtifactsWrongAccount(SoftAssertions softly) {
     List<Artifact> artifacts =
         artifactProvider.getArtifacts(
-            "kubernetes/replicaSet", "backend", "backend-ns", "wrong-account");
+            KubernetesKind.REPLICA_SET, "backend", "backend-ns", "wrong-account");
     softly.assertThat(artifacts).isEmpty();
   }
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -160,7 +160,7 @@ final class KubernetesDataProviderIntegrationTest {
   private static KubernetesV2ServerGroupManagerProvider serverGroupManagerProvider =
       new KubernetesV2ServerGroupManagerProvider(cacheUtils);
   private static KubernetesV2ArtifactProvider artifactProvider =
-      new KubernetesV2ArtifactProvider(cacheUtils, objectMapper);
+      new KubernetesV2ArtifactProvider(accountResolver);
   private static KubernetesManifestProvider manifestProvider =
       new KubernetesManifestProvider(accountResolver);
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
@@ -231,7 +231,7 @@ final class KubernetesDeployManifestOperationTest {
   private static OperationResult deploy(KubernetesDeployManifestDescription description) {
     ArtifactProvider provider = mock(ArtifactProvider.class);
     when(provider.getArtifacts(
-            any(String.class), any(String.class), any(String.class), any(String.class)))
+            any(KubernetesKind.class), any(String.class), any(String.class), any(String.class)))
         .thenReturn(ImmutableList.of());
     return new KubernetesDeployManifestOperation(description, provider).operate(ImmutableList.of());
   }

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
@@ -195,7 +195,7 @@ final class KubernetesRunJobOperationTest {
       KubernetesRunJobOperationDescription description, boolean appendSuffix) {
     ArtifactProvider provider = mock(ArtifactProvider.class);
     when(provider.getArtifacts(
-            any(String.class), any(String.class), any(String.class), any(String.class)))
+            any(KubernetesKind.class), any(String.class), any(String.class), any(String.class)))
         .thenReturn(ImmutableList.of());
     return new KubernetesRunJobOperation(description, provider, appendSuffix)
         .operate(ImmutableList.of());


### PR DESCRIPTION
* refactor(kubernetes): Update getArtifacts to accept kind

  As we'll be directly querying the cluster, it makes more sense to accept the actual kind rather than the artifact kind, which is "kubernetes/kind". For now we'll just re-construct the kind in the function, but that will shortly be unnecessary when we move to directly queryin the cluster.

* fix(kubernetes): Do a live lookup in the artifact provider

  This is only used during deploys, so latency is not a big issue here. This will fix race conditions with live manifest calls enabled where operations later in a pipeline don't account for operations that happened earlier in the pipeline.

  For now I am just replacing the exact same logic with a live call, including:
  * Building the whole artifact (even though we only need a few fields)
  * Sorting by creation timestamp instead of by version

  This unblocks deleting the code that caches artifacts, which then unblocks some futher simplifications.

* test(kubernetes): Move a test to Java

  As part of my goal to incrementally move tests to Java, if I break a test and need to fix it, I'm converting it to Java. The next commit breaks this test, so first convert it to Java.

* refactor(kubernetes): Stop caching artifacts

  Now that we always do a live lookup of artifacts, we can stop caching them, as no code reads artifacts from the cache.

  I've left the enum constant for artifact cache keys, and left the core caching agent authoritative, so that existing entries get evicted. We can remove this code after we've done a release with it present.