### PR TITLE
feat(test): Add initial ECS integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -42,3 +42,5 @@ jobs:
     # Separating integration tests by provider allows to have separate logs
     - name: Kubernetes Provider Integration Tests
       run: ./gradlew --build-cache :clouddriver-kubernetes:integrationTest
+    - name: Amazon ECS Provider Integration Tests
+      run: ./gradlew --build-cache :clouddriver-ecs:integrationTest

--- a/clouddriver-ecs/clouddriver-ecs.gradle
+++ b/clouddriver-ecs/clouddriver-ecs.gradle
@@ -1,3 +1,17 @@
+sourceSets {
+  integration {
+    java.srcDirs = ["src/integration/java"]
+    resources.srcDirs = ["src/integration/resources"]
+    compileClasspath += main.output + test.output
+    runtimeClasspath += main.output + test.output
+  }
+}
+
+configurations {
+  integrationImplementation.extendsFrom testImplementation
+  integrationRuntime.extendsFrom testRuntime
+}
+
 dependencies {
   implementation project(":cats:cats-core")
   implementation project(":clouddriver-api")
@@ -37,4 +51,24 @@ dependencies {
   testImplementation "org.objenesis:objenesis"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
+
+  integrationImplementation project(":clouddriver-web")
+  integrationImplementation "org.springframework:spring-test"
+  integrationImplementation "org.testcontainers:mysql"
+  integrationImplementation "mysql:mysql-connector-java"
+  integrationImplementation ("io.rest-assured:rest-assured:4.0.0") {
+    exclude group: "org.codehaus.groovy", module: "groovy" // use kork's version
+  }
+}
+
+task integrationTest(type: Test) {
+  description = "Runs Amazon ECS provider integration tests."
+  group = 'verification'
+
+  environment "PROJECT_ROOT", project.rootDir.toString()
+  useJUnitPlatform()
+
+  testClassesDirs = sourceSets.integration.output.classesDirs
+  classpath = sourceSets.integration.runtimeClasspath
+  shouldRunAfter test
 }

--- a/clouddriver-ecs/clouddriver-ecs.gradle
+++ b/clouddriver-ecs/clouddriver-ecs.gradle
@@ -3,7 +3,6 @@ sourceSets {
     java.srcDirs = ["src/integration/java"]
     resources.srcDirs = ["src/integration/resources"]
     compileClasspath += main.output + test.output
-    runtimeClasspath += main.output + test.output
   }
 }
 

