### PR TITLE
fix(servergroups): Add fields server group instanceType and instance availabilityZone fields

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstance.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstance.groovy
@@ -88,6 +88,10 @@ class AmazonInstance implements Instance, Serializable {
     getExtraAttributes().get("placement")?.availabilityZone
   }
 
+  String getAvailabilityZone() {
+    return this.getZone()
+  }
+
   @Override
   boolean equals(Object o) {
     if (o instanceof AmazonInstance)

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstanceSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonInstanceSpec.groovy
@@ -26,10 +26,18 @@ import spock.lang.Unroll
  */
 class AmazonInstanceSpec extends Specification {
 
-  Instance instance
+  AmazonInstance instance
 
   def setup() {
     instance = new AmazonInstance(name: 'foo')
+  }
+
+  def "get availability zone from extra attributes"() {
+    when:
+    instance = new AmazonInstance([placement: [availabilityZone: "us-east-1"]])
+
+    then:
+    instance.getAvailabilityZone() == "us-east-1"
   }
 
   def "getHealthState for ALL UP health states"() {

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstance.groovy
@@ -107,6 +107,10 @@ class TitusInstance implements Instance {
     agentId
   }
 
+  String getAvailabilityZone() {
+    return placement.getZone()
+  }
+
   String getIpv4Address() {
     return ipv4Address
   }

--- a/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
+++ b/clouddriver-titus/src/test/groovy/com/netflix/spinnaker/clouddriver/titus/model/TitusInstanceSpec.groovy
@@ -74,6 +74,7 @@ class TitusInstanceSpec extends Specification {
     titusInstance.finishedAt == null
     titusInstance.privateIpAddress == task.data.ipAddresses.nfvpc
     titusInstance.agentId == task.agentId
+    titusInstance.availabilityZone == task.zone
   }
 
   void 'can handle null ports'() {

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy
@@ -129,12 +129,21 @@ class ServerGroupController {
   Map expanded(ServerGroup serverGroup, Cluster cluster) {
     Map sg = objectMapper.convertValue(serverGroup, Map)
     sg.accountName = cluster.accountName
-    sg.account = cluster.accountName
     def moniker = cluster.moniker
     sg.cluster = moniker.cluster
     sg.application = moniker.app
     sg.stack = moniker.stack
     sg.freeFormDetail = moniker.detail
+
+    //The following fields exist in the non-expanded result and so even though there is some
+    //minor data duplication here it seems reasonable to also set these fields in the expanded result.
+    if (serverGroup.launchConfig) {
+      if (serverGroup.launchConfig.instanceType) {
+        sg.instanceType = serverGroup.launchConfig.instanceType
+      }
+    }
+    sg.account = cluster.accountName
+
     return sg
   }
 


### PR DESCRIPTION
This way, when a request for `expanded` results comes in it includes fields that we also return on non-expanded requests.
