### PR TITLE
fix(sql): Add config for limiting amount of aggregate cleanup

### DIFF
--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventCleanupAgent.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventCleanupAgent.kt
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.clouddriver.core.provider.CoreProvider
 import com.netflix.spinnaker.clouddriver.sql.SqlAgent
 import com.netflix.spinnaker.config.ConnectionPools
 import com.netflix.spinnaker.config.SqlEventCleanupAgentConfigProperties
+import com.netflix.spinnaker.config.SqlEventCleanupAgentConfigProperties.Companion.EVENT_CLEANUP_LIMIT
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.sql.routing.withPool
 import java.sql.Timestamp
 import java.time.Duration
@@ -39,7 +41,8 @@ import org.slf4j.LoggerFactory
 class SqlEventCleanupAgent(
   private val jooq: DSLContext,
   private val registry: Registry,
-  private val properties: SqlEventCleanupAgentConfigProperties
+  private val properties: SqlEventCleanupAgentConfigProperties,
+  private val dynamicConfigService: DynamicConfigService
 ) : RunnableAgent, CustomScheduledAgent, SqlAgent {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -50,7 +53,9 @@ class SqlEventCleanupAgent(
   override fun run() {
     val duration = Duration.ofDays(properties.maxAggregateAgeDays)
     val cutoff = Instant.now().minus(duration)
-    log.info("Deleting aggregates last updated earlier than $cutoff ($duration)")
+    val limit = dynamicConfigService.getConfig(Int::class.java, EVENT_CLEANUP_CONFIG_KEY, EVENT_CLEANUP_LIMIT)
+
+    log.info("Deleting aggregates last updated earlier than $cutoff ($duration), max $limit events")
 
     registry.timer(timingId).record {
       withPool(ConnectionPools.EVENTS.value) {
@@ -66,6 +71,7 @@ class SqlEventCleanupAgent(
               // timestampDiff will return `microsecond / 1000`
               .gt(duration.toMillis().toInt() as Integer)
           )
+          .limit(limit)
           .fetch()
           .intoResultSet()
 
@@ -90,4 +96,8 @@ class SqlEventCleanupAgent(
   override fun getProviderName(): String = CoreProvider.PROVIDER_NAME
   override fun getPollIntervalMillis() = properties.frequency.toMillis()
   override fun getTimeoutMillis() = properties.timeout.toMillis()
+
+  companion object {
+    private const val EVENT_CLEANUP_CONFIG_KEY = "spinnaker.clouddriver.eventing.cleanup-agent.cleanup-limit"
+  }
 }

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.clouddriver.sql.SqlTaskCleanupAgent
 import com.netflix.spinnaker.clouddriver.sql.SqlTaskRepository
 import com.netflix.spinnaker.clouddriver.sql.event.SqlEventCleanupAgent
 import com.netflix.spinnaker.clouddriver.sql.event.SqlEventRepository
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer
 import com.netflix.spinnaker.kork.jackson.ObjectMapperSubtypeConfigurer.SubtypeLocator
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
@@ -117,8 +118,9 @@ class SqlConfiguration {
   fun sqlEventCleanupAgent(
     jooq: DSLContext,
     registry: Registry,
-    properties: SqlEventCleanupAgentConfigProperties
+    properties: SqlEventCleanupAgentConfigProperties,
+    dynamicConfigService: DynamicConfigService
   ): SqlEventCleanupAgent {
-    return SqlEventCleanupAgent(jooq, registry, properties)
+    return SqlEventCleanupAgent(jooq, registry, properties, dynamicConfigService)
   }
 }

--- a/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlEventCleanupAgentConfigProperties.kt
+++ b/clouddriver-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlEventCleanupAgentConfigProperties.kt
@@ -39,4 +39,14 @@ class SqlEventCleanupAgentConfigProperties {
    */
   @Positive
   var maxAggregateAgeDays: Long = 7
+
+  /**
+   * The max number of events to cleanup in each agent invocation.
+   */
+  @Positive
+  var cleanupLimit: Int = EVENT_CLEANUP_LIMIT
+
+  companion object {
+    const val EVENT_CLEANUP_LIMIT = 100_000
+  }
 }

--- a/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventCleanupAgentTest.kt
+++ b/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/event/SqlEventCleanupAgentTest.kt
@@ -18,10 +18,14 @@ package com.netflix.spinnaker.clouddriver.sql.event
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.SqlEventCleanupAgentConfigProperties
+import com.netflix.spinnaker.config.SqlEventCleanupAgentConfigProperties.Companion.EVENT_CLEANUP_LIMIT
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import de.huxhorn.sulky.ulid.ULID
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
 import org.jooq.impl.DSL
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
@@ -68,11 +72,17 @@ class SqlEventCleanupAgentTest : JUnit5Minutests {
 
   private inner class Fixture {
     val database = SqlTestUtil.initTcMysqlDatabase()!!
+    val dynamicConfigService: DynamicConfigService = mockk(relaxed = true)
 
     val subject = SqlEventCleanupAgent(
       database.context,
       NoopRegistry(),
-      SqlEventCleanupAgentConfigProperties()
+      SqlEventCleanupAgentConfigProperties(),
+      dynamicConfigService
     )
+
+    init {
+      every { dynamicConfigService.getConfig(eq(Int::class.java), any(), eq(EVENT_CLEANUP_LIMIT)) } returns EVENT_CLEANUP_LIMIT
+    }
   }
 }


### PR DESCRIPTION
Agent isn't completing in time. Not a big deal, just kinda annoying. This will be good safety to have anyway.