### PR TITLE
refactor(kubernetes): Fix short circuit boolean error prone warning.

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesManifestProvider.java
@@ -125,7 +125,8 @@ public class KubernetesManifestProvider {
                     .filter(
                         m ->
                             cluster.equals(KubernetesManifestAnnotater.getManifestCluster(m))
-                                & app.equals(KubernetesManifestAnnotater.getManifestApplication(m)))
+                                && app.equals(
+                                    KubernetesManifestAnnotater.getManifestApplication(m)))
                     .sorted(
                         (m1, m2) ->
                             credentials


### PR DESCRIPTION
* refactor(kubernetes): Fix short circuit boolean error prone warning. 

  The right hand side of the & has no side effect, so we can simply fix by switching to &&.
