### PR TITLE
fix (aws): Fix broken deserialization of uuid after aws lambda get

### DIFF
--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/cache/client/LambdaCacheClient.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/clouddriver/lambda/cache/client/LambdaCacheClient.java
@@ -56,7 +56,7 @@ public class LambdaCacheClient extends AbstractCacheClient<LambdaFunction> {
         .getEventSourceMappings()
         .forEach(
             currMapping -> {
-              currMapping.setUUID((String) arnUuidMap.get("uuid"));
+              currMapping.setUUID((String) arnUuidMap.get(currMapping.getEventSourceArn()));
             });
     return lambdaFunction;
   }


### PR DESCRIPTION
fix (aws): Fix broken deserialization of uuid after aws lambda get