### PR TITLE
fix(build): Remove use of gradle constraint on elasticsearch and jest dependencies

### DIFF
--- a/clouddriver-elasticsearch-aws/clouddriver-elasticsearch-aws.gradle
+++ b/clouddriver-elasticsearch-aws/clouddriver-elasticsearch-aws.gradle
@@ -23,16 +23,13 @@ dependencies {
   implementation("org.elasticsearch:elasticsearch")
   implementation "org.springframework.boot:spring-boot-starter-web"
 
-  constraints {
-    implementation("io.searchbox:jest") {
-      version {
-        strictly "2.0.3"
-      }
-    }
-    implementation("org.elasticsearch:elasticsearch") {
-      version {
-        strictly "2.4.1"
-      }
-    }
+  //TODO(jonsie): Determine why this is necessary to extend and build clouddriver so we can
+  // use the version constraints that were introduced in this PR:
+  // https://github.com/spinnaker/clouddriver/pull/4826
+  implementation("org.elasticsearch:elasticsearch:2.4.1") {
+    force = true
+  }
+  implementation("io.searchbox:jest:2.0.3") {
+    force = true
   }
 }

--- a/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
+++ b/clouddriver-elasticsearch/clouddriver-elasticsearch.gradle
@@ -19,16 +19,13 @@ dependencies {
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"
 
-  constraints {
-    implementation("io.searchbox:jest") {
-      version {
-        strictly "6.3.1"
-      }
-    }
-    implementation("org.elasticsearch:elasticsearch") {
-      version {
-        strictly "6.8.6"
-      }
-    }
+  //TODO(jonsie): Determine why this is necessary to extend and build clouddriver so we can
+  // use the version constraints that were introduced in this PR:
+  // https://github.com/spinnaker/clouddriver/pull/4826
+  implementation("org.elasticsearch:elasticsearch:6.8.6") {
+    force = true
+  }
+  implementation("io.searchbox:jest:6.3.1") {
+    force = true
   }
 }


### PR DESCRIPTION
Using the contraints we are running into build errors internally, like so:

```
Could not determine the dependencies of task ':clouddriver-package:installDist'.
> Could not resolve all task dependencies for configuration ':clouddriver-package:runtimeClasspath'.
   > Could not resolve org.elasticsearch:elasticsearch:{strictly 2.4.1}.
     Required by:
         project :clouddriver-package > project :clouddriver:clouddriver-web
         project :clouddriver-package > project :clouddriver:clouddriver-web > project :clouddriver:clouddriver-elasticsearch-aws
      > Cannot find a version of 'org.elasticsearch:elasticsearch' that satisfies the version constraints:
           Dependency path 'com.netflix.spinnaker.clouddriver.internal:clouddriver-package:unspecified' --> 'com.netflix.spinnaker.clouddriver.internal:clouddriver-nflx:unspecified' --> 'com.netflix.spinnaker.clouddriver.internal:clouddriver-elasticsearch-docker:unspecified' --> 'org.elasticsearch:elasticsearch'
```

This restores the behavior prior to https://github.com/spinnaker/clouddriver/pull/4826 and allows us to build and deploy.  The errors using the Gradle constraint method needs more investigation.