### PR TITLE
refactor(kubernetes): Fix string splitter error prone warning.

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -33,7 +33,6 @@ tasks.withType(JavaCompile) {
     "ImmutableEnumChecker",
     "JdkObsolete",
     "MissingOverride",
-    "StringSplitter",
     "UnnecessaryParentheses",
     "UnusedVariable"
   )


### PR DESCRIPTION
* refactor(kubernetes): Fix string splitter error prone warning. 

  Switched to using Splitter in PropertyParser.java since the behavior is properly defined, unlike String.split(String). The reason for omitting empty strings here is because otherwise there is a scenario where it will attempt to parse properties with empty values. There is a test case for this scenario.
