### PR TITLE
refactor(kubernetes): Fix default charset error prone warning and enable warning moving forward. 

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -28,7 +28,6 @@ tasks.withType(JavaCompile) {
   // Temporarily disable error-prone checks that are generating warnings. These
   // are only here while we fix or suppress the warnings in these categories.
   options.errorprone.disable(
-    "DefaultCharset",
     "EmptyCatch",
     "ImmutableEnumChecker",
     "JdkObsolete",

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutor.java
@@ -38,6 +38,7 @@ import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -431,7 +432,9 @@ public class KubectlJobExecutor {
 
     JobResult<String> status =
         jobExecutor.runJob(
-            new JobRequest(command, new ByteArrayInputStream(manifestAsJson.getBytes())));
+            new JobRequest(
+                command,
+                new ByteArrayInputStream(manifestAsJson.getBytes(StandardCharsets.UTF_8))));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException("Deploy failed: " + status.getError());
@@ -459,7 +462,9 @@ public class KubectlJobExecutor {
 
     JobResult<String> status =
         jobExecutor.runJob(
-            new JobRequest(command, new ByteArrayInputStream(manifestAsJson.getBytes())));
+            new JobRequest(
+                command,
+                new ByteArrayInputStream(manifestAsJson.getBytes(StandardCharsets.UTF_8))));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       if (status.getError().contains(NOT_FOUND_STRING)) {
@@ -489,7 +494,9 @@ public class KubectlJobExecutor {
 
     JobResult<String> status =
         jobExecutor.runJob(
-            new JobRequest(command, new ByteArrayInputStream(manifestAsJson.getBytes())));
+            new JobRequest(
+                command,
+                new ByteArrayInputStream(manifestAsJson.getBytes(StandardCharsets.UTF_8))));
 
     if (status.getResult() != JobResult.Result.SUCCESS) {
       throw new KubectlException("Create failed: " + status.getError());


### PR DESCRIPTION
* refactor(kubernetes): Fix default charset error prone warning and enable warning moving forward. 

  Specifying standard charset that is available in every implementation of Java platform instead of using platform default that varies from machine to machine or JVM to JVM.
