### PR TITLE
fix(aws): Adjusting the interval for elastic ip and key pair caching

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonElasticIpCachingAgent.groovy
@@ -29,6 +29,9 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
+
+import java.util.concurrent.TimeUnit
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.ELASTIC_IPS
@@ -36,7 +39,9 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.ELASTIC
 import groovy.util.logging.Slf4j
 
 @Slf4j
-class AmazonElasticIpCachingAgent implements CachingAgent, AccountAware {
+class AmazonElasticIpCachingAgent implements CachingAgent, AccountAware, CustomScheduledAgent {
+  private static final long DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(5)
+  private static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5)
 
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
@@ -91,5 +96,15 @@ class AmazonElasticIpCachingAgent implements CachingAgent, AccountAware {
     }
     log.info("Caching ${data.size()} items in ${agentType}")
     new DefaultCacheResult([(ELASTIC_IPS.ns): data])
+  }
+
+  @Override
+  long getPollIntervalMillis() {
+    return DEFAULT_POLL_INTERVAL_MILLIS
+  }
+
+  @Override
+  long getTimeoutMillis() {
+    return DEFAULT_TIMEOUT_MILLIS
   }
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonKeyPairCachingAgent.groovy
@@ -29,6 +29,9 @@ import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.aws.cache.Keys
 import com.netflix.spinnaker.clouddriver.aws.provider.AwsInfrastructureProvider
+import com.netflix.spinnaker.clouddriver.cache.CustomScheduledAgent
+
+import java.util.concurrent.TimeUnit
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.KEY_PAIRS
@@ -36,7 +39,9 @@ import static com.netflix.spinnaker.clouddriver.aws.cache.Keys.Namespace.KEY_PAI
 import groovy.util.logging.Slf4j
 
 @Slf4j
-class AmazonKeyPairCachingAgent implements CachingAgent, AccountAware {
+class AmazonKeyPairCachingAgent implements CachingAgent, AccountAware, CustomScheduledAgent {
+  private static final long DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(5)
+  private static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5)
 
   final AmazonClientProvider amazonClientProvider
   final NetflixAmazonCredentials account
@@ -88,5 +93,15 @@ class AmazonKeyPairCachingAgent implements CachingAgent, AccountAware {
     }
     log.info("Caching ${data.size()} items in ${agentType}")
     new DefaultCacheResult([(KEY_PAIRS.ns): data])
+  }
+
+  @Override
+  long getPollIntervalMillis() {
+    return DEFAULT_POLL_INTERVAL_MILLIS
+  }
+
+  @Override
+  long getTimeoutMillis() {
+    return DEFAULT_TIMEOUT_MILLIS
   }
 }


### PR DESCRIPTION
These are lower priority agents and decreasing the interval may
play a little nicer with aws rate limits.
