### PR TITLE
fix(titus): `DeleteServerGroupEvent` should use server group name rather than job id

### DIFF
--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/ResolveTitusJobId.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/actions/ResolveTitusJobId.java
@@ -69,6 +69,7 @@ public class ResolveTitusJobId implements SagaAction<ResolveTitusJobId.ResolveTi
       destroyTitusJobDescription.setAccount(command.getAccount());
       destroyTitusJobDescription.setRegion(command.getRegion());
       destroyTitusJobDescription.setJobId(job.getId());
+      destroyTitusJobDescription.setServerGroupName(job.getName());
       destroyTitusJobDescription.setUser(command.getUser());
 
       return new Result(

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/converters/DestroyTitusJobAtomicOperationConverter.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/converters/DestroyTitusJobAtomicOperationConverter.groovy
@@ -56,6 +56,7 @@ class DestroyTitusJobAtomicOperationConverter extends AbstractAtomicOperationsCr
       def job = titusJobProvider.collectJob(converted.credentials.name, converted.region, converted.jobId)
       converted.applications = [job.application] as Set
       converted.requiresApplicationRestriction = !converted.applications.isEmpty()
+      converted.serverGroupName = job.name
     } catch (Exception e) {
       converted.applications = []
       converted.requiresApplicationRestriction = true

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DestroyTitusJobDescription.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/description/DestroyTitusJobDescription.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.security.resources.ApplicationNameable
 class DestroyTitusJobDescription extends AbstractTitusCredentialsDescription implements ApplicationNameable{
   String region
   String jobId
+  String serverGroupName
   String user
 
   Set<String> applications

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/DestroyTitusJobCompletionHandler.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/DestroyTitusJobCompletionHandler.java
@@ -41,6 +41,6 @@ public class DestroyTitusJobCompletionHandler
         // titus entity tags are created using the account name (and not the accountId)
         description.getAccount(),
         description.getRegion(),
-        description.getJobId());
+        description.getServerGroupName());
   }
 }


### PR DESCRIPTION
Fixes an issue where entity tags would not be correctly removed after the related server group
was destroyed.