### PR TITLE
fix(kubernetes): only workload types have cluster relationships

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverter.java
@@ -67,9 +67,13 @@ public class KubernetesCacheDataConverter {
   @Getter private static final List<KubernetesKind> stickyKinds = Arrays.asList(SERVICE, POD);
 
   @Getter
-  private static final ImmutableList<KubernetesKind> clusterRelationshipKinds =
+  private static final ImmutableList<KubernetesKind> logicalRelationshipKinds =
       ImmutableList.of(
           DAEMON_SET, DEPLOYMENT, INGRESS, NETWORK_POLICY, REPLICA_SET, SERVICE, STATEFUL_SET);
+
+  @Getter
+  private static final ImmutableList<KubernetesKind> clusterRelationshipKinds =
+      ImmutableList.of(DAEMON_SET, DEPLOYMENT, REPLICA_SET, STATEFUL_SET);
 
   @NonnullByDefault
   public static CacheData mergeCacheData(CacheData current, CacheData added) {
@@ -129,8 +133,9 @@ public class KubernetesCacheDataConverter {
     Keys.CacheKey key = new Keys.InfrastructureCacheKey(kind, account, namespace, name);
     kubernetesCacheData.addItem(key, attributes);
 
-    if (hasClusterRelationship(kind) && !Strings.isNullOrEmpty(moniker.getApp())) {
-      addLogicalRelationships(kubernetesCacheData, key, account, moniker);
+    if (hasLogicalRelationship(kind) && !Strings.isNullOrEmpty(moniker.getApp())) {
+      addLogicalRelationships(
+          kubernetesCacheData, key, account, moniker, hasClusterRelationship(kind));
     }
     kubernetesCacheData.addRelationships(
         key, ownerReferenceRelationships(account, namespace, manifest.getOwnerReferences()));
@@ -159,13 +164,14 @@ public class KubernetesCacheDataConverter {
       KubernetesCacheData kubernetesCacheData,
       Keys.CacheKey infrastructureKey,
       String account,
-      Moniker moniker) {
+      Moniker moniker,
+      boolean hasClusterRelationship) {
     String application = moniker.getApp();
     Keys.CacheKey applicationKey = new Keys.ApplicationCacheKey(application);
     kubernetesCacheData.addRelationship(infrastructureKey, applicationKey);
 
     String cluster = moniker.getCluster();
-    if (!Strings.isNullOrEmpty(cluster)) {
+    if (hasClusterRelationship && !Strings.isNullOrEmpty(cluster)) {
       CacheKey clusterKey = new ClusterCacheKey(account, application, cluster);
       kubernetesCacheData.addRelationship(infrastructureKey, clusterKey);
       kubernetesCacheData.addRelationship(applicationKey, clusterKey);
@@ -212,6 +218,10 @@ public class KubernetesCacheDataConverter {
 
   private static int relationshipCount(CacheData data) {
     return data.getRelationships().values().stream().mapToInt(Collection::size).sum();
+  }
+
+  private static boolean hasLogicalRelationship(KubernetesKind kind) {
+    return logicalRelationshipKinds.contains(kind);
   }
 
   private static boolean hasClusterRelationship(KubernetesKind kind) {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2CachingAgent.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesV2CachingAgent.java
@@ -225,7 +225,7 @@ public abstract class KubernetesV2CachingAgent
                 KubernetesCacheDataConverter.convertAsResource(
                     kubernetesCacheData,
                     accountName,
-                    credentials.getKindProperties(rs.getKind()),
+                    credentials.getKubernetesSpinnakerKindMap(),
                     credentials.getNamer(),
                     rs,
                     relationships.getOrDefault(rs, ImmutableList.of()));

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKindProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKindProperties.java
@@ -30,62 +30,58 @@ import lombok.Getter;
 public class KubernetesKindProperties {
   public static List<KubernetesKindProperties> getGlobalKindProperties() {
     return ImmutableList.of(
-        new KubernetesKindProperties(KubernetesKind.API_SERVICE, false, false),
-        new KubernetesKindProperties(KubernetesKind.CLUSTER_ROLE, false, false),
-        new KubernetesKindProperties(KubernetesKind.CLUSTER_ROLE_BINDING, false, false),
-        new KubernetesKindProperties(KubernetesKind.CONFIG_MAP, true, false),
-        new KubernetesKindProperties(KubernetesKind.CONTROLLER_REVISION, true, false),
-        new KubernetesKindProperties(KubernetesKind.CUSTOM_RESOURCE_DEFINITION, false, false),
-        new KubernetesKindProperties(KubernetesKind.CRON_JOB, true, false),
-        new KubernetesKindProperties(KubernetesKind.DAEMON_SET, true, true),
-        new KubernetesKindProperties(KubernetesKind.DEPLOYMENT, true, true),
-        new KubernetesKindProperties(KubernetesKind.EVENT, true, false),
-        new KubernetesKindProperties(KubernetesKind.HORIZONTAL_POD_AUTOSCALER, true, false),
-        new KubernetesKindProperties(KubernetesKind.INGRESS, true, true),
-        new KubernetesKindProperties(KubernetesKind.JOB, true, false),
-        new KubernetesKindProperties(KubernetesKind.LIMIT_RANGE, true, false),
-        new KubernetesKindProperties(KubernetesKind.MUTATING_WEBHOOK_CONFIGURATION, false, false),
-        new KubernetesKindProperties(KubernetesKind.NAMESPACE, false, false),
-        new KubernetesKindProperties(KubernetesKind.NETWORK_POLICY, true, true),
-        new KubernetesKindProperties(KubernetesKind.PERSISTENT_VOLUME, false, false),
-        new KubernetesKindProperties(KubernetesKind.PERSISTENT_VOLUME_CLAIM, true, false),
-        new KubernetesKindProperties(KubernetesKind.POD, true, false),
-        new KubernetesKindProperties(KubernetesKind.POD_PRESET, true, false),
-        new KubernetesKindProperties(KubernetesKind.POD_SECURITY_POLICY, false, false),
-        new KubernetesKindProperties(KubernetesKind.POD_DISRUPTION_BUDGET, true, false),
-        new KubernetesKindProperties(KubernetesKind.REPLICA_SET, true, true),
-        new KubernetesKindProperties(KubernetesKind.ROLE, true, false),
-        new KubernetesKindProperties(KubernetesKind.ROLE_BINDING, true, false),
-        new KubernetesKindProperties(KubernetesKind.SECRET, true, false),
-        new KubernetesKindProperties(KubernetesKind.SERVICE, true, true),
-        new KubernetesKindProperties(KubernetesKind.SERVICE_ACCOUNT, true, false),
-        new KubernetesKindProperties(KubernetesKind.STATEFUL_SET, true, true),
-        new KubernetesKindProperties(KubernetesKind.STORAGE_CLASS, false, false),
-        new KubernetesKindProperties(KubernetesKind.VALIDATING_WEBHOOK_CONFIGURATION, false, false),
-        new KubernetesKindProperties(KubernetesKind.NONE, true, false));
+        new KubernetesKindProperties(KubernetesKind.API_SERVICE, false),
+        new KubernetesKindProperties(KubernetesKind.CLUSTER_ROLE, false),
+        new KubernetesKindProperties(KubernetesKind.CLUSTER_ROLE_BINDING, false),
+        new KubernetesKindProperties(KubernetesKind.CONFIG_MAP, true),
+        new KubernetesKindProperties(KubernetesKind.CONTROLLER_REVISION, true),
+        new KubernetesKindProperties(KubernetesKind.CUSTOM_RESOURCE_DEFINITION, false),
+        new KubernetesKindProperties(KubernetesKind.CRON_JOB, true),
+        new KubernetesKindProperties(KubernetesKind.DAEMON_SET, true),
+        new KubernetesKindProperties(KubernetesKind.DEPLOYMENT, true),
+        new KubernetesKindProperties(KubernetesKind.EVENT, true),
+        new KubernetesKindProperties(KubernetesKind.HORIZONTAL_POD_AUTOSCALER, true),
+        new KubernetesKindProperties(KubernetesKind.INGRESS, true),
+        new KubernetesKindProperties(KubernetesKind.JOB, true),
+        new KubernetesKindProperties(KubernetesKind.LIMIT_RANGE, true),
+        new KubernetesKindProperties(KubernetesKind.MUTATING_WEBHOOK_CONFIGURATION, false),
+        new KubernetesKindProperties(KubernetesKind.NAMESPACE, false),
+        new KubernetesKindProperties(KubernetesKind.NETWORK_POLICY, true),
+        new KubernetesKindProperties(KubernetesKind.PERSISTENT_VOLUME, false),
+        new KubernetesKindProperties(KubernetesKind.PERSISTENT_VOLUME_CLAIM, true),
+        new KubernetesKindProperties(KubernetesKind.POD, true),
+        new KubernetesKindProperties(KubernetesKind.POD_PRESET, true),
+        new KubernetesKindProperties(KubernetesKind.POD_SECURITY_POLICY, false),
+        new KubernetesKindProperties(KubernetesKind.POD_DISRUPTION_BUDGET, true),
+        new KubernetesKindProperties(KubernetesKind.REPLICA_SET, true),
+        new KubernetesKindProperties(KubernetesKind.ROLE, true),
+        new KubernetesKindProperties(KubernetesKind.ROLE_BINDING, true),
+        new KubernetesKindProperties(KubernetesKind.SECRET, true),
+        new KubernetesKindProperties(KubernetesKind.SERVICE, true),
+        new KubernetesKindProperties(KubernetesKind.SERVICE_ACCOUNT, true),
+        new KubernetesKindProperties(KubernetesKind.STATEFUL_SET, true),
+        new KubernetesKindProperties(KubernetesKind.STORAGE_CLASS, false),
+        new KubernetesKindProperties(KubernetesKind.VALIDATING_WEBHOOK_CONFIGURATION, false),
+        new KubernetesKindProperties(KubernetesKind.NONE, true));
   }
 
   @Nonnull @Getter private final KubernetesKind kubernetesKind;
   @Getter private final boolean isNamespaced;
-  // generally reserved for workloads, can be read as "does this belong to a spinnaker cluster?"
-  private final boolean hasClusterRelationship;
 
-  private KubernetesKindProperties(
-      KubernetesKind kubernetesKind, boolean isNamespaced, boolean hasClusterRelationship) {
+  private KubernetesKindProperties(KubernetesKind kubernetesKind, boolean isNamespaced) {
     this.kubernetesKind = kubernetesKind;
     this.isNamespaced = isNamespaced;
-    this.hasClusterRelationship = hasClusterRelationship;
   }
 
   @Nonnull
   public static KubernetesKindProperties withDefaultProperties(KubernetesKind kubernetesKind) {
-    return new KubernetesKindProperties(kubernetesKind, true, false);
+    return new KubernetesKindProperties(kubernetesKind, true);
   }
 
   @Nonnull
   public static KubernetesKindProperties create(
       KubernetesKind kubernetesKind, boolean isNamespaced) {
-    return new KubernetesKindProperties(kubernetesKind, isNamespaced, false);
+    return new KubernetesKindProperties(kubernetesKind, isNamespaced);
   }
 
   @Nonnull
@@ -94,10 +90,6 @@ public class KubernetesKindProperties {
     return create(
         KubernetesKind.fromCustomResourceDefinition(crd),
         crd.getSpec().getScope().equalsIgnoreCase("namespaced"));
-  }
-
-  public boolean hasClusterRelationship() {
-    return this.hasClusterRelationship;
   }
 
   public ResourceScope getResourceScope() {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -125,7 +125,7 @@ public class KubernetesCredentials {
 
   @Getter private final ResourcePropertyRegistry resourcePropertyRegistry;
   private final KubernetesKindRegistry kindRegistry;
-  private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
+  @Getter private final KubernetesSpinnakerKindMap kubernetesSpinnakerKindMap;
   private final PermissionValidator permissionValidator;
   private final Supplier<ImmutableMap<KubernetesKind, KubernetesKindProperties>> crdSupplier =
       Suppliers.memoizeWithExpiration(this::crdSupplier, CRD_EXPIRY_SECONDS, TimeUnit.SECONDS);

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConvertSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConvertSpec.groovy
@@ -18,16 +18,19 @@
 package com.netflix.spinnaker.clouddriver.kubernetes.caching.agent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.cats.cache.CacheData
+import com.google.common.collect.ImmutableList
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider
 import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys
 import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesPodMetric
+import com.netflix.spinnaker.clouddriver.kubernetes.description.KubernetesSpinnakerKindMap
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind
-import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKindProperties
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifestAnnotater
 import com.netflix.spinnaker.clouddriver.kubernetes.names.KubernetesManifestNamer
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesDeploymentHandler
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesReplicaSetHandler
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesServiceHandler
 import com.netflix.spinnaker.clouddriver.names.NamerRegistry
 import com.netflix.spinnaker.moniker.Moniker
 import org.apache.commons.lang3.tuple.Pair
@@ -39,8 +42,6 @@ import spock.lang.Unroll
 class KubernetesCacheDataConvertSpec extends Specification {
   def mapper = new ObjectMapper()
   def yaml = new Yaml(new SafeConstructor())
-  def ACCOUNT = "my-account"
-  def NAMESPACE = "spinnaker"
 
   KubernetesManifest stringToManifest(String input) {
     return mapper.convertValue(yaml.load(input), KubernetesManifest.class)
@@ -76,7 +77,7 @@ metadata:
     KubernetesCacheDataConverter.convertAsResource(
       kubernetesCacheData,
       account,
-      KubernetesKindProperties.create(kind, true),
+      new KubernetesSpinnakerKindMap(ImmutableList.of(new KubernetesDeploymentHandler(), new KubernetesReplicaSetHandler(), new KubernetesServiceHandler())),
       new KubernetesManifestNamer(),
       manifest,
       [])

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKindPropertiesSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKindPropertiesSpec.groovy
@@ -35,7 +35,6 @@ class KubernetesKindPropertiesSpec extends Specification {
     then:
     properties.getKubernetesKind() == KubernetesKind.REPLICA_SET
     properties.isNamespaced()
-    !properties.hasClusterRelationship()
 
     when:
     properties = KubernetesKindProperties.create(KubernetesKind.REPLICA_SET, false)
@@ -43,7 +42,6 @@ class KubernetesKindPropertiesSpec extends Specification {
     then:
     properties.getKubernetesKind() == KubernetesKind.REPLICA_SET
     !properties.isNamespaced()
-    !properties.hasClusterRelationship()
   }
 
   def "sets default properties to the expected values"() {
@@ -52,7 +50,6 @@ class KubernetesKindPropertiesSpec extends Specification {
 
     then:
     properties.isNamespaced()
-    !properties.hasClusterRelationship()
   }
 
   def "returns expected results for built-in kinds"() {
@@ -68,11 +65,9 @@ class KubernetesKindPropertiesSpec extends Specification {
     then:
     replicaSetProperties.isPresent()
     replicaSetProperties.get().isNamespaced()
-    replicaSetProperties.get().hasClusterRelationship()
 
     namespaceProperties.isPresent()
     !namespaceProperties.get().isNamespaced()
-    !namespaceProperties.get().hasClusterRelationship()
   }
 
   @Unroll

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -182,24 +182,16 @@ final class KubernetesDataProviderIntegrationTest {
     assertThat(results).containsKey(ACCOUNT_NAME);
 
     Set<KubernetesV2Cluster> clusters = results.get(ACCOUNT_NAME);
-    assertThat(clusters).hasSize(4);
+    assertThat(clusters).hasSize(2);
 
-    // TODO(ezimanyi): I don't think it's correct that we are returning services/load balancers as
-    // clusters. I believe that they are just being ignored by deck, and should be removed from
-    // the result of this call (likely with performance benefits). In any case, as seen in the
-    // assertions below, these load balancer clusters are not well formed and don't map to any
-    // server groups.
     assertThat(clusters)
         .extracting(KubernetesV2Cluster::getName)
-        .containsExactlyInAnyOrder(
-            "service frontend", "deployment frontend", "service backendlb", "replicaSet backend");
+        .containsExactlyInAnyOrder("deployment frontend", "replicaSet backend");
 
     Map<String, KubernetesV2Cluster> clusterLookup =
         clusters.stream().collect(toImmutableMap(KubernetesV2Cluster::getName, c -> c));
 
-    assertFrontendServiceCluster(softly, clusterLookup.get("service frontend"));
     assertFrontendCluster(softly, clusterLookup.get("deployment frontend"), true);
-    assertBackendServiceCluster(softly, clusterLookup.get("service backendlb"));
     assertBackendCluster(softly, clusterLookup.get("replicaSet backend"), true);
   }
 
@@ -210,32 +202,30 @@ final class KubernetesDataProviderIntegrationTest {
     assertThat(results).containsKey(ACCOUNT_NAME);
 
     Set<KubernetesV2Cluster> clusters = results.get(ACCOUNT_NAME);
-    assertThat(clusters).hasSize(2);
+    assertThat(clusters).hasSize(1);
 
     assertThat(clusters)
         .extracting(KubernetesV2Cluster::getName)
-        .containsExactlyInAnyOrder("service backendlb", "replicaSet backend");
+        .containsExactlyInAnyOrder("replicaSet backend");
 
     Map<String, KubernetesV2Cluster> clusterLookup =
         clusters.stream().collect(toImmutableMap(KubernetesV2Cluster::getName, c -> c));
 
-    assertBackendServiceCluster(softly, clusterLookup.get("service backendlb"));
     assertBackendCluster(softly, clusterLookup.get("replicaSet backend"), true);
   }
 
   @Test
   void getClustersForApplicationAndAccount(SoftAssertions softly) {
     Set<KubernetesV2Cluster> clusters = clusterProvider.getClusters("backendapp", ACCOUNT_NAME);
-    assertThat(clusters).hasSize(2);
+    assertThat(clusters).hasSize(1);
 
     assertThat(clusters)
         .extracting(KubernetesV2Cluster::getName)
-        .containsExactlyInAnyOrder("service backendlb", "replicaSet backend");
+        .containsExactlyInAnyOrder("replicaSet backend");
 
     Map<String, KubernetesV2Cluster> clusterLookup =
         clusters.stream().collect(toImmutableMap(KubernetesV2Cluster::getName, c -> c));
 
-    assertBackendServiceCluster(softly, clusterLookup.get("service backendlb"));
     assertBackendCluster(softly, clusterLookup.get("replicaSet backend"), true);
   }
 
@@ -285,16 +275,15 @@ final class KubernetesDataProviderIntegrationTest {
     assertThat(results).containsKey(ACCOUNT_NAME);
 
     Set<KubernetesV2Cluster> clusters = results.get(ACCOUNT_NAME);
-    assertThat(clusters).hasSize(2);
+    assertThat(clusters).hasSize(1);
 
     assertThat(clusters)
         .extracting(KubernetesV2Cluster::getName)
-        .containsExactlyInAnyOrder("service backendlb", "replicaSet backend");
+        .containsExactlyInAnyOrder("replicaSet backend");
 
     Map<String, KubernetesV2Cluster> clusterLookup =
         clusters.stream().collect(toImmutableMap(KubernetesV2Cluster::getName, c -> c));
 
-    assertBackendServiceCluster(softly, clusterLookup.get("service backendlb"));
     assertBackendCluster(softly, clusterLookup.get("replicaSet backend"), false);
   }
 
@@ -628,18 +617,6 @@ final class KubernetesDataProviderIntegrationTest {
     return new KubernetesNamedAccountCredentials(managedAccount, credentialFactory);
   }
 
-  // This is documenting the current cluster that is returned representing a service, but we
-  // probably should not return a cluster for a service at all.
-  private void assertFrontendServiceCluster(SoftAssertions softly, KubernetesV2Cluster cluster) {
-    softly.assertThat(cluster.getMoniker().getApp()).isEqualTo("frontendapp");
-    softly.assertThat(cluster.getMoniker().getCluster()).isEqualTo("service frontend");
-    softly.assertThat(cluster.getType()).isEqualTo("kubernetes");
-    softly.assertThat(cluster.getAccountName()).isEqualTo(ACCOUNT_NAME);
-    softly.assertThat(cluster.getServerGroups()).isEmpty();
-    softly.assertThat(cluster.getLoadBalancers()).isEmpty();
-    softly.assertThat(cluster.getApplication()).isEqualTo("frontendapp");
-  }
-
   private void assertFrontendLoadBalancer(
       SoftAssertions softly, KubernetesV2LoadBalancer loadBalancer) {
     softly.assertThat(loadBalancer.getRegion()).isEqualTo("frontend-ns");
@@ -950,18 +927,6 @@ final class KubernetesDataProviderIntegrationTest {
     softly.assertThat(serverGroup.getRegion()).isEqualTo("frontend-ns");
   }
 
-  // This is documenting the current cluster that is returned representing a service, but we
-  // probably should not return a cluster for a service at all.
-  private void assertBackendServiceCluster(SoftAssertions softly, KubernetesV2Cluster cluster) {
-    softly.assertThat(cluster.getMoniker().getApp()).isEqualTo("backendapp");
-    softly.assertThat(cluster.getMoniker().getCluster()).isEqualTo("service backendlb");
-    softly.assertThat(cluster.getType()).isEqualTo("kubernetes");
-    softly.assertThat(cluster.getAccountName()).isEqualTo(ACCOUNT_NAME);
-    softly.assertThat(cluster.getServerGroups()).isEmpty();
-    softly.assertThat(cluster.getLoadBalancers()).isEmpty();
-    softly.assertThat(cluster.getApplication()).isEqualTo("backendapp");
-  }
-
   private void assertBackendLoadBalancer(
       SoftAssertions softly, KubernetesV2LoadBalancer loadBalancer) {
     softly.assertThat(loadBalancer.getRegion()).isEqualTo("backend-ns");
@@ -1175,9 +1140,7 @@ final class KubernetesDataProviderIntegrationTest {
     Set<String> clusterNames = application.getClusterNames().get(ACCOUNT_NAME);
     softly.assertThat(clusterNames).isNotNull();
     if (clusterNames != null) {
-      softly
-          .assertThat(clusterNames)
-          .containsExactlyInAnyOrder("deployment frontend", "service frontend");
+      softly.assertThat(clusterNames).containsExactlyInAnyOrder("deployment frontend");
     }
   }
 
@@ -1191,9 +1154,7 @@ final class KubernetesDataProviderIntegrationTest {
     Set<String> clusterNames = application.getClusterNames().get(ACCOUNT_NAME);
     softly.assertThat(clusterNames).isNotNull();
     if (clusterNames != null) {
-      softly
-          .assertThat(clusterNames)
-          .containsExactlyInAnyOrder("service backendlb", "replicaSet backend");
+      softly.assertThat(clusterNames).containsExactlyInAnyOrder("replicaSet backend");
     }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/spinnaker/spinnaker/issues/5985

* refactor(kubernetes): move hasClusterRelationship from KubernetesKindProperties to KubernetesCacheDataConverter 

  Moves logic determining whether to cache cluster relationships for a given kind to the only place it is needed. (Will also make next commits more readable.)

* fix(kubernetes): differentiate between logical and cluster relationships 

  Only kinds that map to Spinnaker server groups and server group managers are considered Spinnaker clusters, and should be differentiated between the other "logical" kinds surfaced in the Application UI as Spinnaker Load Balancers and Firewalls. Stop caching cluster relationships for non-cluster kinds, and update tests accordingly.

* refactor(kubernetes): make logical and cluster relationships agnostic to Kubernetes kind 

  We map Kubernetes kinds to Spinnaker kinds in order to surface them in the Application UI as Clusters, Load Balancers, and Firewalls. Looking ahead to when CRDs may be mappable to Spinnaker kinds as well, let's not keep a fragile list of Kubernetes kinds that have these Spinnaker-kind-specific relationships, and instead just check by Spinnaker kind.

  (This commit is not necessary to solve the problem this PR set out to solve, so if y'all think this actually makes it less clear or it's too cumbersome to pass around the SpinnakerKubernetesKindMap, happy to remove it from this PR!)
