### PR TITLE
refactor(kubernetes): add missing @Overrides to non-generated code

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
@@ -41,7 +41,7 @@ public class KubernetesCoreCachingAgent extends KubernetesV2OnDemandCachingAgent
     super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount, agentInterval);
   }
 
-  public Collection<AgentDataType> getProvidedDataTypes() {
+  @Override public Collection<AgentDataType> getProvidedDataTypes() {
     // The ARTIFACT kind is deprecated; no new entries of this type will be created. We are leaving
     // it in the authoritative types for now so that existing entries get evicted.
     @SuppressWarnings("deprecation")
@@ -72,7 +72,7 @@ public class KubernetesCoreCachingAgent extends KubernetesV2OnDemandCachingAgent
    * these requests, and have it return all pending on-demand refresh requests (not just ones
    * related to its slice of namespaces).
    */
-  protected boolean handlePendingOnDemandRequests() {
+  @Override protected boolean handlePendingOnDemandRequests() {
     return agentIndex == 0;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgent.java
@@ -41,7 +41,8 @@ public class KubernetesCoreCachingAgent extends KubernetesV2OnDemandCachingAgent
     super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount, agentInterval);
   }
 
-  @Override public Collection<AgentDataType> getProvidedDataTypes() {
+  @Override
+  public Collection<AgentDataType> getProvidedDataTypes() {
     // The ARTIFACT kind is deprecated; no new entries of this type will be created. We are leaving
     // it in the authoritative types for now so that existing entries get evicted.
     @SuppressWarnings("deprecation")
@@ -72,7 +73,8 @@ public class KubernetesCoreCachingAgent extends KubernetesV2OnDemandCachingAgent
    * these requests, and have it return all pending on-demand refresh requests (not just ones
    * related to its slice of namespaces).
    */
-  @Override protected boolean handlePendingOnDemandRequests() {
+  @Override
+  protected boolean handlePendingOnDemandRequests() {
     return agentIndex == 0;
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -40,7 +40,8 @@ public class KubernetesUnregisteredCustomResourceCachingAgent
     super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount, agentInterval);
   }
 
-  @Override public ImmutableSet<AgentDataType> getProvidedDataTypes() {
+  @Override
+  public ImmutableSet<AgentDataType> getProvidedDataTypes() {
     return primaryKinds().stream()
         .map(k -> AUTHORITATIVE.forType(k.toString()))
         .collect(toImmutableSet());

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgent.java
@@ -40,7 +40,7 @@ public class KubernetesUnregisteredCustomResourceCachingAgent
     super(namedAccountCredentials, objectMapper, registry, agentIndex, agentCount, agentInterval);
   }
 
-  public ImmutableSet<AgentDataType> getProvidedDataTypes() {
+  @Override public ImmutableSet<AgentDataType> getProvidedDataTypes() {
     return primaryKinds().stream()
         .map(k -> AUTHORITATIVE.forType(k.toString()))
         .collect(toImmutableSet());

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Application.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Application.java
@@ -28,7 +28,8 @@ public final class KubernetesV2Application implements Application {
   private final String name;
   private final Map<String, Set<String>> clusterNames;
 
-  @Override public Map<String, String> getAttributes() {
+  @Override
+  public Map<String, String> getAttributes() {
     return new ImmutableMap.Builder<String, String>().put("name", name).build();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Application.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/model/KubernetesV2Application.java
@@ -28,7 +28,7 @@ public final class KubernetesV2Application implements Application {
   private final String name;
   private final Map<String, Set<String>> clusterNames;
 
-  public Map<String, String> getAttributes() {
+  @Override public Map<String, String> getAttributes() {
     return new ImmutableMap.Builder<String, String>().put("name", name).build();
   }
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesV2JobStatus.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/model/KubernetesV2JobStatus.java
@@ -60,6 +60,7 @@ public class KubernetesV2JobStatus implements JobStatus {
             job.getMetadata().getCreationTimestamp().toString(), "yyyy-MM-dd'T'HH:mm:ss");
   }
 
+  @Override
   public Map<String, String> getCompletionDetails() {
     Map<String, String> details = new HashMap<>();
     details.put("exitCode", this.exitCode != null ? this.exitCode.toString() : "");
@@ -69,6 +70,7 @@ public class KubernetesV2JobStatus implements JobStatus {
     return details;
   }
 
+  @Override
   public JobState getJobState() {
     V1JobStatus status = job.getStatus();
     if (status == null) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanUndoRollout.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanUndoRollout.java
@@ -21,7 +21,8 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 
 public interface CanUndoRollout extends CanRollout {
-  @Override KubernetesKind kind();
+  @Override
+  KubernetesKind kind();
 
   default void undoRollout(
       KubernetesCredentials credentials, String namespace, String name, int revision) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanUndoRollout.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanUndoRollout.java
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 
 public interface CanUndoRollout extends CanRollout {
-  KubernetesKind kind();
+  @Override KubernetesKind kind();
 
   default void undoRollout(
       KubernetesCredentials credentials, String namespace, String name, int revision) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java
@@ -51,6 +51,7 @@ public abstract class KubernetesHandler implements CanDeploy, CanDelete, CanPatc
 
   public abstract int deployPriority();
 
+  @Override
   @Nonnull
   public abstract KubernetesKind kind();
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperation.java
@@ -55,7 +55,8 @@ public class KubernetesRunJobOperation
     return TaskRepository.threadLocalTask.get();
   }
 
-  @Override public KubernetesRunJobDeploymentResult operate(List<KubernetesRunJobDeploymentResult> _unused) {
+  @Override
+  public KubernetesRunJobDeploymentResult operate(List<KubernetesRunJobDeploymentResult> _unused) {
     getTask().updateStatus(OP_NAME, "Running Kubernetes job...");
     KubernetesManifest jobSpec = this.description.getManifest();
     KubernetesKind kind = jobSpec.getKind();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperation.java
@@ -55,7 +55,7 @@ public class KubernetesRunJobOperation
     return TaskRepository.threadLocalTask.get();
   }
 
-  public KubernetesRunJobDeploymentResult operate(List<KubernetesRunJobDeploymentResult> _unused) {
+  @Override public KubernetesRunJobDeploymentResult operate(List<KubernetesRunJobDeploymentResult> _unused) {
     getTask().updateStatus(OP_NAME, "Running Kubernetes job...");
     KubernetesManifest jobSpec = this.description.getManifest();
     KubernetesKind kind = jobSpec.getKind();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesV2JobProvider.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/provider/view/KubernetesV2JobProvider.java
@@ -54,6 +54,7 @@ public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatu
     this.manifestProvider = manifestProvider;
   }
 
+  @Override
   @Nullable
   public KubernetesV2JobStatus collectJob(String account, String location, String id) {
     Optional<V1Job> optionalJob = getKubernetesJob(account, location, id);
@@ -84,6 +85,7 @@ public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatu
     return jobStatus;
   }
 
+  @Override
   @Nullable
   public Map<String, Object> getFileContents(
       String account, String location, String id, String containerName) {
@@ -104,6 +106,7 @@ public class KubernetesV2JobProvider implements JobProvider<KubernetesV2JobStatu
         .orElse(null);
   }
 
+  @Override
   public void cancelJob(String account, String location, String id) {
     throw new NotImplementedException(
         "cancelJob is not implemented for the V2 Kubernetes provider");

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -212,7 +212,8 @@ public class KubernetesCredentials {
               .build(key -> supplier.get());
     }
 
-    @Override public T get() {
+    @Override
+    public T get() {
       return cache.get(CACHE_KEY);
     }
 

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -212,7 +212,7 @@ public class KubernetesCredentials {
               .build(key -> supplier.get());
     }
 
-    public T get() {
+    @Override public T get() {
       return cache.get(CACHE_KEY);
     }
 


### PR DESCRIPTION
We cannot yet enable the error-prone warnings as there are a few dozen classes with Lombok-generated getter overrides that I'll handle in a followup PR.