--- a/clouddriver-ecs/src/integration/README.md
+++ b/clouddriver-ecs/src/integration/README.md
@@ -1,0 +1,10 @@
+# Amazon ECS Integration tests
+
+Tests which exercise Amazon ECS controllers and atomic operations against a running `clouddriver` application.
+
+## Running the tests
+
+To manually run the gradle task for these tests:
+```bash
+$> ./gradlew :clouddriver-ecs:integrationTest
+```

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsSpec.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
+import com.netflix.spinnaker.cats.cache.CacheData;
+import com.netflix.spinnaker.cats.cache.DefaultCacheData;
+import com.netflix.spinnaker.cats.module.CatsModule;
+import com.netflix.spinnaker.clouddriver.Main;
+import com.netflix.spinnaker.clouddriver.aws.security.*;
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsLoader;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    classes = {Main.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"spring.config.location = classpath:clouddriver.yml"})
+public class EcsSpec {
+  protected static final String TEST_OPERATIONS_LOCATION =
+      "src/integration/resources/testoperations";
+  protected final String ECS_ACCOUNT_NAME = "ecs-account";
+  protected final String TEST_REGION = "us-west-2";
+
+  @Value("${ecs.enabled}")
+  Boolean ecsEnabled;
+
+  @Value("${aws.enabled}")
+  Boolean awsEnabled;
+
+  @LocalServerPort private int port;
+
+  @MockBean AmazonClientProvider mockAwsProvider;
+
+  @MockBean AmazonAccountsSynchronizer mockAccountsSyncer;
+
+  @BeforeEach
+  public void setup() {
+    NetflixAmazonCredentials mockAwsCreds = mock(NetflixAmazonCredentials.class);
+    when(mockAccountsSyncer.synchronize(
+            any(CredentialsLoader.class),
+            any(CredentialsConfig.class),
+            any(AccountCredentialsRepository.class),
+            any(DefaultAccountConfigurationProperties.class),
+            any(CatsModule.class)))
+        .thenReturn(Collections.singletonList(mockAwsCreds));
+  }
+
+  @DisplayName(".\n===\n" + "Assert AWS and ECS providers are enabled" + "\n===")
+  @Test
+  public void configTest() {
+    assertTrue(awsEnabled);
+    assertTrue(ecsEnabled);
+  }
+
+  protected String generateStringFromTestFile(String path) throws IOException {
+
+    return new String(Files.readAllBytes(Paths.get(TEST_OPERATIONS_LOCATION, path)));
+  }
+
+  protected String getTestUrl(String path) {
+    return "http://localhost:" + port + path;
+  }
+
+  protected DefaultCacheResult buildCacheResult(
+      Map<String, Object> attributes, String namespace, String key) {
+    Collection<CacheData> dataPoints = new LinkedList<>();
+    dataPoints.add(new DefaultCacheData(key, attributes, Collections.emptyMap()));
+
+    Map<String, Collection<CacheData>> dataMap = new HashMap<>();
+    dataMap.put(namespace, dataPoints);
+
+    return new DefaultCacheResult(dataMap);
+  }
+}

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/EcsSpec.java
@@ -86,7 +86,6 @@ public class EcsSpec {
   }
 
   protected String generateStringFromTestFile(String path) throws IOException {
-
     return new String(Files.readAllBytes(Paths.get(TEST_OPERATIONS_LOCATION, path)));
   }
 

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.ecs.EcsSpec;
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository;
+import io.restassured.http.ContentType;
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CreateServerGroupSpec extends EcsSpec {
+
+  @Autowired AccountCredentialsRepository accountCredentialsRepository;
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given description w/ inputs, EC2 launch type, and legacy target group fields, "
+          + "successfully submit createServerGroup operation"
+          + "\n===")
+  @Test
+  public void createServerGroupOperationTest() throws IOException { //
+    // given
+    String url = getTestUrl("/ecs/ops/createServerGroup");
+    String requestBody = generateStringFromTestFile("/createServerGroup-inputs-ec2.json");
+    setEcsAccountCreds();
+
+    // when
+    given()
+        .contentType(ContentType.JSON)
+        .body(requestBody)
+        .when()
+        .post(url)
+        // then
+        .then()
+        .statusCode(200)
+        .contentType(ContentType.JSON)
+        .body("id", notNullValue())
+        .body("resourceUri", containsString("/task/"));
+
+    // TODO: spy on resulting ecs:create-service call to verify well-formed request
+  }
+
+  private void setEcsAccountCreds() {
+    AmazonCredentials.AWSRegion testRegion = new AmazonCredentials.AWSRegion(TEST_REGION, null);
+
+    NetflixAmazonCredentials ecsCreds =
+        new NetflixAmazonCredentials(
+            ECS_ACCOUNT_NAME,
+            "test",
+            "test",
+            "123456789012",
+            null,
+            true,
+            Collections.singletonList(testRegion),
+            null,
+            null,
+            null,
+            null,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            false,
+            false,
+            false);
+
+    accountCredentialsRepository.save(ECS_ACCOUNT_NAME, ecsCreds);
+  }
+}

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/CreateServerGroupSpec.java
@@ -40,7 +40,13 @@ public class CreateServerGroupSpec extends EcsSpec {
           + "successfully submit createServerGroup operation"
           + "\n===")
   @Test
