### PR TITLE
chore(java11): Target Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Java 8 for cross-compilation support. Setting it up before
-      # Java 11 means it comes later in $PATH (because of how setup-java works)
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -31,4 +26,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Build
-        run: ./gradlew -PenableCrossCompilerPlugin=true build --stacktrace
+        run: ./gradlew build --stacktrace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    # Install Java 8 for cross-compilation support. Setting it up before
-    # Java 11 means it comes later in $PATH (because of how setup-java works)
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
     - uses: actions/setup-java@v1
       with:
         java-version: 11
@@ -25,4 +20,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Build
-      run: ./gradlew -PenableCrossCompilerPlugin=true build
+      run: ./gradlew build
+    - name: Integration Tests
+      run: ./gradlew --info integrationTest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,5 +21,3 @@ jobs:
           ${{ runner.os }}-gradle-
     - name: Build
       run: ./gradlew build
-    - name: Integration Tests
-      run: ./gradlew --info integrationTest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
-      # Install Java 8 for cross-compilation support. Setting it up before
-      # Java 11 means it comes later in $PATH (because of how setup-java works)
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -45,7 +40,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           RELEASE_VERSION: ${{ steps.release_info.outputs.RELEASE_VERSION }}
         run: |
-          ./gradlew -PenableCrossCompilerPlugin=true --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" publish
+          ./gradlew --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" publish
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,11 +1,8 @@
 FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y \
