### PR TITLE
fix(servergroups): add `account` property when expand=true

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
@@ -129,6 +129,7 @@ class ServerGroupController {
   Map expanded(ServerGroup serverGroup, Cluster cluster) {
     Map sg = objectMapper.convertValue(serverGroup, Map)
     sg.accountName = cluster.accountName
+    sg.account = cluster.accountName
     def moniker = cluster.moniker
     sg.cluster = moniker.cluster
     sg.application = moniker.app


### PR DESCRIPTION
When calling `application/{}/serverGroups?expand=false` clouddriver returns an account field as part of the servergroupviewmodel.
However, when calling the same with `expand=true` the `account` field is missing and isntead we have an `accountName` field representing same information

This if difficult to deal with for API users. Adding, `account` field for consistency
