### PR TITLE
refactor(kubernetes): Fix JdkObsolete warnings

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -31,7 +31,6 @@ tasks.withType(JavaCompile) {
     "DefaultCharset",
     "EmptyCatch",
     "ImmutableEnumChecker",
-    "JdkObsolete",
     "MissingOverride",
     "StringSplitter"
   )

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Instance.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Instance.java
@@ -75,7 +75,7 @@ public final class KubernetesV2Instance implements Instance, KubernetesResource 
     this.kind = manifest.getKind();
     this.labels = ImmutableMap.copyOf(manifest.getLabels());
     this.moniker = moniker;
-    this.createdTime = manifest.getFormattedCreationTimestamp();
+    this.createdTime = manifest.getCreationTimestampEpochMillis();
 
     this.health = new ArrayList<>();
     V1PodStatus status =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2LoadBalancer.java
@@ -66,7 +66,7 @@ public final class KubernetesV2LoadBalancer
     this.labels = ImmutableMap.copyOf(manifest.getLabels());
     this.moniker = moniker;
     this.serverGroups = serverGroups;
-    this.createdTime = manifest.getFormattedCreationTimestamp();
+    this.createdTime = manifest.getCreationTimestampEpochMillis();
   }
 
   @Nullable

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2SecurityGroup.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2SecurityGroup.java
@@ -101,7 +101,7 @@ public final class KubernetesV2SecurityGroup implements KubernetesResource, Secu
     this.namespace = manifest.getNamespace();
     this.labels = ImmutableMap.copyOf(manifest.getLabels());
     this.moniker = moniker;
-    this.createdTime = manifest.getFormattedCreationTimestamp();
+    this.createdTime = manifest.getCreationTimestampEpochMillis();
 
     this.inboundRules = inboundRules;
     this.outboundRules = outboundRules;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroup.java
@@ -134,7 +134,7 @@ public final class KubernetesV2ServerGroup implements KubernetesResource, Server
     this.displayName = manifest.getName();
     this.labels = ImmutableMap.copyOf(manifest.getLabels());
     this.moniker = moniker;
-    this.createdTime = manifest.getFormattedCreationTimestamp();
+    this.createdTime = manifest.getCreationTimestampEpochMillis();
     this.buildInfo =
         ImmutableMap.of(
             "images",

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2ServerGroupManager.java
@@ -66,7 +66,7 @@ public final class KubernetesV2ServerGroupManager
     this.labels = ImmutableMap.copyOf(manifest.getLabels());
     this.moniker = moniker;
     this.serverGroups = serverGroups;
-    this.createdTime = manifest.getFormattedCreationTimestamp();
+    this.createdTime = manifest.getCreationTimestampEpochMillis();
   }
 
   public static KubernetesV2ServerGroupManager fromCacheData(

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesCoordinates;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -160,15 +160,11 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   @Nullable
   public Long getCreationTimestampEpochMillis() {
-    String timestamp = getCreationTimestamp();
     try {
-      if (!timestamp.isEmpty()) {
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse(timestamp).getTime();
-      }
-    } catch (ParseException e) {
+      return Instant.parse(getCreationTimestamp()).toEpochMilli();
+    } catch (DateTimeParseException e) {
       log.warn("Failed to parse timestamp: ", e);
     }
-
     return null;
   }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifest.java
@@ -150,17 +150,19 @@ public class KubernetesManifest extends HashMap<String, Object> {
   @JsonIgnore
   @Nonnull
   public String getCreationTimestamp() {
-    return getMetadata().containsKey("creationTimestamp")
-        ? getMetadata().get("creationTimestamp").toString()
-        : "";
+    Object timestamp = getMetadata().get("creationTimestamp");
+    if (timestamp == null) {
+      return "";
+    }
+    return timestamp.toString();
   }
 
   @JsonIgnore
   @Nullable
-  public Long getFormattedCreationTimestamp() {
+  public Long getCreationTimestampEpochMillis() {
     String timestamp = getCreationTimestamp();
     try {
-      if (!Strings.isNullOrEmpty(timestamp)) {
+      if (!timestamp.isEmpty()) {
         return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse(timestamp).getTime();
       }
     } catch (ParseException e) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesV2JobStatus.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesV2JobStatus.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.clouddriver.kubernetes.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
-import com.netflix.spinnaker.clouddriver.kubernetes.provider.KubernetesModelUtil;
 import com.netflix.spinnaker.clouddriver.model.JobState;
 import com.netflix.spinnaker.clouddriver.model.JobStatus;
 import io.kubernetes.client.openapi.models.V1Job;
@@ -55,9 +54,7 @@ public class KubernetesV2JobStatus implements JobStatus {
     this.account = account;
     this.name = job.getMetadata().getName();
     this.location = job.getMetadata().getNamespace();
-    this.createdTime =
-        KubernetesModelUtil.translateTime(
-            job.getMetadata().getCreationTimestamp().toString(), "yyyy-MM-dd'T'HH:mm:ss");
+    this.createdTime = job.getMetadata().getCreationTimestamp().getMillis();
   }
 
   public Map<String, String> getCompletionDetails() {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesModelUtil.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/KubernetesModelUtil.java
@@ -18,31 +18,11 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.provider;
 
 import com.netflix.spinnaker.clouddriver.model.HealthState;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class KubernetesModelUtil {
-  private static final Logger log = LoggerFactory.getLogger(KubernetesModelUtil.class);
-
-  public static long translateTime(String time) {
-    return KubernetesModelUtil.translateTime(time, "yyyy-MM-dd'T'HH:mm:ssX");
-  }
-
-  public static long translateTime(String time, String format) {
-    try {
-      return StringUtils.isNotEmpty(time) ? new SimpleDateFormat(format).parse(time).getTime() : 0;
-    } catch (ParseException e) {
-      log.error("Failed to parse kubernetes timestamp", e);
-      return 0;
-    }
-  }
-
   public static HealthState getHealthState(List<Map<String, Object>> health) {
     return someUpRemainingUnknown(health)
         ? HealthState.Up


### PR DESCRIPTION
* refactor(kubernetes): Minor refactor of timestamp function

  Instead of looking twice in the map, just check if the result is null in getCreationTimestamp.  (Since this is a mutable map, the presence of the key doesn't guarantee the value is null anyway, so let's jut get the value.) I didn't use Optional here because this is used in a comparator that might be called a lot for large sorts, but maybe that's a micro-optimization.

  The result is non-null so we can use .isEmpty() in getFormattedTimestamp.

  Finally let's rename getFormattedTimestamp to getCreationTimestampEpochMillis, as the result is not formatted.

* refactor(kubernetes): Fix JdkObsolete warnings

  [JdkObsolete] Date has a bad API that leads to bugs; prefer java.time.Instant or LocalDate.

  In KubernetesManifest, we can parse the String into an Instant instead of a Date. (There's also no point separately handling an empty string; anything invalid will cause a ParseException so just let that happen.)

  In KubernetesModelUtil, the only place that was calling this function already had a org.joda.time.DateTime object and was serializing it before calling this function; we can just directly get the milliseconds from the object and delete translateTime.