### PR TITLE
fix(provider/gce): Fix NullPointerException when additional pathMatcher defined for InternalHttpLB

### DIFF
--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalHttpLoadBalancerCachingAgent.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/provider/agent/GoogleInternalHttpLoadBalancerCachingAgent.java
@@ -460,6 +460,8 @@ public class GoogleInternalHttpLoadBalancerCachingAgent
       if (urlMap.getPathMatchers() != null) {
         for (PathMatcher pathMatcher : urlMap.getPathMatchers()) {
           String pathMatchDefaultService = Utils.getLocalName(pathMatcher.getDefaultService());
+          List<PathRule> pathRules =
+              pathMatcher.getPathRules() != null ? pathMatcher.getPathRules() : new ArrayList<>();
           for (HostRule hostRule : urlMap.getHostRules()) {
             if (hostRule.getPathMatcher() != null
                 && hostRule.getPathMatcher().equals(pathMatcher.getName())) {
@@ -474,7 +476,7 @@ public class GoogleInternalHttpLoadBalancerCachingAgent
               gHostRule.setHostPatterns(hostRule.getHosts());
               gHostRule.setPathMatcher(gPathMatcher);
               List<GooglePathRule> collect =
-                  pathMatcher.getPathRules().stream()
+                  pathRules.stream()
                       .map(
                           pathRule -> {
                             GoogleBackendService service = new GoogleBackendService();
@@ -492,7 +494,7 @@ public class GoogleInternalHttpLoadBalancerCachingAgent
           }
 
           queuedServices.add(pathMatchDefaultService);
-          for (PathRule pathRule : pathMatcher.getPathRules()) {
+          for (PathRule pathRule : pathRules) {
             if (pathRule.getService() != null) {
               queuedServices.add(Utils.getLocalName(pathRule.getService()));
             }


### PR DESCRIPTION
spinnaker/spinnaker#6016

When additional pathMatcher is defined, `urlMap.getPathMatchers()` returns a list.
And default path matcher doesn't have any path rule then `pathMatcher.getPathRules()` returns null.