### PR TITLE
fix(aws): Fetch launch template versions at once

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgent.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgent.java
@@ -58,6 +58,8 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
   private final ObjectMapper objectMapper;
   private final String region;
 
+  private static final String[] DEFAULT_VERSIONS = new String[] {"$Default", "$Latest"};
+
   private static final TypeReference<Map<String, Object>> ATTRIBUTES =
       new TypeReference<Map<String, Object>>() {};
   private static final Set<AgentDataType> types =
@@ -85,7 +87,7 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
     final AmazonEC2 ec2 = amazonClientProvider.getAmazonEC2(account, region);
     final List<LaunchTemplate> launchTemplates = getLaunchTemplates(ec2);
     final List<LaunchTemplateVersion> launchTemplateVersions =
-        getLaunchTemplateVersions(ec2, launchTemplates);
+        getLaunchTemplateVersions(ec2, DEFAULT_VERSIONS);
     final List<CacheData> cachedData = new ArrayList<>();
     for (LaunchTemplate launchTemplate : launchTemplates) {
       Set<LaunchTemplateVersion> versions =
@@ -147,24 +149,11 @@ public class AmazonLaunchTemplateCachingAgent implements CachingAgent, AccountAw
     return launchTemplates;
   }
 
-  /** Gets Launch template versions */
-  private List<LaunchTemplateVersion> getLaunchTemplateVersions(
-      AmazonEC2 ec2, List<LaunchTemplate> launchTemplates) {
-    final List<LaunchTemplateVersion> launchTemplateVersions = new ArrayList<>();
-    for (LaunchTemplate launchTemplate : launchTemplates) {
-      launchTemplateVersions.addAll(getLaunchTemplateVersions(ec2, launchTemplate));
-    }
-
-    return launchTemplateVersions;
-  }
-
   /** Gets a list of ec2 Launch template versions for a Launch template */
-  private List<LaunchTemplateVersion> getLaunchTemplateVersions(
-      AmazonEC2 ec2, LaunchTemplate template) {
+  private List<LaunchTemplateVersion> getLaunchTemplateVersions(AmazonEC2 ec2, String... versions) {
     final List<LaunchTemplateVersion> launchTemplateVersions = new ArrayList<>();
     final DescribeLaunchTemplateVersionsRequest request =
-        new DescribeLaunchTemplateVersionsRequest()
-            .withLaunchTemplateId(template.getLaunchTemplateId());
+        new DescribeLaunchTemplateVersionsRequest().withVersions(versions);
     while (true) {
       final DescribeLaunchTemplateVersionsResult result =
           ec2.describeLaunchTemplateVersions(request);

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/security/sdkclient/AmazonClientInvocationHandler.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult;
 import com.amazonaws.services.cloudwatch.model.MetricAlarm;
 import com.amazonaws.services.ec2.model.*;
 import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.LaunchTemplate;
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest;
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult;
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription;
@@ -191,6 +192,17 @@ public class AmazonClientInvocationHandler implements InvocationHandler {
   // AmazonEC2
   //
   ////////////////////////////////////
+  public DescribeLaunchTemplatesResult describeLaunchTemplates() {
+    return describeLaunchTemplates(null);
+  }
+
+  public DescribeLaunchTemplatesResult describeLaunchTemplates(
+      DescribeLaunchTemplatesRequest request) {
+    return new DescribeLaunchTemplatesResult()
+        .withLaunchTemplates(
+            describe(request, "launchTemplateNames", "launchTemplates", LaunchTemplate.class));
+  }
+
   public DescribeImagesResult describeImages() {
     return describeImages(null);
   }

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgentSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLaunchTemplateCachingAgentSpec.groovy
@@ -87,13 +87,7 @@ class AmazonLaunchTemplateCachingAgentSpec extends Specification {
 
     then:
     1 * ec2.describeLaunchTemplates(_) >> new DescribeLaunchTemplatesResult(launchTemplates: [lt1, lt2])
-    1 * ec2.describeLaunchTemplateVersions(
-      {it.launchTemplateId == lt1.launchTemplateId} as DescribeLaunchTemplateVersionsRequest
-    ) >> new DescribeLaunchTemplateVersionsResult(launchTemplateVersions: [lt1Version0, lt1Version1])
-
-    1 * ec2.describeLaunchTemplateVersions(
-      {it.launchTemplateId == lt2.launchTemplateId} as DescribeLaunchTemplateVersionsRequest
-    ) >> new DescribeLaunchTemplateVersionsResult(launchTemplateVersions: [lt2Version0])
+    1 * ec2.describeLaunchTemplateVersions(_) >> new DescribeLaunchTemplateVersionsResult(launchTemplateVersions: [lt1Version0, lt1Version1, lt2Version0])
 
     result.size() == 2
     def lt1Result = result.find { it.attributes.launchTemplateName == lt1.launchTemplateName }


### PR DESCRIPTION
- added proxy method for describe launch templates
- updated caching agent to fetch versions in one call
- TODO(not supported): Add proxy method for describe versions
