### PR TITLE
fix(kubernetes/artifacts): Update Clouddriver's artifact replacement logic to replace docker images even if the image specified in the manifest includes a tag.

### DIFF
--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.AccessLevel;
@@ -136,7 +137,7 @@ public final class Replacer {
   private static final Replacer DOCKER_IMAGE =
       builder()
           .path("$..spec.template.spec['containers', 'initContainers'].[?].image")
-          .replaceFilter(a -> filter(where("image").is(a.getName())))
+          .replaceFilter(a -> filter(where("image").regex(Pattern.compile(a.getName() + "(:.*)?"))))
           .nameFromReference(
               ref -> {
                 // @ can only show up in image references denoting a digest
@@ -162,7 +163,7 @@ public final class Replacer {
   private static final Replacer POD_DOCKER_IMAGE =
       builder()
           .path("$.spec.containers.[?].image")
-          .replaceFilter(a -> filter(where("image").is(a.getName())))
+          .replaceFilter(a -> filter(where("image").regex(Pattern.compile(a.getName() + "(:.*)?"))))
           .type(KubernetesArtifactType.DockerImage)
           .build();
   private static final Replacer CONFIG_MAP_VOLUME =

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java
@@ -116,6 +116,9 @@ public final class Replacer {
     return ctx -> {
       ValueNode node = ValueNode.toValueNode("@." + replacePath).asPathNode().evaluate(ctx);
       String value = node.asStringNode().getString();
+      if (!node.isStringNode()) {
+        return false;
+      }
       return nameFromReference.apply(value).equals(name);
     };
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java
@@ -115,10 +115,10 @@ public final class Replacer {
   private Predicate createReplaceFilterPredicate(String replacePath, String name) {
     return ctx -> {
       ValueNode node = ValueNode.toValueNode("@." + replacePath).asPathNode().evaluate(ctx);
-      String value = node.asStringNode().getString();
       if (!node.isStringNode()) {
         return false;
       }
+      String value = node.asStringNode().getString();
       return nameFromReference.apply(value).equals(name);
     };
   }

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/KubernetesDeployManifestOperation.java
@@ -96,8 +96,11 @@ public class KubernetesDeployManifestOperation implements AtomicOperation<Operat
     }
 
     List<Artifact> artifacts = new ArrayList<>();
-    artifacts.addAll(requiredArtifacts);
+    // Optional artifacts are intentionally added before required artifacts. This is to ensure that
+    // when artifact replacement occurs the required artifacts are not overwritten by optional
+    // artifacts.
     artifacts.addAll(optionalArtifacts);
+    artifacts.addAll(requiredArtifacts);
 
     Set<Artifact> boundArtifacts = new HashSet<>();
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java
@@ -179,12 +179,8 @@ final class ArtifactReplacerTest {
     assertThat(Iterables.getOnlyElement(result.getBoundArtifacts())).isEqualTo(inputArtifact);
   }
 
-  /**
-   * If there is already a tag on the image in the manifest, we currently don't replace it. We may
-   * want to change this behavior in the future, but this test is documenting the current behavior.
-   */
   @Test
-  void doesNotReplaceImageWithTag() {
+  void replacesDockerImageWithTag() {
     ArtifactReplacer artifactReplacer =
         new ArtifactReplacer(ImmutableList.of(Replacer.dockerImage()));
     KubernetesManifest deployment = getDeploymentWithContainer(getContainer("nginx:1.18.0"));
@@ -195,8 +191,9 @@ final class ArtifactReplacerTest {
         artifactReplacer.replaceAll(
             deployment, ImmutableList.of(inputArtifact), NAMESPACE, ACCOUNT);
 
-    assertThat(result.getManifest()).isEqualTo(deployment);
-    assertThat(result.getBoundArtifacts()).isEmpty();
+    assertThat(extractImage(result.getManifest())).contains("nginx:1.19.1");
+    assertThat(result.getBoundArtifacts()).hasSize(1);
+    assertThat(Iterables.getOnlyElement(result.getBoundArtifacts())).isEqualTo(inputArtifact);
   }
 
   /**


### PR DESCRIPTION
* fix(kubernetes/artifacts): Update Clouddriver's artifact replacement logic to replace docker images even if the image specified in the manifest includes a tag. 

  Previous implementation didn't allow overwriting a image in a manifest with a bound artifact if the input manifest had a tag on it. This was problematic when using helm since most helm charts have a tag.

  BREAKING CHANGE: Can no longer rely on Spinnaker ignoring any matching image artifacts available in the pipeline and using the tag specified in the manifest image.

* Use nameFromReference to extract the artifact name in the input manifest rather than using regex. 

* Use JsonPath in replace filter predicate. 

* Change artifact replacement in KubernetesDeployManifestOperation from replacing required then optional artifacts to replacing optional then required artifacts. This change is being done to prevent optional artifacts from replacing required artifacts. 