### PR TITLE
fix(aws): fix Lambda memory and KMS Key not settable

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/CreateLambdaFunctionConfigurationDescription.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/CreateLambdaFunctionConfigurationDescription.java
@@ -30,7 +30,7 @@ public class CreateLambdaFunctionConfigurationDescription
   String functionName;
   String description;
   String handler;
-  Integer memory;
+  Integer memorySize;
   String role;
   String runtime;
   Integer timeout;
@@ -39,7 +39,7 @@ public class CreateLambdaFunctionConfigurationDescription
   Map<String, String> envVariables;
   Map<String, String> tags;
   DeadLetterConfig deadLetterConfig;
-  String encryptionKMSKeyArn;
+  String kmskeyArn;
   TracingConfig tracingConfig;
   String targetGroups;
   String runTime;

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/CreateLambdaFunctionDescription.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/description/CreateLambdaFunctionDescription.java
@@ -35,7 +35,7 @@ public class CreateLambdaFunctionDescription extends AbstractLambdaFunctionDescr
   String runtime;
   String appName;
 
-  Integer memory;
+  Integer memorySize;
   Integer timeout;
 
   Map<String, String> tags;
@@ -50,5 +50,5 @@ public class CreateLambdaFunctionDescription extends AbstractLambdaFunctionDescr
 
   DeadLetterConfig deadLetterConfig;
   TracingConfig tracingConfig;
-  String encryptionKMSKeyArn;
+  String kmskeyArn;
 }

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/CreateLambdaAtomicOperation.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/CreateLambdaAtomicOperation.java
@@ -76,7 +76,7 @@ public class CreateLambdaAtomicOperation
         combineAppDetail(description.getAppName(), description.getFunctionName()));
     request.setDescription(description.getDescription());
     request.setHandler(description.getHandler());
-    request.setMemorySize(description.getMemory());
+    request.setMemorySize(description.getMemorySize());
     request.setPublish(description.getPublish());
     request.setRole(description.getRole());
     request.setRuntime(description.getRuntime());
@@ -99,7 +99,7 @@ public class CreateLambdaAtomicOperation
     if (!description.getDeadLetterConfig().getTargetArn().isEmpty()) {
       request.setDeadLetterConfig(description.getDeadLetterConfig());
     }
-    request.setKMSKeyArn(description.getEncryptionKMSKeyArn());
+    request.setKMSKeyArn(description.getKmskeyArn());
     request.setTracingConfig(description.getTracingConfig());
 
     CreateFunctionResult result = client.createFunction(request);

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/UpdateLambdaConfigurationAtomicOperation.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/deploy/ops/UpdateLambdaConfigurationAtomicOperation.java
@@ -59,7 +59,7 @@ public class UpdateLambdaConfigurationAtomicOperation
             .withFunctionName(cache.getFunctionArn())
             .withDescription(description.getDescription())
             .withHandler(description.getHandler())
-            .withMemorySize(description.getMemory())
+            .withMemorySize(description.getMemorySize())
             .withRole(description.getRole())
             .withTimeout(description.getTimeout())
             .withDeadLetterConfig(description.getDeadLetterConfig())
@@ -67,7 +67,7 @@ public class UpdateLambdaConfigurationAtomicOperation
                 new VpcConfig()
                     .withSecurityGroupIds(description.getSecurityGroupIds())
                     .withSubnetIds(description.getSubnetIds()))
-            .withKMSKeyArn(description.getEncryptionKMSKeyArn())
+            .withKMSKeyArn(description.getKmskeyArn())
             .withTracingConfig(description.getTracingConfig())
             .withRuntime(description.getRuntime());
 


### PR DESCRIPTION
Inputting memory and/or KMS Key Arn into Deck does not change Lambda values on creation or update.

1. CloudDriver is expecting `memory` from Deck when `memorySize` is provided by Deck on form submit and is provided to Deck by function cache.
2. CloudDriver is expecting `encryptionKMSKeyArn` from Deck when `kmskeyArn` is provided by Deck on form submit and is provided to Deck by function cache.

_fix_: 
1. `memory` &rarr; `memorySize` to match Deck and AWS data model
2. `encryptionKMSKeyArn` &rarr; `kmskeyArn` to match Deck and AWS data model