### PR TITLE
fix(cats/sql): Reintroduce fix to Clouddriver SQL Cache failing due to id or agent being too long to be stored. 

### DIFF
--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/SqlProviderCache.kt
@@ -61,7 +61,7 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
     return getAll(type, null as CacheFilter?)
   }
 
-  override fun getAll(type: String, identifiers: MutableCollection<String>?): MutableCollection<CacheData> {
+  override fun getAll(type: String, identifiers: MutableCollection<String?>?): MutableCollection<CacheData> {
     return getAll(type, identifiers, null)
   }
 
@@ -72,7 +72,7 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
 
   override fun getAll(
     type: String,
-    identifiers: MutableCollection<String>?,
+    identifiers: MutableCollection<String?>?,
     cacheFilter: CacheFilter?
   ): MutableCollection<CacheData> {
     validateTypes(type)
@@ -112,7 +112,7 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
    * @param identifiers the identifiers
    * @return the items matching the type and identifiers
    */
-  override fun getAll(type: String, vararg identifiers: String): MutableCollection<CacheData> {
+  override fun getAll(type: String, vararg identifiers: String?): MutableCollection<CacheData> {
     return getAll(type, identifiers.toMutableList())
   }
 
@@ -137,7 +137,7 @@ class SqlProviderCache(private val backingStore: WriteableCache) : ProviderCache
     return backingStore.get(type, id, cacheFilter) ?: return null
   }
 
-  override fun evictDeletedItems(type: String, ids: Collection<String>) {
+  override fun evictDeletedItems(type: String, ids: Collection<String?>) {
     try {
       MDC.put("agentClass", "evictDeletedItems")
 

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlAdminCommandsRepository.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlAdminCommandsRepository.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.cats.sql.cache
+
+import com.netflix.spinnaker.kork.sql.config.SqlProperties
+import java.sql.Connection
+import java.sql.DriverManager
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.slf4j.LoggerFactory
+
+class SqlAdminCommandsRepository(private val properties: SqlProperties) {
+
+  companion object {
+    private val log by lazy { LoggerFactory.getLogger(SqlAdminCommandsRepository::class.java) }
+  }
+
+  /**
+   * Truncates CATS tables of the given namespace for the current schema version.
+   *
+   * @param truncateNamespace namespace of tables to truncate.
+   * @return String collection of the tables truncated.
+   */
+  fun truncateTablesByNamespace(truncateNamespace: String): Collection<String> {
+    val conn = getConnection()
+    val tablesTruncated = mutableListOf<String>()
+
+    conn.use { c ->
+      val jooq = DSL.using(c, SQLDialect.MYSQL)
+      val rs =
+        jooq.fetch(
+          "show tables like ?",
+          "cats_v${SqlSchemaVersion.current()}_${truncateNamespace}_%"
+        ).intoResultSet()
+
+      while (rs.next()) {
+        val table = rs.getString(1)
+        val truncateSql = "truncate table `$table`"
+        log.info("Truncating $table")
+
+        jooq.query(truncateSql).execute()
+        tablesTruncated.add(table)
+      }
+    }
+
+    return tablesTruncated
+  }
+
+  /**
+   * Drops CATS tables of the given namespace for the current schema version.
+   *
+   * @param dropNamespace namespace of tables to drop.
+   * @return String collection of the tables dropped.
+   */
+  fun dropTablesByNamespace(dropNamespace: String): Collection<String> {
+    val conn = getConnection()
+    val tablesDropped = mutableListOf<String>()
+
+    conn.use { c ->
+      val jooq = DSL.using(c, SQLDialect.MYSQL)
+      val rs =
+        jooq.fetch("show tables like ?", "cats_v${SqlSchemaVersion.current()}_${dropNamespace}_%")
+          .intoResultSet()
+
+      while (rs.next()) {
+        val table = rs.getString(1)
+        val dropSql = "drop table `$table`"
+        log.info("Dropping $table")
+
+        jooq.query(dropSql).execute()
+        tablesDropped.add(table)
+      }
+    }
+
+    return tablesDropped
+  }
+
+  /**
+   * Drops CATS tables of the given schema version.
+   *
+   * @param dropVersion the schema version of tables to drop.
+   * @return String collection of the tables dropped.
+   */
+  fun dropTablesByVersion(dropVersion: SqlSchemaVersion): Collection<String> {
+    val conn = getConnection()
+    val tablesDropped = mutableListOf<String>()
+
+    conn.use { c ->
+      val jooq = DSL.using(c, SQLDialect.MYSQL)
+      val rs = jooq.fetch("show tables like ?", "cats_v${dropVersion.version}_%").intoResultSet()
+
+      while (rs.next()) {
+        val table = rs.getString(1)
+        val dropSql = "drop table `$table`"
+        log.info("Dropping $table")
+
+        jooq.query(dropSql).execute()
+        tablesDropped.add(table)
+      }
+    }
+
+    return tablesDropped
+  }
+
+  private fun getConnection(): Connection {
+    return DriverManager.getConnection(
+      properties.migration.jdbcUrl,
+      properties.migration.user,
+      properties.migration.password
+    )
+  }
+}

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.cats.sql.cache
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.hash.Hashing
 import com.netflix.spinnaker.cats.cache.CacheData
 import com.netflix.spinnaker.cats.cache.CacheFilter
 import com.netflix.spinnaker.cats.cache.DefaultJsonCacheData
@@ -15,13 +16,11 @@ import de.huxhorn.sulky.ulid.ULID
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import io.vavr.control.Try
-import java.security.MessageDigest
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.SQLSyntaxErrorException
 import java.time.Clock
 import java.time.Duration
-import java.util.Arrays
 import java.util.concurrent.ConcurrentSkipListSet
 import java.util.concurrent.atomic.AtomicInteger
 import javax.annotation.PreDestroy
@@ -80,38 +79,14 @@ class SqlCache(
   }
 
   /**
-   * Only evicts cache records but not relationship rows
+   * Evicts cache records, but does not evict relationship rows.
+   *
+   * @param type the type of the records that will be removed.
+   * @param ids the ids of the records that will be removed.
    */
-  override fun evictAll(type: String, ids: Collection<String>) {
-    if (ids.isEmpty()) {
-      return
-    }
-
-    log.info("evicting ${ids.size} $type records")
-
-    var deletedCount = 0
-    var opCount = 0
-    try {
-      ids.chunked(dynamicConfigService.getConfig(Int::class.java, "sql.cache.read-batch-size", 500)) { chunk ->
-        withRetry(RetryCategory.WRITE) {
-          jooq.deleteFrom(table(sqlNames.resourceTableName(type)))
-            .where(field("id").`in`(*chunk.toTypedArray()))
-            .execute()
-        }
-        deletedCount += chunk.size
-        opCount += 1
-      }
-    } catch (e: Exception) {
-      log.error("error evicting records", e)
-    }
-
-    cacheMetrics.evict(
-      prefix = name,
-      type = type,
-      itemCount = ids.size,
-      itemsDeleted = deletedCount,
-      deleteOperations = opCount
-    )
+  override fun evictAll(type: String, ids: Collection<String?>) {
+    val hashedIds = ids.asSequence().filterNotNull().map { getIdHash(it) }.toList()
+    evictAllInternal(type, hashedIds)
   }
 
   fun mergeAll(
@@ -211,13 +186,13 @@ class SqlCache(
    * @param ids the ids
    * @return the items matching the type and ids
    */
-  override fun getAll(type: String, ids: MutableCollection<String>?): MutableCollection<CacheData> {
+  override fun getAll(type: String, ids: MutableCollection<String?>?): MutableCollection<CacheData> {
     return getAll(type, ids, null as CacheFilter?)
   }
 
   override fun getAll(
     type: String,
-    ids: MutableCollection<String>?,
+    ids: MutableCollection<String?>?,
     cacheFilter: CacheFilter?
   ): MutableCollection<CacheData> {
     if (ids.isNullOrEmpty()) {
@@ -232,12 +207,13 @@ class SqlCache(
       return mutableListOf()
     }
 
+    val hashedIds = ids.asSequence().filterNotNull().map { getIdHash(it) }.toList()
     val relationshipPrefixes = getRelationshipFilterPrefixes(cacheFilter)
 
     val result = if (relationshipPrefixes.isEmpty()) {
-      getDataWithoutRelationships(type, ids)
+      getDataWithoutRelationships(type, hashedIds)
     } else {
-      getDataWithRelationships(type, ids, relationshipPrefixes)
+      getDataWithRelationships(type, hashedIds, relationshipPrefixes)
     }
 
     if (result.selectQueries > -1) {
@@ -263,8 +239,8 @@ class SqlCache(
    * @return the items matching the type and identifiers
    */
   override fun getAll(type: String, vararg identifiers: String?): MutableCollection<CacheData> {
-    val ids = mutableListOf<String>()
-    identifiers.forEach { ids.add(it!!) }
+    val ids = mutableListOf<String?>()
+    identifiers.forEach { ids.add(it) }
     return getAll(type, ids)
   }
 
@@ -297,7 +273,13 @@ class SqlCache(
       )
     }
 
-    return mapOf(type to mergeDataAndRelationships(result.data, result.relPointers, relationshipPrefixes))
+    return mapOf(
+      type to mergeDataAndRelationships(
+        result.data,
+        result.relPointers,
+        relationshipPrefixes
+      )
+    )
   }
 
   override fun getAllByApplication(
@@ -310,7 +292,13 @@ class SqlCache(
     if (coroutineContext.useAsync(this::asyncEnabled)) {
       val scope = CatsCoroutineScope(coroutineContext)
 
-      types.chunked(dynamicConfigService.getConfig(Int::class.java, "sql.cache.max-query-concurrency", 4)) { batch ->
+      types.chunked(
+        dynamicConfigService.getConfig(
+          Int::class.java,
+          "sql.cache.max-query-concurrency",
+          4
+        )
+      ) { batch ->
         val deferred = batch.map { type ->
           scope.async { getAllByApplication(type, application, cacheFilters[type]) }
         }
@@ -333,10 +321,10 @@ class SqlCache(
   }
 
   /**
-   * Retrieves all the identifiers for a type
+   * Retrieves all the identifiers for a type.
    *
-   * @param type the type for which to retrieve identifiers
-   * @return the identifiers for the type
+   * @param type the type for which to retrieve identifiers.
+   * @return the identifiers for the type.
    */
   override fun getIdentifiers(type: String): MutableCollection<String> {
     val ids = try {
@@ -366,26 +354,31 @@ class SqlCache(
   /**
    * Filters the supplied list of identifiers to only those that exist in the cache.
    *
-   * @param type the type of the item
-   * @param identifiers the identifiers for the items
-   * @return the list of identifiers that are present in the cache from the provided identifiers
+   * @param type the type of the item.
+   * @param identifiers the identifiers for the items.
+   * @return the list of identifiers that are present in the cache from the provided identifiers.
    */
-  override fun existingIdentifiers(type: String, identifiers: MutableCollection<String>): MutableCollection<String> {
+  override fun existingIdentifiers(
+    type: String,
+    identifiers: MutableCollection<String?>
+  ): MutableCollection<String> {
     var selects = 0
     var withAsync = false
     val existing = mutableListOf<String>()
-    val batchSize = dynamicConfigService.getConfig(Int::class.java, "sql.cache.read-batch-size", 500)
+    val batchSize =
+      dynamicConfigService.getConfig(Int::class.java, "sql.cache.read-batch-size", 500)
+    val hashedIds = identifiers.asSequence().filterNotNull().map { getIdHash(it) }.toList()
 
-    if (coroutineContext.useAsync(identifiers.size, this::useAsync)) {
+    if (coroutineContext.useAsync(hashedIds.size, this::useAsync)) {
       withAsync = true
       val scope = CatsCoroutineScope(coroutineContext)
 
-      identifiers.chunked(batchSize).chunked(
+      hashedIds.chunked(batchSize).chunked(
         dynamicConfigService.getConfig(Int::class.java, "sql.cache.max-query-concurrency", 4)
       ) { batch ->
-        val deferred = batch.map { ids ->
+        val deferred = batch.map { idHashes ->
           scope.async {
-            selectIdentifiers(type, ids)
+            selectIdentifiers(type, idHashes)
           }
         }
         runBlocking {
@@ -394,7 +387,7 @@ class SqlCache(
         selects += deferred.size
       }
     } else {
-      identifiers.chunked(batchSize) { chunk ->
+      hashedIds.chunked(batchSize) { chunk ->
         existing.addAll(selectIdentifiers(type, chunk))
         selects += 1
       }
@@ -416,9 +409,9 @@ class SqlCache(
   /**
    * Returns the identifiers for the specified type that match the provided glob.
    *
-   * @param type The type for which to retrieve identifiers
-   * @param glob The glob to match against the identifiers
-   * @return the identifiers for the type that match the glob
+   * @param type The type for which to retrieve identifiers.
+   * @param glob The glob to match against the identifiers.
+   * @return the identifiers for the type that match the glob.
    */
   override fun filterIdentifiers(type: String, glob: String?): MutableCollection<String> {
     if (glob == null) {
@@ -444,7 +437,10 @@ class SqlCache(
           .fetch(field("id"), String::class.java)
       }
     } catch (e: Exception) {
-      suppressedLog("Failed searching for identifiers type: $type glob: $glob reason: ${e.message}", e)
+      suppressedLog(
+        "Failed searching for identifiers type: $type glob: $glob reason: ${e.message}",
+        e
+      )
       mutableSetOf<String>()
     }
 
@@ -472,28 +468,40 @@ class SqlCache(
   }
 
   override fun get(type: String, id: String?, cacheFilter: CacheFilter?): CacheData? {
-    val result = getAll(type, Arrays.asList<String>(id), cacheFilter)
+    val result = getAll(type, mutableListOf(id), cacheFilter)
     return if (result.isEmpty()) {
       null
     } else result.iterator().next()
   }
 
-  override fun evict(type: String, id: String) {
+  /**
+   * Evicts a cache record, but does not evict relationships.
+   *
+   * @param type the type of the record that will be removed.
+   * @param id the id of the record that will be removed.
+   */
+  override fun evict(type: String, id: String?) {
     evictAll(type, listOf(id))
   }
 
+  /**
+   * Evicts on demand cache records that are older than the given time.
+   *
+   * @param maxAgeMs deletes records before this time.
+   * @return the number of records removed.
+   */
   fun cleanOnDemand(maxAgeMs: Long): Int {
-    val toClean = withRetry(RetryCategory.READ) {
-      jooq.select(field("id"))
+    val hashedIdsToClean = withRetry(RetryCategory.READ) {
+      jooq.select(field("id_hash"))
         .from(table(sqlNames.resourceTableName(onDemandType)))
         .where(field("last_updated").lt(clock.millis() - maxAgeMs))
         .fetch()
         .into(String::class.java)
     }
 
-    evictAll(onDemandType, toClean)
+    evictAllInternal(onDemandType, hashedIdsToClean)
 
-    return toClean.size
+    return hashedIdsToClean.size
   }
 
   private fun storeAuthoritative(
@@ -505,48 +513,43 @@ class SqlCache(
     val result = StoreResult()
     result.itemCount.addAndGet(items.size)
 
-    val agent = if (type == ON_DEMAND.ns) {
-      // onDemand keys aren't initially written by the agents that update and expire them. since agent is
-      // part of the primary key, we need to ensure a consistent value across initial and subsequent writes
-      ON_DEMAND.ns
-    } else {
-      agentHint ?: "unknown"
-    }
+    // onDemand keys aren't initially written by the agents that update and expire them. Since agent
+    // is part of the primary key, we need to ensure a consistent value across initial and
+    // subsequent writes.
+    val agent = if (type == ON_DEMAND.ns) ON_DEMAND.ns else agentHint ?: "unknown"
+    val agentHash = getAgentHash(agent)
 
-    val existingHashIds = getHashIds(type, agent)
+    val existingBodyHashesAndIdHashes = getBodyHashesAndIdHashes(type, agentHash)
     result.selectQueries.incrementAndGet()
 
-    val existingHashes = existingHashIds // ids previously store by the calling caching agent
+    val existingBodyHashes = existingBodyHashesAndIdHashes // body hashes previously stored.
       .asSequence()
       .map { it.body_hash }
+      .filterNotNull()
       .toSet()
-    val existingIds = existingHashIds
+    val existingIdHashes = existingBodyHashesAndIdHashes // id hashes previously stored.
       .asSequence()
-      .map { it.id }
+      .map { it.id_hash }
+      .filterNotNull()
       .toSet()
-    val currentIds = mutableSetOf<String>() // current ids from the caching agent
-    val toStore = mutableListOf<String>() // ids that are new or changed
-    val bodies = mutableMapOf<String, String>() // id to body
-    val hashes = mutableMapOf<String, String>() // id to sha256(body)
-    val apps = mutableMapOf<String, String>()
-
-    items.filter { it.id.length > sqlConstraints.maxIdLength }
-      .forEach {
-        log.error("Dropping ${it.id} - character length exceeds MAX_ID_LENGTH ($sqlConstraints.maxIdLength)")
-      }
+    val currentIdHashes = mutableSetOf<String>() // current ids from the caching agent hashed.
+    val resourceEntriesToStore = mutableListOf<ResourceEntry>()
+    val now = clock.millis()
 
     items
-      .filter { it.id != "_ALL_" && it.id.length <= sqlConstraints.maxIdLength }
+      .filter { it.id != "_ALL_" }
       .forEach {
-        currentIds.add(it.id)
+        val idHash = getIdHash(it.id)
+        currentIdHashes.add(idHash)
+
         val nullKeys = it.attributes
           .filter { e -> e.value == null }
           .keys
         nullKeys.forEach { na -> it.attributes.remove(na) }
 
-        if (it.attributes.containsKey("application")) {
-          apps[it.id] = it.attributes["application"] as String
-        }
+        val application: String? =
+          if (it.attributes.containsKey("application")) it.attributes["application"] as String
+          else null
 
         val keysToNormalize = it.relationships.keys.filter { k -> k.contains(':') }
         if (keysToNormalize.isNotEmpty()) {
@@ -556,22 +559,37 @@ class SqlCache(
         }
 
         val body: String? = mapper.writeValueAsString(it)
-        val bodyHash = getHash(body)
+        val bodyHash = getBodyHash(body)
 
-        if (body != null && bodyHash != null && !existingHashes.contains(bodyHash)) {
-          toStore.add(it.id)
-          bodies[it.id] = body
-          hashes[it.id] = bodyHash
+        if (body != null && bodyHash != null && !existingBodyHashes.contains(bodyHash)) {
+          resourceEntriesToStore.add(
+            ResourceEntry(
+              idHash,
+              it.id,
+              agentHash,
+              agent,
+              application,
+              bodyHash,
+              body,
+              now
+            )
+          )
         }
       }
 
-    val now = clock.millis()
-
-    toStore.chunked(dynamicConfigService.getConfig(Int::class.java, "sql.cache.write-batch-size", 100)) { chunk ->
+    resourceEntriesToStore.chunked(
+      dynamicConfigService.getConfig(
+        Int::class.java,
+        "sql.cache.write-batch-size",
+        100
+      )
+    ) { chunk ->
       try {
         val insert = jooq.insertInto(
           table(sqlNames.resourceTableName(type)),
+          field("id_hash"),
           field("id"),
+          field("agent_hash"),
           field("agent"),
           field("application"),
           field("body_hash"),
@@ -581,7 +599,16 @@ class SqlCache(
 
         insert.apply {
           chunk.forEach {
-            values(it, sqlNames.checkAgentName(agent), apps[it], hashes[it], bodies[it], now)
+            values(
+              it.id_hash,
+              it.id,
+              it.agent_hash,
+              it.agent,
+              it.application,
+              it.body_hash,
+              it.body,
+              it.last_updated
+            )
           }
 
           onDuplicateKeyUpdate()
@@ -604,7 +631,7 @@ class SqlCache(
             jooq.fetchExists(
               jooq.select()
                 .from(sqlNames.resourceTableName(type))
-                .where(field("id").eq(it), field("agent").eq(sqlNames.checkAgentName(agent)))
+                .where(field("id_hash").eq(it.id_hash), field("agent_hash").eq(it.agent_hash))
                 .forUpdate()
             )
           }
@@ -612,11 +639,11 @@ class SqlCache(
           if (exists) {
             withRetry(RetryCategory.WRITE) {
               jooq.update(table(sqlNames.resourceTableName(type)))
-                .set(field("application"), apps[it])
-                .set(field("body_hash"), hashes[it])
-                .set(field("body"), bodies[it])
+                .set(field("application"), it.application)
+                .set(field("body_hash"), it.body_hash)
+                .set(field("body"), it.body)
                 .set(field("last_updated"), clock.millis())
-                .where(field("id").eq(it), field("agent").eq(sqlNames.checkAgentName(agent)))
+                .where(field("id_hash").eq(it.id_hash), field("agent_hash").eq(it.agent_hash))
                 .execute()
             }
             result.writeQueries.incrementAndGet()
@@ -625,18 +652,22 @@ class SqlCache(
             withRetry(RetryCategory.WRITE) {
               jooq.insertInto(
                 table(sqlNames.resourceTableName(type)),
+                field("id_hash"),
                 field("id"),
+                field("agent_hash"),
                 field("agent"),
                 field("application"),
                 field("body_hash"),
                 field("body"),
                 field("last_updated")
               ).values(
-                it,
-                sqlNames.checkAgentName(agent),
-                apps[it],
-                hashes[it],
-                bodies[it],
+                it.id_hash,
+                it.id,
+                it.agent_hash,
+                it.agent,
+                it.application,
+                it.body_hash,
+                it.body,
                 clock.millis()
               ).execute()
             }
@@ -651,115 +682,214 @@ class SqlCache(
       return result
     }
 
-    val toDelete = existingIds
-      .asSequence()
-      .filter { !currentIds.contains(it) }
-      .toSet()
+    val idHashesToDelete = existingIdHashes.filter { !currentIdHashes.contains(it) }
 
-    evictAll(type, toDelete)
+    evictAllInternal(type, idHashesToDelete)
 
     return result
   }
 
-  private fun storeInformative(type: String, items: MutableCollection<CacheData>, cleanup: Boolean): StoreResult {
+  private fun storeInformative(
+    type: String,
+    items: MutableCollection<CacheData>,
+    cleanup: Boolean
+  ): StoreResult {
     val result = StoreResult()
 
-    val sourceAgents = items.filter { it.relationships.isNotEmpty() }
+    val relAgentHashes = items.asSequence()
+      .filter { it.relationships.isNotEmpty() }
       .map { it.relationships.keys }
       .flatten()
+      .map { getAgentHash(it) }
       .toSet()
 
-    if (sourceAgents.isEmpty()) {
+    if (relAgentHashes.isEmpty()) {
       log.warn("no relationships found for type $type")
       return result
     }
 
-    val existingFwdRelIds = sourceAgents
+    val existingFwdRelKeys = relAgentHashes
       .map {
         result.selectQueries.incrementAndGet()
         getRelationshipKeys(type, it)
       }
       .flatten()
 
-    val existingRevRelTypes = mutableSetOf<String>()
+    // The current reverse relationship types provided from the calling caching agent.
+    val currentRevRelTypes = mutableSetOf<String>()
     items
       .filter { it.id != "_ALL_" }
       .forEach { cacheData ->
         cacheData.relationships.entries.forEach { rels ->
           val relType = rels.key.substringBefore(delimiter = ":", missingDelimiterValue = "")
-          existingRevRelTypes.add(relType)
+          currentRevRelTypes.add(relType)
         }
       }
 
-    existingRevRelTypes.filter { !createdTables.contains(it) }
-      .forEach { createTables(it) }
-
-    val existingRevRelIds = existingRevRelTypes
+    val existingRevRelKeys = currentRevRelTypes // Reverse relationships previously stored.
+      .filter { createdTables.contains(it) }
       .map { relType ->
-        sourceAgents
-          .map { agent ->
+        relAgentHashes
+          .map { relAgentHash ->
             result.selectQueries.incrementAndGet()
-            getRelationshipKeys(relType, type, agent)
+            getRelationshipKeysAndAgent(relType, type, relAgentHash)
           }
           .flatten()
       }
       .flatten()
 
-    val oldFwdIds: Map<String, String> = existingFwdRelIds
+    // Create tables for the reverse relationship types that have not been previously stored.
+    currentRevRelTypes.filter { !createdTables.contains(it) }
+      .forEach { createTables(it) }
+
+    val oldFwdIds: Map<String, String?> = existingFwdRelKeys
       .asSequence()
       .map { it.key() to it.uuid }
       .toMap()
 
-    val oldRevIds = mutableMapOf<String, String>()
-    val oldRevIdsToType = mutableMapOf<String, String>()
+    val oldRevIds = mutableMapOf<String, String?>()
+    val oldRevIdsToType = mutableMapOf<String, String?>()
 
-    existingRevRelIds
+    existingRevRelKeys
       .forEach {
         oldRevIds[it.key()] = it.uuid
-        oldRevIdsToType[it.key()] = it.rel_agent.substringBefore(delimiter = ":", missingDelimiterValue = "")
+        oldRevIdsToType[it.key()] = it.rel_agent?.substringBefore(
+          delimiter = ":",
+          missingDelimiterValue = ""
+        )
       }
 
     val currentIds = mutableSetOf<String>()
-    val newFwdRelPointers = mutableMapOf<String, MutableList<RelPointer>>()
-    val newRevRelIds = mutableSetOf<String>()
+    // Use map for reverse relationships vs list for forward so that we can do batch inserts for
+    // reverse relationships by the rel type. This isn't necessary for forward because there is only
+    // one type and it's provided by the calling caching agent.
+    val newFwdRelEntries = mutableListOf<RelEntry>()
+    val newRevTypeToRelEntries = mutableMapOf<String, MutableList<RelEntry>>()
 
     items
-      .filter { it.id != "_ALL_" && it.id.length <= sqlConstraints.maxIdLength }
+      .filter { it.id != "_ALL_" }
       .forEach { cacheData ->
         cacheData.relationships.entries.forEach { rels ->
-          val relType = rels.key.substringBefore(delimiter = ":", missingDelimiterValue = "")
-          rels.value.filter { it.length <= sqlConstraints.maxIdLength }
-            .forEach { r ->
-              val fwdKey = "${cacheData.id}|$r"
-              val revKey = "$r|${cacheData.id}"
-              currentIds.add(fwdKey)
-              currentIds.add(revKey)
+          val relAgent = rels.key
+          val relAgentHash = getAgentHash(relAgent)
+          val relType = relAgent.substringBefore(delimiter = ":", missingDelimiterValue = "")
 
-              result.relationshipCount.incrementAndGet()
+          rels.value.forEach { relId ->
+            val idHash = getIdHash(cacheData.id)
+            val relIdHash = getIdHash(relId)
 
-              if (!oldFwdIds.contains(fwdKey)) {
-                newFwdRelPointers.getOrPut(relType) { mutableListOf() }
-                  .add(RelPointer(cacheData.id, r, rels.key))
-              }
+            val fwdKey = "$idHash|$relIdHash"
+            val revKey = "$relIdHash|$idHash"
+            currentIds.add(fwdKey)
+            currentIds.add(revKey)
 
-              if (!oldRevIds.containsKey(revKey)) {
-                newRevRelIds.add(revKey)
-              }
+            result.relationshipCount.incrementAndGet()
+
+            if (!oldFwdIds.containsKey(fwdKey)) {
+              newFwdRelEntries.add(
+                RelEntry(
+                  uuid = null,
+                  id_hash = idHash,
+                  id = cacheData.id,
+                  rel_id_hash = relIdHash,
+                  rel_id = relId,
+                  rel_agent_hash = relAgentHash,
+                  rel_agent = relAgent,
+                  rel_type = relType,
+                  last_updated = null
+                )
+              )
             }
+
+            if (!oldRevIds.containsKey(revKey)) {
+              newRevTypeToRelEntries.getOrPut(relType) { mutableListOf() }
+                .add(
+                  RelEntry(
+                    uuid = null,
+                    id_hash = relIdHash,
+                    id = relId,
+                    rel_id_hash = idHash,
+                    rel_id = cacheData.id,
+                    rel_agent_hash = relAgentHash,
+                    rel_agent = relAgent,
+                    rel_type = type,
+                    last_updated = null
+                  )
+                )
+            }
+          }
         }
       }
 
-    newFwdRelPointers.forEach { (relType, pointers) ->
-      val now = clock.millis()
-      var ulid = ULID().nextValue()
+    val now = clock.millis()
+    val ulid = ULID()
+    var ulidValue = ulid.nextValue()
 
-      pointers.chunked(dynamicConfigService.getConfig(Int::class.java, "sql.cache.write-batch-size", 100)) { chunk ->
+    newFwdRelEntries.chunked(
+      dynamicConfigService.getConfig(
+        Int::class.java,
+        "sql.cache.write-batch-size",
+        100
+      )
+    ) { chunk ->
+      try {
+        val insert = jooq.insertInto(
+          table(sqlNames.relTableName(type)),
+          field("uuid"),
+          field("id_hash"),
+          field("id"),
+          field("rel_id_hash"),
+          field("rel_id"),
+          field("rel_agent_hash"),
+          field("rel_agent"),
+          field("rel_type"),
+          field("last_updated")
+        )
+
+        insert.apply {
+          chunk.forEach {
+            values(
+              ulidValue.toString(),
+              it.id_hash,
+              it.id,
+              it.rel_id_hash,
+              it.rel_id,
+              it.rel_agent_hash,
+              it.rel_agent,
+              it.rel_type,
+              now
+            )
+            ulidValue = ulid.nextMonotonicValue(ulidValue)
+          }
+        }
+
+        withRetry(RetryCategory.WRITE) {
+          insert.execute()
+        }
+        result.writeQueries.incrementAndGet()
+        result.relationshipsStored.addAndGet(chunk.size)
+      } catch (e: Exception) {
+        log.error("Error inserting forward relationships for $type", e)
+      }
+    }
+
+    newRevTypeToRelEntries.forEach { (revType, relEntries) ->
+      relEntries.chunked(
+        dynamicConfigService.getConfig(
+          Int::class.java,
+          "sql.cache.write-batch-size",
+          100
+        )
+      ) { chunk ->
         try {
           val insert = jooq.insertInto(
-            table(sqlNames.relTableName(type)),
+            table(sqlNames.relTableName(revType)),
             field("uuid"),
+            field("id_hash"),
             field("id"),
+            field("rel_id_hash"),
             field("rel_id"),
+            field("rel_agent_hash"),
             field("rel_agent"),
             field("rel_type"),
             field("last_updated")
@@ -767,8 +897,18 @@ class SqlCache(
 
           insert.apply {
             chunk.forEach {
-              values(ulid.toString(), it.id, it.rel_id, sqlNames.checkAgentName(it.rel_type), relType, now)
-              ulid = ULID().nextMonotonicValue(ulid)
+              values(
+                ulidValue.toString(),
+                it.id_hash,
+                it.id,
+                it.rel_id_hash,
+                it.rel_id,
+                it.rel_agent_hash,
+                it.rel_agent,
+                it.rel_type,
+                now
+              )
+              ulidValue = ulid.nextMonotonicValue(ulidValue)
             }
           }
 
@@ -778,39 +918,9 @@ class SqlCache(
           result.writeQueries.incrementAndGet()
           result.relationshipsStored.addAndGet(chunk.size)
         } catch (e: Exception) {
-          log.error("Error inserting forward relationships for $type -> $relType", e)
+          log.error("Error inserting reverse relationships for $revType -> $type", e)
         }
       }
-
-      pointers.asSequence().filter { newRevRelIds.contains("${it.rel_id}|${it.id}") }
-        .chunked(dynamicConfigService.getConfig(Int::class.java, "sql.cache.write-batch-size", 100)) { chunk ->
-          try {
-            val insert = jooq.insertInto(
-              table(sqlNames.relTableName(relType)),
-              field("uuid"),
-              field("id"),
-              field("rel_id"),
-              field("rel_agent"),
-              field("rel_type"),
-              field("last_updated")
-            )
-
-            insert.apply {
-              chunk.forEach {
-                values(ulid.toString(), it.rel_id, it.id, sqlNames.checkAgentName(it.rel_type), type, now)
-                ulid = ULID().nextMonotonicValue(ulid)
-              }
-            }
-
-            withRetry(RetryCategory.WRITE) {
-              insert.execute()
-            }
-            result.writeQueries.incrementAndGet()
-            result.relationshipsStored.addAndGet(chunk.size)
-          } catch (e: Exception) {
-            log.error("Error inserting reverse relationships for $relType -> $type", e)
-          }
-        }.toList()
     }
 
     if (!cleanup) {
@@ -831,7 +941,7 @@ class SqlCache(
           result.deleteQueries.incrementAndGet()
         }
         revToDelete.forEach {
-          if (oldRevIdsToType.getOrDefault(it.key, "").isNotBlank()) {
+          if (!oldRevIdsToType.getOrDefault(it.key, "").isNullOrEmpty()) {
             withRetry(RetryCategory.WRITE) {
               jooq.deleteFrom(table(sqlNames.relTableName(oldRevIdsToType[it.key]!!)))
                 .where(field("uuid").eq(it.value))
@@ -903,57 +1013,121 @@ class SqlCache(
     }
   }
 
-  private fun getHash(body: String?): String? {
+  /**
+   * Returns a hash of the body given if not null or blank, otherwise returns null.
+   *
+   * @param body the body to hash.
+   * @return hash of the body.
+   */
+  private fun getBodyHash(body: String?): String? {
     if (body.isNullOrBlank()) {
       return null
     }
-    return try {
-      val digest = MessageDigest.getInstance("SHA-256")
-        .digest(body.toByteArray())
-      digest.fold("") { str, it ->
-        str + "%02x".format(it)
-      }
-    } catch (e: Exception) {
-      log.error("error calculating hash for body: $body", e)
-      null
-    }
+    return getSha256Hash(body)
   }
 
-  private fun getHashIds(type: String, agent: String?): List<HashId> {
+  /**
+   * Returns a hash of the id given.
+   *
+   * @param id The id to hash.
+   * @return hash of the id.
+   */
+  private fun getIdHash(id: String): String {
+    return getSha256Hash(id)
+  }
+
+  /**
+   * Returns a hash of the agent given.
+   *
+   * @param agent the agent to hash.
+   * @return hash of the agent.
+   */
+  private fun getAgentHash(agent: String): String {
+    return getSha256Hash(agent)
+  }
+
+  /**
+   * Gets a SHA-256 hash value for a given String.
+   *
+   * @param str the String to hash.
+   * @return the hashed value.
+   */
+  private fun getSha256Hash(str: String): String {
+    return Hashing.sha256().hashUnencodedChars(str).toString()
+  }
+
+  /**
+   * Returns the body hashes and id hashes stored for the given type and agent hash.
+   *
+   * @param type the type of the records to retrieve.
+   * @param agentHash the agent hash of the records to retrieve.
+   * @return list of resource entries with body hash and id hash populated.
+   */
+  private fun getBodyHashesAndIdHashes(type: String, agentHash: String?): List<ResourceEntry> {
     return withRetry(RetryCategory.READ) {
       jooq
-        .select(field("body_hash"), field("id"))
+        .select(field("body_hash"), field("id_hash"))
         .from(table(sqlNames.resourceTableName(type)))
         .where(
-          field("agent").eq(sqlNames.checkAgentName(agent))
+          field("agent_hash").eq(agentHash)
         )
         .fetch()
-        .into(HashId::class.java)
+        .into(ResourceEntry::class.java)
     }
   }
 
-  private fun getRelationshipKeys(type: String, sourceAgent: String): MutableList<RelId> {
+  /**
+   * Returns the following identifying fields of records matching the given rel agent hash from the
+   * relationship table of the given type: uuid, id hash, rel id hash, and rel agent hash.
+   *
+   * @param type the type of the relationship table.
+   * @param relAgentHash the rel agent hash of the records whose identifying fields are retrieved.
+   * @return list of relationship entries with uuid, id hash, rel id hash, and rel agent hash
+   * populated.
+   */
+  private fun getRelationshipKeys(type: String, relAgentHash: String): MutableList<RelEntry> {
     return withRetry(RetryCategory.READ) {
       jooq
-        .select(field("uuid"), field("id"), field("rel_id"), field("rel_agent"))
+        .select(field("uuid"), field("id_hash"), field("rel_id_hash"), field("rel_agent_hash"))
         .from(table(sqlNames.relTableName(type)))
-        .where(field("rel_agent").eq(sqlNames.checkAgentName(sourceAgent)))
+        .where(field("rel_agent_hash").eq(relAgentHash))
         .fetch()
-        .into(RelId::class.java)
+        .into(RelEntry::class.java)
     }
   }
 
-  private fun getRelationshipKeys(type: String, origType: String, sourceAgent: String): MutableList<RelId> {
+  /**
+   * Returns the rel agent and the following identifying fields of records matching the given rel
+   * agent hash and rel type from the relationship table of the given type: uuid, id hash, rel id
+   * hash, and rel agent hash.
+   *
+   * @param type the type of the relationship table.
+   * @param origType the rel type of the records whose identifying fields are retrieved.
+   * @param relAgentHash the rel agent hash of the records whose identifying fields are retrieved.
+   * @return list of relationship entries with uuid, id hash, rel id hash, and rel agent hash
+   * populated.
+   */
+  private fun getRelationshipKeysAndAgent(
+    type: String,
+    origType: String,
+    relAgentHash: String
+  ): MutableList<RelEntry> {
     return withRetry(RetryCategory.READ) {
       jooq
-        .select(field("uuid"), field("id"), field("rel_id"), field("rel_agent"))
+        .select(
+          field("uuid"),
+          field("id_hash"),
+          field("rel_id_hash"),
+          field("rel_agent_hash"),
+          field("rel_agent")
+        )
         .from(table(sqlNames.relTableName(type)))
         .where(
-          field("rel_agent").eq(sqlNames.checkAgentName(sourceAgent)),
+          field("rel_agent_hash").eq(relAgentHash),
           field("rel_type").eq(origType)
         )
         .fetch()
-        .into(RelId::class.java)
+        .into(RelEntry::class.java)
     }
   }
 
@@ -963,16 +1137,16 @@ class SqlCache(
 
   private fun getDataWithoutRelationships(
     type: String,
-    ids: Collection<String>
+    hashedIds: Collection<String>
   ): DataWithRelationshipPointersResult {
     val cacheData = mutableListOf<CacheData>()
-    val relPointers = mutableSetOf<RelPointer>()
-    val batchSize = dynamicConfigService.getConfig(Int::class.java, "sql.cache.read-batch-size", 500)
+    val batchSize =
+      dynamicConfigService.getConfig(Int::class.java, "sql.cache.read-batch-size", 500)
     var selectQueries = 0
     var withAsync = false
 
     try {
-      if (ids.isEmpty()) {
+      if (hashedIds.isEmpty()) {
         withRetry(RetryCategory.READ) {
           cacheData.addAll(
             jooq.select(field("body"))
@@ -986,15 +1160,15 @@ class SqlCache(
         }
         selectQueries += 1
       } else {
-        if (coroutineContext.useAsync(ids.size, this::useAsync)) {
+        if (coroutineContext.useAsync(hashedIds.size, this::useAsync)) {
           withAsync = true
           val scope = CatsCoroutineScope(coroutineContext)
 
-          ids.chunked(batchSize).chunked(
+          hashedIds.chunked(batchSize).chunked(
             dynamicConfigService.getConfig(Int::class.java, "sql.cache.max-query-concurrency", 4)
           ) { batch ->
-            val deferred = batch.map { ids ->
-              scope.async { selectBodies(type, ids) }
+            val deferred = batch.map { hashedIds ->
+              scope.async { selectBodies(type, hashedIds) }
             }
             runBlocking {
               cacheData.addAll(deferred.awaitAll().flatten())
@@ -1002,14 +1176,14 @@ class SqlCache(
             selectQueries += deferred.size
           }
         } else {
-          ids.chunked(batchSize) { chunk ->
+          hashedIds.chunked(batchSize) { chunk ->
             cacheData.addAll(selectBodies(type, chunk))
             selectQueries += 1
           }
         }
       }
 
-      return DataWithRelationshipPointersResult(cacheData, relPointers, selectQueries, withAsync)
+      return DataWithRelationshipPointersResult(cacheData, mutableSetOf(), selectQueries, withAsync)
     } catch (e: Exception) {
       suppressedLog("Failed selecting ids for type $type", e)
 
@@ -1025,13 +1199,20 @@ class SqlCache(
 
       selectQueries = -1
 
-      return DataWithRelationshipPointersResult(mutableListOf(), mutableSetOf(), selectQueries, withAsync)
+      return DataWithRelationshipPointersResult(
+        mutableListOf(),
+        mutableSetOf(),
+        selectQueries,
+        withAsync
+      )
     }
   }
 
-  private fun getDataWithoutRelationshipsByApp(type: String, application: String): DataWithRelationshipPointersResult {
+  private fun getDataWithoutRelationshipsByApp(
+    type: String,
+    application: String
+  ): DataWithRelationshipPointersResult {
     val cacheData = mutableListOf<CacheData>()
-    val relPointers = mutableSetOf<RelPointer>()
     var selectQueries = 0
 
     try {
@@ -1048,7 +1229,7 @@ class SqlCache(
         )
       }
       selectQueries += 1
-      return DataWithRelationshipPointersResult(cacheData, relPointers, selectQueries, false)
+      return DataWithRelationshipPointersResult(cacheData, mutableSetOf(), selectQueries, false)
     } catch (e: Exception) {
       suppressedLog("Failed selecting resources of type $type for application $application", e)
 
@@ -1064,7 +1245,12 @@ class SqlCache(
 
       selectQueries = -1
 
-      return DataWithRelationshipPointersResult(mutableListOf(), mutableSetOf(), selectQueries, false)
+      return DataWithRelationshipPointersResult(
+        mutableListOf(),
+        mutableSetOf(),
+        selectQueries,
+        false
+      )
     }
   }
 
@@ -1137,7 +1323,12 @@ class SqlCache(
 
       selectQueries = -1
 
-      return DataWithRelationshipPointersResult(mutableListOf(), mutableSetOf(), selectQueries, false)
+      return DataWithRelationshipPointersResult(
+        mutableListOf(),
+        mutableSetOf(),
+        selectQueries,
+        false
+      )
     }
   }
 
@@ -1151,14 +1342,15 @@ class SqlCache(
 
   private fun getDataWithRelationships(
     type: String,
-    ids: Collection<String>,
+    hashedIds: Collection<String>,
     relationshipPrefixes: List<String>
   ): DataWithRelationshipPointersResult {
     val cacheData = mutableListOf<CacheData>()
     val relPointers = mutableSetOf<RelPointer>()
     var selectQueries = 0
     var withAsync = false
-    val batchSize = dynamicConfigService.getConfig(Int::class.java, "sql.cache.read-batch-size", 500)
+    val batchSize =
+      dynamicConfigService.getConfig(Int::class.java, "sql.cache.read-batch-size", 500)
 
     /*
         Approximating the following query pattern in jooq:
@@ -1170,7 +1362,7 @@ class SqlCache(
     */
 
     try {
-      if (ids.isEmpty()) {
+      if (hashedIds.isEmpty()) {
 
         val relWhere = getRelWhere(relationshipPrefixes)
 
@@ -1200,10 +1392,10 @@ class SqlCache(
         parseCacheRelResultSet(type, resultSet, cacheData, relPointers)
         selectQueries += 1
       } else {
-        if (coroutineContext.useAsync(ids.size, this::useAsync)) {
+        if (coroutineContext.useAsync(hashedIds.size, this::useAsync)) {
           withAsync = true
 
-          ids.chunked(batchSize).chunked(
+          hashedIds.chunked(batchSize).chunked(
             dynamicConfigService.getConfig(Int::class.java, "sql.cache.max-query-concurrency", 4)
           ) { batch ->
             val scope = CatsCoroutineScope(coroutineContext)
@@ -1222,7 +1414,7 @@ class SqlCache(
             }
           }
         } else {
-          ids.chunked(batchSize) { chunk ->
+          hashedIds.chunked(batchSize) { chunk ->
             val resultSet = selectBodiesWithRelationships(type, relationshipPrefixes, chunk)
 
             parseCacheRelResultSet(type, resultSet, cacheData, relPointers)
@@ -1246,15 +1438,28 @@ class SqlCache(
 
       selectQueries = -1
 
-      return DataWithRelationshipPointersResult(mutableListOf(), mutableSetOf(), selectQueries, withAsync)
+      return DataWithRelationshipPointersResult(
+        mutableListOf(),
+        mutableSetOf(),
+        selectQueries,
+        withAsync
+      )
     }
   }
 
-  private fun selectBodies(type: String, ids: List<String>): Collection<CacheData> {
+  /**
+   * Returns collection of cache data constructed from the bodies stored for the given type and id
+   * hashes.
+   *
+   * @param type the type of the records to retrieve.
+   * @param idHashes list of id hashes of the records to retrieve.
+   * @return collection of cache data constructed from stored bodies.
+   */
+  private fun selectBodies(type: String, idHashes: List<String>): Collection<CacheData> {
     return withRetry(RetryCategory.READ) {
       jooq.select(field("body"))
         .from(table(sqlNames.resourceTableName(type)))
-        .where(field("ID").`in`(*ids.toTypedArray()))
+        .where(field("id_hash").`in`(*idHashes.toTypedArray()))
         .fetch()
         .getValues(0)
         .map { mapper.readValue(it as String, DefaultJsonCacheData::class.java) }
@@ -1262,12 +1467,21 @@ class SqlCache(
     }
   }
 
+  /**
+   * Returns a result set where each row has the following columns in the order they are written:
+   * body, id, rel id, and rel type.
+   *
+   * @param type the type of the records to retrieve.
+   * @param relationshipPrefixes prefixes to determine the rel types of the records to retrieve.
+   * @param hashedIds list of id hashes of the records to retrieve.
+   * @return result set with rows containing body, id, rel id, and rel type.
+   */
   private fun selectBodiesWithRelationships(
     type: String,
     relationshipPrefixes: List<String>,
-    ids: List<String>
+    hashedIds: List<String>
   ): ResultSet {
-    val where = field("ID").`in`(*ids.toTypedArray())
+    val where = field("id_hash").`in`(*hashedIds.toTypedArray())
 
     val relWhere = getRelWhere(relationshipPrefixes, where)
 
@@ -1296,16 +1510,79 @@ class SqlCache(
     }
   }
 
-  private fun selectIdentifiers(type: String, ids: List<String>): MutableCollection<String> {
+  /**
+   * Returns the ids stored for the given type and hashed ids.
+   *
+   * @param type the type of the ids to retrieve.
+   * @param hashedIds the hashed ids of the ids to retrieve.
+   * @return list of ids stored in the cache that matched the type and hashed ids provided.
+   */
+  private fun selectIdentifiers(type: String, hashedIds: List<String>): MutableCollection<String> {
     return withRetry(RetryCategory.READ) {
       jooq.select(field("id"))
         .from(table(sqlNames.resourceTableName(type)))
-        .where(field("id").`in`(*ids.toTypedArray()))
+        .where(field("id_hash").`in`(*hashedIds.toTypedArray()))
         .fetch()
         .intoSet(field("id"), String::class.java)
     }
   }
 
+  /**
+   * Evicts cache records, but does not evict relationship rows. Difference between internal and
+   * public function is that the internal function takes in hashed ids rather than the ids.
+   *
+   * @param type the type of the records that will be removed.
+   * @param hashedIds collection of hashed ids to be removed.
+   */
+  private fun evictAllInternal(type: String, hashedIds: Collection<String>) {
+    if (hashedIds.isEmpty()) {
+      return
+    }
+
+    log.info("evicting ${hashedIds.size} $type records")
+
+    var deletedCount = 0
+    var opCount = 0
+    try {
+      hashedIds.chunked(
+        dynamicConfigService.getConfig(
+          Int::class.java,
+          "sql.cache.write-batch-size",
+          300
+        )
+      ) { chunk ->
+        withRetry(RetryCategory.WRITE) {
+          jooq.deleteFrom(table(sqlNames.resourceTableName(type)))
+            .where(field("id_hash").`in`(*chunk.toTypedArray()))
+            .execute()
+        }
+        deletedCount += chunk.size
+        opCount += 1
+      }
+    } catch (e: Exception) {
+      log.error("error evicting records", e)
+    }
+
+    cacheMetrics.evict(
+      prefix = name,
+      type = type,
+      itemCount = hashedIds.size,
+      itemsDeleted = deletedCount,
+      deleteOperations = opCount
+    )
+  }
+
+  /**
+   * Adds entries into the provided cache data and rel pointer lists based on the given result set.
+   * In order to properly add entries into cache data and rel pointer lists, the result set rows
+   * must have the following columns in the order they are written: body, id, rel id, and rel type.
+   *
+   * @param type the type of the cached records.
+   * @param resultSet the result set with columns body, id, rel id, and rel type used to populate
+   * cache data and rel pointer lists.
+   * @param cacheData cache data list populated by result set.
+   * @param relPointers rel pointer list populated by result set
+   */
   private fun parseCacheRelResultSet(
     type: String,
     resultSet: ResultSet,
@@ -1317,11 +1594,20 @@ class SqlCache(
         try {
           cacheData.add(mapper.readValue(resultSet.getString(1), DefaultJsonCacheData::class.java))
         } catch (e: Exception) {
-          log.error("Failed to deserialize cached value: type $type, body ${resultSet.getString(1)}", e)
+          log.error(
+            "Failed to deserialize cached value: type $type, body ${resultSet.getString(1)}",
+            e
+          )
         }
       } else {
         try {
-          relPointers.add(RelPointer(resultSet.getString(2), resultSet.getString(3), resultSet.getString(4)))
+          relPointers.add(
+            RelPointer(
+              resultSet.getString(2),
+              resultSet.getString(3),
+              resultSet.getString(4)
+            )
+          )
         } catch (e: SQLException) {
           log.error("Error reading relationship of type $type", e)
         }
@@ -1347,7 +1633,12 @@ class SqlCache(
         // to prevent fetching more. TODO: update the test?
         if (relationshipPrefixes.isNotEmpty()) {
           if (item.relationships.any { it.key.contains(':') }) {
-            data[item.id]!!.relationships.putAll(normalizeRelationships(item.relationships, relationshipPrefixes))
+            data[item.id]!!.relationships.putAll(
+              normalizeRelationships(
+                item.relationships,
+                relationshipPrefixes
+              )
+            )
           }
         } else {
           relKeysToRemove.getOrPut(item.id) { mutableSetOf() }
@@ -1437,7 +1728,10 @@ class SqlCache(
     return relationships
   }
 
-  private fun getRelWhere(relationshipPrefixes: List<String>, prefix: Condition? = null): Condition {
+  private fun getRelWhere(
+    relationshipPrefixes: List<String>,
+    prefix: Condition? = null
+  ): Condition {
     var relWhere: Condition = noCondition()
 
     if (relationshipPrefixes.isNotEmpty() && !relationshipPrefixes.contains("ALL")) {
@@ -1487,8 +1781,16 @@ class SqlCache(
 
   @ExperimentalContracts
   private fun useAsync(items: Int): Boolean {
-    return dynamicConfigService.getConfig(Int::class.java, "sql.cache.max-query-concurrency", 4) > 1 &&
-      items > dynamicConfigService.getConfig(Int::class.java, "sql.cache.read-batch-size", 500) * 2
+    return dynamicConfigService.getConfig(
+      Int::class.java,
+      "sql.cache.max-query-concurrency",
+      4
+    ) > 1 &&
+      items > dynamicConfigService.getConfig(
+      Int::class.java,
+      "sql.cache.read-batch-size",
+      500
+    ) * 2
   }
 
   @ExperimentalContracts
@@ -1528,19 +1830,30 @@ class SqlCache(
     createdTables.removeAll(tables)
   }
 
-  data class HashId(
-    val body_hash: String,
-    val id: String
+  data class ResourceEntry(
+    val id_hash: String?,
+    val id: String?,
+    val agent_hash: String?,
+    val agent: String?,
+    val application: String?,
+    val body_hash: String?,
+    val body: String?,
+    val last_updated: Long?
   )
 
-  data class RelId(
-    val uuid: String,
-    val id: String,
-    val rel_id: String,
-    val rel_agent: String
+  data class RelEntry(
+    val uuid: String?,
+    val id_hash: String?,
+    val id: String?,
+    val rel_id_hash: String?,
+    val rel_id: String?,
+    val rel_agent_hash: String?,
+    val rel_agent: String?,
+    val rel_type: String?,
+    val last_updated: Long?
   ) {
     fun key(): String {
-      return "$id|$rel_id"
+      return "$id_hash|$rel_id_hash"
     }
   }
 

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlCache.kt
@@ -1023,7 +1023,7 @@ class SqlCache(
     if (body.isNullOrBlank()) {
       return null
     }
-    return getSha256Hash(body)
+    return getMurmur3Hash(body)
   }
 
   /**
@@ -1033,7 +1033,7 @@ class SqlCache(
    * @return hash of the id.
    */
   private fun getIdHash(id: String): String {
-    return getSha256Hash(id)
+    return getMurmur3Hash(id)
   }
 
   /**
@@ -1043,17 +1043,17 @@ class SqlCache(
    * @return hash of the agent.
    */
   private fun getAgentHash(agent: String): String {
-    return getSha256Hash(agent)
+    return getMurmur3Hash(agent)
   }
 
   /**
-   * Gets a SHA-256 hash value for a given String.
+   * Gets a Murmur3 hash value for a given String.
    *
    * @param str the String to hash.
    * @return the hashed value.
    */
-  private fun getSha256Hash(str: String): String {
-    return Hashing.sha256().hashUnencodedChars(str).toString()
+  private fun getMurmur3Hash(str: String): String {
+    return Hashing.murmur3_128().hashUnencodedChars(str).toString()
   }
 
   /**

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNames.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNames.kt
@@ -75,34 +75,6 @@ class SqlNames(
     throw IllegalArgumentException("property sql.table-namespace $tableNamespace is too long")
   }
 
-  /**
-   * Truncates the agent string if too long to fit in @SqlConstraints.maxAgentLength
-   * @return agent string to store
-   */
-  @VisibleForTesting
-  internal fun checkAgentName(agent: String?): String? {
-    if (agent == null) {
-      return null
-    }
-    if (agent.length <= sqlConstraints.maxAgentLength) {
-      return agent
-    }
-
-    val hash = Hashing.murmur3_128().hashBytes((agent).toByteArray()).toString()
-    val colIdx = agent.indexOf(':')
-
-    // We want to store at least <type>:<some hash bytes>
-    if (colIdx > sqlConstraints.maxAgentLength - 2) {
-      throw IllegalArgumentException("Type ${agent.substring(0, colIdx)} is too long, record cannot be stored")
-    }
-
-    // How much we can keep of the agent string, we need to preserve the colon
-    val available = Math.max(sqlConstraints.maxAgentLength - hash.length - 1, colIdx)
-    // How much of the hash will fit if we want to preserve the colon
-    val hashLength = Math.min(hash.length, sqlConstraints.maxAgentLength - colIdx - 1)
-    return agent.substring(0..available) + hash.substring(0, hashLength)
-  }
-
   companion object {
     private val schemaVersion = SqlSchemaVersion.current()
     private val typeSanitization =

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlSchemaVersion.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlSchemaVersion.kt
@@ -1,9 +1,10 @@
 package com.netflix.spinnaker.cats.sql.cache
 
 enum class SqlSchemaVersion(val version: Int) {
-  V1(1);
+  V1(1),
+  V2(2);
 
   companion object {
-    fun current(): Int = V1.version
+    fun current(): Int = V2.version
   }
 }

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgent.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgent.kt
@@ -175,7 +175,7 @@ class SqlUnknownAgentCleanupAgent(
         .map { it.typeName }
         .toSet()
 
-      result = Pair(agents.mapNotNull { sqlNames.checkAgentName(it.agentType) }.toSet(), dataTypes)
+      result = Pair(agents.map { it.agentType }.toSet(), dataTypes)
     }
     return result
   }

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/controllers/CatsSqlAdminController.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/cats/sql/controllers/CatsSqlAdminController.kt
@@ -1,16 +1,12 @@
 package com.netflix.spinnaker.cats.sql.controllers
 
+import com.netflix.spinnaker.cats.sql.cache.SqlAdminCommandsRepository
 import com.netflix.spinnaker.cats.sql.cache.SqlSchemaVersion
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
-import com.netflix.spinnaker.kork.sql.config.SqlProperties
 import com.netflix.spinnaker.security.AuthenticatedRequest
-import java.sql.DriverManager
-import org.jooq.SQLDialect
-import org.jooq.impl.DSL
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -20,12 +16,11 @@ import org.springframework.web.bind.annotation.RestController
 // TODO: Replace validatePermissions() with a to-be-implemented fiat isAdmin() decorator
 
 @ConditionalOnProperty("sql.cache.enabled")
-@EnableConfigurationProperties(SqlProperties::class)
 @RestController
 @RequestMapping("/admin/db")
 class CatsSqlAdminController(
   private val fiat: FiatPermissionEvaluator,
-  private val properties: SqlProperties
+  private val adminCommands: SqlAdminCommandsRepository
 ) {
 
   companion object {
@@ -39,31 +34,9 @@ class CatsSqlAdminController(
   ): CleanTablesResult {
 
     validatePermissions()
-    validateParams(currentNamespace, truncateNamespace)
+    validateNamespaceParams(currentNamespace, truncateNamespace)
 
-    val conn = DriverManager.getConnection(
-      properties.migration.jdbcUrl,
-      properties.migration.user,
-      properties.migration.password
-    )
-
-    val tablesTruncated = mutableListOf<String>()
-    val sql = "show tables like 'cats_v${SqlSchemaVersion.current()}_${truncateNamespace}_%'"
-
-    conn.use { c ->
-      val jooq = DSL.using(c, SQLDialect.MYSQL)
-      val rs = jooq.fetch(sql).intoResultSet()
-
-      while (rs.next()) {
-        val table = rs.getString(1)
-        val truncateSql = "truncate table `$table`"
-        log.info("Truncating $table")
-
-        jooq.query(truncateSql).execute()
-        tablesTruncated.add(table)
-      }
-    }
-
+    val tablesTruncated = adminCommands.truncateTablesByNamespace(truncateNamespace)
     return CleanTablesResult(tableCount = tablesTruncated.size, tables = tablesTruncated)
   }
 
@@ -74,35 +47,24 @@ class CatsSqlAdminController(
   ): CleanTablesResult {
 
     validatePermissions()
-    validateParams(currentNamespace, dropNamespace)
+    validateNamespaceParams(currentNamespace, dropNamespace)
 
-    val conn = DriverManager.getConnection(
-      properties.migration.jdbcUrl,
-      properties.migration.user,
-      properties.migration.password
-    )
-
-    val tablesDropped = mutableListOf<String>()
-    val sql = "show tables like 'cats_v${SqlSchemaVersion.current()}_${dropNamespace}_%'"
-
-    conn.use { c ->
-      val jooq = DSL.using(c, SQLDialect.MYSQL)
-      val rs = jooq.fetch(sql).intoResultSet()
-
-      while (rs.next()) {
-        val table = rs.getString(1)
-        val dropSql = "drop table `$table`"
-        log.info("Dropping $table")
-
-        jooq.query(dropSql).execute()
-        tablesDropped.add(table)
-      }
-    }
-
+    val tablesDropped = adminCommands.dropTablesByNamespace(dropNamespace)
     return CleanTablesResult(tableCount = tablesDropped.size, tables = tablesDropped)
   }
 
-  private fun validateParams(currentNamespace: String?, targetNamespace: String) {
+  @PutMapping(path = ["drop_version/{version}"])
+  fun dropTablesByVersion(
+    @PathVariable("version") dropVersion: SqlSchemaVersion
+  ): CleanTablesResult {
+
+    validatePermissions()
+
+    val tablesDropped = adminCommands.dropTablesByVersion(dropVersion)
+    return CleanTablesResult(tableCount = tablesDropped.size, tables = tablesDropped)
+  }
+
+  private fun validateNamespaceParams(currentNamespace: String?, targetNamespace: String) {
     if (currentNamespace == null) {
       throw IllegalStateException("truncate can only be called when sql.tableNamespace is set")
     }

--- a/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConstraints.kt
+++ b/cats/cats-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConstraints.kt
@@ -21,7 +21,4 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("sql.constraints")
 class SqlConstraints {
   var maxTableNameLength: Int = 64
-  // 352 * 2 + 64 (max rel_type length) == 768; 768 * 4 (utf8mb4) == 3072 == Aurora's max index length
-  var maxIdLength: Int = 352
-  var maxAgentLength: Int = 127
 }

--- a/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamesTest.kt
+++ b/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlNamesTest.kt
@@ -17,10 +17,7 @@ package com.netflix.spinnaker.cats.sql.cache
 
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import java.lang.IllegalArgumentException
-import strikt.api.expect
 import strikt.api.expectThat
-import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 
 class SqlNamesTest : JUnit5Minutests {
@@ -40,42 +37,6 @@ class SqlNamesTest : JUnit5Minutests {
       test("max length of table name is checked: $table") {
         expectThat(checkTableName("cats_v1_", table.name, table.suffix))
           .isEqualTo(table.expected)
-      }
-    }
-  }
-
-  fun agentTests() = rootContext<SqlNames> {
-    fixture {
-      SqlNames()
-    }
-    listOf(
-      Pair(null, null),
-      Pair("myagent", "myagent"),
-      Pair(
-        "abcdefghij".repeat(20),
-        "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdebb43b982e477772faa2e899f65d0a86b"
-      ),
-      Pair(
-        "abcdefghij".repeat(10) + ":" + "abcdefghij".repeat(10),
-        "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij:20f5a9d8d3f4f18cfec8a40eda"
-      ),
-      Pair(
-        "abcdefghij:" + "abcdefghij".repeat(20),
-        "abcdefghij:abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcd5bfa5c163877f247769cd6b488dff339"
-      )
-    ).forEach { test ->
-      test("max length of table name is checked: ${test.first}") {
-        expectThat(checkAgentName(test.first))
-          .isEqualTo(test.second)
-      }
-    }
-
-    test("do not accept types that are too long") {
-      expect {
-        that(
-          kotlin.runCatching { checkAgentName("abcdefghij".repeat(20) + ":abcdefghij") }
-            .exceptionOrNull()
-        ).isA<IllegalArgumentException>()
       }
     }
   }

--- a/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgentTest.kt
+++ b/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgentTest.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.cats.sql.cache
 
+import com.google.common.hash.Hashing
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.cats.agent.CachingAgent
 import com.netflix.spinnaker.cats.cache.DefaultCacheData
@@ -40,6 +41,17 @@ import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
 
 class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
+
+  companion object {
+    private const val idProd = "aws:instances:prod:us-east-1:i-abcd1234"
+    private const val idTest = "aws:instances:test:us-east-1:i-abcd1234"
+    private const val agentProd = "prod/TestAgent"
+    private const val agentTest = "test/TestAgent"
+    private const val relIdProd = "aws:serverGroups:myapp-prod:prod:us-east-1:myapp-prod-v000"
+    private const val relIdTest = "aws:serverGroups:myapp-test:test:us-east-1:myapp-test-v000"
+    private const val relAgentProd = "serverGroups:prod/TestAgent"
+    private const val relAgentTest = "serverGroups:test/TestAgent"
+  }
 
   fun tests() = rootContext<Fixture> {
     fixture { Fixture() }
@@ -84,12 +96,12 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
 
         test("relationships referencing old data are deleted") {
           expectThat(selectAllResources())
-            .hasSize(1)[0].isEqualTo("aws:instances:prod:us-east-1:i-abcd1234")
+            .hasSize(1)[0].isEqualTo(idProd)
         }
 
         test("resources referencing old data are deleted") {
           expectThat(selectAllRels())
-            .hasSize(1)[0].isEqualTo("aws:serverGroups:myapp-prod:prod:us-east-1:myapp-prod-v000")
+            .hasSize(1)[0].isEqualTo(relIdProd)
         }
       }
     }
@@ -118,26 +130,41 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
     )
     val registry = NoopRegistry()
 
-    val subject = SqlUnknownAgentCleanupAgent(StaticObjectProvider(providerRegistry), dslContext, registry, SqlNames())
+    val subject =
+      SqlUnknownAgentCleanupAgent(
+        StaticObjectProvider(providerRegistry),
+        dslContext,
+        registry,
+        SqlNames()
+      )
 
     fun seedDatabase(includeTestAccount: Boolean, includeProdAccount: Boolean) {
       SqlNames().run {
         val resource = resourceTableName("instances")
         val rel = relTableName("instances")
-        dslContext.execute("CREATE TABLE IF NOT EXISTS $resource LIKE cats_v1_resource_template")
-        dslContext.execute("CREATE TABLE IF NOT EXISTS $rel LIKE cats_v1_rel_template")
+        dslContext.execute("CREATE TABLE IF NOT EXISTS $resource LIKE cats_v2_resource_template")
+        dslContext.execute("CREATE TABLE IF NOT EXISTS $rel LIKE cats_v2_rel_template")
       }
 
-      dslContext.insertInto(table("cats_v1_instances"))
+      dslContext.insertInto(table("cats_v2_instances"))
         .columns(
-          field("id"), field("agent"), field("application"), field("body_hash"), field("body"), field("last_updated")
+          field("id_hash"),
+          field("id"),
+          field("agent_hash"),
+          field("agent"),
+          field("application"),
+          field("body_hash"),
+          field("body"),
+          field("last_updated")
         )
         .let {
           if (includeProdAccount) {
             it
               .values(
-                "aws:instances:prod:us-east-1:i-abcd1234",
-                "prod/TestAgent",
+                getSha256Hash(idProd),
+                idProd,
+                getSha256Hash(agentProd),
+                agentProd,
                 "myapp",
                 "",
                 "",
@@ -151,8 +178,10 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
           if (includeTestAccount) {
             it
               .values(
-                "aws:instances:test:us-east-1:i-abcd1234",
-                "test/TestAgent",
+                getSha256Hash(idTest),
+                idTest,
+                getSha256Hash(agentTest),
+                agentTest,
                 "myapp",
                 "",
                 "",
@@ -164,11 +193,14 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
         }
         .execute()
 
-      dslContext.insertInto(table("cats_v1_instances_rel"))
+      dslContext.insertInto(table("cats_v2_instances_rel"))
         .columns(
           field("uuid"),
+          field("id_hash"),
           field("id"),
+          field("rel_id_hash"),
           field("rel_id"),
+          field("rel_agent_hash"),
           field("rel_agent"),
           field("rel_type"),
           field("last_updated")
@@ -178,9 +210,12 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
             it
               .values(
                 ULID().nextULID(),
-                "aws:instances:prod:us-east-1:i-abcd1234",
-                "aws:serverGroups:myapp-prod:prod:us-east-1:myapp-prod-v000",
-                "serverGroups:prod/TestAgent",
+                getSha256Hash(idProd),
+                idProd,
+                getSha256Hash(relIdProd),
+                relIdProd,
+                getSha256Hash(relAgentProd),
+                relAgentProd,
                 "serverGroups",
                 System.currentTimeMillis()
               )
@@ -193,9 +228,12 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
             it
               .values(
                 ULID().nextULID(),
-                "aws:instances:test:us-east-1:i-abcd1234",
-                "aws:serverGroups:myapp-test:test:us-east-1:myapp-test-v000",
-                "serverGroups:test/TestAgent",
+                getSha256Hash(idTest),
+                idTest,
+                getSha256Hash(relIdTest),
+                relIdTest,
+                getSha256Hash(relAgentTest),
+                relAgentTest,
                 "serverGroups",
                 System.currentTimeMillis()
               )
@@ -214,12 +252,10 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
         it.results = mapOf(
           INSTANCES.ns to listOf(
             DefaultCacheData(
-              "aws:instances:test:us-east-1:i-abcd1234",
+              idTest,
               mapOf(),
               mapOf(
-                SERVER_GROUPS.ns to listOf(
-                  "aws:serverGroups:myapp-test:test:us-east-1:myapp-test-v000"
-                )
+                SERVER_GROUPS.ns to listOf(relIdTest)
               )
             )
           )
@@ -234,12 +270,10 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
         it.results = mapOf(
           INSTANCES.ns to listOf(
             DefaultCacheData(
-              "aws:instances:prod:us-east-1:i-abcd1234",
+              idProd,
               mapOf(),
               mapOf(
-                SERVER_GROUPS.ns to listOf(
-                  "aws:serverGroups:myapp-prod:prod:us-east-1:myapp-prod-v000"
-                )
+                SERVER_GROUPS.ns to listOf(relIdProd)
               )
             )
           )
@@ -262,9 +296,13 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
       dslContext.select(field("rel_id"))
         .from(table(SqlNames().relTableName("instances")))
         .fetch(0, String::class.java)
+
+    fun getSha256Hash(str: String): String =
+      Hashing.sha256().hashBytes(str.toByteArray()).toString()
   }
 
-  private inner class StaticObjectProvider(val obj: ProviderRegistry) : ObjectProvider<ProviderRegistry> {
+  private inner class StaticObjectProvider(val obj: ProviderRegistry) :
+    ObjectProvider<ProviderRegistry> {
     override fun getIfUnique(): ProviderRegistry? = obj
     override fun getObject(vararg args: Any?): ProviderRegistry = obj
     override fun getObject(): ProviderRegistry = obj

--- a/clouddriver-sql/src/main/resources/db/changelog-master.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog-master.yml
@@ -14,3 +14,6 @@ databaseChangeLog:
 - include:
     file: changelog/20190913-task-sagaids.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/20200709-cats-v2.yml
+    relativeToChangelogFile: true

--- a/clouddriver-sql/src/main/resources/db/changelog/20200709-cats-v2.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20200709-cats-v2.yml
@@ -1,0 +1,202 @@
+databaseChangeLog:
+- changeSet:
+    id: create-cats-v2-resource-template-table
+    author: mattsanta
+    changes:
+    - createTable:
+        tableName: cats_v2_resource_template
+        columns:
+        - column:
+            name: id_hash
+            type: char(64)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: id
+            type: varchar(768)
+            constraints:
+              nullable: false
+        - column:
+            name: agent_hash
+            type: char(64)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: agent
+            type: varchar(400)
+            constraints:
+              nullable: false
+        - column:
+            name: application
+            type: varchar(255)
+        - column:
+            name: body_hash
+            type: char(64)
+            constraints:
+              nullable: false
+        - column:
+            name: body
+            type: longtext
+            constraints:
+              nullable: false
+        - column:
+            name: last_updated
+            type: bigint
+            constraints:
+              nullable: false
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: cats_v2_resource_template
+
+- changeSet:
+    id: create-cats-v2-resource-template-table-indices
+    author: mattsanta
+    changes:
+    - createIndex:
+        indexName: agent_hash_body_hash_idx
+        tableName: cats_v2_resource_template
+        columns:
+        - column:
+            name: agent_hash
+        - column:
+            name: body_hash
+    - createIndex:
+        indexName: resource_last_updated_idx
+        tableName: cats_v2_resource_template
+        columns:
+        - column:
+            name: last_updated
+    - createIndex:
+        indexName: application_idx
+        tableName: cats_v2_resource_template
+        columns:
+        - column:
+            name: application
+    - createIndex:
+        indexName: id_idx
+        tableName: cats_v2_resource_template
+        columns:
+        - column:
+            name: id
+    rollback:
+    - dropIndex:
+        indexName: agent_hash_body_hash_idx
+        tableName: cats_v2_resource_template
+    - dropIndex:
+        indexName: resource_last_updated_idx
+        tableName: cats_v2_resource_template
+    - dropIndex:
+        indexName: application_idx
+        tableName: cats_v2_resource_template
+    - dropIndex:
+        indexName: id_idx
+        tableName: cats_v2_resource_template
+
+- changeSet:
+    id: create-cats-v2-rel-template-table
+    author: mattsanta
+    changes:
+    - createTable:
+        tableName: cats_v2_rel_template
+        columns:
+        - column:
+            name: uuid
+            type: char(26)
+            constraints:
+              primaryKey: true
+              nullable: false
+        - column:
+            name: id_hash
+            type: char(64)
+            constraints:
+              nullable: false
+        - column:
+            name: id
+            type: varchar(768)
+            constraints:
+              nullable: false
+        - column:
+            name: rel_id_hash
+            type: char(64)
+            constraints:
+              nullable: false
+        - column:
+            name: rel_id
+            type: varchar(768)
+            constraints:
+              nullable: false
+        - column:
+            name: rel_agent_hash
+            type: char(64)
+            constraints:
+              nullable: false
+        - column:
+            name: rel_agent
+            type: varchar(400)
+            constraints:
+              nullable: false
+        - column:
+            name: rel_type
+            type: varchar(64)
+        - column:
+            name: last_updated
+            type: bigint
+    - modifySql:
+        dbms: mysql
+        append:
+          value: " engine innodb"
+    rollback:
+    - dropTable:
+        tableName: cats_v2_rel_template
+
+- changeSet:
+    id: create-cats-v2-rel-template-table-indices
+    author: mattsanta
+    changes:
+    - createIndex:
+        indexName: id_hash_idx
+        tableName: cats_v2_rel_template
+        columns:
+        - column:
+            name: id_hash
+    - createIndex:
+        indexName: rel_agent_hash_idx
+        tableName: cats_v2_rel_template
+        columns:
+        - column:
+            name: rel_agent_hash
+    - createIndex:
+        indexName: rel_type_idx
+        tableName: cats_v2_rel_template
+        columns:
+        - column:
+            name: rel_type
+    - createIndex:
+        indexName: rel_ids_hash_type_idx
+        tableName: cats_v2_rel_template
+        columns:
+        - column:
+            name: id_hash
+        - column:
+            name: rel_type
+        - column:
+            name: rel_id_hash
+    rollback:
+    - dropIndex:
+        indexName: id_hash_idx
+        tableName: cats_v2_rel_template
+    - dropIndex:
+        indexName: rel_agent_hash_idx
+        tableName: cats_v2_rel_template
+    - dropIndex:
+        indexName: rel_type_idx
+        tableName: cats_v2_rel_template
+    - dropIndex:
+        indexName: rel_ids_hash_type_idx
+        tableName: cats_v2_rel_template

--- a/clouddriver-sql/src/main/resources/db/changelog/20200709-cats-v2.yml
+++ b/clouddriver-sql/src/main/resources/db/changelog/20200709-cats-v2.yml
@@ -166,11 +166,13 @@ databaseChangeLog:
         - column:
             name: id_hash
     - createIndex:
-        indexName: rel_agent_hash_idx
+        indexName: rel_agent_hash_rel_type_idx
         tableName: cats_v2_rel_template
         columns:
         - column:
             name: rel_agent_hash
+        - column:
+            name: rel_type
     - createIndex:
         indexName: rel_type_idx
         tableName: cats_v2_rel_template
@@ -192,7 +194,7 @@ databaseChangeLog:
         indexName: id_hash_idx
         tableName: cats_v2_rel_template
     - dropIndex:
-        indexName: rel_agent_hash_idx
+        indexName: rel_agent_hash_rel_type_idx
         tableName: cats_v2_rel_template
     - dropIndex:
         indexName: rel_type_idx


### PR DESCRIPTION
* fix(cats/sql): Reintroduce fix to Clouddriver SQL Cache failing due to id or agent being too long to be stored. 

  Revert "fix(cats/sql): Reverting changes to SQL Cache due to seeing a major increase in CPU usage and deadlocking. (#4811)"

  This reverts commit 618921b0d0f8f9f1aed30e16a8f44abff6348acd.

* perf(cats/sql): Change relationship table index with rel_agent_hash to include rel_type. 

  Including the rel_type in the the index will improve the query where rel_agent_hash and rel_type is given. There's also a query to get all entries with a given rel_agent_hash, this index still works for that query since the rel_agent_hash is the first column.

* perf(cats/sql): Switch SqlCache hashing function from SHA256 to Murmur3. 

  Moving towards using a faster hashing function since we're spending a lot of CPU time hashing at the moment. Furthermore, the values we are hashing do not need to be hashed by a cryptographic hash function so SHA256 is overkill.
