### PR TITLE
fix(test): Changed cache refreshed check, precreated ns

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -1,5 +1,6 @@
 plugins {
   id("net.ltgt.errorprone") version "1.2.1"
+  id 'com.adarshr.test-logger' version '2.1.0'
 }
 
 tasks.compileGroovy.enabled = false
@@ -116,4 +117,12 @@ task integrationTest(type: Test) {
   testClassesDirs = sourceSets.integration.output.classesDirs
   classpath = sourceSets.integration.runtimeClasspath
   shouldRunAfter test
+
+  testlogger {
+    theme 'standard'
+    showStandardStreams true
+    showPassedStandardStreams false
+    showFailedStandardStreams true
+    showPassed false
+  }
 }

--- a/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
+++ b/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
@@ -9,6 +9,7 @@ kubernetes:
   primaryAccount: account1
   accounts:
     - name: account1
+      cacheIntervalSeconds: 10
       requiredGroupMembership: []
       providerVersion: V2
       permissions: {}
@@ -28,6 +29,7 @@ kubernetes:
       metrics: false
       kubeconfigFile: ${PROJECT_ROOT}/clouddriver-kubernetes/build/kubeconfigs/kubecfg-${account1_containername}.yml  # File is automatically created during initialization
     - name: account2
+      cacheIntervalSeconds: 30
       requiredGroupMembership: []
       providerVersion: V2
       permissions: {}


### PR DESCRIPTION
There have been some one-off failures in kubernetes integration tests: https://github.com/spinnaker/clouddriver/runs/1103123724?check_suite_focus=true
The above job was successful after a re-run.

Failure message:
```
===
Given a secret manifest
When sending deploy manifest request
  And sending force cache refresh request
  And waiting on manifest stable
Then secret is deployed with a version suffix name
=== FAILED
    org.opentest4j.AssertionFailedError: GET /cache/kubernetes/manifest did not returned processedTime > -1 for object "secret mysecret-v000" after 5 minutes
```

This PR introduces these changes:
* List filter code for the above request was rewritten from rest-assured jsonpath to plain java code
* More logging of relevant response fragments
* Test namespaces are created on startup, rather than on each test case. This allows the namespaces to be already available in the cache when the test cases start, as oposed of doing deployments to not-yet-cached namespaces
* A gradle plugin is added for printing better test reports: this allows to print stdout and stderr only for the failed tests instead of all tests, when run without the `--info` flag