### PR TITLE
refactor(kubernetes): Remove liveManifestCalls flag

### DIFF
--- a/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
+++ b/clouddriver-kubernetes/src/integration/resources/clouddriver.yml
@@ -22,7 +22,6 @@ kubernetes:
       omitKinds: []
       customResources: []
       cachingPolicies: []
-      liveManifestCalls: false
       oauthScopes: []
       oAuthScopes: []
       onlySpinnakerManaged: true
@@ -43,7 +42,6 @@ kubernetes:
       omitKinds: []
       customResources: []
       cachingPolicies: []
-      liveManifestCalls: false
       oauthScopes: []
       oAuthScopes: []
       onlySpinnakerManaged: true

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -54,7 +54,6 @@ public class KubernetesConfigurationProperties {
     private List<String> kinds = new ArrayList<>();
     private List<String> omitKinds = new ArrayList<>();
     private boolean onlySpinnakerManaged = false;
-    private boolean liveManifestCalls = false;
     private Long cacheIntervalSeconds;
 
     public void validate() {

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentials.java
@@ -109,8 +109,6 @@ public class KubernetesCredentials {
 
   @Include @Getter private final boolean onlySpinnakerManaged;
 
-  @Include @Getter private final boolean liveManifestCalls;
-
   @Include private final boolean checkPermissionsOnStartup;
 
   @Include @Getter private final List<KubernetesCachingPolicy> cachingPolicies;
@@ -185,7 +183,6 @@ public class KubernetesCredentials {
     this.context = managedAccount.getContext();
 
     this.onlySpinnakerManaged = managedAccount.isOnlySpinnakerManaged();
-    this.liveManifestCalls = managedAccount.isLiveManifestCalls();
     this.checkPermissionsOnStartup = managedAccount.isCheckPermissionsOnStartup();
     this.cachingPolicies = managedAccount.getCachingPolicies();
 

--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesProviderSynchronizableSpec.groovy
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/caching/KubernetesProviderSynchronizableSpec.groovy
@@ -146,7 +146,6 @@ class KubernetesProviderSynchronizableSpec extends Specification {
     accountCredentials.isOnlySpinnakerManaged() == false
     accountCredentials.isDebug() == false
     accountCredentials.isMetricsEnabled() == true
-    accountCredentials.isLiveManifestCalls() == false
 
     kubernetesProvider.agents.size() == 2
     kubernetesProvider.agents.find { it.agentType == "test-account/KubernetesCoreCachingAgent[1/1]" } != null

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -118,7 +118,6 @@ final class KubernetesCoreCachingAgentTest {
   /** Returns a mock KubernetesCredentials object */
   private static KubernetesCredentials mockKubernetesCredentials() {
     KubernetesCredentials credentials = mock(KubernetesCredentials.class);
-    when(credentials.isLiveManifestCalls()).thenReturn(false);
     when(credentials.getGlobalKinds()).thenReturn(kindProperties.keySet().asList());
     when(credentials.getKindProperties(any(KubernetesKind.class)))
         .thenAnswer(invocation -> kindProperties.get(invocation.getArgument(0)));


### PR DESCRIPTION
The performance improvements of the past few months have ultimately led to this flag no longer being read anywhere. Spinnaker now decides whether to read from the cache or to make a live call based on the context of the call rather than based on a flag.

From a practical perspective this means that:
* Users who had liveManifestCalls enabled will see the same fast deploys as always; bugs and race conditions with dynamic target selection have now been fixed.
* Users who had liveManifestCalls disabled will notice significantly faster deployments.