### PR TITLE
fix(cache): OnDemandCacheStatus no longer an inner enum

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/CacheController.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.clouddriver.controllers
 
 import com.netflix.spinnaker.cats.cache.AgentIntrospection
 import com.netflix.spinnaker.cats.cache.CacheIntrospectionStore
-import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
+import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheStatus
 import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.cache.OnDemandType
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
@@ -45,7 +45,7 @@ class CacheController {
     }?.handle(onDemandType, cloudProvider, data)
 
     def cacheStatus = onDemandCacheResult?.status
-    def httpStatus = (cacheStatus == OnDemandCacheUpdater.OnDemandCacheStatus.PENDING) ? HttpStatus.ACCEPTED : HttpStatus.OK
+    def httpStatus = (cacheStatus == OnDemandCacheStatus.PENDING) ? HttpStatus.ACCEPTED : HttpStatus.OK
 
     return new ResponseEntity(
       [


### PR DESCRIPTION
`OnDemandCacheStatus` was recently moved to its own class instead of being an inner enum of `OnDemandCacheUpdater`.

@robzienert this was caught by the soon-to-be-merged integration tests from https://github.com/spinnaker/clouddriver/pull/4827, so once those are merged we can catch these before reaching `master` :) 