### PR TITLE
fix(kubernetes): Fix ImmutableEnumChecker and rawtypes warnings

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -21,7 +21,6 @@ tasks.withType(JavaCompile) {
 
     // Temporarily suppressed warnings. These are here only while we fix or
     // suppress the warnings in these categories.
-    '-Xlint:-rawtypes',
     '-Xlint:-unchecked',
   ]
 

--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -30,7 +30,6 @@ tasks.withType(JavaCompile) {
   options.errorprone.disable(
     "DefaultCharset",
     "EmptyCatch",
-    "ImmutableEnumChecker",
     "MissingOverride",
   )
 }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesV2ProviderSynchronizable.java
@@ -102,7 +102,7 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
               KubernetesNamedAccountCredentials credentials =
                   new KubernetesNamedAccountCredentials(managedAccount, credentialFactory);
 
-              AccountCredentials existingCredentials =
+              AccountCredentials<?> existingCredentials =
                   accountCredentialsRepository.getOne(managedAccount.getName());
 
               if (existingCredentials == null || !existingCredentials.equals(credentials)) {
@@ -146,9 +146,11 @@ public class KubernetesV2ProviderSynchronizable implements CredentialsInitialize
   private List<String> getDeletedAccountNames() {
     List<String> existingNames =
         accountCredentialsRepository.getAll().stream()
-            .filter(
-                (AccountCredentials c) -> KubernetesCloudProvider.ID.equals(c.getCloudProvider()))
-            .map(AccountCredentials::getName)
+            .filter(c -> KubernetesCloudProvider.ID.equals(c.getCloudProvider()))
+            // Using a lambda here causes a warning about raw types; the real fix would be to have
+            // the credentials repository return AccountCredentials<?> instead of an
+            // AccountCredentials.
+            .map(c -> c.getName())
             .collect(Collectors.toList());
 
     Set<String> newNames =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2OnDemandCachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2OnDemandCachingAgent.java
@@ -328,6 +328,9 @@ public abstract class KubernetesV2OnDemandCachingAgent extends KubernetesV2Cachi
   }
 
   @Override
+  // The raw Map is required by the method we're overriding; suppress the warning until the
+  // interface adds type bounds.
+  @SuppressWarnings("rawtypes")
   public Collection<Map> pendingOnDemandRequests(ProviderCache providerCache) {
     if (!handlePendingOnDemandRequests()) {
       return ImmutableList.of();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestAnnotater.java
@@ -89,7 +89,7 @@ public class KubernetesManifestAnnotater {
     return getAnnotation(annotations, key, typeReference, null);
   }
 
-  private static boolean stringTypeReference(TypeReference typeReference) {
+  private static boolean stringTypeReference(TypeReference<?> typeReference) {
     if (typeReference.getType() == null || typeReference.getType().getTypeName() == null) {
       log.warn("Malformed type reference {}", typeReference);
       return false;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesPodHandler.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesPodHandler.java
@@ -91,8 +91,8 @@ public class KubernetesPodHandler extends KubernetesHandler {
     Failed(true, "Pod has failed"),
     Unknown(true, "Pod phase is unknown");
 
-    @Getter private String message;
-    @Getter private boolean unstable;
+    @Getter private final String message;
+    @Getter private final boolean unstable;
 
     PodPhase(boolean unstable, String message) {
       this.message = message;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperation.java
@@ -109,7 +109,7 @@ public class KubernetesRunJobOperation
 
     KubernetesDeployManifestOperation deployManifestOperation =
         new KubernetesDeployManifestOperation(deployManifestDescription, provider);
-    OperationResult operationResult = deployManifestOperation.operate(new ArrayList());
+    OperationResult operationResult = deployManifestOperation.operate(new ArrayList<>());
     KubernetesRunJobDeploymentResult deploymentResult =
         new KubernetesRunJobDeploymentResult(operationResult);
     Map<String, List<String>> deployedNames = deploymentResult.getDeployedNamesByLocation();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtil.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/validator/KubernetesValidationUtil.java
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentia
 import com.netflix.spinnaker.clouddriver.security.AccountCredentials;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
@@ -65,24 +64,6 @@ public class KubernetesValidationUtil {
     return true;
   }
 
-  public boolean validateSizeEquals(String attribute, Collection items, int size) {
-    if (items.size() != size) {
-      reject("size!=" + size, attribute);
-      return false;
-    }
-
-    return true;
-  }
-
-  private boolean validateNotEmpty(String attribute, String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      reject("empty", attribute);
-      return false;
-    }
-
-    return true;
-  }
-
   public boolean validateCredentials(
       AccountCredentialsProvider provider, String accountName, KubernetesManifest manifest) {
     KubernetesKind kind = manifest.getKind();
@@ -96,7 +77,8 @@ public class KubernetesValidationUtil {
       KubernetesKind kind,
       String namespace) {
     log.info("Validating credentials for {} {} {}", accountName, kind, namespace);
-    if (!validateNotEmpty("account", accountName)) {
+    if (Strings.isNullOrEmpty(accountName)) {
+      reject("empty", "account");
       return false;
     }
 
@@ -104,7 +86,7 @@ public class KubernetesValidationUtil {
       return true;
     }
 
-    AccountCredentials credentials = provider.getCredentials(accountName);
+    AccountCredentials<?> credentials = provider.getCredentials(accountName);
     if (credentials == null) {
       reject("notFound", "account");
       return false;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicatorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicatorTest.java
@@ -167,16 +167,16 @@ final class KubernetesHealthIndicatorTest {
     return managedAccount;
   }
 
-  private static AccountCredentials nonKubernetesAccount(String name) {
-    AccountCredentials credentials = mock(AccountCredentials.class);
+  private static AccountCredentials<?> nonKubernetesAccount(String name) {
+    AccountCredentials<?> credentials = mock(AccountCredentials.class);
     when(credentials.getName()).thenReturn(name);
     return credentials;
   }
 
   private static AccountCredentialsProvider stubAccountCredentialsProvider(
-      Iterable<AccountCredentials> accounts) {
+      Iterable<AccountCredentials<?>> accounts) {
     AccountCredentialsRepository accountRepository = new MapBackedAccountCredentialsRepository();
-    for (AccountCredentials account : accounts) {
+    for (AccountCredentials<?> account : accounts) {
       accountRepository.save(account.getName(), account);
     }
     return new DefaultAccountCredentialsProvider(accountRepository);


### PR DESCRIPTION
* fix(kubernetes): Make enum fields final

  [ImmutableEnumChecker] enums should be immutable: 'PodPhase' has non-final field 'message'.

* fix(kubernetes): Fix use of raw types and enable warning

  I suppressed one warning because the interface requires using a raw type.

  Also the AccountCredentialsRepository interface returns raw types, which causes one issue where we try to directly use a lambda on the stream of results. I updated that to not use a lambda (which I think implicitly implies (AccountCredentials<?> c) -> c.getName() avoiding the warning, but we should also consider fixing AccountCredentials itself.