### PR TITLE
feat(lambda-configuration): change the way lambda is enabled for aws

### DIFF
--- a/clouddriver-lambda/README.md
+++ b/clouddriver-lambda/README.md
@@ -8,11 +8,22 @@ Spinnaker CloudDriver has been enhanced to add support for AWS Lambda. Below lis
 
 ```yaml
 aws:
-  lambda:
-    enabled: true
+  features:
+    lambda:
+      enabled: true
   accounts:
     - name: test
       lambdaEnabled: true
+```
+
+_Deprecation Notice_:
+
+We are deprecating the following configuration in favor of unifying configuration of AWS services and features:
+
+```yaml
+aws:
+  lambda:
+    enabled: true
 ```
 
 # Controller calls

--- a/clouddriver-lambda/src/main/java/com/netflix/spinnaker/config/LambdaConfiguration.java
+++ b/clouddriver-lambda/src/main/java/com/netflix/spinnaker/config/LambdaConfiguration.java
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ComponentScan("com.netflix.spinnaker.clouddriver.lambda")
-@ConditionalOnProperty("aws.lambda.enabled")
+@ConditionalOnExpression(
+    "${aws.enabled:false} and (${aws.lambda.enabled:false} or ${aws.features.lambda.enabled:false})")
 public class LambdaConfiguration {}


### PR DESCRIPTION
CloudFormation and Launch Templates for AWS are already enabled by putting them under
`aws.features`. To unify how other AWS features are configured, we also change
`aws.lambda.enabled` to `aws.features.lambda.enabled`(deprecating `aws.lambda.enabled`).

This follows the conversation we had at the SIG meeting to also try and unify other AWS features.

/cc @kevinawoo 
/cc @akshayabd
/cc @clareliguori 