-  public void createServerGroupOperationTest() throws IOException { //
+  public void createServerGroupOperationTest() throws IOException {
+    /**
+     * TODO (allisaurus): Ideally this test would go further and actually assert that the resulting
+     * ecs:create-service call is formed as expected, but for now, it asserts that the given
+     * operation is correctly validated and submitted as a task.
+     */
+
     // given
     String url = getTestUrl("/ecs/ops/createServerGroup");
     String requestBody = generateStringFromTestFile("/createServerGroup-inputs-ec2.json");
@@ -58,8 +64,6 @@ public class CreateServerGroupSpec extends EcsSpec {
         .contentType(ContentType.JSON)
         .body("id", notNullValue())
         .body("resourceUri", containsString("/task/"));
-
-    // TODO: spy on resulting ecs:create-service call to verify well-formed request
   }
 
   private void setEcsAccountCreds() {

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
@@ -78,14 +78,15 @@ public class EcsControllersSpec extends EcsSpec {
     ProviderCache ecsCache = providerRegistry.getProviderCache(EcsProvider.NAME);
     String testSecretName = "tut/secret";
     String testNamespace = Keys.Namespace.SECRETS.ns;
+    String testSecretArn = "arn:aws:secretsmanager:region:aws_account_id:secret:tut/sevret-jiObOV";
+
     String secretKey = Keys.getClusterKey(ECS_ACCOUNT_NAME, TEST_REGION, testSecretName);
     String url = getTestUrl("/ecs/secrets");
     Map<String, Object> attributes = new HashMap<>();
     attributes.put("account", ECS_ACCOUNT_NAME);
     attributes.put("region", TEST_REGION);
-    attributes.put("secretName", "tut/secret");
-    attributes.put(
-        "secretArn", "arn:aws:secretsmanager:region:aws_account_id:secret:tut/sevret-jiObOV");
+    attributes.put("secretName", testSecretName);
+    attributes.put("secretArn", testSecretArn);
 
     DefaultCacheResult testResult = buildCacheResult(attributes, testNamespace, secretKey);
     ecsCache.addCacheResult("TestAgent", Collections.singletonList(testNamespace), testResult);
@@ -99,10 +100,8 @@ public class EcsControllersSpec extends EcsSpec {
     String responseStr = response.asString();
     assertTrue(responseStr.contains(ECS_ACCOUNT_NAME));
     assertTrue(responseStr.contains(TEST_REGION));
-    assertTrue(responseStr.contains("tut/secret"));
-    assertTrue(
-        responseStr.contains(
-            "arn:aws:secretsmanager:region:aws_account_id:secret:tut/sevret-jiObOV"));
+    assertTrue(responseStr.contains(testSecretName));
+    assertTrue(responseStr.contains(testSecretArn));
   }
 
   @DisplayName(
@@ -115,6 +114,9 @@ public class EcsControllersSpec extends EcsSpec {
     ProviderCache ecsCache = providerRegistry.getProviderCache(EcsProvider.NAME);
     String testRegistryId = "spinnaker-registry";
     String testNamespace = Keys.Namespace.SERVICE_DISCOVERY_REGISTRIES.ns;
+    String testSdServiceArn =
+        "arn:aws:servicediscovery:region:aws_account_id:service/srv-utcrh6wavdkggqtk";
+
     String serviceDiscoveryRegistryKey =
         Keys.getServiceDiscoveryRegistryKey(ECS_ACCOUNT_NAME, TEST_REGION, testRegistryId);
     String url = getTestUrl("/ecs/serviceDiscoveryRegistries");
@@ -123,9 +125,7 @@ public class EcsControllersSpec extends EcsSpec {
     attributes.put("region", TEST_REGION);
     attributes.put("serviceName", "spinnaker-demo");
     attributes.put("serviceId", "srv-v001");
-    attributes.put(
-        "serviceArn",
-        "arn:aws:servicediscovery:region:aws_account_id:service/srv-utcrh6wavdkggqtk");
+    attributes.put("serviceArn", testSdServiceArn);
 
     DefaultCacheResult testResult =
         buildCacheResult(attributes, testNamespace, serviceDiscoveryRegistryKey);
@@ -142,8 +142,6 @@ public class EcsControllersSpec extends EcsSpec {
     assertTrue(responseStr.contains(TEST_REGION));
     assertTrue(responseStr.contains("spinnaker-demo"));
     assertTrue(responseStr.contains("srv-v001"));
-    assertTrue(
-        responseStr.contains(
-            "arn:aws:servicediscovery:region:aws_account_id:service/srv-utcrh6wavdkggqtk"));
+    assertTrue(responseStr.contains(testSdServiceArn));
   }
 }

--- a/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
+++ b/clouddriver-ecs/src/integration/java/com/netflix/spinnaker/clouddriver/ecs/test/EcsControllersSpec.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.test;
+
+import static io.restassured.RestAssured.get;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.spinnaker.cats.agent.DefaultCacheResult;
+import com.netflix.spinnaker.cats.provider.ProviderCache;
+import com.netflix.spinnaker.cats.provider.ProviderRegistry;
+import com.netflix.spinnaker.clouddriver.ecs.EcsSpec;
+import com.netflix.spinnaker.clouddriver.ecs.cache.Keys;
+import com.netflix.spinnaker.clouddriver.ecs.provider.EcsProvider;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class EcsControllersSpec extends EcsSpec {
+
+  @Autowired private ProviderRegistry providerRegistry;
+
+  @DisplayName(".\n===\n" + "Given cached ECS cluster, retrieve it from /ecs/ecsClusters" + "\n===")
+  @Test
+  public void getEcsClustersTest() {
+    // given
+    ProviderCache ecsCache = providerRegistry.getProviderCache(EcsProvider.NAME);
+    String testClusterName = "integ-test-cluster";
+    String testNamespace = Keys.Namespace.ECS_CLUSTERS.ns;
+
+    String clusterKey = Keys.getClusterKey(ECS_ACCOUNT_NAME, TEST_REGION, testClusterName);
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("account", ECS_ACCOUNT_NAME);
+    attributes.put("region", TEST_REGION);
+    attributes.put("clusterArn", "arn:aws:ecs:::cluster/" + testClusterName);
+    attributes.put("clusterName", testClusterName);
+
+    DefaultCacheResult testResult = buildCacheResult(attributes, testNamespace, clusterKey);
+    ecsCache.addCacheResult("TestAgent", Collections.singletonList(testNamespace), testResult);
+
+    // when
+    String testUrl = getTestUrl("/ecs/ecsClusters");
+
+    Response response =
+        get(testUrl).then().statusCode(200).contentType(ContentType.JSON).extract().response();
+
+    // then
+    assertNotNull(response);
+    // TODO: serialize into expected return type to validate API contract hasn't changed
+    String responseStr = response.asString();
+    assertTrue(responseStr.contains(testClusterName));
+    assertTrue(responseStr.contains(ECS_ACCOUNT_NAME));
+    assertTrue(responseStr.contains(TEST_REGION));
+  }
+
+  @DisplayName(".\n===\n" + "Given cached ECS secret, retrieve it from /ecs/secrets" + "\n===")
+  @Test
+  public void getEcsSecretsTest() {
+    // given
+    ProviderCache ecsCache = providerRegistry.getProviderCache(EcsProvider.NAME);
+    String testSecretName = "tut/secret";
+    String testNamespace = Keys.Namespace.SECRETS.ns;
+    String secretKey = Keys.getClusterKey(ECS_ACCOUNT_NAME, TEST_REGION, testSecretName);
+    String url = getTestUrl("/ecs/secrets");
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("account", ECS_ACCOUNT_NAME);
+    attributes.put("region", TEST_REGION);
+    attributes.put("secretName", "tut/secret");
+    attributes.put(
+        "secretArn", "arn:aws:secretsmanager:region:aws_account_id:secret:tut/sevret-jiObOV");
+
+    DefaultCacheResult testResult = buildCacheResult(attributes, testNamespace, secretKey);
+    ecsCache.addCacheResult("TestAgent", Collections.singletonList(testNamespace), testResult);
+
+    // when
+    Response response = get(url).then().contentType(ContentType.JSON).extract().response();
+
+    // then
+    assertNotNull(response);
+
+    String responseStr = response.asString();
+    assertTrue(responseStr.contains(ECS_ACCOUNT_NAME));
+    assertTrue(responseStr.contains(TEST_REGION));
+    assertTrue(responseStr.contains("tut/secret"));
+    assertTrue(
+        responseStr.contains(
+            "arn:aws:secretsmanager:region:aws_account_id:secret:tut/sevret-jiObOV"));
+  }
+
+  @DisplayName(
+      ".\n===\n"
+          + "Given cached service disc registry, retrieve it from /ecs/serviceDiscoveryRegistries"
+          + "\n===")
+  @Test
+  public void getServiceDiscoveryRegistriesTest() {
+    // given
+    ProviderCache ecsCache = providerRegistry.getProviderCache(EcsProvider.NAME);
+    String testRegistryId = "spinnaker-registry";
+    String testNamespace = Keys.Namespace.SERVICE_DISCOVERY_REGISTRIES.ns;
+    String serviceDiscoveryRegistryKey =
+        Keys.getServiceDiscoveryRegistryKey(ECS_ACCOUNT_NAME, TEST_REGION, testRegistryId);
+    String url = getTestUrl("/ecs/serviceDiscoveryRegistries");
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("account", ECS_ACCOUNT_NAME);
+    attributes.put("region", TEST_REGION);
+    attributes.put("serviceName", "spinnaker-demo");
+    attributes.put("serviceId", "srv-v001");
+    attributes.put(
+        "serviceArn",
+        "arn:aws:servicediscovery:region:aws_account_id:service/srv-utcrh6wavdkggqtk");
+
+    DefaultCacheResult testResult =
+        buildCacheResult(attributes, testNamespace, serviceDiscoveryRegistryKey);
+    ecsCache.addCacheResult("TestAgent", Collections.singletonList(testNamespace), testResult);
+
+    // when
+    Response response = get(url).then().contentType(ContentType.JSON).extract().response();
+
+    // then
+    assertNotNull(response);
+
+    String responseStr = response.asString();
+    assertTrue(responseStr.contains(ECS_ACCOUNT_NAME));
+    assertTrue(responseStr.contains(TEST_REGION));
+    assertTrue(responseStr.contains("spinnaker-demo"));
+    assertTrue(responseStr.contains("srv-v001"));
+    assertTrue(
+        responseStr.contains(
+            "arn:aws:servicediscovery:region:aws_account_id:service/srv-utcrh6wavdkggqtk"));
+  }
+}

--- a/clouddriver-ecs/src/integration/resources/clouddriver.yml
+++ b/clouddriver-ecs/src/integration/resources/clouddriver.yml
@@ -1,0 +1,63 @@
+spring:
+  application:
+    name: clouddriver
+
+aws:
+  enabled: true
+  primaryAccount: aws-account
+  accounts:
+    - name: aws-account
+      requiredGroupMembership: []
+      providerVersion: V1
+      permissions: {}
+      accountId: '123456789012'
+      regions:
+        - name: us-west-2
+      assumeRole: role/SpinnakerManaged
+  bakeryDefaults:
+    baseImages: []
+  defaultKeyPairTemplate: '{{name}}-keypair'
+  defaultRegions:
+    - name: us-west-2
+  defaults:
+    iamRole: BaseIAMRole
+ecs:
+  enabled: true
+  primaryAccount: ecs-account
+  accounts:
+    - name: ecs-account
+      providerVersion: V1
+      awsAccount: aws-account
+sql:
+  enabled: true
+  taskRepository:
+    enabled: true
+  cache:
+    enabled: true
+    readBatchSize: 500
+    writeBatchSize: 300
+  scheduler:
+    enabled: true
+  connectionPools:
+    default:
+      default: true
+      jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+    tasks:
+      jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+  migration:
+    jdbcUrl: jdbc:tc:mysql:5.7.22://somehostname:someport/clouddriver?user=root?password=&
+
+redis:
+  enabled: false
+  cache:
+    enabled: false
+  scheduler:
+    enabled: false
+  taskRepository:
+    enabled: false
+
+services:
+  fiat:
+    baseUrl: http://fiat.net
+  front50:
+    baseUrl: http://front50.net

--- a/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-inputs-ec2.json
+++ b/clouddriver-ecs/src/integration/resources/testoperations/createServerGroup-inputs-ec2.json
@@ -1,0 +1,27 @@
+{
+  "account": "ecs-account",
+  "application": "ecs",
+  "availabilityZones": {
+    "us-west-1": [
+      "us-west-1a",
+      "us-west-1c"
+    ]
+  },
+  "capacity": {
+    "desired": 1,
+    "max": 1,
+    "min": 1
+  },
+  "cloudProvider": "ecs",
+  "computeUnits": 256,
+  "containerPort": 80,
+  "credentials": "ecs-account",
+  "dockerImageAddress": "nginx",
+  "ecsClusterName": "spinnaker-deployment-cluster",
+  "launchType": "EC2",
+  "networkMode": "bridge",
+  "placementStrategySequence": [],
+  "reservedMemory": 512,
+  "stack": "integ-test-stack",
+  "targetGroup": "spin-ec2-instanceTG"
+}


### PR DESCRIPTION
Adds new `integration` sourceSet to `clouddriver-ecs`, which contains setup and initial test cases for Amazon ECS provider integration tests. Package structure builds off precedents set in https://github.com/spinnaker/clouddriver/pull/4827. 

Intention is to have these run during the ["Integration Tests"](https://github.com/spinnaker/clouddriver/blob/master/.github/workflows/pr.yml#L29) step of the PR approval workflow.
