### PR TITLE
chore(aws): Inject objectmapper in CredentialsLoader

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.security
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsLoader
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
@@ -50,8 +51,9 @@ class AmazonCredentialsInitializer {
   @ConditionalOnMissingBean(CredentialsLoader.class)
   CredentialsLoader<? extends NetflixAmazonCredentials> credentialsLoader(AWSCredentialsProvider awsCredentialsProvider,
                                                                           AmazonClientProvider amazonClientProvider,
+                                                                          ObjectMapper objectMapper,
                                                                           Class<? extends NetflixAmazonCredentials> credentialsType) {
-    new CredentialsLoader<? extends NetflixAmazonCredentials>(awsCredentialsProvider, amazonClientProvider, credentialsType)
+    new CredentialsLoader<? extends NetflixAmazonCredentials>(awsCredentialsProvider, amazonClientProvider, objectMapper, credentialsType)
   }
 
   @Bean

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoader.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoader.java
@@ -46,10 +46,12 @@ public class CredentialsLoader<T extends AmazonCredentials> {
   public CredentialsLoader(
       AWSCredentialsProvider credentialsProvider,
       AmazonClientProvider amazonClientProvider,
+      ObjectMapper objectMapper,
       Class<T> credentialsType) {
     this(
         credentialsProvider,
         amazonClientProvider,
+        objectMapper,
         credentialsType,
         Collections.<String, String>emptyMap());
   }
@@ -57,11 +59,13 @@ public class CredentialsLoader<T extends AmazonCredentials> {
   public CredentialsLoader(
       AWSCredentialsProvider credentialsProvider,
       AmazonClientProvider amazonClientProvider,
+      ObjectMapper objectMapper,
       Class<T> credentialsType,
       Map<String, String> templateValues) {
     this(
         credentialsProvider,
         new DefaultAWSAccountInfoLookup(credentialsProvider, amazonClientProvider),
+        objectMapper,
         credentialsType,
         templateValues);
   }
@@ -69,10 +73,12 @@ public class CredentialsLoader<T extends AmazonCredentials> {
   public CredentialsLoader(
       AWSCredentialsProvider credentialsProvider,
       AWSAccountInfoLookup awsAccountInfoLookup,
-      Class<T> credentialsType) {
+      Class<T> credentialsType,
+      ObjectMapper objectMapper) {
     this(
         credentialsProvider,
         awsAccountInfoLookup,
+        objectMapper,
         credentialsType,
         Collections.<String, String>emptyMap());
   }
@@ -80,12 +86,13 @@ public class CredentialsLoader<T extends AmazonCredentials> {
   public CredentialsLoader(
       AWSCredentialsProvider credentialsProvider,
       AWSAccountInfoLookup awsAccountInfoLookup,
+      ObjectMapper objectMapper,
       Class<T> credentialsType,
       Map<String, String> templateValues) {
     this.credentialsProvider = Objects.requireNonNull(credentialsProvider, "credentialsProvider");
     this.awsAccountInfoLookup = awsAccountInfoLookup;
     this.templateValues = templateValues;
-    this.objectMapper = new ObjectMapper();
+    this.objectMapper = objectMapper;
     this.credentialTranslator = findTranslator(credentialsType, this.objectMapper);
   }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoaderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/security/config/CredentialsLoaderSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.aws.security.config
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.aws.security.AWSAccountInfoLookup
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.security.AssumeRoleAmazonCredentials
@@ -27,6 +28,7 @@ import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig.R
 import spock.lang.Specification
 
 class CredentialsLoaderSpec extends Specification {
+    def objectMapper = new ObjectMapper();
 
     def 'basic test with defaults'() {
         setup:
@@ -47,7 +49,7 @@ class CredentialsLoaderSpec extends Specification {
         )
         AWSCredentialsProvider provider = Mock(AWSCredentialsProvider)
         AWSAccountInfoLookup lookup = Mock(AWSAccountInfoLookup)
-        CredentialsLoader<AmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, AmazonCredentials)
+        CredentialsLoader<AmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, AmazonCredentials, objectMapper)
 
         when:
         List<AmazonCredentials> creds = ci.load(config)
@@ -80,7 +82,7 @@ class CredentialsLoaderSpec extends Specification {
         def config = new CredentialsConfig(accounts: [new Account(name: 'default')])
         AWSCredentialsProvider provider = Mock(AWSCredentialsProvider)
         AWSAccountInfoLookup lookup = Mock(AWSAccountInfoLookup)
-        def ci = new CredentialsLoader<AmazonCredentials>(provider, lookup, AmazonCredentials)
+        def ci = new CredentialsLoader<AmazonCredentials>(provider, lookup, AmazonCredentials, objectMapper)
 
         when:
         List<AmazonCredentials> creds = ci.load(config)
@@ -106,7 +108,7 @@ class CredentialsLoaderSpec extends Specification {
         def config = new CredentialsConfig(defaultRegions: [new Region(name: 'us-east-1'), new Region(name: 'us-west-2')], accounts: [new Account(name: 'default', accountId: 1), new Account(name: 'other', accountId: 2)])
         AWSCredentialsProvider provider = Mock(AWSCredentialsProvider)
         AWSAccountInfoLookup lookup = Mock(AWSAccountInfoLookup)
-        CredentialsLoader<AmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, AmazonCredentials)
+        CredentialsLoader<AmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, AmazonCredentials, objectMapper)
 
         when:
         List<AmazonCredentials> creds = ci.load(config)
@@ -131,7 +133,7 @@ class CredentialsLoaderSpec extends Specification {
                                 regions: [ new Region(name: 'us-west-2')])])
         AWSCredentialsProvider provider = Mock(AWSCredentialsProvider)
         AWSAccountInfoLookup lookup = Mock(AWSAccountInfoLookup)
-        CredentialsLoader<AmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, AmazonCredentials)
+        CredentialsLoader<AmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, AmazonCredentials, objectMapper)
 
         when:
         List<AmazonCredentials> creds = ci.load(config)
@@ -178,7 +180,7 @@ class CredentialsLoaderSpec extends Specification {
         )
         AWSCredentialsProvider provider = Mock(AWSCredentialsProvider)
         AWSAccountInfoLookup lookup = Mock(AWSAccountInfoLookup)
-        CredentialsLoader<NetflixAmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, NetflixAmazonCredentials)
+        CredentialsLoader<NetflixAmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, NetflixAmazonCredentials, objectMapper)
 
         when:
         List<NetflixAmazonCredentials> creds = ci.load(config)
@@ -213,7 +215,7 @@ class CredentialsLoaderSpec extends Specification {
         setup:
         AWSCredentialsProvider provider = Mock(AWSCredentialsProvider)
         AWSAccountInfoLookup lookup = Mock(AWSAccountInfoLookup)
-        CredentialsLoader<NetflixAmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, NetflixAmazonCredentials)
+        CredentialsLoader<NetflixAmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, NetflixAmazonCredentials, objectMapper)
 
         when:
         NetflixAmazonCredentials cred = ci.load('default')
@@ -238,7 +240,7 @@ class CredentialsLoaderSpec extends Specification {
                 accounts: [new Account(name: 'gonnaFail')])
         AWSCredentialsProvider provider = Mock(AWSCredentialsProvider)
         AWSAccountInfoLookup lookup = Mock(AWSAccountInfoLookup)
-        CredentialsLoader<AssumeRoleAmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, AssumeRoleAmazonCredentials)
+        CredentialsLoader<AssumeRoleAmazonCredentials> ci = new CredentialsLoader<>(provider, lookup, AssumeRoleAmazonCredentials, objectMapper)
 
         when:
         ci.load(config)


### PR DESCRIPTION
- Updated to use the same objectMapper used elsewhere.