### PR TITLE
feat(*): Add optional code coverage reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ subprojects {
     apply plugin: 'groovy'
     apply plugin: 'nebula.kotlin'
     apply plugin: "kotlin-allopen"
+    apply plugin: "jacoco"
 
     sourceSets.main.java.srcDirs = []
     sourceSets.main.groovy.srcDirs += ["src/main/java"]
@@ -81,6 +82,14 @@ subprojects {
         minHeapSize = "512m"
         maxHeapSize = "512m"
       }
+      jacoco {
+        enabled = project.hasProperty('testCoverage')
+      }
+    }
+
+    // The test report requires tests to have run first
+    jacocoTestReport {
+      dependsOn test
     }
   }
 

--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,3 @@
 lombok.nonNull.exceptionType = IllegalArgumentException
 lombok.accessors.chain = true
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
This commit applies the jacoco pluigin to all subprojects, giving them the task jacocoTestReport to get a test coverage report.

When the plugin is present, tests are instrumented by default (as the tests don't know if we'll later want to generate a report), which slows them down. To prevent slowing down all builds, I've put the test instrumentation behind a flag.

Now if you run
```
./gradlew -PtestCoverage jacocoTestReport
```
it will instrument the tests and generate a coverage report for each submodule.

Also configure lombok to add a Generated annotation to code that it generates, so that it gets excluded from code coverage reports.