### PR TITLE
(fix) Parameterize hard-coded startingPosition field for lambda event sources

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/UpsertLambdaFunctionEventMappingDescription.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/UpsertLambdaFunctionEventMappingDescription.java
@@ -28,4 +28,5 @@ public class UpsertLambdaFunctionEventMappingDescription extends AbstractLambdaF
   Boolean enabled = false;
   String eventSourceArn = null;
   String uuid = null;
+  String startingPosition = null;
 }

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/UpsertLambdaEventSourceAtomicOperation.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/UpsertLambdaEventSourceAtomicOperation.java
@@ -82,7 +82,7 @@ public class UpsertLambdaEventSourceAtomicOperation
             .withFunctionName(cache.getFunctionArn())
             .withBatchSize(description.getBatchsize())
             .withEnabled(description.getEnabled())
-            .withStartingPosition("LATEST")
+            .withStartingPosition(description.getStartingPosition())
             .withEventSourceArn(description.getEventSourceArn());
 
     CreateEventSourceMappingResult result = client.createEventSourceMapping(request);


### PR DESCRIPTION
fix : Parameterize hard-coded startingPosition field for lambda event sources 