### PR TITLE
feat(test/int): Run int tests only on pushes to master

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,33 @@
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx6g -Xms6g
+
+jobs:
+  it-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # Install Java 8 for cross-compilation support. Setting it up before
+    # Java 11 means it comes later in $PATH (because of how setup-java works)
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - uses: actions/cache@v2
+      with:
+        path: ~/.gradle
+        key: ${{ runner.os }}-cd-build-${{ github.sha }}
+        # Restore build outputs from the previous commit (if successful), if current commit hasn't run successfully yet
+        restore-keys: |
+          ${{ runner.os }}-cd-build-${{ github.event.before }}
+    # Separating integration tests by provider allows to have separate logs
+    - name: Kubernetes Provider Integration Tests
+      run: ./gradlew --build-cache :clouddriver-kubernetes:integrationTest

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx6g -Xms6g
@@ -21,13 +22,23 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/cache@v2
+    - name: Cache on push
+      if: github.event_name == 'push'
+      uses: actions/cache@v2
       with:
         path: ~/.gradle
-        key: ${{ runner.os }}-cd-build-${{ github.sha }}
+        key: ${{ runner.os }}-cd-it-${{ github.sha }}
         # Restore build outputs from the previous commit (if successful), if current commit hasn't run successfully yet
         restore-keys: |
-          ${{ runner.os }}-cd-build-${{ github.event.before }}
+          ${{ runner.os }}-cd-it-${{ github.event.before }}
+    - name: Cache on pull_request
+      if: github.event_name == 'pull_request'
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle
+        key: ${{ runner.os }}-cd-it-${{ github.event.pull_request.head.sha }}
+        restore-keys: |
+          ${{ runner.os }}-cd-it-${{ github.event.before }}
     # Separating integration tests by provider allows to have separate logs
     - name: Kubernetes Provider Integration Tests
       run: ./gradlew --build-cache :clouddriver-kubernetes:integrationTest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,5 +26,3 @@ jobs:
           ${{ runner.os }}-gradle-
     - name: Build
       run: ./gradlew -PenableCrossCompilerPlugin=true build
-    - name: Integration Tests
-      run: ./gradlew --info integrationTest


### PR DESCRIPTION
There are two concerns when running integration tests to block PR builds:
1. Builds take a long time to complete. With the few tests added so far in clouddriver, build times were increased by about 13 minutes. This is only going to take longer as more tests are added to the service.
2. Test flakiness. Given the inherent complexity of integration tests, there could be sometimes when they fail in a particular execution without any code change.

The goal of integration tests is to find bugs before doing releases, the sooner the better. A good compromise would be to run them on pushes to `master` branch, so that PR builds are not delayed or blocked by the tests, but yet there's a clear indication of exactly which PR broke the tests, which is not possible when they are run on a scheduled basis like the current end to end tests.

This PR introduces a new workflow for running integration tests only on pushes to `master` branch. It makes use of gradle's [build cache](https://docs.gradle.org/current/userguide/build_cache.html) and github's [cache action](https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows), so that only gradle tasks that were affected by a commit are executed. This allows to save a lot of time and unnecessary test runs on changes that could not affect test output. As an example, build time for changing a workflow file goes down from ~23 minutes to ~3 minutes, because gradle doesn't detect any changes and marks all tasks as up-to-date.