-    openjdk-8-jdk \
     openjdk-11-jdk \
  && rm -rf /var/lib/apt/lists/*
 LABEL maintainer="sig-platform@spinnaker.io"
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
-ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS "-Xmx4g -Xms2g"
-CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true clouddriver-web:installDist -x test
+CMD ./gradlew --no-daemon clouddriver-web:installDist -x test

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolverSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AmiIdResolverSpec.groovy
@@ -27,8 +27,8 @@ import spock.lang.Specification
 
 class AmiIdResolverSpec extends Specification {
 
-  private final String amiId = 'ami-12345'
-  private final String accountId = '98765'
+  private String amiId = 'ami-12345'
+  private String accountId = '98765'
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAlarmOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteAlarmOperationUnitSpec.groovy
@@ -43,12 +43,12 @@ class DeleteAlarmOperationUnitSpec extends Specification {
     credentials: credz
   )
 
-  final cloudWatch = Mock(AmazonCloudWatch)
-  final amazonClientProvider = Stub(AmazonClientProvider) {
+  def cloudWatch = Mock(AmazonCloudWatch)
+  def amazonClientProvider = Stub(AmazonClientProvider) {
     getCloudWatch(credz, "us-west-1", true) >> cloudWatch
   }
 
-  @Subject final op = new DeleteAlarmAtomicOperation(description)
+  @Subject def op = new DeleteAlarmAtomicOperation(description)
 
   def setup() {
     op.amazonClientProvider = amazonClientProvider

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteScalingPolicyAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/DeleteScalingPolicyAtomicOperationUnitSpec.groovy
@@ -47,21 +47,21 @@ class DeleteScalingPolicyAtomicOperationUnitSpec extends Specification {
     TaskRepository.threadLocalTask.set(Mock(Task))
   }
 
-  final description = new DeleteScalingPolicyDescription(
+  def description = new DeleteScalingPolicyDescription(
     serverGroupName: "kato-main-v000",
     policyName: "scalingPolicy1",
     region: "us-west-1",
     credentials: credz
   )
 
-  final autoScaling = Mock(AmazonAutoScaling)
-  final cloudWatch = Mock(AmazonCloudWatch)
-  final amazonClientProvider = Stub(AmazonClientProvider) {
+  def autoScaling = Mock(AmazonAutoScaling)
+  def cloudWatch = Mock(AmazonCloudWatch)
+  def amazonClientProvider = Stub(AmazonClientProvider) {
     getAutoScaling(credz, "us-west-1", true) >> autoScaling
     getCloudWatch(credz, "us-west-1", true) >> cloudWatch
   }
 
-  @Subject final op = new DeleteScalingPolicyAtomicOperation(description)
+  @Subject def op = new DeleteScalingPolicyAtomicOperation(description)
 
   def setup() {
     op.amazonClientProvider = amazonClientProvider

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAlarmOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAlarmOperationUnitSpec.groovy
@@ -56,12 +56,12 @@ class UpsertAlarmOperationUnitSpec extends Specification {
     unit: StandardUnit.Percent,
   )
 
-  final cloudWatch = Mock(AmazonCloudWatch)
-  final amazonClientProvider = Stub(AmazonClientProvider) {
+  def cloudWatch = Mock(AmazonCloudWatch)
+  def amazonClientProvider = Stub(AmazonClientProvider) {
     getCloudWatch(_, _, true) >> cloudWatch
   }
 
-  @Subject final op = new UpsertAlarmAtomicOperation(description)
+  @Subject def op = new UpsertAlarmAtomicOperation(description)
 
   def setup() {
     op.amazonClientProvider = amazonClientProvider

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertAsgLifecycleHookAtomicOperationUnitSpec.groovy
@@ -31,17 +31,17 @@ class UpsertAsgLifecycleHookAtomicOperationUnitSpec extends Specification {
     TaskRepository.threadLocalTask.set(Mock(Task))
   }
 
-  final description = new UpsertAsgLifecycleHookDescription(
+  def description = new UpsertAsgLifecycleHookDescription(
     serverGroupName: 'asg-v000',
     region: 'us-west-1',
     roleARN: 'arn:aws:iam::123456789012:role/my-notification-role',
     notificationTargetARN: 'arn:aws:sns:us-west-1:123456789012:my-sns-topic'
   )
 
-  @Subject final op = new UpsertAsgLifecycleHookAtomicOperation(description)
+  @Subject def op = new UpsertAsgLifecycleHookAtomicOperation(description)
 
-  final autoScaling = Mock(AmazonAutoScaling)
-  final amazonClientProvider = Stub(AmazonClientProvider) {
+  def autoScaling = Mock(AmazonAutoScaling)
+  def amazonClientProvider = Stub(AmazonClientProvider) {
     getAutoScaling(_, _, true) >> autoScaling
   }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertScalingPolicyAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/UpsertScalingPolicyAtomicOperationUnitSpec.groovy
@@ -37,7 +37,7 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
     TaskRepository.threadLocalTask.set(Mock(Task))
   }
 
-  final description = new UpsertScalingPolicyDescription(
+  def description = new UpsertScalingPolicyDescription(
     serverGroupName: "kato-main-v000",
     region: "us-west-1",
     adjustmentType: AdjustmentType.PercentChangeInCapacity,
@@ -48,14 +48,14 @@ class UpsertScalingPolicyAtomicOperationUnitSpec extends Specification {
     )
   )
 
-  final autoScaling = Mock(AmazonAutoScaling)
-  final cloudWatch = Mock(AmazonCloudWatch)
-  final amazonClientProvider = Stub(AmazonClientProvider) {
+  def autoScaling = Mock(AmazonAutoScaling)
+  def cloudWatch = Mock(AmazonCloudWatch)
+  def amazonClientProvider = Stub(AmazonClientProvider) {
     getAutoScaling(_, _, true) >> autoScaling
     getCloudWatch(_, _, true) >> cloudWatch
   }
 
-  @Subject final op = new UpsertScalingPolicyAtomicOperation(description)
+  @Subject def op = new UpsertScalingPolicyAtomicOperation(description)
 
   def setup() {
     op.amazonClientProvider = amazonClientProvider

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/SecurityGroupLookupSpec.groovy
@@ -34,11 +34,11 @@ import spock.lang.Subject
 
 class SecurityGroupLookupSpec extends Specification {
 
-  final amazonEC2 = Mock(AmazonEC2)
-  final amazonClientProvider = Stub(AmazonClientProvider) {
+  def amazonEC2 = Mock(AmazonEC2)
+  def amazonClientProvider = Stub(AmazonClientProvider) {
     getAmazonEC2(_, "us-east-1", _) >> amazonEC2
   }
-  final accountCredentialsRepository = Stub(AccountCredentialsRepository) {
+  def accountCredentialsRepository = Stub(AccountCredentialsRepository) {
     getAll() >> [
       Stub(NetflixAmazonCredentials) {
         getName() >> "test"
@@ -51,11 +51,11 @@ class SecurityGroupLookupSpec extends Specification {
     ]
   }
 
-  final securityGroupLookupFactory = new SecurityGroupLookupFactory(amazonClientProvider,
+  def securityGroupLookupFactory = new SecurityGroupLookupFactory(amazonClientProvider,
     accountCredentialsRepository)
 
   @Subject
-  final securityGroupLookup = securityGroupLookupFactory.getInstance("us-east-1")
+  def securityGroupLookup = securityGroupLookupFactory.getInstance("us-east-1")
 
   void "should create security group"() {
     when:

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/securitygroup/UpsertSecurityGroupAtomicOperationUnitSpec.groovy
@@ -48,9 +48,9 @@ class UpsertSecurityGroupAtomicOperationUnitSpec extends Specification {
   )
 
 
-  final securityGroupLookup = Mock(SecurityGroupLookupFactory.SecurityGroupLookup)
+  def securityGroupLookup = Mock(SecurityGroupLookupFactory.SecurityGroupLookup)
 
-  final securityGroupLookupFactory = Stub(SecurityGroupLookupFactory) {
+  def securityGroupLookupFactory = Stub(SecurityGroupLookupFactory) {
     getInstance(_) >> securityGroupLookup
   }
 

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/validators/UpsertSecurityGroupDescriptionValidatorSpec.groovy
@@ -34,7 +34,7 @@ class UpsertSecurityGroupDescriptionValidatorSpec extends Specification {
   SecurityGroupService securityGroupService = Mock(SecurityGroupService)
   ValidationErrors errors = Mock(ValidationErrors)
 
-  final description = new UpsertSecurityGroupDescription(
+  def description = new UpsertSecurityGroupDescription(
     credentials: TestCredential.named('test'),
     region: "us-east-1",
     name: "foo",

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/provider/view/AmazonSecurityGroupProviderSpec.groovy
@@ -47,17 +47,17 @@ class AmazonSecurityGroupProviderSpec extends Specification {
   WriteableCache cache = new InMemoryCache()
   ObjectMapper mapper = new ObjectMapper()
 
-  final credential1 = Stub(NetflixAmazonCredentials) {
+  def credential1 = Stub(NetflixAmazonCredentials) {
     getName() >> "accountName1"
     getAccountId() >> "accountId1"
   }
 
-  final credential2 = Stub(NetflixAmazonCredentials) {
+  def credential2 = Stub(NetflixAmazonCredentials) {
     getName() >> "accountName2"
     getAccountId() >> "accountId2"
   }
 
-  final accountCredentialsProvider = new AccountCredentialsProvider() {
+  def accountCredentialsProvider = new AccountCredentialsProvider() {
 
     @Override
     Set<? extends AccountCredentials> getAll() {

--- a/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgentTest.groovy
+++ b/clouddriver-docker/src/test/groovy/com/netflix/spinnaker/clouddriver/docker/registry/provider/agent/DockerRegistryImageCachingAgentTest.groovy
@@ -28,11 +28,11 @@ import java.time.Instant
 
 class DockerRegistryImageCachingAgentTest extends Specification {
 
-  final KEY_PREFIX = "dockerRegistry"
-  final ACCOUNT_NAME = "test-docker"
-  final REGISTRY_NAME = "test-registry"
-  final CACHE_GROUP_TAGGED_IMAGE = "taggedImage"
-  final CACHE_GROUP_IMAGE_ID = "imageId"
+  def KEY_PREFIX = "dockerRegistry"
+  def ACCOUNT_NAME = "test-docker"
+  def REGISTRY_NAME = "test-registry"
+  def CACHE_GROUP_TAGGED_IMAGE = "taggedImage"
+  def CACHE_GROUP_IMAGE_ID = "imageId"
 
   DockerRegistryImageCachingAgent agent
   def credentials = Mock(DockerRegistryCredentials)

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/SecretCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/SecretCacheClientSpec.groovy
@@ -29,7 +29,7 @@ import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SECRETS
 class SecretCacheClientSpec extends Specification {
   def cacheView = Mock(Cache)
   @Subject
-  private final SecretCacheClient client = new SecretCacheClient(cacheView)
+  private SecretCacheClient client = new SecretCacheClient(cacheView)
 
   def 'should convert'() {
     given:

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/ServiceDiscoveryCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/ServiceDiscoveryCacheClientSpec.groovy
@@ -29,7 +29,7 @@ import static com.netflix.spinnaker.clouddriver.ecs.cache.Keys.Namespace.SERVICE
 class ServiceDiscoveryCacheClientSpec extends Specification {
   def cacheView = Mock(Cache)
   @Subject
-  private final ServiceDiscoveryCacheClient client = new ServiceDiscoveryCacheClient(cacheView)
+  private ServiceDiscoveryCacheClient client = new ServiceDiscoveryCacheClient(cacheView)
 
   def 'should convert'() {
     given:

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TargetHealthCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TargetHealthCacheClientSpec.groovy
@@ -34,7 +34,7 @@ class TargetHealthCacheClientSpec extends Specification {
   def cacheView = Mock(Cache)
   def objectMapper = new ObjectMapper()
   @Subject
-  private final TargetHealthCacheClient client = new TargetHealthCacheClient(cacheView, objectMapper)
+  private TargetHealthCacheClient client = new TargetHealthCacheClient(cacheView, objectMapper)
 
   def 'should convert'() {
     given:

--- a/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TaskHealthCacheClientSpec.groovy
+++ b/clouddriver-ecs/src/test/groovy/com/netflix/spinnaker/clouddriver/ecs/cache/TaskHealthCacheClientSpec.groovy
@@ -28,7 +28,7 @@ import spock.lang.Subject
 class TaskHealthCacheClientSpec extends Specification {
   def cacheView = Mock(Cache)
   @Subject
-  private final TaskHealthCacheClient client = new TaskHealthCacheClient(cacheView)
+  private TaskHealthCacheClient client = new TaskHealthCacheClient(cacheView)
 
   def 'should convert'() {
     given:

--- a/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/BatchComputeRequestImpl.java
+++ b/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/compute/BatchComputeRequestImpl.java
@@ -86,7 +86,7 @@ final class BatchComputeRequestImpl<RequestT extends ComputeRequest<ResponseT>, 
         partition(queuedRequests, MAX_BATCH_SIZE);
     List<BatchRequest> queuedBatches = createBatchRequests(requestPartitions);
 
-    String statusCode = "500";
+    var statusCode = "500";
     String success = "false";
     long start = registry.clock().monotonicTime();
     try {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ fiatVersion=1.23.0
 korkVersion=7.69.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.6.0
+targetJava11=true
 kotlinVersion=1.4.0
 
 # To enable a composite reference to a project, set the

--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -39,6 +39,6 @@ test {
 compileTestKotlin {
   kotlinOptions {
     languageVersion = "1.4"
-    jvmTarget = "1.8"
+    jvmTarget = "11"
   }
 }

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -30,6 +30,6 @@ configurations.all {
 compileKotlin {
   kotlinOptions {
     languageVersion = "1.4"
-    jvmTarget = "1.8"
+    jvmTarget = "11"
   }
 }


### PR DESCRIPTION
After this commit, we can use Java 11 language features and APIs.

I added a single var declaration to make it more obvious if any of our various CI systems are misconfigured.

I had to remove `final` from a bunch of Spock tests because of an issue with Spock: spockframework/spock#1011