### PR TITLE
fix(saga): Support for multiple atomic operations in a single task

### DIFF
--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/deploy/DeployAtomicOperation.groovy
@@ -75,4 +75,12 @@ class DeployAtomicOperation implements AtomicOperation<DeploymentResult>, SagaCo
       ((SagaContextAware) description).sagaContext = sagaContext
     }
   }
+
+  @Override
+  SagaContext getSagaContext() {
+    if (description instanceof SagaContextAware) {
+      return description.sagaContext
+    }
+    return null
+  }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/SagaContextAware.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/SagaContextAware.java
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.clouddriver.orchestration;
 
 import java.util.Map;
 import javax.annotation.Nonnull;
-import lombok.AllArgsConstructor;
+import javax.annotation.Nullable;
 import lombok.Data;
 
 /**
@@ -30,11 +30,20 @@ import lombok.Data;
 public interface SagaContextAware {
   void setSagaContext(@Nonnull SagaContext sagaContext);
 
+  @Nullable
+  SagaContext getSagaContext();
+
   @Data
-  @AllArgsConstructor
   class SagaContext {
     private String cloudProvider;
     private String descriptionName;
     private Map originalInput;
+    private String sagaId;
+
+    public SagaContext(String cloudProvider, String descriptionName, Map originalInput) {
+      this.cloudProvider = cloudProvider;
+      this.descriptionName = descriptionName;
+      this.originalInput = originalInput;
+    }
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/AbstractSagaAtomicOperation.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/AbstractSagaAtomicOperation.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.saga.flow.SagaFlow;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nonnull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -83,7 +84,8 @@ public abstract class AbstractSagaAtomicOperation<T, SR, R>
     configureSagaBridge(builder);
 
     // TODO(rz): Should make SagaAtomicOperationBridge a bean and inject that instead
-    SR result = new SagaAtomicOperationBridge(sagaService).apply(builder.build());
+    SR result =
+        new SagaAtomicOperationBridge(sagaService, sagaContext.getSagaId()).apply(builder.build());
 
     return parseSagaResult(result);
   }
@@ -91,5 +93,11 @@ public abstract class AbstractSagaAtomicOperation<T, SR, R>
   @Override
   public void setSagaContext(@Nonnull SagaContext sagaContext) {
     this.sagaContext = sagaContext;
+  }
+
+  @Nullable
+  @Override
+  public SagaContext getSagaContext() {
+    return sagaContext;
   }
 }

--- a/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/SagaAtomicOperationBridge.java
+++ b/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/orchestration/sagas/SagaAtomicOperationBridge.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.clouddriver.saga.SagaCommand;
 import com.netflix.spinnaker.clouddriver.saga.SagaService;
 import com.netflix.spinnaker.clouddriver.saga.flow.SagaFlow;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -33,9 +34,11 @@ import lombok.Builder;
 public class SagaAtomicOperationBridge {
 
   private final SagaService sagaService;
+  private final String sagaId;
 
-  public SagaAtomicOperationBridge(SagaService sagaService) {
+  public SagaAtomicOperationBridge(SagaService sagaService, String sagaId) {
     this.sagaService = sagaService;
+    this.sagaId = sagaId;
   }
 
   public <T> T apply(@Nonnull ApplyCommandWrapper applyCommand) {
@@ -44,8 +47,9 @@ public class SagaAtomicOperationBridge {
     final String sagaName = applyCommand.sagaName;
 
     // use a random uuid to guarantee a unique saga id (rather than task.getId() or
-    // task.getRequestId())
-    final String sagaId = UUID.randomUUID().toString();
+    // task.getRequestId()). A sagaId may be provided at construct time due to retries.
+    final String sagaId =
+        Optional.ofNullable(this.sagaId).orElseGet(() -> UUID.randomUUID().toString());
 
     task.addSagaId(SagaId.builder().id(sagaId).name(sagaName).build());
 

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.java
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/handlers/TitusDeployHandler.java
@@ -61,7 +61,7 @@ public class TitusDeployHandler implements DeployHandler<TitusDeployDescription>
             .completionHandler(TitusDeployCompletionHandler.class);
 
     final TitusDeploymentResult result =
-        new SagaAtomicOperationBridge(sagaService)
+        new SagaAtomicOperationBridge(sagaService, inputDescription.getSagaContext().getSagaId())
             .apply(
                 ApplyCommandWrapper.builder()
                     .sagaName(TitusDeployHandler.class.getSimpleName())

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/CloneTitusServerGroupAtomicOperation.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/CloneTitusServerGroupAtomicOperation.groovy
@@ -56,8 +56,11 @@ class CloneTitusServerGroupAtomicOperation implements AtomicOperation<Deployment
 
   @Override
   void setSagaContext(@Nonnull SagaContext sagaContext) {
-    if (description instanceof SagaContextAware) {
-      ((SagaContextAware) description).sagaContext = sagaContext
-    }
+    description.sagaContext = sagaContext
+  }
+
+  @Override
+  SagaContext getSagaContext() {
+    return description.sagaContext
   }
 }

--- a/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/RunTitusJobAtomicOperation.groovy
+++ b/clouddriver-titus/src/main/groovy/com/netflix/spinnaker/clouddriver/titus/deploy/ops/RunTitusJobAtomicOperation.groovy
@@ -57,8 +57,11 @@ class RunTitusJobAtomicOperation implements AtomicOperation<DeploymentResult>, S
 
   @Override
   void setSagaContext(@Nonnull SagaContext sagaContext) {
-    if (description instanceof SagaContextAware) {
-      ((SagaContextAware) description).sagaContext = sagaContext
-    }
+    description.sagaContext = sagaContext
+  }
+
+  @Override
+  SagaContext getSagaContext() {
+    return description.sagaContext
   }
 }


### PR DESCRIPTION
The idea is simple: Tasks can have more than one `AtomicOperation` submitted for it. Changes recently went in that made each saga ID unique to correctly support this use case, but it broke resumability of sagas in the process, and kind of caused some cascading failures. This PR fixes the resume capabilities. Resume requests will now search through all sagas attached to a Task and filter them down to a unique list of sagas (which it should already be, actually) based on the snapshotted description information: Each unique description is a unique atomic operation that has its own saga. The saga's ID is captured and added to the SagaContext, which is already used for bridge data between sagas and atomic operations - we use this context data if present, or create a new UUID if absent (which will happen any time the operation has never run).

I need a shower. 😆  This doesn't include tests, I'm a little fried so I won't be doing that tonight. I'm going to be out (or in meetings) for most of the day tomorrow, so if someone needs to expedite this into an environment and I'm unavailable, they at least have something to start from. This _should_ work as-is, but due to reasons, I can't run clouddriver on my laptop anymore so I haven't run it through any spot-checks.