### PR TITLE
fix(event): Force cleanup agent to compare ints

### DIFF
--- a/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventCleanupAgentTest.kt
+++ b/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventCleanupAgentTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.clouddriver.sql.event
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.SqlEventCleanupAgentConfigProperties
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import de.huxhorn.sulky.ulid.ULID
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.jooq.impl.DSL
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class SqlEventCleanupAgentTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    before {
+      listOf(
+        Instant.now().minus(3, ChronoUnit.DAYS),
+        Instant.now().minus(10, ChronoUnit.DAYS)
+      ).forEachIndexed { i, ts ->
+        database.context
+          .insertInto(DSL.table("event_aggregates"))
+          .values(
+            "mytype",
+            "myid$i",
+            ULID().nextULID(),
+            1,
+            Timestamp.from(ts)
+          )
+          .execute()
+      }
+    }
+
+    test("deletes old aggregates") {
+      subject.run()
+
+      val count = database.context.fetchCount(DSL.table("event_aggregates"))
+      expectThat(count).isEqualTo(1)
+    }
+
+    after {
+      database.context.truncate("event_aggregates")
+    }
+  }
+
+  private inner class Fixture {
+    val database = SqlTestUtil.initTcMysqlDatabase()!!
+
+    val subject = SqlEventCleanupAgent(
+      database.context,
+      NoopRegistry(),
+      SqlEventCleanupAgentConfigProperties()
+    )
+  }
+}


### PR DESCRIPTION
Two problems here:

1. The `timestampDiff` returns an `INTERVAL` type, which jOOQ doesn't handle correctly when doing comparisons in MySQL.
2. `timestampDiff` parameters were reversed, so even if the first thing wasn't broken, it never would've cleaned anything up.

I'm not particularly sure how this had worked before. It definitely has worked before, because our oldest events are from April; long after we'd enabled this functionality.