### PR TITLE
chore(aws): add method sig to AmazonAccountSynchronizer

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonAccountsSynchronizer.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonAccountsSynchronizer.groovy
@@ -16,8 +16,16 @@
 
 package com.netflix.spinnaker.clouddriver.aws.security
 
+import com.netflix.spinnaker.cats.module.CatsModule
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsLoader
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
+
 interface AmazonAccountsSynchronizer {
 
-  List<? extends NetflixAmazonCredentials> synchronize
-
+  List<? extends NetflixAmazonCredentials> synchronize(
+    CredentialsLoader<? extends NetflixAmazonCredentials> credentialsLoader,
+    CredentialsConfig credentialsConfig, AccountCredentialsRepository accountCredentialsRepository,
+    DefaultAccountConfigurationProperties defaultAccountConfigurationProperties,
+    CatsModule catsModule)
 }


### PR DESCRIPTION
When mocking bean of type `AmazonAccountsSynchronizer` during integration tests, we need to mock the `synchronize(...)` call to avoid a `MissingMethodException` on app startup. However b/c there is no method defined on the interface which matches the [concrete implementation](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/DefaultAmazonAccountsSynchronizer.groovy#L29) called in [AmazonCredentialsInitializer](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.groovy#L71), the (Java) compiler complains with "error: cannot find symbol" if you try to mock it with the correct parameters. 

This change adds the full method signature invoked by `AmazonCredentialsInitializer.groovy` to the interface so we can avoid a  `MissingMethodException` and make the compiler happy when running integration tests written in Java. 

* NOTE: I don't know if adding an explicit method signature will break something in Groovy-land, but this method always seems to be called with this signature in `clouddriver-aws` so I don't see a downside to actually defining it?